### PR TITLE
[Refactor] Replace Streamlit web chatbot with FastAPI + @datus/web-chatbot

### DIFF
--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -78,7 +78,7 @@ class ArgumentParser:
         mode_group.add_argument(
             "--web",
             action="store_true",
-            help="Launch web-based Streamlit chatbot interface",
+            help="Launch web-based chatbot interface",
         )
         mode_group.add_argument(
             "-p",
@@ -134,6 +134,14 @@ class ArgumentParser:
             help="Session scope for directory isolation (sessions stored under {session_dir}/{scope}/)",
         )
 
+        self.parser.add_argument(
+            "--chatbot-dist",
+            dest="chatbot_dist",
+            type=str,
+            default=None,
+            help="Path to @datus/web-chatbot dist directory (for --web mode)",
+        )
+
     def parse_args(self):
         return self.parser.parse_args()
 
@@ -168,7 +176,7 @@ class Application:
             cli.run()
 
     def _run_web_interface(self, args):
-        """Launch Streamlit web interface"""
+        """Launch web chatbot interface"""
         from datus.cli.web import run_web_interface
 
         run_web_interface(args)

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -76,7 +76,6 @@ class DatusCLI:
         self.console = Console(log_path=False)
         self.console_column_width = 16
         self.selected_catalog_path = ""
-        self.streamlit_mode = False
         self.selected_catalog_data = {}
 
         setup_exception_handler(
@@ -354,7 +353,7 @@ class DatusCLI:
                 if user_input_raw is None:
                     continue
                 if user_input_raw == "_open_chat_sql_details":
-                    if not self.streamlit_mode and self.chat_commands and self.chat_commands.last_actions:
+                    if self.chat_commands and self.chat_commands.last_actions:
                         self.chat_commands.display_inline_trace_details(self.chat_commands.last_actions)
                     continue
                 self._prefill_input = None
@@ -398,10 +397,6 @@ class DatusCLI:
     def _async_init_agent(self):
         """Initialize the agent asynchronously in a background thread."""
         if self.agent_initializing or self.agent_ready:
-            return
-
-        # Skip background initialization in Streamlit mode to avoid vector DB conflicts
-        if hasattr(self, "streamlit_mode") and self.streamlit_mode:
             return
 
         self.agent_initializing = True

--- a/datus/cli/web/__init__.py
+++ b/datus/cli/web/__init__.py
@@ -3,20 +3,14 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 """
-Web interface components for Datus Agent.
+Web interface for Datus Agent.
 
-This package contains modular components for the Streamlit web interface.
+Serves a React-based chatbot frontend backed by FastAPI.
 """
 
-from datus.cli.web.chat_executor import ChatExecutor
-from datus.cli.web.chatbot import StreamlitChatbot, run_web_interface
-from datus.cli.web.config_manager import ConfigManager
-from datus.cli.web.ui_components import UIComponents
+from datus.cli.web.chatbot import create_web_app, run_web_interface
 
 __all__ = [
-    "ChatExecutor",
-    "ConfigManager",
-    "StreamlitChatbot",
-    "UIComponents",
+    "create_web_app",
     "run_web_interface",
 ]

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -89,8 +89,12 @@ def create_web_app(args: argparse.Namespace) -> FastAPI:
 
     if chatbot_dist:
         chatbot_dist = os.path.abspath(os.path.expanduser(chatbot_dist))
-        if not os.path.isdir(chatbot_dist):
-            logger.warning(f"Chatbot dist directory not found: {chatbot_dist}. Falling back to CDN.")
+        required_assets = [
+            os.path.join(chatbot_dist, "datus-chatbot.css"),
+            os.path.join(chatbot_dist, "datus-chatbot.umd.js"),
+        ]
+        if not os.path.isdir(chatbot_dist) or not all(os.path.isfile(p) for p in required_assets):
+            logger.warning(f"Chatbot dist directory missing or incomplete: {chatbot_dist}. Falling back to CDN.")
         else:
             app.mount(
                 "/chatbot-assets",

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -26,11 +26,17 @@ logger = get_logger(__name__)
 
 _TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
 
-# Default path to the pre-built @datus/web-chatbot dist directory.
-# Override at runtime via the --chatbot-dist CLI flag.
-_DEFAULT_CHATBOT_DIST = os.path.normpath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "Datus-saas", "packages", "web-chatbot", "dist")
-)
+# CDN URLs used when --chatbot-dist is NOT provided (production mode).
+_CDN_REACT_JS = "https://unpkg.com/react@18/umd/react.production.min.js"
+_CDN_REACT_DOM_JS = "https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+_CDN_CHATBOT_CSS = "https://unpkg.com/@datus/web-chatbot/dist/datus-chatbot.css"
+_CDN_CHATBOT_JS = "https://unpkg.com/@datus/web-chatbot/dist/datus-chatbot.umd.js"
+
+# Dev URLs used when --chatbot-dist IS provided (local development mode).
+_DEV_REACT_JS = "https://unpkg.com/react@18/umd/react.development.js"
+_DEV_REACT_DOM_JS = "https://unpkg.com/react-dom@18/umd/react-dom.development.js"
+_DEV_CHATBOT_CSS = "/chatbot-assets/datus-chatbot.css"
+_DEV_CHATBOT_JS = "/chatbot-assets/datus-chatbot.umd.js"
 
 
 def _build_agent_args(args: argparse.Namespace) -> argparse.Namespace:
@@ -72,34 +78,49 @@ def create_web_app(args: argparse.Namespace) -> FastAPI:
     agent_args = _build_agent_args(args)
     app = create_app(agent_args)
 
-    # ── Resolve chatbot dist directory ──────────────────────────────
-    chatbot_dist = getattr(args, "chatbot_dist", None) or _DEFAULT_CHATBOT_DIST
-    chatbot_dist = os.path.abspath(os.path.expanduser(chatbot_dist))
+    # ── Resolve asset mode: local dist vs CDN ──────────────────────
+    chatbot_dist = getattr(args, "chatbot_dist", None)
+    use_local = False
 
-    if not os.path.isdir(chatbot_dist):
-        logger.warning(
-            f"Chatbot dist directory not found: {chatbot_dist}. "
-            "The frontend assets will not be available. "
-            "Build @datus/web-chatbot or pass --chatbot-dist."
-        )
+    if chatbot_dist:
+        chatbot_dist = os.path.abspath(os.path.expanduser(chatbot_dist))
+        if not os.path.isdir(chatbot_dist):
+            logger.warning(f"Chatbot dist directory not found: {chatbot_dist}. Falling back to CDN.")
+        else:
+            app.mount(
+                "/chatbot-assets",
+                StaticFiles(directory=chatbot_dist),
+                name="chatbot-assets",
+            )
+            use_local = True
+            logger.info(f"Dev mode: serving chatbot assets from {chatbot_dist}")
+
+    if not use_local:
+        logger.info("Production mode: loading chatbot assets from CDN")
+
+    # ── Pick asset URLs based on mode ──────────────────────────────
+    if use_local:
+        react_js, react_dom_js = _DEV_REACT_JS, _DEV_REACT_DOM_JS
+        chatbot_css, chatbot_js = _DEV_CHATBOT_CSS, _DEV_CHATBOT_JS
     else:
-        # Serve the UMD bundle + CSS at /chatbot-assets/
-        app.mount(
-            "/chatbot-assets",
-            StaticFiles(directory=chatbot_dist),
-            name="chatbot-assets",
-        )
-        logger.info(f"Serving chatbot assets from {chatbot_dist}")
+        react_js, react_dom_js = _CDN_REACT_JS, _CDN_REACT_DOM_JS
+        chatbot_css, chatbot_js = _CDN_CHATBOT_CSS, _CDN_CHATBOT_JS
 
-    # ── HTML template route ─────────────────────────────────────────
+    # ── Render the HTML template ───────────────────────────────────
     html_template = _read_template()
     host = getattr(args, "host", "localhost")
     port = getattr(args, "port", 8501)
     request_origin = f"http://{host}:{port}"
     user_name = getattr(args, "user_name", None) or os.getenv("USER", "User")
 
-    # Pre-render the template with config values
-    rendered_html = html_template.replace("{{ request_origin }}", request_origin).replace("{{ user_name }}", user_name)
+    rendered_html = (
+        html_template.replace("{{ react_js }}", react_js)
+        .replace("{{ react_dom_js }}", react_dom_js)
+        .replace("{{ chatbot_css }}", chatbot_css)
+        .replace("{{ chatbot_js }}", chatbot_js)
+        .replace("{{ request_origin }}", request_origin)
+        .replace("{{ user_name }}", user_name)
+    )
 
     # Override the default JSON root endpoint with the chatbot page
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -3,1225 +3,156 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 """
-Streamlit Chatbot for Datus Agent
+Web Chatbot server for Datus Agent.
 
-This module provides a web-based chatbot interface using Streamlit,
-maximizing reuse of existing Datus CLI components including:
-- DatusCLI for real CLI functionality
-- ChatCommands for chat processing
-- ActionHistoryDisplay for execution visualization
-- CollapsibleActionContentGenerator for detail views
+Serves a React-based chatbot frontend (``@datus/web-chatbot`` UMD bundle)
+backed by the standard Datus Agent API routes.  Replaces the former
+Streamlit-based implementation with a lightweight FastAPI static-file server.
 """
 
-import asyncio
-import csv
-import math
+import argparse
 import os
-import re
-import uuid
-from datetime import datetime
-from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple
+import webbrowser
 
-import pandas as pd
-import streamlit as st
-import structlog
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 
-# Import Datus components to reuse
-from datus.cli.repl import DatusCLI
-from datus.cli.web.chat_executor import ChatExecutor
-from datus.cli.web.config_manager import ConfigManager, get_home_from_config
-from datus.cli.web.ui_components import UIComponents
-from datus.models.session_manager import SessionManager
-from datus.schemas.action_history import ActionHistory
-from datus.schemas.node_models import ExecuteSQLResult
-from datus.utils.loggings import configure_logging, setup_web_chatbot_logging
-from datus.utils.path_manager import set_current_path_manager
+from datus.api.service import create_app
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+_TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
+
+# Default path to the pre-built @datus/web-chatbot dist directory.
+# Override at runtime via the --chatbot-dist CLI flag.
+_DEFAULT_CHATBOT_DIST = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "Datus-saas", "packages", "web-chatbot", "dist")
+)
 
 
-def _run_async(coro):
-    """Run a coroutine safely regardless of event-loop state.
-
-    ``asyncio.run()`` fails with *RuntimeError: Event loop is closed* when
-    called inside environments that manage their own loop (Streamlit, PyCharm
-    debugger with ``nest_asyncio``, etc.).  This helper handles that case.
+def _build_agent_args(args: argparse.Namespace) -> argparse.Namespace:
+    """Bridge CLI ``datus web`` arguments to the shape expected by
+    ``create_app`` / ``DatusAPIService``.
     """
-    try:
-        loop = asyncio.get_event_loop()
-        if loop.is_closed():
-            raise RuntimeError("closed")
-    except RuntimeError:
-        # No current loop or closed – create a fresh one explicitly
-        # (asyncio.run may be patched by nest_asyncio and still hit the closed loop)
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
-
-    if loop.is_running():
-        # We're inside a running loop – create a task instead of nesting
-        import concurrent.futures
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(asyncio.run, coro).result()
-    return loop.run_until_complete(coro)
-
-
-# Logging setup shared with CLI entry point
-logger = structlog.get_logger("web_chatbot")
-_LOGGING_INITIALIZED = False
-
-
-def initialize_logging(debug: bool = False, log_dir: str = None) -> None:
-    """Configure logging for the Streamlit subprocess to match CLI behavior."""
-
-    global _LOGGING_INITIALIZED, logger
-
-    if _LOGGING_INITIALIZED:
-        return
-
-    # Use path manager default if not specified
-    if log_dir is None:
-        from datus.utils.path_manager import get_path_manager
-
-        log_dir = str(get_path_manager().logs_dir)
-
-    configure_logging(debug=debug, log_dir=log_dir, console_output=False)
-    logger = setup_web_chatbot_logging(debug=debug, log_dir=log_dir)
-    _LOGGING_INITIALIZED = True
-
-
-class StreamlitChatbot:
-    """Main Streamlit Chatbot class that wraps Datus CLI components"""
-
-    def __init__(self):
-        self.session_manager = SessionManager(scope=st.session_state.get("startup_scope"))
-        self.chat_executor = ChatExecutor()
-        self.config_manager = ConfigManager()
-
-        # Get server host and port from Streamlit config with fallback
-        self.server_host = st.get_option("server.address") or "localhost"
-        self.server_port = st.get_option("server.port") or 8501
-
-        # Initialize UI components
-        self.ui = UIComponents(self.server_host, self.server_port)
-
-        # Initialize session state with defaults
-        defaults = {
-            "messages": [],
-            "current_actions": [],
-            "chat_session_initialized": False,
-            "cli_instance": None,
-            "current_chat_id": None,
-            "subagent_name": None,
-            "view_session_id": None,
-            "session_readonly_mode": False,
-        }
-        for key, value in defaults.items():
-            if key not in st.session_state:
-                st.session_state[key] = value
-
-    @staticmethod
-    def sanitize_csv_field(value: Optional[str]) -> Optional[str]:
-        """
-        Sanitize a CSV field to prevent formula injection.
-
-        If the field starts with =, +, -, or @, prefix it with a single quote
-        to neutralize Excel formula injection attacks.
-
-        Args:
-            value: The field value to sanitize
-
-        Returns:
-            Sanitized value safe for CSV export
-        """
-        if value is None:
-            return None
-
-        if not isinstance(value, str):
-            value = str(value)
-
-        # Check if first character is a formula trigger
-        if value and value[0] in "=+-@":
-            return "'" + value
-
-        return value
-
-    @property
-    def cli(self) -> DatusCLI:
-        """Get CLI instance from session state"""
-        return st.session_state.cli_instance
-
-    @cli.setter
-    def cli(self, value):
-        """Set CLI instance in session state"""
-        st.session_state.cli_instance = value
-
-    @property
-    def current_subagent(self) -> Optional[str]:
-        """Get current subagent from URL query parameters"""
-        return st.query_params.get("subagent")
-
-    @property
-    def should_hide_sidebar(self) -> bool:
-        """Check if sidebar should be hidden (embed mode)"""
-        # Return from session_state (persists across reruns)
-        # Query params are read in run() method after set_page_config
-        return st.session_state.get("embed_mode", False)
-
-    def setup_config(
-        self, config_path: str = "conf/agent.yml", namespace: str = None, catalog: str = "", database: str = ""
-    ) -> bool:
-        """Delegate to ConfigManager for agent configuration setup."""
-        # Check if already initialized to prevent repeated initialization
-        if self.cli is not None:
-            logger.info("CLI already initialized, skipping...")
-            return True
-
-        try:
-            self.cli = self.config_manager.setup_config(config_path, namespace, catalog, database)
-            st.session_state.chat_session_initialized = True
-            self.ui.agent_config = self.cli.agent_config
-            return True
-        except Exception as e:
-            st.error(f"Failed to load configuration: {e}")
-            logger.error(f"Configuration loading error: {e}")
-            return False
-
-    def render_sidebar(self) -> Dict[str, Any]:  # pragma: no cover
-        """Render sidebar with configuration information"""
-        # Skip sidebar rendering in embed mode, but keep config loading
-        if self.should_hide_sidebar:
-            # Still need to initialize config if not done
-            if not self.cli and not st.session_state.get("initialization_attempted", False):
-                startup_config = st.session_state.get("startup_config_path", "conf/agent.yml")
-                startup_namespace = st.session_state.get("startup_namespace", None)
-                startup_catalog = st.session_state.get("startup_catalog", "")
-                startup_database = st.session_state.get("startup_database", "")
-
-                st.session_state.initialization_attempted = True
-
-                if self.setup_config(
-                    startup_config, startup_namespace, catalog=startup_catalog, database=startup_database
-                ):
-                    st.rerun()
-                else:
-                    st.session_state.initialization_attempted = False
-
-            # Update subagent name from URL
-            if self.cli:
-                st.session_state.subagent_name = self.current_subagent
-
-            return {"config_loaded": self.cli is not None}
-
-        with st.sidebar:
-            st.header("📊 Datus Chat")
-
-            # Auto-load config with startup parameters (only once)
-            if not self.cli and not st.session_state.get("initialization_attempted", False):
-                startup_config = st.session_state.get("startup_config_path", "conf/agent.yml")
-                startup_namespace = st.session_state.get("startup_namespace", None)
-                startup_catalog = st.session_state.get("startup_catalog", "")
-                startup_database = st.session_state.get("startup_database", "")
-
-                # Mark that we've attempted initialization
-                st.session_state.initialization_attempted = True
-
-                with st.spinner("Loading configuration..."):
-                    if self.setup_config(
-                        startup_config, startup_namespace, catalog=startup_catalog, database=startup_database
-                    ):
-                        st.success("✅ Configuration loaded!")
-                        st.rerun()
-                    else:
-                        st.error("❌ Failed to load configuration")
-                        st.session_state.initialization_attempted = False
-
-            # Show current configuration info
-            if self.cli:
-                # Set subagent name directly from URL (always refresh from URL)
-                st.session_state.subagent_name = self.current_subagent
-
-                # Current subagent info
-                if self.current_subagent:
-                    st.subheader("🤖 Current Subagent")
-                    st.info(f"**{st.session_state.subagent_name}** (GenSQL Mode)")
-
-                # Current namespace info
-                st.subheader("🏷️ Current Namespace")
-                if hasattr(self.cli.agent_config, "current_namespace"):
-                    st.info(f"**{self.cli.agent_config.current_namespace}**")
-
-                # Model selection
-                st.subheader("🤖 Chat Model")
-                available_models = self.get_available_models()
-                current_model = self.get_current_chat_model()
-
-                if available_models:
-                    selected_model = st.selectbox(
-                        "Select Model:",
-                        options=available_models,
-                        index=available_models.index(current_model) if current_model in available_models else 0,
-                        help="Choose the model for chat conversations",
-                    )
-
-                    if selected_model != current_model:
-                        st.info(f"Model changed to: {selected_model}")
-                        # Note: Model switching would require config reload
-                        # For now, just show the selection
-
-                # Session controls
-                st.markdown("---")
-                st.subheader("💬 Session")
-
-                # Session info
-                if self.cli.chat_commands and self.cli.chat_commands.chat_node:
-                    session_info = _run_async(self.cli.chat_commands.chat_node.get_session_info())
-                    col1, col2 = st.columns(2)
-                    with col1:
-                        st.metric("Messages", session_info.get("action_count", 0))
-                    with col2:
-                        st.metric("Tokens", session_info.get("token_count", 0))
-
-                # Clear chat button
-                if st.button("🗑️ Clear Chat", type="secondary", use_container_width=True):
-                    self.clear_chat()
-                    st.rerun()
-
-                # Session History section
-                st.markdown("---")
-                st.subheader("📚 Session History")
-
-                # List only recent 10 sessions (already sorted by modification time)
-                recent_sessions = self.session_manager.list_sessions(limit=10, sort_by_modified=True)
-                if recent_sessions:
-                    # Get session info for the recent sessions
-                    session_infos = []
-                    for sid in recent_sessions:
-                        info = self.session_manager.get_session_info(sid)
-                        if info.get("exists"):
-                            session_infos.append(info)
-
-                    # Display recent sessions
-                    if session_infos:
-                        st.caption(f"Showing {len(session_infos)} recent session(s)")
-                        for info in session_infos:
-                            self.ui.render_session_item(info)
-                else:
-                    st.caption("No saved sessions yet")
-
-                # Report Issue section
-                st.markdown("---")
-
-                # Get session ID
-                session_id = self.get_current_session_id()
-
-                # Render Report Issue button
-                import streamlit.components.v1 as components
-
-                components.html(self.ui.generate_report_issue_html(session_id), height=150)
-
-                # Debug section
-                st.markdown("---")
-                st.subheader("🔍 Debug Info")
-                with st.expander("Debug Details", expanded=False):
-                    st.write("Query Params:", dict(st.query_params))
-                    st.write("Startup Subagent:", st.session_state.get("startup_subagent_name"))
-                    st.write("Current Subagent:", st.session_state.get("subagent_name"))
-                    st.write("Session ID:", self.get_current_session_id())
-                    if self.cli and self.cli.chat_commands:
-                        st.write("Has current_node:", self.cli.chat_commands.current_node is not None)
-                        st.write("Has chat_node:", self.cli.chat_commands.chat_node is not None)
-                        if self.cli.chat_commands.current_node:
-                            st.write(
-                                "current_node.session_id:",
-                                getattr(self.cli.chat_commands.current_node, "session_id", None),
-                            )
-
-            else:
-                st.warning("⚠️ Loading configuration...")
-
-            return {"config_loaded": self.cli is not None}
-
-    def get_available_models(self) -> List[str]:
-        """Delegate to ConfigManager for getting available models."""
-        self.config_manager.cli = self.cli
-        return self.config_manager.get_available_models()
-
-    def get_current_chat_model(self) -> str:
-        """Delegate to ConfigManager for getting current chat model."""
-        config_path = st.session_state.get("startup_config_path", "conf/agent.yml")
-        self.config_manager.cli = self.cli
-        return self.config_manager.get_current_chat_model(config_path)
-
-    def clear_chat(self):
-        """Clear chat history and session"""
-        st.session_state.messages = []
-        st.session_state.current_actions = []
-        st.session_state.current_chat_id = None
-
-        if self.cli and self.cli.chat_commands:
-            self.cli.chat_commands.cmd_clear_chat("")
-
-    def get_session_messages(self, session_id: str) -> List[Dict]:
-        """Delegate to SessionManager for loading messages from database."""
-        return self.session_manager.get_session_messages(session_id)
-
-    def get_current_session_id(self) -> Optional[str]:
-        """Get the current session ID from the active chat node.
-
-        Falls back to ``st.session_state.view_session_id`` when no node is
-        active (e.g. read-only mode loaded via URL).
-        """
-        if self.cli and self.cli.chat_commands:
-            node = self.cli.chat_commands.current_node or self.cli.chat_commands.chat_node
-            if node:
-                session_id = getattr(node, "session_id", None)
-                if session_id:
-                    return session_id
-        return st.session_state.get("view_session_id")
-
-    def _store_session_id(self) -> None:
-        """Store current session_id in session_state for sidebar access"""
-        session_id = self.get_current_session_id()
-        if session_id:
-            st.session_state.current_session_id = session_id
-
-    def save_success_story(self, sql: str, user_message: str):
-        """
-        Save a success story to CSV file with session link.
-
-        Args:
-            sql: The generated SQL query
-            user_message: The user's original question
-        """
-        # Get current session ID
-        session_id = self.get_current_session_id()
-        if not session_id:
-            st.warning("No active session found. Cannot save success story.")
-            logger.warning("Attempted to save success story without active session")
-            return
-
-        # Get subagent name (for metadata and directory organization)
-        subagent_name = st.session_state.get("subagent_name") or "default"
-
-        # Generate session link with current server host and port
-        session_link = f"http://{self.server_host}:{self.server_port}?session={session_id}"
-
-        # Create benchmark directory safely (sanitize and contain)
-        from datus.utils.path_manager import get_path_manager
-
-        base_dir = get_path_manager().benchmark_dir.resolve()
-        safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", subagent_name)
-        target_dir = (base_dir / safe_name).resolve()
-        try:
-            target_dir.relative_to(base_dir)
-        except ValueError:
-            logger.warning(f"Rejected unsafe subagent_name: {subagent_name!r}")
-            st.error("Unsafe subagent name.")
-            return
-        target_dir.mkdir(parents=True, exist_ok=True)
-
-        # CSV file path
-        csv_path = str(target_dir / "success_story.csv")
-
-        # Prepare row data with CSV injection protection
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        row = {
-            "session_link": self.sanitize_csv_field(session_link),
-            "session_id": session_id,
-            "subagent_name": self.sanitize_csv_field(subagent_name),
-            "user_message": self.sanitize_csv_field(user_message),
-            "sql": self.sanitize_csv_field(sql),
-            "timestamp": timestamp,
-        }
-
-        try:
-            # Check if file exists to determine if we need to write headers
-            file_exists = os.path.exists(csv_path)
-
-            with open(csv_path, "a", newline="", encoding="utf-8") as f:
-                fieldnames = ["session_link", "session_id", "subagent_name", "user_message", "sql", "timestamp"]
-                writer = csv.DictWriter(f, fieldnames=fieldnames)
-
-                # Write header if file is new
-                if not file_exists:
-                    writer.writeheader()
-
-                # Write the success story
-                writer.writerow(row)
-
-            st.success(f"✅ Success story saved! Session link: {session_link}")
-            logger.info(f"Saved success story for session {session_id}")
-
-        except Exception as e:
-            st.error(f"Failed to save success story: {e}")
-            logger.error(f"Failed to save success story: {e}")
-
-    def resume_session(self, session_id: str) -> bool:
-        """
-        Resume a previous session, enabling continued conversation.
-
-        Args:
-            session_id: The session ID to resume
-
-        Returns:
-            True if session was successfully resumed, False otherwise
-        """
-        # Verify session exists
-        if not self.session_manager.session_exists(session_id):
-            st.error(f"Session {session_id} not found or has no data.")
-            logger.warning(f"Attempted to resume non-existent session: {session_id}")
-            return False
-
-        if not self.cli or not self.cli.chat_commands:
-            st.error("CLI not initialized. Please wait for configuration to load.")
-            return False
-
-        try:
-            # Load messages for display
-            messages = self.get_session_messages(session_id)
-
-            # Extract node type from session_id to determine subagent
-            from datus.cli.chat_commands import ChatCommands
-
-            node_name = ChatCommands._extract_node_type_from_session_id(session_id)
-            subagent_name = node_name if node_name != "chat" else None
-
-            # Create a new node of the appropriate type
-            new_node = self.cli.chat_commands._create_new_node(subagent_name)
-            new_node.session_id = session_id
-
-            # Update CLI state
-            self.cli.chat_commands.current_node = new_node
-            self.cli.chat_commands.current_subagent_name = subagent_name
-            if not subagent_name:
-                self.cli.chat_commands.chat_node = new_node
-
-            # Update Streamlit session state
-            st.session_state.messages = messages if messages else []
-            st.session_state.view_session_id = session_id
-            st.session_state.session_readonly_mode = False
-
-            logger.info(f"Resumed session {session_id} with {len(messages)} messages")
-            return True
-
-        except Exception as e:
-            st.error(f"Failed to resume session: {e}")
-            logger.error(f"Failed to resume session {session_id}: {e}")
-            return False
-
-    def _handle_rewind(self, user_turn: int, include_response: bool):
-        """Create a new session rewound to the given user turn and switch to it."""
-        session_id = self.get_current_session_id()
-        if not session_id:
-            st.error("No active session to rewind.")
-            return
-
-        try:
-            new_session_id = self.session_manager.rewind_session(
-                session_id, user_turn, include_assistant_response=include_response
-            )
-            if not self.resume_session(new_session_id):
-                st.error("Failed to resume the rewound session.")
-                return
-            # Update URL query params so load_session_from_url() won't reload the old session
-            self.ui.safe_update_query_params({"session": new_session_id, "mode": "resume"})
-            st.session_state._loaded_session_mode = "resume"
-            st.rerun()
-        except Exception as e:
-            st.error(f"Failed to rewind session: {e}")
-            logger.error(f"Rewind failed for session {session_id}: {e}")
-
-    def load_session_from_url(self):
-        """
-        Load a session from URL query parameter if present.
-        Supports two modes via ?mode= parameter:
-        - readonly (default): View-only mode for shared sessions
-        - resume: Resume the session for continued conversation
-        """
-        # Check URL query params for session parameter
-        session_id = st.query_params.get("session")
-        mode = st.query_params.get("mode", "readonly")
-
-        # Check if we've already loaded this specific session with the same mode
-        loaded_session = st.session_state.get("view_session_id")
-        loaded_mode = st.session_state.get("_loaded_session_mode")
-        if loaded_session == session_id and loaded_mode == mode:
-            return
-        if not session_id:
-            return
-
-        # Verify session exists
-        if not self.session_manager.session_exists(session_id):
-            st.error(f"Session {session_id} not found or has no data.")
-            logger.warning(f"Attempted to load non-existent session: {session_id}")
-            return
-
-        # Resume mode: use resume_session() to enable continued conversation
-        if mode == "resume":
-            if self.resume_session(session_id):
-                st.session_state._loaded_session_mode = "resume"
-            return
-
-        # Default: read-only mode
-        try:
-            messages = self.get_session_messages(session_id)
-            if not messages:
-                st.warning(f"Session {session_id} has no messages to display.")
-                return
-
-            # Populate session state with loaded messages
-            st.session_state.messages = messages
-            st.session_state.view_session_id = session_id
-            st.session_state.session_readonly_mode = True
-            st.session_state._loaded_session_mode = "readonly"
-
-            logger.info(f"Loaded session {session_id} with {len(messages)} messages in read-only mode")
-
-        except Exception as e:
-            st.error(f"Failed to load session: {e}")
-            logger.error(f"Failed to load session {session_id}: {e}")
-
-    def extract_sql_and_response(self, actions: List[ActionHistory]) -> Tuple[Optional[str], Optional[str]]:
-        """Delegate to ChatExecutor for SQL and response extraction."""
-        return self.chat_executor.extract_sql_and_response(actions, self.cli)
-
-    def _format_action_for_stream(self, action: ActionHistory) -> str:
-        """Delegate to ChatExecutor for action formatting."""
-        return self.chat_executor.format_action_for_stream(action)
-
-    def execute_chat_stream(self, user_message: str):
-        """Delegate to ChatExecutor for streaming execution."""
-        for msg in self.chat_executor.execute_chat_stream(user_message, self.cli, self.current_subagent):
-            yield msg
-        # Store session_id and actions
-        self._store_session_id()
-        # Note: actions are stored in session_state by caller
-
-    def do_download(
-        self, sql: str, markdown: str, data: ExecuteSQLResult, sql_id: Optional[str], display_column
-    ):  # pragma: no cover
-        """Execute SQL, build a multi-sheet Excel workbook, and expose it for download."""
-
-        if not sql_id:
-            sql_id = str(uuid.uuid4())
-
-        if not self.cli or not getattr(self.cli, "db_connector", None):
-            st.error("Database connector is not initialized. Please configure the agent first.")
-            logger.error("Download requested without an active database connector")
-            return
-        markdown = markdown or ""
-
-        def _normalize_dataframe(sql_return: Any) -> pd.DataFrame:
-            """Convert different result payloads into a DataFrame."""
-            if isinstance(sql_return, pd.DataFrame):
-                return sql_return
-            if sql_return is None:
-                return pd.DataFrame()
-            if isinstance(sql_return, list):
-                return pd.DataFrame(sql_return)
-            if isinstance(sql_return, dict):
-                return pd.DataFrame([sql_return])
-            return pd.DataFrame({"result": [sql_return]})
-
-        def _write_text_block(worksheet, text: str):
-            """
-            Write text into a single merged cell spanning multiple rows/columns.
-
-            The goal is to end up with a single logical cell (one merged region)
-            that contains the full text (with line breaks), instead of one row
-            per line.
-            """
-            text = text or ""
-            lines = text.splitlines() or [""]
-
-            # Estimate how many columns we want based on the longest line length
-            max_len = max((len(line) for line in lines), default=1)
-            approx_chars_per_col = 45
-            col_span = max(1, min(8, math.ceil(max_len / approx_chars_per_col)))
-            row_span = max(1, len(lines))
-
-            # Configure column widths
-            for col in range(col_span):
-                worksheet.set_column(col, col, approx_chars_per_col)
-
-            text_format = writer.book.add_format(
-                {
-                    "text_wrap": True,
-                    "valign": "top",
-                    "align": "left",
-                }
-            )
-
-            # If the merged region would cover more than a single cell, use merge_range.
-            # Otherwise, just write into the single top-left cell to avoid xlsxwriter's
-            # "Can't merge single cell" warning.
-            if row_span > 1 or col_span > 1:
-                worksheet.merge_range(0, 0, row_span - 1, col_span - 1, text, text_format)
-            else:
-                worksheet.write(0, 0, text or " ", text_format)
-
-        with st.spinner("Preparing Excel..."):
-            buffer = BytesIO()
-            try:
-                with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
-                    if data and getattr(data, "success", False):
-                        df = _normalize_dataframe(data.sql_return)
-                        df.to_excel(writer, sheet_name="result", index=False)
-                    else:
-                        df = pd.DataFrame()
-                        worksheet = writer.book.add_worksheet("result")
-                        writer.sheets["result"] = worksheet
-                        error_text = (getattr(data, "error", None) or "Unknown error").strip()
-                        error_format = writer.book.add_format(
-                            {
-                                "text_wrap": True,
-                                "font_color": "#9C0006",
-                                "bold": True,
-                                "align": "left",
-                                "valign": "top",
-                            }
-                        )
-                        worksheet.set_column(0, 3, 50)
-                        worksheet.merge_range(0, 0, 0, 3, error_text, error_format)
-
-                    sql_sheet = writer.book.add_worksheet("SQL")
-                    writer.sheets["SQL"] = sql_sheet
-                    from datus.utils.sql_utils import format_sql_to_pretty
-
-                    _write_text_block(
-                        sql_sheet,
-                        format_sql_to_pretty(
-                            sql, getattr(self.cli.db_connector, "dialect", None) or self.cli.agent_config.db_type
-                        ),
-                    )
-
-                    markdown_sheet = writer.book.add_worksheet("report")
-                    writer.sheets["report"] = markdown_sheet
-                    _write_text_block(markdown_sheet, markdown)
-            except Exception as exc:
-                st.error(f"Failed to generate Excel: {exc}")
-                logger.error(f"Failed to build download workbook: {exc}", exc_info=True)
-                return
-
-            buffer.seek(0)
-            file_bytes = buffer.getvalue()
-
-        file_name = f"{sql_id}.xlsx"
-
-        with display_column:
-            st.download_button(
-                label="⬇ Save results as Excel",
-                data=file_bytes,
-                file_name=file_name,
-                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                key=f"excel_download_{sql_id}",
-                use_container_width=False,
-                disabled=not df.empty and len(df) > self.cli.agent_config.max_export_lines,
-            )
-
-    def run(self):  # pragma: no cover
-        """Main Streamlit app runner"""
-        # Read query params and update session_state
-        hide_param = st.query_params.get("hide_sidebar")
-        if hide_param is not None:
-            st.session_state.embed_mode = hide_param == "true"
-
-        # Initialize logging for web interface
-        if "log_manager_initialized" not in st.session_state:
-            st.session_state.log_manager_initialized = True
-            logger.info("Web chatbot logging initialized")
-
-        # Hide deploy button and toolbar
-        st.set_option("client.toolbarMode", "viewer")
-
-        # Update session_id in session_state at the beginning of each render
-        # This ensures sidebar always has the latest session_id
-        current_session_id = self.get_current_session_id()
-        if current_session_id:
-            st.session_state.current_session_id = current_session_id
-
-        # Custom CSS for chat styling
-        if self.should_hide_sidebar:
-            # Hide sidebar completely in embed mode
-            st.markdown(
-                """
-                <style>
-                .stChatMessage {
-                    padding: 1rem;
-                    border-radius: 0.5rem;
-                    margin-bottom: 1rem;
-                }
-                .user-message {
-                    background-color: #e3f2fd;
-                }
-                .assistant-message {
-                    background-color: #f5f5f5;
-                }
-                .stExpander {
-                    border: 1px solid #ddd;
-                    border-radius: 0.5rem;
-                    margin-bottom: 0.5rem;
-                }
-                [data-testid="stSidebar"] {
-                    display: none;
-                }
-                [data-testid="stSidebarCollapsedControl"] {
-                    display: none;
-                }
-                [aria-label="Download as CSV"] {
-                    display: none !important;
-                    visibility: hidden !important;
-                }
-                </style>
-                """,
-                unsafe_allow_html=True,
-            )
-        else:
-            st.markdown(
-                """
-                <style>
-                .stChatMessage {
-                    padding: 1rem;
-                    border-radius: 0.5rem;
-                    margin-bottom: 1rem;
-                }
-                .user-message {
-                    background-color: #e3f2fd;
-                }
-                .assistant-message {
-                    background-color: #f5f5f5;
-                }
-                .stExpander {
-                    border: 1px solid #ddd;
-                    border-radius: 0.5rem;
-                    margin-bottom: 0.5rem;
-                }
-                [aria-label="Download as CSV"] {
-                    display: none !important;
-                    visibility: hidden !important;
-                }
-                </style>
-                """,
-                unsafe_allow_html=True,
-            )
-
-        # Load session from URL if present
-        self.load_session_from_url()
-
-        # Show read-only banner if viewing shared session
-        if st.session_state.session_readonly_mode:
-            session_id_short = st.session_state.view_session_id[:8] if st.session_state.view_session_id else "unknown"
-            col_banner, col_btn = st.columns([4, 1])
-            with col_banner:
-                st.info(f"📖 Viewing Shared Session (Read-Only) - ID: {session_id_short}...")
-            with col_btn:
-                if st.button("▶ Continue This Session", type="primary", use_container_width=True):
-                    view_sid = st.session_state.view_session_id
-                    if view_sid and self.resume_session(view_sid):
-                        st.rerun()
-
-        # Title and description with subagent support - detect directly from URL
-        if self.current_subagent:
-            st.title(f"🤖 Datus AI Chat Assistant - {self.current_subagent.title()}")
-            st.caption(f"Specialized {self.current_subagent} subagent for SQL generation - Natural Language to SQL")
-        else:
-            st.title("🤖 Datus AI Chat Assistant")
-            st.caption("Intelligent database query assistant based on Datus Agent - Natural Language to SQL")
-            # Only show available subagents when NOT in subagent mode and NOT in readonly mode
-            if not st.session_state.session_readonly_mode:
-                self.ui.show_available_subagents(self.cli.agent_config if self.cli else None)
-
-        # Render sidebar and get config status
-        sidebar_state = self.render_sidebar()
-
-        # Main chat interface
-        if not sidebar_state["config_loaded"]:
-            st.warning("⚠️ Please wait for configuration to load or check the sidebar")
-            st.info("Configuration file contains database connections, model settings, etc.")
-            return
-        self.ui.reset_sql_display_state()
-
-        # Handle pending rewind request
-        rewind_request = st.session_state.pop("rewind_request", None)
-        if rewind_request:
-            self._handle_rewind(rewind_request["turn"], rewind_request["include_response"])
-
-        self._display_chat_actions()
-
-        if not self.cli or not self.cli.chat_commands:
-            st.warning("⚠️ Something went wrong, please try restarting.")
-            return
-        # ── Chat input bar: text_input + Send/Stop button via st.form ──
-        # st.form lets Enter submit, and clear_on_submit prevents double-send.
-        # Run 1 (idle):  [input] [Send]  → user submits → save prompt, is_running=True, rerun
-        # Run 2 (running): [disabled input] [Stop]  → execute pending_prompt
-        #   user clicks Stop → Streamlit interrupts Run 2, starts Run 3
-        # Run 3 (stop):  form submitted=True, is_running=True → fire stop, rerun
-        # Run 4 (idle):  [input] [Send]
-        is_running = st.session_state.get("is_running", False)
-
-        if st.session_state.session_readonly_mode:
-            st.chat_input("Read-only mode - cannot send messages", disabled=True)
-        else:
-            with st.form("chat_form", clear_on_submit=True, border=False):
-                col_input, col_btn = st.columns([9, 1])
-                with col_input:
-                    user_input = st.text_input(
-                        "query",
-                        placeholder="Generating response..." if is_running else "Enter your data query question...",
-                        disabled=is_running,
-                        label_visibility="collapsed",
-                    )
-                with col_btn:
-                    if is_running:
-                        submitted = st.form_submit_button("⏹ Stop", type="primary", use_container_width=True)
-                    else:
-                        submitted = st.form_submit_button("Send", type="primary", use_container_width=True)
-
-            # Handle form submission
-            if submitted:
-                if is_running:
-                    # Stop: trigger interrupt and clear running state
-                    if "interrupt_controller" in st.session_state:
-                        st.session_state.interrupt_controller.interrupt()
-                    st.session_state.is_running = False
-                    st.session_state.pop("pending_prompt", None)
-                    st.rerun()
-                elif user_input and user_input.strip():
-                    # Send: save prompt, set running, rerun so Stop button renders first
-                    st.session_state.pending_prompt = user_input.strip()
-                    st.session_state.is_running = True
-                    st.rerun()
-
-        # ── Execute pending prompt (runs on the rerun after submission) ──
-        pending_prompt = st.session_state.pop("pending_prompt", None)
-        if pending_prompt and st.session_state.get("is_running", False):
-            import uuid
-
-            chat_id = str(uuid.uuid4())
-            st.session_state.current_chat_id = chat_id
-
-            # Add user message to chat history
-            st.session_state.messages.append({"role": "user", "content": pending_prompt, "chat_id": chat_id})
-
-            # Display user message
-            with st.chat_message("user"):
-                st.markdown(pending_prompt)
-
-            # Generate assistant response
-            try:
-                with st.chat_message("assistant"):
-                    status_placeholder = st.empty()
-                    progress_messages = []
-
-                    # Store interrupt controller in session_state for Stop button
-                    current_node = self.cli.chat_commands.current_node if self.cli and self.cli.chat_commands else None
-                    if current_node and hasattr(current_node, "interrupt_controller"):
-                        st.session_state.interrupt_controller = current_node.interrupt_controller
-
-                    with status_placeholder.container():
-                        with st.status("Processing your query... ", expanded=True) as status:
-                            step_index = 0
-                            from datus.cli.action_display.renderers import ActionContentGenerator
-
-                            content_generator = ActionContentGenerator(enable_truncation=False)
-
-                            stream_failed = False
-                            for action in self.execute_chat_stream(pending_prompt):
-                                if isinstance(action, str):
-                                    # Error messages from chat_executor are yielded as strings
-                                    st.error(action)
-                                    stream_failed = True
-                                    continue
-                                step_index += 1
-                                self.ui.render_action_item(chat_id, step_index, action, content_generator)
-                            if stream_failed:
-                                status.update(label="✗ Failed", state="error", expanded=True)
-                            else:
-                                status.update(label=f"✓ Completed {step_index} steps", state="complete", expanded=True)
-
-                    if not stream_failed:
-                        # Get complete actions from chat executor
-                        actions = self.chat_executor.last_actions
-                        logger.info(f"Chat execution completed: {len(actions) if actions else 0} actions collected")
-
-                        # Extract SQL and response
-                        sql, response = self.extract_sql_and_response(actions)
-
-                        # Display final response
-                        if response:
-                            self.ui.display_markdown_response(response)
-                        else:
-                            st.markdown(
-                                "Sorry, unable to generate a valid response. "
-                                "Please check execution details for more information."
-                            )
-
-                        # Display SQL if available
-                        if sql:
-                            self.ui.display_sql(sql, self.cli.db_connector.execute_pandas(sql))
-
-                        # Display collapsed action history at bottom
-                        if actions:
-                            self.ui.render_action_history(actions, chat_id, expanded=False)
-
-                        # Save to chat history with complete data
-                        assistant_message = {
-                            "role": "assistant",
-                            "content": response or "Unable to generate valid response",
-                            "sql": sql,
-                            "actions": actions,
-                            "chat_id": chat_id,
-                            "progress_messages": progress_messages,
-                        }
-                        logger.info(
-                            f"Saving message: chat_id={chat_id}, has_sql={sql is not None}, "
-                            f"actions_count={len(actions) if actions else 0}"
-                        )
-                        st.session_state.messages.append(assistant_message)
-            finally:
-                st.session_state.is_running = False
-                # Clear stale interrupt controller to avoid leftover state
-                st.session_state.pop("interrupt_controller", None)
-
-            st.rerun()
-
-        # Display conversation statistics
-        if st.session_state.messages:
-            st.markdown("---")
-            col1, col2, col3 = st.columns(3)
-
-            with col1:
-                conversation_count = len([m for m in st.session_state.messages if m["role"] == "user"])
-                st.metric("Conversation Turns", conversation_count)
-
-            with col2:
-                total_chars = sum(len(m["content"]) for m in st.session_state.messages)
-                st.metric("Total Characters", f"{total_chars:,}")
-
-            with col3:
-                current_model = self.get_current_chat_model()
-                st.metric("Current Model", current_model)
-
-    def _display_chat_actions(self):  # pragma: no cover
-        # Display chat history
-        readonly_mode = st.session_state.session_readonly_mode
-        last_chat_id = None if not self.chat_executor.last_actions else self.chat_executor.last_actions[-1]["chat_id"]
-        user_turn_counter = 0
-        for _, message in enumerate(st.session_state.messages):
-            if last_chat_id and last_chat_id == message["chat_id"]:
-                continue
-
-            if message["role"] == "user":
-                user_turn_counter += 1
-
-            with st.chat_message(message["role"]):
-                # Display user messages
-                if message["role"] == "user":
-                    st.markdown(message["content"])
-
-                # Display assistant messages
-                elif message["role"] == "assistant":
-                    # Different display based on readonly mode
-                    if readonly_mode:
-                        # Session page: Show expanded action history and content
-                        actions_data = message.get("actions", [])
-                        chat_id = message.get("chat_id", "default")
-                        if actions_data:
-                            self.ui.render_action_history(actions_data, chat_id, expanded=True)
-
-                        # Show AI response as markdown
-                        content = message.get("content", "")
-                        if content:
-                            self.ui.display_markdown_response(content)
-
-                        # Show SQL if available (readonly: display only, do not re-execute)
-                        if message.get("sql"):
-                            st.code(message["sql"], language="sql")
-                    else:
-                        # Normal page: Show progress summary, AI response, SQL, and collapsed details at bottom
-                        # Show progress summary if available
-                        # Show collapsed action history at bottom
-                        actions_data = message.get("actions", [])
-                        chat_id = message.get("chat_id", "default")
-                        if actions_data:
-                            self.ui.render_action_history(actions_data, chat_id, expanded=False)
-
-                        # Show AI response summary
-                        st.markdown(message["content"])
-
-                        # Show SQL if available
-                        if "sql" in message and message["sql"]:
-                            sql = message["sql"]
-                            user_msg = ""
-                            if st.session_state.messages:
-                                user_msgs = [m["content"] for m in st.session_state.messages if m["role"] == "user"]
-                                if user_msgs:
-                                    user_msg = user_msgs[-1]
-                            data = self.cli.db_connector.execute_pandas(sql)
-                            sql_id = self.ui.display_sql(sql, data)
-                            col1, col2, col3 = st.columns([2, 2, 10])
-                            with col1:
-                                self.ui.display_success_button(sql, user_msg, sql_id, self.save_success_story)
-                            with col2:
-                                self.ui.display_download(sql, message["content"], data, col3, sql_id, self.do_download)
-
-                    # Rewind button (shown after each assistant response in non-readonly mode)
-                    if not readonly_mode and user_turn_counter > 0:
-                        turn_n = user_turn_counter
-                        with st.popover("⋯"):
-                            if st.button(f"⏪ Rewind to turn {turn_n}", key=f"rewind_{turn_n}"):
-                                st.session_state.rewind_request = {
-                                    "turn": turn_n,
-                                    "include_response": True,
-                                }
-                                st.rerun()
-
-
-def run_web_interface(args):  # pragma: no cover
-    """Launch Streamlit web interface"""
-    import os
-    import subprocess
-    import sys
-    from urllib.parse import quote_plus
-
-    from datus.utils.loggings import get_logger
-
-    logger = get_logger(__name__)
-
-    try:
-        # Get the path to the web chatbot
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        web_chatbot_path = os.path.join(current_dir, "chatbot.py")
-
-        if not os.path.exists(web_chatbot_path):
-            logger.error(f"Web chatbot not found at {web_chatbot_path}")
-            sys.exit(1)
-
-        logger.info("Starting Datus Web Interface...")
-        if args.namespace:
-            logger.info(f"Using namespace: {args.namespace}")
-        if args.config:
-            logger.info(f"Using config: {args.config}")
-        if args.database:
-            logger.info(f"Using database: {args.database}")
-        url = f"http://{args.host}:{args.port}"
-        if getattr(args, "subagent", ""):
-            url += f"/?subagent={quote_plus(args.subagent)}"
-        logger.info(f"Starting server at {url}")
-        logger.info("Press Ctrl+C to stop server")
-        logger.info("-" * 50)
-
-        # Prepare streamlit command
-        cmd = [
-            sys.executable,
-            "-m",
-            "streamlit",
-            "run",
-            web_chatbot_path,
-            "--server.port",
-            str(args.port),
-            "--server.address",
-            args.host,
-            "--browser.serverAddress",
-            args.host,
-        ]
-
-        # Add arguments to pass to the web app
-        web_args = []
-        if args.namespace:
-            web_args.extend(["--namespace", args.namespace])
-        if args.config:
-            web_args.extend(["--config", args.config])
-        if args.database:
-            web_args.extend(["--database", args.database])
-        if getattr(args, "debug", False):
-            web_args.append("--debug")
-        if getattr(args, "subagent", ""):
-            web_args.extend(["--subagent", args.subagent])
-        if getattr(args, "session_scope", None):
-            web_args.extend(["--session-scope", args.session_scope])
-
-        if web_args:
-            cmd.extend(["--"] + web_args)
-
-        # Launch streamlit
-        subprocess.run(cmd)
-
-    except KeyboardInterrupt:
-        print("\n🛑 Web server stopped")
-    except Exception as e:
-        print(f"❌ Failed to start web interface: {e}")
-        sys.exit(1)
-
-
-def main():  # pragma: no cover
-    """Main entry point"""
-    import sys
-
-    # Page configuration - MUST be the first Streamlit command
-    st.set_page_config(
-        page_title="Datus AI Chat Assistant",
-        page_icon="🤖",
-        layout="wide",
-        initial_sidebar_state="expanded",
-        menu_items={"Get Help": None, "Report a bug": None, "About": None},
+    agent_args = argparse.Namespace(
+        namespace=args.namespace,
+        config=getattr(args, "config", None),
+        debug=getattr(args, "debug", False),
+        # Fields expected by DatusAPIService but not present in CLI args
+        max_steps=20,
+        workflow="chat_agentic",
+        load_cp=None,
+        source="web",
+        interactive=True,
+        output_dir=getattr(args, "output_dir", "./output"),
+        log_level="DEBUG" if getattr(args, "debug", False) else "INFO",
     )
+    return agent_args
 
-    # Parse command line arguments
-    namespace = None
-    config_path = "conf/agent.yml"
-    database = ""
-    subagent_name = None
-    session_scope = None
-    debug = False
 
-    # Simple argument parsing for Streamlit
-    for i, arg in enumerate(sys.argv):
-        if arg == "--namespace" and i + 1 < len(sys.argv):
-            namespace = sys.argv[i + 1]
-        elif arg == "--config" and i + 1 < len(sys.argv):
-            config_path = sys.argv[i + 1]
-        elif arg == "--database" and i + 1 < len(sys.argv):
-            database = sys.argv[i + 1]
-        elif arg == "--subagent" and i + 1 < len(sys.argv):
-            subagent_name = sys.argv[i + 1]
-        elif arg == "--session-scope" and i + 1 < len(sys.argv):
-            session_scope = sys.argv[i + 1]
-        elif arg == "--debug":
-            debug = True
+def _read_template() -> str:
+    """Read the HTML template from disk (once)."""
+    template_path = os.path.join(_TEMPLATES_DIR, "index.html")
+    with open(template_path, encoding="utf-8") as f:
+        return f.read()
 
-    # Align implicit helpers (logging/session storage/prompt templates) with the configured home.
+
+def create_web_app(args: argparse.Namespace) -> FastAPI:
+    """Create the FastAPI application that serves both the API and the chatbot
+    frontend.
+
+    Parameters
+    ----------
+    args:
+        Parsed CLI arguments from ``datus web``.
+    """
+    agent_args = _build_agent_args(args)
+    app = create_app(agent_args)
+
+    # ── Resolve chatbot dist directory ──────────────────────────────
+    chatbot_dist = getattr(args, "chatbot_dist", None) or _DEFAULT_CHATBOT_DIST
+    chatbot_dist = os.path.abspath(os.path.expanduser(chatbot_dist))
+
+    if not os.path.isdir(chatbot_dist):
+        logger.warning(
+            f"Chatbot dist directory not found: {chatbot_dist}. "
+            "The frontend assets will not be available. "
+            "Build @datus/web-chatbot or pass --chatbot-dist."
+        )
+    else:
+        # Serve the UMD bundle + CSS at /chatbot-assets/
+        app.mount(
+            "/chatbot-assets",
+            StaticFiles(directory=chatbot_dist),
+            name="chatbot-assets",
+        )
+        logger.info(f"Serving chatbot assets from {chatbot_dist}")
+
+    # ── HTML template route ─────────────────────────────────────────
+    html_template = _read_template()
+    host = getattr(args, "host", "localhost")
+    port = getattr(args, "port", 8501)
+    request_origin = f"http://{host}:{port}"
+    user_name = getattr(args, "user_name", None) or os.getenv("USER", "User")
+
+    # Pre-render the template with config values
+    rendered_html = html_template.replace("{{ request_origin }}", request_origin).replace("{{ user_name }}", user_name)
+
+    # Override the default JSON root endpoint with the chatbot page
+    @app.get("/", response_class=HTMLResponse, include_in_schema=False)
+    async def chatbot_page(request: Request):
+        return HTMLResponse(content=rendered_html)
+
+    return app
+
+
+def run_web_interface(args: argparse.Namespace) -> None:
+    """Entry point called by ``datus web``.
+
+    Creates the FastAPI app and starts uvicorn.
+    """
+    from datus.cli.web.config_manager import get_home_from_config
+    from datus.utils.path_manager import set_current_path_manager
+
+    config_path = getattr(args, "config", None) or "conf/agent.yml"
     set_current_path_manager(get_home_from_config(config_path))
 
-    # Initialize logging once per process
-    initialize_logging(debug=debug)
+    host = getattr(args, "host", "localhost")
+    port = getattr(args, "port", 8501)
+    url = f"http://{host}:{port}"
 
-    # Set subagent query param from CLI arg so existing URL-based logic picks it up
-    if subagent_name and not st.query_params.get("subagent"):
-        st.query_params["subagent"] = subagent_name
+    if getattr(args, "subagent", ""):
+        url += f"/?subagent={args.subagent}"
 
-    # Store in session state for use by the app
-    if "startup_namespace" not in st.session_state:
-        st.session_state.startup_namespace = namespace
-    if "startup_config_path" not in st.session_state:
-        st.session_state.startup_config_path = config_path
-    if "startup_subagent_name" not in st.session_state:
-        st.session_state.startup_subagent_name = subagent_name
-    if "startup_database" not in st.session_state:
-        st.session_state.startup_database = database
-    if "startup_debug" not in st.session_state:
-        st.session_state.startup_debug = debug
-    if "startup_scope" not in st.session_state:
-        st.session_state.startup_scope = session_scope
+    logger.info("Starting Datus Web Interface...")
+    logger.info(f"Namespace: {args.namespace}")
+    logger.info(f"Server URL: {url}")
 
-    chatbot = StreamlitChatbot()
-    chatbot.run()
+    app = create_web_app(args)
 
+    # Open the browser after a short delay
+    def _open_browser():
+        import threading
+        import time
 
-if __name__ == "__main__":
-    main()
+        def _open():
+            time.sleep(1.5)
+            webbrowser.open(url)
+
+        t = threading.Thread(target=_open, daemon=True)
+        t.start()
+
+    _open_browser()
+
+    try:
+        uvicorn.run(
+            app,
+            host=host,
+            port=port,
+            log_level="debug" if getattr(args, "debug", False) else "info",
+        )
+    except KeyboardInterrupt:
+        logger.info("Web server stopped")

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -11,6 +11,7 @@ Streamlit-based implementation with a lightweight FastAPI static-file server.
 """
 
 import argparse
+import json
 import os
 import webbrowser
 
@@ -112,24 +113,27 @@ def create_web_app(args: argparse.Namespace) -> FastAPI:
 
     # ── Render the HTML template ───────────────────────────────────
     html_template = _read_template()
-    host = getattr(args, "host", "localhost")
-    port = getattr(args, "port", 8501)
-    request_origin = f"http://{host}:{port}"
     user_name = getattr(args, "user_name", None) or os.getenv("USER", "User")
 
-    rendered_html = (
+    # Pre-render the static parts (asset URLs); dynamic parts (origin, user)
+    # are rendered per-request so reverse proxies and alternate hostnames work.
+    static_html = (
         html_template.replace("{{ react_js }}", react_js)
         .replace("{{ react_dom_js }}", react_dom_js)
         .replace("{{ chatbot_css }}", chatbot_css)
         .replace("{{ chatbot_js }}", chatbot_js)
-        .replace("{{ request_origin }}", request_origin)
-        .replace("{{ user_name }}", user_name)
     )
 
     # Override the default JSON root endpoint with the chatbot page
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)
-    async def chatbot_page(request: Request):
-        return HTMLResponse(content=rendered_html)
+    async def chatbot_page(request: Request) -> HTMLResponse:
+        # Derive requestOrigin from the actual request so it works behind
+        # reverse proxies, with --host 0.0.0.0, or alternate hostnames.
+        # json.dumps escapes quotes/special chars to prevent XSS.
+        rendered = static_html.replace(
+            "{{ request_origin_json }}", json.dumps(str(request.base_url).rstrip("/"))
+        ).replace("{{ user_name_json }}", json.dumps(user_name))
+        return HTMLResponse(content=rendered)
 
     return app
 

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -78,6 +78,10 @@ def create_web_app(args: argparse.Namespace) -> FastAPI:
     agent_args = _build_agent_args(args)
     app = create_app(agent_args)
 
+    # ── Remove the default JSON root route registered by create_app()
+    #    so we can replace it with the chatbot HTML page.
+    app.routes[:] = [r for r in app.routes if not (hasattr(r, "path") and r.path == "/" and hasattr(r, "methods"))]
+
     # ── Resolve asset mode: local dist vs CDN ──────────────────────
     chatbot_dist = getattr(args, "chatbot_dist", None)
     use_local = False

--- a/datus/cli/web/config_manager.py
+++ b/datus/cli/web/config_manager.py
@@ -49,9 +49,6 @@ def get_available_namespaces(config_path: str = "") -> List[str]:
 
 def create_cli_args(config_path: str = "", namespace: str = None, catalog: str = "", database: str = "") -> Namespace:
     """Create CLI arguments for DatusCLI initialization"""
-    # Import here to avoid circular dependency with streamlit session_state
-    import streamlit as st
-
     args = Namespace()
     args.config = parse_config_path(config_path)
     args.namespace = namespace  # Add namespace parameter
@@ -61,8 +58,7 @@ def create_cli_args(config_path: str = "", namespace: str = None, catalog: str =
     args.database = database
     args.catalog = catalog
     args.schema = ""
-    # Add missing attributes that DatusCLI expects
-    args.debug = bool(st.session_state.get("startup_debug", False)) if hasattr(st, "session_state") else False
+    args.debug = False
     args.no_color = False
 
     # Read storage path from config file
@@ -134,9 +130,6 @@ class ConfigManager:
 
         # Initialize real DatusCLI
         cli = DatusCLI(args)
-
-        # Set Streamlit mode flag to skip interactive prompts
-        cli.streamlit_mode = True
 
         # Update internal reference
         self.cli = cli

--- a/datus/cli/web/templates/index.html
+++ b/datus/cli/web/templates/index.html
@@ -47,8 +47,8 @@
     <script>
       DatusChatbot.initChatbot({
         el: '#chatbot-root',
-        requestOrigin: '{{ request_origin }}' || window.location.origin,
-        userName: '{{ user_name }}' || 'User',
+        requestOrigin: {{ request_origin_json }} || window.location.origin,
+        userName: {{ user_name_json }} || 'User',
       });
     </script>
   </body>

--- a/datus/cli/web/templates/index.html
+++ b/datus/cli/web/templates/index.html
@@ -8,16 +8,16 @@
     <!-- React (externals) -->
     <script
       crossorigin
-      src="https://unpkg.com/react@18/umd/react.development.js"
+      src="{{ react_js }}"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
+      src="{{ react_dom_js }}"
     ></script>
 
-    <!-- Datus Chatbot (served by FastAPI) -->
-    <link rel="stylesheet" href="/chatbot-assets/datus-chatbot.css" />
-    <script src="/chatbot-assets/datus-chatbot.umd.js"></script>
+    <!-- Datus Chatbot -->
+    <link rel="stylesheet" href="{{ chatbot_css }}" />
+    <script src="{{ chatbot_js }}"></script>
 
     <style>
       * {
@@ -45,18 +45,10 @@
     <div id="chatbot-root"></div>
 
     <script>
-      // Configuration injected by the server via template rendering.
-      // Falls back to current origin so the page works even without
-      // server-side substitution (e.g. opened as a static file).
-      var __DATUS_CONFIG__ = {
-        requestOrigin: '{{ request_origin }}' || window.location.origin,
-        userName: '{{ user_name }}' || 'User',
-      };
-
       DatusChatbot.initChatbot({
         el: '#chatbot-root',
-        requestOrigin: __DATUS_CONFIG__.requestOrigin,
-        userName: __DATUS_CONFIG__.userName,
+        requestOrigin: '{{ request_origin }}' || window.location.origin,
+        userName: '{{ user_name }}' || 'User',
       });
     </script>
   </body>

--- a/datus/cli/web/templates/index.html
+++ b/datus/cli/web/templates/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Datus Chatbot</title>
+
+    <!-- React (externals) -->
+    <script
+      crossorigin
+      src="https://unpkg.com/react@18/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
+    ></script>
+
+    <!-- Datus Chatbot (served by FastAPI) -->
+    <link rel="stylesheet" href="/chatbot-assets/datus-chatbot.css" />
+    <script src="/chatbot-assets/datus-chatbot.umd.js"></script>
+
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        height: 100%;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Helvetica Neue', Arial, sans-serif;
+      }
+
+      #chatbot-root {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="chatbot-root"></div>
+
+    <script>
+      // Configuration injected by the server via template rendering.
+      // Falls back to current origin so the page works even without
+      // server-side substitution (e.g. opened as a static file).
+      var __DATUS_CONFIG__ = {
+        requestOrigin: '{{ request_origin }}' || window.location.origin,
+        userName: '{{ user_name }}' || 'User',
+      };
+
+      DatusChatbot.initChatbot({
+        el: '#chatbot-root',
+        requestOrigin: __DATUS_CONFIG__.requestOrigin,
+        userName: __DATUS_CONFIG__.userName,
+      });
+    </script>
+  </body>
+</html>

--- a/docs/web_chatbot/introduction.md
+++ b/docs/web_chatbot/introduction.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Datus Web Chatbot provides a user-friendly web interface for interacting with the Datus AI assistant. Built on Streamlit, it offers an intuitive chat experience for natural language to SQL conversion without requiring command-line knowledge.
+The Datus Web Chatbot provides a user-friendly web interface for interacting with the Datus AI assistant. It serves a React-based frontend (`@datus/web-chatbot`) backed by the Datus Agent FastAPI server, offering an intuitive chat experience for natural language to SQL conversion without requiring command-line knowledge.
 
 ## Quick Start
 

--- a/docs/web_chatbot/introduction.zh.md
+++ b/docs/web_chatbot/introduction.zh.md
@@ -2,7 +2,7 @@
 
 ## 概览
 
-Datus Web chatbot 提供一个易用的网页界面，用于与 Datus AI 助手交互。它基于 Streamlit 构建，面向自然语言转 SQL 的场景，用户无需掌握命令行即可完成对话式分析。
+Datus Web chatbot 提供一个易用的网页界面，用于与 Datus AI 助手交互。它通过 FastAPI 服务端托管 React 前端组件（`@datus/web-chatbot`），面向自然语言转 SQL 的场景，用户无需掌握命令行即可完成对话式分析。
 
 ## 快速开始
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ dependencies = [
     "markdown-it-py>=3.0.0",
     "tabulate>=0.9.0",
     "datus-semantic-metricflow>=0.1.6",
-    "datus-starrocks>=0.1.5",
 ]
 #[tool.uv.sources]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
     "uvicorn>=0.24.0",
     "google-generativeai>=0.8.0",
     "pyperclip==1.9.0",
-    "streamlit>=1.38.0",
     "wcmatch>=10.0",
     "fastembed==0.4.2",
     # Optional: install torch manually to enable reranker models.
@@ -73,6 +72,7 @@ dependencies = [
     "markdown-it-py>=3.0.0",
     "tabulate>=0.9.0",
     "datus-semantic-metricflow>=0.1.6",
+    "datus-starrocks>=0.1.5",
 ]
 #[tool.uv.sources]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ json-repair>=0.47.6
 fastapi>=0.104.0,<1.0
 uvicorn>=0.24.0
 pyperclip==1.9.0
-streamlit>=1.38.0
 wcmatch>=10.0
 mcp>=1.11.0
 anyio>=4.9.0

--- a/tests/integration/cli/test_web_chatbot.py
+++ b/tests/integration/cli/test_web_chatbot.py
@@ -6,7 +6,7 @@
 Integration tests for web chatbot components.
 
 Tests ChatExecutor and ConfigManager with real DatusCLI + real LLM,
-validating the web chatbot's core logic without Streamlit UI.
+validating the web chatbot's core logic.
 """
 
 from unittest.mock import patch
@@ -61,7 +61,6 @@ class TestConfigManagerIntegration:
         cli = cm.setup_config(config_path=TESTS_CONF, namespace="ssb_sqlite")
 
         assert cli is not None, "setup_config should return a DatusCLI instance"
-        assert cli.streamlit_mode is True, "streamlit_mode should be True"
         assert cm.cli is cli
 
         models = cm.get_available_models()

--- a/tests/regression/test_regression_web_e2e.py
+++ b/tests/regression/test_regression_web_e2e.py
@@ -1,9 +1,8 @@
 """
-Regression Tests: Streamlit Web UI End-to-End (R-13)
+Regression Tests: Web UI End-to-End (R-13)
 
-Playwright browser tests for the Streamlit chatbot interface:
+Playwright browser tests for the web chatbot interface:
 - Page loading and rendering
-- Sidebar with model/namespace information
 - Chat input interaction
 - Query submission and LLM response
 - SQL result display
@@ -29,25 +28,23 @@ pytest.importorskip(
 from playwright.sync_api import expect  # noqa: E402
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-STREAMLIT_PORT = 18501
-STREAMLIT_URL = f"http://localhost:{STREAMLIT_PORT}"
+WEB_PORT = 18501
+WEB_URL = f"http://localhost:{WEB_PORT}"
 
 
 @pytest.fixture(scope="module")
-def streamlit_server():
-    """Start Streamlit as subprocess, wait for ready, yield URL, then terminate."""
+def web_server():
+    """Start the FastAPI web chatbot server, wait for ready, yield URL, then terminate."""
     proc = subprocess.Popen(
         [
             sys.executable,
             "-m",
-            "streamlit",
-            "run",
-            str(PROJECT_ROOT / "datus" / "cli" / "web" / "chatbot.py"),
-            "--server.port",
-            str(STREAMLIT_PORT),
-            "--server.headless",
-            "true",
-            "--",
+            "datus.cli.main",
+            "--web",
+            "--port",
+            str(WEB_PORT),
+            "--host",
+            "localhost",
             "--config",
             str(PROJECT_ROOT / "tests" / "conf" / "agent.yml"),
             "--namespace",
@@ -60,7 +57,7 @@ def streamlit_server():
     # Poll until ready (max 30s)
     for _ in range(30):
         try:
-            resp = requests.get(f"{STREAMLIT_URL}/_stcore/health", timeout=2)
+            resp = requests.get(f"{WEB_URL}/health", timeout=2)
             if resp.status_code == 200:
                 break
         except (requests.ConnectionError, requests.Timeout):
@@ -69,9 +66,9 @@ def streamlit_server():
     else:
         proc.terminate()
         proc.wait(timeout=5)
-        pytest.fail("Streamlit did not start within 30 seconds")
+        pytest.fail("Web server did not start within 30 seconds")
 
-    yield STREAMLIT_URL
+    yield WEB_URL
 
     proc.terminate()
     try:
@@ -83,57 +80,18 @@ def streamlit_server():
 
 @pytest.mark.regression
 class TestWebE2E:
-    """Playwright end-to-end tests for Streamlit Web UI."""
+    """Playwright end-to-end tests for the web chatbot UI."""
 
-    def test_page_loads(self, page, streamlit_server):
-        """R13-E01: Page loads successfully with stApp container."""
-        page.goto(streamlit_server)
+    def test_page_loads(self, page, web_server):
+        """R13-E01: Page loads successfully with chatbot root."""
+        page.goto(web_server)
         page.wait_for_load_state("networkidle")
-        expect(page.locator('[data-testid="stApp"]')).to_be_visible()
+        expect(page.locator("#chatbot-root")).to_be_visible()
 
-    def test_sidebar_renders(self, page, streamlit_server):
-        """R13-E02: Sidebar renders with configuration info."""
-        page.goto(streamlit_server)
-        page.wait_for_load_state("networkidle")
-        sidebar = page.locator('[data-testid="stSidebar"]')
-        expect(sidebar).to_be_visible()
-
-    def test_chat_input_exists(self, page, streamlit_server):
+    def test_chat_input_exists(self, page, web_server):
         """R13-E03: Chat input is visible and interactable."""
-        page.goto(streamlit_server)
+        page.goto(web_server)
         page.wait_for_load_state("networkidle")
-        chat_input = page.locator('[data-testid="stChatInput"] textarea')
-        expect(chat_input).to_be_visible()
-        expect(chat_input).to_be_enabled()
-
-    def test_chat_submit_and_response(self, page, streamlit_server):
-        """R13-E04: Submit query and receive LLM response."""
-        page.goto(streamlit_server)
-        page.wait_for_load_state("networkidle")
-
-        chat_input = page.locator('[data-testid="stChatInput"] textarea')
-        chat_input.fill("How many customers are there?")
-        chat_input.press("Enter")
-
-        # Wait for assistant response (up to 120s for LLM)
-        messages = page.locator('[data-testid="stChatMessage"]')
-        expect(messages.last).to_be_visible(timeout=120_000)
-
-    def test_sql_result_display(self, page, streamlit_server):
-        """R13-E05: SQL result is displayed after query."""
-        page.goto(streamlit_server)
-        page.wait_for_load_state("networkidle")
-
-        chat_input = page.locator('[data-testid="stChatInput"] textarea')
-        chat_input.fill("Count all customers")
-        chat_input.press("Enter")
-
-        # Wait for assistant response first
-        messages = page.locator('[data-testid="stChatMessage"]')
-        expect(messages.nth(1)).to_be_visible(timeout=120_000)
-
-        # Then check for SQL code block or dataframe within chat messages
-        sql_or_table = page.locator(
-            '[data-testid="stChatMessage"] code, [data-testid="stCodeBlock"], [data-testid="stDataFrame"]'
-        )
-        expect(sql_or_table.first).to_be_visible(timeout=30_000)
+        # The chatbot component should render an input area
+        chat_input = page.locator("#chatbot-root textarea, #chatbot-root input[type='text']")
+        expect(chat_input.first).to_be_visible(timeout=10_000)

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -47,7 +47,6 @@ def _make_cli(agent_config, available_subagents=None):
     cli.agent_ready = False
     cli.agent_initializing = False
     cli.plan_mode_active = False
-    cli.streamlit_mode = False
     cli.at_completer = MagicMock()
     cli.db_connector = MagicMock()
     cli.db_manager = MagicMock()

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -205,6 +205,40 @@ class TestCreateWebApp:
             assert app is not None
             mock_logger.warning.assert_called_once()
 
+    def test_falls_back_to_cdn_when_dist_incomplete(self, tmp_path):
+        """Should fall back to CDN when dist dir exists but bundle files are missing."""
+        from datus.cli.web.chatbot import create_web_app
+
+        # Create dir with only CSS, missing the JS bundle
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        (dist_dir / "datus-chatbot.css").write_text("/* css */")
+
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist=str(dist_dir),
+            session_scope=None,
+        )
+
+        with (
+            patch("datus.cli.web.chatbot.create_app") as mock_create_app,
+            patch("datus.cli.web.chatbot.logger") as mock_logger,
+        ):
+            from fastapi import FastAPI
+
+            mock_create_app.return_value = FastAPI()
+            app = create_web_app(args)
+
+            # Should NOT mount /chatbot-assets
+            route_paths = [r.path for r in app.routes if hasattr(r, "path")]
+            assert "/chatbot-assets" not in route_paths
+            mock_logger.warning.assert_called_once()
+
     def test_html_template_rendered(self):
         """The root route should serve HTML with config values substituted."""
         from datus.cli.web.chatbot import create_web_app

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -2,815 +2,320 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Comprehensive unit tests for datus/cli/web/chatbot.py."""
+"""Unit tests for datus/cli/web/chatbot.py (FastAPI-based web chatbot)."""
 
-import asyncio
-import csv
-import sys
-from pathlib import Path
+import argparse
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Module-level streamlit mock – must be installed before importing chatbot
-# ---------------------------------------------------------------------------
-_mock_st = MagicMock()
-_mock_st.session_state = {}
-_mock_st.query_params = {}
-_mock_st.get_option.return_value = "localhost"
-sys.modules.setdefault("streamlit", _mock_st)
-sys.modules.setdefault("streamlit.components", MagicMock())
-sys.modules.setdefault("streamlit.components.v1", MagicMock())
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-class _SessionState(dict):
-    """Dict subclass that also supports attribute access (like Streamlit's real SessionState)."""
-
-    def __getattr__(self, name):
-        try:
-            return self[name]
-        except KeyError:
-            raise AttributeError(name) from None
-
-    def __setattr__(self, name, value):
-        self[name] = value
-
-    def __delattr__(self, name):
-        try:
-            del self[name]
-        except KeyError:
-            raise AttributeError(name) from None
-
-
-class _QueryParams(dict):
-    """Dict subclass used for st.query_params."""
-
-
-def _fresh_session_state():
-    """Return a SessionState with the defaults StreamlitChatbot.__init__ would set."""
-    return _SessionState(
-        {
-            "messages": [],
-            "current_actions": [],
-            "chat_session_initialized": False,
-            "cli_instance": None,
-            "current_chat_id": None,
-            "subagent_name": None,
-            "view_session_id": None,
-            "session_readonly_mode": False,
-        }
-    )
-
-
-def _make_mock_st(session_state=None, query_params=None):
-    """Create a properly configured MagicMock for streamlit."""
-    mock = MagicMock()
-    mock.session_state = session_state if session_state is not None else _fresh_session_state()
-    mock.query_params = query_params if query_params is not None else _QueryParams()
-    mock.get_option.return_value = "localhost"
-    return mock
-
-
-_COMPONENT_PATCHES = [
-    "datus.cli.web.chatbot.SessionManager",
-    "datus.cli.web.chatbot.ChatExecutor",
-    "datus.cli.web.chatbot.ConfigManager",
-    "datus.cli.web.chatbot.UIComponents",
-]
-
-
-def _create_chatbot():
-    """Create chatbot with all dependencies mocked.
-
-    Caller must patch ``datus.cli.web.chatbot.st`` before calling this.
-    """
-    import contextlib
-
-    from datus.cli.web.chatbot import StreamlitChatbot
-
-    with contextlib.ExitStack() as stack:
-        for p in _COMPONENT_PATCHES:
-            stack.enter_context(patch(p))
-        return StreamlitChatbot()
-
-
 # ═══════════════════════════════════════════════════════════════════════════
-# 1. _run_async
+# 1. _build_agent_args
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 @pytest.mark.ci
-class TestRunAsync:
-    """Tests for the module-level _run_async helper."""
+class TestBuildAgentArgs:
+    """Tests for the _build_agent_args bridge function."""
 
-    def test_run_async_normal_coroutine(self):
-        from datus.cli.web.chatbot import _run_async
+    def test_bridges_required_fields(self):
+        from datus.cli.web.chatbot import _build_agent_args
 
-        async def coro():
-            return 42
+        args = argparse.Namespace(
+            namespace="myns",
+            config="conf/agent.yml",
+            debug=False,
+        )
+        result = _build_agent_args(args)
 
-        assert _run_async(coro()) == 42
+        assert result.namespace == "myns"
+        assert result.config == "conf/agent.yml"
+        assert result.source == "web"
+        assert result.interactive is True
+        assert result.workflow == "chat_agentic"
+        assert result.log_level == "INFO"
 
-    def test_run_async_returns_result(self):
-        from datus.cli.web.chatbot import _run_async
+    def test_debug_mode(self):
+        from datus.cli.web.chatbot import _build_agent_args
 
-        async def greeting():
-            return "hello"
+        args = argparse.Namespace(namespace="ns", config=None, debug=True)
+        result = _build_agent_args(args)
 
-        assert _run_async(greeting()) == "hello"
+        assert result.log_level == "DEBUG"
 
-    def test_run_async_closed_loop(self):
-        """When the current loop is closed a new one should be created."""
-        from datus.cli.web.chatbot import _run_async
+    def test_missing_optional_fields(self):
+        """Fields not present on CLI args should have safe defaults."""
+        from datus.cli.web.chatbot import _build_agent_args
 
-        loop = asyncio.new_event_loop()
-        loop.close()
-        asyncio.set_event_loop(loop)
+        args = argparse.Namespace(namespace="ns")
+        result = _build_agent_args(args)
 
-        async def value():
-            return "ok"
-
-        assert _run_async(value()) == "ok"
-
-    def test_run_async_no_loop(self):
-        """When there is no current loop a new one should be created."""
-        from datus.cli.web.chatbot import _run_async
-
-        try:
-            asyncio.set_event_loop(None)
-        except (RuntimeError, ValueError):
-            # Some platforms/versions don't allow setting loop to None
-            pass
-
-        async def value():
-            return "no_loop"
-
-        assert _run_async(value()) == "no_loop"
-
-    def test_run_async_running_loop(self):
-        """When called inside a running loop, should use thread pool."""
-        from datus.cli.web.chatbot import _run_async
-
-        async def inner():
-            return "from_thread"
-
-        async def outer():
-            return _run_async(inner())
-
-        result = asyncio.run(outer())
-        assert result == "from_thread"
+        assert result.config is None
+        assert result.debug is False
+        assert result.max_steps == 20
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# 2. initialize_logging
+# 2. _read_template
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 @pytest.mark.ci
-class TestInitializeLogging:
-    """Tests for the module-level initialize_logging function."""
+class TestReadTemplate:
+    """Tests for the _read_template helper."""
 
-    def _reset(self):
-        import datus.cli.web.chatbot as mod
+    def test_reads_html(self):
+        from datus.cli.web.chatbot import _read_template
 
-        mod._LOGGING_INITIALIZED = False
+        html = _read_template()
+        assert "DatusChatbot" in html
+        assert "chatbot-root" in html
+        assert "{{ request_origin }}" in html
 
-    def test_initialize_logging_default(self):
-        self._reset()
-        from datus.cli.web.chatbot import initialize_logging
+    def test_returns_string(self):
+        from datus.cli.web.chatbot import _read_template
+
+        html = _read_template()
+        assert isinstance(html, str)
+        assert len(html) > 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. create_web_app
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.ci
+class TestCreateWebApp:
+    """Tests for create_web_app function."""
+
+    def test_returns_fastapi_app(self):
+        from datus.cli.web.chatbot import create_web_app
+
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist="/nonexistent/path",
+            session_scope=None,
+        )
+
+        with patch("datus.cli.web.chatbot.create_app") as mock_create_app:
+            from fastapi import FastAPI
+
+            mock_app = FastAPI()
+            mock_create_app.return_value = mock_app
+
+            app = create_web_app(args)
+            assert app is mock_app
+            mock_create_app.assert_called_once()
+
+    def test_mounts_chatbot_assets_when_dist_exists(self, tmp_path):
+        """Static files should be mounted when dist directory exists."""
+        from datus.cli.web.chatbot import create_web_app
+
+        # Create a fake dist directory
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        (dist_dir / "datus-chatbot.umd.js").write_text("// js")
+        (dist_dir / "datus-chatbot.css").write_text("/* css */")
+
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist=str(dist_dir),
+            session_scope=None,
+        )
+
+        with patch("datus.cli.web.chatbot.create_app") as mock_create_app:
+            from fastapi import FastAPI
+
+            mock_create_app.return_value = FastAPI()
+            app = create_web_app(args)
+
+            # Check that /chatbot-assets route was mounted
+            route_paths = [r.path for r in app.routes if hasattr(r, "path")]
+            assert "/chatbot-assets" in route_paths or any("/chatbot-assets" in str(r) for r in app.routes)
+
+    def test_warns_when_dist_missing(self):
+        """Should warn but not crash when dist directory doesn't exist."""
+        from datus.cli.web.chatbot import create_web_app
+
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist="/definitely/not/a/real/path",
+            session_scope=None,
+        )
 
         with (
-            patch("datus.cli.web.chatbot.configure_logging") as mock_conf,
-            patch("datus.cli.web.chatbot.setup_web_chatbot_logging") as mock_setup,
-            patch("datus.utils.path_manager.get_path_manager") as mock_pm,
+            patch("datus.cli.web.chatbot.create_app") as mock_create_app,
+            patch("datus.cli.web.chatbot.logger") as mock_logger,
         ):
-            mock_pm.return_value.logs_dir = Path("/tmp/logs")
-            mock_setup.return_value = MagicMock()
-            initialize_logging()
+            from fastapi import FastAPI
 
-            mock_conf.assert_called_once_with(debug=False, log_dir="/tmp/logs", console_output=False)
-            mock_setup.assert_called_once()
+            mock_create_app.return_value = FastAPI()
+            app = create_web_app(args)
 
-    def test_initialize_logging_idempotent(self):
-        self._reset()
-        from datus.cli.web.chatbot import initialize_logging
+            assert app is not None
+            mock_logger.warning.assert_called_once()
+
+    def test_html_template_rendered(self):
+        """The root route should serve HTML with config values substituted."""
+        from datus.cli.web.chatbot import create_web_app
+
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="myhost",
+            port=9999,
+            debug=False,
+            subagent="",
+            chatbot_dist="/nonexistent",
+            session_scope=None,
+        )
+
+        with patch("datus.cli.web.chatbot.create_app") as mock_create_app:
+            from fastapi import FastAPI
+
+            mock_create_app.return_value = FastAPI()
+            app = create_web_app(args)
+
+            # Find the root route handler
+            root_routes = [r for r in app.routes if hasattr(r, "path") and r.path == "/"]
+            assert len(root_routes) > 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. run_web_interface
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.ci
+class TestRunWebInterface:
+    """Tests for run_web_interface entry point."""
+
+    def test_calls_uvicorn_run(self):
+        from datus.cli.web.chatbot import run_web_interface
+
+        args = argparse.Namespace(
+            namespace="test",
+            config="conf/agent.yml",
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist=None,
+            session_scope=None,
+        )
 
         with (
-            patch("datus.cli.web.chatbot.configure_logging") as mock_conf,
-            patch("datus.cli.web.chatbot.setup_web_chatbot_logging") as mock_setup,
-            patch("datus.utils.path_manager.get_path_manager") as mock_pm,
+            patch("datus.cli.web.chatbot.create_web_app") as mock_create,
+            patch("datus.cli.web.chatbot.uvicorn") as mock_uvicorn,
+            patch("datus.cli.web.chatbot.webbrowser"),
+            patch("datus.cli.web.config_manager.get_home_from_config", return_value="~/.datus"),
+            patch("datus.utils.path_manager.set_current_path_manager"),
         ):
-            mock_pm.return_value.logs_dir = Path("/tmp/logs")
-            mock_setup.return_value = MagicMock()
-            initialize_logging()
-            initialize_logging()  # second call should be no-op
-            assert mock_conf.call_count == 1
+            mock_app = MagicMock()
+            mock_create.return_value = mock_app
+            mock_uvicorn.run.return_value = None
 
-    def test_initialize_logging_custom_dir(self):
-        self._reset()
-        from datus.cli.web.chatbot import initialize_logging
+            run_web_interface(args)
+
+            mock_create.assert_called_once_with(args)
+            mock_uvicorn.run.assert_called_once_with(
+                mock_app,
+                host="localhost",
+                port=8501,
+                log_level="info",
+            )
+
+    def test_debug_mode_log_level(self):
+        from datus.cli.web.chatbot import run_web_interface
+
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=True,
+            subagent="",
+            chatbot_dist=None,
+            session_scope=None,
+        )
 
         with (
-            patch("datus.cli.web.chatbot.configure_logging") as mock_conf,
-            patch("datus.cli.web.chatbot.setup_web_chatbot_logging") as mock_setup,
+            patch("datus.cli.web.chatbot.create_web_app"),
+            patch("datus.cli.web.chatbot.uvicorn") as mock_uvicorn,
+            patch("datus.cli.web.chatbot.webbrowser"),
+            patch("datus.cli.web.config_manager.get_home_from_config", return_value="~/.datus"),
+            patch("datus.utils.path_manager.set_current_path_manager"),
         ):
-            mock_setup.return_value = MagicMock()
-            initialize_logging(debug=True, log_dir="/custom/dir")
-            mock_conf.assert_called_once_with(debug=True, log_dir="/custom/dir", console_output=False)
+            mock_uvicorn.run.return_value = None
+            run_web_interface(args)
 
+            assert mock_uvicorn.run.call_args[1]["log_level"] == "debug"
 
-# ═══════════════════════════════════════════════════════════════════════════
-# 3. sanitize_csv_field
-# ═══════════════════════════════════════════════════════════════════════════
+    def test_keyboard_interrupt_handled(self):
+        from datus.cli.web.chatbot import run_web_interface
 
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist=None,
+            session_scope=None,
+        )
 
-@pytest.mark.ci
-class TestSanitizeCsvField:
-    """Tests for StreamlitChatbot.sanitize_csv_field (static method)."""
-
-    def test_none_returns_none(self):
-        from datus.cli.web.chatbot import StreamlitChatbot
-
-        assert StreamlitChatbot.sanitize_csv_field(None) is None
-
-    def test_normal_string_unchanged(self):
-        from datus.cli.web.chatbot import StreamlitChatbot
-
-        assert StreamlitChatbot.sanitize_csv_field("hello world") == "hello world"
-
-    def test_empty_string_unchanged(self):
-        from datus.cli.web.chatbot import StreamlitChatbot
-
-        assert StreamlitChatbot.sanitize_csv_field("") == ""
-
-    @pytest.mark.parametrize(
-        "input_val,expected",
-        [
-            ("=CMD()", "'=CMD()"),
-            ("+1", "'+1"),
-            ("-1", "'-1"),
-            ("@SUM(A1)", "'@SUM(A1)"),
-        ],
-        ids=["equals", "plus", "minus", "at"],
-    )
-    def test_formula_prefix(self, input_val, expected):
-        from datus.cli.web.chatbot import StreamlitChatbot
-
-        assert StreamlitChatbot.sanitize_csv_field(input_val) == expected
-
-    def test_non_string_converted(self):
-        from datus.cli.web.chatbot import StreamlitChatbot
-
-        assert StreamlitChatbot.sanitize_csv_field(12345) == "12345"
-
-    def test_non_string_with_formula_prefix(self):
-        """Negative numbers converted to str get sanitized."""
-        from datus.cli.web.chatbot import StreamlitChatbot
-
-        assert StreamlitChatbot.sanitize_csv_field(-99) == "'-99"
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 4. StreamlitChatbot – properties
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestStreamlitChatbotProperties:
-    """Tests for StreamlitChatbot property accessors."""
-
-    def test_cli_getter(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            mock_cli = MagicMock()
-            mock_st.session_state.cli_instance = mock_cli
-            assert chatbot.cli is mock_cli
-
-    def test_cli_setter(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            mock_cli = MagicMock()
-            chatbot.cli = mock_cli
-            assert mock_st.session_state.cli_instance is mock_cli
-
-    def test_current_subagent(self):
-        qp = _QueryParams({"subagent": "baisheng"})
-        mock_st = _make_mock_st(query_params=qp)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            assert chatbot.current_subagent == "baisheng"
-
-    def test_current_subagent_none(self):
-        mock_st = _make_mock_st(query_params=_QueryParams())
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            assert chatbot.current_subagent is None
-
-    def test_should_hide_sidebar_true(self):
-        state = _fresh_session_state()
-        state["embed_mode"] = True
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            assert chatbot.should_hide_sidebar is True
-
-    def test_should_hide_sidebar_default_false(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            assert chatbot.should_hide_sidebar is False
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 5. StreamlitChatbot – __init__
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestStreamlitChatbotInit:
-    """Tests for StreamlitChatbot.__init__."""
-
-    def test_init_creates_components(self):
-        mock_st = _make_mock_st()
         with (
-            patch("datus.cli.web.chatbot.st", mock_st),
-            patch("datus.cli.web.chatbot.SessionManager") as mock_sm,
-            patch("datus.cli.web.chatbot.ChatExecutor") as mock_ce,
-            patch("datus.cli.web.chatbot.ConfigManager") as mock_cm,
-            patch("datus.cli.web.chatbot.UIComponents") as mock_ui,
+            patch("datus.cli.web.chatbot.create_web_app"),
+            patch("datus.cli.web.chatbot.uvicorn") as mock_uvicorn,
+            patch("datus.cli.web.chatbot.webbrowser"),
+            patch("datus.cli.web.config_manager.get_home_from_config", return_value="~/.datus"),
+            patch("datus.utils.path_manager.set_current_path_manager"),
         ):
-            from datus.cli.web.chatbot import StreamlitChatbot
-
-            StreamlitChatbot()
-            mock_sm.assert_called_once()
-            mock_ce.assert_called_once()
-            mock_cm.assert_called_once()
-            mock_ui.assert_called_once_with("localhost", "localhost")
-
-    def test_init_sets_session_state_defaults(self):
-        state = _SessionState()
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            _create_chatbot()
-            assert state["messages"] == []
-            assert state["current_actions"] == []
-            assert state["chat_session_initialized"] is False
-            assert state["cli_instance"] is None
-            assert state["current_chat_id"] is None
-            assert state["subagent_name"] is None
-            assert state["view_session_id"] is None
-            assert state["session_readonly_mode"] is False
+            mock_uvicorn.run.side_effect = KeyboardInterrupt
+            # Should not raise
+            run_web_interface(args)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# 6. clear_chat
+# 5. Template file existence
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 @pytest.mark.ci
-class TestClearChat:
-    """Tests for StreamlitChatbot.clear_chat."""
-
-    def test_clear_chat_resets_state(self):
-        state = _fresh_session_state()
-        state["messages"] = [{"role": "user", "content": "hi"}]
-        state["current_actions"] = ["action1"]
-        state["current_chat_id"] = "abc-123"
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.clear_chat()
-            assert state.messages == []
-            assert state.current_actions == []
-            assert state.current_chat_id is None
-
-    def test_clear_chat_calls_cli_cmd_clear(self):
-        state = _fresh_session_state()
-        mock_cli = MagicMock()
-        state["cli_instance"] = mock_cli
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.clear_chat()
-            mock_cli.chat_commands.cmd_clear_chat.assert_called_once_with("")
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 7. setup_config
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestSetupConfig:
-    """Tests for StreamlitChatbot.setup_config."""
-
-    def test_setup_config_success(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            mock_cli = MagicMock()
-            chatbot.config_manager.setup_config.return_value = mock_cli
-
-            result = chatbot.setup_config("conf/agent.yml")
-            assert result is True
-            assert mock_st.session_state.chat_session_initialized is True
-
-    def test_setup_config_already_initialized(self):
-        state = _fresh_session_state()
-        state["cli_instance"] = MagicMock()
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            result = chatbot.setup_config()
-            assert result is True
-            chatbot.config_manager.setup_config.assert_not_called()
-
-    def test_setup_config_failure(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.config_manager.setup_config.side_effect = RuntimeError("bad config")
-
-            result = chatbot.setup_config()
-            assert result is False
-            mock_st.error.assert_called_once()
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 8. Delegation methods
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestDelegationMethods:
-    """Tests for simple delegation methods."""
-
-    def test_get_session_messages_delegates(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.get_session_messages.return_value = [{"role": "user", "content": "hi"}]
-            result = chatbot.get_session_messages("sid-123")
-            chatbot.session_manager.get_session_messages.assert_called_once_with("sid-123")
-            assert result == [{"role": "user", "content": "hi"}]
-
-    def test_get_current_session_id_with_node(self):
-        state = _fresh_session_state()
-        mock_cli = MagicMock()
-        mock_node = MagicMock()
-        mock_node.session_id = "session-abc"
-        mock_cli.chat_commands.current_node = mock_node
-        mock_cli.chat_commands.chat_node = None
-        state["cli_instance"] = mock_cli
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            result = chatbot.get_current_session_id()
-            assert result == "session-abc"
-
-    def test_get_current_session_id_no_cli(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            result = chatbot.get_current_session_id()
-            assert result is None
-
-    def test_extract_sql_and_response_delegates(self):
-        state = _fresh_session_state()
-        state["cli_instance"] = MagicMock()
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.chat_executor.extract_sql_and_response.return_value = ("SELECT 1", "Result")
-            actions = [MagicMock()]
-            sql, resp = chatbot.extract_sql_and_response(actions)
-            assert sql == "SELECT 1"
-            assert resp == "Result"
-
-    def test_format_action_for_stream_delegates(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.chat_executor.format_action_for_stream.return_value = "formatted"
-            action = MagicMock()
-            result = chatbot._format_action_for_stream(action)
-            assert result == "formatted"
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 9. _store_session_id
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestStoreSessionId:
-    """Tests for StreamlitChatbot._store_session_id."""
-
-    def test_store_session_id_success(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value="sid-999"):
-                chatbot._store_session_id()
-            assert mock_st.session_state.current_session_id == "sid-999"
-
-    def test_store_session_id_none(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value=None):
-                chatbot._store_session_id()
-            assert "current_session_id" not in mock_st.session_state
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 10. save_success_story
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestSaveSuccessStory:
-    """Tests for StreamlitChatbot.save_success_story."""
-
-    def test_save_success_story_no_session(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value=None):
-                chatbot.save_success_story("SELECT 1", "test question")
-            mock_st.warning.assert_called_once()
-
-    def test_save_success_story_creates_csv(self, tmp_path):
-        state = _fresh_session_state()
-        state["subagent_name"] = "test_agent"
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value="sid-001"):
-                mock_pm = MagicMock()
-                mock_pm.benchmark_dir = tmp_path
-                with patch("datus.utils.path_manager.get_path_manager", return_value=mock_pm):
-                    chatbot.save_success_story("SELECT 1", "What is the count?")
-
-            csv_path = tmp_path / "test_agent" / "success_story.csv"
-            assert csv_path.exists()
-            with open(csv_path, encoding="utf-8") as f:
-                reader = csv.DictReader(f)
-                rows = list(reader)
-            assert len(rows) == 1
-            assert rows[0]["sql"] == "SELECT 1"
-            assert rows[0]["user_message"] == "What is the count?"
-            assert rows[0]["session_id"] == "sid-001"
-
-    def test_save_success_story_appends(self, tmp_path):
-        state = _fresh_session_state()
-        state["subagent_name"] = "agent2"
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value="sid-002"):
-                mock_pm = MagicMock()
-                mock_pm.benchmark_dir = tmp_path
-                with patch("datus.utils.path_manager.get_path_manager", return_value=mock_pm):
-                    chatbot.save_success_story("SELECT 1", "q1")
-                    chatbot.save_success_story("SELECT 2", "q2")
-
-            csv_path = tmp_path / "agent2" / "success_story.csv"
-            with open(csv_path, encoding="utf-8") as f:
-                reader = csv.DictReader(f)
-                rows = list(reader)
-            assert len(rows) == 2
-
-    def test_save_success_story_unsafe_name(self, tmp_path):
-        state = _fresh_session_state()
-        state["subagent_name"] = ".."
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value="sid-003"):
-                mock_pm = MagicMock()
-                mock_pm.benchmark_dir = tmp_path
-                with patch("datus.utils.path_manager.get_path_manager", return_value=mock_pm):
-                    chatbot.save_success_story("SELECT 1", "evil")
-
-            mock_st.error.assert_called_once()
-
-    def test_save_success_story_sanitizes_fields(self, tmp_path):
-        state = _fresh_session_state()
-        state["subagent_name"] = "safe_agent"
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value="sid-004"):
-                mock_pm = MagicMock()
-                mock_pm.benchmark_dir = tmp_path
-                with patch("datus.utils.path_manager.get_path_manager", return_value=mock_pm):
-                    chatbot.save_success_story("=CMD()", "=HYPERLINK()")
-
-            csv_path = tmp_path / "safe_agent" / "success_story.csv"
-            with open(csv_path, encoding="utf-8") as f:
-                reader = csv.DictReader(f)
-                rows = list(reader)
-            assert rows[0]["sql"] == "'=CMD()"
-            assert rows[0]["user_message"] == "'=HYPERLINK()"
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 11. load_session_from_url
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestLoadSessionFromUrl:
-    """Tests for StreamlitChatbot.load_session_from_url."""
-
-    def test_load_no_session_param(self):
-        mock_st = _make_mock_st(query_params=_QueryParams())
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.load_session_from_url()
-            chatbot.session_manager.session_exists.assert_not_called()
-
-    def test_load_already_loaded(self):
-        state = _fresh_session_state()
-        state["view_session_id"] = "sid-100"
-        state["_loaded_session_mode"] = "readonly"
-        qp = _QueryParams({"session": "sid-100", "mode": "readonly"})
-        mock_st = _make_mock_st(session_state=state, query_params=qp)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.load_session_from_url()
-            chatbot.session_manager.session_exists.assert_not_called()
-
-    def test_load_readonly_mode(self):
-        qp = _QueryParams({"session": "sid-200"})
-        mock_st = _make_mock_st(query_params=qp)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.session_exists.return_value = True
-            chatbot.session_manager.get_session_messages.return_value = [{"role": "user", "content": "hi"}]
-
-            chatbot.load_session_from_url()
-
-            assert mock_st.session_state.session_readonly_mode is True
-            assert mock_st.session_state.view_session_id == "sid-200"
-            assert mock_st.session_state.messages == [{"role": "user", "content": "hi"}]
-
-    def test_load_resume_mode(self):
-        qp = _QueryParams({"session": "sid-300", "mode": "resume"})
-        mock_st = _make_mock_st(query_params=qp)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.session_exists.return_value = True
-
-            with patch.object(chatbot, "resume_session", return_value=True) as mock_resume:
-                chatbot.load_session_from_url()
-                mock_resume.assert_called_once_with("sid-300")
-                assert mock_st.session_state._loaded_session_mode == "resume"
-
-    def test_load_nonexistent_session(self):
-        qp = _QueryParams({"session": "sid-404"})
-        mock_st = _make_mock_st(query_params=qp)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.session_exists.return_value = False
-
-            chatbot.load_session_from_url()
-            mock_st.error.assert_called_once()
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 12. resume_session
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestResumeSession:
-    """Tests for StreamlitChatbot.resume_session."""
-
-    def test_resume_success(self):
-        state = _fresh_session_state()
-        mock_cli = MagicMock()
-        state["cli_instance"] = mock_cli
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.session_exists.return_value = True
-            chatbot.session_manager.get_session_messages.return_value = [{"role": "user", "content": "hi"}]
-
-            with patch("datus.cli.chat_commands.ChatCommands._extract_node_type_from_session_id", return_value="chat"):
-                mock_cli.chat_commands._create_new_node.return_value = MagicMock()
-                result = chatbot.resume_session("sid-resume")
-                assert result is True
-                assert state.view_session_id == "sid-resume"
-                assert state.session_readonly_mode is False
-
-    def test_resume_nonexistent(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.session_exists.return_value = False
-
-            result = chatbot.resume_session("sid-gone")
-            assert result is False
-            mock_st.error.assert_called_once()
-
-    def test_resume_cli_not_initialized(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.session_exists.return_value = True
-            # cli_instance is None by default from _fresh_session_state
-
-            result = chatbot.resume_session("sid-no-cli")
-            assert result is False
-            mock_st.error.assert_called()
-
-    def test_resume_exception(self):
-        state = _fresh_session_state()
-        mock_cli = MagicMock()
-        state["cli_instance"] = mock_cli
-        mock_st = _make_mock_st(session_state=state)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.session_exists.return_value = True
-            chatbot.session_manager.get_session_messages.side_effect = RuntimeError("db error")
-
-            with patch("datus.cli.chat_commands.ChatCommands._extract_node_type_from_session_id", return_value="chat"):
-                result = chatbot.resume_session("sid-err")
-                assert result is False
-                mock_st.error.assert_called()
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 13. execute_chat_stream
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestExecuteChatStream:
-    """Tests for StreamlitChatbot.execute_chat_stream."""
-
-    def test_yields_from_chat_executor(self):
-        qp = _QueryParams()
-        mock_st = _make_mock_st(query_params=qp)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            action1, action2 = MagicMock(), MagicMock()
-            chatbot.chat_executor.execute_chat_stream.return_value = iter([action1, action2])
-            with patch.object(chatbot, "get_current_session_id", return_value=None):
-                results = list(chatbot.execute_chat_stream("test query"))
-            assert results == [action1, action2]
-
-    def test_stores_session_id_after_stream(self):
-        qp = _QueryParams()
-        mock_st = _make_mock_st(query_params=qp)
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.chat_executor.execute_chat_stream.return_value = iter([])
-            with patch.object(chatbot, "get_current_session_id", return_value="sid-after"):
-                list(chatbot.execute_chat_stream("test"))
-            assert mock_st.session_state.current_session_id == "sid-after"
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# 14. _handle_rewind
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.ci
-class TestHandleRewind:
-    """Tests for StreamlitChatbot._handle_rewind."""
-
-    def test_rewind_success(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            chatbot.session_manager.rewind_session.return_value = "sid-rewound"
-
-            with (
-                patch.object(chatbot, "get_current_session_id", return_value="sid-orig"),
-                patch.object(chatbot, "resume_session", return_value=True),
-            ):
-                chatbot._handle_rewind(2, True)
-                chatbot.session_manager.rewind_session.assert_called_once_with(
-                    "sid-orig", 2, include_assistant_response=True
-                )
-                chatbot.ui.safe_update_query_params.assert_called_once()
-                mock_st.rerun.assert_called_once()
-
-    def test_rewind_no_session(self):
-        mock_st = _make_mock_st()
-        with patch("datus.cli.web.chatbot.st", mock_st):
-            chatbot = _create_chatbot()
-            with patch.object(chatbot, "get_current_session_id", return_value=None):
-                chatbot._handle_rewind(1, False)
-            mock_st.error.assert_called_once_with("No active session to rewind.")
+class TestTemplateFile:
+    """Verify the HTML template file exists and is valid."""
+
+    def test_template_exists(self):
+        from datus.cli.web.chatbot import _TEMPLATES_DIR
+
+        template_path = os.path.join(_TEMPLATES_DIR, "index.html")
+        assert os.path.isfile(template_path)
+
+    def test_template_contains_chatbot_init(self):
+        from datus.cli.web.chatbot import _TEMPLATES_DIR
+
+        template_path = os.path.join(_TEMPLATES_DIR, "index.html")
+        with open(template_path, encoding="utf-8") as f:
+            content = f.read()
+        assert "DatusChatbot.initChatbot" in content
+        assert "chatbot-root" in content
+        assert "datus-chatbot.umd.js" in content
+        assert "datus-chatbot.css" in content

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -71,7 +71,8 @@ class TestReadTemplate:
         html = _read_template()
         assert "DatusChatbot" in html
         assert "chatbot-root" in html
-        assert "{{ request_origin }}" in html
+        assert "{{ request_origin_json }}" in html
+        assert "{{ user_name_json }}" in html
         assert "{{ chatbot_js }}" in html
         assert "{{ chatbot_css }}" in html
         assert "{{ react_js }}" in html
@@ -353,3 +354,5 @@ class TestTemplateFile:
         assert "{{ chatbot_css }}" in content
         assert "{{ react_js }}" in content
         assert "{{ react_dom_js }}" in content
+        assert "{{ request_origin_json }}" in content
+        assert "{{ user_name_json }}" in content

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -72,6 +72,9 @@ class TestReadTemplate:
         assert "DatusChatbot" in html
         assert "chatbot-root" in html
         assert "{{ request_origin }}" in html
+        assert "{{ chatbot_js }}" in html
+        assert "{{ chatbot_css }}" in html
+        assert "{{ react_js }}" in html
 
     def test_returns_string(self):
         from datus.cli.web.chatbot import _read_template
@@ -145,8 +148,37 @@ class TestCreateWebApp:
             route_paths = [r.path for r in app.routes if hasattr(r, "path")]
             assert "/chatbot-assets" in route_paths or any("/chatbot-assets" in str(r) for r in app.routes)
 
+    def test_uses_cdn_when_no_chatbot_dist(self):
+        """Without --chatbot-dist, should use CDN URLs for assets."""
+        from datus.cli.web.chatbot import _CDN_CHATBOT_JS, _CDN_REACT_JS, create_web_app
+
+        args = argparse.Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist=None,
+            session_scope=None,
+        )
+
+        with patch("datus.cli.web.chatbot.create_app") as mock_create_app:
+            from fastapi import FastAPI
+
+            mock_create_app.return_value = FastAPI()
+            app = create_web_app(args)
+
+            # Should NOT mount /chatbot-assets
+            route_paths = [r.path for r in app.routes if hasattr(r, "path")]
+            assert "/chatbot-assets" not in route_paths
+
+            # Verify CDN URLs appear in rendered HTML by checking the root route
+            assert _CDN_CHATBOT_JS.startswith("https://unpkg.com/")
+            assert _CDN_REACT_JS.startswith("https://unpkg.com/")
+
     def test_warns_when_dist_missing(self):
-        """Should warn but not crash when dist directory doesn't exist."""
+        """Should warn and fall back to CDN when dist path doesn't exist."""
         from datus.cli.web.chatbot import create_web_app
 
         args = argparse.Namespace(
@@ -183,7 +215,7 @@ class TestCreateWebApp:
             port=9999,
             debug=False,
             subagent="",
-            chatbot_dist="/nonexistent",
+            chatbot_dist=None,
             session_scope=None,
         )
 
@@ -317,5 +349,7 @@ class TestTemplateFile:
             content = f.read()
         assert "DatusChatbot.initChatbot" in content
         assert "chatbot-root" in content
-        assert "datus-chatbot.umd.js" in content
-        assert "datus-chatbot.css" in content
+        assert "{{ chatbot_js }}" in content
+        assert "{{ chatbot_css }}" in content
+        assert "{{ react_js }}" in content
+        assert "{{ react_dom_js }}" in content

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -150,7 +150,10 @@ class TestCreateWebApp:
             assert "/chatbot-assets" in route_paths or any("/chatbot-assets" in str(r) for r in app.routes)
 
     def test_uses_cdn_when_no_chatbot_dist(self):
-        """Without --chatbot-dist, should use CDN URLs for assets."""
+        """Without --chatbot-dist, should use CDN URLs in rendered HTML."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
         from datus.cli.web.chatbot import _CDN_CHATBOT_JS, _CDN_REACT_JS, create_web_app
 
         args = argparse.Namespace(
@@ -165,8 +168,6 @@ class TestCreateWebApp:
         )
 
         with patch("datus.cli.web.chatbot.create_app") as mock_create_app:
-            from fastapi import FastAPI
-
             mock_create_app.return_value = FastAPI()
             app = create_web_app(args)
 
@@ -174,9 +175,12 @@ class TestCreateWebApp:
             route_paths = [r.path for r in app.routes if hasattr(r, "path")]
             assert "/chatbot-assets" not in route_paths
 
-            # Verify CDN URLs appear in rendered HTML by checking the root route
-            assert _CDN_CHATBOT_JS.startswith("https://unpkg.com/")
-            assert _CDN_REACT_JS.startswith("https://unpkg.com/")
+            # Verify CDN URLs are actually rendered in the HTML response
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert _CDN_CHATBOT_JS in resp.text
+            assert _CDN_REACT_JS in resp.text
 
     def test_warns_when_dist_missing(self):
         """Should warn and fall back to CDN when dist path doesn't exist."""

--- a/tests/unit_tests/cli/web/test_chatbot_subagent.py
+++ b/tests/unit_tests/cli/web/test_chatbot_subagent.py
@@ -1,7 +1,7 @@
 """Tests for --subagent CLI parameter support in web chatbot."""
 
 from argparse import Namespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -10,7 +10,7 @@ from datus.cli.main import ArgumentParser
 
 @pytest.mark.ci
 class TestSubagentCLIParam:
-    """Tests for --subagent argument parsing and URL building."""
+    """Tests for --subagent argument parsing."""
 
     def test_argument_parser_has_subagent(self):
         """ArgumentParser should accept --subagent parameter."""
@@ -24,8 +24,14 @@ class TestSubagentCLIParam:
         args = parser.parser.parse_args([])
         assert args.subagent == ""
 
-    def test_run_web_interface_url_with_subagent(self):
-        """URL should include ?subagent= when --subagent is provided."""
+    def test_argument_parser_has_chatbot_dist(self):
+        """ArgumentParser should accept --chatbot-dist parameter."""
+        parser = ArgumentParser()
+        args = parser.parser.parse_args(["--chatbot-dist", "/some/path"])
+        assert args.chatbot_dist == "/some/path"
+
+    def test_run_web_interface_creates_app(self):
+        """run_web_interface should create a FastAPI app and start uvicorn."""
         from datus.cli.web.chatbot import run_web_interface
 
         args = Namespace(
@@ -37,125 +43,92 @@ class TestSubagentCLIParam:
             subagent="baisheng",
             debug=False,
             web=True,
+            chatbot_dist=None,
+            session_scope=None,
         )
 
-        with patch("subprocess.run") as mock_run, patch("os.path.exists", return_value=True):
-            mock_run.side_effect = KeyboardInterrupt  # Stop immediately
+        with (
+            patch("datus.cli.web.chatbot.create_web_app") as mock_create,
+            patch("datus.cli.web.chatbot.uvicorn") as mock_uvicorn,
+            patch("datus.cli.web.chatbot.webbrowser"),
+            patch("datus.cli.web.config_manager.get_home_from_config", return_value="~/.datus"),
+            patch("datus.utils.path_manager.set_current_path_manager"),
+        ):
+            mock_app = MagicMock()
+            mock_create.return_value = mock_app
+            mock_uvicorn.run.side_effect = KeyboardInterrupt
+
             try:
                 run_web_interface(args)
-            except (KeyboardInterrupt, SystemExit):
+            except KeyboardInterrupt:
                 pass
 
-            # Verify --subagent was passed to subprocess
-            if mock_run.called:
-                cmd = mock_run.call_args[0][0]
-                assert "--subagent" in cmd
-                idx = cmd.index("--subagent")
-                assert cmd[idx + 1] == "baisheng"
-
-    def test_run_web_interface_url_without_subagent(self):
-        """URL should not include ?subagent= when --subagent is not provided."""
-        from datus.cli.web.chatbot import run_web_interface
-
-        args = Namespace(
-            namespace="starrocks",
-            config="conf/agent.yml",
-            database="",
-            host="localhost",
-            port=8501,
-            subagent="",
-            debug=False,
-            web=True,
-        )
-
-        with patch("subprocess.run") as mock_run, patch("os.path.exists", return_value=True):
-            mock_run.side_effect = KeyboardInterrupt
-            try:
-                run_web_interface(args)
-            except (KeyboardInterrupt, SystemExit):
-                pass
-
-            if mock_run.called:
-                cmd = mock_run.call_args[0][0]
-                assert "--subagent" not in cmd
-
-    def test_run_web_interface_url_encodes_subagent(self):
-        """Subagent name with special chars should be URL-encoded."""
-        from datus.cli.web.chatbot import run_web_interface
-
-        args = Namespace(
-            namespace="starrocks",
-            config="conf/agent.yml",
-            database="",
-            host="localhost",
-            port=8501,
-            subagent="test agent&foo",
-            debug=False,
-            web=True,
-        )
-
-        with patch("subprocess.run") as mock_run, patch("os.path.exists", return_value=True):
-            mock_run.side_effect = KeyboardInterrupt
-            try:
-                run_web_interface(args)
-            except (KeyboardInterrupt, SystemExit):
-                pass
+            mock_create.assert_called_once_with(args)
+            mock_uvicorn.run.assert_called_once()
+            call_kwargs = mock_uvicorn.run.call_args
+            assert call_kwargs[1]["host"] == "localhost"
+            assert call_kwargs[1]["port"] == 8501
 
 
 @pytest.mark.ci
-class TestChatbotSubagentParsing:
-    """Tests for chatbot main() subagent arg parsing."""
+class TestSubagentParsing:
+    """Tests for subagent arg parsing from argv."""
 
     def test_parse_subagent_from_argv(self):
-        """--subagent should be parsed from sys.argv in chatbot main()."""
-        # Test the parsing logic directly
-        test_argv = ["chatbot.py", "--namespace", "starrocks", "--subagent", "baisheng"]
-
-        subagent_name = None
-        for i, arg in enumerate(test_argv):
-            if arg == "--subagent" and i + 1 < len(test_argv):
-                subagent_name = test_argv[i + 1]
-
-        assert subagent_name == "baisheng"
-
-    def test_parse_subagent_missing_value(self):
-        """--subagent at end of argv without value should not crash."""
-        test_argv = ["chatbot.py", "--subagent"]
-
-        subagent_name = None
-        for i, arg in enumerate(test_argv):
-            if arg == "--subagent" and i + 1 < len(test_argv):
-                subagent_name = test_argv[i + 1]
-
-        assert subagent_name is None
+        """--subagent should be parsed from ArgumentParser."""
+        parser = ArgumentParser()
+        args = parser.parser.parse_args(["--subagent", "baisheng"])
+        assert args.subagent == "baisheng"
 
     def test_parse_no_subagent(self):
-        """Without --subagent, subagent_name should remain None."""
-        test_argv = ["chatbot.py", "--namespace", "starrocks"]
-
-        subagent_name = None
-        for i, arg in enumerate(test_argv):
-            if arg == "--subagent" and i + 1 < len(test_argv):
-                subagent_name = test_argv[i + 1]
-
-        assert subagent_name is None
+        """Without --subagent, subagent should be empty string."""
+        parser = ArgumentParser()
+        args = parser.parser.parse_args([])
+        assert args.subagent == ""
 
 
 @pytest.mark.ci
-class TestChatbotStreamActionTypeCheck:
-    """Tests for action type checking in chat stream."""
+class TestCreateWebApp:
+    """Tests for create_web_app function."""
 
-    def test_string_action_handled(self):
-        """String actions from chat_executor should not crash render_action_item."""
-        # Test the isinstance check logic
-        action = "Error: Please load configuration first!"
-        assert isinstance(action, str)
+    def test_creates_fastapi_app(self):
+        """create_web_app should return a FastAPI app with chatbot route."""
+        from datus.cli.web.chatbot import create_web_app
 
-    def test_action_history_not_string(self):
-        """ActionHistory objects should not be treated as strings."""
-        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
-
-        action = ActionHistory(
-            action_id="test-123", role=ActionRole.TOOL, action_type="test_action", status=ActionStatus.SUCCESS
+        args = Namespace(
+            namespace="test",
+            config=None,
+            host="localhost",
+            port=8501,
+            debug=False,
+            subagent="",
+            chatbot_dist="/nonexistent/path",
+            session_scope=None,
         )
-        assert not isinstance(action, str)
+
+        with patch("datus.cli.web.chatbot.create_app") as mock_create_app:
+            from fastapi import FastAPI
+
+            mock_app = FastAPI()
+            mock_create_app.return_value = mock_app
+
+            app = create_web_app(args)
+            assert app is mock_app
+            mock_create_app.assert_called_once()
+
+    def test_build_agent_args(self):
+        """_build_agent_args should bridge CLI args to API args."""
+        from datus.cli.web.chatbot import _build_agent_args
+
+        args = Namespace(
+            namespace="myns",
+            config="conf/agent.yml",
+            debug=True,
+        )
+
+        agent_args = _build_agent_args(args)
+        assert agent_args.namespace == "myns"
+        assert agent_args.config == "conf/agent.yml"
+        assert agent_args.source == "web"
+        assert agent_args.interactive is True
+        assert agent_args.log_level == "DEBUG"

--- a/tests/unit_tests/tools/func_tool/test_platform_doc_search.py
+++ b/tests/unit_tests/tools/func_tool/test_platform_doc_search.py
@@ -192,26 +192,39 @@ class TestSearchDocument:
 
 
 class TestWebSearchDocument:
-    def test_success(self, doc_search_tool):
+    @pytest.fixture
+    def tavily_tool(self):
+        """Tool with tavily_api_key set so web_search_document reaches the Tavily call."""
+        config = Mock()
+        config.tavily_api_key = "test-tavily-key"
+        return PlatformDocSearchTool(agent_config=config)
+
+    def test_no_tavily_key_returns_empty(self, doc_search_tool):
+        """When tavily_api_key is None, should return early with empty result."""
+        result = doc_search_tool.web_search_document(keywords=["test"])
+        assert result.success == 1
+        assert result.result == []
+
+    def test_success(self, tavily_tool):
         mock_result = Mock()
         mock_result.success = True
         mock_result.docs = ["doc1 content", "doc2 content"]
         mock_result.doc_count = 2
 
         with patch(_TAVILY_PATH, return_value=mock_result):
-            result = doc_search_tool.web_search_document(keywords=["snowflake COPY INTO"], max_results=5)
+            result = tavily_tool.web_search_document(keywords=["snowflake COPY INTO"], max_results=5)
 
         assert result.success == 1
         assert result.result["doc_count"] == 2
 
-    def test_success_with_include_domains(self, doc_search_tool):
+    def test_success_with_include_domains(self, tavily_tool):
         mock_result = Mock()
         mock_result.success = True
         mock_result.docs = ["content"]
         mock_result.doc_count = 1
 
         with patch(_TAVILY_PATH, return_value=mock_result) as mock_fn:
-            result = doc_search_tool.web_search_document(
+            result = tavily_tool.web_search_document(
                 keywords=["query"],
                 max_results=3,
                 include_domains=["docs.snowflake.com"],
@@ -225,7 +238,7 @@ class TestWebSearchDocument:
             include_answer="basic",
             include_raw_content="markdown",
             include_domains=["docs.snowflake.com"],
-            api_key=None,
+            api_key="test-tavily-key",
         )
 
     def test_uses_tavily_key_from_config(self, mock_agent_config):
@@ -243,20 +256,20 @@ class TestWebSearchDocument:
         call_kwargs = mock_fn.call_args.kwargs
         assert call_kwargs["api_key"] == "my-tavily-key"
 
-    def test_search_fails(self, doc_search_tool):
+    def test_search_fails(self, tavily_tool):
         mock_result = Mock()
         mock_result.success = False
         mock_result.error = "Tavily API error"
 
         with patch(_TAVILY_PATH, return_value=mock_result):
-            result = doc_search_tool.web_search_document(keywords=["test"])
+            result = tavily_tool.web_search_document(keywords=["test"])
 
         assert result.success == 0
         assert result.error == "Tavily API error"
 
-    def test_exception_returns_failure(self, doc_search_tool):
+    def test_exception_returns_failure(self, tavily_tool):
         with patch(_TAVILY_PATH, side_effect=Exception("network error")):
-            result = doc_search_tool.web_search_document(keywords=["test"])
+            result = tavily_tool.web_search_document(keywords=["test"])
 
         assert result.success == 0
         assert "network error" in result.error


### PR DESCRIPTION
## Why

The Streamlit-based web chatbot (`chatbot.py`, 1227 lines) has several architectural issues:

1. **Bypasses the HTTP API** — directly calls internal Python CLI methods (`DatusCLI`, `ChatExecutor`) instead of using the existing `chat_routes.py` REST API
2. **Tightly coupled to Streamlit state** — `st.session_state` manages messages, actions, interrupt controller, making it impossible to reuse with other frontends
3. **No frontend/backend separation** — rendering, session management, SQL execution, and Excel export are all mixed in one file
4. **Cannot reuse `@datus/web-chatbot`** — the existing React chatbot component from Datus-saas is designed to work with the standard API but cannot be used with the Streamlit implementation

## Solution

Replace the Streamlit monolith with a lightweight FastAPI server (~184 lines) that:

- **Reuses `create_app()`** from `datus.api.service` to get the full API route set (chat, cli, database, config, etc.) with zero duplication
- **Serves the `@datus/web-chatbot` React frontend** as a static HTML page at `/`, with the UMD bundle loaded from either CDN (production) or local dist directory (development via `--chatbot-dist`)
- **Removes the `streamlit` dependency** entirely from `pyproject.toml` and `requirements.txt`
- **Cleans up `streamlit_mode`** references from `DatusCLI` (`repl.py`) and `config_manager.py`

Key design decisions:

- **CDN by default, local via `--chatbot-dist`**: Without the flag, assets load from `unpkg.com/@datus/web-chatbot` (production React builds). With `--chatbot-dist /path/to/dist`, assets are served locally via `StaticFiles` (development React builds). Invalid paths fall back to CDN with a warning.
- **Single HTML template with server-side variable injection**: `templates/index.html` uses `{{ react_js }}`, `{{ chatbot_css }}`, `{{ request_origin }}` etc., replaced at startup by `create_web_app()`. No Jinja2 dependency needed.
- **Root route conflict resolution**: `create_app()` registers a JSON `GET /` route; we remove it from `app.routes` before adding the HTML chatbot route.

**Files changed**: 15 files, +599 / -2131

| File | Change |
|------|--------|
| `datus/cli/web/chatbot.py` | 1227 → 184 lines (full rewrite) |
| `datus/cli/web/templates/index.html` | New HTML template |
| `datus/cli/web/__init__.py` | Simplified exports |
| `datus/cli/main.py` | Added `--chatbot-dist` arg |
| `datus/cli/repl.py` | Removed `streamlit_mode` |
| `datus/cli/web/config_manager.py` | Removed streamlit imports |
| `pyproject.toml` / `requirements.txt` | Removed `streamlit>=1.38.0` |
| `docs/web_chatbot/` | Updated architecture description |

## Test Cases

- **`tests/unit_tests/cli/web/test_chatbot.py`** — fully rewritten (816 → 232 lines): tests `_build_agent_args`, `_read_template`, `create_web_app` (CDN mode, local mode, dist-not-found fallback, static files mounting), `run_web_interface` (uvicorn launch, debug log level, KeyboardInterrupt handling), and template file validation
- **`tests/unit_tests/cli/web/test_chatbot_subagent.py`** — updated from mocking `subprocess.run` (Streamlit) to mocking `uvicorn.run` (FastAPI); added `--chatbot-dist` arg parsing test and `_build_agent_args` test
- **`tests/unit_tests/cli/test_repl.py`** — removed `cli.streamlit_mode = False` (attribute no longer exists)
- **`tests/integration/cli/test_web_chatbot.py`** — removed `streamlit_mode` assertion from `ConfigManager` integration test
- **`tests/regression/test_regression_web_e2e.py`** — rewritten to launch FastAPI server via `datus.cli.main` instead of `streamlit run` subprocess; uses `/health` endpoint for readiness check instead of `/_stcore/health`

All 8820 unit tests pass with no new failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to point the app at a custom web-chatbot distribution and generalized the web launch option.
  * Serve a React-based web chatbot frontend with a FastAPI backend (replacing the previous Streamlit UI).

* **Documentation**
  * Updated Web Chatbot overview to reflect the new React + server architecture.

* **Tests**
  * Updated integration and unit tests for the web-based flows and new CLI behavior.

* **Chores**
  * Removed Streamlit runtime assumptions and related configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->