### PR TITLE
[Feature] Add multi-select support for ask_user_tool in API layer

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -440,7 +440,10 @@ class UserInteractionInput(BaseModel):
 
     session_id: str = Field(..., description="Session ID for the active chat task")
     interaction_key: str = Field(..., description="Interaction key (action_id) for the interaction request")
-    input: List[str] = Field(..., description="List of user answers, one per request")
+    input: List[List[str]] = Field(
+        ...,
+        description="List of user answers, one per request. Single-select: ['key'], multi-select: ['key1', 'key2'].",
+    )
 
 
 class StreamChatChunk(BaseModel):

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -201,7 +201,14 @@ async def submit_user_interaction(
             errorMessage="Interaction broker not found for this session",
         )
 
-    user_choice = request.input[0] if len(request.input) == 1 else json.dumps(request.input)
+    # Convert List[List[str]] → broker format
+    # Single-element lists unwrap to string, multi-element stay as list
+    answers = [ans[0] if len(ans) == 1 else ans for ans in request.input]
+    if len(answers) == 1:
+        answer = answers[0]
+        user_choice = json.dumps(answer) if isinstance(answer, list) else answer
+    else:
+        user_choice = json.dumps(answers)
     success = await broker.submit(request.interaction_key, user_choice)
     return Result[dict](
         success=success,

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -156,6 +156,7 @@ def _build_interaction_content(action: ActionHistory) -> List[IMessageContent]:
     contents = input_data.get("contents", [])
     choices_list = input_data.get("choices", [])
     default_choices = input_data.get("default_choices", [])
+    multi_selects = input_data.get("multi_selects", [])
     content_type = input_data.get("content_type", "markdown")
     allow_free_text = input_data.get("allow_free_text", False)
 
@@ -164,6 +165,7 @@ def _build_interaction_content(action: ActionHistory) -> List[IMessageContent]:
         choices = choices_list[i] if i < len(choices_list) else {}
         options = [{"key": k, "title": v} for k, v in choices.items()] if choices else None
         default_choice = default_choices[i] if i < len(default_choices) else ""
+        allow_multi_select = multi_selects[i] if i < len(multi_selects) else False
         requests_payload.append(
             {
                 "content": content,
@@ -171,6 +173,7 @@ def _build_interaction_content(action: ActionHistory) -> List[IMessageContent]:
                 "defaultChoice": default_choice,
                 "contentType": content_type,
                 "allowFreeText": allow_free_text,
+                "multiSelect": allow_multi_select,
             }
         )
 

--- a/tests/unit_tests/api/models/test_cli_models.py
+++ b/tests/unit_tests/api/models/test_cli_models.py
@@ -2,9 +2,12 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Unit tests for SSEEndData token fields in datus/api/models/cli_models.py."""
+"""Unit tests for datus/api/models/cli_models.py."""
 
-from datus.api.models.cli_models import SSEEndData
+import pytest
+from pydantic import ValidationError
+
+from datus.api.models.cli_models import SSEEndData, UserInteractionInput
 
 
 class TestSSEEndDataTokenFields:
@@ -61,3 +64,34 @@ class TestSSEEndDataTokenFields:
         assert "input_tokens" in d
         assert d["input_tokens"] == 42
         assert d["output_tokens"] == 0
+
+
+class TestUserInteractionInput:
+    """Tests for UserInteractionInput with List[List[str]] input type."""
+
+    def test_single_select(self):
+        """Single-select: input=[['2']]."""
+        obj = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["2"]])
+        assert obj.input == [["2"]]
+
+    def test_multi_select(self):
+        """Multi-select: input=[['1','3']]."""
+        obj = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["1", "3"]])
+        assert obj.input == [["1", "3"]]
+
+    def test_batch_mixed(self):
+        """Batch: single + multi select."""
+        obj = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["2"], ["1", "3"]])
+        assert len(obj.input) == 2
+        assert obj.input[0] == ["2"]
+        assert obj.input[1] == ["1", "3"]
+
+    def test_rejects_flat_strings(self):
+        """Old format List[str] should be rejected by validation."""
+        with pytest.raises(ValidationError):
+            UserInteractionInput(session_id="s1", interaction_key="k1", input=["2", "3"])
+
+    def test_rejects_empty_input(self):
+        """Missing input raises validation error."""
+        with pytest.raises(ValidationError):
+            UserInteractionInput(session_id="s1", interaction_key="k1")

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -1,0 +1,117 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/api/routes/chat_routes.py — submit_user_interaction endpoint."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from datus.api.models.cli_models import UserInteractionInput
+from datus.api.routes.chat_routes import submit_user_interaction
+
+
+def _mock_svc(task=None):
+    """Build a mock DatusService with task_manager."""
+    svc = MagicMock()
+    svc.task_manager.get_task.return_value = task
+    return svc
+
+
+def _mock_task(broker_submit_return=True):
+    """Build a mock task with node and interaction_broker."""
+    task = MagicMock()
+    task.node.interaction_broker = AsyncMock()
+    task.node.interaction_broker.submit = AsyncMock(return_value=broker_submit_return)
+    return task
+
+
+class TestSubmitUserInteractionConversion:
+    """Tests for the List[List[str]] → broker format conversion."""
+
+    @pytest.mark.asyncio
+    async def test_single_question_single_select(self):
+        """input=[['2']] → broker receives '2' (plain string)."""
+        task = _mock_task()
+        svc = _mock_svc(task=task)
+        request = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["2"]])
+
+        result = await submit_user_interaction(request, svc)
+
+        task.node.interaction_broker.submit.assert_called_once_with("k1", "2")
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_single_question_multi_select(self):
+        """input=[['1','3']] → broker receives '["1", "3"]' (JSON array string)."""
+        task = _mock_task()
+        svc = _mock_svc(task=task)
+        request = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["1", "3"]])
+
+        result = await submit_user_interaction(request, svc)
+
+        submitted = task.node.interaction_broker.submit.call_args[0][1]
+        assert json.loads(submitted) == ["1", "3"]
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_batch_mixed(self):
+        """input=[['2'], ['1','3']] → broker receives '["2", ["1", "3"]]'."""
+        task = _mock_task()
+        svc = _mock_svc(task=task)
+        request = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["2"], ["1", "3"]])
+
+        result = await submit_user_interaction(request, svc)
+
+        submitted = task.node.interaction_broker.submit.call_args[0][1]
+        assert json.loads(submitted) == ["2", ["1", "3"]]
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_batch_all_single_select(self):
+        """input=[['a'], ['b']] → broker receives '["a", "b"]'."""
+        task = _mock_task()
+        svc = _mock_svc(task=task)
+        request = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["a"], ["b"]])
+
+        await submit_user_interaction(request, svc)
+
+        submitted = task.node.interaction_broker.submit.call_args[0][1]
+        assert json.loads(submitted) == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_session_not_found(self):
+        """Returns error when task is not found."""
+        svc = _mock_svc(task=None)
+        request = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["1"]])
+
+        result = await submit_user_interaction(request, svc)
+
+        assert result.success is False
+        assert result.errorCode == "SESSION_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_broker_not_found(self):
+        """Returns error when broker is None."""
+        task = MagicMock()
+        task.node.interaction_broker = None
+        svc = _mock_svc(task=task)
+        request = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["1"]])
+
+        result = await submit_user_interaction(request, svc)
+
+        assert result.success is False
+        assert result.errorCode == "BROKER_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_broker_submit_failure(self):
+        """Returns success=False when broker.submit returns False."""
+        task = _mock_task(broker_submit_return=False)
+        svc = _mock_svc(task=task)
+        request = UserInteractionInput(session_id="s1", interaction_key="k1", input=[["1"]])
+
+        result = await submit_user_interaction(request, svc)
+
+        assert result.success is False

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -331,6 +331,56 @@ class TestBuildInteractionContent:
         contents = _build_interaction_content(action)
         assert contents[0].payload["requests"] == []
 
+    def test_multi_select_field_present(self):
+        """multiSelect field is included in SSE payload when multi_selects is provided."""
+        action = _make_action(
+            action_id="interact-3",
+            action_type="ask_user",
+            input={
+                "contents": ["Pick databases:"],
+                "choices": [{"db1": "DB 1", "db2": "DB 2"}],
+                "default_choices": [""],
+                "multi_selects": [True],
+            },
+        )
+        contents = _build_interaction_content(action)
+        req = contents[0].payload["requests"][0]
+        assert req["multiSelect"] is True
+
+    def test_multi_select_defaults_to_false(self):
+        """multiSelect defaults to False when multi_selects is not provided."""
+        action = _make_action(
+            action_id="interact-4",
+            action_type="ask_user",
+            input={
+                "contents": ["Pick one:"],
+                "choices": [{"a": "A"}],
+                "default_choices": ["a"],
+            },
+        )
+        contents = _build_interaction_content(action)
+        req = contents[0].payload["requests"][0]
+        assert req["multiSelect"] is False
+
+    def test_multi_select_batch_mixed(self):
+        """Batch with mixed multi_selects values."""
+        action = _make_action(
+            action_id="interact-5",
+            action_type="ask_user",
+            input={
+                "contents": ["Single select:", "Multi select:", "No flag:"],
+                "choices": [{"a": "A"}, {"b": "B", "c": "C"}, {"d": "D"}],
+                "default_choices": ["a", "", ""],
+                "multi_selects": [False, True],
+            },
+        )
+        contents = _build_interaction_content(action)
+        requests = contents[0].payload["requests"]
+        assert len(requests) == 3
+        assert requests[0]["multiSelect"] is False
+        assert requests[1]["multiSelect"] is True
+        assert requests[2]["multiSelect"] is False  # defaults when index out of range
+
 
 class TestBuildInteractionResultContent:
     """Tests for _build_interaction_result_content."""


### PR DESCRIPTION
- Add multiSelect field to SSE interaction payload from multi_selects input
- Change UserInteractionInput.input type from List[str] to List[List[str]]
- Convert List[List[str]] to broker-compatible format in route handler
- Add unit tests for SSE converter, model validation, and route handler

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-select support for user interaction responses. Users can now submit multiple selections simultaneously, with the system intelligently handling both single-select and multi-select scenarios in batch operations.

* **Tests**
  * Expanded and enhanced test coverage for user interaction submission, including comprehensive validation for single-select, multi-select, and mixed batch response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->