### PR TITLE
[Enhancement] Add subagent depth and parent_action_id to SSE events

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -639,6 +639,8 @@ class SSEMessagePayload(BaseModel):
     message_id: str = Field(..., description="Message ID")
     role: str = Field(..., description="Message role (user, assistant)")
     content: List[IMessageContent] = Field(default_factory=list, description="Message content list")
+    depth: int = Field(default=0, description="Nesting depth (0=main, 1=sub-agent)")
+    parent_action_id: Optional[str] = Field(default=None, description="Parent action ID for sub-agent grouping")
 
 
 class SSEMessageData(BaseModel):

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -16,7 +16,7 @@ from datus.api.models.cli_models import (
     SSEMessageData,
     SSEMessagePayload,
 )
-from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 from datus.utils.json_utils import llm_result2json
 from datus.utils.loggings import get_logger
 
@@ -241,6 +241,19 @@ def action_to_sse_event(
                 sse_role = "user"
             else:
                 return None
+        elif action.action_type == SUBAGENT_COMPLETE_ACTION_TYPE:
+            output = action.output if isinstance(action.output, dict) else {}
+            duration = (
+                (action.end_time - action.start_time).total_seconds()
+                if action.start_time and action.end_time
+                else 0.0
+            )
+            payload_data = {
+                "subagentType": output.get("subagent_type", "unknown"),
+                "toolCount": output.get("tool_count", 0),
+                "duration": duration,
+            }
+            contents = [IMessageContent(type="subagent-complete", payload=payload_data)]
         elif (
             role == ActionRole.ASSISTANT and status == ActionStatus.SUCCESS and action.action_type.endswith("_response")
         ):
@@ -256,6 +269,8 @@ def action_to_sse_event(
                 message_id=message_id,
                 role=sse_role,
                 content=contents,
+                depth=action.depth,
+                parent_action_id=action.parent_action_id,
             ),
         )
 

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -70,7 +70,8 @@ def _build_tool_result_content(action: ActionHistory) -> List[IMessageContent]:
     if start_time and end_time:
         duration = (end_time - start_time).total_seconds()
 
-    short_desc = output.get("summary", "") if isinstance(output, dict) else ""
+    output_dict = output if isinstance(output, dict) else None
+    short_desc = output_dict.get("summary", "") if output_dict else ""
     function_name, _ = _extract_function(action)
 
     payload_data = {
@@ -78,7 +79,7 @@ def _build_tool_result_content(action: ActionHistory) -> List[IMessageContent]:
         "toolName": function_name,
         "duration": duration,
         "shortDesc": short_desc,
-        "result": output.get("raw_output", output),
+        "result": output_dict.get("raw_output", output) if output_dict else output,
     }
     return [IMessageContent(type="call-tool-result", payload=payload_data)]
 
@@ -235,10 +236,10 @@ def action_to_sse_event(
 
         sse_role = "assistant"
 
-        if action.action_type == SUBAGENT_COMPLETE_ACTION_TYPE:
-            contents = _build_subagent_complete_content(action)
-        elif status == ActionStatus.FAILED:
+        if status == ActionStatus.FAILED:
             contents = _build_error_content(action)
+        elif action.action_type == SUBAGENT_COMPLETE_ACTION_TYPE:
+            contents = _build_subagent_complete_content(action)
         elif role == ActionRole.TOOL and status == ActionStatus.PROCESSING:
             contents = _build_tool_call_content(action)
         elif role == ActionRole.TOOL:

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -182,6 +182,18 @@ def _build_interaction_content(action: ActionHistory) -> List[IMessageContent]:
     return [IMessageContent(type="user-interaction", payload=payload_data)]
 
 
+def _build_subagent_complete_content(action: ActionHistory) -> List[IMessageContent]:
+    """Build content for sub-agent completion summary event."""
+    output = action.output if isinstance(action.output, dict) else {}
+    duration = (action.end_time - action.start_time).total_seconds() if action.start_time and action.end_time else 0.0
+    payload_data = {
+        "subagentType": output.get("subagent_type", "unknown"),
+        "toolCount": output.get("tool_count", 0),
+        "duration": duration,
+    }
+    return [IMessageContent(type="subagent-complete", payload=payload_data)]
+
+
 def _build_interaction_result_content(action: ActionHistory) -> Optional[List[IMessageContent]]:
     """Build content for interaction result event (SUCCESS status)."""
     output = action.output if isinstance(action.output, dict) else {}
@@ -223,7 +235,9 @@ def action_to_sse_event(
 
         sse_role = "assistant"
 
-        if status == ActionStatus.FAILED:
+        if action.action_type == SUBAGENT_COMPLETE_ACTION_TYPE:
+            contents = _build_subagent_complete_content(action)
+        elif status == ActionStatus.FAILED:
             contents = _build_error_content(action)
         elif role == ActionRole.TOOL and status == ActionStatus.PROCESSING:
             contents = _build_tool_call_content(action)
@@ -241,19 +255,6 @@ def action_to_sse_event(
                 sse_role = "user"
             else:
                 return None
-        elif action.action_type == SUBAGENT_COMPLETE_ACTION_TYPE:
-            output = action.output if isinstance(action.output, dict) else {}
-            duration = (
-                (action.end_time - action.start_time).total_seconds()
-                if action.start_time and action.end_time
-                else 0.0
-            )
-            payload_data = {
-                "subagentType": output.get("subagent_type", "unknown"),
-                "toolCount": output.get("tool_count", 0),
-                "duration": duration,
-            }
-            contents = [IMessageContent(type="subagent-complete", payload=payload_data)]
         elif (
             role == ActionRole.ASSISTANT and status == ActionStatus.SUCCESS and action.action_type.endswith("_response")
         ):

--- a/docs/API/chat.md
+++ b/docs/API/chat.md
@@ -165,9 +165,11 @@ are infrastructure.
 {
   "type":    "createMessage",
   "payload": {
-    "message_id": "act_0001",
-    "role":       "assistant",
-    "content":    [ /* one or more content items, see below */ ]
+    "message_id":       "act_0001",
+    "role":             "assistant",
+    "content":          [ /* one or more content items, see below */ ],
+    "depth":            0,
+    "parent_action_id": null
   }
 }
 ```
@@ -178,6 +180,11 @@ are infrastructure.
   `role: "user"`.
 - `message_id` is the action id; it is **also the `interactionKey`** when the content describes a user interaction
   (see below).
+- `depth` indicates the nesting level of the action: `0` for the main agent, `1` for a sub-agent invoked via the
+  `task()` tool. Clients can use this to visually group or indent sub-agent events.
+- `parent_action_id` is the action id of the parent `task()` tool call that spawned this sub-agent action. It is
+  `null` for main-agent actions (`depth=0`). Together with `depth`, it allows the frontend to build a hierarchical
+  tree of agent activities.
 
 ### Content item types
 
@@ -302,12 +309,56 @@ Notes on `requests`:
 - `allowFreeText: true` means the user may type a custom answer even when `options` is non-empty.
 - `contentType` is usually `markdown`.
 
+#### `subagent-complete`
+
+Emitted when a sub-agent finishes its delegated task. This event always has `depth >= 1` and a non-null
+`parent_action_id`. It acts as a summary marker — clients can use it to collapse sub-agent activity into a
+single status line.
+
+```json
+{
+  "type": "subagent-complete",
+  "payload": {
+    "subagentType": "gen_sql",
+    "toolCount":    5,
+    "duration":     3.21
+  }
+}
+```
+
+| Field          | Type   | Description |
+|----------------|--------|-------------|
+| `subagentType` | string | Name of the sub-agent that ran (e.g. `explore`, `gen_sql`) |
+| `toolCount`    | int    | Number of tool calls the sub-agent made |
+| `duration`     | float  | Wall-clock seconds the sub-agent ran |
+
+> The enclosing `MessageData.payload` will carry `depth: 1` and a `parent_action_id` pointing to the `task()` tool
+> call that spawned the sub-agent. See [MessageData](#messagedata) for the full payload schema.
+
 ### A complete frame example
+
+Main agent event (`depth=0`):
 
 ```
 id: 5
 event: message
-data: {"type":"createMessage","payload":{"message_id":"act_0005","role":"assistant","content":[{"type":"markdown","payload":{"content":"Here are the top 5 customers:\n"}}]}}
+data: {"type":"createMessage","payload":{"message_id":"act_0005","role":"assistant","content":[{"type":"markdown","payload":{"content":"Here are the top 5 customers:\n"}}],"depth":0,"parent_action_id":null}}
+```
+
+Sub-agent event (`depth=1`):
+
+```
+id: 12
+event: message
+data: {"type":"createMessage","payload":{"message_id":"act_0012","role":"assistant","content":[{"type":"call-tool","payload":{"callToolId":"act_0012","toolName":"execute_sql","toolParams":{"sql":"SELECT 1"}}}],"depth":1,"parent_action_id":"act_0006"}}
+```
+
+Sub-agent completion:
+
+```
+id: 15
+event: message
+data: {"type":"createMessage","payload":{"message_id":"act_0015","role":"assistant","content":[{"type":"subagent-complete","payload":{"subagentType":"gen_sql","toolCount":5,"duration":3.21}}],"depth":1,"parent_action_id":"act_0006"}}
 ```
 
 ### Resume by cursor

--- a/docs/API/chat.zh.md
+++ b/docs/API/chat.zh.md
@@ -163,9 +163,11 @@ X-Accel-Buffering: no
 {
   "type":    "createMessage",
   "payload": {
-    "message_id": "act_0001",
-    "role":       "assistant",
-    "content":    [ /* 一个或多个 content 项,见下 */ ]
+    "message_id":       "act_0001",
+    "role":             "assistant",
+    "content":          [ /* 一个或多个 content 项,见下 */ ],
+    "depth":            0,
+    "parent_action_id": null
   }
 }
 ```
@@ -174,6 +176,10 @@ X-Accel-Buffering: no
   客户端遇到未知 `type` 应优雅忽略)。
 - 流式期间 `role` 始终为 `assistant`;`GET /chat/history` 拉取时,用户消息会以 `role: "user"` 出现。
 - `message_id` 即 action id;当 content 为用户交互时,**它同时也是 `interactionKey`**(详见下文)。
+- `depth` 表示动作的嵌套层级:`0` 为主 agent,`1` 为通过 `task()` 工具调起的 sub-agent。客户端可据此
+  对 sub-agent 事件进行分组或缩进展示。
+- `parent_action_id` 是触发此 sub-agent 动作的父 `task()` 工具调用的 action id。主 agent 动作(`depth=0`)
+  该字段为 `null`。结合 `depth`,前端可构建 agent 活动的层级树。
 
 ### content 元素类型
 
@@ -293,12 +299,55 @@ Agent 需要用户做决策才能继续时下发。SSE 流随后暂停,直到通
 - `allowFreeText: true` 表示即使有 `options`,也允许用户输入自定义答案。
 - `contentType` 通常为 `markdown`。
 
+#### `subagent-complete`
+
+当 sub-agent 完成委派任务时下发。此事件的 `depth >= 1` 且 `parent_action_id` 非空。它作为汇总标记,
+客户端可据此将 sub-agent 活动折叠为一行状态摘要。
+
+```json
+{
+  "type": "subagent-complete",
+  "payload": {
+    "subagentType": "gen_sql",
+    "toolCount":    5,
+    "duration":     3.21
+  }
+}
+```
+
+| 字段           | 类型   | 描述 |
+|----------------|--------|------|
+| `subagentType` | string | 运行的 sub-agent 名称(如 `explore`、`gen_sql`) |
+| `toolCount`    | int    | sub-agent 执行的工具调用次数 |
+| `duration`     | float  | sub-agent 运行的挂钟时间(秒) |
+
+> 外层 `MessageData.payload` 将携带 `depth: 1` 和指向触发该 sub-agent 的 `task()` 工具调用的
+> `parent_action_id`。完整 payload 结构参见 [MessageData](#messagedata)。
+
 ### 完整事件帧示例
+
+主 agent 事件(`depth=0`):
 
 ```
 id: 5
 event: message
-data: {"type":"createMessage","payload":{"message_id":"act_0005","role":"assistant","content":[{"type":"markdown","payload":{"content":"销售额前 5 的客户:\n"}}]}}
+data: {"type":"createMessage","payload":{"message_id":"act_0005","role":"assistant","content":[{"type":"markdown","payload":{"content":"销售额前 5 的客户:\n"}}],"depth":0,"parent_action_id":null}}
+```
+
+Sub-agent 事件(`depth=1`):
+
+```
+id: 12
+event: message
+data: {"type":"createMessage","payload":{"message_id":"act_0012","role":"assistant","content":[{"type":"call-tool","payload":{"callToolId":"act_0012","toolName":"execute_sql","toolParams":{"sql":"SELECT 1"}}}],"depth":1,"parent_action_id":"act_0006"}}
+```
+
+Sub-agent 完成:
+
+```
+id: 15
+event: message
+data: {"type":"createMessage","payload":{"message_id":"act_0015","role":"assistant","content":[{"type":"subagent-complete","payload":{"subagentType":"gen_sql","toolCount":5,"duration":3.21}}],"depth":1,"parent_action_id":"act_0006"}}
 ```
 
 ### 按游标续传

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -404,6 +404,21 @@ class TestActionToSSEEvent:
         assert event is not None
         assert event.data.payload.content[0].type == "call-tool-result"
 
+    def test_tool_success_non_dict_output(self):
+        """TOOL + SUCCESS with non-dict output does not crash."""
+        action = _make_action(
+            role=ActionRole.TOOL,
+            status=ActionStatus.SUCCESS,
+            input={"function_name": "run_sql"},
+            output="plain string result",
+        )
+        event = action_to_sse_event(action, event_id=30, message_id="msg-30")
+        assert event is not None
+        content = event.data.payload.content[0]
+        assert content.type == "call-tool-result"
+        assert content.payload["result"] == "plain string result"
+        assert content.payload["shortDesc"] == ""
+
     def test_user_role_excluded_by_default(self):
         """USER role returns None when include_user_message=False."""
         action = _make_action(role=ActionRole.USER, input={"user_message": "Hello"})
@@ -575,15 +590,16 @@ class TestActionToSSEEvent:
         assert event is not None
         assert event.data.payload.content[0].payload["duration"] == 0.0
 
-    def test_subagent_complete_failed_still_produces_subagent_event(self):
-        """subagent_complete with FAILED status still produces subagent-complete, not error."""
+    def test_subagent_complete_failed_produces_error_event(self):
+        """subagent_complete with FAILED status produces error content, not subagent-complete."""
         action = _make_action(
             role=ActionRole.SYSTEM,
             status=ActionStatus.FAILED,
             action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
-            output={"subagent_type": "gen_sql", "tool_count": 0},
+            output={"error": "sub-agent timed out"},
         )
         event = action_to_sse_event(action, event_id=17, message_id="msg-17")
         assert event is not None
         content = event.data.payload.content[0]
-        assert content.type == "subagent-complete"
+        assert content.type == "error"
+        assert "timed out" in content.payload["content"]

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -15,7 +15,7 @@ from datus.api.services.action_sse_converter import (
     _extract_function,
     action_to_sse_event,
 )
-from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 
 
 def _make_action(**overrides) -> ActionHistory:
@@ -489,3 +489,61 @@ class TestActionToSSEEvent:
         )
         event = action_to_sse_event(action, event_id=10, message_id="msg-10")
         assert event is not None
+
+    def test_depth_and_parent_action_id_forwarded(self):
+        """depth=1 and parent_action_id are forwarded to SSEMessagePayload."""
+        action = _make_action(
+            role=ActionRole.TOOL,
+            status=ActionStatus.PROCESSING,
+            input={"function_name": "run_sql", "arguments": {}},
+            depth=1,
+            parent_action_id="parent-001",
+        )
+        event = action_to_sse_event(action, event_id=11, message_id="msg-11")
+        assert event is not None
+        assert event.data.payload.depth == 1
+        assert event.data.payload.parent_action_id == "parent-001"
+
+    def test_default_depth_is_zero(self):
+        """Normal action has depth=0 and parent_action_id=None by default."""
+        action = _make_action(
+            role=ActionRole.TOOL,
+            status=ActionStatus.PROCESSING,
+            input={"function_name": "list_tables", "arguments": {}},
+        )
+        event = action_to_sse_event(action, event_id=12, message_id="msg-12")
+        assert event is not None
+        assert event.data.payload.depth == 0
+        assert event.data.payload.parent_action_id is None
+
+    def test_subagent_complete_produces_event(self):
+        """subagent_complete action produces type='subagent-complete' content."""
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.SUCCESS,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output={"subagent_type": "sql_gen", "tool_count": 3},
+        )
+        event = action_to_sse_event(action, event_id=13, message_id="msg-13")
+        assert event is not None
+        assert len(event.data.payload.content) == 1
+        content = event.data.payload.content[0]
+        assert content.type == "subagent-complete"
+        assert content.payload["subagentType"] == "sql_gen"
+        assert content.payload["toolCount"] == 3
+        assert content.payload["duration"] == 5.0  # end - start = 5s from defaults
+
+    def test_subagent_complete_with_depth(self):
+        """subagent_complete event carries depth=1 and parent_action_id."""
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.SUCCESS,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output={"subagent_type": "data_viz", "tool_count": 1},
+            depth=1,
+            parent_action_id="parent-002",
+        )
+        event = action_to_sse_event(action, event_id=14, message_id="msg-14")
+        assert event is not None
+        assert event.data.payload.depth == 1
+        assert event.data.payload.parent_action_id == "parent-002"

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -547,3 +547,43 @@ class TestActionToSSEEvent:
         assert event is not None
         assert event.data.payload.depth == 1
         assert event.data.payload.parent_action_id == "parent-002"
+
+    def test_subagent_complete_non_dict_output(self):
+        """subagent_complete with non-dict output uses safe defaults."""
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.SUCCESS,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output="not a dict",
+        )
+        event = action_to_sse_event(action, event_id=15, message_id="msg-15")
+        assert event is not None
+        content = event.data.payload.content[0]
+        assert content.payload["subagentType"] == "unknown"
+        assert content.payload["toolCount"] == 0
+
+    def test_subagent_complete_missing_times_gives_zero_duration(self):
+        """subagent_complete with missing end_time gives duration=0."""
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.SUCCESS,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output={"subagent_type": "explore", "tool_count": 2},
+            end_time=None,
+        )
+        event = action_to_sse_event(action, event_id=16, message_id="msg-16")
+        assert event is not None
+        assert event.data.payload.content[0].payload["duration"] == 0.0
+
+    def test_subagent_complete_failed_still_produces_subagent_event(self):
+        """subagent_complete with FAILED status still produces subagent-complete, not error."""
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.FAILED,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output={"subagent_type": "gen_sql", "tool_count": 0},
+        )
+        event = action_to_sse_event(action, event_id=17, message_id="msg-17")
+        assert event is not None
+        content = event.data.payload.content[0]
+        assert content.type == "subagent-complete"


### PR DESCRIPTION
Propagate depth and parent_action_id from ActionHistory through the SSE layer so frontends can distinguish main-agent vs sub-agent events and build hierarchical activity trees. Also handle subagent_complete actions as a new "subagent-complete" content type with summary metadata.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hierarchical tracking for multi-agent operations with `depth` and `parent_action_id` fields in message payloads.
  * Introduced `subagent-complete` event type to signal sub-agent task completion with metrics (duration, tool count, agent type).

* **Documentation**
  * Updated API documentation with new payload fields and event types in both English and Chinese versions.

* **Tests**
  * Added comprehensive test coverage for hierarchical message fields and sub-agent completion events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->