### PR TITLE
[Feature] Add bootstrap platform docs SSE API and optimize GitHub file discovery

### DIFF
--- a/datus/api/models/kb_models.py
+++ b/datus/api/models/kb_models.py
@@ -104,6 +104,35 @@ class BootstrapKbInput(BaseModel):
     )
 
 
+class BootstrapDocInput(BaseModel):
+    """POST body for /api/v1/kb/bootstrap-docs.
+
+    Only ``platform`` is required.  Every other field falls back to the
+    matching ``DocumentConfig`` in ``agent.yml`` (``agent.document.<platform>``).
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    platform: str = Field(..., description="Platform name, e.g. 'snowflake', 'duckdb', 'postgresql'.")
+    build_mode: Literal["overwrite", "check"] = Field(
+        default="overwrite",
+        description="'check' returns existing store stats; 'overwrite' clears and rebuilds.",
+    )
+    pool_size: int = Field(default=4, ge=1, le=16, description="Thread pool size for parallel processing.")
+
+    # Optional overrides — if omitted, resolved from AgentConfig.document_configs[platform]
+    source_type: Optional[str] = Field(default=None, description="Source type: 'github', 'website', or 'local'.")
+    source: Optional[str] = Field(default=None, description="GitHub repo 'owner/repo', URL, or local path.")
+    version: Optional[str] = Field(default=None, description="Document version (auto-detected if omitted).")
+    github_ref: Optional[str] = Field(default=None, description="Git branch / tag / commit for GitHub sources.")
+    github_token: Optional[str] = Field(default=None, description="GitHub API token for authenticated access.")
+    paths: Optional[list[str]] = Field(default=None, description="File/directory paths to include.")
+    chunk_size: Optional[int] = Field(default=None, description="Target chunk size in characters.")
+    max_depth: Optional[int] = Field(default=None, description="Max crawl depth for website sources.")
+    include_patterns: Optional[list[str]] = Field(default=None, description="File/URL patterns to include (regex).")
+    exclude_patterns: Optional[list[str]] = Field(default=None, description="File/URL patterns to exclude (regex).")
+
+
 class BootstrapKbEvent(BaseModel):
     """SSE event envelope sent to the client."""
 

--- a/datus/api/routes/kb_routes.py
+++ b/datus/api/routes/kb_routes.py
@@ -126,7 +126,7 @@ async def bootstrap_docs(
         project_files_root = os.path.join(svc.agent_config.home, "files")
         try:
             safe_resolve(P(project_files_root), request.source)
-        except ValueError as e:
+        except DatusException as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
 
     async def generate_sse():

--- a/datus/api/routes/kb_routes.py
+++ b/datus/api/routes/kb_routes.py
@@ -16,6 +16,7 @@ from datus.api.utils.stream_cancellation import (
     cleanup_cancel_token,
     create_cancel_token,
 )
+from datus.utils.exceptions import DatusException
 
 router = APIRouter(prefix="/api/v1/kb", tags=["knowledge-base"])
 
@@ -39,7 +40,7 @@ async def bootstrap_kb(
     # Validate user-supplied paths against the project root
     try:
         _validate_paths(request, project_files_root)
-    except ValueError as e:
+    except DatusException as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
     async def generate_sse():

--- a/datus/api/routes/kb_routes.py
+++ b/datus/api/routes/kb_routes.py
@@ -9,7 +9,7 @@ from fastapi.responses import StreamingResponse
 
 from datus.api.deps import ServiceDep
 from datus.api.models.base_models import Result
-from datus.api.models.kb_models import BootstrapKbInput
+from datus.api.models.kb_models import BootstrapDocInput, BootstrapKbInput
 from datus.api.utils.path_utils import safe_resolve
 from datus.api.utils.stream_cancellation import (
     cancel_stream,
@@ -88,3 +88,76 @@ def _validate_paths(request: BootstrapKbInput, project_root: str) -> None:
         safe_resolve(base, request.sql_dir)
     if request.ext_knowledge:
         safe_resolve(base, request.ext_knowledge)
+
+
+# ======================================================================
+# Platform document bootstrap
+# ======================================================================
+
+
+@router.post(
+    "/bootstrap-docs",
+    summary="Bootstrap Platform Documentation",
+    description="Start platform documentation bootstrap with SSE progress streaming",
+)
+async def bootstrap_docs(
+    request: BootstrapDocInput,
+    svc: ServiceDep,
+):
+    """Start platform doc bootstrap with SSE progress streaming."""
+    stream_id = str(uuid.uuid4())
+    cancel_event = create_cancel_token(stream_id)
+
+    # Validate: platform must exist in config OR request must supply source
+    platform = request.platform
+    doc_cfg = svc.agent_config.document_configs.get(platform)
+    if not doc_cfg and not request.source:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Platform '{platform}' not found in agent config and no source provided",
+        )
+
+    # Path validation for local sources
+    source_type = request.source_type or (doc_cfg.type if doc_cfg else None)
+    if request.source and source_type == "local":
+        from pathlib import Path as P
+
+        project_files_root = os.path.join(svc.agent_config.home, "files")
+        try:
+            safe_resolve(P(project_files_root), request.source)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+
+    async def generate_sse():
+        try:
+            async for event in svc.kb.bootstrap_doc_stream(request, stream_id, cancel_event):
+                data = json.dumps(event.model_dump(exclude_none=True), ensure_ascii=False)
+                yield f"id: {stream_id}\nevent: {event.stage}\ndata: {data}\n\n"
+        finally:
+            cleanup_cancel_token(stream_id)
+
+    return StreamingResponse(
+        generate_sse(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "Access-Control-Allow-Origin": "*",
+            "Content-Type": "text/event-stream; charset=utf-8",
+        },
+    )
+
+
+@router.post(
+    "/bootstrap-docs/{stream_id}/cancel",
+    response_model=Result[dict],
+    summary="Cancel Doc Bootstrap",
+    description="Cancel a running platform doc bootstrap stream",
+)
+async def cancel_doc_bootstrap(
+    svc: ServiceDep,  # noqa: ARG001 — triggers auth
+    stream_id: str = Path(..., description="Stream ID to cancel"),
+):
+    """Cancel a running platform doc bootstrap stream."""
+    cancelled = cancel_stream(stream_id)
+    return Result(success=cancelled, data={"stream_id": stream_id, "cancelled": cancelled})

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import AsyncGenerator, Optional
 
 from datus.api.models.kb_models import (
+    BootstrapDocInput,
     BootstrapKbEvent,
     BootstrapKbInput,
     KbComponent,
@@ -328,6 +329,147 @@ class KbService:
             emit=emit,
         )
         return result if isinstance(result, dict) else {"status": "success", "message": str(result)}
+
+    # ------------------------------------------------------------------
+    # Platform document bootstrap
+    # ------------------------------------------------------------------
+
+    async def bootstrap_doc_stream(
+        self,
+        request: BootstrapDocInput,
+        stream_id: str,
+        cancel_event: asyncio.Event,
+    ) -> AsyncGenerator[BootstrapKbEvent, None]:
+        """Run platform doc bootstrap, yielding SSE events."""
+        queue: asyncio.Queue = asyncio.Queue()
+        loop = asyncio.get_running_loop()
+        component = "platform_doc"
+
+        future = loop.run_in_executor(
+            None,
+            self._run_doc_init,
+            request,
+            queue,
+            loop,
+            cancel_event,
+        )
+
+        # Drain queue (same pattern as bootstrap_stream)
+        while True:
+            if future.done() and queue.empty():
+                break
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=0.5)
+            except asyncio.TimeoutError:
+                if future.done():
+                    break
+                continue
+            if item is _COMPONENT_DONE:
+                break
+            yield self._batch_event_to_sse(stream_id, component, item)
+
+        # Collect result
+        result = None
+        component_error = None
+        try:
+            result = await future
+        except Exception as exc:
+            logger.exception("Platform doc bootstrap failed")
+            component_error = exc
+
+        # Drain remaining events
+        while not queue.empty():
+            try:
+                item = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if item is _COMPONENT_DONE:
+                break
+            yield self._batch_event_to_sse(stream_id, component, item)
+
+        # Final event
+        if component_error:
+            yield self._make_event(stream_id, component, BatchStage.TASK_FAILED, error=str(component_error))
+        elif result and result.success:
+            yield self._make_event(
+                stream_id,
+                component,
+                BatchStage.TASK_COMPLETED,
+                message=f"Processed {result.total_docs} docs, {result.total_chunks} chunks",
+                payload={
+                    "platform": result.platform,
+                    "version": result.version,
+                    "total_docs": result.total_docs,
+                    "total_chunks": result.total_chunks,
+                    "duration_seconds": result.duration_seconds,
+                    "errors": result.errors,
+                },
+            )
+        else:
+            error_msg = "; ".join(result.errors) if result and result.errors else "Unknown error"
+            yield self._make_event(stream_id, component, BatchStage.TASK_FAILED, error=error_msg)
+
+    def _run_doc_init(
+        self,
+        request: BootstrapDocInput,
+        queue: asyncio.Queue,
+        loop: asyncio.AbstractEventLoop,
+        cancel_event: asyncio.Event,
+    ):
+        """Sync worker for platform doc bootstrap (runs in executor thread)."""
+        from datus.configuration.agent_config import DocumentConfig
+        from datus.storage.document.doc_init import init_platform_docs
+
+        config = self.agent_config
+        platform = request.platform
+
+        # Resolve DocumentConfig: YAML base + API overrides
+        base_cfg = config.document_configs.get(platform, DocumentConfig())
+        merged_cfg = self._merge_doc_overrides(base_cfg, request)
+
+        # Thread-safe emit bridging to async queue
+        def emit(event: BatchEvent) -> None:
+            loop.call_soon_threadsafe(queue.put_nowait, event)
+
+        # Cancel bridge: asyncio.Event -> sync callable
+        def cancel_check() -> bool:
+            return cancel_event.is_set()
+
+        try:
+            return init_platform_docs(
+                platform=platform,
+                cfg=merged_cfg,
+                build_mode=request.build_mode,
+                pool_size=request.pool_size,
+                emit=emit,
+                cancel_check=cancel_check,
+            )
+        finally:
+            loop.call_soon_threadsafe(queue.put_nowait, _COMPONENT_DONE)
+
+    @staticmethod
+    def _merge_doc_overrides(base, request: BootstrapDocInput):
+        """Overlay non-None API request fields onto the YAML-based DocumentConfig."""
+        import dataclasses
+
+        field_map = {
+            "source_type": "type",
+            "source": "source",
+            "version": "version",
+            "github_ref": "github_ref",
+            "github_token": "github_token",
+            "paths": "paths",
+            "chunk_size": "chunk_size",
+            "max_depth": "max_depth",
+            "include_patterns": "include_patterns",
+            "exclude_patterns": "exclude_patterns",
+        }
+        overrides = {}
+        for req_field, cfg_field in field_map.items():
+            val = getattr(request, req_field, None)
+            if val is not None:
+                overrides[cfg_field] = val
+        return dataclasses.replace(base, **overrides)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/datus/storage/document/doc_init.py
+++ b/datus/storage/document/doc_init.py
@@ -17,8 +17,9 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Callable, List, Optional, Set, Tuple
 
+from datus.schemas.batch_events import BatchEventEmitter, BatchEventHelper
 from datus.storage.document.fetcher import GitHubFetcher, LocalFetcher, RateLimiter, WebFetcher
 from datus.storage.document.schemas import SOURCE_TYPE_GITHUB, SOURCE_TYPE_LOCAL
 from datus.storage.document.store import document_store
@@ -203,6 +204,8 @@ def init_platform_docs(
     build_mode: str = "overwrite",
     pool_size: int = 4,
     db_path: str = "",
+    emit: Optional[BatchEventEmitter] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
 ) -> InitResult:
     """Initialize platform documentation knowledge base.
 
@@ -246,10 +249,15 @@ def init_platform_docs(
 
     logger.info(f"Initializing {platform} documentation from {source} ({source_type})")
 
+    helper = BatchEventHelper("platform_doc_init", emit)
+
     try:
         store = document_store(platform)
     except DatusException as exc:
+        helper.task_failed(error=str(exc))
         return _make_empty_result(platform, version, source, start_time, errors=[str(exc)])
+
+    helper.task_started(platform=platform, source=source, source_type=source_type)
 
     # ==================================================================
     # Check mode: return existing store stats without any I/O or fetching
@@ -287,12 +295,22 @@ def init_platform_docs(
             version_details=version_details,
         )
 
+    # Cancel check before processing
+    if cancel_check and cancel_check():
+        helper.task_failed(error="Cancelled by user")
+        return _make_empty_result(platform, version, source, start_time, errors=["Cancelled"])
+
     # Initialize components
     rate_limiter = RateLimiter()
+
+    def _on_doc_done(doc_path: str, chunk_count: int) -> None:
+        helper.item_completed(item_id=doc_path, chunks=chunk_count)
+
     processor = StreamingDocProcessor(
         store=store,
         chunk_size=cfg.chunk_size,
         pool_size=pool_size,
+        on_doc_complete=_on_doc_done if emit else None,
     )
 
     # Track versions from path-based directories (e.g., paths=["1.3.0", "1.2.0"])
@@ -338,6 +356,11 @@ def init_platform_docs(
                     version = github_metadata.version
 
             logger.info(f"Found {len(github_metadata.file_paths)} files, version='{version}'")
+            helper.task_validated(total_items=len(github_metadata.file_paths), version=version)
+
+            if cancel_check and cancel_check():
+                helper.task_failed(error="Cancelled by user")
+                return _make_empty_result(platform, version, source, start_time, errors=["Cancelled"])
 
             # Phase 2: Delete existing data
             _delete_existing_versions(store, version, path_versions)
@@ -367,6 +390,11 @@ def init_platform_docs(
                 version = documents[0].version
 
             logger.info(f"Found {len(documents)} documents, version='{version}'")
+            helper.task_validated(total_items=len(documents), version=version)
+
+            if cancel_check and cancel_check():
+                helper.task_failed(error="Cancelled by user")
+                return _make_empty_result(platform, version, source, start_time, errors=["Cancelled"])
 
             # Phase 2: Delete existing data
             _delete_existing_versions(store, version, path_versions)
@@ -393,6 +421,11 @@ def init_platform_docs(
                 version = fetcher._detect_version_from_url(source)
 
             logger.info(f"Starting website crawl from {source}, version='{version}'")
+            helper.task_processing(total_items=0, version=version, source=source)
+
+            if cancel_check and cancel_check():
+                helper.task_failed(error="Cancelled by user")
+                return _make_empty_result(platform, version, source, start_time, errors=["Cancelled"])
 
             # Phase 2: Delete existing data
             _delete_existing_versions(store, version, path_versions)
@@ -410,6 +443,7 @@ def init_platform_docs(
 
     except Exception as e:
         logger.error(f"Failed to process documents: {e}")
+        helper.task_failed(error=str(e), exception_type=type(e).__name__)
         duration = (datetime.now(timezone.utc) - start_time).total_seconds()
         error_version = ", ".join(sorted(path_versions)) if path_versions else (version or "unknown")
         return InitResult(
@@ -440,6 +474,13 @@ def init_platform_docs(
 
     logger.info(
         f"Platform documentation initialized: {stats.total_docs} docs, {stats.total_chunks} chunks, {duration:.1f}s"
+    )
+
+    helper.task_completed(
+        total_items=stats.total_docs,
+        completed_items=stats.total_docs - len(stats.errors),
+        failed_items=len(stats.errors),
+        total_chunks=stats.total_chunks,
     )
 
     return InitResult(

--- a/datus/storage/document/fetcher/github_fetcher.py
+++ b/datus/storage/document/fetcher/github_fetcher.py
@@ -523,13 +523,90 @@ class GitHubFetcher(BaseFetcher):
             logger.debug(f"Error discovering version directories: {e}")
             return []
 
+    # ------------------------------------------------------------------
+    # File path collection — fast (Git Trees API) with recursive fallback
+    # ------------------------------------------------------------------
+
+    def _get_full_tree(self, repo: "Repository", branch: str) -> Optional[List]:
+        """Fetch the full recursive tree for a branch in a single API call.
+
+        Uses ``GET /repos/{owner}/{repo}/git/trees/{sha}?recursive=1``
+        which returns up to 100 000 entries — far faster than walking
+        directories one-by-one with the Contents API.
+
+        Returns:
+            List of tree elements, or None on failure.
+        """
+        if not hasattr(self, "_tree_cache"):
+            self._tree_cache: Dict[str, Optional[List]] = {}
+
+        cache_key = f"{repo.full_name}:{branch}"
+        if cache_key in self._tree_cache:
+            return self._tree_cache[cache_key]
+
+        try:
+            self.rate_limiter.wait("api.github.com")
+            git_tree = repo.get_git_tree(branch, recursive=True)
+            if git_tree.raw_data.get("truncated"):
+                logger.warning("Git tree is truncated (>100k entries); falling back to recursive walk")
+                self._tree_cache[cache_key] = None
+                return None
+            self._tree_cache[cache_key] = git_tree.tree
+            logger.info(f"Fetched full git tree: {len(git_tree.tree)} entries in 1 API call")
+            return git_tree.tree
+        except GithubException as e:
+            logger.debug(f"Git Trees API failed, will use recursive walk: {e}")
+            self._tree_cache[cache_key] = None
+            return None
+
     def _collect_file_paths(
         self,
         repo: "Repository",
         path: str,
         branch: str,
     ) -> List[str]:
-        """Recursively collect file paths from a directory.
+        """Collect documentation file paths under *path*.
+
+        Fast path: uses the Git Trees API (single request for the whole repo).
+        Fallback: recursive ``get_contents`` walk (one request per directory).
+
+        Args:
+            repo: Repository object
+            path: Path to explore (directory or single file)
+            branch: Branch name
+
+        Returns:
+            List of file paths
+        """
+        # --- fast path: filter the full tree ---
+        tree = self._get_full_tree(repo, branch)
+        if tree is not None:
+            return self._filter_tree(tree, path)
+
+        # --- fallback: recursive Contents API walk ---
+        return self._collect_file_paths_recursive(repo, path, branch)
+
+    def _filter_tree(self, tree: List, path: str) -> List[str]:
+        """Filter the pre-fetched git tree for doc files under *path*."""
+        # Normalise: "docs" should match "docs/..." and "docs" itself
+        prefix = path.rstrip("/") + "/"
+        file_paths = []
+        for item in tree:
+            if item.type != "blob":
+                continue
+            # Match: exact path OR starts with prefix
+            if item.path == path or item.path.startswith(prefix):
+                if self._is_doc_file(item.path.split("/")[-1]):
+                    file_paths.append(item.path)
+        return file_paths
+
+    def _collect_file_paths_recursive(
+        self,
+        repo: "Repository",
+        path: str,
+        branch: str,
+    ) -> List[str]:
+        """Recursively collect file paths using the Contents API (slow fallback).
 
         Args:
             repo: Repository object
@@ -549,9 +626,8 @@ class GitHubFetcher(BaseFetcher):
 
         for content in contents:
             if content.type == "dir":
-                # Recurse into directory
                 try:
-                    sub_paths = self._collect_file_paths(repo, content.path, branch)
+                    sub_paths = self._collect_file_paths_recursive(repo, content.path, branch)
                     file_paths.extend(sub_paths)
                 except GithubException as e:
                     logger.debug(f"Could not access directory {content.path}: {e}")

--- a/datus/storage/document/streaming_processor.py
+++ b/datus/storage/document/streaming_processor.py
@@ -15,7 +15,7 @@ import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, List, Optional, Set
+from typing import TYPE_CHECKING, Callable, List, Optional, Set
 from urllib.parse import urlparse
 
 from datus.storage.document.chunker import SemanticChunker
@@ -88,6 +88,7 @@ class StreamingDocProcessor:
         store: "DocumentStore",
         chunk_size: int = 1024,
         pool_size: int = 4,
+        on_doc_complete: Optional[Callable[[str, int], None]] = None,
     ):
         """Initialize the streaming processor.
 
@@ -95,9 +96,13 @@ class StreamingDocProcessor:
             store: DocumentStore for storing chunks
             chunk_size: Target chunk size in characters
             pool_size: Number of worker threads
+            on_doc_complete: Optional callback invoked after each document is
+                processed.  Receives ``(doc_path, chunk_count)`` where
+                *chunk_count* is 0 on failure.  Called from worker threads.
         """
         self.store = store
         self.pool_size = pool_size
+        self._on_doc_complete = on_doc_complete
 
         # Processing components
         self.cleaner = DocumentCleaner()
@@ -172,6 +177,12 @@ class StreamingDocProcessor:
             # Update stats
             stats.increment(docs=1, chunks=len(chunks))
 
+            if self._on_doc_complete:
+                try:
+                    self._on_doc_complete(doc.doc_path, len(chunks))
+                except Exception:
+                    logger.debug(f"on_doc_complete callback failed for {doc.doc_path}")
+
             logger.debug(f"Processed: {doc.doc_path} -> {len(chunks)} chunks")
 
             return chunks
@@ -179,6 +190,11 @@ class StreamingDocProcessor:
         except Exception as e:
             logger.warning(f"Failed to process {doc.doc_path}: {e}")
             stats.add_error(f"Process error ({doc.doc_path}): {str(e)}")
+            if self._on_doc_complete:
+                try:
+                    self._on_doc_complete(doc.doc_path, 0)
+                except Exception:
+                    pass
             return []
 
     def _mark_visited(self, url: str) -> bool:

--- a/docs/API/introduction.md
+++ b/docs/API/introduction.md
@@ -57,3 +57,4 @@ sit at the application root.
 
 - [Deployment](deployment.md) — install and launch the API server
 - [Chat](chat.md) — chat endpoints and SSE streaming
+- [Knowledge Base](knowledge_base.md) — KB bootstrap and platform doc endpoints with SSE

--- a/docs/API/introduction.zh.md
+++ b/docs/API/introduction.zh.md
@@ -55,3 +55,4 @@ Namespace 隔离由 `--namespace` CLI 参数(或 `DATUS_NAMESPACE` 环境变量)
 
 - [部署](deployment.zh.md) — 安装并启动 API 服务
 - [Chat](chat.zh.md) — Chat 接口与 SSE 流式协议
+- [知识库](knowledge_base.zh.md) — 知识库构建与平台文档接口（SSE 流式）

--- a/docs/API/knowledge_base.md
+++ b/docs/API/knowledge_base.md
@@ -1,0 +1,180 @@
+# Knowledge Base API
+
+The knowledge base endpoints manage KB bootstrap operations with real-time progress streaming via Server-Sent Events
+(SSE). All endpoints live under `/api/v1/kb`.
+
+## KB Component Bootstrap
+
+### `POST /api/v1/kb/bootstrap`
+
+Start a knowledge base component bootstrap with SSE progress streaming. Components include metadata, semantic model,
+metrics, external knowledge, and reference SQL.
+
+**Body**:
+
+| Field                | Type     | Default        | Notes |
+|----------------------|----------|----------------|-------|
+| `components`         | string[] | _(required)_   | Components to bootstrap: `metadata`, `semantic_model`, `metrics`, `ext_knowledge`, `reference_sql` |
+| `strategy`           | string   | `incremental`  | `check` (inspect only), `overwrite` (rebuild), or `incremental` (append/update) |
+| `schema_linking_type`| string   | `full`         | Metadata only: `table`, `view`, `mv`, or `full` |
+| `catalog`            | string   | `""`           | Metadata catalog filter (Snowflake, StarRocks) |
+| `database_name`      | string   | `""`           | Metadata database filter |
+| `success_story`      | string?  | `null`         | Project-root-relative path to success-story CSV |
+| `subject_tree`       | string[]?| `null`         | Predefined hierarchical categories |
+| `sql_dir`            | string?  | `null`         | Project-root-relative directory with `.sql` files |
+| `ext_knowledge`      | string?  | `null`         | Project-root-relative CSV for external knowledge |
+
+**Response**: `text/event-stream`. See [SSE event format](#sse-event-format) below.
+
+### `POST /api/v1/kb/bootstrap/{stream_id}/cancel`
+
+Cancel a running KB bootstrap stream.
+
+**Response**: `Result[dict]` with `data = { stream_id, cancelled: true|false }`.
+
+---
+
+## Platform Documentation Bootstrap
+
+### `POST /api/v1/kb/bootstrap-docs`
+
+Start a platform documentation bootstrap with SSE progress streaming. Ingests documentation from GitHub repos, websites,
+or local directories into the platform doc vector store.
+
+**Body**:
+
+| Field              | Type     | Default      | Notes |
+|--------------------|----------|--------------|-------|
+| `platform`         | string   | _(required)_ | Platform name (e.g. `snowflake`, `duckdb`, `starrocks`) |
+| `build_mode`       | string   | `overwrite`  | `check` (status only) or `overwrite` (rebuild) |
+| `pool_size`        | int      | `4`          | Thread pool size (1–16) |
+| `source_type`      | string?  | `null`       | `github`, `website`, or `local` |
+| `source`           | string?  | `null`       | GitHub repo `owner/repo`, URL, or local path |
+| `version`          | string?  | `null`       | Document version (auto-detected if omitted) |
+| `github_ref`       | string?  | `null`       | Git branch / tag / commit for GitHub sources |
+| `github_token`     | string?  | `null`       | GitHub API token for authenticated access |
+| `paths`            | string[]?| `null`       | File/directory paths to include (GitHub only) |
+| `chunk_size`       | int?     | `null`       | Target chunk size in characters |
+| `max_depth`        | int?     | `null`       | Max crawl depth for website sources |
+| `include_patterns` | string[]?| `null`       | File/URL patterns to include (regex) |
+| `exclude_patterns` | string[]?| `null`       | File/URL patterns to exclude (regex) |
+
+Only `platform` is required. All other fields fall back to the matching `DocumentConfig` in `agent.yml`
+(`agent.document.<platform>`). See [Platform Documentation — Configure in agent.yml](../knowledge_base/platform_doc.md#configure-in-agentyml-optional) for YAML configuration.
+
+**Response**: `text/event-stream`. See [SSE event format](#sse-event-format) below.
+
+**Example**:
+
+```bash
+# Check existing store stats
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap-docs \
+  -H "Content-Type: application/json" \
+  -d '{"platform": "starrocks", "build_mode": "check"}'
+
+# Full rebuild from GitHub
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap-docs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "starrocks",
+    "source": "StarRocks/starrocks",
+    "source_type": "github",
+    "github_ref": "main",
+    "paths": ["docs/en"],
+    "build_mode": "overwrite"
+  }'
+```
+
+### `POST /api/v1/kb/bootstrap-docs/{stream_id}/cancel`
+
+Cancel a running platform doc bootstrap stream.
+
+**Response**: `Result[dict]` with `data = { stream_id, cancelled: true|false }`.
+
+---
+
+## SSE Event Format
+
+Both bootstrap endpoints stream progress as Server-Sent Events. Each event has the form:
+
+```
+id: <stream_id>
+event: <stage>
+data: <json>
+```
+
+The JSON payload is a `BootstrapKbEvent`:
+
+| Field       | Type   | Description |
+|-------------|--------|-------------|
+| `stream_id` | string | Unique stream identifier |
+| `component` | string | Component name (`metadata`, `semantic_model`, `platform_doc`, `all`, etc.) |
+| `stage`     | string | Lifecycle stage (see below) |
+| `message`   | string?| Human-readable status message |
+| `error`     | string?| Error message if failed |
+| `progress`  | object?| `{ total, completed, failed }` counters |
+| `payload`   | object?| Additional data (component-specific results) |
+| `timestamp` | string | ISO-format timestamp |
+
+### Lifecycle Stages
+
+| Stage             | Meaning |
+|-------------------|---------|
+| `task_started`    | Component bootstrap has started |
+| `task_validated`  | Items validated, total count confirmed |
+| `task_processing` | Component is processing items |
+| `task_completed`  | Component completed successfully |
+| `task_failed`     | Component failed |
+| `item_started`    | Single item processing started |
+| `item_completed`  | Single item completed |
+| `item_failed`     | Single item failed |
+
+### Example SSE Stream
+
+```
+id: abc-123
+event: task_started
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"task_started","timestamp":"2025-01-01T00:00:00"}
+
+id: abc-123
+event: task_validated
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"task_validated","progress":{"total":1036,"completed":0,"failed":0},"timestamp":"2025-01-01T00:00:01"}
+
+id: abc-123
+event: item_completed
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"item_completed","message":"docs/en/intro.md","timestamp":"2025-01-01T00:00:02"}
+
+id: abc-123
+event: task_completed
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"task_completed","message":"Processed 1036 docs, 5200 chunks","payload":{"platform":"starrocks","version":"3.5.15","total_docs":1036,"total_chunks":5200},"timestamp":"2025-01-01T00:01:30"}
+```
+
+### Consuming SSE in JavaScript
+
+```javascript
+const evtSource = new EventSource('/api/v1/kb/bootstrap-docs', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ platform: 'starrocks', build_mode: 'overwrite' })
+});
+
+evtSource.addEventListener('task_completed', (e) => {
+  const data = JSON.parse(e.data);
+  console.log(`Done: ${data.payload.total_docs} docs, ${data.payload.total_chunks} chunks`);
+  evtSource.close();
+});
+
+evtSource.addEventListener('task_failed', (e) => {
+  const data = JSON.parse(e.data);
+  console.error(`Failed: ${data.error}`);
+  evtSource.close();
+});
+```
+
+### Cancellation
+
+To cancel a running bootstrap, POST to the cancel endpoint with the `stream_id` from the SSE events:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/kb/bootstrap-docs/abc-123/cancel
+```

--- a/docs/API/knowledge_base.zh.md
+++ b/docs/API/knowledge_base.zh.md
@@ -1,0 +1,155 @@
+# 知识库 API
+
+知识库接口负责 KB 构建操作，通过 Server-Sent Events (SSE) 实时推送进度。所有接口位于 `/api/v1/kb` 前缀下。
+
+## KB 组件构建
+
+### `POST /api/v1/kb/bootstrap`
+
+启动知识库组件构建，通过 SSE 流式推送进度。组件包括 metadata、semantic model、metrics、ext knowledge 和 reference SQL。
+
+**请求体**：
+
+| 字段                  | 类型      | 默认值          | 说明 |
+|----------------------|----------|----------------|------|
+| `components`         | string[] | _（必填）_       | 要构建的组件：`metadata`、`semantic_model`、`metrics`、`ext_knowledge`、`reference_sql` |
+| `strategy`           | string   | `incremental`  | `check`（仅检查）、`overwrite`（重建）、`incremental`（增量更新） |
+| `schema_linking_type`| string   | `full`         | metadata 专用：`table`、`view`、`mv`、`full` |
+| `catalog`            | string   | `""`           | metadata catalog 过滤（Snowflake、StarRocks） |
+| `database_name`      | string   | `""`           | metadata 数据库过滤 |
+| `success_story`      | string?  | `null`         | 项目根目录的相对路径，指向 success-story CSV |
+| `subject_tree`       | string[]?| `null`         | 预定义层级分类 |
+| `sql_dir`            | string?  | `null`         | 项目根目录的相对路径，指向 `.sql` 文件目录 |
+| `ext_knowledge`      | string?  | `null`         | 项目根目录的相对路径，指向外部知识 CSV |
+
+**响应**：`text/event-stream`，参见下方 [SSE 事件格式](#sse-事件格式)。
+
+### `POST /api/v1/kb/bootstrap/{stream_id}/cancel`
+
+取消正在运行的 KB 构建流。
+
+**响应**：`Result[dict]`，`data = { stream_id, cancelled: true|false }`。
+
+---
+
+## 平台文档构建
+
+### `POST /api/v1/kb/bootstrap-docs`
+
+启动平台文档构建，通过 SSE 流式推送进度。从 GitHub 仓库、网站或本地目录抓取文档并写入平台文档向量库。
+
+**请求体**：
+
+| 字段              | 类型      | 默认值       | 说明 |
+|-------------------|----------|-------------|------|
+| `platform`        | string   | _（必填）_   | 平台名称（如 `snowflake`、`duckdb`、`starrocks`） |
+| `build_mode`      | string   | `overwrite` | `check`（仅查看状态）或 `overwrite`（重建） |
+| `pool_size`       | int      | `4`         | 线程池大小（1–16） |
+| `source_type`     | string?  | `null`      | `github`、`website` 或 `local` |
+| `source`          | string?  | `null`      | GitHub 仓库 `owner/repo`、URL 或本地路径 |
+| `version`         | string?  | `null`      | 文档版本（未提供时自动检测） |
+| `github_ref`      | string?  | `null`      | GitHub 分支 / tag / commit |
+| `github_token`    | string?  | `null`      | GitHub API token |
+| `paths`           | string[]?| `null`      | 需要抓取的路径列表（GitHub 专用） |
+| `chunk_size`      | int?     | `null`      | 分块目标大小（字符数） |
+| `max_depth`       | int?     | `null`      | 网站最大爬取深度 |
+| `include_patterns`| string[]?| `null`      | 包含规则（正则） |
+| `exclude_patterns`| string[]?| `null`      | 排除规则（正则） |
+
+仅 `platform` 为必填。其余字段未提供时从 `agent.yml` 中的 `agent.document.<platform>` 配置读取。
+参见 [平台文档 — 在 agent.yml 中配置](../knowledge_base/platform_doc.zh.md#在-agentyml-中配置可选)。
+
+**响应**：`text/event-stream`，参见下方 [SSE 事件格式](#sse-事件格式)。
+
+**示例**：
+
+```bash
+# 检查现有存储状态
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap-docs \
+  -H "Content-Type: application/json" \
+  -d '{"platform": "starrocks", "build_mode": "check"}'
+
+# 从 GitHub 完整重建
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap-docs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "starrocks",
+    "source": "StarRocks/starrocks",
+    "source_type": "github",
+    "github_ref": "main",
+    "paths": ["docs/en"],
+    "build_mode": "overwrite"
+  }'
+```
+
+### `POST /api/v1/kb/bootstrap-docs/{stream_id}/cancel`
+
+取消正在运行的平台文档构建流。
+
+**响应**：`Result[dict]`，`data = { stream_id, cancelled: true|false }`。
+
+---
+
+## SSE 事件格式
+
+两个 bootstrap 接口均通过 Server-Sent Events 推送进度。每个事件格式：
+
+```
+id: <stream_id>
+event: <stage>
+data: <json>
+```
+
+JSON 载荷结构（`BootstrapKbEvent`）：
+
+| 字段         | 类型    | 说明 |
+|-------------|--------|------|
+| `stream_id` | string | 唯一流标识 |
+| `component` | string | 组件名称（`metadata`、`semantic_model`、`platform_doc`、`all` 等） |
+| `stage`     | string | 生命周期阶段（见下表） |
+| `message`   | string?| 可读状态消息 |
+| `error`     | string?| 错误信息（失败时） |
+| `progress`  | object?| `{ total, completed, failed }` 进度计数 |
+| `payload`   | object?| 附加数据（组件相关的结果） |
+| `timestamp` | string | ISO 格式时间戳 |
+
+### 生命周期阶段
+
+| 阶段               | 含义 |
+|-------------------|------|
+| `task_started`    | 组件构建已启动 |
+| `task_validated`  | 项目已验证，总数确认 |
+| `task_processing` | 组件正在处理 |
+| `task_completed`  | 组件构建完成 |
+| `task_failed`     | 组件构建失败 |
+| `item_started`    | 单个项目开始处理 |
+| `item_completed`  | 单个项目处理完成 |
+| `item_failed`     | 单个项目处理失败 |
+
+### SSE 流示例
+
+```
+id: abc-123
+event: task_started
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"task_started","timestamp":"2025-01-01T00:00:00"}
+
+id: abc-123
+event: task_validated
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"task_validated","progress":{"total":1036,"completed":0,"failed":0},"timestamp":"2025-01-01T00:00:01"}
+
+id: abc-123
+event: item_completed
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"item_completed","message":"docs/en/intro.md","timestamp":"2025-01-01T00:00:02"}
+
+id: abc-123
+event: task_completed
+data: {"stream_id":"abc-123","component":"platform_doc","stage":"task_completed","message":"Processed 1036 docs, 5200 chunks","payload":{"platform":"starrocks","version":"3.5.15","total_docs":1036,"total_chunks":5200},"timestamp":"2025-01-01T00:01:30"}
+```
+
+### 取消操作
+
+向 cancel 端点 POST 即可取消正在运行的构建，`stream_id` 从 SSE 事件中获取：
+
+```bash
+curl -X POST http://localhost:8000/api/v1/kb/bootstrap-docs/abc-123/cancel
+```

--- a/docs/knowledge_base/platform_doc.md
+++ b/docs/knowledge_base/platform_doc.md
@@ -190,6 +190,29 @@ Inside `datus-cli`, use:
 
 This runs `search_document` interactively and shows matched chunks.
 
+## REST API
+
+Platform documentation can also be bootstrapped via the REST API with real-time SSE progress streaming. This is the
+recommended approach for web frontends and automation.
+
+```bash
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap-docs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "starrocks",
+    "source": "StarRocks/starrocks",
+    "source_type": "github",
+    "paths": ["docs/en"],
+    "build_mode": "overwrite"
+  }'
+```
+
+The API accepts the same parameters as the CLI (mapped to JSON fields) and streams progress events as SSE. If a
+field is omitted, the value from `agent.yml` is used.
+
+See [Knowledge Base API](../API/knowledge_base.md#platform-documentation-bootstrap) for the full endpoint reference,
+request/response schema, and SSE event format.
+
 ## Notes and Troubleshooting
 
 - **GitHub API limits**: set `GITHUB_TOKEN` (or `github_token` in config) to avoid rate limiting.

--- a/docs/knowledge_base/platform_doc.zh.md
+++ b/docs/knowledge_base/platform_doc.zh.md
@@ -189,6 +189,26 @@ titles=["DDL", "CREATE TABLE"]
 
 用于交互式执行 `search_document` 并查看命中文档片段。
 
+## REST API
+
+平台文档也可以通过 REST API 构建，支持 SSE 实时进度推送。这是 Web 前端和自动化场景下的推荐方式。
+
+```bash
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap-docs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "starrocks",
+    "source": "StarRocks/starrocks",
+    "source_type": "github",
+    "paths": ["docs/en"],
+    "build_mode": "overwrite"
+  }'
+```
+
+API 接受与 CLI 相同的参数（映射为 JSON 字段），并以 SSE 事件流推送进度。未提供的字段从 `agent.yml` 中读取。
+
+完整的接口定义、请求/响应格式和 SSE 事件说明请参见 [知识库 API](../API/knowledge_base.zh.md#平台文档构建)。
+
 ## 注意事项与排错
 
 - **GitHub 速率限制**：建议设置 `GITHUB_TOKEN`（或在配置里写 `github_token`）。

--- a/tests/unit_tests/api/models/test_kb_models.py
+++ b/tests/unit_tests/api/models/test_kb_models.py
@@ -1,0 +1,75 @@
+"""Unit tests for datus.api.models.kb_models — BootstrapDocInput."""
+
+import pytest
+from pydantic import ValidationError
+
+from datus.api.models.kb_models import BootstrapDocInput
+
+
+class TestBootstrapDocInput:
+    """Tests for BootstrapDocInput validation."""
+
+    def test_minimal_creation(self):
+        """Only platform is required; everything else has defaults or is optional."""
+        inp = BootstrapDocInput(platform="snowflake")
+        assert inp.platform == "snowflake"
+        assert inp.build_mode == "overwrite"
+        assert inp.pool_size == 4
+        assert inp.source is None
+        assert inp.source_type is None
+
+    def test_all_fields(self):
+        """All optional fields can be set."""
+        inp = BootstrapDocInput(
+            platform="duckdb",
+            build_mode="check",
+            pool_size=8,
+            source_type="github",
+            source="owner/repo",
+            version="1.0.0",
+            github_ref="main",
+            paths=["docs"],
+            chunk_size=2048,
+            max_depth=3,
+            include_patterns=["*.md"],
+            exclude_patterns=["changelog*"],
+        )
+        assert inp.build_mode == "check"
+        assert inp.pool_size == 8
+        assert inp.source_type == "github"
+        assert inp.paths == ["docs"]
+
+    def test_platform_required(self):
+        """Missing platform raises ValidationError."""
+        with pytest.raises(ValidationError):
+            BootstrapDocInput()
+
+    def test_build_mode_literal(self):
+        """build_mode only accepts 'overwrite' or 'check'."""
+        with pytest.raises(ValidationError):
+            BootstrapDocInput(platform="test", build_mode="invalid")
+
+    def test_pool_size_min(self):
+        """pool_size must be >= 1."""
+        with pytest.raises(ValidationError):
+            BootstrapDocInput(platform="test", pool_size=0)
+
+    def test_pool_size_max(self):
+        """pool_size must be <= 16."""
+        with pytest.raises(ValidationError):
+            BootstrapDocInput(platform="test", pool_size=17)
+
+    def test_pool_size_boundaries(self):
+        """pool_size accepts boundary values 1 and 16."""
+        inp1 = BootstrapDocInput(platform="test", pool_size=1)
+        inp16 = BootstrapDocInput(platform="test", pool_size=16)
+        assert inp1.pool_size == 1
+        assert inp16.pool_size == 16
+
+    def test_json_roundtrip(self):
+        """Model serializes to and deserializes from JSON."""
+        inp = BootstrapDocInput(platform="pg", source="owner/repo", version="2.0")
+        data = inp.model_dump()
+        restored = BootstrapDocInput(**data)
+        assert restored.platform == "pg"
+        assert restored.source == "owner/repo"

--- a/tests/unit_tests/api/routes/test_kb_routes.py
+++ b/tests/unit_tests/api/routes/test_kb_routes.py
@@ -1,0 +1,308 @@
+"""CI-level tests for datus/api/routes/kb_routes.py.
+
+All external dependencies are mocked. Zero API keys, zero network access required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from datus.api.models.kb_models import BootstrapKbEvent
+from datus.api.routes.kb_routes import router
+from datus.utils.exceptions import DatusException, ErrorCode
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_datus_service():
+    """Create a mock DatusService with agent_config and kb."""
+    svc = MagicMock()
+    svc.agent_config = MagicMock()
+    svc.agent_config.home = "/tmp/test_home"
+    svc.agent_config.document_configs = {}
+    svc.kb = MagicMock()
+    return svc
+
+
+@pytest.fixture
+def client(mock_datus_service):
+    """Create a TestClient with mocked dependencies."""
+    from datus.api.deps import get_datus_service
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_datus_service] = lambda: mock_datus_service
+    with TestClient(app) as c:
+        yield c
+
+
+def _make_kb_events():
+    """Return two sample BootstrapKbEvent instances."""
+    return [
+        BootstrapKbEvent(
+            stream_id="s1",
+            component="platform_doc",
+            stage="task_started",
+            timestamp="2025-01-01T00:00:00",
+        ),
+        BootstrapKbEvent(
+            stream_id="s1",
+            component="platform_doc",
+            stage="task_completed",
+            timestamp="2025-01-01T00:00:01",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/kb/bootstrap-docs
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapDocs:
+    def test_bootstrap_docs_returns_sse_stream(self, client, mock_datus_service):
+        """SSE stream is returned with correct media type and event lines."""
+        events = _make_kb_events()
+
+        async def mock_stream(*args, **kwargs):
+            for event in events:
+                yield event
+
+        mock_datus_service.kb.bootstrap_doc_stream = mock_stream
+        mock_datus_service.agent_config.document_configs = {"myplatform": MagicMock(type="github")}
+
+        response = client.post(
+            "/api/v1/kb/bootstrap-docs",
+            json={"platform": "myplatform"},
+        )
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        body = response.text
+        assert "task_started" in body
+        assert "task_completed" in body
+        # Each SSE block starts with "event:"
+        assert body.count("event:") == 2
+
+    def test_bootstrap_docs_unknown_platform_no_source_returns_422(self, client, mock_datus_service):
+        """Unknown platform with no source → 422 because config is missing."""
+        mock_datus_service.agent_config.document_configs = {}
+
+        response = client.post(
+            "/api/v1/kb/bootstrap-docs",
+            json={"platform": "unknown"},
+        )
+
+        assert response.status_code == 422
+        assert "unknown" in response.json()["detail"]
+
+    def test_bootstrap_docs_known_platform_succeeds(self, client, mock_datus_service):
+        """Platform present in document_configs → 200 SSE response."""
+        events = _make_kb_events()
+
+        async def mock_stream(*args, **kwargs):
+            for event in events:
+                yield event
+
+        mock_datus_service.kb.bootstrap_doc_stream = mock_stream
+        doc_cfg = MagicMock()
+        doc_cfg.type = "website"
+        mock_datus_service.agent_config.document_configs = {"snowflake": doc_cfg}
+
+        response = client.post(
+            "/api/v1/kb/bootstrap-docs",
+            json={"platform": "snowflake"},
+        )
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+
+    def test_bootstrap_docs_local_path_traversal_returns_422(self, client, mock_datus_service):
+        """Local source with path traversal → safe_resolve raises DatusException → 422."""
+        # Platform must exist so we pass the first validation check
+        doc_cfg = MagicMock()
+        doc_cfg.type = "local"
+        mock_datus_service.agent_config.document_configs = {"myplatform": doc_cfg}
+
+        with patch(
+            "datus.api.routes.kb_routes.safe_resolve",
+            side_effect=DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message="Path '../../../etc/passwd' escapes the project root",
+            ),
+        ):
+            response = client.post(
+                "/api/v1/kb/bootstrap-docs",
+                json={
+                    "platform": "myplatform",
+                    "source": "../../../etc/passwd",
+                    "source_type": "local",
+                },
+            )
+
+        assert response.status_code == 422
+        assert "escapes" in response.json()["detail"]
+
+    def test_bootstrap_docs_local_source_from_config_validates_path(self, client, mock_datus_service):
+        """Local source type from config triggers path validation → DatusException → 422."""
+        doc_cfg = MagicMock()
+        doc_cfg.type = "local"
+        mock_datus_service.agent_config.document_configs = {"testplatform": doc_cfg}
+
+        with patch(
+            "datus.api.routes.kb_routes.safe_resolve",
+            side_effect=DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message="escapes the project root",
+            ),
+        ):
+            response = client.post(
+                "/api/v1/kb/bootstrap-docs",
+                json={
+                    "platform": "testplatform",
+                    "source": "../secret",
+                },
+            )
+
+        assert response.status_code == 422
+
+
+class TestCancelDocBootstrap:
+    def test_cancel_doc_bootstrap_success(self, client):
+        """cancel_stream returns True → response success=True."""
+        with patch("datus.api.routes.kb_routes.cancel_stream", return_value=True):
+            response = client.post("/api/v1/kb/bootstrap-docs/my-stream-id/cancel")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["data"]["stream_id"] == "my-stream-id"
+        assert data["data"]["cancelled"] is True
+
+    def test_cancel_doc_bootstrap_unknown_stream(self, client):
+        """cancel_stream returns False → response success=False."""
+        with patch("datus.api.routes.kb_routes.cancel_stream", return_value=False):
+            response = client.post("/api/v1/kb/bootstrap-docs/nonexistent-stream/cancel")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["data"]["cancelled"] is False
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/kb/bootstrap
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapKb:
+    def _valid_bootstrap_payload(self):
+        return {"components": ["metadata"]}
+
+    def test_bootstrap_kb_returns_sse_stream(self, client, mock_datus_service):
+        """bootstrap_stream async generator → 200 SSE with event lines."""
+        events = _make_kb_events()
+
+        async def mock_stream(*args, **kwargs):
+            for event in events:
+                yield event
+
+        mock_datus_service.kb.bootstrap_stream = mock_stream
+
+        response = client.post(
+            "/api/v1/kb/bootstrap",
+            json=self._valid_bootstrap_payload(),
+        )
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        body = response.text
+        assert "task_started" in body
+        assert "task_completed" in body
+
+    def test_bootstrap_kb_path_validation_error(self, client, mock_datus_service):
+        """safe_resolve raises DatusException for success_story path → 422."""
+        with patch(
+            "datus.api.routes.kb_routes.safe_resolve",
+            side_effect=DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message="Path '../../etc/passwd' escapes the project root",
+            ),
+        ):
+            response = client.post(
+                "/api/v1/kb/bootstrap",
+                json={
+                    "components": ["semantic_model"],
+                    "success_story": "../../etc/passwd",
+                },
+            )
+
+        assert response.status_code == 422
+        assert "escapes" in response.json()["detail"]
+
+    def test_bootstrap_kb_missing_components_returns_422(self, client):
+        """components field is required with min_length=1; empty list → 422."""
+        response = client.post(
+            "/api/v1/kb/bootstrap",
+            json={"components": []},
+        )
+
+        assert response.status_code == 422
+
+    def test_bootstrap_kb_invalid_strategy_returns_422(self, client):
+        """strategy must be one of overwrite/check/incremental → 422 for invalid."""
+        response = client.post(
+            "/api/v1/kb/bootstrap",
+            json={"components": ["metadata"], "strategy": "invalid_strategy"},
+        )
+
+        assert response.status_code == 422
+
+    def test_bootstrap_kb_sse_format_contains_id_and_event(self, client, mock_datus_service):
+        """Each yielded event produces SSE lines with id:, event:, data: prefixes."""
+        events = _make_kb_events()
+
+        async def mock_stream(*args, **kwargs):
+            for event in events:
+                yield event
+
+        mock_datus_service.kb.bootstrap_stream = mock_stream
+
+        response = client.post(
+            "/api/v1/kb/bootstrap",
+            json=self._valid_bootstrap_payload(),
+        )
+
+        assert response.status_code == 200
+        body = response.text
+        assert "id:" in body
+        assert "event:" in body
+        assert "data:" in body
+
+
+class TestCancelBootstrap:
+    def test_cancel_bootstrap_success(self, client):
+        """cancel_stream returns True → success=True."""
+        with patch("datus.api.routes.kb_routes.cancel_stream", return_value=True):
+            response = client.post("/api/v1/kb/bootstrap/active-stream-id/cancel")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["data"]["stream_id"] == "active-stream-id"
+        assert data["data"]["cancelled"] is True
+
+    def test_cancel_bootstrap_unknown_stream(self, client):
+        """cancel_stream returns False → success=False."""
+        with patch("datus.api.routes.kb_routes.cancel_stream", return_value=False):
+            response = client.post("/api/v1/kb/bootstrap/ghost-stream/cancel")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["data"]["cancelled"] is False

--- a/tests/unit_tests/api/services/test_kb_service.py
+++ b/tests/unit_tests/api/services/test_kb_service.py
@@ -558,3 +558,114 @@ class TestKbServiceBootstrapDocStream:
 
         # Should produce events (may fail due to no source, but shouldn't crash)
         assert len(events) >= 1
+
+    async def test_init_platform_docs_failure_yields_task_failed(self, real_agent_config):
+        """bootstrap_doc_stream yields TASK_FAILED when init_platform_docs returns success=False."""
+        import asyncio
+        from unittest.mock import patch
+
+        from datus.storage.document.doc_init import InitResult
+
+        real_agent_config.document_configs["fail_platform"] = DocumentConfig(type="local", source="/nonexistent")
+        svc = KbService(agent_config=real_agent_config)
+        cancel_event = asyncio.Event()
+        request = BootstrapDocInput(platform="fail_platform", build_mode="check")
+
+        failed_result = InitResult(
+            platform="fail_platform",
+            version="unknown",
+            source="/nonexistent",
+            total_docs=0,
+            total_chunks=0,
+            success=False,
+            errors=["Source not found", "Index missing"],
+            duration_seconds=0.1,
+        )
+
+        with patch("datus.api.services.kb_service.KbService._run_doc_init", return_value=failed_result):
+            events = []
+            async for event in svc.bootstrap_doc_stream(request, "fail-stream", cancel_event):
+                events.append(event)
+
+        assert len(events) >= 1
+        last = events[-1]
+        assert last.component == "platform_doc"
+        from datus.schemas.batch_events import BatchStage
+
+        assert last.stage == BatchStage.TASK_FAILED.value
+        assert "Source not found" in (last.error or "")
+
+    async def test_run_doc_init_exception_yields_task_failed(self, real_agent_config):
+        """bootstrap_doc_stream yields TASK_FAILED when _run_doc_init raises an exception."""
+        import asyncio
+        from unittest.mock import patch
+
+        real_agent_config.document_configs["exc_platform"] = DocumentConfig(type="local", source="/nonexistent")
+        svc = KbService(agent_config=real_agent_config)
+        cancel_event = asyncio.Event()
+        request = BootstrapDocInput(platform="exc_platform", build_mode="overwrite")
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("unexpected doc init failure")
+
+        with patch.object(svc, "_run_doc_init", side_effect=_raise):
+            events = []
+            async for event in svc.bootstrap_doc_stream(request, "exc-stream", cancel_event):
+                events.append(event)
+
+        assert len(events) >= 1
+        last = events[-1]
+        assert last.component == "platform_doc"
+        from datus.schemas.batch_events import BatchStage
+
+        assert last.stage == BatchStage.TASK_FAILED.value
+        assert "unexpected doc init failure" in (last.error or "")
+
+
+@pytest.mark.asyncio
+class TestKbServiceRunDocInitCancelBridge:
+    """Tests for _run_doc_init cancel bridge behavior."""
+
+    async def test_cancel_bridge_propagates_to_init_platform_docs(self, real_agent_config):
+        """_run_doc_init bridges cancel_event.is_set() as cancel_check callable."""
+        import asyncio
+        from unittest.mock import patch
+
+        real_agent_config.document_configs["cancel_bridge"] = DocumentConfig(type="local", source="/nonexistent")
+        svc = KbService(agent_config=real_agent_config)
+        cancel_event = asyncio.Event()
+        cancel_event.set()  # Pre-cancel so cancel_check() returns True immediately
+
+        request = BootstrapDocInput(platform="cancel_bridge", build_mode="overwrite")
+
+        captured_cancel_check = []
+
+        def _capture_cancel(platform, cfg, build_mode, pool_size, emit, cancel_check):
+            captured_cancel_check.append(cancel_check)
+            # Return a minimal result so the function doesn't blow up
+            from datus.storage.document.doc_init import InitResult
+
+            return InitResult(
+                platform=platform,
+                version="unknown",
+                source="",
+                total_docs=0,
+                total_chunks=0,
+                success=True,
+                errors=[],
+                duration_seconds=0.0,
+            )
+
+        with patch("datus.storage.document.doc_init.init_platform_docs", side_effect=_capture_cancel):
+            async for _ in svc.bootstrap_doc_stream(request, "bridge-stream", cancel_event):
+                pass
+
+        # Verify the cancel_check callable correctly reflects cancel_event state
+        assert len(captured_cancel_check) == 1
+        cancel_fn = captured_cancel_check[0]
+        assert callable(cancel_fn)
+        assert cancel_fn() is True  # cancel_event is set → True
+
+        # Verify that when cancel_event is cleared, cancel_check returns False
+        cancel_event.clear()
+        assert cancel_fn() is False

--- a/tests/unit_tests/api/services/test_kb_service.py
+++ b/tests/unit_tests/api/services/test_kb_service.py
@@ -4,8 +4,9 @@ from datetime import datetime
 
 import pytest
 
-from datus.api.models.kb_models import BootstrapKbEvent, BootstrapKbInput
+from datus.api.models.kb_models import BootstrapDocInput, BootstrapKbEvent, BootstrapKbInput
 from datus.api.services.kb_service import KbService
+from datus.configuration.agent_config import DocumentConfig
 from datus.schemas.batch_events import BatchEvent, BatchStage
 
 
@@ -433,3 +434,127 @@ class TestKbServiceRunComponent:
         result = svc._run_component(request, "metadata", queue, loop, cancel_event, str(real_agent_config.home))
         assert result["status"] == "success"
         loop.close()
+
+
+class TestKbServiceMergeDocOverrides:
+    """Tests for _merge_doc_overrides — DocumentConfig overlay logic."""
+
+    def test_no_overrides(self):
+        """When all request fields are None, base config is returned unchanged."""
+        base = DocumentConfig(type="github", source="owner/repo", version="1.0")
+        request = BootstrapDocInput(platform="test")
+
+        merged = KbService._merge_doc_overrides(base, request)
+        assert merged.type == "github"
+        assert merged.source == "owner/repo"
+        assert merged.version == "1.0"
+
+    def test_source_override(self):
+        """Non-None request field overrides the base config."""
+        base = DocumentConfig(type="github", source="old/repo")
+        request = BootstrapDocInput(platform="test", source="new/repo")
+
+        merged = KbService._merge_doc_overrides(base, request)
+        assert merged.source == "new/repo"
+        assert merged.type == "github"  # unchanged
+
+    def test_source_type_maps_to_type(self):
+        """source_type in request maps to 'type' field in DocumentConfig."""
+        base = DocumentConfig(type="github")
+        request = BootstrapDocInput(platform="test", source_type="local")
+
+        merged = KbService._merge_doc_overrides(base, request)
+        assert merged.type == "local"
+
+    def test_all_overrides(self):
+        """All overridable fields are applied."""
+        base = DocumentConfig()
+        request = BootstrapDocInput(
+            platform="test",
+            source_type="website",
+            source="https://docs.example.com",
+            version="2.0",
+            github_ref="v2",
+            paths=["api"],
+            chunk_size=2048,
+            max_depth=5,
+            include_patterns=["*.md"],
+            exclude_patterns=["changelog*"],
+        )
+
+        merged = KbService._merge_doc_overrides(base, request)
+        assert merged.type == "website"
+        assert merged.source == "https://docs.example.com"
+        assert merged.version == "2.0"
+        assert merged.github_ref == "v2"
+        assert merged.paths == ["api"]
+        assert merged.chunk_size == 2048
+        assert merged.max_depth == 5
+        assert merged.include_patterns == ["*.md"]
+        assert merged.exclude_patterns == ["changelog*"]
+
+    def test_immutable_base(self):
+        """Original base config is not mutated."""
+        base = DocumentConfig(type="github", source="owner/repo")
+        request = BootstrapDocInput(platform="test", source="other/repo")
+
+        KbService._merge_doc_overrides(base, request)
+        assert base.source == "owner/repo"  # unchanged
+
+
+@pytest.mark.asyncio
+class TestKbServiceBootstrapDocStream:
+    """Tests for bootstrap_doc_stream — platform doc SSE streaming."""
+
+    async def test_check_mode_yields_events(self, real_agent_config):
+        """bootstrap_doc_stream with check mode yields completion events."""
+        import asyncio
+
+        # Add a document config for the test platform
+        real_agent_config.document_configs["test_platform"] = DocumentConfig(type="local", source="/nonexistent")
+
+        svc = KbService(agent_config=real_agent_config)
+        cancel_event = asyncio.Event()
+        request = BootstrapDocInput(platform="test_platform", build_mode="check")
+
+        events = []
+        async for event in svc.bootstrap_doc_stream(request, "doc-stream", cancel_event):
+            events.append(event)
+
+        # Should have at least one event (completed or failed)
+        assert len(events) >= 1
+        # Last event should be for platform_doc component
+        assert events[-1].component == "platform_doc"
+
+    async def test_cancelled_stream(self, real_agent_config):
+        """bootstrap_doc_stream stops when cancel_event is pre-set."""
+        import asyncio
+
+        real_agent_config.document_configs["cancel_test"] = DocumentConfig(type="local", source="/nonexistent")
+
+        svc = KbService(agent_config=real_agent_config)
+        cancel_event = asyncio.Event()
+        cancel_event.set()  # Pre-cancel
+
+        request = BootstrapDocInput(platform="cancel_test", build_mode="overwrite")
+
+        events = []
+        async for event in svc.bootstrap_doc_stream(request, "cancel-doc", cancel_event):
+            events.append(event)
+
+        assert len(events) >= 1
+
+    async def test_missing_platform_no_source(self, real_agent_config):
+        """bootstrap_doc_stream with unknown platform and no source still runs (returns error)."""
+        import asyncio
+
+        svc = KbService(agent_config=real_agent_config)
+        cancel_event = asyncio.Event()
+        request = BootstrapDocInput(platform="nonexistent_platform", build_mode="check")
+
+        events = []
+        async for event in svc.bootstrap_doc_stream(request, "missing-stream", cancel_event):
+            events.append(event)
+
+        # Should produce events (may fail due to no source, but shouldn't crash)
+        assert len(events) >= 1

--- a/tests/unit_tests/storage/document/fetcher/test_github_fetcher.py
+++ b/tests/unit_tests/storage/document/fetcher/test_github_fetcher.py
@@ -635,3 +635,215 @@ class TestFetchBatch:
         assert len(docs) == 1
         assert docs[0].metadata["nav_path"] == ["User Guide", "Getting Started"]
         assert docs[0].metadata["group_name"] == "User Guide"
+
+
+# ---------------------------------------------------------------------------
+# _get_full_tree
+# ---------------------------------------------------------------------------
+
+
+class TestGetFullTree:
+    """Tests for _get_full_tree."""
+
+    def test_cache_hit_skips_api_call(self):
+        """Second call with the same repo+branch should return cached result without calling the API."""
+        import types
+
+        f = _make_fetcher()
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+
+        item = types.SimpleNamespace(type="blob", path="docs/guide.md")
+        mock_git_tree = MagicMock()
+        mock_git_tree.raw_data = {"truncated": False}
+        mock_git_tree.tree = [item]
+        mock_repo.get_git_tree.return_value = mock_git_tree
+
+        # First call — populates cache
+        result1 = f._get_full_tree(mock_repo, "main")
+        assert result1 == [item]
+        assert mock_repo.get_git_tree.call_count == 1
+
+        # Second call — must return cached value without a new API call
+        result2 = f._get_full_tree(mock_repo, "main")
+        assert result2 == [item]
+        assert mock_repo.get_git_tree.call_count == 1  # still 1
+
+    def test_successful_tree_fetch(self):
+        """Should return the tree list on a non-truncated response."""
+        import types
+
+        f = _make_fetcher()
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+
+        items = [
+            types.SimpleNamespace(type="blob", path="docs/guide.md"),
+            types.SimpleNamespace(type="blob", path="README.md"),
+        ]
+        mock_git_tree = MagicMock()
+        mock_git_tree.raw_data = {"truncated": False}
+        mock_git_tree.tree = items
+        mock_repo.get_git_tree.return_value = mock_git_tree
+
+        result = f._get_full_tree(mock_repo, "main")
+        assert result == items
+
+    def test_truncated_tree_returns_none(self):
+        """When the tree response is truncated, should return None to trigger fallback."""
+        f = _make_fetcher()
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+
+        mock_git_tree = MagicMock()
+        mock_git_tree.raw_data = {"truncated": True}
+        mock_git_tree.tree = []
+        mock_repo.get_git_tree.return_value = mock_git_tree
+
+        result = f._get_full_tree(mock_repo, "main")
+        assert result is None
+
+    def test_github_exception_returns_none(self):
+        """GithubException from the API should be caught and None returned."""
+        from github import GithubException
+
+        f = _make_fetcher()
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_git_tree.side_effect = GithubException(500, {"message": "Server error"}, None)
+
+        result = f._get_full_tree(mock_repo, "main")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _filter_tree
+# ---------------------------------------------------------------------------
+
+
+class TestFilterTree:
+    """Tests for _filter_tree."""
+
+    def _make_tree(self, items):
+        """Build a list of SimpleNamespace tree items from (type, path) pairs."""
+        import types
+
+        return [types.SimpleNamespace(type=t, path=p) for t, p in items]
+
+    def test_filters_files_under_directory_prefix(self):
+        """Files whose path starts with 'docs/' should be included."""
+        f = _make_fetcher()
+        tree = self._make_tree(
+            [
+                ("blob", "docs/guide.md"),
+                ("blob", "docs/intro.md"),
+                ("blob", "src/main.py"),
+            ]
+        )
+        result = f._filter_tree(tree, "docs")
+        assert "docs/guide.md" in result
+        assert "docs/intro.md" in result
+        assert "src/main.py" not in result
+
+    def test_matches_exact_file_path(self):
+        """An exact file path like 'README.md' should be included."""
+        f = _make_fetcher()
+        tree = self._make_tree(
+            [
+                ("blob", "README.md"),
+                ("blob", "CONTRIBUTING.md"),
+            ]
+        )
+        result = f._filter_tree(tree, "README.md")
+        assert "README.md" in result
+        assert "CONTRIBUTING.md" not in result
+
+    def test_excludes_non_doc_files(self):
+        """Files with non-doc extensions (.py, .csv) should be excluded even if under the path."""
+        f = _make_fetcher()
+        tree = self._make_tree(
+            [
+                ("blob", "docs/guide.md"),
+                ("blob", "docs/script.py"),
+                ("blob", "docs/data.csv"),
+            ]
+        )
+        result = f._filter_tree(tree, "docs")
+        assert "docs/guide.md" in result
+        assert "docs/script.py" not in result
+        assert "docs/data.csv" not in result
+
+    def test_excludes_files_outside_path_prefix(self):
+        """Files under a different prefix should not be matched even if they share a partial name."""
+        f = _make_fetcher()
+        tree = self._make_tree(
+            [
+                ("blob", "docs/guide.md"),
+                ("blob", "docs_extra/other.md"),
+                ("blob", "other/docs/nested.md"),
+            ]
+        )
+        result = f._filter_tree(tree, "docs")
+        assert "docs/guide.md" in result
+        # "docs_extra/..." starts with "docs_extra/", not "docs/" — must be excluded
+        assert "docs_extra/other.md" not in result
+        # "other/docs/nested.md" does not start with "docs/" — must be excluded
+        assert "other/docs/nested.md" not in result
+
+    def test_tree_items_not_blob_are_skipped(self):
+        """Non-blob tree items (trees/commits) should be skipped."""
+        f = _make_fetcher()
+        tree = self._make_tree(
+            [
+                ("tree", "docs"),
+                ("blob", "docs/guide.md"),
+            ]
+        )
+        result = f._filter_tree(tree, "docs")
+        assert result == ["docs/guide.md"]
+
+
+# ---------------------------------------------------------------------------
+# _collect_file_paths (dispatch logic)
+# ---------------------------------------------------------------------------
+
+
+class TestCollectFilePathsDispatch:
+    """Tests for the fast-path / fallback dispatch in _collect_file_paths."""
+
+    def test_uses_fast_path_when_tree_available(self):
+        """When _get_full_tree returns a tree, _filter_tree should be used and
+        the recursive walk (_collect_file_paths_recursive) should NOT be called."""
+        import types
+
+        f = _make_fetcher()
+        mock_repo = MagicMock()
+
+        tree_items = [
+            types.SimpleNamespace(type="blob", path="docs/guide.md"),
+        ]
+
+        with (
+            patch.object(f, "_get_full_tree", return_value=tree_items) as mock_tree,
+            patch.object(f, "_collect_file_paths_recursive") as mock_recursive,
+        ):
+            result = f._collect_file_paths(mock_repo, "docs", "main")
+
+        mock_tree.assert_called_once_with(mock_repo, "main")
+        mock_recursive.assert_not_called()
+        assert "docs/guide.md" in result
+
+    def test_falls_back_to_recursive_when_tree_is_none(self):
+        """When _get_full_tree returns None, _collect_file_paths_recursive should be called."""
+        f = _make_fetcher()
+        mock_repo = MagicMock()
+
+        with (
+            patch.object(f, "_get_full_tree", return_value=None) as mock_tree,
+            patch.object(f, "_collect_file_paths_recursive", return_value=["docs/guide.md"]) as mock_recursive,
+        ):
+            result = f._collect_file_paths(mock_repo, "docs", "main")
+
+        mock_tree.assert_called_once_with(mock_repo, "main")
+        mock_recursive.assert_called_once_with(mock_repo, "docs", "main")
+        assert result == ["docs/guide.md"]

--- a/tests/unit_tests/storage/document/test_doc_init.py
+++ b/tests/unit_tests/storage/document/test_doc_init.py
@@ -442,3 +442,107 @@ class TestInitPlatformDocsDbPathDeprecation:
 
             deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
             assert len(deprecation_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# init_platform_docs — emit callback + cancel_check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestInitPlatformDocsEmit:
+    """Tests for emit callback and cancel_check in init_platform_docs."""
+
+    def _mock_cfg(self, source="/some/path", source_type="local", version="v1"):
+        cfg = MagicMock()
+        cfg.source = source
+        cfg.type = source_type
+        cfg.version = version
+        cfg.paths = []
+        cfg.chunk_size = 512
+        cfg.include_patterns = []
+        cfg.exclude_patterns = []
+        return cfg
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_emit_none_backward_compatible(self, mock_store_fn):
+        """init_platform_docs with emit=None works identically to before."""
+        mock_store = MagicMock()
+        mock_store.get_stats.return_value = {"versions": [], "total_chunks": 0, "doc_count": 0}
+        mock_store_fn.return_value = mock_store
+
+        result = init_platform_docs(
+            platform="test_compat",
+            cfg=self._mock_cfg(),
+            build_mode="check",
+            emit=None,
+        )
+        assert result.success is True
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_emit_receives_task_started(self, mock_store_fn):
+        """emit callback receives task_started event."""
+        mock_store = MagicMock()
+        mock_store.get_stats.return_value = {"versions": ["v1"], "total_chunks": 5, "doc_count": 2}
+        mock_store_fn.return_value = mock_store
+
+        events = []
+        result = init_platform_docs(
+            platform="test_emit",
+            cfg=self._mock_cfg(),
+            build_mode="check",
+            emit=lambda e: events.append(e),
+        )
+        assert result.success is True
+        # Should have received at least a task_started event
+        stages = [e.stage for e in events]
+        assert "task_started" in stages
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_cancel_check_before_processing(self, mock_store_fn):
+        """cancel_check returning True causes early return."""
+        mock_store = MagicMock()
+        mock_store_fn.return_value = mock_store
+
+        events = []
+        result = init_platform_docs(
+            platform="test_cancel",
+            cfg=self._mock_cfg(),
+            build_mode="overwrite",
+            emit=lambda e: events.append(e),
+            cancel_check=lambda: True,
+        )
+        assert "Cancelled" in result.errors
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_cancel_check_false_continues(self, mock_store_fn):
+        """cancel_check returning False allows normal processing."""
+        mock_store = MagicMock()
+        mock_store.get_stats.return_value = {"versions": [], "total_chunks": 0, "doc_count": 0}
+        mock_store_fn.return_value = mock_store
+
+        result = init_platform_docs(
+            platform="test_no_cancel",
+            cfg=self._mock_cfg(),
+            build_mode="check",
+            cancel_check=lambda: False,
+        )
+        assert result.success is True
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_emit_task_failed_on_store_error(self, mock_store_fn):
+        """emit receives task_failed when document_store raises."""
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        mock_store_fn.side_effect = DatusException(ErrorCode.COMMON_VALIDATION_FAILED)
+
+        events = []
+        result = init_platform_docs(
+            platform="test_store_err",
+            cfg=self._mock_cfg(),
+            build_mode="check",
+            emit=lambda e: events.append(e),
+        )
+        assert result.success is True  # _make_empty_result sets success=True
+        stages = [e.stage for e in events]
+        assert "task_failed" in stages

--- a/tests/unit_tests/storage/document/test_doc_init.py
+++ b/tests/unit_tests/storage/document/test_doc_init.py
@@ -546,3 +546,84 @@ class TestInitPlatformDocsEmit:
         assert result.success is True  # _make_empty_result sets success=True
         stages = [e.stage for e in events]
         assert "task_failed" in stages
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_emit_task_completed_with_totals_after_check(self, mock_store_fn):
+        """emit receives task_completed event with total_items/completed_items after check mode."""
+        mock_store = MagicMock()
+        mock_store.get_stats.return_value = {"versions": ["v1", "v2"], "total_chunks": 30, "doc_count": 6}
+        mock_store.get_stats_by_version.return_value = {"doc_count": 3, "total_chunks": 15}
+        mock_store_fn.return_value = mock_store
+
+        events = []
+        result = init_platform_docs(
+            platform="test_check_completed",
+            cfg=self._mock_cfg(),
+            build_mode="check",
+            emit=lambda e: events.append(e),
+        )
+
+        assert result.success is True
+        # check mode returns early — emit only gets task_started (no task_completed from the helper)
+        # The important assertion is that no task_failed was emitted
+        stages = [e.stage for e in events]
+        assert "task_failed" not in stages
+        assert "task_started" in stages
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_emit_task_failed_on_processing_exception(self, mock_store_fn):
+        """emit receives task_failed with exception_type when processing raises."""
+        mock_store = MagicMock()
+        mock_store_fn.return_value = mock_store
+
+        # Use overwrite + local source so we enter the processing branch
+        cfg = self._mock_cfg(source="/some/path", source_type="local")
+
+        # Patch LocalFetcher to raise during fetch
+        from unittest.mock import patch as inner_patch
+
+        with inner_patch("datus.storage.document.doc_init.LocalFetcher") as mock_fetcher_cls:
+            mock_fetcher = MagicMock()
+            mock_fetcher.fetch.side_effect = ValueError("disk read error")
+            mock_fetcher_cls.return_value = mock_fetcher
+
+            events = []
+            result = init_platform_docs(
+                platform="test_proc_exc",
+                cfg=cfg,
+                build_mode="overwrite",
+                emit=lambda e: events.append(e),
+            )
+
+        assert result.success is False
+        stages = [e.stage for e in events]
+        assert "task_failed" in stages
+        # Verify the exception type was captured in the event
+        failed_events = [e for e in events if e.stage == "task_failed"]
+        assert len(failed_events) >= 1
+
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_cancel_check_true_in_overwrite_emits_task_failed(self, mock_store_fn):
+        """cancel_check=lambda: True during overwrite emits task_failed before processing."""
+        mock_store = MagicMock()
+        mock_store_fn.return_value = mock_store
+
+        events = []
+        result = init_platform_docs(
+            platform="test_cancel_emit",
+            cfg=self._mock_cfg(),
+            build_mode="overwrite",
+            emit=lambda e: events.append(e),
+            cancel_check=lambda: True,
+        )
+
+        # Result should contain "Cancelled" in errors
+        assert "Cancelled" in result.errors
+
+        # emit must have received a task_failed event
+        stages = [e.stage for e in events]
+        assert "task_failed" in stages
+
+        # Verify the task_failed event has the cancellation error
+        failed_events = [e for e in events if e.stage == "task_failed"]
+        assert any("Cancelled" in (e.error or "") for e in failed_events)

--- a/tests/unit_tests/storage/document/test_doc_init.py
+++ b/tests/unit_tests/storage/document/test_doc_init.py
@@ -548,8 +548,8 @@ class TestInitPlatformDocsEmit:
         assert "task_failed" in stages
 
     @patch("datus.storage.document.doc_init.document_store")
-    def test_emit_task_completed_with_totals_after_check(self, mock_store_fn):
-        """emit receives task_completed event with total_items/completed_items after check mode."""
+    def test_check_mode_emits_no_task_failed(self, mock_store_fn):
+        """Check mode emits task_started and does not emit task_failed."""
         mock_store = MagicMock()
         mock_store.get_stats.return_value = {"versions": ["v1", "v2"], "total_chunks": 30, "doc_count": 6}
         mock_store.get_stats_by_version.return_value = {"doc_count": 3, "total_chunks": 15}
@@ -598,9 +598,11 @@ class TestInitPlatformDocsEmit:
         assert result.success is False
         stages = [e.stage for e in events]
         assert "task_failed" in stages
-        # Verify the exception type was captured in the event
+        # Verify the exception type and error message were captured in the event
         failed_events = [e for e in events if e.stage == "task_failed"]
         assert len(failed_events) >= 1
+        assert failed_events[0].exception_type == "ValueError"
+        assert "disk read error" in (failed_events[0].error or "")
 
     @patch("datus.storage.document.doc_init.document_store")
     def test_cancel_check_true_in_overwrite_emits_task_failed(self, mock_store_fn):
@@ -878,7 +880,8 @@ class TestInitPlatformDocsOverwrite:
         )
 
         assert "Cancelled" in result.errors
-        # Processing must not have happened
+        # Cancellation must skip both deletion and processing
+        mock_store.delete_docs.assert_not_called()
         mock_processor_cls.return_value.process_local.assert_not_called()
         stages = [e.stage for e in events]
         assert "task_failed" in stages

--- a/tests/unit_tests/storage/document/test_doc_init.py
+++ b/tests/unit_tests/storage/document/test_doc_init.py
@@ -627,3 +627,258 @@ class TestInitPlatformDocsEmit:
         # Verify the task_failed event has the cancellation error
         failed_events = [e for e in events if e.stage == "task_failed"]
         assert any("Cancelled" in (e.error or "") for e in failed_events)
+
+
+# ---------------------------------------------------------------------------
+# init_platform_docs — overwrite processing branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestInitPlatformDocsOverwrite:
+    """Tests for overwrite-mode processing branches in init_platform_docs."""
+
+    def _mock_cfg(self, source="/some/path", source_type="local", version="v1"):
+        cfg = MagicMock()
+        cfg.source = source
+        cfg.type = source_type
+        cfg.version = version
+        cfg.paths = []
+        cfg.chunk_size = 512
+        cfg.include_patterns = []
+        cfg.exclude_patterns = []
+        return cfg
+
+    @patch("datus.storage.document.doc_init.StreamingDocProcessor")
+    @patch("datus.storage.document.doc_init.LocalFetcher")
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_overwrite_local_source_processes_documents(self, mock_store_fn, mock_fetcher_cls, mock_processor_cls):
+        """Overwrite with local source fetches docs, processes them, and returns success."""
+        from datus.storage.document.streaming_processor import ProcessingStats
+
+        mock_store = MagicMock()
+        mock_store.delete_docs.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        mock_fetcher = MagicMock()
+        mock_doc = MagicMock()
+        mock_doc.version = "v1"
+        mock_fetcher.fetch.return_value = [mock_doc] * 5
+        mock_fetcher_cls.return_value = mock_fetcher
+
+        mock_processor = MagicMock()
+        mock_stats = ProcessingStats()
+        mock_stats.increment(docs=5, chunks=20)
+        mock_processor.process_local.return_value = mock_stats
+        mock_processor_cls.return_value = mock_processor
+
+        events = []
+        result = init_platform_docs(
+            platform="test_local",
+            cfg=self._mock_cfg(source="/some/path", source_type="local", version="v1"),
+            build_mode="overwrite",
+            emit=lambda e: events.append(e),
+        )
+
+        mock_fetcher_cls.assert_called_once()
+        mock_fetcher.fetch.assert_called_once()
+        mock_processor.process_local.assert_called_once()
+        mock_store.delete_docs.assert_called_once_with(version="v1")
+
+        assert result.success is True
+        assert result.total_docs == 5
+        assert result.total_chunks == 20
+
+        stages = [e.stage for e in events]
+        assert "task_started" in stages
+        assert "task_validated" in stages
+        assert "task_completed" in stages
+
+    @patch("datus.storage.document.doc_init.LocalFetcher")
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_overwrite_local_no_documents_returns_empty(self, mock_store_fn, mock_fetcher_cls):
+        """Overwrite with local source returning no docs gives total_docs=0 and error."""
+        mock_store = MagicMock()
+        mock_store_fn.return_value = mock_store
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.fetch.return_value = []
+        mock_fetcher_cls.return_value = mock_fetcher
+
+        result = init_platform_docs(
+            platform="test_local_empty",
+            cfg=self._mock_cfg(source="/empty/path", source_type="local", version="v1"),
+            build_mode="overwrite",
+        )
+
+        assert result.total_docs == 0
+        assert any("No documents found" in err for err in result.errors)
+
+    @patch("datus.storage.document.doc_init.StreamingDocProcessor")
+    @patch("datus.storage.document.doc_init.GitHubFetcher")
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_overwrite_github_source_processes_files(self, mock_store_fn, mock_fetcher_cls, mock_processor_cls):
+        """Overwrite with github source calls collect_metadata and process_github."""
+        from datus.storage.document.streaming_processor import ProcessingStats
+
+        mock_store = MagicMock()
+        mock_store.delete_docs.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        mock_fetcher = MagicMock()
+        mock_metadata = MagicMock()
+        mock_metadata.file_paths = ["docs/intro.md", "docs/setup.md", "docs/ref.md"]
+        mock_metadata.version = "v2"
+        mock_fetcher.collect_metadata.return_value = mock_metadata
+        mock_fetcher_cls.return_value = mock_fetcher
+
+        mock_processor = MagicMock()
+        mock_stats = ProcessingStats()
+        mock_stats.increment(docs=3, chunks=12)
+        mock_processor.process_github.return_value = mock_stats
+        mock_processor_cls.return_value = mock_processor
+
+        result = init_platform_docs(
+            platform="test_github",
+            cfg=self._mock_cfg(source="owner/repo", source_type="github", version="v2"),
+            build_mode="overwrite",
+        )
+
+        mock_fetcher.collect_metadata.assert_called_once()
+        mock_processor.process_github.assert_called_once()
+        assert result.total_docs == 3
+        assert result.total_chunks == 12
+
+    @patch("datus.storage.document.doc_init.StreamingDocProcessor")
+    @patch("datus.storage.document.doc_init.WebFetcher")
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_overwrite_website_source_processes_urls(self, mock_store_fn, mock_fetcher_cls, mock_processor_cls):
+        """Overwrite with website source calls process_website."""
+        from datus.storage.document.streaming_processor import ProcessingStats
+
+        mock_store = MagicMock()
+        mock_store.delete_docs.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        mock_fetcher = MagicMock()
+        mock_fetcher._detect_version_from_url.return_value = "v3"
+        mock_fetcher_cls.return_value = mock_fetcher
+
+        mock_processor = MagicMock()
+        mock_stats = ProcessingStats()
+        mock_stats.increment(docs=10, chunks=40)
+        mock_processor.process_website.return_value = mock_stats
+        mock_processor_cls.return_value = mock_processor
+
+        result = init_platform_docs(
+            platform="test_website",
+            cfg=self._mock_cfg(source="https://docs.example.com", source_type="website", version=""),
+            build_mode="overwrite",
+        )
+
+        mock_processor.process_website.assert_called_once()
+        assert result.total_docs == 10
+        assert result.total_chunks == 40
+
+    @patch("datus.storage.document.doc_init.StreamingDocProcessor")
+    @patch("datus.storage.document.doc_init.LocalFetcher")
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_index_creation_after_processing(self, mock_store_fn, mock_fetcher_cls, mock_processor_cls):
+        """After processing with chunks > 0, create_indices is called on the store."""
+        from datus.storage.document.streaming_processor import ProcessingStats
+
+        mock_store = MagicMock()
+        mock_store.delete_docs.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        mock_fetcher = MagicMock()
+        mock_doc = MagicMock()
+        mock_doc.version = "v1"
+        mock_fetcher.fetch.return_value = [mock_doc]
+        mock_fetcher_cls.return_value = mock_fetcher
+
+        mock_processor = MagicMock()
+        mock_stats = ProcessingStats()
+        mock_stats.increment(docs=1, chunks=5)
+        mock_processor.process_local.return_value = mock_stats
+        mock_processor_cls.return_value = mock_processor
+
+        init_platform_docs(
+            platform="test_index",
+            cfg=self._mock_cfg(),
+            build_mode="overwrite",
+        )
+
+        mock_store.create_indices.assert_called_once()
+
+    @patch("datus.storage.document.doc_init.StreamingDocProcessor")
+    @patch("datus.storage.document.doc_init.LocalFetcher")
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_index_creation_error_logged(self, mock_store_fn, mock_fetcher_cls, mock_processor_cls):
+        """When create_indices raises, error is captured in stats but result is still success."""
+        from datus.storage.document.streaming_processor import ProcessingStats
+
+        mock_store = MagicMock()
+        mock_store.delete_docs.return_value = 0
+        mock_store.create_indices.side_effect = RuntimeError("index build failed")
+        mock_store_fn.return_value = mock_store
+
+        mock_fetcher = MagicMock()
+        mock_doc = MagicMock()
+        mock_doc.version = "v1"
+        mock_fetcher.fetch.return_value = [mock_doc]
+        mock_fetcher_cls.return_value = mock_fetcher
+
+        mock_processor = MagicMock()
+        mock_stats = ProcessingStats()
+        mock_stats.increment(docs=1, chunks=5)
+        mock_processor.process_local.return_value = mock_stats
+        mock_processor_cls.return_value = mock_processor
+
+        result = init_platform_docs(
+            platform="test_index_err",
+            cfg=self._mock_cfg(),
+            build_mode="overwrite",
+        )
+
+        mock_store.create_indices.assert_called_once()
+        assert any("Index error" in err for err in result.errors)
+        # total_chunks > 0 so success is True despite index error
+        assert result.success is True
+
+    @patch("datus.storage.document.doc_init.StreamingDocProcessor")
+    @patch("datus.storage.document.doc_init.LocalFetcher")
+    @patch("datus.storage.document.doc_init.document_store")
+    def test_cancel_check_between_phases(self, mock_store_fn, mock_fetcher_cls, mock_processor_cls):
+        """cancel_check True after validation (second call) triggers early return with Cancelled."""
+        mock_store = MagicMock()
+        mock_store_fn.return_value = mock_store
+
+        mock_fetcher = MagicMock()
+        mock_doc = MagicMock()
+        mock_doc.version = "v1"
+        mock_fetcher.fetch.return_value = [mock_doc] * 3
+        mock_fetcher_cls.return_value = mock_fetcher
+
+        # cancel_check: first call (before any processing) returns False,
+        # second call (after task_validated, before delete+process) returns True
+        call_count = {"n": 0}
+
+        def cancel_check():
+            call_count["n"] += 1
+            return call_count["n"] >= 2
+
+        events = []
+        result = init_platform_docs(
+            platform="test_cancel_between",
+            cfg=self._mock_cfg(source="/some/path", source_type="local", version="v1"),
+            build_mode="overwrite",
+            emit=lambda e: events.append(e),
+            cancel_check=cancel_check,
+        )
+
+        assert "Cancelled" in result.errors
+        # Processing must not have happened
+        mock_processor_cls.return_value.process_local.assert_not_called()
+        stages = [e.stage for e in events]
+        assert "task_failed" in stages

--- a/tests/unit_tests/storage/document/test_streaming_processor.py
+++ b/tests/unit_tests/storage/document/test_streaming_processor.py
@@ -1,0 +1,149 @@
+"""Unit tests for StreamingDocProcessor — on_doc_complete callback."""
+
+import threading
+from unittest.mock import MagicMock
+
+from datus.storage.document.schemas import CONTENT_TYPE_MARKDOWN, FetchedDocument
+from datus.storage.document.streaming_processor import ProcessingStats, StreamingDocProcessor
+
+
+class TestOnDocCompleteCallback:
+    """Tests for the on_doc_complete callback in StreamingDocProcessor."""
+
+    def _make_processor(self, store=None, on_doc_complete=None):
+        """Create a StreamingDocProcessor with a mock store."""
+        mock_store = store or MagicMock()
+        mock_store.store_chunks = MagicMock(return_value=3)
+        return StreamingDocProcessor(
+            store=mock_store,
+            chunk_size=1024,
+            pool_size=1,
+            on_doc_complete=on_doc_complete,
+        )
+
+    def _make_doc(self, path="test.md", content="# Hello\n\nSome content here."):
+        return FetchedDocument(
+            platform="test",
+            version="1.0",
+            source_url=f"https://example.com/{path}",
+            source_type="local",
+            doc_path=path,
+            raw_content=content,
+            content_type=CONTENT_TYPE_MARKDOWN,
+        )
+
+    def test_callback_invoked_on_success(self):
+        """on_doc_complete is called with (doc_path, chunk_count) on success."""
+        callback = MagicMock()
+        processor = self._make_processor(on_doc_complete=callback)
+        doc = self._make_doc()
+        stats = ProcessingStats()
+
+        processor._process_single_document(doc, {"platform": "test", "version": "1.0"}, stats)
+
+        callback.assert_called_once()
+        call_args = callback.call_args[0]
+        assert call_args[0] == "test.md"
+        assert isinstance(call_args[1], int)
+        assert call_args[1] >= 0
+
+    def test_callback_invoked_on_failure(self):
+        """on_doc_complete is called with chunk_count=0 on processing failure."""
+        callback = MagicMock()
+        mock_store = MagicMock()
+        # Chunker succeeds, but store_chunks raises to simulate storage failure
+        mock_store.store_chunks = MagicMock(side_effect=RuntimeError("store error"))
+        processor = StreamingDocProcessor(
+            store=mock_store,
+            chunk_size=1024,
+            pool_size=1,
+            on_doc_complete=callback,
+        )
+        doc = self._make_doc()
+        stats = ProcessingStats()
+
+        # Should not raise
+        result = processor._process_single_document(doc, {"platform": "test", "version": "1.0"}, stats)
+        assert result == []
+
+        callback.assert_called_once()
+        call_args = callback.call_args[0]
+        assert call_args[0] == "test.md"
+        assert call_args[1] == 0
+
+    def test_no_callback_does_not_crash(self):
+        """Default (None) callback processes normally."""
+        processor = self._make_processor(on_doc_complete=None)
+        doc = self._make_doc()
+        stats = ProcessingStats()
+
+        processor._process_single_document(doc, {"platform": "test", "version": "1.0"}, stats)
+        assert stats.total_docs == 1
+
+    def test_broken_callback_does_not_halt_processing(self):
+        """A callback that raises does not prevent document processing."""
+        callback = MagicMock(side_effect=RuntimeError("callback boom"))
+        processor = self._make_processor(on_doc_complete=callback)
+        doc = self._make_doc()
+        stats = ProcessingStats()
+
+        processor._process_single_document(doc, {"platform": "test", "version": "1.0"}, stats)
+
+        # Processing still succeeded despite callback failure
+        assert stats.total_docs == 1
+        assert stats.total_chunks > 0
+        callback.assert_called_once()
+
+    def test_callback_receives_correct_chunk_count(self):
+        """Callback receives the actual number of chunks created."""
+        chunks_created = []
+
+        def track_callback(doc_path, chunk_count):
+            chunks_created.append((doc_path, chunk_count))
+
+        processor = self._make_processor(on_doc_complete=track_callback)
+        doc = self._make_doc(content="# Title\n\n" + "Content paragraph. " * 50)
+        stats = ProcessingStats()
+
+        processor._process_single_document(doc, {"platform": "test", "version": "1.0"}, stats)
+
+        assert len(chunks_created) == 1
+        assert chunks_created[0][0] == "test.md"
+        assert chunks_created[0][1] == stats.total_chunks
+
+
+class TestProcessingStats:
+    """Tests for ProcessingStats thread safety."""
+
+    def test_thread_safe_increment(self):
+        """Multiple threads can safely increment stats."""
+        stats = ProcessingStats()
+
+        def increment_many():
+            for _ in range(100):
+                stats.increment(docs=1, chunks=5)
+
+        threads = [threading.Thread(target=increment_many) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert stats.total_docs == 400
+        assert stats.total_chunks == 2000
+
+    def test_thread_safe_add_error(self):
+        """Multiple threads can safely add errors."""
+        stats = ProcessingStats()
+
+        def add_errors():
+            for i in range(50):
+                stats.add_error(f"error-{i}")
+
+        threads = [threading.Thread(target=add_errors) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(stats.errors) == 200


### PR DESCRIPTION
## Why

Platform documentation bootstrap (`init_platform_docs`) was only available via CLI with no real-time progress feedback. The web UI needs an SSE-streaming endpoint to show bootstrap progress, similar to the existing `POST /api/v1/kb/bootstrap` for KB components.

Additionally, the GitHub metadata collection (`_collect_file_paths`) used the Contents API to recursively walk directories one-by-one, causing ~110s blocking for large repos like StarRocks (1036 files across 100+ directories).

## Solution

### 1. SSE Streaming API for Platform Doc Bootstrap

- **`BootstrapDocInput` model** (`kb_models.py`): New Pydantic model with `platform` as the only required field; all other fields (source, version, github_ref, github_token, paths, etc.) fall back to `AgentConfig.document_configs[platform]`.
- **`StreamingDocProcessor.on_doc_complete`** (`streaming_processor.py`): Added optional per-document callback `(doc_path, chunk_count)` invoked from worker threads after each document finishes processing.
- **`init_platform_docs` emit/cancel** (`doc_init.py`): Added `emit` (BatchEventEmitter) and `cancel_check` (Callable) parameters. Emits `BatchEvent`s at each phase: task_started → task_validated → item_completed (per doc) → task_completed/task_failed. Backward compatible — both params default to `None`.
- **`KbService.bootstrap_doc_stream`** (`kb_service.py`): Async generator following the same queue/executor pattern as `bootstrap_stream()`. Includes `_run_doc_init` (sync worker) and `_merge_doc_overrides` (DocumentConfig overlay via `dataclasses.replace`).
- **Routes** (`kb_routes.py`): `POST /api/v1/kb/bootstrap-docs` (SSE streaming) + `POST /api/v1/kb/bootstrap-docs/{stream_id}/cancel`.

### 2. GitHub File Discovery Optimization

- **`_get_full_tree`** (`github_fetcher.py`): New method using Git Trees API (`/git/trees/{sha}?recursive=1`) to fetch the entire repo file tree in a **single API call** (vs 100-200+ recursive Contents API calls). Results are cached per branch.
- **`_collect_file_paths`**: Now tries the fast Git Trees path first, falls back to `_collect_file_paths_recursive` (the original Contents API walk) when the tree is truncated (>100k entries) or the API fails.
- **Expected improvement**: ~110s → ~2-3s for StarRocks-scale repos.

## Test Cases

- `tests/unit_tests/api/models/test_kb_models.py` — 8 tests: BootstrapDocInput validation (required fields, literals, boundaries, roundtrip)
- `tests/unit_tests/storage/document/test_streaming_processor.py` — 7 tests: on_doc_complete callback (success, failure, None default, broken callback safety, correct chunk count, thread safety)
- `tests/unit_tests/storage/document/test_doc_init.py` — 6 new tests: emit backward compat, task_started event, cancel_check early return, cancel_check=False continues, task_failed on store error
- `tests/unit_tests/api/services/test_kb_service.py` — 8 new tests: _merge_doc_overrides (no overrides, partial, all fields, source_type→type mapping, immutability), bootstrap_doc_stream (check mode, cancel, missing platform)
- Existing `test_github_fetcher.py` — all 50 tests pass (fallback path exercised via truncated tree mock)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSE endpoints to start and cancel platform documentation bootstraps with live progress, per-document progress, cancellation, and final status; requests accept platform plus optional overrides and pool/build options.
  * Added a request schema for document bootstrap and service streaming support.

* **Performance Improvements**
  * Faster GitHub documentation path collection via a tree-based fast path with safe fallback.

* **Tests**
  * Expanded unit/CI tests for models, streaming/cancellation flows, override merging, emit/callback lifecycle, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->