### PR TITLE
[BugFix] Fixed the REPL help to include the .table_schema command

### DIFF
--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -894,6 +894,7 @@ class DatusCLI:
             (".tables", "List all tables"),
             (".schemas", "List all schemas or show detailed schema information"),
             (".schema schema_name", "Switch current schema"),
+            (".table_schema table_name", "Show table field details"),
             (".indexes table_name", "Show indexes for a table"),
             (".namespace namespace", "Switch current namespace"),
             (".mcp", "Manage MCP (Model Configuration Protocol) servers"),


### PR DESCRIPTION
* Added comprehensive unit tests to verify DBFuncTool's handling of wildcard patterns in scoped_tables, ensuring correct filtering of databases, schemas, and tables. 
* Updated the REPL help to include the .table_schema command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI help hint for table schema information lookup.
  * Enhanced scope-based filtering with wildcard pattern support (e.g., `db.*.table`, `*.schema.*`) for flexible database and schema selection.

* **Tests**
  * Expanded test coverage for wildcard scoping behavior including edge cases, view handling, and schema filtering validation across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->