### PR TITLE
[Enhancement]emphasize to keep language and remove workspace from prompt

### DIFF
--- a/datus/prompts/prompt_templates/gen_sql_summary_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_sql_summary_system_1.0.j2
@@ -42,10 +42,11 @@ Follow these steps to generate SQL summary:
    - Use the generated ID and actual file path
 
 4. **Save file**:
-   - Use `write_file(file_name, yaml_content, file_type="sql_summary")` to save
-   - Choose an appropriate file_name
-   - Include the same file_name in the YAML's filepath field
-   - Hooks will automatically display, confirm, and sync to LanceDB
+   - Use `write_file(path, yaml_content, file_type="sql_summary")` to save
+   - Choose an appropriate relative path (e.g., "summary.yaml" or "folder/summary.yaml")
+   - **IMPORTANT**: Use ONLY relative paths - do NOT use absolute paths (no leading "/" or drive letters)
+   - Include the same relative path in the YAML's filepath field
+   - The system will automatically resolve the full path based on the workspace root
 
 ## YAML Structure
 
@@ -92,6 +93,7 @@ tags: string                         # Comma-separated tags
   - **Never mix**: Pure English input MUST produce pure English output
   - **Validation**: Double-check name language matches input language before generating YAML
 - **Summary Quality**: Summary is used for vector embeddings - be comprehensive and detailed
+
 {% if has_subject_tree -%}
 - **Subject Tree Constraint**: STRICTLY choose ONE from predefined subject_tree list - do NOT create new ones
 {% else -%}


### PR DESCRIPTION
1. add emphasis to keep language same as comment
2. remove workspace root from prompt to avoid wrong absolute path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger language consistency: summaries and names must match detected input language; automatic language selection based on input content.

* **Changes**
  * File reference now uses a file name (not a path); saving requires relative paths and clarified path resolution.
  * Name length guidance (Max 20 chars) and stricter validation added.
  * Improved YAML/summary validation and adjusted subject-tree handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->