### PR TITLE
[BugFix] Add fallback and exception handling for illegal format response

### DIFF
--- a/datus/tools/llms_tools/reasoning_sql.py
+++ b/datus/tools/llms_tools/reasoning_sql.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 from typing import Any, AsyncGenerator, Dict, Optional
 
 from langsmith import traceable
@@ -9,13 +8,12 @@ from datus.models.base import LLMBaseModel
 from datus.prompts.prompt_manager import prompt_manager
 from datus.prompts.reasoning_sql_with_mcp import get_reasoning_prompt
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
-from datus.schemas.node_models import ExecuteSQLResult
 from datus.schemas.reason_sql_node_models import ReasoningInput, ReasoningResult
 from datus.tools.llms_tools.mcp_stream_utils import base_mcp_stream
 from datus.tools.mcp_server import MCPServer
 from datus.utils.constants import DBType
-from datus.utils.json_utils import llm_result2json, llm_result2sql
 from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.json_utils import llm_result2json, llm_result2sql
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -48,7 +48,10 @@ class ErrorCode(Enum):
     MODEL_QUOTA_EXCEEDED = ("300020", "Usage quota exceeded - please check your billing plan")
     MODEL_TIMEOUT_ERROR = ("300021", "Request timeout - the API took too long to respond")
     MODEL_MAX_TURNS_EXCEEDED = ("300022", "Maximum turns ({max_turns}) exceeded - agent execution stopped")
-    MODEL_ILLEGAL_FORMAT_RESPONSE = ("300023", "Model returned response in illegal format - unable to extract JSON or SQL. Response: '{response_preview}' (length: {response_length})")
+    MODEL_ILLEGAL_FORMAT_RESPONSE = (
+        "300023",
+        "Model returned response in illegal format. Response: '{response_preview}' (length: {response_length})",
+    )
     # Tool errors
     TOOL_EXECUTION_FAILED = ("400001", "Tool execution failed")
     TOOL_INVALID_INPUT = ("400002", "Invalid tool input")

--- a/datus/utils/json_utils.py
+++ b/datus/utils/json_utils.py
@@ -181,69 +181,71 @@ def llm_result2json(llm_str: str, expected_type: type[Dict | List] = dict) -> Un
         cleaned_string = strip_json_str(llm_str)
         if not cleaned_string:
             return None  # Empty string should be treated as failure
-        
+
         result = json_repair.loads(cleaned_string)
-        
+
         # Ensure the result is of the expected type (dict or list)
         if not isinstance(result, (dict, list)):
             return None
-            
+
         # If it's a dict, check if it has meaningful content
         if isinstance(result, dict):
             # Check if we have meaningful SQL content
             sql_content = result.get("sql", "")
             if not sql_content or not sql_content.strip():
                 return None
-                
+
         return result
-        
+
     except (json.JSONDecodeError, ValueError, AttributeError, TypeError):
         return None
+
 
 def llm_result2sql(llm_str: str) -> Optional[str]:
     """
     Extract SQL from LLM output string.
     Looks for SQL in code blocks like ```sql ... ``` or ```SQL ... ```
-    
+
     Args:
         llm_str: String output from LLM
-        
+
     Returns:
         Optional[str]: Extracted SQL query if found, None if not found or invalid
     """
     try:
         if not llm_str or not isinstance(llm_str, str):
             return None
-        
+
         # Look for SQL code blocks (case insensitive)
         import re
-        
+
         # Pattern to match ```sql or ```SQL followed by content and ending ```
-        sql_pattern = r'```(?:sql|SQL)\s*\n?(.*?)\n?```'
+        sql_pattern = r"```(?:sql|SQL)\s*\n?(.*?)\n?```"
         match = re.search(sql_pattern, llm_str, re.DOTALL | re.IGNORECASE)
-        
+
         if match:
             sql_content = match.group(1).strip()
             return sql_content if sql_content else None
-        
+
         # Fallback: look for any code block that might contain SQL
-        generic_pattern = r'```\s*\n?(.*?)\n?```'
+        generic_pattern = r"```\s*\n?(.*?)\n?```"
         matches = re.findall(generic_pattern, llm_str, re.DOTALL)
-        
+
         for code_block in matches:
             code_block = code_block.strip()
             if not code_block:
                 continue
-                
+
             # Simple heuristic: if it contains SQL keywords, consider it SQL
-            sql_keywords = ['SELECT', 'FROM', 'WHERE', 'INSERT', 'UPDATE', 'DELETE', 'CREATE', 'DROP']
+            sql_keywords = ["SELECT", "FROM", "WHERE", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP"]
             if any(keyword.lower() in code_block.lower() for keyword in sql_keywords):
                 return code_block
-        
+
         return None
-        
+
     except (AttributeError, TypeError, ValueError):
         return None
+
 
 def json_list2markdown_table(json_list: List[Dict[str, Any]]) -> str | None:
     """

--- a/tests/test_claude_model.py
+++ b/tests/test_claude_model.py
@@ -1,6 +1,6 @@
 import pytest
-from dotenv import load_dotenv
 from agents import set_tracing_disabled
+from dotenv import load_dotenv
 
 from datus.configuration.agent_config_loader import load_agent_config
 from datus.models.claude_model import ClaudeModel

--- a/tests/test_other_models.py
+++ b/tests/test_other_models.py
@@ -1,8 +1,8 @@
 import os
 
 import pytest
-from dotenv import load_dotenv
 from agents import set_tracing_disabled
+from dotenv import load_dotenv
 
 from datus.configuration.agent_config_loader import load_agent_config
 from datus.models.gemini_model import GeminiModel


### PR DESCRIPTION
fix: deepseek dones't follow instruction sometimes, add fallback a…nd exception handling for illegal format

if no json returned. try to extract sql from response, if failed again, raise a Datuseception.

disable openai trace in testcases.