### PR TITLE
[Enhancement]allow not to config built-in subagents

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -31,6 +31,7 @@ from datus.storage.sub_agent_kb_bootstrap import SUPPORTED_COMPONENTS as SUB_AGE
 from datus.storage.sub_agent_kb_bootstrap import SubAgentBootstrapper
 from datus.tools.db_tools.db_manager import DBManager, db_manager_instance
 from datus.utils.benchmark_utils import load_benchmark_tasks
+from datus.utils.constants import SYS_SUB_AGENTS
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_str
 from datus.utils.loggings import get_logger
@@ -191,7 +192,7 @@ class Agent:
             return
         current_namespace = self.global_config.current_namespace
         for name, raw_config in agent_nodes.items():
-            if name in ("gen_semantic_model", "gen_metrics", "gen_sql_summary"):
+            if name in SYS_SUB_AGENTS:
                 continue
             try:
                 sub_config = SubAgentConfig.model_validate(raw_config)

--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -20,7 +20,7 @@ from pygments.token import Token
 
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
-from datus.utils.constants import DBType
+from datus.utils.constants import SYS_SUB_AGENTS, DBType
 from datus.utils.loggings import get_logger
 from datus.utils.path_utils import get_file_fuzzy_matches
 from datus.utils.reference_paths import REFERENCE_PATH_REGEX, normalize_reference_path
@@ -976,11 +976,11 @@ class SubagentCompleter(Completer):
         self._available_subagents = self._load_subagents()
 
     def _load_subagents(self) -> List[str]:
-        """Load available subagents from configuration."""
-        subagents = []
+        """Load available subagents from configuration and include built-in subagents."""
+        subagents = list(SYS_SUB_AGENTS)
         if hasattr(self.agent_config, "agentic_nodes") and self.agent_config.agentic_nodes:
             for name in self.agent_config.agentic_nodes.keys():
-                if name != "chat":  # Exclude default chat
+                if name != "chat" and name not in SYS_SUB_AGENTS:  # Exclude default chat and avoid duplicates
                     subagents.append(name)
         return subagents
 

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -35,7 +35,7 @@ from datus.schemas.action_history import ActionHistory, ActionHistoryManager, Ac
 from datus.schemas.node_models import SQLContext
 from datus.tools.db_tools import BaseSqlConnector
 from datus.tools.db_tools.db_manager import db_manager_instance
-from datus.utils.constants import DBType, SQLType
+from datus.utils.constants import SYS_SUB_AGENTS, DBType, SQLType
 from datus.utils.exceptions import setup_exception_handler
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_sql_type
@@ -110,10 +110,10 @@ class DatusCLI:
         )
         self.db_manager = db_manager_instance(self.agent_config.namespaces)
 
-        # Initialize available subagents from agentic_nodes (excluding 'chat')
-        self.available_subagents = set()
+        # Initialize available subagents from agentic_nodes (excluding 'chat') and include built-in subagents
+        self.available_subagents = set(SYS_SUB_AGENTS)
         if hasattr(self.agent_config, "agentic_nodes") and self.agent_config.agentic_nodes:
-            self.available_subagents = {name for name in self.agent_config.agentic_nodes.keys() if name != "chat"}
+            self.available_subagents.update(name for name in self.agent_config.agentic_nodes.keys() if name != "chat")
 
         # Initialize command handlers after cli_context is created
         self.agent_commands = AgentCommands(self, self.cli_context)

--- a/datus/cli/sub_agent_commands.py
+++ b/datus/cli/sub_agent_commands.py
@@ -11,9 +11,10 @@ from rich.table import Table
 from datus.cli.sub_agent_wizard import run_wizard
 from datus.schemas.agent_models import SubAgentConfig
 from datus.storage.sub_agent_kb_bootstrap import SUPPORTED_COMPONENTS
+from datus.utils.constants import SYS_SUB_AGENTS
 from datus.utils.json_utils import to_pretty_str
 from datus.utils.loggings import get_logger
-from datus.utils.sub_agent_manager import SYS_SUB_AGENTS, SubAgentManager
+from datus.utils.sub_agent_manager import SubAgentManager
 
 if TYPE_CHECKING:
     from datus.cli.repl import DatusCLI

--- a/datus/cli/sub_agent_wizard.py
+++ b/datus/cli/sub_agent_wizard.py
@@ -34,10 +34,9 @@ from datus.cli.autocomplete import TableCompleter
 from datus.prompts.prompt_manager import prompt_manager
 from datus.schemas.agent_models import ScopedContext, SubAgentConfig
 from datus.tools.mcp_tools import MCPTool
-from datus.utils.constants import DBType
+from datus.utils.constants import SYS_SUB_AGENTS, DBType
 from datus.utils.loggings import get_logger
 from datus.utils.reference_paths import normalize_reference_path
-from datus.utils.sub_agent_manager import SYS_SUB_AGENTS
 
 logger = get_logger(__name__)
 

--- a/datus/utils/constants.py
+++ b/datus/utils/constants.py
@@ -83,6 +83,10 @@ class EmbeddingProvider(str, Enum):
     HUGGINGFACE = "huggingface"
 
 
+# System sub-agents that are built-in and not user-configurable
+SYS_SUB_AGENTS = {"gen_semantic_model", "gen_metrics", "gen_sql_summary"}
+
+
 class SQLType(str, Enum):
     """SQL statement types."""
 

--- a/datus/utils/sub_agent_manager.py
+++ b/datus/utils/sub_agent_manager.py
@@ -15,8 +15,6 @@ from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
 
-SYS_SUB_AGENTS = {"gen_semantic_model", "gen_metrics", "gen_sql_summary"}
-
 
 class SubAgentManager:
     """Encapsulates sub-agent configuration and prompt management operations."""


### PR DESCRIPTION
1. built-in subagents should be valid when user not config them in agent.yml, and will use default configs.
2. unify the subagents list using constants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized management of system subagents through a unified constant definition.
  * Reorganized imports to consolidate subagent configuration references.

* **Improvements**
  * Built-in subagents are now consistently included and deduplicated across CLI interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->