### PR TITLE
[BugFix] Fix max_truns overwrite by None

### DIFF
--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -65,7 +65,11 @@ class ChatAgenticNode(AgenticNode):
         self.max_turns = 30
         if agent_config and hasattr(agent_config, "nodes") and "chat" in agent_config.nodes:
             chat_node_config = agent_config.nodes["chat"]
-            if chat_node_config.input and hasattr(chat_node_config.input, "max_turns") and chat_node_config.input.max_turns is not None:
+            if (
+                chat_node_config.input
+                and hasattr(chat_node_config.input, "max_turns")
+                and chat_node_config.input.max_turns is not None
+            ):
                 self.max_turns = chat_node_config.input.max_turns
 
         # Initialize MCP servers based on namespace


### PR DESCRIPTION
if there is no max_turns set in agent.yml's chat agentic node, it throws:

│ 💬 Error: '>' not supported between instances of 'int' and 'NoneType'                                                                                                                                   
│ 💬 Chat interaction failed: '>' not supported between instances of 'int' and 'NoneType'                                                                                                                 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unspecified configuration values from unintentionally overriding existing chat interaction limits; when max turns is left unspecified, previously set or default limits are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->