### PR TITLE
[Enhancement] Fix session_total_tokens semantics and add LLM call count tracking

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -32,6 +32,7 @@ from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
     from datus.agent.workflow import Workflow
+    from datus.schemas.token_usage import TokenUsage
     from datus.tools.permission.permission_manager import PermissionManager
     from datus.tools.skill_tools.skill_manager import SkillManager
 
@@ -987,6 +988,21 @@ class AgenticNode(Node):
             "context_remaining": self.context_length - current_tokens if self.context_length else 0,
             "context_length": self.context_length,
         }
+
+    async def get_last_turn_usage(self) -> Optional[TokenUsage]:
+        """Get token usage from the last assistant action that contains usage data."""
+        from datus.schemas.token_usage import TokenUsage as _TokenUsage
+
+        for action in reversed(self.actions):
+            if action.role == ActionRole.ASSISTANT and isinstance(action.output, dict) and "usage" in action.output:
+                usage_dict = action.output["usage"]
+                return _TokenUsage.from_usage_dict(
+                    usage_dict,
+                    session_total_tokens=usage_dict.get("last_call_input_tokens", 0)
+                    or usage_dict.get("input_tokens", 0),
+                    context_length=self.context_length or 0,
+                )
+        return None
 
     def _resolve_workspace_root(self) -> str:
         """

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -994,7 +994,15 @@ class AgenticNode(Node):
         from datus.schemas.token_usage import TokenUsage as _TokenUsage
 
         for action in reversed(self.actions):
-            if action.role == ActionRole.ASSISTANT and isinstance(action.output, dict) and "usage" in action.output:
+            # Stop at the last root-level user message to scope to the current turn
+            if action.role == ActionRole.USER and action.depth == 0:
+                break
+            if (
+                action.role == ActionRole.ASSISTANT
+                and action.depth == 0
+                and isinstance(action.output, dict)
+                and isinstance(action.output.get("usage"), dict)
+            ):
                 usage_dict = action.output["usage"]
                 return _TokenUsage.from_usage_dict(
                     usage_dict,

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -659,6 +659,13 @@ class SSEEndData(BaseModel):
     total_events: int = Field(..., description="Total events sent")
     action_count: int = Field(..., description="Total actions performed")
     duration: float = Field(..., description="Duration in seconds")
+    requests: int = Field(0, description="Number of LLM calls in this turn")
+    input_tokens: int = Field(0, description="Turn input tokens")
+    output_tokens: int = Field(0, description="Turn output tokens")
+    total_tokens: int = Field(0, description="Turn total tokens")
+    cached_tokens: int = Field(0, description="Cache hit tokens")
+    session_total_tokens: int = Field(0, description="Current context window usage (last model call input_tokens)")
+    context_length: int = Field(0, description="Model max context window")
 
 
 class SSEPingData(BaseModel):

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -169,7 +169,7 @@ class ChatService:
             )
             node.session_id = session_id
 
-            old_tokens = node._count_session_tokens()
+            old_tokens = await node._count_session_tokens()
             result = await node._manual_compact()
 
             if not result.get("success", False):

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -331,6 +331,21 @@ class ChatTaskManager:
                     event_id += 1
 
             # 7. End event
+            token_kwargs: dict = {}
+            try:
+                turn_usage = await node.get_last_turn_usage()
+                if turn_usage:
+                    token_kwargs = {
+                        "requests": turn_usage.requests,
+                        "input_tokens": turn_usage.input_tokens,
+                        "output_tokens": turn_usage.output_tokens,
+                        "total_tokens": turn_usage.total_tokens,
+                        "cached_tokens": turn_usage.cached_tokens,
+                        "session_total_tokens": turn_usage.session_total_tokens,
+                        "context_length": turn_usage.context_length,
+                    }
+            except Exception:
+                logger.debug("Failed to extract turn token usage for end event", exc_info=True)
 
             await self._push_event(
                 task,
@@ -343,6 +358,7 @@ class ChatTaskManager:
                         total_events=event_id,
                         action_count=action_count,
                         duration=(datetime.now() - start_time).total_seconds(),
+                        **token_kwargs,
                     ),
                     timestamp=datetime.now().isoformat() + "Z",
                 ),

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -27,6 +27,7 @@ from datus.cli.action_display.display import ActionHistoryDisplay
 from datus.cli.execution_state import ExecutionInterrupted, auto_submit_interaction
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
+from datus.schemas.token_usage import TokenUsage
 from datus.utils.loggings import get_logger
 from datus.utils.terminal_utils import interrupt_on_escape
 
@@ -391,6 +392,7 @@ class ChatCommands:
                         self.add_in_sql_context(sql, clean_output, incremental_actions)
 
                     self._render_final_response(final_action)
+                    self._display_turn_token_usage(final_action, current_node)
 
                     # Merge node_final_action back for history tracking
                     all_actions = incremental_actions + ([node_final_action] if node_final_action else [])
@@ -457,6 +459,60 @@ class ChatCommands:
 
         if clean_output:
             self._display_markdown_response(clean_output)
+
+    def _get_turn_token_usage(self, final_action: "ActionHistory", node) -> Optional[TokenUsage]:
+        """Extract token usage from the final action or fall back to node lookup."""
+        usage_dict = None
+        if final_action and isinstance(final_action.output, dict) and "usage" in final_action.output:
+            usage_dict = final_action.output["usage"]
+
+        if not usage_dict:
+            try:
+                turn_usage = asyncio.run(node.get_last_turn_usage())
+                return turn_usage
+            except Exception:
+                return None
+
+        tu = TokenUsage.from_usage_dict(usage_dict)
+        tu.session_total_tokens = usage_dict.get("last_call_input_tokens", 0) or tu.input_tokens
+        tu.context_length = getattr(node, "context_length", 0) or 0
+        return tu
+
+    def _get_turn_token_usage_from_node(self, node) -> Optional[dict]:
+        """Get detailed token usage from the node's session manager."""
+        try:
+            if (
+                hasattr(node, "session_manager")
+                and node.session_manager
+                and hasattr(node, "session_id")
+                and node.session_id
+            ):
+                return node.session_manager.get_detailed_usage(node.session_id)
+        except Exception:
+            pass
+        return None
+
+    def _display_turn_token_usage(self, final_action: "ActionHistory", node) -> None:
+        """Display a compact one-line token usage summary after each turn."""
+        tu = self._get_turn_token_usage(final_action, node)
+        if not tu or tu.total_tokens == 0:
+            return
+
+        parts = [f"Tokens: {tu.input_tokens:,} in / {tu.output_tokens:,} out"]
+
+        if tu.cached_tokens > 0:
+            rate = tu.cache_hit_rate * 100
+            parts.append(f"({tu.cached_tokens:,} cached, {rate:.1f}%)")
+
+        if tu.context_length > 0 and tu.session_total_tokens > 0:
+            ratio = tu.session_total_tokens / tu.context_length * 100
+            parts.append(f"| Context: {tu.session_total_tokens:,}/{tu.context_length:,} ({ratio:.1f}%)")
+
+        if tu.requests > 0:
+            parts.append(f"| {tu.requests} calls")
+
+        line = " ".join(parts)
+        self.console.print(f"[dim]{line}[/dim]")
 
     def _find_node_final_action(self, actions: List["ActionHistory"]) -> Optional["ActionHistory"]:
         """Find the node final action (e.g. chat_response) from an action list."""
@@ -886,9 +942,30 @@ class ChatCommands:
 
                 self.console.print(f"[bold green]{node_type} Session Info:[/]")
                 self.console.print(f"  Session ID: {session_info['session_id']}")
-                self.console.print(f"  Token Count: {session_info['token_count']}")
                 self.console.print(f"  Action Count: {session_info['action_count']}")
                 self.console.print(f"  Total Conversations: {len(self.chat_history)}")
+
+                # Detailed token usage
+                turn_usage = self._get_turn_token_usage_from_node(self.current_node)
+                if turn_usage:
+                    total = turn_usage.get("total", {})
+                    total_tokens = total.get("total_tokens", 0)
+                    inp = total.get("input_tokens", 0)
+                    out = total.get("output_tokens", 0)
+                    cached = total.get("cached_tokens", 0)
+                    self.console.print(f"  Token Usage: {total_tokens:,} total ({inp:,} in / {out:,} out)")
+                    if cached > 0:
+                        rate = cached / inp * 100 if inp > 0 else 0
+                        self.console.print(f"  Cached Tokens: {cached:,} ({rate:.1f}% hit rate)")
+                else:
+                    token_count = session_info.get("token_count", 0)
+                    self.console.print(f"  Token Count: {token_count}")
+
+                ctx_length = session_info.get("context_length", 0)
+                ctx_tokens = session_info.get("token_count", 0)
+                if ctx_length and ctx_tokens:
+                    ratio = ctx_tokens / ctx_length * 100
+                    self.console.print(f"  Context: {ctx_tokens:,}/{ctx_length:,} ({ratio:.1f}%)")
 
                 if self.chat_history:
                     self.console.print("\n[bold blue]Recent Conversations:[/]")

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -962,7 +962,8 @@ class ChatCommands:
                     self.console.print(f"  Token Count: {token_count}")
 
                 ctx_length = session_info.get("context_length", 0)
-                ctx_tokens = session_info.get("token_count", 0)
+                last_turn_usage = asyncio.run(self.current_node.get_last_turn_usage())
+                ctx_tokens = last_turn_usage.session_total_tokens if last_turn_usage else 0
                 if ctx_length and ctx_tokens:
                     ratio = ctx_tokens / ctx_length * 100
                     self.console.print(f"  Context: {ctx_tokens:,}/{ctx_length:,} ({ratio:.1f}%)")

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -605,6 +605,10 @@ class ClaudeModel(OpenAICompatibleModel):
                 logger.debug("Agent execution completed")
                 total_tokens = cumulative_input_tokens + cumulative_output_tokens
                 cached_tokens = cache_read_tokens
+                # Last model call's input_tokens = real context window usage
+                last_call_input_tokens = 0
+                if hasattr(response, "usage") and response.usage:
+                    last_call_input_tokens = getattr(response.usage, "input_tokens", 0)
                 usage_info = {
                     "requests": turn + 1,
                     "input_tokens": cumulative_input_tokens,
@@ -621,6 +625,7 @@ class ClaudeModel(OpenAICompatibleModel):
                         if self.context_length() and total_tokens > 0
                         else 0
                     ),
+                    "last_call_input_tokens": last_call_input_tokens,
                 }
                 logger.debug(f"Native API cumulative token usage: {usage_info}")
 

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -422,6 +422,7 @@ class ClaudeModel(OpenAICompatibleModel):
                 cumulative_output_tokens = 0
                 cache_creation_tokens = 0
                 cache_read_tokens = 0
+                last_call_input_tokens = 0
 
                 # Execute conversation loop
                 turn = -1
@@ -448,6 +449,7 @@ class ClaudeModel(OpenAICompatibleModel):
                         cumulative_output_tokens += getattr(response.usage, "output_tokens", 0)
                         cache_creation_tokens += getattr(response.usage, "cache_creation_input_tokens", 0)
                         cache_read_tokens += getattr(response.usage, "cache_read_input_tokens", 0)
+                        last_call_input_tokens = getattr(response.usage, "input_tokens", 0)
 
                     message = response.content
 
@@ -605,10 +607,6 @@ class ClaudeModel(OpenAICompatibleModel):
                 logger.debug("Agent execution completed")
                 total_tokens = cumulative_input_tokens + cumulative_output_tokens
                 cached_tokens = cache_read_tokens
-                # Last model call's input_tokens = real context window usage
-                last_call_input_tokens = 0
-                if hasattr(response, "usage") and response.usage:
-                    last_call_input_tokens = getattr(response.usage, "input_tokens", 0)
                 usage_info = {
                     "requests": turn + 1,
                     "input_tokens": cumulative_input_tokens,

--- a/datus/models/litellm_adapter.py
+++ b/datus/models/litellm_adapter.py
@@ -286,6 +286,11 @@ class LiteLLMAdapter:
 
         logger.debug(f"Creating LitellmModel with model={self.litellm_model_name}")
 
+        if self.provider == "claude":
+            from datus.models.litellm_cache_control import CacheControlLitellmModel
+
+            return CacheControlLitellmModel(**model_kwargs)
+
         return LitellmModel(**model_kwargs)
 
     def get_completion_kwargs(self) -> dict:

--- a/datus/models/litellm_cache_control.py
+++ b/datus/models/litellm_cache_control.py
@@ -1,0 +1,116 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+LiteLLM model subclass that injects Anthropic prompt caching markers.
+
+LiteLLM forwards OpenAI-style ``cache_control`` annotations inside message
+content blocks and tool definitions to the Anthropic Messages API when the
+underlying provider is ``anthropic/*``. This enables prompt caching on the
+standard LiteLLM path (used by ``ClaudeModel`` when no OAuth token is
+configured), which otherwise pays full input cost on every turn.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, List
+
+import litellm
+from agents.extensions.models.litellm_model import LitellmModel
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+_EPHEMERAL = {"type": "ephemeral"}
+
+
+def _tag_last_block(content: Any) -> Any:
+    """Normalize ``content`` into a list of blocks and tag the last block."""
+    if isinstance(content, str):
+        blocks: List[dict] = [{"type": "text", "text": content}]
+    elif isinstance(content, list):
+        blocks = [dict(b) if isinstance(b, dict) else {"type": "text", "text": str(b)} for b in content]
+    else:
+        return content
+
+    if not blocks:
+        return content
+
+    blocks[-1] = {**blocks[-1], "cache_control": _EPHEMERAL}
+    return blocks
+
+
+def apply_cache_control(messages: list | None, tools: list | None) -> tuple[list | None, list | None]:
+    """Return deep-copied ``(messages, tools)`` with ephemeral cache markers.
+
+    Adds up to 3 cache breakpoints:
+    1. System prompt (first message with ``role=="system"``).
+    2. Last content block of the last ``user``/``tool`` message.
+    3. Last tool definition.
+    """
+    new_messages = copy.deepcopy(messages) if messages else messages
+    new_tools = copy.deepcopy(tools) if tools else tools
+
+    if new_messages:
+        # 1. System prompt
+        if new_messages and new_messages[0].get("role") == "system":
+            tagged = _tag_last_block(new_messages[0].get("content"))
+            if tagged is not None:
+                new_messages[0]["content"] = tagged
+
+        # 2. Last user/tool message's last content block
+        for i in range(len(new_messages) - 1, -1, -1):
+            role = new_messages[i].get("role")
+            if role in ("user", "tool"):
+                tagged = _tag_last_block(new_messages[i].get("content"))
+                if tagged is not None:
+                    new_messages[i]["content"] = tagged
+                break
+
+    # 3. Last tool definition
+    if new_tools:
+        last = new_tools[-1]
+        if isinstance(last, dict):
+            new_tools[-1] = {**last, "cache_control": _EPHEMERAL}
+
+    return new_messages, new_tools
+
+
+class CacheControlLitellmModel(LitellmModel):
+    """``LitellmModel`` subclass that injects Anthropic prompt-caching markers.
+
+    Transparently wraps ``litellm.acompletion`` during ``_fetch_response`` to
+    add ephemeral ``cache_control`` annotations on the system prompt, the last
+    user/tool message, and the last tool definition — but only when the
+    configured model routes to the Anthropic provider (``anthropic/*``).
+    """
+
+    def _is_anthropic(self) -> bool:
+        return isinstance(self.model, str) and self.model.startswith("anthropic/")
+
+    async def _fetch_response(self, *args, **kwargs):  # type: ignore[override]
+        if not self._is_anthropic():
+            return await super()._fetch_response(*args, **kwargs)
+
+        original_acompletion = litellm.acompletion
+
+        async def patched_acompletion(**ll_kwargs):
+            try:
+                messages = ll_kwargs.get("messages")
+                tools = ll_kwargs.get("tools")
+                new_messages, new_tools = apply_cache_control(messages, tools)
+                ll_kwargs["messages"] = new_messages
+                if tools is not None:
+                    ll_kwargs["tools"] = new_tools
+            except Exception as exc:  # defensive: never break the request
+                logger.warning(f"Failed to apply Anthropic cache_control markers: {exc}")
+            return await original_acompletion(**ll_kwargs)
+
+        litellm.acompletion = patched_acompletion
+        try:
+            return await super()._fetch_response(*args, **kwargs)
+        finally:
+            litellm.acompletion = original_acompletion

--- a/datus/models/litellm_cache_control.py
+++ b/datus/models/litellm_cache_control.py
@@ -14,6 +14,7 @@ configured), which otherwise pays full input cost on every turn.
 
 from __future__ import annotations
 
+import contextvars
 import copy
 from typing import Any, List
 
@@ -25,6 +26,10 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 _EPHEMERAL = {"type": "ephemeral"}
+
+# Per-task flag: when True the wrapper applies cache_control markers.
+# ContextVar is inherently per-async-task, so concurrent requests never interfere.
+_apply_cache: contextvars.ContextVar[bool] = contextvars.ContextVar("_apply_cache", default=False)
 
 
 def _tag_last_block(content: Any) -> Any:
@@ -79,12 +84,45 @@ def apply_cache_control(messages: list | None, tools: list | None) -> tuple[list
     return new_messages, new_tools
 
 
+def _install_cache_control_wrapper() -> None:
+    """Install a one-time wrapper around ``litellm.acompletion``.
+
+    The wrapper checks the per-task ``_apply_cache`` ContextVar and, when set,
+    injects cache_control markers into messages and tools.  Because ContextVar
+    is per-async-task, concurrent requests never interfere with each other.
+    """
+    if getattr(litellm, "_datus_cache_control_installed", False):
+        return
+
+    original_acompletion = litellm.acompletion
+
+    async def _cache_aware_acompletion(*args: Any, **ll_kwargs: Any) -> Any:
+        if _apply_cache.get():
+            try:
+                messages = ll_kwargs.get("messages")
+                tools = ll_kwargs.get("tools")
+                new_messages, new_tools = apply_cache_control(messages, tools)
+                ll_kwargs["messages"] = new_messages
+                if tools is not None:
+                    ll_kwargs["tools"] = new_tools
+            except Exception as exc:  # defensive: never break the request
+                logger.warning(f"Failed to apply Anthropic cache_control markers: {exc}")
+        return await original_acompletion(*args, **ll_kwargs)
+
+    litellm.acompletion = _cache_aware_acompletion
+    litellm._datus_cache_control_installed = True  # type: ignore[attr-defined]
+
+
+# Install the wrapper once at import time.
+_install_cache_control_wrapper()
+
+
 class CacheControlLitellmModel(LitellmModel):
     """``LitellmModel`` subclass that injects Anthropic prompt-caching markers.
 
-    Transparently wraps ``litellm.acompletion`` during ``_fetch_response`` to
-    add ephemeral ``cache_control`` annotations on the system prompt, the last
-    user/tool message, and the last tool definition — but only when the
+    Sets the per-task ``_apply_cache`` ContextVar so that the globally-installed
+    wrapper applies ephemeral ``cache_control`` annotations on the system prompt,
+    the last user/tool message, and the last tool definition — but only when the
     configured model routes to the Anthropic provider (``anthropic/*``).
     """
 
@@ -95,22 +133,8 @@ class CacheControlLitellmModel(LitellmModel):
         if not self._is_anthropic():
             return await super()._fetch_response(*args, **kwargs)
 
-        original_acompletion = litellm.acompletion
-
-        async def patched_acompletion(**ll_kwargs):
-            try:
-                messages = ll_kwargs.get("messages")
-                tools = ll_kwargs.get("tools")
-                new_messages, new_tools = apply_cache_control(messages, tools)
-                ll_kwargs["messages"] = new_messages
-                if tools is not None:
-                    ll_kwargs["tools"] = new_tools
-            except Exception as exc:  # defensive: never break the request
-                logger.warning(f"Failed to apply Anthropic cache_control markers: {exc}")
-            return await original_acompletion(**ll_kwargs)
-
-        litellm.acompletion = patched_acompletion
+        token = _apply_cache.set(True)
         try:
             return await super()._fetch_response(*args, **kwargs)
         finally:
-            litellm.acompletion = original_acompletion
+            _apply_cache.reset(token)

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -1102,6 +1102,11 @@ class OpenAICompatibleModel(LLMBaseModel):
         if max_context and total_tokens > 0:
             context_usage_ratio = round(total_tokens / max_context, 3)
 
+        # Last model call's input_tokens = real context window usage
+        last_call_input_tokens = 0
+        if hasattr(usage, "request_usage_entries") and usage.request_usage_entries:
+            last_call_input_tokens = getattr(usage.request_usage_entries[-1], "input_tokens", 0)
+
         return {
             "requests": getattr(usage, "requests", 0),
             "input_tokens": input_tokens,
@@ -1111,6 +1116,7 @@ class OpenAICompatibleModel(LLMBaseModel):
             "reasoning_tokens": reasoning_tokens,
             "cache_hit_rate": cache_hit_rate,
             "context_usage_ratio": context_usage_ratio,
+            "last_call_input_tokens": last_call_input_tokens,
         }
 
     async def _extract_and_distribute_token_usage(self, result, action_history_manager: ActionHistoryManager) -> None:

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -540,9 +540,15 @@ class SessionManager:
 
     def get_detailed_usage(self, session_id: str) -> Dict[str, Any]:
         """Query turn_usage table and return aggregated + per-turn token usage."""
+        self._validate_session_id(session_id)
         db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        empty_result = {
+            "total": {"requests": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "cached_tokens": 0},
+            "turns": [],
+            "turn_count": 0,
+        }
         if not os.path.exists(db_path):
-            return {"total": {}, "turns": [], "turn_count": 0}
+            return empty_result
 
         total = {
             "requests": 0,

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -538,6 +538,71 @@ class SessionManager:
             **session_metadata,
         }
 
+    def get_detailed_usage(self, session_id: str) -> Dict[str, Any]:
+        """Query turn_usage table and return aggregated + per-turn token usage."""
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if not os.path.exists(db_path):
+            return {"total": {}, "turns": [], "turn_count": 0}
+
+        total = {
+            "requests": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "cached_tokens": 0,
+        }
+        turns: List[Dict[str, Any]] = []
+
+        try:
+            with sqlite3.connect(db_path, timeout=5.0) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT user_turn_number, requests, input_tokens, output_tokens, "
+                    "total_tokens, input_tokens_details, output_tokens_details, created_at "
+                    "FROM turn_usage WHERE session_id = ? ORDER BY user_turn_number",
+                    (session_id,),
+                )
+                for row in cursor.fetchall():
+                    turn_number, requests, inp, out, tot, inp_details, out_details, created_at = row
+                    total["requests"] += requests or 0
+                    total["input_tokens"] += inp or 0
+                    total["output_tokens"] += out or 0
+                    total["total_tokens"] += tot or 0
+
+                    # Parse JSON detail fields
+                    inp_detail_dict = {}
+                    out_detail_dict = {}
+                    if inp_details:
+                        try:
+                            inp_detail_dict = json.loads(inp_details)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    if out_details:
+                        try:
+                            out_detail_dict = json.loads(out_details)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+
+                    cached = inp_detail_dict.get("cached_tokens", 0)
+                    total["cached_tokens"] += cached or 0
+
+                    turns.append(
+                        {
+                            "turn_number": turn_number,
+                            "requests": requests or 0,
+                            "input_tokens": inp or 0,
+                            "output_tokens": out or 0,
+                            "total_tokens": tot or 0,
+                            "input_tokens_details": inp_detail_dict,
+                            "output_tokens_details": out_detail_dict,
+                            "created_at": created_at,
+                        }
+                    )
+        except sqlite3.OperationalError:
+            logger.debug(f"turn_usage table not found for session {session_id}")
+
+        return {"total": total, "turns": turns, "turn_count": len(turns)}
+
     @staticmethod
     def _parse_final_output(actions: List[ActionHistory], current_assistant_group: Dict) -> Optional[ActionHistory]:
         """Try to parse sql/output from the last assistant action's messages and update assistant group.

--- a/datus/schemas/token_usage.py
+++ b/datus/schemas/token_usage.py
@@ -1,0 +1,38 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Standardized token usage model for LLM consumption reporting."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TokenUsage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    requests: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    cached_tokens: int = 0
+    reasoning_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_hit_rate: float = 0.0
+    context_usage_ratio: float = 0.0
+    # Session-level context information (optionally populated)
+    context_length: int = 0
+    session_total_tokens: int = 0  # Current context window usage (last model call's input_tokens)
+
+    @classmethod
+    def from_usage_dict(cls, d: Dict[str, Any], **overrides) -> "TokenUsage":
+        """Construct a TokenUsage from a usage dict (e.g. from _extract_usage_info).
+
+        Extra keys in *d* are silently ignored thanks to ``extra="ignore"``.
+        *overrides* take precedence over values in *d*.
+        """
+        merged = {**d, **overrides}
+        return cls(**merged)

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1119,3 +1119,120 @@ class TestAutoCompactExtended:
 
         result = asyncio.run(node._auto_compact())
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# TestGetLastTurnUsage
+# ---------------------------------------------------------------------------
+
+
+class TestGetLastTurnUsage:
+    def test_returns_none_when_no_actions(self):
+        node = _make_node()
+        node.actions = []
+        result = asyncio.run(node.get_last_turn_usage())
+        assert result is None
+
+    def test_returns_none_when_no_usage_in_actions(self):
+        node = _make_node()
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="test",
+            messages="hello",
+            input_data={},
+            output_data={"response": "ok"},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions = [action]
+        result = asyncio.run(node.get_last_turn_usage())
+        assert result is None
+
+    def test_returns_usage_from_last_assistant_action(self):
+        node = _make_node(context_length=128000)
+        usage_dict = {
+            "requests": 2,
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "total_tokens": 1200,
+            "cached_tokens": 500,
+            "cache_hit_rate": 0.5,
+            "last_call_input_tokens": 600,
+        }
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat_response",
+            messages="result",
+            input_data={},
+            output_data={"response": "ok", "usage": usage_dict},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions = [action]
+        result = asyncio.run(node.get_last_turn_usage())
+        assert result is not None
+        assert result.input_tokens == 1000
+        assert result.output_tokens == 200
+        assert result.cached_tokens == 500
+        # session_total_tokens should use last_call_input_tokens, not cumulative input_tokens
+        assert result.session_total_tokens == 600
+        assert result.context_length == 128000
+
+    def test_session_total_tokens_falls_back_to_input_tokens(self):
+        """When last_call_input_tokens is missing/zero, fallback to input_tokens."""
+        node = _make_node(context_length=128000)
+        usage_dict = {
+            "requests": 1,
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "total_tokens": 1200,
+        }
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat_response",
+            messages="result",
+            input_data={},
+            output_data={"response": "ok", "usage": usage_dict},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions = [action]
+        result = asyncio.run(node.get_last_turn_usage())
+        assert result is not None
+        assert result.session_total_tokens == 1000
+
+    def test_skips_tool_actions(self):
+        node = _make_node(context_length=64000)
+        tool_action = ActionHistory.create_action(
+            role=ActionRole.TOOL,
+            action_type="db_query",
+            messages="SELECT 1",
+            input_data={},
+            output_data={"result": "ok"},
+            status=ActionStatus.SUCCESS,
+        )
+        assistant_action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat_response",
+            messages="done",
+            input_data={},
+            output_data={"response": "done", "usage": {"input_tokens": 500, "output_tokens": 100, "total_tokens": 600}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions = [assistant_action, tool_action]
+        result = asyncio.run(node.get_last_turn_usage())
+        # Should find the assistant action even though tool action is last
+        assert result is not None
+        assert result.input_tokens == 500
+
+    def test_context_length_none_defaults_to_zero(self):
+        node = _make_node(context_length=None)
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="test",
+            messages="r",
+            input_data={},
+            output_data={"usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions = [action]
+        result = asyncio.run(node.get_last_turn_usage())
+        assert result is not None
+        assert result.context_length == 0

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1222,6 +1222,64 @@ class TestGetLastTurnUsage:
         assert result is not None
         assert result.input_tokens == 500
 
+    def test_ignores_sub_agent_usage(self):
+        """Usage from sub-agent actions (depth > 0) should be skipped."""
+        node = _make_node(context_length=128000)
+        sub_agent_action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="sub_response",
+            messages="sub",
+            input_data={},
+            output_data={"usage": {"input_tokens": 9999, "output_tokens": 100, "total_tokens": 10099}},
+            status=ActionStatus.SUCCESS,
+        )
+        sub_agent_action.depth = 1
+        root_action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat_response",
+            messages="main",
+            input_data={},
+            output_data={"usage": {"input_tokens": 500, "output_tokens": 50, "total_tokens": 550}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions = [root_action, sub_agent_action]
+        result = asyncio.run(node.get_last_turn_usage())
+        assert result is not None
+        assert result.input_tokens == 500  # root action, not sub-agent
+
+    def test_scoped_to_current_turn(self):
+        """Should stop at the last root-level user message to avoid returning stale usage."""
+        node = _make_node(context_length=128000)
+        old_usage = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat_response",
+            messages="old",
+            input_data={},
+            output_data={"usage": {"input_tokens": 1000, "output_tokens": 200, "total_tokens": 1200}},
+            status=ActionStatus.SUCCESS,
+        )
+        user_msg = ActionHistory.create_action(
+            role=ActionRole.USER,
+            action_type="message",
+            messages="new question",
+            input_data={},
+            output_data={},
+            status=ActionStatus.SUCCESS,
+        )
+        # Current turn has a tool action but no assistant usage yet
+        tool_action = ActionHistory.create_action(
+            role=ActionRole.TOOL,
+            action_type="db_query",
+            messages="SELECT 1",
+            input_data={},
+            output_data={"result": "ok"},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions = [old_usage, user_msg, tool_action]
+        result = asyncio.run(node.get_last_turn_usage())
+        # Should return None because old_usage is from a previous turn
+        assert result is None
+
     def test_context_length_none_defaults_to_zero(self):
         node = _make_node(context_length=None)
         action = ActionHistory.create_action(

--- a/tests/unit_tests/api/models/test_cli_models.py
+++ b/tests/unit_tests/api/models/test_cli_models.py
@@ -1,0 +1,63 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for SSEEndData token fields in datus/api/models/cli_models.py."""
+
+from datus.api.models.cli_models import SSEEndData
+
+
+class TestSSEEndDataTokenFields:
+    def test_backward_compatible_defaults(self):
+        """New token fields default to 0 — existing callers unaffected."""
+        data = SSEEndData(
+            session_id="s1",
+            total_events=5,
+            action_count=3,
+            duration=1.5,
+        )
+        assert data.requests == 0
+        assert data.input_tokens == 0
+        assert data.output_tokens == 0
+        assert data.total_tokens == 0
+        assert data.cached_tokens == 0
+        assert data.session_total_tokens == 0
+        assert data.context_length == 0
+
+    def test_token_fields_populated(self):
+        data = SSEEndData(
+            session_id="s1",
+            total_events=5,
+            action_count=3,
+            duration=1.5,
+            requests=3,
+            input_tokens=1000,
+            output_tokens=200,
+            total_tokens=1200,
+            cached_tokens=500,
+            session_total_tokens=1000,
+            context_length=128000,
+        )
+        assert data.requests == 3
+        assert data.input_tokens == 1000
+        assert data.output_tokens == 200
+        assert data.total_tokens == 1200
+        assert data.cached_tokens == 500
+        assert data.session_total_tokens == 1000
+        assert data.context_length == 128000
+
+    def test_serialization_includes_token_fields(self):
+        data = SSEEndData(
+            session_id="s1",
+            total_events=1,
+            action_count=1,
+            duration=0.1,
+            requests=2,
+            input_tokens=42,
+        )
+        d = data.model_dump()
+        assert "requests" in d
+        assert d["requests"] == 2
+        assert "input_tokens" in d
+        assert d["input_tokens"] == 42
+        assert d["output_tokens"] == 0

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3584,6 +3584,7 @@ class TestCmdChatInfoExtended:
 
         mock_node = MagicMock()
         mock_node.get_session_info = mock_get_info
+        mock_node.session_manager = None  # Prevent MagicMock auto-chain for get_detailed_usage
         chat_cmd.current_node = mock_node
         chat_cmd.current_subagent_name = "gensql"
 

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3582,8 +3582,12 @@ class TestCmdChatInfoExtended:
                 "action_count": 3,
             }
 
+        async def mock_get_last_turn_usage():
+            return None
+
         mock_node = MagicMock()
         mock_node.get_session_info = mock_get_info
+        mock_node.get_last_turn_usage = mock_get_last_turn_usage
         mock_node.session_manager = None  # Prevent MagicMock auto-chain for get_detailed_usage
         chat_cmd.current_node = mock_node
         chat_cmd.current_subagent_name = "gensql"

--- a/tests/unit_tests/models/test_litellm_adapter.py
+++ b/tests/unit_tests/models/test_litellm_adapter.py
@@ -205,13 +205,12 @@ class TestGetAgentsSdkModel:
         headers = {"User-Agent": "datus-agent (cli)"}
         adapter = LiteLLMAdapter(provider="claude", model="claude-sonnet-4", api_key="key", default_headers=headers)
         mock_model = MagicMock()
-        mock_litellm_model_cls = MagicMock(return_value=mock_model)
-        mock_module = MagicMock()
-        mock_module.LitellmModel = mock_litellm_model_cls
-
-        with patch.dict("sys.modules", {"agents.extensions.models.litellm_model": mock_module}):
+        with patch(
+            "datus.models.litellm_cache_control.CacheControlLitellmModel",
+            return_value=mock_model,
+        ) as mock_cls:
             adapter.get_agents_sdk_model()
-        call_kwargs = mock_litellm_model_cls.call_args
+        call_kwargs = mock_cls.call_args
         assert "extra_headers" not in (call_kwargs.kwargs or {})
 
 
@@ -406,3 +405,25 @@ class TestCreateLiteLLMAdapter:
             default_headers=headers,
         )
         assert adapter.default_headers == headers
+
+
+class TestGetAgentsSdkModelRouting:
+    def test_claude_returns_cache_control_subclass(self):
+        from agents.extensions.models.litellm_model import LitellmModel
+
+        from datus.models.litellm_cache_control import CacheControlLitellmModel
+
+        adapter = LiteLLMAdapter(provider="claude", model="claude-sonnet-4", api_key="sk-test")
+        model = adapter.get_agents_sdk_model()
+        assert isinstance(model, CacheControlLitellmModel)
+        assert isinstance(model, LitellmModel)
+
+    def test_openai_returns_plain_litellm_model(self):
+        from agents.extensions.models.litellm_model import LitellmModel
+
+        from datus.models.litellm_cache_control import CacheControlLitellmModel
+
+        adapter = LiteLLMAdapter(provider="openai", model="gpt-4o", api_key="sk-test")
+        model = adapter.get_agents_sdk_model()
+        assert isinstance(model, LitellmModel)
+        assert not isinstance(model, CacheControlLitellmModel)

--- a/tests/unit_tests/models/test_litellm_cache_control.py
+++ b/tests/unit_tests/models/test_litellm_cache_control.py
@@ -94,11 +94,6 @@ async def test_cache_control_wrapper_applies_markers_when_flag_set():
         captured.update(kwargs)
         return "ret"
 
-    # Replace the wrapper's delegate with our fake
-    wrapper = litellm.acompletion
-    with patch("datus.models.litellm_cache_control._install_cache_control_wrapper") as _:
-        pass  # prevent re-install
-
     # Temporarily re-install wrapper around our fake
     import datus.models.litellm_cache_control as ccmod
 

--- a/tests/unit_tests/models/test_litellm_cache_control.py
+++ b/tests/unit_tests/models/test_litellm_cache_control.py
@@ -7,8 +7,9 @@
 from __future__ import annotations
 
 import copy
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
+import litellm
 import pytest
 
 from datus.models.litellm_cache_control import (
@@ -83,66 +84,128 @@ def test_apply_cache_control_tool_message_tagged():
 
 
 @pytest.mark.asyncio
-async def test_cache_control_model_anthropic_patches_acompletion():
-    model = CacheControlLitellmModel(model="anthropic/claude-sonnet-4", api_key="sk-test")
+async def test_cache_control_wrapper_applies_markers_when_flag_set():
+    """The globally-installed wrapper injects cache markers when _apply_cache is True."""
+    from datus.models.litellm_cache_control import _apply_cache
 
     captured: dict = {}
 
-    async def fake_acompletion(**kwargs):
+    async def fake_original(*args, **kwargs):
         captured.update(kwargs)
         return "ret"
 
-    # Patch parent _fetch_response to invoke litellm.acompletion with known payload
-    async def fake_super_fetch(self_inner, *args, **kwargs):
-        import litellm
+    # Replace the wrapper's delegate with our fake
+    wrapper = litellm.acompletion
+    with patch("datus.models.litellm_cache_control._install_cache_control_wrapper") as _:
+        pass  # prevent re-install
 
-        return await litellm.acompletion(
-            messages=[
-                {"role": "system", "content": "sys"},
-                {"role": "user", "content": "hi"},
-            ],
-            tools=[{"name": "t"}],
-        )
+    # Temporarily re-install wrapper around our fake
+    import datus.models.litellm_cache_control as ccmod
 
-    with patch("litellm.acompletion", new=AsyncMock(side_effect=fake_acompletion)):
-        with patch(
-            "agents.extensions.models.litellm_model.LitellmModel._fetch_response",
-            new=fake_super_fetch,
-        ):
-            await model._fetch_response()
+    saved = litellm.acompletion
+    litellm._datus_cache_control_installed = False  # type: ignore[attr-defined]
+    litellm.acompletion = fake_original
+    ccmod._install_cache_control_wrapper()
+    wrapper_fn = litellm.acompletion
 
-    assert isinstance(captured["messages"][0]["content"], list)
-    assert captured["messages"][0]["content"][-1]["cache_control"] == EPHEMERAL
-    assert captured["messages"][-1]["content"][-1]["cache_control"] == EPHEMERAL
-    assert captured["tools"][-1]["cache_control"] == EPHEMERAL
+    try:
+        # With flag set: should apply cache markers
+        token = _apply_cache.set(True)
+        try:
+            await wrapper_fn(
+                messages=[{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}],
+                tools=[{"name": "t"}],
+            )
+        finally:
+            _apply_cache.reset(token)
 
+        assert isinstance(captured["messages"][0]["content"], list)
+        assert captured["messages"][0]["content"][-1]["cache_control"] == EPHEMERAL
+        assert captured["messages"][-1]["content"][-1]["cache_control"] == EPHEMERAL
+        assert captured["tools"][-1]["cache_control"] == EPHEMERAL
 
-@pytest.mark.asyncio
-async def test_cache_control_model_non_anthropic_passthrough():
-    model = CacheControlLitellmModel(model="openai/gpt-4", api_key="sk-test")
-
-    captured: dict = {}
-
-    async def fake_acompletion(**kwargs):
-        captured.update(kwargs)
-        return "ret"
-
-    async def fake_super_fetch(self_inner, *args, **kwargs):
-        import litellm
-
-        return await litellm.acompletion(
+        # Without flag: should pass through unchanged
+        captured.clear()
+        await wrapper_fn(
             messages=[{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}],
             tools=[{"name": "t"}],
         )
+        assert captured["messages"][0]["content"] == "sys"
+        assert captured["messages"][-1]["content"] == "hi"
+        assert "cache_control" not in captured["tools"][-1]
+    finally:
+        litellm.acompletion = saved
+        litellm._datus_cache_control_installed = True  # type: ignore[attr-defined]
 
-    with patch("litellm.acompletion", new=AsyncMock(side_effect=fake_acompletion)):
-        with patch(
-            "agents.extensions.models.litellm_model.LitellmModel._fetch_response",
-            new=fake_super_fetch,
-        ):
-            await model._fetch_response()
 
-    # No cache_control anywhere
-    assert captured["messages"][0]["content"] == "sys"
-    assert captured["messages"][-1]["content"] == "hi"
-    assert "cache_control" not in captured["tools"][-1]
+@pytest.mark.asyncio
+async def test_fetch_response_sets_flag_for_anthropic():
+    """CacheControlLitellmModel sets _apply_cache=True for anthropic models."""
+    from datus.models.litellm_cache_control import _apply_cache
+
+    model = CacheControlLitellmModel(model="anthropic/claude-sonnet-4", api_key="sk-test")
+    observed_flag: list = []
+
+    async def fake_super_fetch(self_inner, *args, **kwargs):
+        observed_flag.append(_apply_cache.get(False))
+        return "ret"
+
+    with patch(
+        "agents.extensions.models.litellm_model.LitellmModel._fetch_response",
+        new=fake_super_fetch,
+    ):
+        await model._fetch_response()
+
+    assert observed_flag == [True]
+    # After _fetch_response returns, flag should be reset
+    assert _apply_cache.get(False) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_response_skips_flag_for_non_anthropic():
+    """CacheControlLitellmModel does NOT set _apply_cache for non-anthropic models."""
+    from datus.models.litellm_cache_control import _apply_cache
+
+    model = CacheControlLitellmModel(model="openai/gpt-4", api_key="sk-test")
+    observed_flag: list = []
+
+    async def fake_super_fetch(self_inner, *args, **kwargs):
+        observed_flag.append(_apply_cache.get(False))
+        return "ret"
+
+    with patch(
+        "agents.extensions.models.litellm_model.LitellmModel._fetch_response",
+        new=fake_super_fetch,
+    ):
+        await model._fetch_response()
+
+    assert observed_flag == [False]
+
+
+@pytest.mark.asyncio
+async def test_context_var_isolation_between_tasks():
+    """Concurrent tasks with different models should not interfere via ContextVar."""
+    import asyncio
+
+    from datus.models.litellm_cache_control import _apply_cache
+
+    observed: dict = {}
+
+    async def check_flag(label: str, expected: bool):
+        await asyncio.sleep(0)
+        observed[label] = _apply_cache.get(False)
+        assert _apply_cache.get(False) == expected
+
+    async def anthropic_task():
+        token = _apply_cache.set(True)
+        try:
+            await check_flag("anthropic", True)
+        finally:
+            _apply_cache.reset(token)
+
+    async def openai_task():
+        await check_flag("openai", False)
+
+    await asyncio.gather(anthropic_task(), openai_task())
+    assert observed["anthropic"] is True
+    assert observed["openai"] is False

--- a/tests/unit_tests/models/test_litellm_cache_control.py
+++ b/tests/unit_tests/models/test_litellm_cache_control.py
@@ -1,0 +1,148 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``CacheControlLitellmModel`` and ``apply_cache_control``."""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from datus.models.litellm_cache_control import (
+    CacheControlLitellmModel,
+    apply_cache_control,
+)
+
+EPHEMERAL = {"type": "ephemeral"}
+
+
+def test_apply_cache_control_tags_system_user_and_tool():
+    messages = [
+        {"role": "system", "content": "you are helpful"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]},
+    ]
+    tools = [{"name": "t1"}, {"name": "t2"}]
+
+    new_messages, new_tools = apply_cache_control(messages, tools)
+
+    # System prompt: wrapped to list, last block tagged
+    assert isinstance(new_messages[0]["content"], list)
+    assert new_messages[0]["content"][-1]["cache_control"] == EPHEMERAL
+    assert new_messages[0]["content"][-1]["text"] == "you are helpful"
+
+    # Last user message: last block tagged, others not
+    last_user_blocks = new_messages[3]["content"]
+    assert last_user_blocks[-1]["cache_control"] == EPHEMERAL
+    assert "cache_control" not in last_user_blocks[0]
+
+    # Earlier user message not tagged
+    assert new_messages[1]["content"] == "hi"
+
+    # Last tool tagged
+    assert new_tools[-1]["cache_control"] == EPHEMERAL
+    assert "cache_control" not in new_tools[0]
+
+
+def test_apply_cache_control_deepcopy_safety():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": [{"type": "text", "text": "u"}]},
+    ]
+    tools = [{"name": "x"}]
+    original_messages = copy.deepcopy(messages)
+    original_tools = copy.deepcopy(tools)
+
+    apply_cache_control(messages, tools)
+
+    assert messages == original_messages
+    assert tools == original_tools
+
+
+def test_apply_cache_control_handles_empty_inputs():
+    new_messages, new_tools = apply_cache_control(None, None)
+    assert new_messages is None and new_tools is None
+
+    new_messages, new_tools = apply_cache_control([], [])
+    assert new_messages == [] and new_tools == []
+
+
+def test_apply_cache_control_tool_message_tagged():
+    messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "calling"},
+        {"role": "tool", "content": "result"},
+    ]
+    new_messages, _ = apply_cache_control(messages, None)
+    # Last tool message last block tagged
+    assert new_messages[-1]["content"][-1]["cache_control"] == EPHEMERAL
+
+
+@pytest.mark.asyncio
+async def test_cache_control_model_anthropic_patches_acompletion():
+    model = CacheControlLitellmModel(model="anthropic/claude-sonnet-4", api_key="sk-test")
+
+    captured: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return "ret"
+
+    # Patch parent _fetch_response to invoke litellm.acompletion with known payload
+    async def fake_super_fetch(self_inner, *args, **kwargs):
+        import litellm
+
+        return await litellm.acompletion(
+            messages=[
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+            ],
+            tools=[{"name": "t"}],
+        )
+
+    with patch("litellm.acompletion", new=AsyncMock(side_effect=fake_acompletion)):
+        with patch(
+            "agents.extensions.models.litellm_model.LitellmModel._fetch_response",
+            new=fake_super_fetch,
+        ):
+            await model._fetch_response()
+
+    assert isinstance(captured["messages"][0]["content"], list)
+    assert captured["messages"][0]["content"][-1]["cache_control"] == EPHEMERAL
+    assert captured["messages"][-1]["content"][-1]["cache_control"] == EPHEMERAL
+    assert captured["tools"][-1]["cache_control"] == EPHEMERAL
+
+
+@pytest.mark.asyncio
+async def test_cache_control_model_non_anthropic_passthrough():
+    model = CacheControlLitellmModel(model="openai/gpt-4", api_key="sk-test")
+
+    captured: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return "ret"
+
+    async def fake_super_fetch(self_inner, *args, **kwargs):
+        import litellm
+
+        return await litellm.acompletion(
+            messages=[{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}],
+            tools=[{"name": "t"}],
+        )
+
+    with patch("litellm.acompletion", new=AsyncMock(side_effect=fake_acompletion)):
+        with patch(
+            "agents.extensions.models.litellm_model.LitellmModel._fetch_response",
+            new=fake_super_fetch,
+        ):
+            await model._fetch_response()
+
+    # No cache_control anywhere
+    assert captured["messages"][0]["content"] == "sys"
+    assert captured["messages"][-1]["content"] == "hi"
+    assert "cache_control" not in captured["tools"][-1]

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -1242,6 +1242,7 @@ class TestExtractUsageInfo:
         usage.input_tokens_details.cached_tokens = 20
         usage.output_tokens_details = MagicMock()
         usage.output_tokens_details.reasoning_tokens = 10
+        usage.request_usage_entries = None
 
         with patch.object(model, "context_length", return_value=128000):
             info = model._extract_usage_info(usage)
@@ -1254,6 +1255,7 @@ class TestExtractUsageInfo:
         assert info["reasoning_tokens"] == 10
         assert info["cache_hit_rate"] == round(20 / 100, 3)
         assert info["context_usage_ratio"] == round(150 / 128000, 3)
+        assert info["last_call_input_tokens"] == 0
 
     def test_zero_input_tokens_no_division_error(self):
         model = _make_model()
@@ -1301,3 +1303,46 @@ class TestExtractUsageInfo:
             info = model._extract_usage_info(usage)
 
         assert info["context_usage_ratio"] == 0
+
+    def test_last_call_input_tokens_from_request_usage_entries(self):
+        """last_call_input_tokens should come from the last request_usage_entry."""
+        model = _make_model()
+        usage = MagicMock()
+        usage.requests = 3
+        usage.input_tokens = 3000  # Cumulative across all calls
+        usage.output_tokens = 500
+        usage.total_tokens = 3500
+        usage.input_tokens_details = None
+        usage.output_tokens_details = None
+
+        # Simulate 3 model calls with increasing input_tokens (context grows)
+        entry1 = MagicMock()
+        entry1.input_tokens = 800
+        entry2 = MagicMock()
+        entry2.input_tokens = 1000
+        entry3 = MagicMock()
+        entry3.input_tokens = 1200  # Last call = real context window usage
+        usage.request_usage_entries = [entry1, entry2, entry3]
+
+        with patch.object(model, "context_length", return_value=128000):
+            info = model._extract_usage_info(usage)
+
+        assert info["last_call_input_tokens"] == 1200
+        assert info["input_tokens"] == 3000  # Cumulative is unchanged
+
+    def test_last_call_input_tokens_empty_entries(self):
+        """last_call_input_tokens should be 0 when request_usage_entries is empty."""
+        model = _make_model()
+        usage = MagicMock()
+        usage.requests = 1
+        usage.input_tokens = 500
+        usage.output_tokens = 100
+        usage.total_tokens = 600
+        usage.input_tokens_details = None
+        usage.output_tokens_details = None
+        usage.request_usage_entries = []
+
+        with patch.object(model, "context_length", return_value=128000):
+            info = model._extract_usage_info(usage)
+
+        assert info["last_call_input_tokens"] == 0

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1363,6 +1363,97 @@ class TestSessionManagerScope:
         finally:
             manager.close_all_sessions()
 
+
+class TestGetDetailedUsage:
+    """Tests for SessionManager.get_detailed_usage()."""
+
+    def test_nonexistent_session_returns_empty(self, sm):
+        result = sm.get_detailed_usage("nonexistent-session-id")
+        assert result == {"total": {}, "turns": [], "turn_count": 0}
+
+    def test_no_turn_usage_table(self, sm):
+        """Session DB exists but has no turn_usage table."""
+        session_id = "no-usage-table"
+        sm.get_session(session_id)
+        result = sm.get_detailed_usage(session_id)
+        assert result["turn_count"] == 0
+        assert result["turns"] == []
+
+    def test_single_turn(self, sm):
+        session_id = "single-turn"
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS turn_usage ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "session_id TEXT NOT NULL, "
+                "branch_id TEXT, "
+                "user_turn_number INTEGER NOT NULL, "
+                "requests INTEGER DEFAULT 0, "
+                "input_tokens INTEGER DEFAULT 0, "
+                "output_tokens INTEGER DEFAULT 0, "
+                "total_tokens INTEGER DEFAULT 0, "
+                "input_tokens_details TEXT, "
+                "output_tokens_details TEXT, "
+                "created_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO turn_usage (session_id, user_turn_number, requests, input_tokens, "
+                "output_tokens, total_tokens, input_tokens_details, output_tokens_details) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (session_id, 1, 2, 1000, 200, 1200, '{"cached_tokens": 500}', '{"reasoning_tokens": 10}'),
+            )
+            conn.commit()
+
+        result = sm.get_detailed_usage(session_id)
+        assert result["turn_count"] == 1
+        assert result["total"]["input_tokens"] == 1000
+        assert result["total"]["output_tokens"] == 200
+        assert result["total"]["total_tokens"] == 1200
+        assert result["total"]["cached_tokens"] == 500
+        assert result["total"]["requests"] == 2
+        assert len(result["turns"]) == 1
+        assert result["turns"][0]["input_tokens_details"] == {"cached_tokens": 500}
+        assert result["turns"][0]["output_tokens_details"] == {"reasoning_tokens": 10}
+
+    def test_multiple_turns_aggregated(self, sm):
+        session_id = "multi-turn"
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS turn_usage ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "session_id TEXT NOT NULL, "
+                "branch_id TEXT, "
+                "user_turn_number INTEGER NOT NULL, "
+                "requests INTEGER DEFAULT 0, "
+                "input_tokens INTEGER DEFAULT 0, "
+                "output_tokens INTEGER DEFAULT 0, "
+                "total_tokens INTEGER DEFAULT 0, "
+                "input_tokens_details TEXT, "
+                "output_tokens_details TEXT, "
+                "created_at TEXT)"
+            )
+            for turn in range(1, 4):
+                conn.execute(
+                    "INSERT INTO turn_usage (session_id, user_turn_number, requests, input_tokens, "
+                    "output_tokens, total_tokens, input_tokens_details) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (session_id, turn, 1, 100 * turn, 50 * turn, 150 * turn, '{"cached_tokens": 30}'),
+                )
+            conn.commit()
+
+        result = sm.get_detailed_usage(session_id)
+        assert result["turn_count"] == 3
+        assert result["total"]["input_tokens"] == 600  # 100+200+300
+        assert result["total"]["output_tokens"] == 300  # 50+100+150
+        assert result["total"]["total_tokens"] == 900  # 150+300+450
+        assert result["total"]["cached_tokens"] == 90  # 30*3
+        assert len(result["turns"]) == 3
+        assert result["turns"][0]["turn_number"] == 1
+        assert result["turns"][2]["turn_number"] == 3
+
     def test_scope_whitespace_only_uses_session_dir_directly(self, tmp_path):
         """Passing scope='  ' (whitespace only) uses session_dir directly (no subdirectory)."""
         base_dir = str(tmp_path / "sessions")

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1364,12 +1364,31 @@ class TestSessionManagerScope:
             manager.close_all_sessions()
 
 
+_TURN_USAGE_DDL = (
+    "CREATE TABLE IF NOT EXISTS turn_usage ("
+    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+    "session_id TEXT NOT NULL, "
+    "branch_id TEXT, "
+    "user_turn_number INTEGER NOT NULL, "
+    "requests INTEGER DEFAULT 0, "
+    "input_tokens INTEGER DEFAULT 0, "
+    "output_tokens INTEGER DEFAULT 0, "
+    "total_tokens INTEGER DEFAULT 0, "
+    "input_tokens_details TEXT, "
+    "output_tokens_details TEXT, "
+    "created_at TEXT)"
+)
+
+
 class TestGetDetailedUsage:
     """Tests for SessionManager.get_detailed_usage()."""
 
     def test_nonexistent_session_returns_empty(self, sm):
         result = sm.get_detailed_usage("nonexistent-session-id")
-        assert result == {"total": {}, "turns": [], "turn_count": 0}
+        assert result["total"]["input_tokens"] == 0
+        assert result["total"]["output_tokens"] == 0
+        assert result["turns"] == []
+        assert result["turn_count"] == 0
 
     def test_no_turn_usage_table(self, sm):
         """Session DB exists but has no turn_usage table."""
@@ -1384,20 +1403,7 @@ class TestGetDetailedUsage:
         sm.get_session(session_id)
         db_path = os.path.join(sm.session_dir, f"{session_id}.db")
         with sqlite3.connect(db_path) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS turn_usage ("
-                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                "session_id TEXT NOT NULL, "
-                "branch_id TEXT, "
-                "user_turn_number INTEGER NOT NULL, "
-                "requests INTEGER DEFAULT 0, "
-                "input_tokens INTEGER DEFAULT 0, "
-                "output_tokens INTEGER DEFAULT 0, "
-                "total_tokens INTEGER DEFAULT 0, "
-                "input_tokens_details TEXT, "
-                "output_tokens_details TEXT, "
-                "created_at TEXT)"
-            )
+            conn.execute(_TURN_USAGE_DDL)
             conn.execute(
                 "INSERT INTO turn_usage (session_id, user_turn_number, requests, input_tokens, "
                 "output_tokens, total_tokens, input_tokens_details, output_tokens_details) "
@@ -1422,20 +1428,7 @@ class TestGetDetailedUsage:
         sm.get_session(session_id)
         db_path = os.path.join(sm.session_dir, f"{session_id}.db")
         with sqlite3.connect(db_path) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS turn_usage ("
-                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                "session_id TEXT NOT NULL, "
-                "branch_id TEXT, "
-                "user_turn_number INTEGER NOT NULL, "
-                "requests INTEGER DEFAULT 0, "
-                "input_tokens INTEGER DEFAULT 0, "
-                "output_tokens INTEGER DEFAULT 0, "
-                "total_tokens INTEGER DEFAULT 0, "
-                "input_tokens_details TEXT, "
-                "output_tokens_details TEXT, "
-                "created_at TEXT)"
-            )
+            conn.execute(_TURN_USAGE_DDL)
             for turn in range(1, 4):
                 conn.execute(
                     "INSERT INTO turn_usage (session_id, user_turn_number, requests, input_tokens, "

--- a/tests/unit_tests/schemas/test_token_usage.py
+++ b/tests/unit_tests/schemas/test_token_usage.py
@@ -4,7 +4,6 @@
 
 """Unit tests for datus/schemas/token_usage.py."""
 
-
 from datus.schemas.token_usage import TokenUsage
 
 

--- a/tests/unit_tests/schemas/test_token_usage.py
+++ b/tests/unit_tests/schemas/test_token_usage.py
@@ -1,0 +1,87 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/schemas/token_usage.py."""
+
+
+from datus.schemas.token_usage import TokenUsage
+
+
+class TestTokenUsageDefaults:
+    def test_all_defaults_zero(self):
+        tu = TokenUsage()
+        assert tu.requests == 0
+        assert tu.input_tokens == 0
+        assert tu.output_tokens == 0
+        assert tu.total_tokens == 0
+        assert tu.cached_tokens == 0
+        assert tu.reasoning_tokens == 0
+        assert tu.cache_creation_tokens == 0
+        assert tu.cache_hit_rate == 0.0
+        assert tu.context_usage_ratio == 0.0
+        assert tu.context_length == 0
+        assert tu.session_total_tokens == 0
+
+    def test_construct_with_kwargs(self):
+        tu = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        assert tu.input_tokens == 100
+        assert tu.output_tokens == 50
+        assert tu.total_tokens == 150
+
+
+class TestTokenUsageExtraIgnored:
+    def test_extra_fields_ignored(self):
+        tu = TokenUsage(input_tokens=10, unknown_field="should_be_ignored", another=42)
+        assert tu.input_tokens == 10
+        assert not hasattr(tu, "unknown_field")
+        assert not hasattr(tu, "another")
+
+
+class TestTokenUsageFromUsageDict:
+    def test_from_usage_dict_basic(self):
+        d = {
+            "requests": 3,
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "total_tokens": 1200,
+            "cached_tokens": 500,
+            "reasoning_tokens": 10,
+            "cache_hit_rate": 0.5,
+            "context_usage_ratio": 0.01,
+        }
+        tu = TokenUsage.from_usage_dict(d)
+        assert tu.requests == 3
+        assert tu.input_tokens == 1000
+        assert tu.cached_tokens == 500
+        assert tu.cache_hit_rate == 0.5
+
+    def test_from_usage_dict_overrides(self):
+        d = {"input_tokens": 100, "output_tokens": 50}
+        tu = TokenUsage.from_usage_dict(d, context_length=128000, session_total_tokens=100)
+        assert tu.input_tokens == 100
+        assert tu.context_length == 128000
+        assert tu.session_total_tokens == 100
+
+    def test_from_usage_dict_override_takes_precedence(self):
+        d = {"input_tokens": 100}
+        tu = TokenUsage.from_usage_dict(d, input_tokens=999)
+        assert tu.input_tokens == 999
+
+    def test_from_usage_dict_extra_keys_ignored(self):
+        d = {"input_tokens": 50, "some_extra_key": "ignored"}
+        tu = TokenUsage.from_usage_dict(d)
+        assert tu.input_tokens == 50
+
+    def test_from_usage_dict_empty(self):
+        tu = TokenUsage.from_usage_dict({})
+        assert tu.total_tokens == 0
+
+
+class TestTokenUsageSerialization:
+    def test_model_dump(self):
+        tu = TokenUsage(input_tokens=100, output_tokens=50)
+        d = tu.model_dump()
+        assert d["input_tokens"] == 100
+        assert d["output_tokens"] == 50
+        assert "context_length" in d


### PR DESCRIPTION

Use last model call's input_tokens as session_total_tokens (real context window usage) instead of cumulative input_tokens across all calls in a turn. Add requests (LLM call count) to CLI display and SSE end event.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Displays per-turn token usage after each chat response and richer session info with detailed token breakdowns.
  * Background job end events now include token-usage fields when available.
  * Improved Anthropic/Claude handling with optional prompt-caching optimizations and provider-based model routing.
* **Tests**
  * Extensive unit tests added for token usage reporting, SSE payloads, cache-control behavior, model routing, and session usage aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->