### PR TITLE
[BugFix]fix circular dependency

### DIFF
--- a/datus/cli/__init__.py
+++ b/datus/cli/__init__.py
@@ -7,6 +7,14 @@ Datus-CLI package initialization.
 """
 
 from .autocomplete import SQLCompleter
-from .repl import DatusCLI
 
 __all__ = ["DatusCLI", "SQLCompleter"]
+
+
+def __getattr__(name: str):
+    """Lazy import to avoid circular dependency with agent modules."""
+    if name == "DatusCLI":
+        from .repl import DatusCLI
+
+        return DatusCLI
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -7,12 +7,14 @@ Datus-CLI REPL (Read-Eval-Print Loop) implementation.
 This module provides the main interactive shell for the CLI.
 """
 
+from __future__ import annotations
+
 import sys
 import threading
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
@@ -23,7 +25,8 @@ from prompt_toolkit.styles import Style, merge_styles, style_from_pygments_cls
 from rich.console import Console
 from rich.table import Table
 
-from datus.agent.workflow_runner import WorkflowRunner
+if TYPE_CHECKING:
+    from datus.agent.workflow_runner import WorkflowRunner
 from datus.cli._cli_utils import prompt_input
 from datus.cli.agent_commands import AgentCommands
 from datus.cli.autocomplete import AtReferenceCompleter, CustomPygmentsStyle, CustomSqlLexer, SubagentCompleter


### PR DESCRIPTION
Fix import error: `ImportError: cannot import name 'WorkflowRunner' from partially initialized module 'datus.agent.workflow_runner' (most likely due to a circular import) `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CLI module loading performance through lazy initialization.
  * Enhanced type-checking infrastructure to improve code reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->