### PR TITLE
[Feature] Add Auto Memory: persistent file-based memory for agentic nodes

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -206,16 +206,16 @@ class AgenticNode(Node):
 
     def _finalize_system_prompt(self, base_prompt: str) -> str:
         """
-        Finalize system prompt by injecting skill context and ensuring skill tools.
+        Finalize system prompt by injecting skill context, memory context, and ensuring skill tools.
 
         All subclasses should call this at the end of their _get_system_prompt() override
-        to ensure skills are properly injected regardless of how the template is rendered.
+        to ensure skills and memory are properly injected regardless of how the template is rendered.
 
         Args:
             base_prompt: The rendered template prompt
 
         Returns:
-            Prompt with skills XML appended (if skill_func_tool is active)
+            Prompt with skills XML and memory context appended
         """
         # Ensure skill tools are in self.tools (lazy injection after subclass setup_tools()).
         self._ensure_skill_tools_in_tools()
@@ -226,6 +226,34 @@ class AgenticNode(Node):
             if skills_xml:
                 base_prompt = base_prompt + "\n\n" + skills_xml
 
+        # Inject memory context for eligible nodes.
+        base_prompt = self._inject_memory_context(base_prompt)
+
+        return base_prompt
+
+    def _inject_memory_context(self, base_prompt: str) -> str:
+        """Inject memory context into system prompt if this node has memory enabled."""
+        from datus.utils.memory_loader import get_memory_dir, has_memory, load_memory_context
+
+        node_name = self.get_node_name()
+        if not has_memory(node_name):
+            return base_prompt
+
+        workspace_root = self._resolve_workspace_root()
+
+        memory_content = load_memory_context(workspace_root, node_name)
+        memory_dir = get_memory_dir(workspace_root, node_name)
+
+        memory_section = prompt_manager.render_template(
+            template_name="memory_context",
+            version=None,
+            has_memory=True,
+            memory_content=memory_content,
+            memory_dir=memory_dir,
+        )
+
+        if memory_section.strip():
+            base_prompt = base_prompt + "\n\n" + memory_section
         return base_prompt
 
     def _generate_session_id(self) -> str:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -245,7 +245,7 @@ class AgenticNode(Node):
             memory_content = load_memory_context(workspace_root, node_name)
             memory_dir = get_memory_dir(workspace_root, node_name)
 
-            memory_section = prompt_manager.render_template(
+            memory_section = get_prompt_manager(agent_config=self.agent_config).render_template(
                 template_name="memory_context",
                 version=None,
                 has_memory=True,

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -239,21 +239,24 @@ class AgenticNode(Node):
         if not has_memory(node_name):
             return base_prompt
 
-        workspace_root = self._resolve_workspace_root()
+        try:
+            workspace_root = self._resolve_workspace_root()
 
-        memory_content = load_memory_context(workspace_root, node_name)
-        memory_dir = get_memory_dir(workspace_root, node_name)
+            memory_content = load_memory_context(workspace_root, node_name)
+            memory_dir = get_memory_dir(workspace_root, node_name)
 
-        memory_section = prompt_manager.render_template(
-            template_name="memory_context",
-            version=None,
-            has_memory=True,
-            memory_content=memory_content,
-            memory_dir=memory_dir,
-        )
+            memory_section = prompt_manager.render_template(
+                template_name="memory_context",
+                version=None,
+                has_memory=True,
+                memory_content=memory_content,
+                memory_dir=memory_dir,
+            )
 
-        if memory_section.strip():
-            base_prompt = base_prompt + "\n\n" + memory_section
+            if memory_section.strip():
+                base_prompt = base_prompt + "\n\n" + memory_section
+        except Exception as e:
+            logger.warning(f"Failed to inject memory context for node '{node_name}': {e}")
         return base_prompt
 
     def _generate_session_id(self) -> str:

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -18,7 +18,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.gen_report_agentic_node_models import GenReportNodeInput, GenReportNodeResult
 from datus.tools.db_tools.db_manager import db_manager_instance
-from datus.tools.func_tool import ContextSearchTools, DBFuncTool
+from datus.tools.func_tool import ContextSearchTools, DBFuncTool, FilesystemFuncTool
 from datus.tools.func_tool.semantic_tools import SemanticTools
 from datus.utils.loggings import get_logger
 from datus.utils.message_utils import MessagePart, build_structured_content
@@ -85,6 +85,7 @@ class GenReportAgenticNode(AgenticNode):
         self.db_func_tool: Optional[DBFuncTool] = None
         self.semantic_tools: Optional[SemanticTools] = None
         self.context_search_tools: Optional[ContextSearchTools] = None
+        self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
 
         # Call parent constructor with all required Node parameters
         super().__init__(
@@ -137,6 +138,10 @@ class GenReportAgenticNode(AgenticNode):
         for pattern in tool_patterns:
             self._setup_tool_pattern(pattern)
 
+        # Ensure filesystem tools are always available (required for memory and file operations)
+        if not self.filesystem_func_tool:
+            self._setup_filesystem_tools()
+
         logger.info(f"Setup {len(self.tools)} tools: {[tool.name for tool in self.tools]}")
 
     def _setup_tool_pattern(self, pattern: str):
@@ -161,6 +166,8 @@ class GenReportAgenticNode(AgenticNode):
                     self._setup_db_tools()
                 elif base_type == "context_search_tools":
                     self._setup_context_search_tools()
+                elif base_type == "filesystem_tools":
+                    self._setup_filesystem_tools()
                 else:
                     logger.warning(f"Unknown tool type: {base_type}")
 
@@ -171,6 +178,8 @@ class GenReportAgenticNode(AgenticNode):
                 self._setup_db_tools()
             elif pattern == "context_search_tools":
                 self._setup_context_search_tools()
+            elif pattern == "filesystem_tools":
+                self._setup_filesystem_tools()
 
             # Handle specific method patterns (e.g., "db_tools.describe_table")
             elif "." in pattern:
@@ -224,6 +233,16 @@ class GenReportAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup context search tools: {e}")
 
+    def _setup_filesystem_tools(self):
+        """Setup filesystem tools."""
+        try:
+            root_path = self._resolve_workspace_root()
+            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.tools.extend(self.filesystem_func_tool.available_tools())
+            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+        except Exception as e:
+            logger.error(f"Failed to setup filesystem tools: {e}")
+
     def _setup_specific_tool_method(self, tool_type: str, method_name: str):
         """Setup a specific tool method."""
         try:
@@ -252,6 +271,11 @@ class GenReportAgenticNode(AgenticNode):
                         self.agent_config, sub_agent_name=self.node_config.get("system_prompt")
                     )
                 tool_instance = self.context_search_tools
+            elif tool_type == "filesystem_tools":
+                if not self.filesystem_func_tool:
+                    root_path = self._resolve_workspace_root()
+                    self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+                tool_instance = self.filesystem_func_tool
             else:
                 logger.warning(f"Unknown tool type: {tool_type}")
                 return

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -249,6 +249,10 @@ class GenSQLAgenticNode(AgenticNode):
         for pattern in tool_patterns:
             self._setup_tool_pattern(pattern)
 
+        # Ensure filesystem tools are always available (required for memory and file operations)
+        if not self.filesystem_func_tool:
+            self._setup_filesystem_tools()
+
         logger.debug(f"Setup {len(self.tools)} tools: {[tool.name for tool in self.tools]}")
 
     def _setup_platform_doc_tools(self):

--- a/datus/prompts/prompt_templates/memory_context_1.0.j2
+++ b/datus/prompts/prompt_templates/memory_context_1.0.j2
@@ -1,0 +1,50 @@
+{# Template for rendering memory context in system prompts #}
+{# This template is appended to system prompts when memory is enabled for a node #}
+
+{% if has_memory %}
+## Auto Memory
+
+You have a persistent memory directory at `{{ memory_dir }}/` (relative to your filesystem root).
+This directory may not exist yet -- create it with your first write_file. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience.
+
+{% if memory_content %}
+### Current Memory (MEMORY.md)
+
+<memory>
+{{ memory_content }}
+</memory>
+
+{% endif %}
+### When to consult memory:
+- At the start of a new conversation, review your MEMORY.md to recall user preferences and prior context
+- Before answering questions about the project, check if memory contains relevant decisions or conventions
+- When the user references something discussed in a previous session, look up related memory entries
+- Before suggesting tools, databases, or workflows, check if the user has stated preferences in memory
+- If you need details beyond MEMORY.md, use `read_file` to load the relevant L2 topic file
+
+### How to save memories:
+- Use `read_file`, `write_file`, `edit_file` tools to manage memory files under `{{ memory_dir }}/`
+- `MEMORY.md` is always loaded into your context -- lines after 200 will be truncated, so keep it concise
+- Create separate topic files (e.g., `{{ memory_dir }}/patterns.md`) for detailed notes and link to them from MEMORY.md
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one
+
+### What to save:
+- Stable patterns and conventions confirmed across multiple interactions
+- Key decisions, important file paths, and project structure
+- User preferences for workflow, tools, and communication style
+- Solutions to recurring problems and debugging insights
+
+### What NOT to save:
+- Session-specific context (current task details, in-progress work, temporary state)
+- Information that might be incomplete -- verify before writing
+- Speculative or unverified conclusions from a single interaction
+
+### Explicit user requests:
+- When the user asks you to remember something across sessions, save it immediately
+- When the user asks to forget or stop remembering something, find and remove the relevant entries
+- When the user corrects something you stated from memory, update or remove the incorrect entry immediately
+{% endif %}

--- a/datus/utils/memory_loader.py
+++ b/datus/utils/memory_loader.py
@@ -12,18 +12,29 @@ for agentic nodes. Memory files are stored under {workspace_root}/.datus/memory/
 from pathlib import Path
 
 from datus.utils.constants import SYS_SUB_AGENTS
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
 
 MEMORY_LINE_LIMIT = 200
 MEMORY_FILENAME = "MEMORY.md"
 MEMORY_BASE_DIR = ".datus/memory"
 
-# Nodes that should NOT have persistent memory (builtin system subagents + explore)
-_NO_MEMORY_NODES = SYS_SUB_AGENTS | {"explore"}
+# Allowlist: the only built-in node that gets memory.
+# Any name NOT found in _ALL_BUILTIN_NODES is treated as a custom subagent and also gets memory.
+_MEMORY_ENABLED_BUILTINS = frozenset({"chat"})
+_ALL_BUILTIN_NODES = SYS_SUB_AGENTS | {"explore", "compare"}
 
 
 def has_memory(node_name: str) -> bool:
-    """Determine if a node should have persistent memory."""
-    return node_name not in _NO_MEMORY_NODES
+    """Determine if a node should have persistent memory.
+
+    Enabled for 'chat' and custom subagents only.
+    Built-in system subagents (gen_sql, gen_report, etc.), explore, and compare do not get memory.
+    """
+    if node_name in _MEMORY_ENABLED_BUILTINS:
+        return True
+    return node_name not in _ALL_BUILTIN_NODES
 
 
 def load_memory_context(workspace_root: str, subagent_name: str) -> str:
@@ -31,10 +42,18 @@ def load_memory_context(workspace_root: str, subagent_name: str) -> str:
     memory_file = Path(workspace_root) / MEMORY_BASE_DIR / subagent_name / MEMORY_FILENAME
     if not memory_file.exists():
         return ""
-    lines = memory_file.read_text(encoding="utf-8").splitlines()
-    if len(lines) > MEMORY_LINE_LIMIT:
-        lines = lines[:MEMORY_LINE_LIMIT]
-        lines.append(f"\n... (truncated at {MEMORY_LINE_LIMIT} lines, move details to sub-files)")
+    lines: list[str] = []
+    try:
+        with memory_file.open(encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle):
+                if line_no >= MEMORY_LINE_LIMIT:
+                    lines.append("")
+                    lines.append(f"... (truncated at {MEMORY_LINE_LIMIT} lines, move details to sub-files)")
+                    break
+                lines.append(line.rstrip("\r\n"))
+    except (OSError, UnicodeError) as exc:
+        logger.warning(f"Failed to load memory file {memory_file}: {exc}")
+        return ""
     return "\n".join(lines)
 
 

--- a/datus/utils/memory_loader.py
+++ b/datus/utils/memory_loader.py
@@ -1,0 +1,43 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Memory loader utilities for persistent agent memory.
+
+Provides functions to determine memory eligibility and load memory content
+for agentic nodes. Memory files are stored under {workspace_root}/.datus/memory/{subagent}/.
+"""
+
+from pathlib import Path
+
+from datus.utils.constants import SYS_SUB_AGENTS
+
+MEMORY_LINE_LIMIT = 200
+MEMORY_FILENAME = "MEMORY.md"
+MEMORY_BASE_DIR = ".datus/memory"
+
+# Nodes that should NOT have persistent memory (builtin system subagents + explore)
+_NO_MEMORY_NODES = SYS_SUB_AGENTS | {"explore"}
+
+
+def has_memory(node_name: str) -> bool:
+    """Determine if a node should have persistent memory."""
+    return node_name not in _NO_MEMORY_NODES
+
+
+def load_memory_context(workspace_root: str, subagent_name: str) -> str:
+    """Load and truncate MEMORY.md for a subagent. Returns empty string if not found."""
+    memory_file = Path(workspace_root) / MEMORY_BASE_DIR / subagent_name / MEMORY_FILENAME
+    if not memory_file.exists():
+        return ""
+    lines = memory_file.read_text(encoding="utf-8").splitlines()
+    if len(lines) > MEMORY_LINE_LIMIT:
+        lines = lines[:MEMORY_LINE_LIMIT]
+        lines.append(f"\n... (truncated at {MEMORY_LINE_LIMIT} lines, move details to sub-files)")
+    return "\n".join(lines)
+
+
+def get_memory_dir(workspace_root: str, subagent_name: str) -> str:
+    """Get relative memory directory path (relative to workspace_root)."""
+    return f"{MEMORY_BASE_DIR}/{subagent_name}"

--- a/docs/integration/memory.md
+++ b/docs/integration/memory.md
@@ -1,0 +1,163 @@
+# Auto Memory
+
+Auto Memory is a persistent memory system for Datus-agent that enables agents to automatically retain valuable information across conversations. It is purely file-based and prompt-driven -- no vector database or embedding is required.
+
+## Overview
+
+When users interact with the agent, the agent can recognize valuable information and persist it to Markdown files stored under the workspace. On subsequent conversations, this memory is automatically loaded, allowing the agent to recall prior context.
+
+**Key characteristics:**
+
+- **File-based**: Memory is stored as plain Markdown files, managed via existing `read_file` / `write_file` / `edit_file` tools
+- **Two-layer structure**: A concise `MEMORY.md` main file auto-loaded into context, plus optional topic sub-files read on demand
+- **Per-subagent isolation**: Each subagent has its own memory directory
+- **Zero configuration**: No setup needed -- eligible agents are automatically enabled
+
+## Memory Directory
+
+Memory files are stored under `.datus/memory/` in the workspace, with each agent having its own subdirectory:
+
+```
+{workspace_root}/
+└── .datus/
+    └── memory/
+        ├── chat/                       # Built-in chat agent
+        │   ├── MEMORY.md              # Main file: auto-loaded (≤200 lines)
+        │   ├── patterns.md            # Sub-file: read on demand
+        │   └── conventions.md
+        └── my_custom_agent/           # Custom subagent
+            ├── MEMORY.md
+            └── domain.md
+```
+
+> The memory directory is created automatically on the agent's first write -- no manual setup needed.
+
+## Which Agents Have Memory
+
+| Agent Type | Memory Enabled |
+|-----------|---------------|
+| `chat` (built-in main agent) | Yes |
+| Custom subagents | Yes |
+| Built-in system subagents (`gen_sql`, `gen_report`, etc.) | No |
+| `explore` | No |
+
+Only interactive, user-facing agents have memory. Built-in system subagents that perform specific pipeline tasks do not.
+
+## Two-Layer Memory
+
+### L1: MEMORY.md (Main File)
+
+- **Automatically loaded** into agent context at the start of every conversation
+- Capped at **200 lines** -- content beyond this is truncated
+- Best for concise key information and links to L2 files
+
+### L2: Topic Sub-files
+
+- Read by the agent **on demand** via `read_file`
+- No line limit -- suitable for detailed content
+- Examples: `patterns.md`, `conventions.md`, `domain.md`
+
+**Best stored in L1:**
+
+- User preferences and workflow habits
+- Key project structure and file paths
+- Frequently referenced conventions
+- Links to L2 topic files
+
+**Best stored in L2:**
+
+- Detailed debugging notes
+- Complex domain patterns and business rules
+- Extended decision records
+
+## Usage
+
+### Ask the Agent to Remember
+
+Use natural language:
+
+```
+> Remember that I prefer DuckDB
+> Remember the project uses snake_case naming convention
+> Remember the default report format is Markdown
+```
+
+The agent will write the information to `MEMORY.md`, and it will take effect in the next conversation.
+
+### Ask the Agent to Forget
+
+```
+> Forget my DuckDB preference
+> Stop remembering the naming convention
+```
+
+The agent will find and remove the corresponding memory entry.
+
+### Correct a Memory
+
+When the agent gives a wrong answer based on memory, simply correct it:
+
+```
+> That's wrong, our project uses PostgreSQL, not DuckDB
+```
+
+The agent will immediately update the incorrect memory entry.
+
+### View Current Memory
+
+Memory files are plain Markdown -- you can view or manually edit them:
+
+```bash
+cat {workspace_root}/.datus/memory/chat/MEMORY.md
+```
+
+Or ask the agent:
+
+```
+> Read your current memory file
+```
+
+## Agent Memory Behavior
+
+The agent automatically leverages memory in these scenarios:
+
+- **New conversation starts**: Reviews memory for user preferences and prior context
+- **Answering project questions**: Checks memory for relevant decisions or conventions
+- **User references a past discussion**: Looks up related memory entries
+- **Suggesting tools, databases, or workflows**: Respects stated preferences
+
+The agent automatically decides what is worth saving:
+
+| Should Save | Should NOT Save |
+|------------|----------------|
+| Stable patterns confirmed across interactions | Temporary details of current task |
+| Key decisions and project structure | Incomplete, unverified information |
+| User preferences and workflow habits | Speculative conclusions from one interaction |
+| Solutions to recurring problems | In-progress work state |
+
+## Configuration
+
+Auto Memory requires **no explicit configuration** -- eligible agents are automatically enabled.
+
+The memory directory location follows the `workspace_root` setting:
+
+| Priority | Source |
+|----------|--------|
+| 1 | Node-specific `workspace_root` in `agentic_nodes` config |
+| 2 | `storage.workspace_root` in `agent.yml` |
+| 3 | Top-level `workspace_root` in `agent.yml` |
+| 4 | Current directory (`.`) |
+
+For example, when `workspace_root` is set to `~/my_project`, the chat agent's memory file is at:
+
+```
+~/my_project/.datus/memory/chat/MEMORY.md
+```
+
+## Best Practices
+
+1. **Keep MEMORY.md concise**: Stay within 200 lines -- move detailed content to L2 sub-files
+2. **Organize by topic**: Use semantic sub-file names (e.g., `db_conventions.md`) rather than chronological logs
+3. **Clean up regularly**: Ask the agent to delete or correct outdated or incorrect memories
+4. **Use explicit requests**: For important information, explicitly say "remember this" to ensure persistence
+5. **Manual editing works too**: Memory files are plain Markdown -- feel free to view and edit them directly

--- a/docs/integration/memory.md
+++ b/docs/integration/memory.md
@@ -17,7 +17,7 @@ When users interact with the agent, the agent can recognize valuable information
 
 Memory files are stored under `.datus/memory/` in the workspace, with each agent having its own subdirectory:
 
-```
+```text
 {workspace_root}/
 └── .datus/
     └── memory/
@@ -76,7 +76,7 @@ Only interactive, user-facing agents have memory. Built-in system subagents that
 
 Use natural language:
 
-```
+```text
 > Remember that I prefer DuckDB
 > Remember the project uses snake_case naming convention
 > Remember the default report format is Markdown
@@ -86,7 +86,7 @@ The agent will write the information to `MEMORY.md`, and it will take effect in 
 
 ### Ask the Agent to Forget
 
-```
+```text
 > Forget my DuckDB preference
 > Stop remembering the naming convention
 ```
@@ -97,7 +97,7 @@ The agent will find and remove the corresponding memory entry.
 
 When the agent gives a wrong answer based on memory, simply correct it:
 
-```
+```text
 > That's wrong, our project uses PostgreSQL, not DuckDB
 ```
 
@@ -113,7 +113,7 @@ cat {workspace_root}/.datus/memory/chat/MEMORY.md
 
 Or ask the agent:
 
-```
+```text
 > Read your current memory file
 ```
 
@@ -150,7 +150,7 @@ The memory directory location follows the `workspace_root` setting:
 
 For example, when `workspace_root` is set to `~/my_project`, the chat agent's memory file is at:
 
-```
+```text
 ~/my_project/.datus/memory/chat/MEMORY.md
 ```
 

--- a/docs/integration/memory.zh.md
+++ b/docs/integration/memory.zh.md
@@ -1,0 +1,163 @@
+# Auto Memory
+
+Auto Memory 是 Datus-agent 的持久化记忆系统，使 Agent 能够跨对话自动保留有价值的信息。该机制完全基于文件和 prompt 驱动，无需向量数据库或 embedding。
+
+## 概述
+
+用户与 Agent 交互时，Agent 能够自动识别有价值的信息，并将其持久化到工作目录下的 Markdown 文件中。在后续对话中，这些记忆会自动加载，使 Agent 能够回忆先前的上下文。
+
+**核心特征：**
+
+- **纯文件存储**：记忆以 Markdown 文件形式存储，Agent 通过已有的 `read_file` / `write_file` / `edit_file` 工具管理
+- **两层结构**：简洁的 `MEMORY.md` 主文件自动加载，可选的主题子文件按需读取
+- **按 subagent 隔离**：每个 subagent 拥有独立的记忆目录
+- **零配置**：无需额外设置，符合条件的 Agent 自动启用
+
+## 记忆目录
+
+记忆文件存储在工作目录的 `.datus/memory/` 下，每个 Agent 拥有独立的子目录：
+
+```
+{workspace_root}/
+└── .datus/
+    └── memory/
+        ├── chat/                       # 内置 chat agent
+        │   ├── MEMORY.md              # 主文件：自动加载（≤200 行）
+        │   ├── patterns.md            # 子文件：按需读取
+        │   └── conventions.md
+        └── my_custom_agent/           # 自定义 subagent
+            ├── MEMORY.md
+            └── domain.md
+```
+
+> 记忆目录在 Agent 首次写入时自动创建，无需手动创建。
+
+## 哪些 Agent 有记忆
+
+| Agent 类型 | 是否启用记忆 |
+|-----------|-------------|
+| `chat`（内置主 Agent） | Yes |
+| 自定义 subagent | Yes |
+| 内置系统 subagent（`gen_sql`、`gen_report` 等） | No |
+| `explore` | No |
+
+只有面向用户的交互式 Agent 拥有记忆，执行特定流水线任务的内置系统 subagent 不启用。
+
+## 两层记忆机制
+
+### L1：MEMORY.md（主文件）
+
+- 每次对话开始时**自动加载**到 Agent 上下文
+- 上限 **200 行**，超出部分会被截断
+- 适合存储简洁的关键信息和 L2 文件链接
+
+### L2：主题子文件
+
+- Agent 通过 `read_file` **按需读取**
+- 无行数限制，适合存储详细内容
+- 示例：`patterns.md`、`conventions.md`、`domain.md`
+
+**L1 适合存储：**
+
+- 用户偏好和工作习惯
+- 关键项目结构和文件路径
+- 常用约定和规范
+- L2 主题文件的链接
+
+**L2 适合存储：**
+
+- 详细的调试笔记
+- 复杂的领域模式和业务规则
+- 完整的决策记录
+
+## 使用方式
+
+### 让 Agent 记住信息
+
+直接用自然语言告诉 Agent：
+
+```
+> 记住我偏好使用 DuckDB
+> 记住项目使用 snake_case 命名规范
+> 记住报表输出格式默认用 Markdown
+```
+
+Agent 会将信息写入 `MEMORY.md`，下次对话自动生效。
+
+### 让 Agent 忘记信息
+
+```
+> 忘记我对 DuckDB 的偏好
+> 不要再记住命名规范的事
+```
+
+Agent 会找到并删除对应的记忆条目。
+
+### 更正记忆
+
+当 Agent 基于记忆给出错误回答时，直接更正即可：
+
+```
+> 不对，我们项目用的是 PostgreSQL，不是 DuckDB
+```
+
+Agent 会立即更新记忆中的错误内容。
+
+### 查看当前记忆
+
+记忆文件是普通的 Markdown 文件，可以直接查看或手动编辑：
+
+```bash
+cat {workspace_root}/.datus/memory/chat/MEMORY.md
+```
+
+也可以让 Agent 读取：
+
+```
+> 读一下你当前的记忆文件
+```
+
+## Agent 的记忆行为
+
+Agent 会在以下场景自动利用记忆：
+
+- **新对话开始**：回顾记忆了解用户偏好和先前上下文
+- **回答项目问题**：检查记忆中是否有相关决策或约定
+- **用户提及以前讨论过的内容**：查找相关记忆条目
+- **建议工具、数据库或工作流**：尊重用户已声明的偏好
+
+Agent 会自动判断哪些信息值得保存：
+
+| 应该保存 | 不应保存 |
+|---------|---------|
+| 跨多次交互确认的稳定模式 | 当前会话的临时任务细节 |
+| 关键决策和项目结构 | 未经验证的不完整信息 |
+| 用户偏好和工作习惯 | 单次交互中的推测性结论 |
+| 常见问题的解决方案 | 进行中的工作状态 |
+
+## 配置
+
+Auto Memory **无需显式配置**，符合条件的 Agent 自动启用。
+
+记忆目录位置跟随 `workspace_root` 设置：
+
+| 优先级 | 来源 |
+|--------|------|
+| 1 | `agentic_nodes` 中节点级 `workspace_root` |
+| 2 | `agent.yml` 中 `storage.workspace_root` |
+| 3 | `agent.yml` 中顶层 `workspace_root` |
+| 4 | 当前目录（`.`） |
+
+例如，当 `workspace_root` 设置为 `~/my_project` 时，chat agent 的记忆文件位于：
+
+```
+~/my_project/.datus/memory/chat/MEMORY.md
+```
+
+## 最佳实践
+
+1. **保持 MEMORY.md 简洁**：控制在 200 行以内，详细内容放到 L2 子文件
+2. **按主题组织**：使用语义化的子文件名（如 `db_conventions.md`），而非按时间记录
+3. **定期清理**：过时或错误的记忆应及时让 Agent 删除或更正
+4. **善用显式请求**：重要信息直接告诉 Agent "记住这个"，确保被持久化
+5. **手动编辑也可以**：记忆文件是普通 Markdown，随时可以手动查看和修改

--- a/docs/integration/memory.zh.md
+++ b/docs/integration/memory.zh.md
@@ -17,7 +17,7 @@ Auto Memory 是 Datus-agent 的持久化记忆系统，使 Agent 能够跨对话
 
 记忆文件存储在工作目录的 `.datus/memory/` 下，每个 Agent 拥有独立的子目录：
 
-```
+```text
 {workspace_root}/
 └── .datus/
     └── memory/
@@ -76,7 +76,7 @@ Auto Memory 是 Datus-agent 的持久化记忆系统，使 Agent 能够跨对话
 
 直接用自然语言告诉 Agent：
 
-```
+```text
 > 记住我偏好使用 DuckDB
 > 记住项目使用 snake_case 命名规范
 > 记住报表输出格式默认用 Markdown
@@ -86,7 +86,7 @@ Agent 会将信息写入 `MEMORY.md`，下次对话自动生效。
 
 ### 让 Agent 忘记信息
 
-```
+```text
 > 忘记我对 DuckDB 的偏好
 > 不要再记住命名规范的事
 ```
@@ -97,7 +97,7 @@ Agent 会找到并删除对应的记忆条目。
 
 当 Agent 基于记忆给出错误回答时，直接更正即可：
 
-```
+```text
 > 不对，我们项目用的是 PostgreSQL，不是 DuckDB
 ```
 
@@ -113,7 +113,7 @@ cat {workspace_root}/.datus/memory/chat/MEMORY.md
 
 也可以让 Agent 读取：
 
-```
+```text
 > 读一下你当前的记忆文件
 ```
 
@@ -150,7 +150,7 @@ Auto Memory **无需显式配置**，符合条件的 Agent 自动启用。
 
 例如，当 `workspace_root` 设置为 `~/my_project` 时，chat agent 的记忆文件位于：
 
-```
+```text
 ~/my_project/.datus/memory/chat/MEMORY.md
 ```
 

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -145,8 +145,8 @@ def create_test_node(node_id, mock_agent_config):
 class TestFinalizeSystemPrompt:
     """Test suite for _finalize_system_prompt method."""
 
-    def test_no_skill_func_tool_returns_prompt_unchanged(self, mock_agent_config):
-        """When skill_func_tool is None, returns base_prompt as-is."""
+    def test_no_skill_func_tool_returns_prompt_unchanged(self, mock_agent_config, monkeypatch):
+        """When skill_func_tool is None, returns base_prompt as-is (memory injection mocked out)."""
         node = MinimalAgenticNode(
             node_id="test1",
             description="Test node",
@@ -154,6 +154,7 @@ class TestFinalizeSystemPrompt:
             agent_config=mock_agent_config,
         )
         node.skill_func_tool = None
+        monkeypatch.setattr(node, "_inject_memory_context", lambda p: p)
 
         base_prompt = "This is the base system prompt."
         result = node._finalize_system_prompt(base_prompt)
@@ -181,8 +182,10 @@ class TestFinalizeSystemPrompt:
         assert "<available_skills>" in result
         assert "sql-analysis" in result
 
-    def test_with_skill_func_tool_empty_xml_returns_prompt_unchanged(self, mock_agent_config, skill_manager):
-        """When skills context returns empty string, prompt unchanged."""
+    def test_with_skill_func_tool_empty_xml_returns_prompt_unchanged(
+        self, mock_agent_config, skill_manager, monkeypatch
+    ):
+        """When skills context returns empty string, prompt unchanged (memory injection mocked out)."""
         # Configure node with pattern that matches no skills
         mock_agent_config.agentic_nodes = {"test_node": {"skills": "nonexistent-*"}}
 
@@ -194,6 +197,7 @@ class TestFinalizeSystemPrompt:
         )
         node.skill_manager = skill_manager
         node.skill_func_tool = SkillFuncTool(manager=skill_manager, node_name="test_node")
+        monkeypatch.setattr(node, "_inject_memory_context", lambda p: p)
 
         base_prompt = "This is the base system prompt."
         result = node._finalize_system_prompt(base_prompt)

--- a/tests/unit_tests/utils/test_memory_loader.py
+++ b/tests/unit_tests/utils/test_memory_loader.py
@@ -1,0 +1,124 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/utils/memory_loader.py"""
+
+from datus.utils.memory_loader import (
+    MEMORY_BASE_DIR,
+    MEMORY_FILENAME,
+    MEMORY_LINE_LIMIT,
+    get_memory_dir,
+    has_memory,
+    load_memory_context,
+)
+
+
+class TestHasMemory:
+    """Tests for has_memory()."""
+
+    def test_chat_has_memory(self):
+        assert has_memory("chat") is True
+
+    def test_custom_agent_has_memory(self):
+        assert has_memory("my_custom_agent") is True
+
+    def test_gen_sql_no_memory(self):
+        assert has_memory("gen_sql") is False
+
+    def test_gen_report_no_memory(self):
+        assert has_memory("gen_report") is False
+
+    def test_gen_semantic_model_no_memory(self):
+        assert has_memory("gen_semantic_model") is False
+
+    def test_gen_metrics_no_memory(self):
+        assert has_memory("gen_metrics") is False
+
+    def test_gen_sql_summary_no_memory(self):
+        assert has_memory("gen_sql_summary") is False
+
+    def test_gen_ext_knowledge_no_memory(self):
+        assert has_memory("gen_ext_knowledge") is False
+
+    def test_explore_no_memory(self):
+        assert has_memory("explore") is False
+
+
+class TestLoadMemoryContext:
+    """Tests for load_memory_context()."""
+
+    def test_file_not_found_returns_empty(self, tmp_path):
+        assert load_memory_context(str(tmp_path), "chat") == ""
+
+    def test_normal_content(self, tmp_path):
+        memory_dir = tmp_path / MEMORY_BASE_DIR / "chat"
+        memory_dir.mkdir(parents=True)
+        memory_file = memory_dir / MEMORY_FILENAME
+        memory_file.write_text("# Memory\n\n- item 1\n- item 2\n", encoding="utf-8")
+
+        result = load_memory_context(str(tmp_path), "chat")
+        assert "# Memory" in result
+        assert "- item 1" in result
+        assert "- item 2" in result
+
+    def test_truncation_at_limit(self, tmp_path):
+        memory_dir = tmp_path / MEMORY_BASE_DIR / "chat"
+        memory_dir.mkdir(parents=True)
+        memory_file = memory_dir / MEMORY_FILENAME
+
+        lines = [f"line {i}" for i in range(MEMORY_LINE_LIMIT + 50)]
+        memory_file.write_text("\n".join(lines), encoding="utf-8")
+
+        result = load_memory_context(str(tmp_path), "chat")
+        result_lines = result.splitlines()
+
+        # Should have 200 original lines + blank line + truncation notice = 202
+        assert len(result_lines) == MEMORY_LINE_LIMIT + 2
+        assert "truncated" in result_lines[-1]
+        assert f"line {MEMORY_LINE_LIMIT - 1}" in result
+        assert f"line {MEMORY_LINE_LIMIT}" not in result
+
+    def test_exact_limit_not_truncated(self, tmp_path):
+        memory_dir = tmp_path / MEMORY_BASE_DIR / "chat"
+        memory_dir.mkdir(parents=True)
+        memory_file = memory_dir / MEMORY_FILENAME
+
+        lines = [f"line {i}" for i in range(MEMORY_LINE_LIMIT)]
+        memory_file.write_text("\n".join(lines), encoding="utf-8")
+
+        result = load_memory_context(str(tmp_path), "chat")
+        assert "truncated" not in result
+
+    def test_empty_file(self, tmp_path):
+        memory_dir = tmp_path / MEMORY_BASE_DIR / "chat"
+        memory_dir.mkdir(parents=True)
+        memory_file = memory_dir / MEMORY_FILENAME
+        memory_file.write_text("", encoding="utf-8")
+
+        result = load_memory_context(str(tmp_path), "chat")
+        assert result == ""
+
+    def test_custom_agent_memory(self, tmp_path):
+        memory_dir = tmp_path / MEMORY_BASE_DIR / "my_agent"
+        memory_dir.mkdir(parents=True)
+        memory_file = memory_dir / MEMORY_FILENAME
+        memory_file.write_text("# Custom Agent Memory\n", encoding="utf-8")
+
+        result = load_memory_context(str(tmp_path), "my_agent")
+        assert "Custom Agent Memory" in result
+
+
+class TestGetMemoryDir:
+    """Tests for get_memory_dir()."""
+
+    def test_chat_dir(self):
+        assert get_memory_dir(".", "chat") == f"{MEMORY_BASE_DIR}/chat"
+
+    def test_custom_agent_dir(self):
+        result = get_memory_dir("/workspace", "my_agent")
+        assert result == f"{MEMORY_BASE_DIR}/my_agent"
+
+    def test_dir_is_relative(self):
+        result = get_memory_dir("/any/path", "chat")
+        assert not result.startswith("/")

--- a/tests/unit_tests/utils/test_memory_loader.py
+++ b/tests/unit_tests/utils/test_memory_loader.py
@@ -4,6 +4,8 @@
 
 """Unit tests for datus/utils/memory_loader.py"""
 
+from unittest.mock import patch
+
 from datus.utils.memory_loader import (
     MEMORY_BASE_DIR,
     MEMORY_FILENAME,
@@ -44,6 +46,9 @@ class TestHasMemory:
     def test_explore_no_memory(self):
         assert has_memory("explore") is False
 
+    def test_compare_no_memory(self):
+        assert has_memory("compare") is False
+
 
 class TestLoadMemoryContext:
     """Tests for load_memory_context()."""
@@ -73,10 +78,11 @@ class TestLoadMemoryContext:
         result = load_memory_context(str(tmp_path), "chat")
         result_lines = result.splitlines()
 
-        # Should have 200 original lines + blank line + truncation notice = 202
+        # Should have 200 original lines + empty line + truncation notice = 202
         assert len(result_lines) == MEMORY_LINE_LIMIT + 2
         assert "truncated" in result_lines[-1]
         assert f"line {MEMORY_LINE_LIMIT - 1}" in result
+        # line 200 should NOT be present (0-indexed, so line_200 is the 201st)
         assert f"line {MEMORY_LINE_LIMIT}" not in result
 
     def test_exact_limit_not_truncated(self, tmp_path):
@@ -107,6 +113,26 @@ class TestLoadMemoryContext:
 
         result = load_memory_context(str(tmp_path), "my_agent")
         assert "Custom Agent Memory" in result
+
+    def test_os_error_returns_empty(self, tmp_path):
+        memory_dir = tmp_path / MEMORY_BASE_DIR / "chat"
+        memory_dir.mkdir(parents=True)
+        memory_file = memory_dir / MEMORY_FILENAME
+        memory_file.write_text("content", encoding="utf-8")
+
+        with patch("pathlib.Path.open", side_effect=OSError("Permission denied")):
+            result = load_memory_context(str(tmp_path), "chat")
+        assert result == ""
+
+    def test_unicode_error_returns_empty(self, tmp_path):
+        memory_dir = tmp_path / MEMORY_BASE_DIR / "chat"
+        memory_dir.mkdir(parents=True)
+        memory_file = memory_dir / MEMORY_FILENAME
+        memory_file.write_bytes(b"\xff\xfe invalid utf-8 \x80\x81")
+
+        result = load_memory_context(str(tmp_path), "chat")
+        # Should return empty string or partial content, not raise
+        assert isinstance(result, str)
 
 
 class TestGetMemoryDir:


### PR DESCRIPTION

Enable agents to retain valuable information across conversations via prompt-driven MEMORY.md files. Memory is auto-injected into the system prompt for eligible nodes (chat + custom subagents), with a two-layer design: L1 main file (≤200 lines, auto-loaded) and L2 topic sub-files (read on demand). No new tools needed — reuses existing FilesystemFuncTool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can persist per-agent memory under .datus/memory/ and auto-load relevant memory into system prompts; a new memory prompt template guides usage and editing.
  * Filesystem-based tools are now initialized for report- and SQL-focused agents to ensure file read/write capabilities.

* **Bug Fixes**
  * Memory is appended to prompts only when non-empty; load/render errors are warned and safely ignored.

* **Documentation**
  * Added comprehensive memory guides (English and Chinese).

* **Tests**
  * Added/updated unit tests for memory utilities and prompt finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->