### PR TITLE
[Refactor]clean !gen_metrics and !gen_semantic_model

### DIFF
--- a/datus/cli/agent_commands.py
+++ b/datus/cli/agent_commands.py
@@ -751,53 +751,6 @@ class AgentCommands:
         # For now, redirect to normal reason - streaming can be added later
         self.cmd_reason(args)
 
-    def cmd_gen_metrics(self, args: str):
-        """Generate metrics from SQL queries and tables."""
-        # Create input for generate metrics node
-        input_data = self.create_node_input(NodeType.TYPE_GENERATE_METRICS, args)
-        if not input_data:
-            return
-
-        # Run standalone node
-        result = self.run_standalone_node(NodeType.TYPE_GENERATE_METRICS, input_data)
-
-        if result and result.success:
-            self.console.print("[green]Metrics generation completed[/]")
-            # Store generated metrics in CLI context if available
-            if hasattr(result, "metrics") and result.metrics:
-                self.cli_context.add_metrics(result.metrics)
-                self.console.print(f"[blue]Generated {len(result.metrics)} metrics[/]")
-        else:
-            self.console.print("[bold red]Metrics generation failed[/]")
-
-    def cmd_gen_metrics_stream(self, args: str):
-        """Generate metrics with streaming output and action history."""
-        # For now, redirect to normal gen_metrics - streaming can be added later
-        self.cmd_gen_metrics(args)
-
-    def cmd_gen_semantic_model(self, args: str):
-        """Generate semantic model for data modeling."""
-        # Create input for generate semantic model node
-        input_data = self.create_node_input(NodeType.TYPE_GENERATE_SEMANTIC_MODEL, args)
-        if not input_data:
-            return
-
-        # Run standalone node
-        result = self.run_standalone_node(NodeType.TYPE_GENERATE_SEMANTIC_MODEL, input_data)
-
-        if result and result.success:
-            self.console.print("[green]Semantic model generation completed[/]")
-            # Display result if available
-            if hasattr(result, "semantic_model_path"):
-                self.console.print(f"[blue]Semantic model saved to:[/] {result.semantic_model_path}")
-        else:
-            self.console.print("[bold red]Semantic model generation failed[/]")
-
-    def cmd_gen_semantic_model_stream(self, args: str):
-        """Generate semantic model with streaming output and action history."""
-        # For now, redirect to normal gen_semantic_model - streaming can be added later
-        self.cmd_gen_semantic_model(args)
-
     def cmd_daend(self, args: str):
         """End the current agent session."""
         if self.workflow:

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -137,8 +137,6 @@ class DatusCLI:
             # to be deprecated when sub agent is read
             "!reason": self.agent_commands.cmd_reason_stream,
             "!compare": self.agent_commands.cmd_compare_stream,
-            "!gen_metrics": self.agent_commands.cmd_gen_metrics_stream,
-            "!gen_semantic_model": self.agent_commands.cmd_gen_semantic_model_stream,
             # catalog commands
             "@catalog": self.context_commands.cmd_catalog,
             "@subject": self.context_commands.cmd_subject,
@@ -858,8 +856,6 @@ class DatusCLI:
             ("!sq/!search_sql", "Use natural language to search for reference SQL"),
             ("!gen", "Generate SQL, optionally with table constraints"),
             ("!fix <description>", "Fix the last SQL query"),
-            ("!gen_metrics", "Generate metrics with streaming output"),
-            ("!gen_semantic_model", "Generate semantic model with streaming output"),
             ("!save", "Save the last result to a file"),
             ("!bash <command>", "Execute a bash command (limited to safe commands)"),
             # remove this when sub agent is ready


### PR DESCRIPTION
clean two commands as they have been replaced with built-in subagents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * The `!gen_metrics` command has been removed from the CLI interface. This command and its streaming variant are no longer available.
  * The `!gen_semantic_model` command has been removed from the CLI interface. This command and its streaming variant are no longer available.
  * Metrics and semantic model generation functionality are no longer accessible through the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->