### PR TITLE
[BugFix] Add openai/ prefix for self-hosted vLLM endpoints in LiteLLM adapter

### DIFF
--- a/datus/models/litellm_adapter.py
+++ b/datus/models/litellm_adapter.py
@@ -218,6 +218,7 @@ class LiteLLMAdapter:
             - openai/gpt-4o -> gpt-4o (no prefix for OpenAI)
             - claude/claude-sonnet-4 -> anthropic/claude-sonnet-4
             - deepseek/deepseek-chat -> deepseek/deepseek-chat
+            - openai + custom base_url + Qwen3.5-397B -> openai/Qwen3.5-397B
         """
         prefix = self.MODEL_PREFIX_MAP.get(self.provider, "")
 
@@ -230,7 +231,16 @@ class LiteLLMAdapter:
         if "/" in self.model:
             return self.model
 
-        # For OpenAI, no prefix needed
+        # For OpenAI provider with custom base_url (e.g. self-hosted vLLM),
+        # add "openai/" prefix so LiteLLM uses OpenAI-compatible API format
+        # for model names not in its built-in list (e.g. Qwen3.5-397B).
+        if self.provider == "openai" and not prefix and self.base_url:
+            parsed = urlparse(self.base_url)
+            domain = parsed.hostname or ""
+            if domain not in ("api.openai.com",):
+                return f"openai/{self.model}"
+
+        # For OpenAI native models (gpt-4o, o3, etc.), no prefix needed
         if not prefix:
             return self.model
 

--- a/tests/unit_tests/models/test_litellm_adapter.py
+++ b/tests/unit_tests/models/test_litellm_adapter.py
@@ -313,6 +313,37 @@ class TestAutoDetectWithBaseUrl:
         )
         assert adapter.provider == "deepseek"
 
+    def test_vllm_custom_endpoint_openai_prefix(self):
+        """type: openai + custom vLLM base_url + Qwen3.5-397B → openai/Qwen3.5-397B (#532)."""
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="Qwen3.5-397B",
+            api_key="key",
+            base_url="http://192.168.1.100:8015/v1",
+        )
+        assert adapter.provider == "openai"
+        assert adapter.litellm_model_name == "openai/Qwen3.5-397B"
+
+    def test_native_openai_no_extra_prefix(self):
+        """type: openai + api.openai.com → no openai/ prefix for native models."""
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="gpt-4o",
+            api_key="key",
+            base_url="https://api.openai.com/v1",
+        )
+        assert adapter.litellm_model_name == "gpt-4o"
+
+    def test_localhost_vllm_openai_prefix(self):
+        """type: openai + localhost vLLM → openai/ prefix for unknown model."""
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="my-custom-model",
+            api_key="key",
+            base_url="http://localhost:8000/v1",
+        )
+        assert adapter.litellm_model_name == "openai/my-custom-model"
+
 
 class TestDefaultHeaders:
     """Tests for default_headers passthrough to LiteLLM and Anthropic clients."""

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -198,6 +198,7 @@ class TestResolveNodeType:
             "sql_summary": NodeType.TYPE_SQL_SUMMARY,
             "explore": NodeType.TYPE_EXPLORE,
             "gen_table": NodeType.TYPE_GEN_TABLE,
+            "gen_skill": NodeType.TYPE_GEN_SKILL,
         }
         assert set(NODE_CLASS_MAP.keys()) == set(expected_map.keys()), (
             f"NODE_CLASS_MAP keys differ: got {set(NODE_CLASS_MAP.keys())}"


### PR DESCRIPTION
## Summary

- Skip provider auto-detection when user provides a custom `base_url`, respecting explicit endpoint choice (e.g. self-hosted vLLM)
- Add `openai/` prefix for non-`api.openai.com` endpoints so LiteLLM uses OpenAI-compatible API format for unknown model names (e.g. `Qwen3.5-397B`)

Closes #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic provider inference when a custom LLM endpoint is explicitly provided.
  * Improved model naming for OpenAI-compatible non-official endpoints by prefixing models with "openai/" for non-standard hosts (including localhost), while preserving native OpenAI behavior.

* **Tests**
  * Added unit tests validating provider selection and model-name prefixing for custom vs native endpoints.
  * Updated test coverage to include the new "gen_skill" node type mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->