### PR TITLE
[BugFix] Fixed prompt_version for `gen_semantic_model`

### DIFF
--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -275,7 +275,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
             System prompt string loaded from the template
         """
         # Hardcoded prompt version
-        version = "1.0"
+        version = self.node_config.get("prompt_version")
 
         # Hardcoded system_prompt template name
         template_name = f"{self.NODE_NAME}_system"
@@ -302,7 +302,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
             raise DatusException(
                 code=ErrorCode.COMMON_TEMPLATE_NOT_FOUND,
-                message_args={"template_name": template_name, "version": version or "latest"},
+                message_args={"template_name": template_name, "version": version},
             ) from e
         except Exception as e:
             # Other template errors - wrap in DatusException

--- a/datus/cli/interactive_init.py
+++ b/datus/cli/interactive_init.py
@@ -61,8 +61,6 @@ class InteractiveInit:
                     "storage": {"embedding_device_type": "cpu"},  # base_path removed - now fixed at {home}/data
                     "nodes": {
                         "schema_linking": {"matching_rate": "fast"},
-                        "generate_sql": {"prompt_version": "1.0"},
-                        "reflect": {"prompt_version": "2.1"},
                         "date_parser": {"language": "en"},
                     },
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt version is now dynamically configurable at runtime instead of using hardcoded values.

* **Chores**
  * Updated default node configurations in CLI initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->