### PR TITLE
[BugFix] Resolve relative path in reasoning mcp server init

### DIFF
--- a/datus/tools/llms_tools/reasoning_sql.py
+++ b/datus/tools/llms_tools/reasoning_sql.py
@@ -154,7 +154,7 @@ def reasoning_sql_with_mcp(
                 db_path = db_config.uri.replace("sqlite:///", "")
             else:
                 db_path = db_config.uri
-            db_path = str(Path(db_path).expanduser())
+            db_path = str(Path(db_path).expanduser().resolve())
         mcp_server = MCPServer.create_sqlite_mcp_server(db_path=db_path)
     else:
         mcp_server = MCPServer.get_db_mcp_server(db_config)


### PR DESCRIPTION
* If you set relative path in namespace of mcp server(for duckdb and sqlite), it will use mcp/server as default. 
* This is a quickfix, we should replace this mcp server into native tools later.