### PR TITLE
[Feature] Add ClickZetta database type support to datus-agent init

### DIFF
--- a/datus/cli/init_util.py
+++ b/datus/cli/init_util.py
@@ -54,6 +54,18 @@ def detect_db_connectivity(namespace_name, db_config_data) -> tuple[bool, str]:
                 database=db_config_data.get("database", ""),
                 schema=db_config_data.get("schema", ""),
             )
+        elif db_type == "clickzetta":
+            # For ClickZetta connector
+            db_config = DbConfig(
+                type=db_type,
+                service=db_config_data.get("service", ""),
+                username=db_config_data.get("username", ""),
+                password=db_config_data.get("password", ""),
+                instance=db_config_data.get("instance", ""),
+                workspace=db_config_data.get("workspace", ""),
+                schema=db_config_data.get("schema", ""),
+                vcluster=db_config_data.get("vcluster", ""),
+            )
         else:
             # For URI-based connectors (sqlite, duckdb, postgresql)
             uri = db_config_data.get("uri", "")

--- a/datus/cli/interactive_init.py
+++ b/datus/cli/interactive_init.py
@@ -244,7 +244,7 @@ class InteractiveInit:
             return False
 
         # Database type selection
-        db_types = ["sqlite", "duckdb", "snowflake", "mysql", "starrocks"]
+        db_types = ["sqlite", "duckdb", "snowflake", "mysql", "starrocks", "clickzetta"]
         db_type = Prompt.ask("- Database type", choices=db_types, default="duckdb")
 
         # Connection configuration based on database type
@@ -272,6 +272,29 @@ class InteractiveInit:
                 config_data["catalog"] = "default_catalog"
 
             self.config["agent"]["namespace"][self.namespace_name] = config_data
+        elif db_type == "clickzetta":
+            # ClickZetta-specific configuration
+            console.print("  [dim]ClickZetta API configuration[/dim]")
+            service = Prompt.ask("- Service endpoint", default="cn-shanghai-alicloud.api.clickzetta.com")
+            username = Prompt.ask("- Username")
+            password = getpass("- Password: ")
+            instance = Prompt.ask("- Instance ID")
+            workspace = Prompt.ask("- Workspace", default="quick_start")
+            schema = Prompt.ask("- Schema", default="mcp_demo")
+            vcluster = Prompt.ask("- Virtual Cluster", default="default_ap")
+
+            # Store ClickZetta-specific configuration
+            self.config["agent"]["namespace"][self.namespace_name] = {
+                "type": db_type,
+                "name": self.namespace_name,
+                "service": service,
+                "username": username,
+                "password": password,
+                "instance": instance,
+                "workspace": workspace,
+                "schema": schema,
+                "vcluster": vcluster,
+            }
         elif db_type == "snowflake":
             # Snowflake specific configuration
             username = Prompt.ask("- Username")


### PR DESCRIPTION
## Summary

This PR adds support for ClickZetta as a database type option in the `datus-agent init` interactive setup command.

## Changes Made

### 1. Database Type Support
- Added `"clickzetta"` to the supported database types list in `interactive_init.py`
- Updated database type choices: `["sqlite", "duckdb", "snowflake", "mysql", "starrocks", "clickzetta"]`

### 2. ClickZetta Configuration Prompts
Added interactive prompts for ClickZetta-specific configuration:
- **Service endpoint** (default: `cn-shanghai-alicloud.api.clickzetta.com`)
- **Username** and **Password**
- **Instance ID**
- **Workspace** (default: `quick_start`)
- **Schema** (default: `mcp_demo`)
- **Virtual Cluster** (default: `default_ap`)

### 3. Connection Testing
- Added ClickZetta connectivity testing logic in `init_util.py`
- Leverages existing ClickZetta fields in the `DbConfig` class
- Integrates with the existing database testing framework

## Technical Details

- **Backwards Compatible**: No breaking changes to existing functionality
- **Consistent UX**: Follows the same interactive pattern as other database types
- **Reuses Infrastructure**: Utilizes existing ClickZetta fields in `DbConfig` class
- **Validation**: Includes connection testing to ensure configuration correctness

## Files Modified

1. `datus/cli/interactive_init.py` - Added ClickZetta database type and configuration prompts
2. `datus/cli/init_util.py` - Added ClickZetta connection testing logic

## Usage Example

After this PR, users can run:

```bash
datus-agent init
```

And select ClickZetta as their database type:

```
[2/5] Configure Namespace
- Namespace name: clickzetta
- Database type [sqlite/duckdb/snowflake/mysql/starrocks/clickzetta] (duckdb): clickzetta
  ClickZetta API configuration
- Service endpoint (cn-shanghai-alicloud.api.clickzetta.com): 
- Username: your_username
- Password: ********
- Instance ID: your_instance_id
- Workspace (quick_start): 
- Schema (mcp_demo): 
- Virtual Cluster (default_ap): 
→ Testing database connectivity...
 ✅ Database connection test successful
```

## Testing

- [x] Verified ClickZetta appears in database type choices
- [x] Confirmed configuration prompts work correctly
- [x] Validated that existing database types remain unaffected
- [x] Tested that the DbConfig class properly handles ClickZetta fields

## Benefits

- **Improved User Experience**: Users can now set up ClickZetta environments through the guided init process
- **Reduced Manual Configuration**: Eliminates need for manual YAML editing for ClickZetta setup
- **Consistency**: Provides the same guided setup experience as other supported databases

This enhancement makes ClickZetta a first-class citizen in the datus-agent initialization process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ClickZetta database connector now available in the initialization wizard
  * Interactive setup prompts for ClickZetta connection details including service endpoint, credentials, instance, workspace, schema, and virtual cluster configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->