### PR TITLE
[BugFix] Set duckdb version to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "textual[syntax]==5.1.1",
     "anthropic==0.51.0",
     "duckdb-engine>=0.17.0",
+    "duckdb>=1.3.0,<1.4.0",
     "snowflake-sqlalchemy>=1.7.3",
     # Dependencies by snowflake-sqlalchemy
     "opentelemetry-api>=1.33.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ anthropic==0.51.0
 google-generativeai>=0.8.0
 snowflake-sqlalchemy==1.7.3
 duckdb-engine>=0.17.0
+duckdb>=1.3.0,<1.4.0
 uv>=0.7.19
 json-repair>=0.47.6
 pymysql>=1.1.1


### PR DESCRIPTION
It seems that duckdb 1.4.0 is not compactible with current SQLAlchemy

datus.utils.exceptions.DatusException: error_code=500006, error_message=Failed to execute query on database. SQL: , Error details: unhashable type: '_duckdb.typing.DuckDBPyType'

  File "/Users/miniconda3/envs/datus/lib/python3.12/site-packages/sqlalchemy/engine/cursor.py", line 632, in _merge_cursor_description
    context.get_result_processor(
  File "/Users/miniconda3/envs/datus/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 1753, in get_result_processor
    return type_._cached_result_processor(self.dialect, coltype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/miniconda3/envs/datus/lib/python3.12/site-packages/sqlalchemy/sql/type_api.py", line 933, in _cached_result_processor
    d["result"][coltype] = rp
    ~~~~~~~~~~~^^^^^^^^^
TypeError: unhashable type: '_duckdb.typing.DuckDBPyType'