### PR TITLE
[Feature] Add SQL execution stop API with task tracking

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -31,6 +31,7 @@ class ExecuteSQLInput(BaseModel):
 class ExecuteSQLData(BaseModel):
     """Data for SQL execution result."""
 
+    execute_task_id: str = Field(..., description="Task ID for this SQL execution, can be used to stop it")
     sql_query: str = Field(..., description="Executed SQL query")
     row_count: Optional[int] = Field(None, description="Number of rows returned")
     sql_return: Optional[str] = Field(None, description="SQL result data")
@@ -38,6 +39,19 @@ class ExecuteSQLData(BaseModel):
     execution_time: float = Field(..., description="Execution time in seconds")
     executed_at: str = Field(..., description="Execution timestamp")
     columns: Optional[List[str]] = Field(None, description="Column names")
+
+
+class StopExecuteSQLInput(BaseModel):
+    """Input model for stopping a SQL execution."""
+
+    execute_task_id: str = Field(..., description="Task ID of the SQL execution to stop")
+
+
+class StopExecuteSQLData(BaseModel):
+    """Data for stop SQL execution result."""
+
+    execute_task_id: str = Field(..., description="Task ID of the stopped SQL execution")
+    stopped: bool = Field(..., description="Whether the execution was successfully stopped")
 
 
 # Tool Commands models

--- a/datus/api/routes/cli_routes.py
+++ b/datus/api/routes/cli_routes.py
@@ -17,6 +17,8 @@ from datus.api.models.cli_models import (
     ExecuteToolInput,
     InternalCommandData,
     InternalCommandInput,
+    StopExecuteSQLData,
+    StopExecuteSQLInput,
 )
 
 router = APIRouter(prefix="/api/v1", tags=["cli"])
@@ -26,14 +28,28 @@ router = APIRouter(prefix="/api/v1", tags=["cli"])
     "/sql/execute",
     response_model=Result[ExecuteSQLData],
     summary="Execute SQL Query",
-    description="Execute SQL query directly against the database",
+    description="Execute SQL query directly against the database. Returns an execute_task_id that can be used to stop the execution.",
 )
 async def execute_sql(
     request: ExecuteSQLInput,
     svc: ServiceDep,
 ) -> Result[ExecuteSQLData]:
     """Execute SQL query directly."""
-    return svc.cli.execute_sql(request)
+    return await svc.cli.execute_sql(request)
+
+
+@router.post(
+    "/sql/stop_execute",
+    response_model=Result[StopExecuteSQLData],
+    summary="Stop SQL Execution",
+    description="Stop a running SQL execution by its execute_task_id",
+)
+async def stop_execute_sql(
+    request: StopExecuteSQLInput,
+    svc: ServiceDep,
+) -> Result[StopExecuteSQLData]:
+    """Stop a running SQL execution."""
+    return await svc.cli.stop_execute_sql(request.execute_task_id)
 
 
 @router.post(

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -2,7 +2,10 @@
 Service for handling CLI Command operations.
 """
 
+import asyncio
+import threading
 import time
+import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -31,6 +34,7 @@ from datus.api.models.cli_models import (
     SearchHistoryToolInput,
     SearchMetricsResult,
     SearchMetricsToolInput,
+    StopExecuteSQLData,
     TableInfo,
     TableMetadata,
 )
@@ -90,6 +94,10 @@ class CLIService:
         self.agent = None
         self.agent_ready = False
 
+        # Track running SQL execution tasks: {task_id: asyncio.Task}
+        self._sql_tasks: Dict[str, asyncio.Task] = {}
+        self._sql_tasks_lock = threading.Lock()
+
         # Initialize context search tools and output tool
         self.context_search_tools = None
         self.output_tool = None
@@ -143,16 +151,13 @@ class CLIService:
                 return False
         return self.agent_ready
 
-    def execute_sql(self, request: ExecuteSQLInput) -> Result[ExecuteSQLData]:
-        """
-        Execute SQL query.
+    def _cleanup_sql_task(self, task_id: str) -> None:
+        """Remove a completed SQL task from the tracking dict."""
+        with self._sql_tasks_lock:
+            self._sql_tasks.pop(task_id, None)
 
-        Args:
-            request: SQL execution request
-
-        Returns:
-            ExecuteSQLResult with query result
-        """
+    def _execute_sql_sync(self, request: ExecuteSQLInput, task_id: str) -> Result[ExecuteSQLData]:
+        """Synchronous SQL execution logic (runs in a thread)."""
         try:
             if not self.current_db_connector:
                 return Result(
@@ -162,8 +167,6 @@ class CLIService:
                 )
 
             # Switch to the requested database/catalog context before executing.
-            # The connector is initialized without an active database; callers
-            # pass database_name per-request to select the correct one.
             if request.database_name:
                 catalog = getattr(self.current_db_connector, "catalog_name", "") or ""
                 self.current_db_connector.switch_context(
@@ -196,7 +199,6 @@ class CLIService:
             exec_time = end_time - start_time
 
             if not result:
-                # Update action with error
                 actions.update_action_by_id(
                     sql_action.action_id,
                     status=ActionStatus.FAILED,
@@ -210,15 +212,12 @@ class CLIService:
                 )
 
             if result.success:
-                # Convert result data based on format
                 sql_return = None
                 row_count = None
                 columns = None
 
                 if hasattr(result.sql_return, "column_names"):
-                    # Arrow format
                     if request.result_format == "csv":
-                        # Convert Arrow to CSV
                         import csv
                         import io
 
@@ -230,23 +229,19 @@ class CLIService:
                             writer.writerows(rows)
                         sql_return = output.getvalue()
                     elif request.result_format == "json":
-                        # Convert Arrow to JSON
                         import json
 
                         rows = result.sql_return.to_pylist()
                         sql_return = json.dumps(rows)
                     else:
-                        # Keep as Arrow string representation
                         sql_return = str(result.sql_return)
 
                     row_count = result.sql_return.num_rows
                     columns = result.sql_return.column_names
                 else:
-                    # Non-Arrow result
                     sql_return = str(result.sql_return) if result.sql_return else ""
                     row_count = result.row_count
 
-                # Update action with success
                 actions.update_action_by_id(
                     sql_action.action_id,
                     status=ActionStatus.SUCCESS,
@@ -260,6 +255,7 @@ class CLIService:
                 )
 
                 data = ExecuteSQLData(
+                    execute_task_id=task_id,
                     sql_query=request.sql_query,
                     row_count=row_count,
                     sql_return=sql_return,
@@ -273,7 +269,6 @@ class CLIService:
             else:
                 error_msg = result.error or "Unknown SQL error"
 
-                # Update action with error
                 actions.update_action_by_id(
                     sql_action.action_id,
                     status=ActionStatus.FAILED,
@@ -294,6 +289,69 @@ class CLIService:
                 errorCode=ErrorCode.SQL_EXECUTION_ERROR,
                 errorMessage=str(e),
             )
+
+    async def execute_sql(self, request: ExecuteSQLInput) -> Result[ExecuteSQLData]:
+        """Execute SQL query asynchronously with cancellation support.
+
+        Returns a Result containing an execute_task_id that can be used
+        to stop the execution via stop_execute_sql().
+        """
+        task_id = str(uuid.uuid4())
+
+        async def _run() -> Result[ExecuteSQLData]:
+            try:
+                return await asyncio.to_thread(self._execute_sql_sync, request, task_id)
+            except asyncio.CancelledError:
+                logger.info(f"SQL execution task cancelled: {task_id}")
+                return Result(
+                    success=False,
+                    errorCode=ErrorCode.SQL_EXECUTION_ERROR,
+                    errorMessage="SQL execution was cancelled",
+                )
+            finally:
+                self._cleanup_sql_task(task_id)
+
+        task = asyncio.create_task(_run())
+        with self._sql_tasks_lock:
+            self._sql_tasks[task_id] = task
+
+        return await task
+
+    async def stop_execute_sql(self, task_id: str) -> Result[StopExecuteSQLData]:
+        """Stop a running SQL execution task.
+
+        Args:
+            task_id: The execute_task_id returned from execute_sql.
+
+        Returns:
+            Result indicating whether the task was stopped.
+        """
+        with self._sql_tasks_lock:
+            task = self._sql_tasks.get(task_id)
+
+        if not task:
+            return Result(
+                success=False,
+                errorCode=ErrorCode.SQL_EXECUTION_ERROR,
+                errorMessage=f"No running SQL execution found for task ID: {task_id}",
+                data=StopExecuteSQLData(execute_task_id=task_id, stopped=False),
+            )
+
+        if task.done():
+            self._cleanup_sql_task(task_id)
+            return Result(
+                success=False,
+                errorCode=ErrorCode.SQL_EXECUTION_ERROR,
+                errorMessage="SQL execution has already completed",
+                data=StopExecuteSQLData(execute_task_id=task_id, stopped=False),
+            )
+
+        task.cancel()
+        logger.info(f"Cancellation requested for SQL execution task: {task_id}")
+        return Result(
+            success=True,
+            data=StopExecuteSQLData(execute_task_id=task_id, stopped=True),
+        )
 
     def execute_tool(self, tool_name: str, request: Any) -> Result[ExecuteToolData]:
         """Execute Tool Commands API as defined in the design."""

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -1,5 +1,7 @@
 """Tests for datus.api.services.cli_service — CLI command operations."""
 
+import asyncio
+
 import pytest
 
 from datus.api.models.cli_models import ExecuteContextInput, ExecuteSQLInput
@@ -50,79 +52,146 @@ class TestCLIServiceInit:
 class TestCLIServiceExecuteSQL:
     """Tests for execute_sql with real SQLite."""
 
-    def test_execute_sql_select_success(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_select_success(self, cli_svc):
         """execute_sql runs a SELECT query and returns data."""
         request = ExecuteSQLInput(sql_query="SELECT COUNT(*) as cnt FROM schools")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is True
         assert result.data is not None
         assert result.data.sql_query == "SELECT COUNT(*) as cnt FROM schools"
         assert result.data.execution_time > 0
+        assert result.data.execute_task_id is not None
 
-    def test_execute_sql_returns_row_count(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_returns_row_count(self, cli_svc):
         """execute_sql reports row count."""
         request = ExecuteSQLInput(sql_query="SELECT * FROM schools LIMIT 5")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is True
         assert result.data.row_count is not None
 
-    def test_execute_sql_csv_format(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_csv_format(self, cli_svc):
         """execute_sql with csv format returns CSV string."""
         request = ExecuteSQLInput(sql_query="SELECT CDSCode, School FROM schools LIMIT 3", result_format="csv")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is True
         if result.data.sql_return:
             assert "CDSCode" in result.data.sql_return or "School" in result.data.sql_return
 
-    def test_execute_sql_json_format(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_json_format(self, cli_svc):
         """execute_sql with json format returns JSON string."""
         request = ExecuteSQLInput(sql_query="SELECT CDSCode FROM schools LIMIT 2", result_format="json")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is True
 
-    def test_execute_sql_invalid_sql_returns_error(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_invalid_sql_returns_error(self, cli_svc):
         """execute_sql with invalid SQL returns error."""
         request = ExecuteSQLInput(sql_query="SELCT INVALID SYNTAX")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is False
 
-    def test_execute_sql_without_connector_returns_error(self):
+    @pytest.mark.asyncio
+    async def test_execute_sql_without_connector_returns_error(self):
         """execute_sql returns error when no connector available."""
         svc = CLIService(agent_config=None, chat_service=None)
         request = ExecuteSQLInput(sql_query="SELECT 1")
-        result = svc.execute_sql(request)
+        result = await svc.execute_sql(request)
         assert result.success is False
         assert "No database connection" in result.errorMessage
 
-    def test_execute_sql_with_columns(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_with_columns(self, cli_svc):
         """execute_sql returns column names when available."""
         request = ExecuteSQLInput(sql_query="SELECT CDSCode, School FROM schools LIMIT 1")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is True
 
-    def test_execute_sql_arrow_default_format(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_arrow_default_format(self, cli_svc):
         """execute_sql with default format returns arrow string."""
         request = ExecuteSQLInput(sql_query="SELECT CDSCode FROM schools LIMIT 3", result_format="arrow")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is True
         assert result.data.row_count is not None
 
-    def test_execute_sql_has_executed_at(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_has_executed_at(self, cli_svc):
         """execute_sql result includes executed_at timestamp."""
         request = ExecuteSQLInput(sql_query="SELECT 1 as val")
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         assert result.success is True
         assert result.data.executed_at is not None
 
-    def test_execute_sql_with_database_name(self, cli_svc):
+    @pytest.mark.asyncio
+    async def test_execute_sql_with_database_name(self, cli_svc):
         """execute_sql with database_name parameter."""
         request = ExecuteSQLInput(
             sql_query="SELECT COUNT(*) FROM schools",
             database_name="california_schools",
         )
-        result = cli_svc.execute_sql(request)
+        result = await cli_svc.execute_sql(request)
         # May or may not work with switch_context — exercise the code path
         assert result is not None
+
+
+class TestCLIServiceStopExecuteSQL:
+    """Tests for stop_execute_sql."""
+
+    @pytest.mark.asyncio
+    async def test_stop_nonexistent_task_returns_error(self, cli_svc):
+        """stop_execute_sql with unknown task_id returns error."""
+        result = await cli_svc.stop_execute_sql("nonexistent-task-id")
+        assert result.success is False
+        assert result.data.stopped is False
+        assert "No running SQL execution" in result.errorMessage
+
+    @pytest.mark.asyncio
+    async def test_stop_completed_task_returns_error(self, cli_svc):
+        """stop_execute_sql on a completed task returns already-completed error."""
+        request = ExecuteSQLInput(sql_query="SELECT 1 as val")
+        exec_result = await cli_svc.execute_sql(request)
+        assert exec_result.success is True
+        task_id = exec_result.data.execute_task_id
+
+        # Task is already completed and cleaned up
+        stop_result = await cli_svc.stop_execute_sql(task_id)
+        assert stop_result.success is False
+        assert stop_result.data.stopped is False
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_returns_execute_task_id(self, cli_svc):
+        """execute_sql result contains a non-empty execute_task_id."""
+        request = ExecuteSQLInput(sql_query="SELECT 1 as val")
+        result = await cli_svc.execute_sql(request)
+        assert result.success is True
+        assert result.data.execute_task_id
+        assert len(result.data.execute_task_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_stop_running_task(self):
+        """stop_execute_sql cancels a running task."""
+        svc = CLIService(agent_config=None, chat_service=None)
+
+        # Manually inject a long-running task to simulate a slow SQL execution
+        async def _slow_task():
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_slow_task())
+        task_id = "test-stop-task"
+        svc._sql_tasks[task_id] = task
+
+        stop_result = await svc.stop_execute_sql(task_id)
+        assert stop_result.success is True
+        assert stop_result.data.stopped is True
+        assert stop_result.data.execute_task_id == task_id
+
+        # Give the event loop a chance to process the cancellation
+        await asyncio.sleep(0)
+        assert task.cancelled()
 
 
 class TestCLIServiceExecuteTool:


### PR DESCRIPTION
## Why

When executing long-running SQL queries via `POST /api/v1/sql/execute`, there was no way for clients to cancel a query in progress. Users had to wait for the query to complete or time out, which is a poor experience for heavy analytical queries.

## Solution

- **New endpoint**: `POST /api/v1/sql/stop_execute` accepts an `execute_task_id` and cancels the corresponding running SQL execution task.
- **Task tracking in `CLIService`**: `execute_sql()` is now async — the synchronous DB call runs in a background thread via `asyncio.to_thread()`, wrapped in a tracked `asyncio.Task` keyed by a UUID (`execute_task_id`). Tasks are automatically cleaned up on completion.
- **`ExecuteSQLData` updated**: Now includes `execute_task_id` in the response so clients can reference the running task for cancellation.
- **New models**: `StopExecuteSQLInput` (request) and `StopExecuteSQLData` (response) in `cli_models.py`.
- Follows existing cancellation patterns in the codebase (`stream_cancellation.py`, `ChatTaskManager`).

## Test Cases

- Updated all existing `TestCLIServiceExecuteSQL` tests to async (`@pytest.mark.asyncio`) to match the new async `execute_sql()` signature.
- Added `TestCLIServiceStopExecuteSQL` with 4 tests:
  - `test_stop_nonexistent_task_returns_error` — unknown task ID returns failure.
  - `test_stop_completed_task_returns_error` — already-finished task returns failure.
  - `test_execute_sql_returns_execute_task_id` — verifies task ID is present in response.
  - `test_stop_running_task` — injects a slow task and verifies cancellation succeeds.
- Full unit test suite passes (57 tests in `test_cli_service.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQL execution operations can now be stopped or cancelled mid-execution using a unique task identifier.
  * The Execute SQL endpoint now returns a task ID for tracking and cancellation requests.
  * New API endpoint added to stop SQL executions.

* **Tests**
  * Added comprehensive test coverage for SQL execution stopping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->