### PR TITLE
[BugFix] Fix compact API endpoint always returning failure

### DIFF
--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -169,6 +169,9 @@ class ChatService:
             )
             node.session_id = session_id
 
+            # Load the existing SQLite session so _session is populated
+            node._get_or_create_session()
+
             old_tokens = await node._count_session_tokens()
             result = await node._manual_compact()
 


### PR DESCRIPTION
The compact_session() method created a temporary ChatAgenticNode but never loaded the SQLite session, causing _session to remain None and _manual_compact() to always return success=false. Add _get_or_create_session() call before compaction to load the existing session.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed chat session compaction to properly initialize session state before processing, ensuring reliable session management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->