### PR TITLE
[BugFix] Add view and materialized view DDL retrieval for Snowflake

### DIFF
--- a/tests/test_connector_snowflake.py
+++ b/tests/test_connector_snowflake.py
@@ -26,8 +26,7 @@ def test_query(connector: SnowflakeConnector):
 
     res = connector.execute(
         {
-            "sql_query": """select * from PATENTS_GOOGLE.PATENTS_GOOGLE.DISCLOSURES_13
-            where "record_id" = 'REC00003' limit 10""",
+            "sql_query": """select * from BBC.BBC_NEWS.FULLTEXT limit 10""",
         },
         result_format="arrow",
     )
@@ -123,7 +122,7 @@ def test_get_tables_with_ddl(connector: SnowflakeConnector):
         assert table["schema_name"] == "BBC_NEWS"
         assert table["catalog_name"] == ""
         identifier_parts = table["identifier"].split(".")
-        assert len(identifier_parts) == 3
+        assert len(identifier_parts) >= 3
         assert identifier_parts[0] == "BBC"
         assert identifier_parts[1] == "BBC_NEWS"
         assert identifier_parts[2] == table["table_name"]
@@ -164,6 +163,66 @@ def test_get_sample_rows(connector: SnowflakeConnector):
     assert first_item["schema_name"]
     assert first_item["identifier"]
     assert len(first_item["identifier"].split(".")) == 3
+
+
+def test_get_views(connector: SnowflakeConnector):
+    connector.switch_context(database_name="BBC", schema_name="BBC_NEWS")
+    views = connector.get_views(database_name="BBC", schema_name="BBC_NEWS")
+    assert isinstance(views, list)
+    if not views:
+        pytest.skip("No views available in BBC.BBC_NEWS to verify metadata retrieval")
+    for view_name in views:
+        assert isinstance(view_name, str)
+        assert view_name.strip()
+
+
+def test_get_views_with_ddl(connector: SnowflakeConnector):
+    connector.switch_context(database_name="BBC", schema_name="BBC_NEWS")
+    views = connector.get_views_with_ddl(database_name="BBC", schema_name="BBC_NEWS")
+    if not views:
+        pytest.skip("No views available in BBC.BBC_NEWS to verify DDL retrieval")
+    for view in views:
+        assert view["table_name"]
+        assert view["definition"].strip()
+        assert view["table_type"] == "view"
+        assert view["database_name"] == "BBC"
+        assert view["schema_name"] == "BBC_NEWS"
+        assert view["catalog_name"] == ""
+        identifier_parts = view["identifier"].split(".")
+        assert len(identifier_parts) >= 3
+        assert identifier_parts[0] == "BBC"
+        assert identifier_parts[1] == "BBC_NEWS"
+        assert identifier_parts[2] == view["table_name"]
+
+
+def test_get_materialized_views(connector: SnowflakeConnector):
+    connector.switch_context(database_name="BBC", schema_name="BBC_NEWS")
+    materialized_views = connector.get_materialized_views(database_name="BBC", schema_name="BBC_NEWS")
+    assert isinstance(materialized_views, list)
+    if not materialized_views:
+        pytest.skip("No materialized views available in BBC.BBC_NEWS to verify metadata retrieval")
+    for mv_name in materialized_views:
+        assert isinstance(mv_name, str)
+        assert mv_name.strip()
+
+
+def test_get_materialized_views_with_ddl(connector: SnowflakeConnector):
+    connector.switch_context(database_name="BBC", schema_name="BBC_NEWS")
+    materialized_views = connector.get_materialized_views_with_ddl(database_name="BBC", schema_name="BBC_NEWS")
+    if not materialized_views:
+        pytest.skip("No materialized views available in BBC.BBC_NEWS to verify DDL retrieval")
+    for mv in materialized_views:
+        assert mv["table_name"]
+        assert mv["definition"].strip()
+        assert mv["table_type"] == "mv"
+        assert mv["database_name"] == "BBC"
+        assert mv["schema_name"] == "BBC_NEWS"
+        assert mv["catalog_name"] == ""
+        identifier_parts = mv["identifier"].split(".")
+        assert len(identifier_parts) >= 3
+        assert identifier_parts[0] == "BBC"
+        assert identifier_parts[1] == "BBC_NEWS"
+        assert identifier_parts[2] == mv["table_name"]
 
 
 class TestExceptions:


### PR DESCRIPTION
Introduced methods in SnowflakeConnector to fetch views and materialized views along with their DDL definitions. Refactored DDL fetching logic for reusability and added comprehensive tests for the new methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to list views and materialized views by catalog/database/schema.
  * Added DDL-inclusive variants that return view and materialized view metadata with full definitions.
  * Unified DDL retrieval across object types for more consistent behavior and clearer errors.
  * Improved reliability when fetching table DDL through a standardized retrieval path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->