### PR TITLE
[Feature] Add AWS Bedrock support via LiteLLM (LLM + Embedding)

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -31,6 +31,7 @@ from datus.models.mcp_utils import multiple_mcp_servers
 from datus.models.openai_compatible import OpenAICompatibleModel
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
+from datus.utils.constants import BEDROCK_MODEL_PREFIX
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -151,6 +152,8 @@ class ClaudeModel(OpenAICompatibleModel):
 
     def _get_api_key(self) -> str:
         """Get Anthropic API key from config or environment."""
+        if self.model_config.model.startswith(BEDROCK_MODEL_PREFIX):
+            return ""
         if self.model_config.auth_type == "subscription":
             from datus.auth.claude_credential import get_claude_subscription_token
 
@@ -163,10 +166,16 @@ class ClaudeModel(OpenAICompatibleModel):
 
     def _get_base_url(self) -> Optional[str]:
         """Get Anthropic base URL from config."""
+        if self.model_config.model.startswith(BEDROCK_MODEL_PREFIX):
+            return None
         return self.model_config.base_url or "https://api.anthropic.com"
 
     def _init_anthropic_client(self):
         """Initialize native Anthropic client for prompt caching and native API support."""
+        if self.model_config.model.startswith(BEDROCK_MODEL_PREFIX):
+            self.anthropic_client = None
+            return
+
         # Optional proxy configuration
         proxy_url = os.environ.get("HTTP_PROXY") or os.environ.get("HTTPS_PROXY")
         self.proxy_client = None
@@ -245,6 +254,12 @@ class ClaudeModel(OpenAICompatibleModel):
 
     def _anthropic_messages_create(self, **kwargs):
         """Call the correct Anthropic Messages endpoint for the current auth mode."""
+        if self.anthropic_client is None:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message="Native Anthropic API is not available for Bedrock models. "
+                "Set use_native_api=false or use a direct Anthropic API key.",
+            )
         if self._is_oauth_token:
             return self.anthropic_client.beta.messages.create(**kwargs)
         return self.anthropic_client.messages.create(**kwargs)

--- a/datus/storage/embedding_litellm.py
+++ b/datus/storage/embedding_litellm.py
@@ -1,0 +1,113 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, List, Optional, Union
+
+import litellm
+from datus_storage_base.vector.base import EmbeddingFunction
+from pydantic import BaseModel
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+class LiteLLMEmbeddings(BaseModel, EmbeddingFunction):
+    """An embedding function that uses the LiteLLM API.
+
+    Supports any embedding model that LiteLLM supports, including
+    AWS Bedrock Titan, Cohere, and other providers.
+
+    Example model names:
+        - "bedrock/amazon.titan-embed-text-v2:0"
+        - "bedrock/cohere.embed-english-v3"
+    """
+
+    name: str
+    dim: Optional[int] = None
+
+    @classmethod
+    def create(cls, **kwargs) -> "LiteLLMEmbeddings":
+        """Create a new instance with the given parameters."""
+        return cls(**kwargs)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        super().__setattr__(name, value)
+        if name in {"name", "dim"}:
+            self.__dict__.pop("_ndims", None)
+            self.__dict__.pop("_max_input_tokens", None)
+
+    def ndims(self) -> int:
+        return self._ndims
+
+    @staticmethod
+    def sensitive_keys() -> list[str]:
+        return []
+
+    @cached_property
+    def _ndims(self) -> int:
+        if self.dim is not None:
+            return self.dim
+        try:
+            resp = litellm.embedding(model=self.name, input=["test"])
+            return len(resp.data[0]["embedding"])
+        except Exception as e:
+            logger.error(f"Failed to auto-detect embedding dimensions for model '{self.name}': {e}")
+            raise
+
+    @cached_property
+    def _max_input_tokens(self) -> int:
+        """Auto-detect the maximum input tokens for this embedding model."""
+        try:
+            model_info = litellm.get_model_info(self.name)
+            max_tokens = model_info.get("max_input_tokens")
+            if max_tokens and isinstance(max_tokens, int) and max_tokens > 0:
+                logger.debug(f"Model {self.name}: max_input_tokens={max_tokens}")
+                return max_tokens
+        except Exception as e:
+            logger.warning(f"Failed to get model info for '{self.name}': {e}. Using default 8191 tokens.")
+        return 8191  # OpenAI default fallback
+
+    def _truncate(self, text: str) -> str:
+        """Truncate text to fit within the model's token limit.
+
+        Uses a conservative estimate of 3 characters per token.
+        """
+        max_chars = self._max_input_tokens * 3
+        if len(text) <= max_chars:
+            return text
+        logger.warning(
+            f"Truncating text from {len(text)} to {max_chars} chars "
+            f"(~{self._max_input_tokens} tokens) for model {self.name}"
+        )
+        return text[:max_chars]
+
+    def generate_embeddings(self, texts: Union[List[str], "np.ndarray"]) -> List["np.array"]:
+        import numpy as np
+
+        valid_texts = []
+        valid_indices = []
+        for idx, text in enumerate(texts):
+            if text:
+                valid_texts.append(self._truncate(text))
+                valid_indices.append(idx)
+
+        if not valid_texts:
+            return [None] * len(texts)
+
+        valid_embeddings: dict = {}
+        for i, (text, orig_idx) in enumerate(zip(valid_texts, valid_indices)):
+            try:
+                resp = litellm.embedding(model=self.name, input=[text])
+                valid_embeddings[orig_idx] = np.array(resp.data[0]["embedding"])
+            except Exception as e:
+                logger.error(f"LiteLLM embedding failed for text #{i} (len={len(text)}): {e}")
+
+        return [valid_embeddings.get(idx, None) for idx in range(len(texts))]

--- a/datus/storage/embedding_models.py
+++ b/datus/storage/embedding_models.py
@@ -191,6 +191,18 @@ class EmbeddingModel:
             # check if the model is initialized
             self._model.generate_embeddings(["foo"])
             logger.debug(f"Model {self.registry_name}/{self.model_name} initialized successfully")
+
+        elif self.registry_name == EmbeddingProvider.LITELLM:
+            logger.debug(f"Initializing model {self.registry_name}/{self.model_name}")
+            from datus.storage.embedding_litellm import LiteLLMEmbeddings
+
+            self._model = LiteLLMEmbeddings.create(
+                name=self.model_name,
+                dim=self._dim_size,
+            )
+            # Verify the model works
+            self._model.generate_embeddings(["foo"])
+            logger.debug(f"Model {self.registry_name}/{self.model_name} initialized successfully")
         else:
             raise DatusException(
                 ErrorCode.MODEL_EMBEDDING_ERROR,

--- a/datus/storage/vector/lance_backend.py
+++ b/datus/storage/vector/lance_backend.py
@@ -93,6 +93,28 @@ class _LanceOpenAIAdapter(TextEmbeddingFunction):
         return self._impl
 
 
+@register("litellm")
+class _LanceLiteLLMAdapter(TextEmbeddingFunction):
+    """LanceDB adapter for LiteLLM embedding models (Bedrock, etc.)."""
+
+    name: str = "text-embedding-ada-002"
+    dim: Optional[int] = None
+
+    def ndims(self):
+        return self._get_impl().ndims()
+
+    def generate_embeddings(self, texts, *args, **kwargs):
+        return self._get_impl().generate_embeddings(texts)
+
+    def _get_impl(self):
+        if not hasattr(self, "_impl") or self._impl is None:
+            from datus.storage.embedding_litellm import LiteLLMEmbeddings
+
+            impl = LiteLLMEmbeddings.create(name=self.name, dim=self.dim)
+            object.__setattr__(self, "_impl", impl)
+        return self._impl
+
+
 # ---------------------------------------------------------------------------
 # Embedding wrapping helper
 # ---------------------------------------------------------------------------
@@ -108,10 +130,16 @@ def _wrap_embedding(model: EmbeddingFunction) -> TextEmbeddingFunction:
     if isinstance(model, LanceDBEmbeddingFunction):
         return model
 
+    from datus.storage.embedding_litellm import LiteLLMEmbeddings
     from datus.storage.fastembed_embeddings import FastEmbedEmbeddings
 
     if isinstance(model, FastEmbedEmbeddings):
         adapter = _LanceFastEmbedAdapter(name=model.name, batch_size=model.batch_size)
+    elif isinstance(model, LiteLLMEmbeddings):
+        adapter = _LanceLiteLLMAdapter(
+            name=model.name,
+            dim=model.dim,
+        )
     else:
         adapter = _LanceOpenAIAdapter(
             name=getattr(model, "name", ""),

--- a/datus/utils/constants.py
+++ b/datus/utils/constants.py
@@ -41,6 +41,11 @@ class EmbeddingProvider(str, Enum):
     SENTENCE_TRANSFORMERS = "sentence-transformers"
     FASTEMBED = "fastembed"
     HUGGINGFACE = "huggingface"
+    LITELLM = "litellm"
+
+
+# AWS Bedrock model prefix used for provider detection
+BEDROCK_MODEL_PREFIX = "bedrock/"
 
 
 # System sub-agents that are built-in and not user-configurable

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -1198,3 +1198,91 @@ class TestGenerateWithMcpToolRouting:
         passed_args = call_args[1]["arguments"]
         assert passed_args == {"query": "SELECT 1"}
         assert passed_args is not original_input  # must be a different object
+
+
+# ---------------------------------------------------------------------------
+# Bedrock model support
+# ---------------------------------------------------------------------------
+
+
+def _make_bedrock_claude_model(model_config=None):
+    """Create ClaudeModel for Bedrock with all external dependencies mocked.
+
+    Unlike _make_claude_model, this does NOT overwrite anthropic_client after
+    construction, so the Bedrock path (anthropic_client = None) is preserved.
+    """
+    if model_config is None:
+        model_config = _make_model_config(model="bedrock/us.anthropic.claude-opus-4-6-v1", api_key="bedrock-iam")
+
+    mock_litellm_adapter = MagicMock()
+    mock_litellm_adapter.litellm_model_name = "bedrock/us.anthropic.claude-opus-4-6-v1"
+    mock_litellm_adapter.provider = "bedrock"
+    mock_litellm_adapter.is_thinking_model = False
+    mock_litellm_adapter.get_agents_sdk_model.return_value = MagicMock()
+
+    with (
+        patch("datus.models.openai_compatible.setup_tracing"),
+        patch("datus.models.openai_compatible.LiteLLMAdapter", return_value=mock_litellm_adapter),
+        patch("anthropic.Anthropic") as mock_anthropic_cls,
+        patch("langsmith.wrappers.wrap_anthropic", side_effect=lambda c: c),
+        patch(
+            "os.environ.get",
+            side_effect=lambda key, default=None: "" if key == "ANTHROPIC_API_KEY" else default,
+        ),
+    ):
+        model = ClaudeModel(model_config)
+        model.litellm_adapter = mock_litellm_adapter
+        # Do NOT overwrite anthropic_client — Bedrock sets it to None
+        # Verify Anthropic() was never called for Bedrock models
+        mock_anthropic_cls.assert_not_called()
+        return model
+
+
+class TestBedrockSupport:
+    """Tests for AWS Bedrock model support in ClaudeModel."""
+
+    def test_bedrock_api_key_returns_empty(self):
+        """Bedrock models should return empty API key (uses IAM auth)."""
+        config = _make_model_config(model="bedrock/us.anthropic.claude-opus-4-6-v1", api_key="bedrock-iam")
+        model = _make_bedrock_claude_model(config)
+        assert model._get_api_key() == ""
+
+    def test_bedrock_base_url_returns_none(self):
+        """Bedrock models should return None base URL (LiteLLM handles endpoint)."""
+        config = _make_model_config(model="bedrock/us.anthropic.claude-opus-4-6-v1", api_key="bedrock-iam")
+        model = _make_bedrock_claude_model(config)
+        assert model._get_base_url() is None
+
+    def test_bedrock_anthropic_client_is_none(self):
+        """Bedrock models should not initialize native Anthropic client."""
+        config = _make_model_config(model="bedrock/us.anthropic.claude-opus-4-6-v1", api_key="bedrock-iam")
+        model = _make_bedrock_claude_model(config)
+        assert model.anthropic_client is None
+
+    def test_bedrock_converse_model_prefix(self):
+        """Bedrock converse models (bedrock/converse/...) should also be detected."""
+        config = _make_model_config(model="bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0", api_key="iam")
+        model = _make_bedrock_claude_model(config)
+        assert model._get_api_key() == ""
+        assert model._get_base_url() is None
+        assert model.anthropic_client is None
+
+    def test_non_bedrock_model_not_affected(self):
+        """Non-Bedrock models should behave normally."""
+        config = _make_model_config(model="claude-sonnet-4-20250514", api_key="sk-ant-test-key-123")
+        model = _make_claude_model(config)
+        # Non-bedrock should have a real API key
+        assert model._get_api_key() == "sk-ant-test-key-123"
+        # Non-bedrock should have a base URL
+        assert model._get_base_url() is not None
+        # Non-bedrock should have an anthropic client
+        assert model.anthropic_client is not None
+
+    def test_bedrock_native_api_raises_on_messages_create(self):
+        """Calling _anthropic_messages_create on Bedrock model should raise DatusException."""
+        from datus.utils.exceptions import DatusException
+
+        config = _make_model_config(model="bedrock/us.anthropic.claude-opus-4-6-v1", api_key="bedrock-iam")
+        model = _make_bedrock_claude_model(config)
+        with pytest.raises(DatusException):
+            model._anthropic_messages_create(model="test", messages=[], max_tokens=100)

--- a/tests/unit_tests/storage/test_embedding_litellm.py
+++ b/tests/unit_tests/storage/test_embedding_litellm.py
@@ -1,0 +1,255 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus.storage.embedding_litellm (pure logic only, no API calls)."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from datus.storage.embedding_litellm import LiteLLMEmbeddings
+
+# ---------------------------------------------------------------------------
+# Initialization / defaults
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMEmbeddingsInit:
+    """Tests for LiteLLMEmbeddings construction and defaults."""
+
+    @pytest.mark.ci
+    def test_default_dim_is_none(self):
+        """Default dim should be None."""
+        emb = LiteLLMEmbeddings(name="test-model")
+        assert emb.dim is None
+
+    @pytest.mark.ci
+    def test_custom_dim(self):
+        """Custom dim should be stored correctly."""
+        emb = LiteLLMEmbeddings(name="test-model", dim=1024)
+        assert emb.dim == 1024
+
+    @pytest.mark.ci
+    def test_name_stored(self):
+        """Name should be stored as given."""
+        emb = LiteLLMEmbeddings(name="bedrock/amazon.titan-embed-text-v2:0")
+        assert emb.name == "bedrock/amazon.titan-embed-text-v2:0"
+
+
+# ---------------------------------------------------------------------------
+# create() factory
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMEmbeddingsCreate:
+    """Tests for the create() class method."""
+
+    @pytest.mark.ci
+    def test_create_returns_instance(self):
+        """create() should return a LiteLLMEmbeddings instance with given params."""
+        emb = LiteLLMEmbeddings.create(name="test-model", dim=512)
+        assert isinstance(emb, LiteLLMEmbeddings)
+        assert emb.name == "test-model"
+        assert emb.dim == 512
+
+
+# ---------------------------------------------------------------------------
+# ndims / _ndims
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMEmbeddingsNdims:
+    """Tests for dimension calculation logic."""
+
+    @pytest.mark.ci
+    def test_ndims_with_explicit_dim(self):
+        """When dim is set explicitly, ndims() should return it directly."""
+        emb = LiteLLMEmbeddings(name="test-model", dim=1024)
+        assert emb.ndims() == 1024
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_ndims_auto_detect(self, mock_litellm):
+        """When dim is None, ndims() should auto-detect via litellm.embedding call."""
+        mock_resp = MagicMock()
+        mock_resp.data = [{"embedding": [0.1] * 768}]
+        mock_litellm.embedding.return_value = mock_resp
+
+        emb = LiteLLMEmbeddings(name="test-model")
+        assert emb.ndims() == 768
+        mock_litellm.embedding.assert_called_once_with(model="test-model", input=["test"])
+
+
+# ---------------------------------------------------------------------------
+# sensitive_keys()
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMEmbeddingsSensitiveKeys:
+    """Tests for sensitive_keys() static method."""
+
+    @pytest.mark.ci
+    def test_sensitive_keys_empty(self):
+        """sensitive_keys() should return an empty list."""
+        assert LiteLLMEmbeddings.sensitive_keys() == []
+
+
+# ---------------------------------------------------------------------------
+# _max_input_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMEmbeddingsMaxInputTokens:
+    """Tests for _max_input_tokens cached property."""
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_auto_detect_from_model_info(self, mock_litellm):
+        """Should use max_input_tokens from litellm.get_model_info when available."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 8192}
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=256)
+        assert emb._max_input_tokens == 8192
+        mock_litellm.get_model_info.assert_called_once_with("test-model")
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_fallback_on_error(self, mock_litellm):
+        """Should fall back to 8191 when get_model_info raises an exception."""
+        mock_litellm.get_model_info.side_effect = Exception("API error")
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=256)
+        assert emb._max_input_tokens == 8191
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_fallback_on_missing_key(self, mock_litellm):
+        """Should fall back to 8191 when max_input_tokens is not in model info."""
+        mock_litellm.get_model_info.return_value = {}
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=256)
+        assert emb._max_input_tokens == 8191
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_fallback_on_none_value(self, mock_litellm):
+        """Should fall back to 8191 when max_input_tokens is None."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": None}
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=256)
+        assert emb._max_input_tokens == 8191
+
+
+# ---------------------------------------------------------------------------
+# _truncate()
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMEmbeddingsTruncate:
+    """Tests for text truncation logic."""
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_short_text_unchanged(self, mock_litellm):
+        """Text shorter than the limit should be returned as-is."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 100}
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=256)
+        text = "short text"
+        assert emb._truncate(text) == text
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_long_text_truncated(self, mock_litellm):
+        """Text longer than max_tokens * 3 chars should be truncated."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 10}
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=256)
+        text = "a" * 100  # 100 chars, limit is 10 * 3 = 30
+        result = emb._truncate(text)
+        assert len(result) == 30
+        assert result == "a" * 30
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_exact_boundary(self, mock_litellm):
+        """Text exactly at the limit should not be truncated."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 10}
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=256)
+        text = "a" * 30  # exactly 10 * 3 = 30 chars
+        assert emb._truncate(text) == text
+
+
+# ---------------------------------------------------------------------------
+# generate_embeddings()
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMEmbeddingsGenerateEmbeddings:
+    """Tests for the generate_embeddings method."""
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_normal_generation(self, mock_litellm):
+        """Should return list of np.arrays for valid texts."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 8192}
+        mock_resp = MagicMock()
+        mock_resp.data = [{"embedding": [0.1, 0.2, 0.3]}]
+        mock_litellm.embedding.return_value = mock_resp
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=3)
+        result = emb.generate_embeddings(["hello", "world"])
+
+        assert len(result) == 2
+        assert isinstance(result[0], np.ndarray)
+        assert isinstance(result[1], np.ndarray)
+        np.testing.assert_array_almost_equal(result[0], [0.1, 0.2, 0.3])
+        np.testing.assert_array_almost_equal(result[1], [0.1, 0.2, 0.3])
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_empty_texts_return_none(self, mock_litellm):
+        """All-empty texts should return all Nones without calling the API."""
+        emb = LiteLLMEmbeddings(name="test-model", dim=3)
+        result = emb.generate_embeddings(["", "", ""])
+
+        assert result == [None, None, None]
+        mock_litellm.embedding.assert_not_called()
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_mixed_empty_and_valid(self, mock_litellm):
+        """Mix of empty and valid texts should return None for empty, arrays for valid."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 8192}
+        mock_resp = MagicMock()
+        mock_resp.data = [{"embedding": [0.5, 0.6]}]
+        mock_litellm.embedding.return_value = mock_resp
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=2)
+        result = emb.generate_embeddings(["", "hello", ""])
+
+        assert result[0] is None
+        assert isinstance(result[1], np.ndarray)
+        np.testing.assert_array_almost_equal(result[1], [0.5, 0.6])
+        assert result[2] is None
+
+    @pytest.mark.ci
+    @patch("datus.storage.embedding_litellm.litellm")
+    def test_single_failure_continues(self, mock_litellm):
+        """A failure on one text should not prevent others from embedding."""
+        mock_litellm.get_model_info.return_value = {"max_input_tokens": 8192}
+        mock_resp = MagicMock()
+        mock_resp.data = [{"embedding": [0.1, 0.2]}]
+
+        # First call raises, second call succeeds
+        mock_litellm.embedding.side_effect = [Exception("API error"), mock_resp]
+
+        emb = LiteLLMEmbeddings(name="test-model", dim=2)
+        result = emb.generate_embeddings(["fail-text", "good-text"])
+
+        assert result[0] is None
+        assert isinstance(result[1], np.ndarray)
+        np.testing.assert_array_almost_equal(result[1], [0.1, 0.2])

--- a/tests/unit_tests/storage/vector/test_lance_backend.py
+++ b/tests/unit_tests/storage/vector/test_lance_backend.py
@@ -576,6 +576,20 @@ class TestWrapEmbedding:
         assert isinstance(adapter, _LanceOpenAIAdapter)
         assert adapter.name == "text-embedding-3-small"
 
+    def test_wrap_litellm(self):
+        """LiteLLMEmbeddings should be wrapped in _LanceLiteLLMAdapter."""
+        from datus.storage.embedding_litellm import LiteLLMEmbeddings
+        from datus.storage.vector.lance_backend import _LanceLiteLLMAdapter, _wrap_embedding
+
+        model = LiteLLMEmbeddings(name="bedrock/amazon.titan-embed-text-v2:0", dim=1024)
+        adapter = _wrap_embedding(model)
+
+        assert isinstance(adapter, _LanceLiteLLMAdapter)
+        assert adapter.name == "bedrock/amazon.titan-embed-text-v2:0"
+        assert adapter.dim == 1024
+        # Verify the original model is injected as _impl
+        assert adapter._impl is model
+
     def test_wrap_passthrough_lance_embedding(self):
         """_wrap_embedding returns LanceDB EmbeddingFunction as-is."""
         from lancedb.embeddings.base import TextEmbeddingFunction


### PR DESCRIPTION
## Summary

Add AWS Bedrock support for both LLM inference (Claude via Bedrock) and embedding models (Titan Embed, Cohere, etc.) through the LiteLLM unified interface.

### Key Changes

- **LiteLLM Embedding Provider**: New `LiteLLMEmbeddings` class with model-aware text truncation via `litellm.get_model_info()` — automatically adapts to each model's token limit instead of hardcoding
- **ClaudeModel Bedrock Adaptation**: Bedrock models bypass API key validation and native Anthropic client initialization (uses IAM role auth via boto3). Added `BEDROCK_MODEL_PREFIX` constant and `anthropic_client is None` safety guard
- **LanceDB Integration**: `_LanceLiteLLMAdapter` registered with LanceDB's embedding function system for proper serialization/deserialization
- **EmbeddingModel Factory**: Added `LITELLM` provider branch to `init_model()`, following the existing OpenAI/FastEmbed pattern

### Files Changed (8 files)

| File | Change |
|------|--------|
| `datus/utils/constants.py` | +`LITELLM` enum, +`BEDROCK_MODEL_PREFIX` constant |
| `datus/storage/embedding_litellm.py` | **NEW** — LiteLLM embedding with model-aware truncation |
| `datus/storage/embedding_models.py` | +LITELLM provider branch in `init_model()` |
| `datus/storage/vector/lance_backend.py` | +`_LanceLiteLLMAdapter` + `_wrap_embedding()` LiteLLM branch |
| `datus/models/claude_model.py` | Bedrock detection via constant + `anthropic_client` guard |
| `tests/unit_tests/storage/test_embedding_litellm.py` | **NEW** — 18 unit tests |
| `tests/unit_tests/models/test_claude_model.py` | +6 Bedrock-specific tests |
| `tests/unit_tests/storage/vector/test_lance_backend.py` | +1 LiteLLM wrapping test |

### Truncation Strategy

Replaced hardcoded `MAX_CHARS=12000` with model-aware approach:
- Uses `litellm.get_model_info(model)["max_input_tokens"]` to auto-detect each model's token limit
- Conservative char estimation: `max_input_tokens * 3` characters (handles CJK text)
- Graceful fallback to 8191 tokens (OpenAI default) if model info unavailable
- Per-text failure returns `None` instead of crashing the entire batch

### Configuration Example

```yaml
agent:
  target: bedrock_opus
  models:
    bedrock_opus:
      type: claude
      api_key: "bedrock-iam-auth"  # placeholder, IAM role used
      model: bedrock/us.anthropic.claude-opus-4-6-v1
  storage:
    database:
      registry_name: litellm
      model_name: bedrock/amazon.titan-embed-text-v2:0
      dim_size: 1024
```

### Testing

- 25 new unit tests (CI-tier, all mocked, zero external dependencies)
- 7762 existing tests pass with no regressions
- `ruff format` + `ruff check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS Bedrock-targeted Claude models
  * Added LiteLLM as an embedding provider with automatic dimensionality and token limit detection

* **Improvements**
  * Enhanced error handling to prevent native Anthropic API usage with Bedrock models with clear error guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->