### PR TITLE
[Enhancement] Pass subagent names into agent traces

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -359,7 +359,12 @@ class AgenticNode(Node):
 
             try:
                 result = await self.model.generate_with_tools(
-                    prompt=summarization_prompt, session=self._session, max_turns=1, temperature=0.3, max_tokens=2000
+                    prompt=summarization_prompt,
+                    session=self._session,
+                    max_turns=1,
+                    temperature=0.3,
+                    max_tokens=2000,
+                    agent_name=self.get_node_name(),
                 )
                 summary = result.get("content", "")
                 summary_token = result.get("usage", {}).get("output_tokens", 0)

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -599,6 +599,7 @@ class ChatAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=config.get("hooks"),
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/compare_agentic_node.py
+++ b/datus/agent/node/compare_agentic_node.py
@@ -232,6 +232,7 @@ class CompareAgenticNode(AgenticNode):
                 max_turns=self.max_turns,
                 session=session,
                 action_history_manager=action_history_manager,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -246,6 +246,7 @@ class ExploreAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=None,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -817,6 +817,7 @@ Rules:
                     session=session,
                     action_history_manager=action_history_manager,
                     hooks=self.hooks if self.execution_mode == "interactive" else None,
+                    agent_name=self.get_node_name(),
                     interrupt_controller=self.interrupt_controller,
                 ):
                     yield stream_action

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -419,6 +419,7 @@ class GenMetricsAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=None,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -529,6 +529,7 @@ class GenReportAgenticNode(AgenticNode):
                 max_turns=self.max_turns,
                 session=session,
                 action_history_manager=action_history_manager,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 # Collect response content from successful actions

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -415,6 +415,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=self.hooks if self.execution_mode == "interactive" else None,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -421,6 +421,7 @@ class SkillCreatorAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=None,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -958,6 +958,7 @@ class GenSQLAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=config.get("hooks"),
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/gen_table_agentic_node.py
+++ b/datus/agent/node/gen_table_agentic_node.py
@@ -216,6 +216,7 @@ class GenTableAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=None,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -431,6 +431,7 @@ class SqlSummaryAgenticNode(AgenticNode):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=self.hooks if self.execution_mode == "interactive" else None,
+                agent_name=self.get_node_name(),
                 interrupt_controller=self.interrupt_controller,
             ):
                 yield stream_action

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1078,6 +1078,8 @@ class TestManualCompactExtended:
         assert node.last_summary == "summary text"
         assert node._session is None
         assert node.session_id is None
+        mock_model.generate_with_tools.assert_awaited_once()
+        assert mock_model.generate_with_tools.await_args.kwargs["agent_name"] == node.get_node_name()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -898,6 +898,29 @@ class TestChatAgenticNodeExecuteStreamErrors:
         final_action = actions[-1]
         assert final_action.status == ActionStatus.SUCCESS
 
+    @pytest.mark.asyncio
+    async def test_execute_stream_passes_node_name_as_agent_name(self, real_agent_config, mock_llm_create):
+        """execute_stream passes the chat node name through to the model trace metadata."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        node = ChatAgenticNode(
+            node_id="test_trace_agent_name",
+            description="Test trace agent name",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+
+        mock_llm_create.reset(responses=[build_simple_response("Trace name test response.")])
+        node.input = ChatNodeInput(user_message="Test trace naming", database="california_schools")
+
+        actions = []
+        async for action in node.execute_stream(ActionHistoryManager()):
+            actions.append(action)
+
+        assert len(actions) >= 2
+        assert mock_llm_create.call_history[-1]["method"] == "generate_with_tools_stream"
+        assert mock_llm_create.call_history[-1]["kwargs"]["agent_name"] == "chat"
+
 
 # ===========================================================================
 # execute_stream with Tool Calls Tests


### PR DESCRIPTION
## Why
OpenAI Agents SDK / LangSmith traces were showing generic agent names like Tools_Agent or default_agent instead of the active subagent name. That made traces harder to read when debugging multi-node tool execution.

## Solution
Pass each node's get_node_name() through as agent_name when calling generate_with_tools_stream(...) across the agentic nodes that use OpenAI-compatible tool execution. Apply the same change to the non-streaming _manual_compact() path so summary runs use the node name as well. Add unit coverage for both the streaming path and _manual_compact() to verify agent_name forwarding.

## Test Cases
- uv run pytest tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/agent/node/test_agentic_node.py -q
