### PR TITLE
[BugFix] Fix CI workflow failure due to missing dotenv-action dependency

### DIFF
--- a/.github/workflows/run-integration.yml
+++ b/.github/workflows/run-integration.yml
@@ -27,11 +27,7 @@ jobs:
         run: |
           cp /home/datus_ci/ci_template/agent.yml conf/agent.yml
           cp /home/datus_ci/ci_template/ci.env .env
-
-      - name: Load .env into workflow
-        uses: mikeyaworski/dotenv-action@v2
-        with:
-          env-file: .env
+          source .env
 
       - name: Run integration tests
         id: integration_tests


### PR DESCRIPTION
Replace non-existent mikeyaworski/dotenv-action with direct source command to load environment variables in integration test workflow.