### PR TITLE
[BugFix]fix webchat session

### DIFF
--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -58,8 +58,8 @@ class ChatCommands:
             # Create new node only if subagent changed or no current node exists
             return self.current_node is None or self.current_subagent_name != subagent_name
         else:
-            # Create new node only if no current node exists
-            return self.current_node is None
+            # Create new node if no current node exists OR switching from subagent to regular chat
+            return self.current_node is None or self.current_subagent_name is not None
 
     def _trigger_compact_for_current_node(self):
         """Trigger compact on current node before switching."""


### PR DESCRIPTION
reuse session in chatbot if it is the same subagent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Chat sessions now track the active subagent, enabling smarter context handling.

- Refactor
  - Subagent switching reuses an existing conversation when continuing with the same subagent and starts a new conversation only when switching or when none exists.
  - Preserves previous behavior when no subagent is provided.

- Documentation
  - Updated descriptions to reflect subagent-aware chat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->