### PR TITLE
[BugFix] Subagent tools and init errors

### DIFF
--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -55,7 +55,14 @@ class GenSQLAgenticNode(AgenticNode):
         self.configured_node_name = node_name
         self.max_turns = max_turns
 
-        # Call parent constructor first to set up node_config
+        # Initialize tool attributes BEFORE calling parent constructor
+        # This is required because parent's __init__ calls _get_system_prompt()
+        # which may reference these attributes
+        self.db_func_tool: Optional[DBFuncTool] = None
+        self.context_search_tools: Optional[ContextSearchTools] = None
+        self.date_parsing_tools: Optional[DateParsingTools] = None
+
+        # Call parent constructor to set up node_config
         super().__init__(
             tools=[],
             mcp_servers={},  # Initialize empty, will setup after parent init
@@ -71,9 +78,6 @@ class GenSQLAgenticNode(AgenticNode):
         )
 
         # Setup tools based on configuration
-        self.db_func_tool: Optional[DBFuncTool] = None
-        self.context_search_tools: Optional[ContextSearchTools] = None
-        self.date_parsing_tools: Optional[DateParsingTools] = None
         self.setup_tools()
 
     def get_node_name(self) -> str:

--- a/datus/schemas/agent_models.py
+++ b/datus/schemas/agent_models.py
@@ -11,7 +11,7 @@ class ScopedContext(BaseModel):
 
 class SubAgentConfig(BaseModel):
     system_prompt: str = Field(..., init=True, description="Name of sub agent")
-    agent_description: str = Field(..., init=True, description="Description of sub agent")
+    agent_description: Optional[str] = Field(default=None, init=True, description="Description of sub agent")
     tools: str = Field(default="", init=True, description="Native tools to be used by sub-agents")
     mcp: str = Field(default="", init=True, description="MCP tools to be used by sub-agents")
     scoped_context: Optional[ScopedContext] = Field(


### PR DESCRIPTION
1. Change log dir to ./logs if it's develop env. 
2. change agnet_description as optional in gen_sql_agentic_node 
3. fix a tools init bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Logging now auto-detects environment and chooses sensible default directories (project logs in source; user logs in packaged installs). Absolute paths are used, and leaving the log directory unset applies these defaults across app and web chatbot logging.
  - Sub-agent configuration now allows omitting the agent description.

- Bug Fixes
  - Improved reliability during SQL agent startup by adjusting initialization order to prevent intermittent errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->