### PR TITLE
[BugFix] Sync YAML files when updating vector DB entries via update_entry

### DIFF
--- a/datus/api/models/explorer_models.py
+++ b/datus/api/models/explorer_models.py
@@ -1,7 +1,7 @@
 """Data models for Explorer API endpoints."""
 
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -112,6 +112,13 @@ class EditMetricInput(BaseModel):
 
     subject_path: List[str] = Field(..., description="Path to the metric")
     yaml: str = Field(..., description="Updated YAML content")
+
+
+class EditSemanticModelInput(BaseModel):
+    """Edit semantic model entry (table or column)."""
+
+    entry_id: str = Field(..., description="Entry ID (e.g., 'table:orders', 'column:orders.amount')")
+    update_values: Dict[str, Any] = Field(..., description="Fields to update (e.g., {'description': 'new desc'})")
 
 
 # ========== Reference SQL Create/Get/Edit ==========

--- a/datus/api/routes/explorer_routes.py
+++ b/datus/api/routes/explorer_routes.py
@@ -12,6 +12,7 @@ from datus.api.models.explorer_models import (
     DeleteSubjectInput,
     EditKnowledgeInput,
     EditMetricInput,
+    EditSemanticModelInput,
     KnowledgeInfo,
     MetricInfo,
     ReferenceSQLInfo,
@@ -164,6 +165,20 @@ async def edit_metric(
 ) -> Result[dict]:
     """Edit metric YAML."""
     return await svc.explorer.edit_metric(request)
+
+
+@router.post(
+    "/subject/semantic_model/edit",
+    response_model=Result[dict],
+    summary="Edit Semantic Model",
+    description="Update a semantic model entry (table or column) by entry ID",
+)
+async def edit_semantic_model(
+    request: EditSemanticModelInput,
+    svc: ServiceDep,
+) -> Result[dict]:
+    """Edit semantic model entry."""
+    return await svc.explorer.edit_semantic_model(request)
 
 
 # ========== Knowledge Endpoints ==========

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -12,6 +12,7 @@ from datus.api.models.explorer_models import (
     DeleteSubjectInput,
     EditKnowledgeInput,
     EditMetricInput,
+    EditSemanticModelInput,
     KnowledgeInfo,
     MetricInfo,
     ReferenceSQLInfo,
@@ -46,10 +47,12 @@ class ExplorerService:
         from datus.storage.metric.store import MetricRAG
         from datus.storage.reference_sql.store import ReferenceSqlRAG
         from datus.storage.registry import get_subject_tree_store
+        from datus.storage.semantic_model.store import SemanticModelRAG
 
         self.metric_rag = MetricRAG(agent_config, datasource_id=self.datasource_id)
         self.reference_sql_rag = ReferenceSqlRAG(agent_config, datasource_id=self.datasource_id)
         self.knowledge_rag = ExtKnowledgeRAG(agent_config, datasource_id=self.datasource_id)
+        self.semantic_model_rag = SemanticModelRAG(agent_config, datasource_id=self.datasource_id)
         self.subject_tree_store = get_subject_tree_store(namespace=self.datasource_id)
 
     def _gen_reference_sql_id(self, sql: str) -> str:
@@ -1028,6 +1031,63 @@ class ExplorerService:
 
         except Exception as e:
             logger.error(f"Failed to edit metric: {e}")
+            from datus.api.models.config_models import ErrorCode
+
+            return Result[dict](
+                success=False,
+                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorMessage=str(e),
+            )
+
+    async def edit_semantic_model(self, request: EditSemanticModelInput) -> Result[dict]:
+        """Edit a semantic model entry (table or column).
+
+        Updates the vector DB and syncs changes back to the YAML file.
+
+        Args:
+            request: Edit semantic model input with entry_id and update_values
+
+        Returns:
+            Result[dict]
+        """
+        try:
+            from datus.api.models.config_models import ErrorCode
+
+            logger.info(f"Editing semantic model entry: {request.entry_id}")
+
+            if not request.entry_id:
+                return Result[dict](
+                    success=False,
+                    errorCode=ErrorCode.INVALID_PARAMETERS,
+                    errorMessage="entry_id cannot be empty",
+                )
+
+            if not request.update_values:
+                return Result[dict](
+                    success=False,
+                    errorCode=ErrorCode.INVALID_PARAMETERS,
+                    errorMessage="update_values cannot be empty",
+                )
+
+            self.semantic_model_rag.storage.update_entry(
+                entry_id=request.entry_id,
+                update_values=request.update_values,
+            )
+
+            logger.info(f"Successfully updated semantic model entry: {request.entry_id}")
+            return Result[dict](success=True, data={})
+
+        except ValueError as e:
+            logger.error(f"Failed to edit semantic model: {e}")
+            from datus.api.models.config_models import ErrorCode
+
+            return Result[dict](
+                success=False,
+                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorMessage=str(e),
+            )
+        except Exception as e:
+            logger.error(f"Failed to edit semantic model: {e}")
             from datus.api.models.config_models import ErrorCode
 
             return Result[dict](

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -1077,15 +1077,6 @@ class ExplorerService:
             logger.info(f"Successfully updated semantic model entry: {request.entry_id}")
             return Result[dict](success=True, data={})
 
-        except ValueError as e:
-            logger.error(f"Failed to edit semantic model: {e}")
-            from datus.api.models.config_models import ErrorCode
-
-            return Result[dict](
-                success=False,
-                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                errorMessage=str(e),
-            )
         except Exception as e:
             logger.error(f"Failed to edit semantic model: {e}")
             from datus.api.models.config_models import ErrorCode

--- a/datus/cli/screen/base_widgets.py
+++ b/datus/cli/screen/base_widgets.py
@@ -211,6 +211,7 @@ class InputWithLabel(Widget):
     InputWithLabel Label {
         padding: 1;
         width: 10%;
+        min-width: 18;
         text-align: right;
     }
     InputWithLabel TextArea {

--- a/datus/cli/screen/subject_screen.py
+++ b/datus/cli/screen/subject_screen.py
@@ -179,6 +179,21 @@ class MetricsPanel(Vertical):
 
     can_focus = True
 
+    # Field labels that must always be read-only regardless of the panel's overall mode.
+    _ALWAYS_READONLY_LABELS = frozenset({"Dimensions"})
+
+    # Description textarea grows with content, bounded below so short metrics still look
+    # like a writable field and bounded above so very long descriptions don't push the
+    # rest of the panel out of view.
+    _DESCRIPTION_MIN_LINES = 2
+    _DESCRIPTION_MAX_LINES = 20
+
+    @classmethod
+    def _compute_description_lines(cls, text: str) -> int:
+        """Clamp a description's newline count into the panel's min/max bounds."""
+        raw_lines = (text or "").count("\n") + 1
+        return max(cls._DESCRIPTION_MIN_LINES, min(cls._DESCRIPTION_MAX_LINES, raw_lines))
+
     def __init__(self, metric: Dict[str, Any], readonly: bool = True) -> None:
         super().__init__()
         self.entry = metric
@@ -189,10 +204,11 @@ class MetricsPanel(Vertical):
         metric_name = self.entry.get("name", "Unnamed Metric")
         yield Label(f"📊 [bold cyan]Metric: {metric_name}[/]")
 
+        description_text = self.entry.get("description", "")
         description_field = InputWithLabel(
             "Description",
-            self.entry.get("description", ""),
-            lines=10,
+            description_text,
+            lines=self._compute_description_lines(description_text),
             readonly=self.readonly,
             language="markdown",
         )
@@ -204,11 +220,13 @@ class MetricsPanel(Vertical):
         dimensions_str = (
             ", ".join(dimensions_value) if isinstance(dimensions_value, list) else str(dimensions_value or "")
         )
+        # Dimensions are a metricflow-derived view of the metric's available group-by axes,
+        # not a user-editable field — pin it to read-only regardless of the panel's mode.
         dimensions_field = InputWithLabel(
             "Dimensions",
             dimensions_str,
             lines=2,
-            readonly=self.readonly,
+            readonly=True,
             language="markdown",
         )
         self.fields.append(dimensions_field)
@@ -237,10 +255,16 @@ class MetricsPanel(Vertical):
     def set_readonly(self, readonly: bool) -> None:
         """
         Toggle the read-only mode for all fields in this panel.
+
+        Fields listed in ``_ALWAYS_READONLY_LABELS`` are pinned to read-only and
+        ignore the toggle (e.g. Dimensions is derived, not user-editable).
         """
         self.readonly = readonly
         for field in self.fields:
-            field.set_readonly(readonly)
+            if field.label_text in self._ALWAYS_READONLY_LABELS:
+                field.set_readonly(True)
+            else:
+                field.set_readonly(readonly)
 
     def is_modified(self) -> bool:
         """
@@ -290,11 +314,9 @@ class ReferenceSqlPanel(Vertical):
         )
         self.fields.append(summary_field)
         yield summary_field
-        comment_field = InputWithLabel(
-            "Comment", self.entry.get("comment", ""), lines=2, readonly=self.readonly, language="markdown"
-        )
-        self.fields.append(comment_field)
-        yield comment_field
+        # Note: ``comment`` is an internal reserved storage field and is intentionally
+        # not exposed in the UI or round-tripped via edits; the underlying YAML's
+        # ``comment`` is left untouched on update.
         search_text_field = InputWithLabel(
             "Search Text", self.entry.get("search_text", ""), lines=2, readonly=self.readonly, language="markdown"
         )
@@ -314,10 +336,9 @@ class ReferenceSqlPanel(Vertical):
 
     def _fill_data(self):
         self.fields[0].set_value(self.entry.get("summary", ""))
-        self.fields[1].set_value(self.entry.get("comment", ""))
-        self.fields[2].set_value(self.entry.get("search_text", ""))
-        self.fields[3].set_value(self.entry.get("tags", ""))
-        self.fields[4].set_value(self.entry.get("sql", ""))
+        self.fields[1].set_value(self.entry.get("search_text", ""))
+        self.fields[2].set_value(self.entry.get("tags", ""))
+        self.fields[3].set_value(self.entry.get("sql", ""))
 
     def update_data(self, summary_data: Dict[str, Any]):
         self.entry.update(summary_data)
@@ -1726,8 +1747,7 @@ class SubjectScreen(ContextScreen):
 
             if summary := sql_entry.get("summary"):
                 details.add_row("Summary", summary)
-            if comment := sql_entry.get("comment"):
-                details.add_row("Comment", comment)
+            # ``comment`` is an internal reserved field and is intentionally hidden from the detail view.
             if search_text := sql_entry.get("search_text"):
                 details.add_row("Search Text", search_text)
             if tags := sql_entry.get("tags"):

--- a/datus/cli/screen/subject_screen.py
+++ b/datus/cli/screen/subject_screen.py
@@ -188,15 +188,6 @@ class MetricsPanel(Vertical):
     def compose(self) -> ComposeResult:
         metric_name = self.entry.get("name", "Unnamed Metric")
         yield Label(f"📊 [bold cyan]Metric: {metric_name}[/]")
-        semantic_model_field = InputWithLabel(
-            "Semantic Model Name",
-            self.entry.get("semantic_model_name", ""),
-            lines=1,
-            readonly=self.readonly,
-            language="markdown",
-        )
-        self.fields.append(semantic_model_field)
-        yield semantic_model_field
 
         description_field = InputWithLabel(
             "Description",
@@ -235,14 +226,13 @@ class MetricsPanel(Vertical):
         yield sql_field
 
     def _fill_data(self):
-        self.fields[0].set_value(self.entry.get("semantic_model_name", ""))
-        self.fields[1].set_value(self.entry.get("description", ""))
+        self.fields[0].set_value(self.entry.get("description", ""))
         dimensions_value = self.entry.get("dimensions", [])
         dimensions_str = (
             ", ".join(dimensions_value) if isinstance(dimensions_value, list) else str(dimensions_value or "")
         )
-        self.fields[2].set_value(dimensions_str)
-        self.fields[3].set_value(self.entry.get("sql", ""))
+        self.fields[1].set_value(dimensions_str)
+        self.fields[2].set_value(self.entry.get("sql", ""))
 
     def set_readonly(self, readonly: bool) -> None:
         """
@@ -261,17 +251,8 @@ class MetricsPanel(Vertical):
     def get_value(self) -> Dict[str, str]:
         """
         Return a dictionary mapping field labels to their current values.
-
-        Maps field labels to their storage keys.
         """
-        values: Dict[str, str] = {}
-        for field in self.fields:
-            key = field.label_text.lower()
-            if key == "semantic model name":
-                key = "semantic_model_name"
-            # description remains as "description"
-            values[key] = field.get_value()
-        return values
+        return {field.label_text.lower(): field.get_value() for field in self.fields}
 
     def restore(self):
         for field in self.fields:
@@ -309,6 +290,11 @@ class ReferenceSqlPanel(Vertical):
         )
         self.fields.append(summary_field)
         yield summary_field
+        comment_field = InputWithLabel(
+            "Comment", self.entry.get("comment", ""), lines=2, readonly=self.readonly, language="markdown"
+        )
+        self.fields.append(comment_field)
+        yield comment_field
         search_text_field = InputWithLabel(
             "Search Text", self.entry.get("search_text", ""), lines=2, readonly=self.readonly, language="markdown"
         )
@@ -328,9 +314,10 @@ class ReferenceSqlPanel(Vertical):
 
     def _fill_data(self):
         self.fields[0].set_value(self.entry.get("summary", ""))
-        self.fields[1].set_value(self.entry.get("search_text", ""))
-        self.fields[2].set_value(self.entry.get("tags", ""))
-        self.fields[3].set_value(self.entry.get("sql", ""))
+        self.fields[1].set_value(self.entry.get("comment", ""))
+        self.fields[2].set_value(self.entry.get("search_text", ""))
+        self.fields[3].set_value(self.entry.get("tags", ""))
+        self.fields[4].set_value(self.entry.get("sql", ""))
 
     def update_data(self, summary_data: Dict[str, Any]):
         self.entry.update(summary_data)
@@ -392,7 +379,7 @@ class ExtKnowledgePanel(Vertical):
         knowledge_name = self.entry.get("name", "Unnamed Knowledge")
         yield Label(f"📚 [bold cyan]Knowledge: {knowledge_name}[/]")
         search_text_field = InputWithLabel(
-            "search_text",
+            "Search Text",
             self.entry.get("search_text", ""),
             lines=2,
             readonly=self.readonly,
@@ -1448,8 +1435,29 @@ class SubjectScreen(ContextScreen):
             # Apply the edit to SubjectTreeStore or vector store
 
             if node_type == "subject_node":
-                # Rename/move subject node in tree
+                # Capture the node_id BEFORE the rename so we can later walk its
+                # subtree to sync YAML files.
+                old_node = self.subject_tree_store.get_node_by_path(old_path)
+
+                # Rename/move subject node in tree. This updates the subject_tree
+                # table in place -- descendant entries keep their subject_node_id,
+                # so no vector DB changes are needed. However, YAML files on disk
+                # store the subject_tree path as a literal string and must be
+                # synced manually.
                 self.subject_tree_store.rename(old_path, new_path)
+
+                if old_node:
+                    root_id = old_node["node_id"]
+                    try:
+                        self.metrics_rag.storage.sync_yaml_subject_tree_for_subtree(root_id)
+                        _fetch_metrics_with_cache.cache_clear()
+                    except Exception as e:
+                        logger.warning(f"Failed to sync metric YAMLs after subject_node rename: {e}")
+                    try:
+                        self.sql_rag.reference_sql_storage.sync_yaml_subject_tree_for_subtree(root_id)
+                        _sql_details_cache.cache_clear()
+                    except Exception as e:
+                        logger.warning(f"Failed to sync reference_sql YAMLs after subject_node rename: {e}")
 
             elif node_type == "subject_entry":
                 # Rename subject_entry in vector store (storage)
@@ -1718,6 +1726,8 @@ class SubjectScreen(ContextScreen):
 
             if summary := sql_entry.get("summary"):
                 details.add_row("Summary", summary)
+            if comment := sql_entry.get("comment"):
+                details.add_row("Comment", comment)
             if search_text := sql_entry.get("search_text"):
                 details.add_row("Search Text", search_text)
             if tags := sql_entry.get("tags"):

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -538,13 +538,15 @@ class BaseEmbeddingStore(StorageBase):
                     },
                 )
 
-        # Re-embed when the vector source column is updated
+        # Re-embed when the vector source column is updated.
+        # Only overwrite the vector when we got a non-None embedding back; on failure or empty
+        # source text, leave the existing vector untouched so the row stays usable.
         if self.vector_source_name in update_values:
             new_text = update_values[self.vector_source_name]
             if new_text:
                 try:
                     vectors = self.model.model.generate_embeddings([str(new_text)])
-                    if vectors and len(vectors) > 0:
+                    if vectors and len(vectors) > 0 and vectors[0] is not None:
                         update_values[self.vector_column_name] = vectors[0]
                 except Exception as e:
                     logger.warning(f"Failed to re-embed on update for {self.table_name}: {e}")

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -537,6 +537,18 @@ class BaseEmbeddingStore(StorageBase):
                         "error_message": f"Conflicting rows already match {unique_filter}",
                     },
                 )
+
+        # Re-embed when the vector source column is updated
+        if self.vector_source_name in update_values:
+            new_text = update_values[self.vector_source_name]
+            if new_text:
+                try:
+                    vectors = self.model.model.generate_embeddings([str(new_text)])
+                    if vectors and len(vectors) > 0:
+                        update_values[self.vector_column_name] = vectors[0]
+                except Exception as e:
+                    logger.warning(f"Failed to re-embed on update for {self.table_name}: {e}")
+
         self.table.update(where=where, values=update_values)
 
     # -- Convenience methods for subclasses --

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.registry import get_storage
 from datus.storage.semantic_model.store import SemanticModelStorage
+from datus.utils.exceptions import DatusException
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -50,7 +51,7 @@ class CatalogUpdater:
             entry_id = f"table:{table_name}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, {"description": update_values["description"]})
-            except ValueError:
+            except DatusException:
                 logger.warning(f"Table entry not found: {entry_id}")
             else:
                 logger.debug("Updated table-level semantic model description")
@@ -120,7 +121,7 @@ class CatalogUpdater:
             entry_id = f"column:{table_name}.{col_name}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, changed)
-            except ValueError:
+            except DatusException:
                 logger.warning(f"Column entry not found: {entry_id}")
             else:
                 logger.debug(f"Updated column '{col_name}' ({kind_field}): {list(changed.keys())}")

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -47,7 +47,7 @@ class CatalogUpdater:
 
         # 1. Update table-level record (description)
         if "description" in update_values:
-            entry_id = f"table:{semantic_model_name or table_name}"
+            entry_id = f"table:{table_name}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, {"description": update_values["description"]})
             except ValueError:
@@ -117,7 +117,7 @@ class CatalogUpdater:
             if not changed:
                 continue
 
-            entry_id = f"column:{semantic_model_name or table_name}.{col_name}"
+            entry_id = f"column:{table_name}.{col_name}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, changed)
             except ValueError:

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.registry import get_storage
 from datus.storage.semantic_model.store import SemanticModelStorage
-from datus.utils.exceptions import DatusException
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -51,8 +51,11 @@ class CatalogUpdater:
             entry_id = f"table:{table_name}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, {"description": update_values["description"]})
-            except DatusException:
-                logger.warning(f"Table entry not found: {entry_id}")
+            except DatusException as e:
+                if e.code == ErrorCode.STORAGE_ENTRY_NOT_FOUND:
+                    logger.warning(f"Table entry not found: {entry_id}")
+                else:
+                    raise
             else:
                 logger.debug("Updated table-level semantic model description")
 
@@ -121,7 +124,10 @@ class CatalogUpdater:
             entry_id = f"column:{table_name}.{col_name}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, changed)
-            except DatusException:
-                logger.warning(f"Column entry not found: {entry_id}")
+            except DatusException as e:
+                if e.code == ErrorCode.STORAGE_ENTRY_NOT_FOUND:
+                    logger.warning(f"Column entry not found: {entry_id}")
+                else:
+                    raise
             else:
                 logger.debug(f"Updated column '{col_name}' ({kind_field}): {list(changed.keys())}")

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -9,8 +9,6 @@ Used to manage editing operations related to Catalog
 import json
 from typing import Any, Dict, List, Optional
 
-from datus_storage_base.conditions import And, eq
-
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.registry import get_storage
 from datus.storage.semantic_model.store import SemanticModelStorage
@@ -29,11 +27,6 @@ class CatalogUpdater:
         self.datasource_id = datasource_id or agent_config.current_database or ""
         self.semantic_model_storage = get_storage(SemanticModelStorage, "semantic_model", namespace=self.datasource_id)
 
-    def _get_all_storages(self) -> List[SemanticModelStorage]:
-        """Get all storages for updates. All sub-agents share the same singleton storage,
-        so returning it once is sufficient to avoid duplicate updates."""
-        return [self.semantic_model_storage]
-
     def _parse_json_field(self, value: Any) -> Optional[List[Dict[str, Any]]]:
         """Parse JSON string or return list directly."""
         if value is None:
@@ -49,60 +42,39 @@ class CatalogUpdater:
         return None
 
     def update_semantic_model(self, old_values: Dict[str, Any], update_values: Dict[str, Any]):
-        catalog_name = old_values.get("catalog_name", "")
-        database_name = old_values.get("database_name", "")
-        schema_name = old_values.get("schema_name", "")
         table_name = old_values.get("table_name", "")
         semantic_model_name = old_values.get("semantic_model_name", "")
 
-        storages = self._get_all_storages()
-
         # 1. Update table-level record (description)
         if "description" in update_values:
-            table_where = And(
-                [
-                    eq("kind", "table"),
-                    eq("catalog_name", catalog_name),
-                    eq("database_name", database_name),
-                    eq("schema_name", schema_name),
-                    eq("table_name", table_name),
-                    eq("name", semantic_model_name),
-                ]
-            )
-            table_update = {"description": update_values["description"]}
-            for storage in storages:
-                storage.update(table_where, table_update, unique_filter=None)
-            logger.debug("Updated table-level semantic model description")
+            entry_id = f"table:{semantic_model_name or table_name}"
+            try:
+                self.semantic_model_storage.update_entry(entry_id, {"description": update_values["description"]})
+            except ValueError:
+                logger.warning(f"Table entry not found: {entry_id}")
+            else:
+                logger.debug("Updated table-level semantic model description")
 
         # 2. Update column-level records (dimensions, measures, identifiers)
         self._update_columns(
-            storages,
-            catalog_name,
-            database_name,
-            schema_name,
             table_name,
+            semantic_model_name,
             old_values.get("dimensions"),
             update_values.get("dimensions"),
             "is_dimension",
             {"description", "expr", "column_type", "is_partition", "time_granularity"},
         )
         self._update_columns(
-            storages,
-            catalog_name,
-            database_name,
-            schema_name,
             table_name,
+            semantic_model_name,
             old_values.get("measures"),
             update_values.get("measures"),
             "is_measure",
             {"description", "expr", "agg", "create_metric", "agg_time_dimension"},
         )
         self._update_columns(
-            storages,
-            catalog_name,
-            database_name,
-            schema_name,
             table_name,
+            semantic_model_name,
             old_values.get("identifiers"),
             update_values.get("identifiers"),
             "is_entity_key",
@@ -111,11 +83,8 @@ class CatalogUpdater:
 
     def _update_columns(
         self,
-        storages: List[SemanticModelStorage],
-        catalog_name: str,
-        database_name: str,
-        schema_name: str,
         table_name: str,
+        semantic_model_name: str,
         old_columns: Any,
         new_columns: Any,
         kind_field: str,
@@ -139,29 +108,19 @@ class CatalogUpdater:
             changed = {}
             for field in allowed_fields:
                 # Map 'type' field to 'column_type' in storage
-                new_key = field
                 old_key = "type" if field == "column_type" else field
                 new_val = new_item.get("type" if field == "column_type" else field)
                 old_val = old_item.get(old_key)
                 if new_val != old_val:
-                    changed[new_key] = new_val
+                    changed[field] = new_val
 
             if not changed:
                 continue
 
-            # Build where clause for this column
-            col_where = And(
-                [
-                    eq("kind", "column"),
-                    eq(kind_field, True),
-                    eq("catalog_name", catalog_name),
-                    eq("database_name", database_name),
-                    eq("schema_name", schema_name),
-                    eq("table_name", table_name),
-                    eq("name", col_name),
-                ]
-            )
-
-            for storage in storages:
-                storage.update(col_where, changed, unique_filter=None)
-            logger.debug(f"Updated column '{col_name}' ({kind_field}): {list(changed.keys())}")
+            entry_id = f"column:{semantic_model_name or table_name}.{col_name}"
+            try:
+                self.semantic_model_storage.update_entry(entry_id, changed)
+            except ValueError:
+                logger.warning(f"Column entry not found: {entry_id}")
+            else:
+                logger.debug(f"Updated column '{col_name}' ({kind_field}): {list(changed.keys())}")

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -273,6 +273,86 @@ class MetricStorage(BaseSubjectEmbeddingStore):
 
         return result
 
+    def update_entry(
+        self,
+        subject_path: List[str],
+        name: str,
+        update_values: Dict[str, Any],
+        extra_conditions: Optional[List] = None,
+    ) -> bool:
+        """Update a metric in the vector DB and sync changes back to the YAML file.
+
+        Args:
+            subject_path: Subject hierarchy path (e.g., ['Finance', 'Revenue'])
+            name: Name of the metric to update
+            update_values: Dict of field names to new values
+            extra_conditions: Additional filter conditions
+
+        Returns:
+            True if the update succeeded, False otherwise
+        """
+        # Query yaml_path BEFORE the update (same pattern as delete_metric)
+        full_path = subject_path.copy()
+        full_path.append(name)
+        metrics = self.search_all_metrics(
+            subject_path=full_path,
+            select_fields=["name", "yaml_path"],
+            extra_conditions=extra_conditions,
+        )
+        yaml_paths = list({m.get("yaml_path") for m in metrics if m.get("yaml_path")})
+
+        # Update in vector store using base class method
+        result = super().update_entry(subject_path, name, update_values, extra_conditions)
+
+        # Sync changes to each yaml file
+        for yaml_path in yaml_paths:
+            self._sync_metric_update_to_yaml(yaml_path, name, update_values)
+
+        return result
+
+    def _sync_metric_update_to_yaml(self, yaml_path: str, name: str, update_values: Dict[str, Any]) -> None:
+        """Sync metric field updates back to the YAML file.
+
+        Args:
+            yaml_path: Path to the YAML file containing the metric
+            name: Name of the metric to update
+            update_values: Dict of vector DB field names to new values
+        """
+        import os
+
+        import yaml
+
+        _METRIC_DB_TO_YAML = {
+            "description": "description",
+            "metric_type": "type",
+        }
+
+        if not os.path.exists(yaml_path):
+            return
+
+        try:
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+
+            # Filter out None docs (empty sections in multi-doc YAML)
+            docs = [doc for doc in docs if doc is not None]
+
+            updated = False
+            for doc in docs:
+                if doc.get("metric", {}).get("name") == name:
+                    for db_key, yaml_key in _METRIC_DB_TO_YAML.items():
+                        if db_key in update_values:
+                            doc["metric"][yaml_key] = update_values[db_key]
+                    updated = True
+
+            if updated:
+                with open(yaml_path, "w", encoding="utf-8") as f:
+                    yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+                logger.info(f"Updated metric '{name}' in yaml file: {yaml_path}")
+
+        except Exception as e:
+            logger.error(f"Failed to update yaml file {yaml_path}: {e}")
+
 
 class MetricRAG:
     """RAG interface for metric operations.

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -311,6 +311,8 @@ class MetricStorage(BaseSubjectEmbeddingStore):
 
         # Update in vector store using base class method
         result = super().update_entry(subject_path, name, update_values, extra_conditions)
+        if not result:
+            return False
 
         # Sync changes to each yaml file
         for yaml_path in yaml_paths:

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import os
 from typing import Any, Dict, List, Optional
 
 import pyarrow as pa
+import yaml
 from datus_storage_base.conditions import WhereExpr, in_
 
 from datus.configuration.agent_config import AgentConfig
@@ -16,6 +18,11 @@ logger = get_logger(__name__)
 
 
 class MetricStorage(BaseSubjectEmbeddingStore):
+    _METRIC_DB_TO_YAML = {
+        "description": "description",
+        "metric_type": "type",
+    }
+
     def __init__(self, embedding_model: EmbeddingModel, **kwargs):
         super().__init__(
             table_name="metrics",
@@ -318,15 +325,6 @@ class MetricStorage(BaseSubjectEmbeddingStore):
             name: Name of the metric to update
             update_values: Dict of vector DB field names to new values
         """
-        import os
-
-        import yaml
-
-        _METRIC_DB_TO_YAML = {
-            "description": "description",
-            "metric_type": "type",
-        }
-
         if not os.path.exists(yaml_path):
             return
 
@@ -340,7 +338,7 @@ class MetricStorage(BaseSubjectEmbeddingStore):
             updated = False
             for doc in docs:
                 if doc.get("metric", {}).get("name") == name:
-                    for db_key, yaml_key in _METRIC_DB_TO_YAML.items():
+                    for db_key, yaml_key in self._METRIC_DB_TO_YAML.items():
                         if db_key in update_values:
                             doc["metric"][yaml_key] = update_values[db_key]
                     updated = True

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -18,9 +18,10 @@ logger = get_logger(__name__)
 
 
 class MetricStorage(BaseSubjectEmbeddingStore):
+    # Only fields editable through the CLI panel (MetricsPanel) are synced to YAML.
+    # Other metric fields (metric_type, type_params, etc.) are not exposed for UI edits.
     _METRIC_DB_TO_YAML = {
         "description": "description",
-        "metric_type": "type",
     }
 
     def __init__(self, embedding_model: EmbeddingModel, **kwargs):
@@ -350,6 +351,134 @@ class MetricStorage(BaseSubjectEmbeddingStore):
 
         except Exception as e:
             logger.error(f"Failed to update yaml file {yaml_path}: {e}")
+
+    def rename(self, old_path: List[str], new_path: List[str]) -> bool:
+        """Rename or move a metric entry and sync subject_tree to the YAML file.
+
+        When the parent subject path changes, update the metric's
+        ``locked_metadata.tags`` entry to reflect the new subject_tree.
+
+        Args:
+            old_path: Current full path (subject_path + name)
+            new_path: Target full path (subject_path + name)
+
+        Returns:
+            True on successful rename.
+        """
+        # Pre-query yaml_paths BEFORE the rename, using the old path
+        yaml_paths: List[str] = []
+        if len(old_path) >= 2:
+            try:
+                metrics = self.search_all_metrics(
+                    subject_path=old_path,
+                    select_fields=["name", "yaml_path"],
+                )
+                yaml_paths = list({m.get("yaml_path") for m in metrics if m.get("yaml_path")})
+            except Exception as e:
+                logger.warning(f"Failed to query yaml_path before metric rename: {e}")
+
+        result = super().rename(old_path, new_path)
+
+        # Sync subject_tree to YAML only when the parent path actually changes
+        old_parent = old_path[:-1] if len(old_path) >= 2 else []
+        new_parent = new_path[:-1] if len(new_path) >= 2 else []
+        if result and old_parent != new_parent and yaml_paths:
+            new_name = new_path[-1]
+            for yaml_path in yaml_paths:
+                self._sync_metric_subject_tree_to_yaml(yaml_path, new_name, new_parent)
+
+        return result
+
+    def _sync_metric_subject_tree_to_yaml(self, yaml_path: str, metric_name: str, new_parent_path: List[str]) -> None:
+        """Update the metric's locked_metadata.tags subject_tree entry in YAML.
+
+        Tag format: ``"subject_tree: path/component1/component2"``.
+        Replaces an existing subject_tree tag if present, otherwise appends it.
+
+        Args:
+            yaml_path: Path to the YAML file containing the metric
+            metric_name: Name of the metric to locate in the YAML
+            new_parent_path: New subject path components (excluding the metric name)
+        """
+        if not os.path.exists(yaml_path):
+            return
+
+        try:
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+
+            docs = [doc for doc in docs if doc is not None]
+            new_tag = f"subject_tree: {'/'.join(new_parent_path)}"
+
+            updated = False
+            for doc in docs:
+                if doc.get("metric", {}).get("name") != metric_name:
+                    continue
+                metric = doc["metric"]
+                locked_metadata = metric.setdefault("locked_metadata", {})
+                tags = locked_metadata.setdefault("tags", [])
+
+                replaced = False
+                for i, tag in enumerate(tags):
+                    if isinstance(tag, str) and tag.startswith("subject_tree:"):
+                        tags[i] = new_tag
+                        replaced = True
+                        break
+                if not replaced:
+                    tags.append(new_tag)
+                updated = True
+
+            if updated:
+                with open(yaml_path, "w", encoding="utf-8") as f:
+                    yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+                logger.info(f"Updated subject_tree for metric '{metric_name}' in yaml file: {yaml_path}")
+
+        except Exception as e:
+            logger.error(f"Failed to sync subject_tree to yaml {yaml_path}: {e}")
+
+    def sync_yaml_subject_tree_for_subtree(self, root_node_id: int) -> None:
+        """Sync the ``subject_tree`` tag in metric YAML files for a whole subtree.
+
+        Intended to be called AFTER a subject_tree node has been renamed or moved
+        (via ``SubjectTreeStore.rename``). Walks ``root_node_id`` and all descendant
+        nodes, re-computes each node's full path from the (already updated)
+        subject_tree, and rewrites the ``locked_metadata.tags`` subject_tree entry
+        for every metric whose ``subject_node_id`` matches.
+
+        Vector DB rows are not touched here -- only the YAML files on disk.
+
+        Args:
+            root_node_id: ID of the renamed/moved subject node.
+        """
+        try:
+            descendants = self.subject_tree.get_descendants(root_node_id)
+        except Exception as e:
+            logger.warning(f"Failed to enumerate descendants of node {root_node_id}: {e}")
+            return
+
+        node_ids = [root_node_id] + [d["node_id"] for d in descendants]
+
+        for node_id in node_ids:
+            try:
+                new_parent_path = self.subject_tree.get_full_path(node_id)
+            except Exception as e:
+                logger.warning(f"Failed to compute full path for node {node_id}: {e}")
+                continue
+
+            if not new_parent_path:
+                continue
+
+            try:
+                entries = self.list_entries(node_id)
+            except Exception as e:
+                logger.warning(f"Failed to list metrics under node {node_id}: {e}")
+                continue
+
+            for entry in entries:
+                yaml_path = entry.get("yaml_path")
+                name = entry.get("name")
+                if yaml_path and name:
+                    self._sync_metric_subject_tree_to_yaml(yaml_path, name, new_parent_path)
 
 
 class MetricRAG:

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -260,6 +260,113 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
         except Exception as e:
             logger.error(f"Failed to update yaml file {filepath}: {e}")
 
+    def rename(self, old_path: List[str], new_path: List[str]) -> bool:
+        """Rename or move a reference SQL entry and sync subject_tree to YAML.
+
+        When the parent subject path changes, update the top-level
+        ``subject_tree`` field in the YAML file to reflect the new path.
+
+        Args:
+            old_path: Current full path (subject_path + name)
+            new_path: Target full path (subject_path + name)
+
+        Returns:
+            True on successful rename.
+        """
+        # Pre-query filepaths BEFORE the rename, using the old path
+        filepaths: List[str] = []
+        if len(old_path) >= 2:
+            try:
+                entries = self.search_all_reference_sql(
+                    subject_path=old_path,
+                    select_fields=["name", "filepath"],
+                )
+                filepaths = list({e.get("filepath") for e in entries if e.get("filepath")})
+            except Exception as e:
+                logger.warning(f"Failed to query filepath before reference sql rename: {e}")
+
+        result = super().rename(old_path, new_path)
+
+        # Sync subject_tree to YAML only when the parent path actually changes
+        old_parent = old_path[:-1] if len(old_path) >= 2 else []
+        new_parent = new_path[:-1] if len(new_path) >= 2 else []
+        if result and old_parent != new_parent and filepaths:
+            for filepath in filepaths:
+                self._sync_reference_sql_subject_tree_to_yaml(filepath, new_parent)
+
+        return result
+
+    def _sync_reference_sql_subject_tree_to_yaml(self, filepath: str, new_parent_path: List[str]) -> None:
+        """Update the top-level ``subject_tree`` field in a reference SQL YAML file.
+
+        Args:
+            filepath: Path to the YAML file
+            new_parent_path: New subject path components (excluding the entry name)
+        """
+        if not os.path.exists(filepath):
+            return
+
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                doc = yaml.safe_load(f)
+
+            if not isinstance(doc, dict):
+                return
+
+            doc["subject_tree"] = "/".join(new_parent_path)
+
+            with open(filepath, "w", encoding="utf-8") as f:
+                yaml.safe_dump(doc, f, allow_unicode=True, sort_keys=False)
+
+            logger.info(f"Updated subject_tree in reference SQL yaml file: {filepath}")
+        except Exception as e:
+            logger.error(f"Failed to sync subject_tree to yaml {filepath}: {e}")
+
+    def sync_yaml_subject_tree_for_subtree(self, root_node_id: int) -> None:
+        """Sync the ``subject_tree`` field in reference SQL YAML files for a subtree.
+
+        Intended to be called AFTER a subject_tree node has been renamed or moved
+        (via ``SubjectTreeStore.rename``). Walks ``root_node_id`` and all descendant
+        nodes, re-computes each node's full path from the (already updated)
+        subject_tree, and rewrites the top-level ``subject_tree`` field for every
+        reference SQL whose ``subject_node_id`` matches.
+
+        Vector DB rows are not touched here -- only the YAML files on disk.
+
+        Args:
+            root_node_id: ID of the renamed/moved subject node.
+        """
+        try:
+            descendants = self.subject_tree.get_descendants(root_node_id)
+        except Exception as e:
+            logger.warning(f"Failed to enumerate descendants of node {root_node_id}: {e}")
+            return
+
+        node_ids = [root_node_id] + [d["node_id"] for d in descendants]
+
+        for node_id in node_ids:
+            try:
+                new_parent_path = self.subject_tree.get_full_path(node_id)
+            except Exception as e:
+                logger.warning(f"Failed to compute full path for node {node_id}: {e}")
+                continue
+
+            if not new_parent_path:
+                continue
+
+            try:
+                entries = self.list_entries(node_id)
+            except Exception as e:
+                logger.warning(f"Failed to list reference SQL entries under node {node_id}: {e}")
+                continue
+
+            seen: set = set()
+            for entry in entries:
+                filepath = entry.get("filepath")
+                if filepath and filepath not in seen:
+                    seen.add(filepath)
+                    self._sync_reference_sql_subject_tree_to_yaml(filepath, new_parent_path)
+
 
 class ReferenceSqlRAG:
     """RAG interface for reference SQL operations.

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -188,6 +188,80 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
         """
         return self.delete_entry(subject_path, name, extra_conditions=extra_conditions)
 
+    def update_entry(
+        self,
+        subject_path: List[str],
+        name: str,
+        update_values: Dict[str, Any],
+        extra_conditions: Optional[List] = None,
+    ) -> bool:
+        """Update a reference SQL entry in the vector DB and sync changes to the source YAML file.
+
+        Args:
+            subject_path: Subject hierarchy path (e.g., ['Analytics', 'Reports'])
+            name: Name of the reference SQL entry to update
+            update_values: Dictionary of fields to update
+            extra_conditions: Additional filter conditions
+
+        Returns:
+            True if updated successfully, False if entry not found
+        """
+        full_path = list(subject_path) + [name]
+        entries = self.search_all_reference_sql(
+            subject_path=full_path,
+            select_fields=["name", "filepath"],
+            extra_conditions=extra_conditions,
+        )
+        filepaths = list({e.get("filepath") for e in entries if e.get("filepath")})
+
+        result = super().update_entry(subject_path, name, update_values, extra_conditions)
+
+        for filepath in filepaths:
+            self._sync_reference_sql_update_to_yaml(filepath, update_values)
+
+        return result
+
+    _SYNCABLE_FIELDS = {"sql", "comment", "summary", "search_text", "tags"}
+
+    def _sync_reference_sql_update_to_yaml(self, filepath: str, update_values: Dict[str, Any]) -> None:
+        """Sync update_values to the source YAML file for a reference SQL entry.
+
+        Only fields in _SYNCABLE_FIELDS are written back to the YAML file.
+
+        Args:
+            filepath: Path to the YAML file to update
+            update_values: Dictionary of fields to sync
+        """
+        import os
+
+        import yaml
+
+        if not os.path.exists(filepath):
+            return
+
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                doc = yaml.safe_load(f)
+
+            if not isinstance(doc, dict):
+                return
+
+            updated = False
+            for key, value in update_values.items():
+                if key in self._SYNCABLE_FIELDS:
+                    doc[key] = value
+                    updated = True
+
+            if not updated:
+                return
+
+            with open(filepath, "w", encoding="utf-8") as f:
+                yaml.safe_dump(doc, f, allow_unicode=True, sort_keys=False)
+
+            logger.info(f"Updated reference SQL in yaml file: {filepath}")
+        except Exception as e:
+            logger.error(f"Failed to update yaml file {filepath}: {e}")
+
 
 class ReferenceSqlRAG:
     """RAG interface for reference SQL operations.

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -225,14 +225,25 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
 
         return result
 
-    # ``comment`` is intentionally excluded: it is an internal reserved field that
-    # must not round-trip through edits, so pre-existing YAML comments stay untouched.
+    # ``comment`` (the YAML data key, not ``#`` annotations) is intentionally excluded:
+    # it is an internal reserved field, and dropping it here means an incoming
+    # update_values["comment"] is ignored so the existing ``comment:`` key in the
+    # file is not overwritten. This says nothing about ``#`` annotations — see the
+    # sync method's docstring for that caveat.
     _SYNCABLE_FIELDS = {"sql", "summary", "search_text", "tags"}
 
     def _sync_reference_sql_update_to_yaml(self, filepath: str, update_values: Dict[str, Any]) -> None:
         """Sync update_values to the source YAML file for a reference SQL entry.
 
-        Only fields in _SYNCABLE_FIELDS are written back to the YAML file.
+        Only keys in _SYNCABLE_FIELDS are written back to the YAML file; all other
+        keys in ``update_values`` (including the reserved ``comment`` data key) are
+        ignored, leaving those YAML keys untouched.
+
+        Caveat — ``#`` annotations: this helper goes through ``yaml.safe_load`` /
+        ``yaml.safe_dump``, which do not preserve hand-authored ``#`` comments or
+        blank lines. Any such annotations in the source file are lost whenever an
+        update actually rewrites the file. Preserving them would require a
+        round-trip loader (e.g. ``ruamel.yaml(typ="rt")``); that is out of scope.
 
         Args:
             filepath: Path to the YAML file to update

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -225,7 +225,9 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
 
         return result
 
-    _SYNCABLE_FIELDS = {"sql", "comment", "summary", "search_text", "tags"}
+    # ``comment`` is intentionally excluded: it is an internal reserved field that
+    # must not round-trip through edits, so pre-existing YAML comments stay untouched.
+    _SYNCABLE_FIELDS = {"sql", "summary", "search_text", "tags"}
 
     def _sync_reference_sql_update_to_yaml(self, filepath: str, update_values: Dict[str, Any]) -> None:
         """Sync update_values to the source YAML file for a reference SQL entry.

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import os
 from typing import Any, Dict, List, Optional
 
 import pyarrow as pa
+import yaml
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
@@ -232,10 +234,6 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
             filepath: Path to the YAML file to update
             update_values: Dictionary of fields to sync
         """
-        import os
-
-        import yaml
-
         if not os.path.exists(filepath):
             return
 

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -289,12 +289,20 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
 
         result = super().rename(old_path, new_path)
 
-        # Sync subject_tree to YAML only when the parent path actually changes
+        # Sync subject_tree to YAML only when the parent path actually changes;
+        # also sync the top-level ``name`` field when the entry basename changes.
         old_parent = old_path[:-1] if len(old_path) >= 2 else []
         new_parent = new_path[:-1] if len(new_path) >= 2 else []
-        if result and old_parent != new_parent and filepaths:
+        old_name = old_path[-1] if old_path else ""
+        new_name = new_path[-1] if new_path else ""
+        if result and filepaths:
+            parent_changed = old_parent != new_parent
+            name_changed = old_name != new_name
             for filepath in filepaths:
-                self._sync_reference_sql_subject_tree_to_yaml(filepath, new_parent)
+                if parent_changed:
+                    self._sync_reference_sql_subject_tree_to_yaml(filepath, new_parent)
+                if name_changed:
+                    self._sync_reference_sql_name_to_yaml(filepath, old_name, new_name)
 
         return result
 
@@ -323,6 +331,38 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
             logger.info(f"Updated subject_tree in reference SQL yaml file: {filepath}")
         except Exception as e:
             logger.error(f"Failed to sync subject_tree to yaml {filepath}: {e}")
+
+    def _sync_reference_sql_name_to_yaml(self, filepath: str, old_name: str, new_name: str) -> None:
+        """Update the top-level ``name`` field in a reference SQL YAML file after a rename.
+
+        Only rewrites the file when the existing ``name`` matches ``old_name``; this avoids
+        clobbering files that contain a different entry but happen to share a filepath.
+
+        Args:
+            filepath: Path to the YAML file
+            old_name: The previous entry name (for safety check)
+            new_name: The new entry name
+        """
+        if not os.path.exists(filepath):
+            return
+
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                doc = yaml.safe_load(f)
+
+            if not isinstance(doc, dict):
+                return
+            if doc.get("name") != old_name:
+                return
+
+            doc["name"] = new_name
+
+            with open(filepath, "w", encoding="utf-8") as f:
+                yaml.safe_dump(doc, f, allow_unicode=True, sort_keys=False)
+
+            logger.info(f"Updated name '{old_name}' -> '{new_name}' in reference SQL yaml file: {filepath}")
+        except Exception as e:
+            logger.error(f"Failed to sync name to yaml {filepath}: {e}")
 
     def sync_yaml_subject_tree_for_subtree(self, root_node_id: int) -> None:
         """Sync the ``subject_tree`` field in reference SQL YAML files for a subtree.

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -217,6 +217,8 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
         filepaths = list({e.get("filepath") for e in entries if e.get("filepath")})
 
         result = super().update_entry(subject_path, name, update_values, extra_conditions)
+        if not result:
+            return False
 
         for filepath in filepaths:
             self._sync_reference_sql_update_to_yaml(filepath, update_values)

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -121,6 +121,12 @@ class SemanticModelStorage(BaseEmbeddingStore):
         "description": "description",
         "expr": "expr",
         "column_type": "type",
+        "agg": "agg",
+        "create_metric": "create_metric",
+        "agg_time_dimension": "agg_time_dimension",
+        "is_partition": "is_partition",
+        "time_granularity": "time_granularity",
+        "entity": "entity",
     }
 
     def update_entry(self, entry_id: str, update_values: Dict[str, Any]) -> bool:

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pyarrow as pa
+import yaml
 from datus_storage_base.conditions import And, WhereExpr, eq, in_
 
 from datus.storage.base import BaseEmbeddingStore, EmbeddingModel
@@ -166,10 +168,6 @@ class SemanticModelStorage(BaseEmbeddingStore):
             name: Short name of the entry (table name or column name)
             update_values: Dictionary of vector-DB field names and new values
         """
-        import os
-
-        import yaml
-
         if not os.path.exists(yaml_path):
             return
 

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -10,6 +10,7 @@ import yaml
 from datus_storage_base.conditions import And, WhereExpr, eq, in_
 
 from datus.storage.base import BaseEmbeddingStore, EmbeddingModel
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
@@ -143,15 +144,19 @@ class SemanticModelStorage(BaseEmbeddingStore):
             ValueError: If entry not found or update_values is empty
         """
         if not entry_id:
-            raise ValueError("entry_id must not be empty")
+            raise DatusException(
+                ErrorCode.STORAGE_INVALID_ARGUMENT, message_args={"error_message": "entry_id must not be empty"}
+            )
         if not update_values:
-            raise ValueError("update_values must not be empty")
+            raise DatusException(
+                ErrorCode.STORAGE_INVALID_ARGUMENT, message_args={"error_message": "update_values must not be empty"}
+            )
 
         entries = self._search_all(
             where=eq("id", entry_id), select_fields=["id", "kind", "name", "yaml_path"]
         ).to_pylist()
         if not entries:
-            raise ValueError(f"Entry not found: {entry_id}")
+            raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
         entry = entries[0]
         yaml_path = entry.get("yaml_path", "")
 

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -153,23 +153,32 @@ class SemanticModelStorage(BaseEmbeddingStore):
             )
 
         entries = self._search_all(
-            where=eq("id", entry_id), select_fields=["id", "kind", "name", "yaml_path"]
+            where=eq("id", entry_id), select_fields=["id", "kind", "name", "table_name", "yaml_path"]
         ).to_pylist()
         if not entries:
             raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
         entry = entries[0]
         yaml_path = entry.get("yaml_path", "")
+        # Use table_name to disambiguate the data_source document when a YAML file holds
+        # multiple semantic models. For table-kind rows the entry's own ``name`` IS the
+        # data_source name, so fall back to it when ``table_name`` is empty.
+        data_source_name = entry.get("table_name") or entry["name"]
 
         self.update(where=eq("id", entry_id), update_values=update_values)
 
         if yaml_path:
-            self._sync_semantic_update_to_yaml(yaml_path, entry["kind"], entry["name"], update_values)
+            self._sync_semantic_update_to_yaml(yaml_path, entry["kind"], entry["name"], data_source_name, update_values)
 
         logger.info(f"Updated semantic model entry '{entry['name']}' (kind={entry['kind']})")
         return True
 
     def _sync_semantic_update_to_yaml(
-        self, yaml_path: str, kind: str, name: str, update_values: Dict[str, Any]
+        self,
+        yaml_path: str,
+        kind: str,
+        name: str,
+        data_source_name: str,
+        update_values: Dict[str, Any],
     ) -> None:
         """Sync update_values for a semantic model entry back to its YAML file.
 
@@ -177,6 +186,8 @@ class SemanticModelStorage(BaseEmbeddingStore):
             yaml_path: Path to the YAML file containing the data_source document
             kind: Entry kind — "table" or "column"
             name: Short name of the entry (table name or column name)
+            data_source_name: Name of the parent data_source document (used to disambiguate
+                YAML files that contain multiple ``data_source`` blocks)
             update_values: Dictionary of vector-DB field names and new values
         """
         if not os.path.exists(yaml_path):
@@ -186,11 +197,26 @@ class SemanticModelStorage(BaseEmbeddingStore):
             with open(yaml_path, encoding="utf-8") as f:
                 docs = [doc for doc in yaml.safe_load_all(f) if doc is not None]
 
+            # Prefer an exact match on the data_source name; only fall back to the first
+            # data_source doc if no name match exists (preserves legacy single-doc behavior
+            # without silently mutating the wrong model in a multi-doc file).
             data_source = None
+            fallback_data_source = None
             for doc in docs:
-                if "data_source" in doc:
-                    data_source = doc["data_source"]
+                ds = doc.get("data_source") if isinstance(doc, dict) else None
+                if not isinstance(ds, dict):
+                    continue
+                if fallback_data_source is None:
+                    fallback_data_source = ds
+                if data_source_name and ds.get("name") == data_source_name:
+                    data_source = ds
                     break
+            if data_source is None:
+                # Only fall back when the file holds exactly one data_source doc; otherwise
+                # we cannot safely guess which model to mutate.
+                ds_count = sum(1 for d in docs if isinstance(d, dict) and isinstance(d.get("data_source"), dict))
+                if ds_count == 1:
+                    data_source = fallback_data_source
 
             if data_source is None:
                 return

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -111,6 +111,115 @@ class SemanticModelStorage(BaseEmbeddingStore):
         """
         return self._search_all(where=where, select_fields=select_fields).to_pylist()
 
+    # ------------------------------------------------------------------
+    # Field mappings: vector DB field → YAML key
+    # ------------------------------------------------------------------
+    _TABLE_DB_TO_YAML: Dict[str, str] = {"description": "description"}
+    _COLUMN_DB_TO_YAML: Dict[str, str] = {
+        "description": "description",
+        "expr": "expr",
+        "column_type": "type",
+    }
+
+    def update_entry(self, entry_id: str, update_values: Dict[str, Any]) -> bool:
+        """Update a semantic model entry by ID and sync changes to the YAML file.
+
+        Args:
+            entry_id: Unique entry ID (e.g., "table:orders", "column:orders.amount")
+            update_values: Dictionary of field names and new values
+
+        Returns:
+            True if update successful
+
+        Raises:
+            ValueError: If entry not found or update_values is empty
+        """
+        if not entry_id:
+            raise ValueError("entry_id must not be empty")
+        if not update_values:
+            raise ValueError("update_values must not be empty")
+
+        entries = self._search_all(
+            where=eq("id", entry_id), select_fields=["id", "kind", "name", "yaml_path"]
+        ).to_pylist()
+        if not entries:
+            raise ValueError(f"Entry not found: {entry_id}")
+        entry = entries[0]
+        yaml_path = entry.get("yaml_path", "")
+
+        self.update(where=eq("id", entry_id), update_values=update_values)
+
+        if yaml_path:
+            self._sync_semantic_update_to_yaml(yaml_path, entry["kind"], entry["name"], update_values)
+
+        logger.info(f"Updated semantic model entry '{entry['name']}' (kind={entry['kind']})")
+        return True
+
+    def _sync_semantic_update_to_yaml(
+        self, yaml_path: str, kind: str, name: str, update_values: Dict[str, Any]
+    ) -> None:
+        """Sync update_values for a semantic model entry back to its YAML file.
+
+        Args:
+            yaml_path: Path to the YAML file containing the data_source document
+            kind: Entry kind — "table" or "column"
+            name: Short name of the entry (table name or column name)
+            update_values: Dictionary of vector-DB field names and new values
+        """
+        import os
+
+        import yaml
+
+        if not os.path.exists(yaml_path):
+            return
+
+        try:
+            with open(yaml_path, encoding="utf-8") as f:
+                docs = [doc for doc in yaml.safe_load_all(f) if doc is not None]
+
+            data_source = None
+            for doc in docs:
+                if "data_source" in doc:
+                    data_source = doc["data_source"]
+                    break
+
+            if data_source is None:
+                return
+
+            updated = False
+            if kind == "table":
+                for db_key, yaml_key in self._TABLE_DB_TO_YAML.items():
+                    if db_key in update_values:
+                        data_source[yaml_key] = update_values[db_key]
+                        updated = True
+
+            elif kind == "column":
+                target_item = None
+                for section in ("dimensions", "measures", "identifiers"):
+                    for item in data_source.get(section, []):
+                        if item.get("name") == name:
+                            target_item = item
+                            break
+                    if target_item is not None:
+                        break
+
+                if target_item is not None:
+                    for db_key, yaml_key in self._COLUMN_DB_TO_YAML.items():
+                        if db_key in update_values:
+                            target_item[yaml_key] = update_values[db_key]
+                            updated = True
+
+            if not updated:
+                return
+
+            with open(yaml_path, "w", encoding="utf-8") as f:
+                yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+
+            logger.info(f"Updated semantic model entry '{name}' (kind={kind}) in yaml file: {yaml_path}")
+
+        except Exception as e:
+            logger.error(f"Failed to update yaml file {yaml_path}: {e}")
+
 
 class SemanticModelRAG:
     """RAG interface for semantic model operations.

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -99,6 +99,8 @@ class ErrorCode(Enum):
         ),
     )
     STORAGE_INDEX_FAILED = ("410005", "Vector database index operation failed: {error_message}")
+    STORAGE_ENTRY_NOT_FOUND = ("410006", "Storage entry not found: {entry_id}")
+    STORAGE_INVALID_ARGUMENT = ("410007", "Invalid storage argument: {error_message}")
 
     # Database errors
     DB_FAILED = ("500000", "Database operation failed. Error details: {error_message}")

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -283,31 +283,6 @@ class TestUpdateMetricYaml:
             if os.path.exists(yaml_path):
                 os.remove(yaml_path)
 
-    def test_update_metric_maps_metric_type_to_yaml(self, metric_storage: MetricStorage):
-        """update_entry should map metric_type (DB) -> type (YAML)."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
-            yaml_path = f.name
-            docs = [{"metric": {"name": "typed_metric", "type": "simple"}}]
-            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
-
-        try:
-            metric = _make_metric(2, subject_path=["Finance"], yaml_path=yaml_path)
-            metric["name"] = "typed_metric"
-            metric["id"] = "metric:typed_metric"
-            metric["metric_type"] = "simple"
-            metric_storage.batch_store_metrics([metric])
-
-            result = metric_storage.update_entry(["Finance"], "typed_metric", {"metric_type": "derived"})
-            assert result is True
-
-            with open(yaml_path, "r", encoding="utf-8") as f:
-                docs_out = [d for d in yaml.safe_load_all(f) if d is not None]
-
-            assert docs_out[0]["metric"]["type"] == "derived"
-        finally:
-            if os.path.exists(yaml_path):
-                os.remove(yaml_path)
-
     def test_update_metric_no_yaml_path_still_succeeds(self, metric_storage: MetricStorage):
         """update_entry without yaml_path should update vector DB and return True."""
         metric = _make_metric(3, subject_path=["Finance", "Revenue"])
@@ -353,3 +328,287 @@ class TestUpdateMetricYaml:
         finally:
             if os.path.exists(yaml_path):
                 os.remove(yaml_path)
+
+
+# ---------------------------------------------------------------------------
+# YAML subject_tree sync on rename
+# ---------------------------------------------------------------------------
+
+
+class TestRenameMetricSubjectTreeYaml:
+    """Tests for YAML subject_tree sync in rename."""
+
+    def test_rename_move_replaces_subject_tree_tag(self, metric_storage: MetricStorage):
+        """Moving a metric to a new parent path should replace subject_tree in locked_metadata.tags."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            docs = [
+                {
+                    "metric": {
+                        "name": "move_me",
+                        "description": "to be moved",
+                        "locked_metadata": {"tags": ["subject_tree: Finance/Revenue", "other_tag"]},
+                    }
+                }
+            ]
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+
+        try:
+            # Pre-create the destination subject path so rename() can resolve it
+            metric_storage.subject_tree.find_or_create_path(["Finance", "Costs"])
+
+            metric = _make_metric(1, subject_path=["Finance", "Revenue"], yaml_path=yaml_path)
+            metric["name"] = "move_me"
+            metric["id"] = "metric:move_me"
+            metric_storage.batch_store_metrics([metric])
+
+            result = metric_storage.rename(
+                ["Finance", "Revenue", "move_me"],
+                ["Finance", "Costs", "move_me"],
+            )
+            assert result is True
+
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                docs_out = [d for d in yaml.safe_load_all(f) if d is not None]
+            tags = docs_out[0]["metric"]["locked_metadata"]["tags"]
+            assert "subject_tree: Finance/Costs" in tags
+            assert "subject_tree: Finance/Revenue" not in tags
+            assert "other_tag" in tags  # unrelated tag preserved
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
+    def test_rename_move_appends_subject_tree_tag_when_missing(self, metric_storage: MetricStorage):
+        """Moving a metric with no existing subject_tree tag should append a new one."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            docs = [{"metric": {"name": "untagged", "description": "no subject tree tag"}}]
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+
+        try:
+            metric_storage.subject_tree.find_or_create_path(["Finance", "Costs"])
+
+            metric = _make_metric(2, subject_path=["Finance", "Revenue"], yaml_path=yaml_path)
+            metric["name"] = "untagged"
+            metric["id"] = "metric:untagged"
+            metric_storage.batch_store_metrics([metric])
+
+            result = metric_storage.rename(
+                ["Finance", "Revenue", "untagged"],
+                ["Finance", "Costs", "untagged"],
+            )
+            assert result is True
+
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                docs_out = [d for d in yaml.safe_load_all(f) if d is not None]
+            tags = docs_out[0]["metric"]["locked_metadata"]["tags"]
+            assert tags == ["subject_tree: Finance/Costs"]
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
+    def test_rename_only_does_not_touch_subject_tree_tag(self, metric_storage: MetricStorage):
+        """Renaming without moving should leave YAML subject_tree untouched."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            docs = [
+                {
+                    "metric": {
+                        "name": "old_name",
+                        "description": "same parent",
+                        "locked_metadata": {"tags": ["subject_tree: Finance/Revenue"]},
+                    }
+                }
+            ]
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+
+        try:
+            metric = _make_metric(3, subject_path=["Finance", "Revenue"], yaml_path=yaml_path)
+            metric["name"] = "old_name"
+            metric["id"] = "metric:old_name"
+            metric_storage.batch_store_metrics([metric])
+
+            result = metric_storage.rename(
+                ["Finance", "Revenue", "old_name"],
+                ["Finance", "Revenue", "new_name"],
+            )
+            assert result is True
+
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                docs_out = [d for d in yaml.safe_load_all(f) if d is not None]
+            tags = docs_out[0]["metric"]["locked_metadata"]["tags"]
+            # YAML subject_tree tag unchanged — rename() does not touch it when parent is unchanged
+            assert tags == ["subject_tree: Finance/Revenue"]
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
+    def test_rename_move_without_yaml_path_still_succeeds(self, metric_storage: MetricStorage):
+        """Moving a metric without a yaml_path should still return True."""
+        metric_storage.subject_tree.find_or_create_path(["Finance", "Costs"])
+
+        metric = _make_metric(4, subject_path=["Finance", "Revenue"])
+        metric["name"] = "no_yaml_move"
+        metric["id"] = "metric:no_yaml_move"
+        metric["yaml_path"] = ""
+        metric_storage.batch_store_metrics([metric])
+
+        result = metric_storage.rename(
+            ["Finance", "Revenue", "no_yaml_move"],
+            ["Finance", "Costs", "no_yaml_move"],
+        )
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# YAML subject_tree sync when a subject_node is renamed/moved
+# ---------------------------------------------------------------------------
+
+
+class TestSyncYamlSubjectTreeForSubtree:
+    """Tests for sync_yaml_subject_tree_for_subtree — triggered after a
+    subject_tree node is renamed/moved, to sync YAML files of all descendants.
+    """
+
+    def _write_metric_yaml(self, tmp_path, metric_name: str, subject_tree_tag: str) -> str:
+        """Write a simple metric YAML with a subject_tree tag and return its path."""
+        yaml_path = os.path.join(tmp_path, f"{metric_name}.yml")
+        docs = [
+            {
+                "metric": {
+                    "name": metric_name,
+                    "description": f"desc for {metric_name}",
+                    "locked_metadata": {"tags": [f"subject_tree: {subject_tree_tag}", "keep_me"]},
+                }
+            }
+        ]
+        with open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+        return yaml_path
+
+    def _read_subject_tree_tags(self, yaml_path: str, metric_name: str) -> list:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            docs = [d for d in yaml.safe_load_all(f) if d is not None]
+        for doc in docs:
+            if doc.get("metric", {}).get("name") == metric_name:
+                return doc["metric"]["locked_metadata"]["tags"]
+        return []
+
+    def test_rename_node_syncs_yaml_for_direct_and_descendant_metrics(self, metric_storage: MetricStorage, tmp_path):
+        """Renaming an intermediate subject_node should update YAML subject_tree for
+        metrics under that node AND metrics under descendant nodes."""
+        tmp_path_str = str(tmp_path)
+
+        # Create subject tree:  Finance / Revenue / Q1
+        #                                         \ Detail (sub-folder of Q1)
+        metric_storage.subject_tree.find_or_create_path(["Finance", "Revenue", "Q1"])
+        metric_storage.subject_tree.find_or_create_path(["Finance", "Revenue", "Q1", "Detail"])
+
+        # Write YAML files referencing the OLD subject_tree paths
+        top_yaml = self._write_metric_yaml(tmp_path_str, "top_metric", "Finance/Revenue/Q1")
+        deep_yaml = self._write_metric_yaml(tmp_path_str, "deep_metric", "Finance/Revenue/Q1/Detail")
+
+        # Insert metrics pointing at each path
+        top_metric = _make_metric(10, subject_path=["Finance", "Revenue", "Q1"], yaml_path=top_yaml)
+        top_metric["name"] = "top_metric"
+        top_metric["id"] = "metric:top_metric"
+
+        deep_metric = _make_metric(11, subject_path=["Finance", "Revenue", "Q1", "Detail"], yaml_path=deep_yaml)
+        deep_metric["name"] = "deep_metric"
+        deep_metric["id"] = "metric:deep_metric"
+
+        metric_storage.batch_store_metrics([top_metric, deep_metric])
+
+        # Capture node_id BEFORE rename (stable across rename)
+        q1_node = metric_storage.subject_tree.get_node_by_path(["Finance", "Revenue", "Q1"])
+        assert q1_node is not None
+        root_id = q1_node["node_id"]
+
+        # Rename Q1 -> Quarter1 (in place)
+        metric_storage.subject_tree.rename(
+            ["Finance", "Revenue", "Q1"],
+            ["Finance", "Revenue", "Quarter1"],
+        )
+
+        # Sync YAML files for the renamed subtree
+        metric_storage.sync_yaml_subject_tree_for_subtree(root_id)
+
+        # Both YAMLs should reflect the new path
+        top_tags = self._read_subject_tree_tags(top_yaml, "top_metric")
+        assert "subject_tree: Finance/Revenue/Quarter1" in top_tags
+        assert "subject_tree: Finance/Revenue/Q1" not in top_tags
+        assert "keep_me" in top_tags
+
+        deep_tags = self._read_subject_tree_tags(deep_yaml, "deep_metric")
+        assert "subject_tree: Finance/Revenue/Quarter1/Detail" in deep_tags
+        assert "subject_tree: Finance/Revenue/Q1/Detail" not in deep_tags
+        assert "keep_me" in deep_tags
+
+        try:
+            pass
+        finally:
+            for p in (top_yaml, deep_yaml):
+                if os.path.exists(p):
+                    os.remove(p)
+
+    def test_move_node_syncs_yaml_for_descendant_metrics(self, metric_storage: MetricStorage, tmp_path):
+        """Moving a subject_node to a different parent should update YAML subject_tree
+        for all descendant metrics."""
+        tmp_path_str = str(tmp_path)
+
+        metric_storage.subject_tree.find_or_create_path(["Finance", "Revenue", "Q1"])
+        metric_storage.subject_tree.find_or_create_path(["Finance", "Costs"])
+
+        yaml_path = self._write_metric_yaml(tmp_path_str, "movable", "Finance/Revenue/Q1")
+
+        metric = _make_metric(12, subject_path=["Finance", "Revenue", "Q1"], yaml_path=yaml_path)
+        metric["name"] = "movable"
+        metric["id"] = "metric:movable"
+        metric_storage.batch_store_metrics([metric])
+
+        q1_node = metric_storage.subject_tree.get_node_by_path(["Finance", "Revenue", "Q1"])
+        assert q1_node is not None
+        root_id = q1_node["node_id"]
+
+        # Move Q1 from Finance/Revenue to Finance/Costs
+        metric_storage.subject_tree.rename(
+            ["Finance", "Revenue", "Q1"],
+            ["Finance", "Costs", "Q1"],
+        )
+
+        metric_storage.sync_yaml_subject_tree_for_subtree(root_id)
+
+        tags = self._read_subject_tree_tags(yaml_path, "movable")
+        assert "subject_tree: Finance/Costs/Q1" in tags
+        assert "subject_tree: Finance/Revenue/Q1" not in tags
+
+        try:
+            pass
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
+    def test_sync_skips_entries_without_yaml_path(self, metric_storage: MetricStorage, tmp_path):
+        """Metrics with an empty yaml_path should be silently skipped."""
+        metric_storage.subject_tree.find_or_create_path(["Finance", "Revenue", "Q1"])
+
+        metric = _make_metric(13, subject_path=["Finance", "Revenue", "Q1"])
+        metric["name"] = "no_yaml"
+        metric["id"] = "metric:no_yaml"
+        metric["yaml_path"] = ""
+        metric_storage.batch_store_metrics([metric])
+
+        q1_node = metric_storage.subject_tree.get_node_by_path(["Finance", "Revenue", "Q1"])
+        root_id = q1_node["node_id"]
+
+        # Should not raise
+        metric_storage.sync_yaml_subject_tree_for_subtree(root_id)
+
+    def test_sync_handles_subtree_with_no_metrics(self, metric_storage: MetricStorage):
+        """A subtree with no metric entries should be a no-op (no errors)."""
+        metric_storage.subject_tree.find_or_create_path(["Empty", "Branch"])
+        node = metric_storage.subject_tree.get_node_by_path(["Empty", "Branch"])
+        assert node is not None
+
+        # Should not raise
+        metric_storage.sync_yaml_subject_tree_for_subtree(node["node_id"])

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -329,9 +329,27 @@ class TestUpdateMetricYaml:
             if os.path.exists(yaml_path):
                 os.remove(yaml_path)
 
+    # ---------------------------------------------------------------------------
+    # YAML subject_tree sync on rename
+    def test_update_metric_entry_not_found_does_not_touch_yaml(self, metric_storage: MetricStorage):
+        """update_entry on a non-existent metric should raise and leave the YAML file untouched."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            docs = [{"metric": {"name": "existing", "description": "original"}}]
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
 
-# ---------------------------------------------------------------------------
-# YAML subject_tree sync on rename
+        try:
+            with pytest.raises(ValueError):
+                metric_storage.update_entry(["Finance", "Revenue"], "nonexistent_metric", {"description": "new"})
+
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                remaining = [d for d in yaml.safe_load_all(f) if d is not None]
+            assert remaining[0]["metric"]["description"] == "original"
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
+
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -329,8 +329,25 @@ class TestUpdateMetricYaml:
             if os.path.exists(yaml_path):
                 os.remove(yaml_path)
 
+    def test_update_metric_corrupt_yaml_does_not_raise(self, metric_storage: MetricStorage):
+        """_sync_metric_update_to_yaml catches exceptions on corrupt YAML files."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            f.write("{{invalid yaml")
+
+        try:
+            metric = _make_metric(10, subject_path=["Finance"], yaml_path=yaml_path)
+            metric["name"] = "corrupt_yaml_metric"
+            metric["id"] = "metric:corrupt"
+            metric_storage.batch_store_metrics([metric])
+
+            result = metric_storage.update_entry(["Finance"], "corrupt_yaml_metric", {"description": "new"})
+            assert result is True
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
     # ---------------------------------------------------------------------------
-    # YAML subject_tree sync on rename
     def test_update_metric_entry_not_found_does_not_touch_yaml(self, metric_storage: MetricStorage):
         """update_entry on a non-existent metric should raise and leave the YAML file untouched."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -240,3 +240,116 @@ class TestDeleteMetricYaml:
         result = metric_storage.delete_metric(["Finance", "Revenue"], "no_yaml_metric")
         assert result["success"] is True
         assert result.get("yaml_updated", False) is False
+
+
+# ---------------------------------------------------------------------------
+# YAML update logic in update_entry
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMetricYaml:
+    """Tests for YAML file sync in update_entry."""
+
+    def test_update_metric_syncs_to_yaml_file(self, metric_storage: MetricStorage):
+        """update_entry should write the updated description back to the yaml file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            docs = [
+                {"metric": {"name": "to_update", "description": "original description"}},
+                {"metric": {"name": "other_metric", "description": "should stay unchanged"}},
+            ]
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+
+        try:
+            metric = _make_metric(1, subject_path=["Finance", "Revenue"], yaml_path=yaml_path)
+            metric["name"] = "to_update"
+            metric["id"] = "metric:to_update"
+            metric_storage.batch_store_metrics([metric])
+
+            result = metric_storage.update_entry(
+                ["Finance", "Revenue"], "to_update", {"description": "Updated description"}
+            )
+            assert result is True
+
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                remaining = [d for d in yaml.safe_load_all(f) if d is not None]
+
+            updated_doc = next(d for d in remaining if d["metric"]["name"] == "to_update")
+            other_doc = next(d for d in remaining if d["metric"]["name"] == "other_metric")
+
+            assert updated_doc["metric"]["description"] == "Updated description"
+            assert other_doc["metric"]["description"] == "should stay unchanged"
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
+    def test_update_metric_maps_metric_type_to_yaml(self, metric_storage: MetricStorage):
+        """update_entry should map metric_type (DB) -> type (YAML)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            docs = [{"metric": {"name": "typed_metric", "type": "simple"}}]
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+
+        try:
+            metric = _make_metric(2, subject_path=["Finance"], yaml_path=yaml_path)
+            metric["name"] = "typed_metric"
+            metric["id"] = "metric:typed_metric"
+            metric["metric_type"] = "simple"
+            metric_storage.batch_store_metrics([metric])
+
+            result = metric_storage.update_entry(["Finance"], "typed_metric", {"metric_type": "derived"})
+            assert result is True
+
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                docs_out = [d for d in yaml.safe_load_all(f) if d is not None]
+
+            assert docs_out[0]["metric"]["type"] == "derived"
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)
+
+    def test_update_metric_no_yaml_path_still_succeeds(self, metric_storage: MetricStorage):
+        """update_entry without yaml_path should update vector DB and return True."""
+        metric = _make_metric(3, subject_path=["Finance", "Revenue"])
+        metric["name"] = "no_yaml_update"
+        metric["id"] = "metric:no_yaml_update"
+        metric["yaml_path"] = ""
+        metric_storage.batch_store_metrics([metric])
+
+        result = metric_storage.update_entry(["Finance", "Revenue"], "no_yaml_update", {"description": "new desc"})
+        assert result is True
+
+    def test_update_metric_nonexistent_yaml_file_still_succeeds(self, metric_storage: MetricStorage):
+        """update_entry with a yaml_path pointing to a missing file should still return True."""
+        metric = _make_metric(4, subject_path=["Finance"], yaml_path="/nonexistent/path/metrics.yml")
+        metric["name"] = "ghost_metric"
+        metric["id"] = "metric:ghost_metric"
+        metric_storage.batch_store_metrics([metric])
+
+        result = metric_storage.update_entry(["Finance"], "ghost_metric", {"description": "updated"})
+        assert result is True
+
+    def test_update_metric_skips_unmapped_fields_in_yaml(self, metric_storage: MetricStorage):
+        """update_entry with fields not in the YAML mapping should leave the file unchanged."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+            yaml_path = f.name
+            original_docs = [{"metric": {"name": "stable_metric", "description": "stays the same"}}]
+            yaml.safe_dump_all(original_docs, f, allow_unicode=True, sort_keys=False)
+
+        try:
+            metric = _make_metric(5, subject_path=["Finance"], yaml_path=yaml_path)
+            metric["name"] = "stable_metric"
+            metric["id"] = "metric:stable_metric"
+            metric_storage.batch_store_metrics([metric])
+
+            result = metric_storage.update_entry(["Finance"], "stable_metric", {"sql": "SELECT 1"})
+            assert result is True
+
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                docs_out = [d for d in yaml.safe_load_all(f) if d is not None]
+
+            assert docs_out[0]["metric"]["description"] == "stays the same"
+            assert "sql" not in docs_out[0]["metric"]
+        finally:
+            if os.path.exists(yaml_path):
+                os.remove(yaml_path)

--- a/tests/unit_tests/storage/reference_sql/test_store.py
+++ b/tests/unit_tests/storage/reference_sql/test_store.py
@@ -655,8 +655,8 @@ class TestRenameReferenceSqlSubjectTreeYaml:
         finally:
             os.unlink(tmp_file.name)
 
-    def test_rename_only_does_not_touch_subject_tree(self, ref_sql_storage):
-        """Renaming without moving should leave YAML subject_tree untouched."""
+    def test_rename_only_syncs_name_to_yaml(self, ref_sql_storage):
+        """Renaming without moving should update the YAML ``name`` field but leave subject_tree alone."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as tmp_file:
             yaml.dump(
                 {
@@ -685,6 +685,76 @@ class TestRenameReferenceSqlSubjectTreeYaml:
                 updated_doc = yaml.safe_load(f)
             # YAML subject_tree untouched when only the entry name changes
             assert updated_doc["subject_tree"] == "Analytics/Reports"
+            # YAML name must reflect the new entry name
+            assert updated_doc["name"] == "new_name"
+            # Other fields preserved
+            assert updated_doc["sql"] == "SELECT 1"
+        finally:
+            os.unlink(tmp_file.name)
+
+    def test_rename_only_skips_yaml_when_name_does_not_match(self, ref_sql_storage):
+        """If the YAML's ``name`` does not match old_name, the file is not rewritten (safety guard)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as tmp_file:
+            yaml.dump(
+                {
+                    "name": "different_name",  # intentionally NOT old_name
+                    "sql": "SELECT 1",
+                    "summary": "summary",
+                    "search_text": "search",
+                    "subject_tree": "Analytics/Reports",
+                },
+                tmp_file,
+            )
+
+        try:
+            item = _make_sql_item(7, subject_path=["Analytics", "Reports"], name="old_name")
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            result = ref_sql_storage.rename(
+                ["Analytics", "Reports", "old_name"],
+                ["Analytics", "Reports", "new_name"],
+            )
+            assert result is True
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                updated_doc = yaml.safe_load(f)
+            # Mismatched name must not be clobbered
+            assert updated_doc["name"] == "different_name"
+        finally:
+            os.unlink(tmp_file.name)
+
+    def test_rename_move_and_rename_syncs_both_subject_tree_and_name(self, ref_sql_storage):
+        """A combined move + rename should update both subject_tree and name."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as tmp_file:
+            yaml.dump(
+                {
+                    "name": "old_name",
+                    "sql": "SELECT 1",
+                    "summary": "summary",
+                    "search_text": "search",
+                    "subject_tree": "Analytics/Reports",
+                },
+                tmp_file,
+            )
+
+        try:
+            ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Dashboards"])
+
+            item = _make_sql_item(8, subject_path=["Analytics", "Reports"], name="old_name")
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            result = ref_sql_storage.rename(
+                ["Analytics", "Reports", "old_name"],
+                ["Analytics", "Dashboards", "new_name"],
+            )
+            assert result is True
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                updated_doc = yaml.safe_load(f)
+            assert updated_doc["subject_tree"] == "Analytics/Dashboards"
+            assert updated_doc["name"] == "new_name"
         finally:
             os.unlink(tmp_file.name)
 

--- a/tests/unit_tests/storage/reference_sql/test_store.py
+++ b/tests/unit_tests/storage/reference_sql/test_store.py
@@ -513,6 +513,74 @@ class TestUpdateReferenceSqlYaml:
         finally:
             os.unlink(tmp_file.name)
 
+    def test_update_reference_sql_non_dict_yaml_is_noop(self, ref_sql_storage):
+        """_sync_reference_sql_update_to_yaml returns when YAML is not a dict."""
+        tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        try:
+            tmp_file.write("- just a list\n- not a dict\n")
+            tmp_file.close()
+
+            item = _make_sql_item(1, subject_path=["Finance", "Revenue"])
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            result = ref_sql_storage.update_entry(
+                subject_path=["Finance", "Revenue"],
+                name="query_1",
+                update_values={"sql": "SELECT 1"},
+            )
+            assert result is True
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                content = f.read()
+            assert "just a list" in content
+        finally:
+            os.unlink(tmp_file.name)
+
+    def test_update_reference_sql_no_syncable_fields(self, ref_sql_storage):
+        """update_entry with non-syncable fields should not rewrite the YAML file."""
+        original_doc = {"name": "q", "sql": "SELECT 1", "subject_tree": "a/b"}
+        tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        try:
+            yaml.safe_dump(original_doc, tmp_file, allow_unicode=True, sort_keys=False)
+            tmp_file.close()
+
+            item = _make_sql_item(1, subject_path=["Finance", "Revenue"])
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            ref_sql_storage.update_entry(
+                subject_path=["Finance", "Revenue"],
+                name="query_1",
+                update_values={"id": "new_id_value"},  # not in _SYNCABLE_FIELDS
+            )
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                doc = yaml.safe_load(f)
+            assert doc["sql"] == "SELECT 1"
+        finally:
+            os.unlink(tmp_file.name)
+
+    def test_update_reference_sql_corrupt_yaml_does_not_raise(self, ref_sql_storage):
+        """_sync_reference_sql_update_to_yaml catches exceptions on corrupt YAML files."""
+        tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        try:
+            tmp_file.write("{{invalid yaml")
+            tmp_file.close()
+
+            item = _make_sql_item(1, subject_path=["Finance", "Revenue"])
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            result = ref_sql_storage.update_entry(
+                subject_path=["Finance", "Revenue"],
+                name="query_1",
+                update_values={"sql": "SELECT 1"},
+            )
+            assert result is True
+        finally:
+            os.unlink(tmp_file.name)
+
     # ---------------------------------------------------------------------------
     def test_update_reference_sql_entry_not_found_does_not_touch_yaml(self, ref_sql_storage):
         """update_entry on a non-existent entry should raise and leave the YAML file untouched."""

--- a/tests/unit_tests/storage/reference_sql/test_store.py
+++ b/tests/unit_tests/storage/reference_sql/test_store.py
@@ -5,8 +5,11 @@
 """Tests for datus/storage/reference_sql/store.py -- ReferenceSqlStorage."""
 
 import hashlib
+import os
+import tempfile
 
 import pytest
+import yaml
 
 from datus.storage.embedding_models import get_db_embedding_model
 from datus.storage.reference_sql.store import ReferenceSqlStorage
@@ -397,3 +400,115 @@ class TestReferenceSqlStorageCreateIndices:
         # Verify search still works after index creation
         results = ref_sql_storage.search_all_reference_sql()
         assert len(results) == 3
+
+
+# ============================================================
+# ReferenceSqlStorage.update_entry (YAML sync)
+# ============================================================
+
+
+class TestUpdateReferenceSqlYaml:
+    """Tests for update_entry YAML sync in ReferenceSqlStorage."""
+
+    def test_update_reference_sql_syncs_to_yaml_file(self, ref_sql_storage):
+        """update_entry should write changed fields back to the source YAML file."""
+        original_doc = {
+            "id": "abc123",
+            "name": "Daily Sales",
+            "sql": "SELECT * FROM sales",
+            "comment": "Original comment",
+            "summary": "Original summary",
+            "search_text": "daily sales revenue",
+            "filepath": "",
+            "subject_tree": "finance/revenue",
+            "tags": "finance, sales",
+        }
+
+        tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        try:
+            yaml.safe_dump(original_doc, tmp_file, allow_unicode=True, sort_keys=False)
+            tmp_file.close()
+
+            item = _make_sql_item(1, subject_path=["Finance", "Revenue"])
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            ref_sql_storage.update_entry(
+                subject_path=["Finance", "Revenue"],
+                name="query_1",
+                update_values={"sql": "SELECT 1 FROM new_table", "summary": "Updated summary"},
+            )
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                updated_doc = yaml.safe_load(f)
+
+            assert updated_doc["sql"] == "SELECT 1 FROM new_table"
+            assert updated_doc["summary"] == "Updated summary"
+        finally:
+            os.unlink(tmp_file.name)
+
+    def test_update_reference_sql_no_filepath_still_succeeds(self, ref_sql_storage):
+        """update_entry should return True even when filepath is empty."""
+        item = _make_sql_item(1, subject_path=["Finance", "Revenue"])
+        item["filepath"] = ""
+        ref_sql_storage.batch_store_sql([item])
+
+        result = ref_sql_storage.update_entry(
+            subject_path=["Finance", "Revenue"],
+            name="query_1",
+            update_values={"summary": "New summary"},
+        )
+        assert result is True
+
+    def test_update_reference_sql_nonexistent_file_still_succeeds(self, ref_sql_storage):
+        """update_entry should return True even when the YAML file does not exist."""
+        item = _make_sql_item(1, subject_path=["Finance", "Revenue"])
+        item["filepath"] = "/nonexistent/path/query.yaml"
+        ref_sql_storage.batch_store_sql([item])
+
+        result = ref_sql_storage.update_entry(
+            subject_path=["Finance", "Revenue"],
+            name="query_1",
+            update_values={"summary": "New summary"},
+        )
+        assert result is True
+
+    def test_update_reference_sql_preserves_other_yaml_fields(self, ref_sql_storage):
+        """update_entry should only modify the specified syncable fields and leave others intact."""
+        original_doc = {
+            "id": "abc123",
+            "name": "Daily Sales",
+            "sql": "SELECT * FROM sales",
+            "comment": "Keep this comment",
+            "summary": "Original summary",
+            "search_text": "daily sales revenue",
+            "filepath": "",
+            "subject_tree": "finance/revenue",
+            "tags": "finance, sales",
+        }
+
+        tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        try:
+            yaml.safe_dump(original_doc, tmp_file, allow_unicode=True, sort_keys=False)
+            tmp_file.close()
+
+            item = _make_sql_item(1, subject_path=["Finance", "Revenue"])
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            ref_sql_storage.update_entry(
+                subject_path=["Finance", "Revenue"],
+                name="query_1",
+                update_values={"summary": "New summary"},
+            )
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                updated_doc = yaml.safe_load(f)
+
+            assert updated_doc["summary"] == "New summary"
+            assert updated_doc["comment"] == "Keep this comment"
+            assert updated_doc["subject_tree"] == "finance/revenue"
+            assert updated_doc["name"] == "Daily Sales"
+            assert updated_doc["sql"] == "SELECT * FROM sales"
+        finally:
+            os.unlink(tmp_file.name)

--- a/tests/unit_tests/storage/reference_sql/test_store.py
+++ b/tests/unit_tests/storage/reference_sql/test_store.py
@@ -513,8 +513,34 @@ class TestUpdateReferenceSqlYaml:
         finally:
             os.unlink(tmp_file.name)
 
+    # ---------------------------------------------------------------------------
+    def test_update_reference_sql_entry_not_found_does_not_touch_yaml(self, ref_sql_storage):
+        """update_entry on a non-existent entry should raise and leave the YAML file untouched."""
+        original_doc = {
+            "id": "abc123",
+            "name": "Daily Sales",
+            "sql": "SELECT * FROM sales",
+            "summary": "Original summary",
+        }
+        tmp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8")
+        try:
+            yaml.safe_dump(original_doc, tmp_file, allow_unicode=True, sort_keys=False)
+            tmp_file.close()
 
-# ---------------------------------------------------------------------------
+            with pytest.raises(ValueError):
+                ref_sql_storage.update_entry(
+                    subject_path=["Finance", "Revenue"],
+                    name="nonexistent_query",
+                    update_values={"sql": "SELECT 1"},
+                )
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                doc = yaml.safe_load(f)
+            assert doc["sql"] == "SELECT * FROM sales"
+        finally:
+            os.unlink(tmp_file.name)
+
+
 # YAML subject_tree sync on rename
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_tests/storage/reference_sql/test_store.py
+++ b/tests/unit_tests/storage/reference_sql/test_store.py
@@ -512,3 +512,223 @@ class TestUpdateReferenceSqlYaml:
             assert updated_doc["sql"] == "SELECT * FROM sales"
         finally:
             os.unlink(tmp_file.name)
+
+
+# ---------------------------------------------------------------------------
+# YAML subject_tree sync on rename
+# ---------------------------------------------------------------------------
+
+
+class TestRenameReferenceSqlSubjectTreeYaml:
+    """Tests for YAML subject_tree sync in rename."""
+
+    def test_rename_move_rewrites_subject_tree(self, ref_sql_storage):
+        """Moving an entry to a new parent should rewrite the top-level subject_tree field."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as tmp_file:
+            yaml.dump(
+                {
+                    "name": "move_me",
+                    "sql": "SELECT 1",
+                    "summary": "summary",
+                    "search_text": "search",
+                    "tags": "tagA",
+                    "subject_tree": "Analytics/Reports",
+                    "comment": "untouched",
+                },
+                tmp_file,
+            )
+
+        try:
+            # Pre-create the target subject path so rename() can resolve it
+            ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Dashboards"])
+
+            item = _make_sql_item(1, subject_path=["Analytics", "Reports"], name="move_me")
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            result = ref_sql_storage.rename(
+                ["Analytics", "Reports", "move_me"],
+                ["Analytics", "Dashboards", "move_me"],
+            )
+            assert result is True
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                updated_doc = yaml.safe_load(f)
+            assert updated_doc["subject_tree"] == "Analytics/Dashboards"
+            # Unrelated fields preserved
+            assert updated_doc["comment"] == "untouched"
+            assert updated_doc["sql"] == "SELECT 1"
+        finally:
+            os.unlink(tmp_file.name)
+
+    def test_rename_only_does_not_touch_subject_tree(self, ref_sql_storage):
+        """Renaming without moving should leave YAML subject_tree untouched."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as tmp_file:
+            yaml.dump(
+                {
+                    "name": "old_name",
+                    "sql": "SELECT 1",
+                    "summary": "summary",
+                    "search_text": "search",
+                    "tags": "tagA",
+                    "subject_tree": "Analytics/Reports",
+                },
+                tmp_file,
+            )
+
+        try:
+            item = _make_sql_item(2, subject_path=["Analytics", "Reports"], name="old_name")
+            item["filepath"] = tmp_file.name
+            ref_sql_storage.batch_store_sql([item])
+
+            result = ref_sql_storage.rename(
+                ["Analytics", "Reports", "old_name"],
+                ["Analytics", "Reports", "new_name"],
+            )
+            assert result is True
+
+            with open(tmp_file.name, encoding="utf-8") as f:
+                updated_doc = yaml.safe_load(f)
+            # YAML subject_tree untouched when only the entry name changes
+            assert updated_doc["subject_tree"] == "Analytics/Reports"
+        finally:
+            os.unlink(tmp_file.name)
+
+    def test_rename_move_without_filepath_still_succeeds(self, ref_sql_storage):
+        """Moving an entry with no filepath should still return True."""
+        ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Dashboards"])
+
+        item = _make_sql_item(3, subject_path=["Analytics", "Reports"], name="no_filepath")
+        item["filepath"] = ""
+        ref_sql_storage.batch_store_sql([item])
+
+        result = ref_sql_storage.rename(
+            ["Analytics", "Reports", "no_filepath"],
+            ["Analytics", "Dashboards", "no_filepath"],
+        )
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# YAML subject_tree sync when a subject_node is renamed/moved
+# ---------------------------------------------------------------------------
+
+
+class TestSyncYamlSubjectTreeForSubtreeRefSql:
+    """Tests for sync_yaml_subject_tree_for_subtree — triggered after a
+    subject_tree node is renamed/moved, to sync YAML files of all descendants.
+    """
+
+    def _write_ref_sql_yaml(self, tmp_path, name: str, subject_tree_value: str, sql: str) -> str:
+        filepath = os.path.join(tmp_path, f"{name}.yaml")
+        with open(filepath, "w", encoding="utf-8") as f:
+            yaml.safe_dump(
+                {
+                    "name": name,
+                    "sql": sql,
+                    "summary": f"summary for {name}",
+                    "search_text": f"search for {name}",
+                    "tags": "tagA",
+                    "subject_tree": subject_tree_value,
+                    "comment": "keep_me",
+                },
+                f,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+        return filepath
+
+    def test_rename_node_syncs_yaml_for_direct_and_descendant_ref_sql(self, ref_sql_storage, tmp_path):
+        """Renaming an intermediate subject_node should update YAML subject_tree for
+        reference SQL entries under that node AND under descendant nodes."""
+        tmp_path_str = str(tmp_path)
+
+        # Create subject tree: Analytics / Reports / Q1 / Detail
+        ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Reports", "Q1"])
+        ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Reports", "Q1", "Detail"])
+
+        top_fp = self._write_ref_sql_yaml(tmp_path_str, "top_query", "Analytics/Reports/Q1", "SELECT 1")
+        deep_fp = self._write_ref_sql_yaml(tmp_path_str, "deep_query", "Analytics/Reports/Q1/Detail", "SELECT 2")
+
+        top_item = _make_sql_item(10, subject_path=["Analytics", "Reports", "Q1"], name="top_query", sql="SELECT 1")
+        top_item["filepath"] = top_fp
+        deep_item = _make_sql_item(
+            11, subject_path=["Analytics", "Reports", "Q1", "Detail"], name="deep_query", sql="SELECT 2"
+        )
+        deep_item["filepath"] = deep_fp
+        ref_sql_storage.batch_store_sql([top_item, deep_item])
+
+        q1_node = ref_sql_storage.subject_tree.get_node_by_path(["Analytics", "Reports", "Q1"])
+        assert q1_node is not None
+        root_id = q1_node["node_id"]
+
+        # Rename Q1 -> Quarter1 in place
+        ref_sql_storage.subject_tree.rename(
+            ["Analytics", "Reports", "Q1"],
+            ["Analytics", "Reports", "Quarter1"],
+        )
+
+        ref_sql_storage.sync_yaml_subject_tree_for_subtree(root_id)
+
+        with open(top_fp, encoding="utf-8") as f:
+            top_doc = yaml.safe_load(f)
+        assert top_doc["subject_tree"] == "Analytics/Reports/Quarter1"
+        assert top_doc["comment"] == "keep_me"
+
+        with open(deep_fp, encoding="utf-8") as f:
+            deep_doc = yaml.safe_load(f)
+        assert deep_doc["subject_tree"] == "Analytics/Reports/Quarter1/Detail"
+        assert deep_doc["comment"] == "keep_me"
+
+    def test_move_node_syncs_yaml_for_descendant_ref_sql(self, ref_sql_storage, tmp_path):
+        """Moving a subject_node to a different parent should update YAML subject_tree
+        for all descendant reference SQL entries."""
+        tmp_path_str = str(tmp_path)
+
+        ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Reports", "Q1"])
+        ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Dashboards"])
+
+        fp = self._write_ref_sql_yaml(tmp_path_str, "movable", "Analytics/Reports/Q1", "SELECT 1")
+
+        item = _make_sql_item(12, subject_path=["Analytics", "Reports", "Q1"], name="movable", sql="SELECT 1")
+        item["filepath"] = fp
+        ref_sql_storage.batch_store_sql([item])
+
+        q1_node = ref_sql_storage.subject_tree.get_node_by_path(["Analytics", "Reports", "Q1"])
+        assert q1_node is not None
+        root_id = q1_node["node_id"]
+
+        # Move Q1 from Analytics/Reports to Analytics/Dashboards
+        ref_sql_storage.subject_tree.rename(
+            ["Analytics", "Reports", "Q1"],
+            ["Analytics", "Dashboards", "Q1"],
+        )
+
+        ref_sql_storage.sync_yaml_subject_tree_for_subtree(root_id)
+
+        with open(fp, encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+        assert doc["subject_tree"] == "Analytics/Dashboards/Q1"
+
+    def test_sync_skips_entries_without_filepath(self, ref_sql_storage, tmp_path):
+        """Reference SQL entries with an empty filepath should be silently skipped."""
+        ref_sql_storage.subject_tree.find_or_create_path(["Analytics", "Reports", "Q1"])
+
+        item = _make_sql_item(13, subject_path=["Analytics", "Reports", "Q1"], name="no_fp")
+        item["filepath"] = ""
+        ref_sql_storage.batch_store_sql([item])
+
+        q1_node = ref_sql_storage.subject_tree.get_node_by_path(["Analytics", "Reports", "Q1"])
+        root_id = q1_node["node_id"]
+
+        # Should not raise
+        ref_sql_storage.sync_yaml_subject_tree_for_subtree(root_id)
+
+    def test_sync_handles_subtree_with_no_ref_sql(self, ref_sql_storage):
+        """A subtree with no reference SQL entries should be a no-op."""
+        ref_sql_storage.subject_tree.find_or_create_path(["Empty", "Branch"])
+        node = ref_sql_storage.subject_tree.get_node_by_path(["Empty", "Branch"])
+        assert node is not None
+
+        # Should not raise
+        ref_sql_storage.sync_yaml_subject_tree_for_subtree(node["node_id"])

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -479,6 +479,11 @@ class TestUpdateEntryYamlSync:
         with pytest.raises(DatusException, match="entry not found"):
             sem_storage.update_entry("table:nonexistent", {"description": "x"})
 
+    def test_update_entry_empty_id_raises(self, sem_storage):
+        """update_entry raises DatusException when entry_id is empty."""
+        with pytest.raises(DatusException, match="entry_id must not be empty"):
+            sem_storage.update_entry("", {"description": "x"})
+
     def test_update_entry_empty_values_raises(self, sem_storage):
         """update_entry raises DatusException when update_values is empty."""
         table_obj = _make_table_object("orders")
@@ -486,6 +491,76 @@ class TestUpdateEntryYamlSync:
 
         with pytest.raises(DatusException, match="update_values must not be empty"):
             sem_storage.update_entry("table:orders", {})
+
+    def test_update_entry_nonexistent_yaml_file(self, sem_storage):
+        """update_entry succeeds even when yaml_path points to a missing file."""
+        table_obj = _make_table_object("orders", yaml_path="/nonexistent/path.yml")
+        sem_storage.store_batch([table_obj])
+
+        result = sem_storage.update_entry("table:orders", {"description": "new"})
+        assert result is True
+
+    def test_sync_yaml_no_data_source_doc(self, sem_storage):
+        """_sync_semantic_update_to_yaml returns silently when YAML has no data_source."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            yaml.safe_dump_all([{"unrelated": "doc"}], tmp, allow_unicode=True, sort_keys=False)
+            tmp.close()
+
+            table_obj = _make_table_object("orders", yaml_path=tmp.name)
+            sem_storage.store_batch([table_obj])
+
+            result = sem_storage.update_entry("table:orders", {"description": "new"})
+            assert result is True
+
+            with open(tmp.name, encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+            assert docs[0] == {"unrelated": "doc"}
+        finally:
+            os.unlink(tmp.name)
+
+    def test_sync_yaml_corrupt_file_does_not_raise(self, sem_storage):
+        """_sync_semantic_update_to_yaml catches exceptions on corrupt YAML files."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            tmp.write("{{invalid yaml content")
+            tmp.close()
+
+            # Call private method directly — should log error but not raise
+            sem_storage._sync_semantic_update_to_yaml(tmp.name, "table", "orders", {"description": "new"})
+        finally:
+            os.unlink(tmp.name)
+
+    def test_update_column_not_found_in_yaml(self, sem_storage):
+        """_sync_semantic_update_to_yaml for a column not present in YAML leaves file unchanged."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            docs = [
+                {
+                    "data_source": {
+                        "name": "orders",
+                        "description": "Table",
+                        "dimensions": [{"name": "region", "description": "Region"}],
+                    }
+                }
+            ]
+            yaml.safe_dump_all(docs, tmp, allow_unicode=True, sort_keys=False)
+            tmp.close()
+
+            col_obj = _make_column_object("orders", "nonexistent_col", is_dimension=True)
+            col_obj["yaml_path"] = tmp.name
+            table_obj = _make_table_object("orders", yaml_path=tmp.name)
+            sem_storage.store_batch([table_obj, col_obj])
+
+            result = sem_storage.update_entry("column:orders.nonexistent_col", {"description": "new"})
+            assert result is True
+
+            with open(tmp.name, encoding="utf-8") as f:
+                reloaded = list(yaml.safe_load_all(f))
+            # Original region dimension should be untouched
+            assert reloaded[0]["data_source"]["dimensions"][0]["description"] == "Region"
+        finally:
+            os.unlink(tmp.name)
 
 
 # ============================================================

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -4,7 +4,11 @@
 
 """Tests for datus/storage/semantic_model/store.py -- SemanticModelStorage and SemanticModelRAG."""
 
+import os
+import tempfile
+
 import pytest
+import yaml
 from pandas import Timestamp
 
 from datus.storage.embedding_models import get_db_embedding_model
@@ -298,6 +302,141 @@ class TestSemanticModelStorageSearchObjects:
         for r in results:
             assert r["kind"] == "column"
             assert r["table_name"] == "orders"
+
+
+# ============================================================
+# SemanticModelStorage.update_entry / _sync_semantic_update_to_yaml
+# ============================================================
+
+
+class TestUpdateEntryYamlSync:
+    """Tests for update_entry and _sync_semantic_update_to_yaml."""
+
+    def _make_yaml_with_table_only(self, f, description="Original table description"):
+        """Write a minimal single-table YAML (no columns) to file f."""
+        docs = [
+            {
+                "data_source": {
+                    "name": "orders",
+                    "description": description,
+                    "sql_table": "analytics.public.orders",
+                }
+            }
+        ]
+        yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+        f.flush()
+
+    def _make_yaml_with_columns(self, f, dim_description="Region dimension", dim_type="CATEGORICAL"):
+        """Write a YAML with a data_source containing dimensions, measures, identifiers."""
+        docs = [
+            {
+                "data_source": {
+                    "name": "orders",
+                    "description": "Original table description",
+                    "sql_table": "analytics.public.orders",
+                    "dimensions": [
+                        {"name": "region", "type": dim_type, "description": dim_description, "expr": "region"}
+                    ],
+                    "measures": [{"name": "amount", "description": "Total amount", "agg": "SUM", "expr": "amount"}],
+                    "identifiers": [
+                        {"name": "order_id", "type": "PRIMARY", "description": "Primary key", "expr": "order_id"}
+                    ],
+                }
+            }
+        ]
+        yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+        f.flush()
+
+    def test_update_table_description_syncs_to_yaml(self, sem_storage):
+        """update_entry on a table entry syncs the description back to the YAML file."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            self._make_yaml_with_table_only(tmp, description="Original")
+            tmp.close()
+
+            table_obj = _make_table_object("orders", description="Original", yaml_path=tmp.name)
+            sem_storage.store_batch([table_obj])
+
+            result = sem_storage.update_entry("table:orders", {"description": "Updated table description"})
+            assert result is True
+
+            with open(tmp.name, encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+            data_source = next(d["data_source"] for d in docs if d and "data_source" in d)
+            assert data_source["description"] == "Updated table description"
+        finally:
+            os.unlink(tmp.name)
+
+    def test_update_column_description_syncs_to_yaml(self, sem_storage):
+        """update_entry on a column entry syncs the description to the matching dimension item."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            self._make_yaml_with_columns(tmp, dim_description="Original region desc")
+            tmp.close()
+
+            table_obj = _make_table_object("orders", yaml_path=tmp.name)
+            col_obj = _make_column_object(
+                "orders", "region", description="Original region desc", is_dimension=True, column_type="CATEGORICAL"
+            )
+            col_obj["yaml_path"] = tmp.name
+            sem_storage.store_batch([table_obj, col_obj])
+
+            result = sem_storage.update_entry("column:orders.region", {"description": "Updated region desc"})
+            assert result is True
+
+            with open(tmp.name, encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+            data_source = next(d["data_source"] for d in docs if d and "data_source" in d)
+            dim = next(item for item in data_source["dimensions"] if item["name"] == "region")
+            assert dim["description"] == "Updated region desc"
+        finally:
+            os.unlink(tmp.name)
+
+    def test_update_column_type_syncs_to_yaml(self, sem_storage):
+        """update_entry with column_type maps to 'type' key in YAML."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            self._make_yaml_with_columns(tmp, dim_type="CATEGORICAL")
+            tmp.close()
+
+            table_obj = _make_table_object("orders", yaml_path=tmp.name)
+            col_obj = _make_column_object(
+                "orders", "region", description="Region dimension", is_dimension=True, column_type="CATEGORICAL"
+            )
+            col_obj["yaml_path"] = tmp.name
+            sem_storage.store_batch([table_obj, col_obj])
+
+            result = sem_storage.update_entry("column:orders.region", {"column_type": "TIME"})
+            assert result is True
+
+            with open(tmp.name, encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+            data_source = next(d["data_source"] for d in docs if d and "data_source" in d)
+            dim = next(item for item in data_source["dimensions"] if item["name"] == "region")
+            assert dim["type"] == "TIME"
+        finally:
+            os.unlink(tmp.name)
+
+    def test_update_entry_no_yaml_path_still_succeeds(self, sem_storage):
+        """update_entry succeeds and returns True when yaml_path is empty."""
+        table_obj = _make_table_object("orders", description="A table", yaml_path="")
+        sem_storage.store_batch([table_obj])
+
+        result = sem_storage.update_entry("table:orders", {"description": "No yaml sync"})
+        assert result is True
+
+    def test_update_entry_nonexistent_raises(self, sem_storage):
+        """update_entry raises ValueError when the entry_id does not exist."""
+        with pytest.raises(ValueError, match="Entry not found"):
+            sem_storage.update_entry("table:nonexistent", {"description": "x"})
+
+    def test_update_entry_empty_values_raises(self, sem_storage):
+        """update_entry raises ValueError when update_values is empty."""
+        table_obj = _make_table_object("orders")
+        sem_storage.store_batch([table_obj])
+
+        with pytest.raises(ValueError, match="update_values must not be empty"):
+            sem_storage.update_entry("table:orders", {})
 
 
 # ============================================================

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -417,6 +417,54 @@ class TestUpdateEntryYamlSync:
         finally:
             os.unlink(tmp.name)
 
+    def test_update_measure_agg_syncs_to_yaml(self, sem_storage):
+        """update_entry on a measure column syncs 'agg' back to the YAML file."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            self._make_yaml_with_columns(tmp)
+            tmp.close()
+
+            table_obj = _make_table_object("orders", yaml_path=tmp.name)
+            col_obj = _make_column_object("orders", "amount", description="Total amount", is_measure=True, agg="SUM")
+            col_obj["yaml_path"] = tmp.name
+            sem_storage.store_batch([table_obj, col_obj])
+
+            result = sem_storage.update_entry("column:orders.amount", {"agg": "AVERAGE"})
+            assert result is True
+
+            with open(tmp.name, encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+            data_source = next(d["data_source"] for d in docs if d and "data_source" in d)
+            measure = next(item for item in data_source["measures"] if item["name"] == "amount")
+            assert measure["agg"] == "AVERAGE"
+        finally:
+            os.unlink(tmp.name)
+
+    def test_update_identifier_entity_syncs_to_yaml(self, sem_storage):
+        """update_entry on an identifier column syncs 'entity' back to the YAML file."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            self._make_yaml_with_columns(tmp)
+            tmp.close()
+
+            table_obj = _make_table_object("orders", yaml_path=tmp.name)
+            col_obj = _make_column_object(
+                "orders", "order_id", description="Primary key", is_entity_key=True, entity="order"
+            )
+            col_obj["yaml_path"] = tmp.name
+            sem_storage.store_batch([table_obj, col_obj])
+
+            result = sem_storage.update_entry("column:orders.order_id", {"entity": "transaction"})
+            assert result is True
+
+            with open(tmp.name, encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+            data_source = next(d["data_source"] for d in docs if d and "data_source" in d)
+            ident = next(item for item in data_source["identifiers"] if item["name"] == "order_id")
+            assert ident["entity"] == "transaction"
+        finally:
+            os.unlink(tmp.name)
+
     def test_update_entry_no_yaml_path_still_succeeds(self, sem_storage):
         """update_entry succeeds and returns True when yaml_path is empty."""
         table_obj = _make_table_object("orders", description="A table", yaml_path="")

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -527,7 +527,7 @@ class TestUpdateEntryYamlSync:
             tmp.close()
 
             # Call private method directly — should log error but not raise
-            sem_storage._sync_semantic_update_to_yaml(tmp.name, "table", "orders", {"description": "new"})
+            sem_storage._sync_semantic_update_to_yaml(tmp.name, "table", "orders", "orders", {"description": "new"})
         finally:
             os.unlink(tmp.name)
 
@@ -559,6 +559,59 @@ class TestUpdateEntryYamlSync:
                 reloaded = list(yaml.safe_load_all(f))
             # Original region dimension should be untouched
             assert reloaded[0]["data_source"]["dimensions"][0]["description"] == "Region"
+        finally:
+            os.unlink(tmp.name)
+
+    def test_sync_yaml_multi_data_source_targets_matching_doc(self, sem_storage):
+        """When a YAML file holds multiple data_source docs, only the matching one is rewritten."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            docs = [
+                {"data_source": {"name": "customers", "description": "Customers original"}},
+                {"data_source": {"name": "orders", "description": "Orders original"}},
+            ]
+            yaml.safe_dump_all(docs, tmp, allow_unicode=True, sort_keys=False)
+            tmp.close()
+
+            table_obj = _make_table_object("orders", description="Orders original", yaml_path=tmp.name)
+            sem_storage.store_batch([table_obj])
+
+            sem_storage.update_entry("table:orders", {"description": "Orders updated"})
+
+            with open(tmp.name, encoding="utf-8") as f:
+                reloaded = list(yaml.safe_load_all(f))
+
+            ds_by_name = {d["data_source"]["name"]: d["data_source"] for d in reloaded}
+            assert ds_by_name["orders"]["description"] == "Orders updated"
+            # The unrelated data_source must not be touched
+            assert ds_by_name["customers"]["description"] == "Customers original"
+        finally:
+            os.unlink(tmp.name)
+
+    def test_sync_yaml_multi_data_source_no_match_does_not_mutate(self, sem_storage):
+        """When no data_source name matches and >1 docs exist, no doc is rewritten."""
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8")
+        try:
+            docs = [
+                {"data_source": {"name": "customers", "description": "Customers original"}},
+                {"data_source": {"name": "products", "description": "Products original"}},
+            ]
+            yaml.safe_dump_all(docs, tmp, allow_unicode=True, sort_keys=False)
+            tmp.close()
+
+            # The vector-DB row points at this file, but its name "orders" matches no doc
+            table_obj = _make_table_object("orders", description="Orders DB", yaml_path=tmp.name)
+            sem_storage.store_batch([table_obj])
+
+            sem_storage.update_entry("table:orders", {"description": "Should not appear"})
+
+            with open(tmp.name, encoding="utf-8") as f:
+                reloaded = list(yaml.safe_load_all(f))
+
+            ds_by_name = {d["data_source"]["name"]: d["data_source"] for d in reloaded}
+            # Both unrelated docs must remain pristine
+            assert ds_by_name["customers"]["description"] == "Customers original"
+            assert ds_by_name["products"]["description"] == "Products original"
         finally:
             os.unlink(tmp.name)
 

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -13,6 +13,7 @@ from pandas import Timestamp
 
 from datus.storage.embedding_models import get_db_embedding_model
 from datus.storage.semantic_model.store import SemanticModelRAG, SemanticModelStorage
+from datus.utils.exceptions import DatusException
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -474,16 +475,16 @@ class TestUpdateEntryYamlSync:
         assert result is True
 
     def test_update_entry_nonexistent_raises(self, sem_storage):
-        """update_entry raises ValueError when the entry_id does not exist."""
-        with pytest.raises(ValueError, match="Entry not found"):
+        """update_entry raises DatusException when the entry_id does not exist."""
+        with pytest.raises(DatusException, match="entry not found"):
             sem_storage.update_entry("table:nonexistent", {"description": "x"})
 
     def test_update_entry_empty_values_raises(self, sem_storage):
-        """update_entry raises ValueError when update_values is empty."""
+        """update_entry raises DatusException when update_values is empty."""
         table_obj = _make_table_object("orders")
         sem_storage.store_batch([table_obj])
 
-        with pytest.raises(ValueError, match="update_values must not be empty"):
+        with pytest.raises(DatusException, match="update_values must not be empty"):
             sem_storage.update_entry("table:orders", {})
 
 

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -558,6 +558,59 @@ class TestUpdate:
 
         assert original_vector != updated_vector, "Vector should change when vector source text changes"
 
+    def test_update_keeps_existing_vector_when_re_embed_returns_none(self, tmp_path, monkeypatch):
+        """If the embedding model returns [None] (e.g., BadRequestError), preserve the existing vector
+        rather than writing None into the vector column."""
+        store = self._make_store(tmp_path)
+        store.store_batch([self._make_row(1)])
+
+        original = store.query_with_filter(where=eq("identifier", "id_1"), select_fields=["vector"])
+        original_vector = original.column("vector")[0].as_py()
+
+        # Patch the underlying embedding function on the class to bypass pydantic field guards.
+        embedding_cls = type(store.model.model)
+        monkeypatch.setattr(
+            embedding_cls,
+            "generate_embeddings",
+            lambda self, texts: [None] * len(list(texts)),
+        )
+
+        store.update(
+            where=eq("identifier", "id_1"),
+            update_values={"definition": "Some new definition that would otherwise be re-embedded"},
+        )
+
+        updated = store.query_with_filter(where=eq("identifier", "id_1"), select_fields=["vector"])
+        updated_vector = updated.column("vector")[0].as_py()
+
+        # Vector must be unchanged — never overwritten with None
+        assert updated_vector == original_vector
+        assert updated_vector is not None
+
+    def test_update_keeps_existing_vector_when_re_embed_raises(self, tmp_path, monkeypatch):
+        """If the embedding model raises, the update still proceeds and the existing vector is kept."""
+        store = self._make_store(tmp_path)
+        store.store_batch([self._make_row(1)])
+
+        original = store.query_with_filter(where=eq("identifier", "id_1"), select_fields=["vector"])
+        original_vector = original.column("vector")[0].as_py()
+
+        def _boom(self, texts):
+            raise RuntimeError("embedding backend down")
+
+        embedding_cls = type(store.model.model)
+        monkeypatch.setattr(embedding_cls, "generate_embeddings", _boom)
+
+        store.update(
+            where=eq("identifier", "id_1"),
+            update_values={"definition": "Yet another definition that triggers embedding"},
+        )
+
+        updated = store.query_with_filter(where=eq("identifier", "id_1"), select_fields=["vector"])
+        updated_vector = updated.column("vector")[0].as_py()
+
+        assert updated_vector == original_vector
+
 
 # ---------------------------------------------------------------------------
 # query_with_filter

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -537,6 +537,27 @@ class TestUpdate:
         result = store.search_all(catalog_name="cat")
         assert result.num_rows == 1
 
+    def test_update_re_embeds_when_vector_source_changes(self, tmp_path):
+        """update() should regenerate the vector when the vector source column is updated."""
+        store = self._make_store(tmp_path)
+        store.store_batch([self._make_row(1)])
+
+        # Get original vector
+        original = store.query_with_filter(where=eq("identifier", "id_1"), select_fields=["vector"])
+        original_vector = original.column("vector")[0].as_py()
+
+        # Update the vector_source_name column (definition for SchemaStorage)
+        store.update(
+            where=eq("identifier", "id_1"),
+            update_values={"definition": "A completely different table about customer orders and revenue tracking"},
+        )
+
+        # Get updated vector
+        updated = store.query_with_filter(where=eq("identifier", "id_1"), select_fields=["vector"])
+        updated_vector = updated.column("vector")[0].as_py()
+
+        assert original_vector != updated_vector, "Vector should change when vector source text changes"
+
 
 # ---------------------------------------------------------------------------
 # query_with_filter

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -279,7 +279,7 @@ class TestUpdateColumnsMethod:
             allowed_fields={"description"},
         )
         assert len(calls) == 1
-        assert calls[0][0] == "column:t_model.col1"
+        assert calls[0][0] == "column:t.col1"
         assert calls[0][1] == {"description": "new desc"}
 
     def test_update_columns_no_changes_means_no_update(self):
@@ -433,7 +433,7 @@ class TestUpdateSemanticModel:
         updater.update_semantic_model(old_values, update_values)
 
         assert any(
-            entry_id == "table:orders_model" and v.get("description") == "Updated description" for entry_id, v in calls
+            entry_id == "table:orders" and v.get("description") == "Updated description" for entry_id, v in calls
         )
 
     def test_update_semantic_model_description_uses_table_name_fallback(self):
@@ -496,8 +496,7 @@ class TestUpdateSemanticModel:
         updater.update_semantic_model(old_values, update_values)
 
         assert any(
-            entry_id == "column:orders_model.region" and v.get("description") == "new region desc"
-            for entry_id, v in calls
+            entry_id == "column:orders.region" and v.get("description") == "new region desc" for entry_id, v in calls
         )
 
     def test_update_semantic_model_measures(self):
@@ -522,9 +521,7 @@ class TestUpdateSemanticModel:
 
         updater.update_semantic_model(old_values, update_values)
 
-        assert any(
-            entry_id == "column:orders_model.total_amount" and v.get("agg") == "AVERAGE" for entry_id, v in calls
-        )
+        assert any(entry_id == "column:orders.total_amount" and v.get("agg") == "AVERAGE" for entry_id, v in calls)
 
     def test_update_semantic_model_identifiers(self):
         """update_semantic_model updates identifier columns via update_entry."""
@@ -548,6 +545,4 @@ class TestUpdateSemanticModel:
 
         updater.update_semantic_model(old_values, update_values)
 
-        assert any(
-            entry_id == "column:orders_model.order_id" and v.get("entity") == "transaction" for entry_id, v in calls
-        )
+        assert any(entry_id == "column:orders.order_id" and v.get("entity") == "transaction" for entry_id, v in calls)

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -241,15 +241,14 @@ class TestUpdateColumnsMethod:
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append((where, values))
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater.semantic_model_storage = FakeStorage()
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=[{"name": "col1", "description": "old"}],
             new_columns=[{"description": "new"}],  # no 'name'
             kind_field="is_dimension",
@@ -258,29 +257,29 @@ class TestUpdateColumnsMethod:
         assert len(calls) == 0
 
     def test_update_columns_with_matching_names(self):
-        """Matching columns with changed fields trigger storage.update."""
+        """Matching columns with changed fields trigger storage.update_entry."""
         updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append((where, values))
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater.semantic_model_storage = FakeStorage()
 
         old = [{"name": "col1", "description": "old desc"}]
         new = [{"name": "col1", "description": "new desc"}]
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
             kind_field="is_dimension",
             allowed_fields={"description"},
         )
         assert len(calls) == 1
+        assert calls[0][0] == "column:t_model.col1"
         assert calls[0][1] == {"description": "new desc"}
 
     def test_update_columns_no_changes_means_no_update(self):
@@ -289,17 +288,16 @@ class TestUpdateColumnsMethod:
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append((where, values))
+            def update_entry(self, entry_id, values):
+                calls.append(values)
+
+        updater.semantic_model_storage = FakeStorage()
 
         identical = [{"name": "col1", "description": "same", "type": "string"}]
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=identical,
             new_columns=identical,
             kind_field="is_measure",
@@ -307,36 +305,29 @@ class TestUpdateColumnsMethod:
         )
         assert len(calls) == 0
 
-    def test_update_columns_multiple_storages(self):
-        """Update is called on each storage in the list."""
+    def test_update_columns_falls_back_to_table_name_when_no_semantic_model_name(self):
+        """entry_id uses table_name when semantic_model_name is empty."""
         updater = self._make_updater()
-        calls_1 = []
-        calls_2 = []
+        calls = []
 
-        class FakeStorage1:
-            def update(self, where, values, unique_filter=None):
-                calls_1.append(values)
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                calls.append(entry_id)
 
-        class FakeStorage2:
-            def update(self, where, values, unique_filter=None):
-                calls_2.append(values)
+        updater.semantic_model_storage = FakeStorage()
 
         old = [{"name": "col1", "description": "old"}]
         new = [{"name": "col1", "description": "new"}]
 
         updater._update_columns(
-            storages=[FakeStorage1(), FakeStorage2()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
-            table_name="t",
+            table_name="orders",
+            semantic_model_name="",
             old_columns=old,
             new_columns=new,
             kind_field="is_dimension",
             allowed_fields={"description"},
         )
-        assert len(calls_1) == 1
-        assert len(calls_2) == 1
+        assert calls == ["column:orders.col1"]
 
     def test_update_columns_none_inputs_handled(self):
         """None old_columns and new_columns are handled gracefully."""
@@ -344,15 +335,14 @@ class TestUpdateColumnsMethod:
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
+            def update_entry(self, entry_id, values):
                 calls.append(values)
 
+        updater.semantic_model_storage = FakeStorage()
+
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=None,
             new_columns=None,
             kind_field="is_dimension",
@@ -366,18 +356,17 @@ class TestUpdateColumnsMethod:
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
+            def update_entry(self, entry_id, values):
                 calls.append(values)
+
+        updater.semantic_model_storage = FakeStorage()
 
         old_json = json.dumps([{"name": "col1", "description": "old"}])
         new_json = json.dumps([{"name": "col1", "description": "new"}])
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=old_json,
             new_columns=new_json,
             kind_field="is_entity_key",
@@ -385,6 +374,29 @@ class TestUpdateColumnsMethod:
         )
         assert len(calls) == 1
         assert calls[0] == {"description": "new"}
+
+    def test_update_columns_value_error_is_handled(self):
+        """ValueError from update_entry (entry not found) is caught and logged, not raised."""
+        updater = self._make_updater()
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                raise ValueError(f"Entry not found: {entry_id}")
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old = [{"name": "col1", "description": "old"}]
+        new = [{"name": "col1", "description": "new"}]
+
+        # Should not raise
+        updater._update_columns(
+            table_name="t",
+            semantic_model_name="t_model",
+            old_columns=old,
+            new_columns=new,
+            kind_field="is_dimension",
+            allowed_fields={"description"},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -402,20 +414,17 @@ class TestUpdateSemanticModel:
         return obj
 
     def test_update_semantic_model_description(self):
-        """update_semantic_model updates table description across storages."""
+        """update_semantic_model calls update_entry with the correct table entry_id."""
         updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(("update", values))
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
 
-        updater._get_all_storages = lambda: [FakeStorage()]
+        updater.semantic_model_storage = FakeStorage()
 
         old_values = {
-            "catalog_name": "cat",
-            "database_name": "db",
-            "schema_name": "sch",
             "table_name": "orders",
             "semantic_model_name": "orders_model",
         }
@@ -423,24 +432,59 @@ class TestUpdateSemanticModel:
 
         updater.update_semantic_model(old_values, update_values)
 
-        # Should have at least one update call for the description
-        assert any(v[1].get("description") == "Updated description" for v in calls)
+        assert any(
+            entry_id == "table:orders_model" and v.get("description") == "Updated description" for entry_id, v in calls
+        )
 
-    def test_update_semantic_model_dimensions(self):
-        """update_semantic_model updates dimension columns."""
+    def test_update_semantic_model_description_uses_table_name_fallback(self):
+        """When semantic_model_name is empty, table_name is used for the entry_id."""
         updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(values)
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
 
-        updater._get_all_storages = lambda: [FakeStorage()]
+        updater.semantic_model_storage = FakeStorage()
 
         old_values = {
-            "catalog_name": "cat",
-            "database_name": "db",
-            "schema_name": "sch",
+            "table_name": "orders",
+            "semantic_model_name": "",
+        }
+        update_values = {"description": "Updated description"}
+
+        updater.update_semantic_model(old_values, update_values)
+
+        assert any(entry_id == "table:orders" for entry_id, _ in calls)
+
+    def test_update_semantic_model_description_value_error_handled(self):
+        """ValueError from update_entry for table is caught and does not raise."""
+        updater = self._make_updater()
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                raise ValueError("not found")
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {"table_name": "orders", "semantic_model_name": "orders_model"}
+        update_values = {"description": "desc"}
+
+        # Should not raise
+        updater.update_semantic_model(old_values, update_values)
+
+    def test_update_semantic_model_dimensions(self):
+        """update_semantic_model updates dimension columns via update_entry."""
+        updater = self._make_updater()
+        calls = []
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {
             "table_name": "orders",
             "semantic_model_name": "orders_model",
             "dimensions": [{"name": "region", "description": "old region desc"}],
@@ -451,23 +495,23 @@ class TestUpdateSemanticModel:
 
         updater.update_semantic_model(old_values, update_values)
 
-        assert any("description" in v and v["description"] == "new region desc" for v in calls)
+        assert any(
+            entry_id == "column:orders_model.region" and v.get("description") == "new region desc"
+            for entry_id, v in calls
+        )
 
     def test_update_semantic_model_measures(self):
-        """update_semantic_model updates measure columns."""
+        """update_semantic_model updates measure columns via update_entry."""
         updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(values)
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
 
-        updater._get_all_storages = lambda: [FakeStorage()]
+        updater.semantic_model_storage = FakeStorage()
 
         old_values = {
-            "catalog_name": "cat",
-            "database_name": "db",
-            "schema_name": "sch",
             "table_name": "orders",
             "semantic_model_name": "orders_model",
             "measures": [{"name": "total_amount", "agg": "SUM"}],
@@ -478,23 +522,22 @@ class TestUpdateSemanticModel:
 
         updater.update_semantic_model(old_values, update_values)
 
-        assert any("agg" in v and v["agg"] == "AVERAGE" for v in calls)
+        assert any(
+            entry_id == "column:orders_model.total_amount" and v.get("agg") == "AVERAGE" for entry_id, v in calls
+        )
 
     def test_update_semantic_model_identifiers(self):
-        """update_semantic_model updates identifier columns."""
+        """update_semantic_model updates identifier columns via update_entry."""
         updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(values)
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
 
-        updater._get_all_storages = lambda: [FakeStorage()]
+        updater.semantic_model_storage = FakeStorage()
 
         old_values = {
-            "catalog_name": "cat",
-            "database_name": "db",
-            "schema_name": "sch",
             "table_name": "orders",
             "semantic_model_name": "orders_model",
             "identifiers": [{"name": "order_id", "entity": "order"}],
@@ -505,4 +548,6 @@ class TestUpdateSemanticModel:
 
         updater.update_semantic_model(old_values, update_values)
 
-        assert any("entity" in v and v["entity"] == "transaction" for v in calls)
+        assert any(
+            entry_id == "column:orders_model.order_id" and v.get("entity") == "transaction" for entry_id, v in calls
+        )

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -474,6 +474,77 @@ class TestUpdateSemanticModel:
         # Should not raise
         updater.update_semantic_model(old_values, update_values)
 
+    def test_update_semantic_model_description_propagates_non_not_found_exception(self):
+        """Non-NOT_FOUND DatusException from update_entry on table must propagate."""
+        import pytest
+
+        updater = self._make_updater()
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                raise DatusException(
+                    ErrorCode.STORAGE_INVALID_ARGUMENT,
+                    message_args={"error_message": "bad input"},
+                )
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {"table_name": "orders", "semantic_model_name": "orders_model"}
+        update_values = {"description": "desc"}
+
+        with pytest.raises(DatusException) as excinfo:
+            updater.update_semantic_model(old_values, update_values)
+        assert excinfo.value.code == ErrorCode.STORAGE_INVALID_ARGUMENT
+
+    def test_update_semantic_model_columns_propagates_non_not_found_exception(self):
+        """Non-NOT_FOUND DatusException from update_entry on a column must propagate."""
+        import pytest
+
+        updater = self._make_updater()
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                raise DatusException(
+                    ErrorCode.STORAGE_FAILED,
+                    message_args={"error_message": "backend down"},
+                )
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {
+            "table_name": "orders",
+            "semantic_model_name": "orders_model",
+            "dimensions": [{"name": "region", "description": "old"}],
+        }
+        update_values = {"dimensions": [{"name": "region", "description": "new"}]}
+
+        with pytest.raises(DatusException) as excinfo:
+            updater.update_semantic_model(old_values, update_values)
+        assert excinfo.value.code == ErrorCode.STORAGE_FAILED
+
+    def test_update_semantic_model_columns_swallows_not_found(self):
+        """STORAGE_ENTRY_NOT_FOUND from column update is logged and swallowed."""
+        updater = self._make_updater()
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                raise DatusException(
+                    ErrorCode.STORAGE_ENTRY_NOT_FOUND,
+                    message_args={"entry_id": entry_id},
+                )
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {
+            "table_name": "orders",
+            "semantic_model_name": "orders_model",
+            "measures": [{"name": "total", "agg": "SUM"}],
+        }
+        update_values = {"measures": [{"name": "total", "agg": "AVERAGE"}]}
+
+        # Should not raise — NOT_FOUND is intentionally tolerated for partial drift
+        updater.update_semantic_model(old_values, update_values)
+
     def test_update_semantic_model_dimensions(self):
         """update_semantic_model updates dimension columns via update_entry."""
         updater = self._make_updater()

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -378,9 +378,11 @@ class TestUpdateColumnsMethod:
     def test_update_columns_value_error_is_handled(self):
         """DatusException from update_entry (entry not found) is caught and logged, not raised."""
         updater = self._make_updater()
+        calls = []
 
         class FakeStorage:
             def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
                 raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
 
         updater.semantic_model_storage = FakeStorage()
@@ -397,6 +399,10 @@ class TestUpdateColumnsMethod:
             kind_field="is_dimension",
             allowed_fields={"description"},
         )
+        # Verify update_entry was actually invoked — guards against vacuous pass
+        # if a future refactor silently skips the call.
+        assert len(calls) == 1
+        assert calls[0] == ("column:t.col1", {"description": "new"})
 
 
 # ---------------------------------------------------------------------------
@@ -460,9 +466,11 @@ class TestUpdateSemanticModel:
     def test_update_semantic_model_description_value_error_handled(self):
         """DatusException from update_entry for table is caught and does not raise."""
         updater = self._make_updater()
+        calls = []
 
         class FakeStorage:
             def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
                 raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
 
         updater.semantic_model_storage = FakeStorage()
@@ -472,6 +480,10 @@ class TestUpdateSemanticModel:
 
         # Should not raise
         updater.update_semantic_model(old_values, update_values)
+        # Verify update_entry was actually invoked — guards against vacuous pass
+        # if a future refactor silently skips the call.
+        assert len(calls) == 1
+        assert calls[0] == ("table:orders", {"description": "desc"})
 
     def test_update_semantic_model_description_propagates_non_not_found_exception(self):
         """Non-NOT_FOUND DatusException from update_entry on table must propagate."""
@@ -524,9 +536,11 @@ class TestUpdateSemanticModel:
     def test_update_semantic_model_columns_swallows_not_found(self):
         """STORAGE_ENTRY_NOT_FOUND from column update is logged and swallowed."""
         updater = self._make_updater()
+        calls = []
 
         class FakeStorage:
             def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
                 raise DatusException(
                     ErrorCode.STORAGE_ENTRY_NOT_FOUND,
                     message_args={"entry_id": entry_id},
@@ -543,6 +557,9 @@ class TestUpdateSemanticModel:
 
         # Should not raise — NOT_FOUND is intentionally tolerated for partial drift
         updater.update_semantic_model(old_values, update_values)
+        # Verify update_entry was actually invoked on the column entry — guards against
+        # vacuous pass if change-detection silently skips the column.
+        assert any(entry_id == "column:orders.total" and v == {"agg": "AVERAGE"} for entry_id, v in calls)
 
     def test_update_semantic_model_dimensions(self):
         """update_semantic_model updates dimension columns via update_entry."""

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -111,56 +111,55 @@ class TestUpdateColumnsFieldMapping:
     are passed to _update_columns in update_semantic_model.
     """
 
-    def _make_updater(self):
-        """Create a bare CatalogUpdater for pure method tests."""
+    def _make_updater(self, fake_storage):
+        """Create a bare CatalogUpdater wired to ``fake_storage`` for pure method tests."""
         obj = object.__new__(CatalogUpdater)
         obj.datasource_id = "test_datasource"
+        obj.semantic_model_storage = fake_storage
         return obj
 
     def test_type_to_column_type_mapping_detects_change(self):
         """column_type field maps from 'type' key in source data — verified via real method."""
-        updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(values)
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater = self._make_updater(FakeStorage())
 
         old = [{"name": "col1", "type": "string", "description": "A column"}]
         new = [{"name": "col1", "type": "integer", "description": "A column"}]
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
             kind_field="is_dimension",
             allowed_fields={"description", "expr", "column_type"},
         )
         assert len(calls) == 1
-        assert calls[0].get("column_type") == "integer"
-        assert "description" not in calls[0]  # unchanged
+        entry_id, values = calls[0]
+        assert entry_id == "column:t.col1"
+        assert values.get("column_type") == "integer"
+        assert "description" not in values  # unchanged
 
     def test_no_changes_when_values_identical(self):
         """When old and new columns are identical, _update_columns makes no updates."""
-        updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(values)
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater = self._make_updater(FakeStorage())
 
         item = [{"name": "col1", "type": "string", "description": "desc", "expr": "x"}]
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=item,
             new_columns=item,
             kind_field="is_dimension",
@@ -170,56 +169,56 @@ class TestUpdateColumnsFieldMapping:
 
     def test_description_change_detected(self):
         """A changed description field triggers an update with only the changed value."""
-        updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(values)
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater = self._make_updater(FakeStorage())
 
         old = [{"name": "col1", "type": "string", "description": "old desc"}]
         new = [{"name": "col1", "type": "string", "description": "new desc"}]
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
             kind_field="is_dimension",
             allowed_fields={"description", "expr", "column_type"},
         )
         assert len(calls) == 1
-        assert calls[0] == {"description": "new desc"}
+        entry_id, values = calls[0]
+        assert entry_id == "column:t.col1"
+        assert values == {"description": "new desc"}
 
     def test_missing_old_field_detected_as_change(self):
         """If old_item lacks a field that new_item has, _update_columns detects it as a change."""
-        updater = self._make_updater()
         calls = []
 
         class FakeStorage:
-            def update(self, where, values, unique_filter=None):
-                calls.append(values)
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater = self._make_updater(FakeStorage())
 
         old = [{"name": "col1"}]
         new = [{"name": "col1", "description": "new desc", "type": "string"}]
 
         updater._update_columns(
-            storages=[FakeStorage()],
-            catalog_name="cat",
-            database_name="db",
-            schema_name="sch",
             table_name="t",
+            semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
             kind_field="is_dimension",
             allowed_fields={"description", "expr", "column_type"},
         )
         assert len(calls) == 1
-        assert "description" in calls[0]
-        assert "column_type" in calls[0]
+        entry_id, values = calls[0]
+        assert entry_id == "column:t.col1"
+        assert "description" in values
+        assert "column_type" in values
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -7,6 +7,7 @@
 import json
 
 from datus.storage.catalog_manager import CatalogUpdater
+from datus.utils.exceptions import DatusException, ErrorCode
 
 
 class TestParseJsonField:
@@ -376,12 +377,12 @@ class TestUpdateColumnsMethod:
         assert calls[0] == {"description": "new"}
 
     def test_update_columns_value_error_is_handled(self):
-        """ValueError from update_entry (entry not found) is caught and logged, not raised."""
+        """DatusException from update_entry (entry not found) is caught and logged, not raised."""
         updater = self._make_updater()
 
         class FakeStorage:
             def update_entry(self, entry_id, values):
-                raise ValueError(f"Entry not found: {entry_id}")
+                raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
 
         updater.semantic_model_storage = FakeStorage()
 
@@ -458,12 +459,12 @@ class TestUpdateSemanticModel:
         assert any(entry_id == "table:orders" for entry_id, _ in calls)
 
     def test_update_semantic_model_description_value_error_handled(self):
-        """ValueError from update_entry for table is caught and does not raise."""
+        """DatusException from update_entry for table is caught and does not raise."""
         updater = self._make_updater()
 
         class FakeStorage:
             def update_entry(self, entry_id, values):
-                raise ValueError("not found")
+                raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
 
         updater.semantic_model_storage = FakeStorage()
 


### PR DESCRIPTION
## Why 

When update_entry() is called from CLI (SubjectUpdater) or API (ExplorerService), only the vector database (LanceDB) is updated while the corresponding YAML files on disk remain stale. This causes data inconsistency between the two storage layers (vector DB vs. YAML files) for MetricStorage, ReferenceSqlStorage, and SemanticModelStorage.                                                                                                                                                                                                                                                                                                            

For example, editing a metric's description via the CLI subject screen updates the vector DB entry, but the source YAML file still contains the old description. The delete_metric() method already handles YAML sync-back correctly, but update_entry() was missing this logic. 

Additionally, CatalogUpdater.update_semantic_model() calls storage.update() directly, bypassing the YAML sync entirely. And ExplorerService lacks an edit_semantic_model API endpoint.  

## Solution

### Storage layer — add YAML sync-back to update_entry():
- MetricStorage: Override update_entry() to query yaml_path before update, call super().update_entry() for vector DB, then sync mapped fields (description → description, metric_type → type) back to the multi-document YAML file. Follows the existing delete_metric() error-handling pattern (best-effort, log on failure).
- ReferenceSqlStorage: Override update_entry() with the same pattern. Syncs flat fields (sql, summary, search_text, comment, tags) back to the single-document YAML file.
- SemanticModelStorage: Add new update_entry(entry_id, update_values) method (this store extends BaseEmbeddingStore, not BaseSubjectEmbeddingStore). Handles both table-level (description) and column-level (description, expr, column_type → type) updates, searching through dimensions/measures/identifiers sections in the  YAML.

### Consumer refactoring: 

- CatalogUpdater: Refactored to use SemanticModelStorage.update_entry() instead of direct storage.update() with complex WHERE clauses. Removed _get_all_storages() and datus_storage_base.conditions dependency.
- ExplorerService: Added edit_semantic_model() API endpoint with EditSemanticModelInput request model, following the same pattern as edit_knowledge().

### Key design decisions: 

- Only fields with a clear, direct YAML counterpart are synced. Complex nested fields (type_params, base_measures) are intentionally skipped to avoid lossy round-trip conversion.
- File sync errors are logged but do not fail the operation — vector DB remains the primary data source.

## Test Cases

Added 18 new CI-level unit tests (zero external deps, deterministic): 
- tests/unit_tests/storage/metric/test_store.py — TestUpdateMetricYaml (5 tests): YAML description sync, metric_type → type mapping, no yaml_path handling, nonexistent file handling, unmapped fields skipped                                                                                                                  - tests/unit_tests/storage/reference_sql/test_store.py — TestUpdateReferenceSqlYaml (4 tests): YAML field sync, empty filepath, nonexistent file, preservation of non-updated fields
- tests/unit_tests/storage/semantic_model/test_store.py — TestUpdateEntryYamlSync (6 tests): table description sync, column description sync, column_type → type mapping, empty yaml_path, nonexistent entry error, empty update_values error 
- tests/unit_tests/storage/test_catalog_manager.py — Updated existing tests + 3 new tests for update_entry() integration, fallback to table_name, and ValueError handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit edits for semantic models, metrics, and reference-SQL via API and UI; edits can be propagated back to source YAML files. Vector embeddings are re-generated when relevant fields change.

* **Bug Fixes**
  * Safer handling when entries or YAML files are missing; clearer validation and error reporting for edit requests and storage operations.

* **UI**
  * Description textarea auto-sizes; dimensions field forced read-only; search label refined; subject renames trigger YAML sync for affected subtrees.

* **Tests**
  * Expanded unit tests covering update flows, YAML synchronization, renames, and re-embedding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->