### PR TITLE
[Doc] Fix provider docs for current configure flow

### DIFF
--- a/docs/API/chat.zh.md
+++ b/docs/API/chat.zh.md
@@ -173,7 +173,7 @@ X-Accel-Buffering: no
 }
 ```
 
-- 大多数流式事件的 `type` 为 `createMessage`。开启 [Thinking-delta 流式下发](#thinking-delta-流式下发) 后,
+- 大多数流式事件的 `type` 为 `createMessage`。开启 [Thinking-delta 流式下发](#thinking-delta-streaming) 后,
   还会出现 `appendMessage` 和 `updateMessage`。客户端遇到未知 `type` 应优雅忽略。
 - 流式期间 `role` 始终为 `assistant`;`GET /chat/history` 拉取时,用户消息会以 `role: "user"` 出现。
 - `message_id` 即 action id;当 content 为用户交互时,**它同时也是 `interactionKey`**(详见下文)。
@@ -325,7 +325,7 @@ Agent 需要用户做决策才能继续时下发。SSE 流随后暂停,直到通
 > 外层 `MessageData.payload` 将携带 `depth: 1` 和指向触发该 sub-agent 的 `task()` 工具调用的
 > `parent_action_id`。完整 payload 结构参见 [MessageData](#messagedata)。
 
-### Thinking-delta 流式下发
+### Thinking-delta 流式下发 {#thinking-delta-streaming}
 
 `stream_response` 字段控制 LLM 的 thinking 内容是逐 token 增量下发,还是作为单条完整消息一次性下发。
 

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -47,16 +47,61 @@ models:
 
 ## Supported LLM Providers
 
-Datus Agent supports a wide range of LLM providers through standardized interfaces:
+Providers selected in `datus-agent configure` are written into `agent.models`, and `agent.target` points to the default one. In practice:
 
-| Provider | Models | Interface Type |
-|----------|--------|----------------|
-| **OpenAI** | GPT-4, GPT-5, and other OpenAI models | `openai` |
-| **Anthropic** | Claude 4 (Sonnet, Opus) and Claude 3 models | `claude` |
-| **Google** | Gemini models (Pro, Flash, Ultra) | `gemini` |
-| **DeepSeek** | DeepSeek Chat and DeepSeek Reasoning models | `deepseek` |
-| **Kimi** | Moonshot AI's Kimi models | `openai` |
-| **Qwen** | Alibaba's Qwen series models | `openai` |
+- The provider name you choose in `datus-agent configure` becomes the key under `agent.models.<provider>`
+- You can later edit `agent.yml` manually and bind different nodes to different model entries
+
+### General-purpose providers
+
+| Provider | Typical models | Interface Type | Auth |
+|----------|----------------|----------------|------|
+| `openai` | `gpt-5.2`, `gpt-4.1`, `o3` | `openai` | API key |
+| `deepseek` | `deepseek-chat`, `deepseek-reasoner` | `deepseek` | API key |
+| `claude` | `claude-sonnet-4-5`, `claude-opus-4-5` | `claude` | API key |
+| `kimi` | `kimi-k2.5`, `kimi-k2-thinking` | `kimi` | API key |
+| `qwen` | `qwen3-max`, `qwen3-coder-plus` | `openai` | API key |
+| `gemini` | `gemini-2.5-flash`, `gemini-2.5-pro` | `gemini` | API key |
+| `minimax` | `MiniMax-M2.7`, `MiniMax-M2.5` | `minimax` | API key |
+| `glm` | `glm-5`, `glm-4.7` | `glm` | API key |
+
+### Special-auth providers
+
+| Provider | Interface Type | Auth | Notes |
+|----------|----------------|------|-------|
+| `claude_subscription` | `claude` | Claude subscription token | The wizard first tries to auto-detect a local subscription credential and otherwise prompts for `sk-ant-oat01-...` |
+| `codex` | `codex` | OAuth | Uses locally available Codex OAuth credentials and verifies connectivity |
+
+### Coding Plan providers
+
+These providers target coding/planning-oriented endpoints. Even though their names include `coding`, they are configured exactly like any other model entry and can be used as `agent.target` or referenced from node-level `model` fields.
+
+| Provider | Default model | Interface Type | Notes |
+|----------|---------------|----------------|-------|
+| `alibaba_coding` | `qwen3-coder-plus` | `claude` | DashScope Anthropic-compatible coding endpoint |
+| `glm_coding` | `glm-5` | `claude` | GLM Anthropic-compatible coding endpoint |
+| `minimax_coding` | `MiniMax-M2.7` | `claude` | MiniMax Anthropic-compatible coding endpoint |
+| `kimi_coding` | `kimi-for-coding` | `claude` | Kimi coding endpoint |
+
+!!! tip "When to choose a coding plan provider"
+    If your priority is general chat, SQL generation, or cost efficiency, start with a regular provider.
+
+    If you want a default model that is better aligned with planning, code generation, and structured task decomposition, or if you use [Plan Mode](../cli/plan_mode.md) frequently, add one of the `*_coding` providers and route specific nodes to it.
+
+### Environment variables and model overrides
+
+All providers support environment-variable references in `api_key`, for example:
+
+```yaml
+api_key: ${OPENAI_API_KEY}
+```
+
+For OpenAI, DeepSeek, Claude, Kimi, Qwen, and Gemini, the configuration wizard can prompt with provider-specific environment variable hints. For `minimax`, `glm`, and the `*_coding` providers, you can still enter values such as `${MINIMAX_API_KEY}`, `${GLM_API_KEY}`, `${KIMI_API_KEY}`, or `${DASHSCOPE_API_KEY}` directly.
+
+The current implementation also auto-applies fixed parameter overrides for a few models:
+
+- `kimi-k2.5`: `temperature: 1.0`, `top_p: 0.95`
+- `qwen3-coder-plus`: `temperature: 1.0`, `top_p: 0.95`
 
 ### Provider Configuration Examples
 
@@ -67,17 +112,17 @@ Datus Agent supports a wide range of LLM providers through standardized interfac
       type: openai
       base_url: https://api.openai.com/v1
       api_key: ${OPENAI_API_KEY}
-      model: gpt-4-turbo
+      model: gpt-5.2
     ```
 
 === "Anthropic Claude"
 
     ```yaml
-    anthropic:
+    claude:
       type: claude
       base_url: https://api.anthropic.com
       api_key: ${ANTHROPIC_API_KEY}
-      model: claude-sonnet-4-20250514
+      model: claude-sonnet-4-5
     ```
 
 === "DeepSeek"
@@ -93,7 +138,7 @@ Datus Agent supports a wide range of LLM providers through standardized interfac
 === "Google Gemini"
 
     ```yaml
-    google:
+    gemini:
       type: gemini
       base_url: https://generativelanguage.googleapis.com/v1beta
       api_key: ${GEMINI_API_KEY}
@@ -104,30 +149,54 @@ Datus Agent supports a wide range of LLM providers through standardized interfac
 
     ```yaml
     kimi:
-      type: openai  # Uses OpenAI-compatible interface
+      type: kimi
       base_url: https://api.moonshot.cn/v1
       api_key: ${KIMI_API_KEY}
-      model: kimi-k2-turbo-preview
+      model: kimi-k2.5
     ```
 
 === "Qwen (Alibaba)"
 
     ```yaml
     qwen:
-      type: openai  # Uses OpenAI-compatible interface
+      type: openai
       base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
-      api_key: ${QWEN_API_KEY}
-      model: qwen-turbo
+      api_key: ${DASHSCOPE_API_KEY}
+      model: qwen3-max
     ```
 
-=== "Azure OpenAI"
+=== "Alibaba Coding Plan"
 
     ```yaml
-    azure_openai:
-      type: openai
-      base_url: https://${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_DEPLOYMENT_NAME}
-      api_key: ${AZURE_OPENAI_API_KEY}
-      model: gpt-4
+    alibaba_coding:
+      type: claude
+      base_url: https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
+      api_key: ${DASHSCOPE_API_KEY}
+      model: qwen3-coder-plus
+      temperature: 1.0
+      top_p: 0.95
+    ```
+
+=== "Claude Subscription"
+
+    ```yaml
+    claude_subscription:
+      type: claude
+      base_url: https://api.anthropic.com
+      api_key: ${CLAUDE_CODE_OAUTH_TOKEN}
+      model: claude-sonnet-4-6
+      auth_type: subscription
+    ```
+
+=== "Codex"
+
+    ```yaml
+    codex:
+      type: codex
+      base_url: https://chatgpt.com/backend-api/codex
+      api_key: ""
+      model: codex-mini-latest
+      auth_type: oauth
     ```
 
 ## Complete Configuration Example
@@ -137,41 +206,37 @@ Here's a comprehensive agent configuration example with multiple providers:
 ```yaml title="datus-config.yaml"
 # Complete Datus Agent Configuration
 agent:
-  target: openai  # Default model for all operations
+  target: alibaba_coding
+  models:
+    openai:
+      type: openai
+      base_url: https://api.openai.com/v1
+      api_key: ${OPENAI_API_KEY}
+      model: gpt-5.2
 
-models:
-  # Production OpenAI configuration
-  openai:
-    type: openai
-    base_url: https://api.openai.com/v1
-    api_key: ${OPENAI_API_KEY}
-    model: gpt-4-turbo
-    
-  # Alternative Google Gemini
-  google:
-    type: gemini
-    base_url: https://generativelanguage.googleapis.com/v1beta
-    api_key: ${GEMINI_API_KEY}
-    model: gemini-2.5-flash
-    
-  # Anthropic Claude for reasoning
-  anthropic:
-    type: claude
-    base_url: https://api.anthropic.com
-    api_key: ${ANTHROPIC_API_KEY}
-    model: claude-sonnet-4-20250514
-    
-  # Cost-effective DeepSeek
-  deepseek_v3:
-    type: deepseek
-    base_url: https://api.deepseek.com
-    api_key: ${DEEPSEEK_API_KEY}
-    model: deepseek-chat
-    
-  # Azure OpenAI (Enterprise)
-  azure_openai:
-    type: openai
-    base_url: https://${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_DEPLOYMENT_NAME}
-    api_key: ${AZURE_OPENAI_API_KEY}
-    model: gpt-4
+    gemini:
+      type: gemini
+      base_url: https://generativelanguage.googleapis.com/v1beta
+      api_key: ${GEMINI_API_KEY}
+      model: gemini-2.5-flash
+
+    claude:
+      type: claude
+      base_url: https://api.anthropic.com
+      api_key: ${ANTHROPIC_API_KEY}
+      model: claude-sonnet-4-5
+
+    deepseek:
+      type: deepseek
+      base_url: https://api.deepseek.com
+      api_key: ${DEEPSEEK_API_KEY}
+      model: deepseek-chat
+
+    alibaba_coding:
+      type: claude
+      base_url: https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
+      api_key: ${DASHSCOPE_API_KEY}
+      model: qwen3-coder-plus
+      temperature: 1.0
+      top_p: 0.95
 ```

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -26,12 +26,14 @@ Configure LLM providers that your agent can use. Each model configuration includ
 - **`model`** - Specific model name to use from the provider
 
 ```yaml
-models:
-  provider_name:
-    type: provider_type
-    base_url: https://api.example.com/v1
-    api_key: ${API_KEY_ENV_VAR}
-    model: model-name
+agent:
+  target: provider_name
+  models:
+    provider_name:
+      type: provider_type
+      base_url: https://api.example.com/v1
+      api_key: ${API_KEY_ENV_VAR}
+      model: model-name
 ```
 
 !!! tip "Environment Variables"

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -23,12 +23,14 @@ agent:
 - `model`：具体模型名
 
 ```yaml
-models:
-  provider_name:
-    type: provider_type
-    base_url: https://api.example.com/v1
-    api_key: ${API_KEY_ENV_VAR}
-    model: model-name
+agent:
+  target: provider_name
+  models:
+    provider_name:
+      type: provider_type
+      base_url: https://api.example.com/v1
+      api_key: ${API_KEY_ENV_VAR}
+      model: model-name
 ```
 
 !!! tip "环境变量"

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -41,14 +41,61 @@ models:
 
 ## 支持的提供方
 
-| 提供方 | 模型 | 接口类型 |
-|---|---|---|
-| OpenAI | GPT-4、GPT-5 等 | `openai` |
-| Anthropic | Claude 4（Sonnet、Opus）、Claude 3 | `claude` |
-| Google | Gemini（Pro、Flash、Ultra） | `gemini` |
-| DeepSeek | Chat / Reasoning | `deepseek` |
-| Kimi | Moonshot Kimi | `openai` |
-| Qwen | 阿里通义千问 | `openai` |
+初始化/配置向导中的 provider，最终都会写入 `agent.models`，并通过 `agent.target` 指定默认模型。也就是说：
+
+- 你在 `datus-agent configure` 里选择的 provider 名称，就是 `agent.models.<provider>` 的键名
+- 你也可以在后续手动编辑 `agent.yml`，把某个节点单独切换到另一套模型配置
+
+### 通用 provider
+
+| 提供方 | 典型模型 | 接口类型 | 认证方式 |
+|---|---|---|---|
+| `openai` | `gpt-5.2`、`gpt-4.1`、`o3` | `openai` | API Key |
+| `deepseek` | `deepseek-chat`、`deepseek-reasoner` | `deepseek` | API Key |
+| `claude` | `claude-sonnet-4-5`、`claude-opus-4-5` | `claude` | API Key |
+| `kimi` | `kimi-k2.5`、`kimi-k2-thinking` | `kimi` | API Key |
+| `qwen` | `qwen3-max`、`qwen3-coder-plus` | `openai` | API Key |
+| `gemini` | `gemini-2.5-flash`、`gemini-2.5-pro` | `gemini` | API Key |
+| `minimax` | `MiniMax-M2.7`、`MiniMax-M2.5` | `minimax` | API Key |
+| `glm` | `glm-5`、`glm-4.7` | `glm` | API Key |
+
+### 特殊认证 provider
+
+| 提供方 | 接口类型 | 认证方式 | 说明 |
+|---|---|---|---|
+| `claude_subscription` | `claude` | Claude 订阅 token | 优先自动探测本地订阅凭据，失败时可手动粘贴 `sk-ant-oat01-...` |
+| `codex` | `codex` | OAuth | 读取本地 Codex OAuth 凭据并校验连通性 |
+
+### Coding Plan provider
+
+这些 provider 面向编码/规划类 endpoint。虽然它们的名字里带 `coding`，但在配置层面和普通 provider 没有区别，仍然可以作为 `agent.target` 或节点级 `model` 使用。
+
+| 提供方 | 默认模型 | 接口类型 | 说明 |
+|---|---|---|---|
+| `alibaba_coding` | `qwen3-coder-plus` | `claude` | 阿里云 DashScope 的 Anthropic-compatible coding endpoint |
+| `glm_coding` | `glm-5` | `claude` | GLM 的 Anthropic-compatible coding endpoint |
+| `minimax_coding` | `MiniMax-M2.7` | `claude` | MiniMax 的 Anthropic-compatible coding endpoint |
+| `kimi_coding` | `kimi-for-coding` | `claude` | Kimi 的 coding endpoint |
+
+!!! tip "如何选择 coding plan provider"
+    如果你更看重通用问答、SQL 生成和成本控制，通常优先选择常规 provider。
+
+    如果你希望默认模型更偏向规划、代码生成、结构化拆解，或者你会频繁使用 [计划模式](../cli/plan_mode.zh.md)，可以额外配置一个 `*_coding` provider，并按节点切换使用。
+
+### 与环境变量的关系
+
+所有 provider 的 `api_key` 都支持环境变量，例如：
+
+```yaml
+api_key: ${OPENAI_API_KEY}
+```
+
+对于 OpenAI、DeepSeek、Claude、Kimi、Qwen、Gemini，配置向导会自动提示对应环境变量。对于 `minimax`、`glm` 和各类 `*_coding` provider，你也可以在输入 API Key 时直接填入 `${MINIMAX_API_KEY}`、`${GLM_API_KEY}`、`${KIMI_API_KEY}`、`${DASHSCOPE_API_KEY}` 这类环境变量引用。
+
+另外，当前实现会对少数模型自动补充固定参数覆盖：
+
+- `kimi-k2.5`：自动设置 `temperature: 1.0`、`top_p: 0.95`
+- `qwen3-coder-plus`：自动设置 `temperature: 1.0`、`top_p: 0.95`
 
 ### 配置示例
 
@@ -58,16 +105,16 @@ openai:
   type: openai
   base_url: https://api.openai.com/v1
   api_key: ${OPENAI_API_KEY}
-  model: gpt-4-turbo
+  model: gpt-5.2
 ```
 
 === "Anthropic Claude"
 ```yaml
-anthropic:
+claude:
   type: claude
   base_url: https://api.anthropic.com
   api_key: ${ANTHROPIC_API_KEY}
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-5
 ```
 
 === "DeepSeek"
@@ -81,7 +128,7 @@ deepseek:
 
 === "Google Gemini"
 ```yaml
-google:
+gemini:
   type: gemini
   base_url: https://generativelanguage.googleapis.com/v1beta
   api_key: ${GEMINI_API_KEY}
@@ -91,10 +138,10 @@ google:
 === "Kimi (Moonshot)"
 ```yaml
 kimi:
-  type: openai
+  type: kimi
   base_url: https://api.moonshot.cn/v1
   api_key: ${KIMI_API_KEY}
-  model: kimi-k2-turbo-preview
+  model: kimi-k2.5
 ```
 
 === "Qwen (Alibaba)"
@@ -102,52 +149,75 @@ kimi:
 qwen:
   type: openai
   base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
-  api_key: ${QWEN_API_KEY}
-  model: qwen-turbo
+  api_key: ${DASHSCOPE_API_KEY}
+  model: qwen3-max
 ```
 
-=== "Azure OpenAI"
+=== "Alibaba Coding Plan"
 ```yaml
-azure_openai:
-  type: openai
-  base_url: https://${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_DEPLOYMENT_NAME}
-  api_key: ${AZURE_OPENAI_API_KEY}
-  model: gpt-4
+alibaba_coding:
+  type: claude
+  base_url: https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
+  api_key: ${DASHSCOPE_API_KEY}
+  model: qwen3-coder-plus
+  temperature: 1.0
+  top_p: 0.95
+```
+
+=== "Claude Subscription"
+```yaml
+claude_subscription:
+  type: claude
+  base_url: https://api.anthropic.com
+  api_key: ${CLAUDE_CODE_OAUTH_TOKEN}
+  model: claude-sonnet-4-6
+  auth_type: subscription
+```
+
+=== "Codex"
+```yaml
+codex:
+  type: codex
+  base_url: https://chatgpt.com/backend-api/codex
+  api_key: ${CODEX_OAUTH_TOKEN}
+  model: codex-mini-latest
+  auth_type: oauth
 ```
 
 ## 完整示例
 ```yaml title="datus-config.yaml"
 agent:
-  target: openai
+  target: alibaba_coding
+  models:
+    openai:
+      type: openai
+      base_url: https://api.openai.com/v1
+      api_key: ${OPENAI_API_KEY}
+      model: gpt-5.2
 
-models:
-  openai:
-    type: openai
-    base_url: https://api.openai.com/v1
-    api_key: ${OPENAI_API_KEY}
-    model: gpt-4-turbo
+    gemini:
+      type: gemini
+      base_url: https://generativelanguage.googleapis.com/v1beta
+      api_key: ${GEMINI_API_KEY}
+      model: gemini-2.5-flash
 
-  google:
-    type: gemini
-    base_url: https://generativelanguage.googleapis.com/v1beta
-    api_key: ${GEMINI_API_KEY}
-    model: gemini-2.5-flash
+    claude:
+      type: claude
+      base_url: https://api.anthropic.com
+      api_key: ${ANTHROPIC_API_KEY}
+      model: claude-sonnet-4-5
 
-  anthropic:
-    type: claude
-    base_url: https://api.anthropic.com
-    api_key: ${ANTHROPIC_API_KEY}
-    model: claude-sonnet-4-20250514
+    deepseek:
+      type: deepseek
+      base_url: https://api.deepseek.com
+      api_key: ${DEEPSEEK_API_KEY}
+      model: deepseek-chat
 
-  deepseek_v3:
-    type: deepseek
-    base_url: https://api.deepseek.com
-    api_key: ${DEEPSEEK_API_KEY}
-    model: deepseek-chat
-
-  azure_openai:
-    type: openai
-    base_url: https://${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_DEPLOYMENT_NAME}
-    api_key: ${AZURE_OPENAI_API_KEY}
-    model: gpt-4
+    alibaba_coding:
+      type: claude
+      base_url: https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
+      api_key: ${DASHSCOPE_API_KEY}
+      model: qwen3-coder-plus
+      temperature: 1.0
+      top_p: 0.95
 ```

--- a/docs/getting_started/Quickstart.md
+++ b/docs/getting_started/Quickstart.md
@@ -75,6 +75,54 @@ Database adapter plugins (Snowflake, MySQL, PostgreSQL, StarRocks) are auto-inst
 
 Configuration is saved to `~/.datus/conf/agent.yml`. Run `datus-agent configure` again anytime to add more models or databases.
 
+#### Built-in model providers in the configuration wizard
+
+The current wizard includes these providers out of the box:
+
+| Provider | Typical models | Auth | Best for |
+|---|---|---|---|
+| `openai` | `gpt-5.2`, `gpt-4.1`, `o3` | API key with `OPENAI_API_KEY` auto-detection | General chat, reasoning, tool use |
+| `deepseek` | `deepseek-chat`, `deepseek-reasoner` | API key with `DEEPSEEK_API_KEY` auto-detection | Cost-effective reasoning and SQL generation |
+| `claude` | `claude-sonnet-4-5`, `claude-opus-4-5` | API key with `ANTHROPIC_API_KEY` auto-detection | Long context and complex reasoning |
+| `kimi` | `kimi-k2.5`, `kimi-k2-thinking` | API key with `KIMI_API_KEY` auto-detection | Chinese-heavy workloads and long context |
+| `qwen` | `qwen3-max`, `qwen3-coder-plus` | API key with `DASHSCOPE_API_KEY` auto-detection | Chinese workloads, general chat, coding |
+| `gemini` | `gemini-2.5-flash`, `gemini-2.5-pro` | API key with `GEMINI_API_KEY` auto-detection | Large-context analysis |
+| `minimax` | `MiniMax-M2.7`, `MiniMax-M2.5` | API key | General reasoning |
+| `glm` | `glm-5`, `glm-4.7` | API key | Chinese workloads and tool-calling |
+
+There are also two special auth flows:
+
+| Provider | Auth | Notes |
+|---|---|---|
+| `claude_subscription` | Claude subscription token | The wizard first tries to auto-detect a local Claude subscription credential, then falls back to manual token input |
+
+!!! note
+    `codex` still appears in the provider catalog, but the current `datus-agent configure` flow is not ready to set it up end-to-end yet. Do not rely on it as a working interactive wizard option for now.
+
+#### What are Coding Plan providers
+
+The wizard also includes coding/plan-oriented providers. These use Anthropic-compatible endpoints, but from Datus's perspective they are configured just like any other model entry in `agent.models`.
+
+| Provider | Default model | Best for |
+|---|---|---|
+| `alibaba_coding` | `qwen3-coder-plus` | One coding endpoint that can serve Qwen / GLM / Kimi / MiniMax models |
+| `glm_coding` | `glm-5` | GLM coding endpoint |
+| `minimax_coding` | `MiniMax-M2.7` | MiniMax coding endpoint |
+| `kimi_coding` | `kimi-for-coding` | Kimi coding endpoint |
+
+These are a good fit when:
+
+- You want the default model to lean toward planning, coding, or structured decomposition
+- You use [Plan Mode](../cli/plan_mode.md) frequently for multi-step tasks
+- You want to separate general-purpose chat models from coding/plan models and bind them to different nodes later
+
+!!! tip "Environment variables and model overrides"
+    For OpenAI, DeepSeek, Claude, Kimi, Qwen, and Gemini, the wizard can prompt with provider-specific environment variable hints.
+
+    For `minimax`, `glm`, and the `*_coding` providers, you can still enter environment-variable references directly, such as `${MINIMAX_API_KEY}`, `${GLM_API_KEY}`, `${KIMI_API_KEY}`, or `${DASHSCOPE_API_KEY}`.
+
+    The current implementation also auto-applies required parameter overrides for some models, such as `kimi-k2.5` and `qwen3-coder-plus`.
+
 ### Initialize Project (Optional)
 
 In your project directory, run:
@@ -558,4 +606,3 @@ Now that you're up and running with Datus, explore more advanced features:
 - **[Configuration Guide](../configuration/introduction.md)** - Connect to your own databases and customize settings
 - **[CLI Reference](../cli/introduction.md)** - Discover all available commands and options
 - **[Semantic Adapters](../adapters/semantic_adapters.md)** - Generate and query metrics with datus-semantic-metricflow
-

--- a/docs/getting_started/Quickstart.zh.md
+++ b/docs/getting_started/Quickstart.zh.md
@@ -52,43 +52,100 @@ Datus 需要 Python 3.12 运行环境，可按喜好选择以下方式：
     pip install --no-deps -i https://test.pypi.org/simple/ datus-agent
     ```
 
-### 初始化配置
+### 配置模型与数据库
 
-运行初始化命令：
+运行配置向导：
 
 ```bash
-datus-agent init
+datus-agent configure
 ```
 
-初始化流程将引导你完成：
+配置向导会引导你完成：
 
-**1. 大模型配置** —— 选择并配置首选的大模型服务（OpenAI、DeepSeek、Claude、Kimi、Qwen 等）
+**1. 添加模型** —— 选择并配置首选的大模型服务
 
-**2. 命名空间设置** —— 连接到你的数据库。想快速体验，可使用演示数据库：
+**2. 添加数据库** —— 连接到你的数据库。想快速体验，可使用演示数据库：
 
 !!! tip "演示数据库"
     Datus 提供预配置的 DuckDB 演示库，便于测试。
 
     **连接字符串：** `~/.datus/sample/duckdb-demo.duckdb`
 
-**3. 工作区配置** —— 指定 SQL 文件目录（默认：`~/.datus/workspace`）
+配置会写入 `~/.datus/conf/agent.yml`。后续如果你想追加模型或数据库，重新运行 `datus-agent configure` 即可。
 
-**4. 知识库（可选）** —— 初始化向量数据库，用于存储元数据和Reference SQL
+#### 配置向导支持的模型厂商
 
-> **注意**
-> 如果在此步骤卡住或失败，可能是国内访问 HuggingFace 官方源的问题，建议配置国内镜像地址 `export HF_ENDPOINT=https://hf-mirror.com`。
+当前配置向导内置了以下 provider：
 
-完成设置后，你就可以启动 Datus 了！
+| Provider | 典型模型 | 认证方式 | 适用场景 |
+|---|---|---|---|
+| `openai` | `gpt-5.2`、`gpt-4.1`、`o3` | API Key（支持自动识别 `OPENAI_API_KEY`） | 通用对话、推理、工具调用 |
+| `deepseek` | `deepseek-chat`、`deepseek-reasoner` | API Key（支持自动识别 `DEEPSEEK_API_KEY`） | 性价比较高的通用推理与 SQL 生成 |
+| `claude` | `claude-sonnet-4-5`、`claude-opus-4-5` | API Key（支持自动识别 `ANTHROPIC_API_KEY`） | 长上下文、复杂推理 |
+| `kimi` | `kimi-k2.5`、`kimi-k2-thinking` | API Key（支持自动识别 `KIMI_API_KEY`） | 中文场景、长上下文 |
+| `qwen` | `qwen3-max`、`qwen3-coder-plus` | API Key（支持自动识别 `DASHSCOPE_API_KEY`） | 中文场景、通用对话与编码 |
+| `gemini` | `gemini-2.5-flash`、`gemini-2.5-pro` | API Key（支持自动识别 `GEMINI_API_KEY`） | 超长上下文、多轮分析 |
+| `minimax` | `MiniMax-M2.7`、`MiniMax-M2.5` | API Key | 通用对话与推理 |
+| `glm` | `glm-5`、`glm-4.7` | API Key | 中文场景、推理与工具调用 |
+
+另外还有两类特殊入口：
+
+| Provider | 认证方式 | 说明 |
+|---|---|---|
+| `claude_subscription` | Claude 订阅 token | 向导会优先自动探测本地 Claude 订阅凭据，探测失败时可手动粘贴 `sk-ant-oat01-...` |
+
+!!! note
+    `codex` 目前虽然仍出现在 provider catalog 中，但现阶段 `datus-agent configure` 还不能稳定完成它的完整初始化流程，因此这里不把它视为当前可用的交互式配置选项。
+
+#### Coding Plan providers 是什么
+
+配置向导还提供一组面向编码/规划场景的 provider。它们底层使用 Anthropic-compatible endpoint，但在 Datus 里和普通模型一样，最终都会写入 `agent.models`，可以设为默认模型，也可以在节点级单独引用。
+
+| Provider | 默认模型 | 适合场景 |
+|---|---|---|
+| `alibaba_coding` | `qwen3-coder-plus` | 希望在同一个 coding endpoint 下使用 Qwen / GLM / Kimi / MiniMax 等模型 |
+| `glm_coding` | `glm-5` | 使用 GLM 的 coding endpoint |
+| `minimax_coding` | `MiniMax-M2.7` | 使用 MiniMax 的 coding endpoint |
+| `kimi_coding` | `kimi-for-coding` | 使用 Kimi 的 coding endpoint |
+
+这类 provider 适合以下场景：
+
+- 你希望默认模型更偏向规划、编码或结构化任务拆解
+- 你会频繁使用 [计划模式](../cli/plan_mode.zh.md) 处理复杂任务
+- 你想把通用聊天模型和 coding/plan 模型分开配置，后续按节点指定
+
+!!! tip "环境变量与参数覆盖"
+    对 OpenAI、DeepSeek、Claude、Kimi、Qwen、Gemini，向导会自动提示对应的环境变量。
+
+    对 `minimax`、`glm` 以及各类 `*_coding` provider，即使没有内置自动提示，你仍然可以直接输入 `${MINIMAX_API_KEY}`、`${GLM_API_KEY}`、`${KIMI_API_KEY}`、`${DASHSCOPE_API_KEY}` 这类环境变量引用。
+
+    其中 `kimi-k2.5` 和 `qwen3-coder-plus` 会自动附带当前实现要求的参数覆盖，例如 `temperature` 和 `top_p`。
+
+### 初始化项目（可选）
+
+如果你希望在当前项目目录生成面向 agent 的项目说明文件，再运行：
+
+```bash
+datus-agent init
+```
+
+`datus-agent init` 会读取你已经通过 `datus-agent configure` 保存的默认模型和数据库配置，扫描当前目录，并生成项目级 `AGENTS.md`。
+
+如需把某个已配置数据库的表结构摘要一并写入 `AGENTS.md`，可额外指定：
+
+```bash
+datus-agent init --database duckdb-demo
+```
 
 ## 步骤 2：启动 Datus CLI
 
-使用已配置的命名空间启动 Datus CLI：
+使用已配置的数据库启动 Datus CLI：
 
 !!! tip "配置提示"
-    你可以在 `agent.yml` 中添加多个命名空间，以连接不同的数据库。详见我们的[配置指南](../configuration/introduction.md)。
+    你可以随时通过 `datus-agent configure` 继续添加模型或数据库。详见我们的[配置指南](../configuration/introduction.md)。
 
 ```bash title="Terminal"
-datus-cli --namespace duckdb-demo
+datus-cli --database duckdb-demo
 ```
 ```{ .yaml .no-copy }
 Initializing AI capabilities in background...
@@ -96,9 +153,9 @@ Initializing AI capabilities in background...
 Datus - AI-powered SQL command-line interface
 Type '.help' for a list of commands or '.exit' to quit.
 
-Namespace duckdb selected
-Connected to duckdb using database duckdb
-Context: Current: database: duckdb
+Database duckdb-demo selected
+Connected to duckdb-demo using database duckdb-demo
+Context: Current: database: duckdb-demo
 Type SQL statements or use ! @ . commands to interact.
 Datus>
 ```
@@ -547,6 +604,3 @@ Datus 会自动分析该表，并将元数据加入上下文。
 - **[配置指南](../configuration/introduction.md)** —— 连接自有数据库并自定义设置
 - **[CLI 参考手册](../cli/introduction.md)** —— 掌握全部命令与选项
 - **[语义层适配器](../adapters/semantic_adapters.md)** —— 使用 datus-semantic-metricflow 构建与查询指标
-
-
-

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -224,17 +224,19 @@ class TestChatServiceStreamChat:
         with patch.object(tm, "_create_node", return_value=BlockingNode("dup-stream")):
             request1 = StreamChatInput(message="first", session_id="dup-stream")
             stream1 = svc.stream_chat(request1)
-            first_event = await anext(stream1)
-            assert first_event.event == "session"
-            assert "dup-stream" in tm._tasks
-
-            request2 = StreamChatInput(message="second", session_id="dup-stream")
-            stream2 = svc.stream_chat(request2)
+            stream2 = None
             try:
-                duplicate_event = await anext(stream2)
+                first_event = await asyncio.wait_for(anext(stream1), timeout=2)
+                assert first_event.event == "session"
+                assert "dup-stream" in tm._tasks
+
+                request2 = StreamChatInput(message="second", session_id="dup-stream")
+                stream2 = svc.stream_chat(request2)
+                duplicate_event = await asyncio.wait_for(anext(stream2), timeout=2)
                 assert duplicate_event.event == "error"
             finally:
                 release_first_task.set()
                 await stream1.aclose()
-                await stream2.aclose()
+                if stream2 is not None:
+                    await stream2.aclose()
                 await tm.shutdown()

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -1,5 +1,6 @@
 """Tests for datus.api.services.chat_service — chat session management."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -203,23 +204,37 @@ class TestChatServiceStreamChat:
         tm = ChatTaskManager()
         svc = ChatService(agent_config=real_agent_config, task_manager=tm, project_id="test-proj")
 
-        # Mock _create_node to avoid real storage initialization in the background task
-        mock_node = MagicMock()
-        mock_node.session_id = "dup-stream"
-        with patch.object(tm, "_create_node", return_value=mock_node):
-            # Start first chat
+        release_first_task = asyncio.Event()
+
+        class BlockingNode:
+            """Keep the first task running so duplicate-session handling is deterministic."""
+
+            def __init__(self, session_id: str):
+                self.session_id = session_id
+
+            async def execute_stream_with_interactions(self, action_history):
+                if False:
+                    yield None
+                await release_first_task.wait()
+
+            async def get_last_turn_usage(self):
+                return None
+
+        # Mock _create_node to avoid real storage initialization and keep the task active.
+        with patch.object(tm, "_create_node", return_value=BlockingNode("dup-stream")):
             request1 = StreamChatInput(message="first", session_id="dup-stream")
-            async for _ in svc.stream_chat(request1):
-                break
+            stream1 = svc.stream_chat(request1)
+            first_event = await anext(stream1)
+            assert first_event.event == "session"
+            assert "dup-stream" in tm._tasks
 
-            # Second should yield error event
             request2 = StreamChatInput(message="second", session_id="dup-stream")
-            events = []
-            async for event in svc.stream_chat(request2):
-                events.append(event)
-                break
-
-        assert len(events) >= 1
-        # First event should be an error
-        assert events[0].event == "error"
-        await tm.shutdown()
+            stream2 = svc.stream_chat(request2)
+            try:
+                duplicate_event = await anext(stream2)
+                assert duplicate_event.event == "error"
+            finally:
+                release_first_task.set()
+                await stream1.aclose()
+                await stream2.aclose()
+                await tm.shutdown()


### PR DESCRIPTION
## Summary

This PR updates the provider documentation to match the current implementation of `datus-agent configure` and `agent.yml`.

It fixes two user-facing issues found during review:
- the complete `agent.yml` examples now place `models` under `agent.models`
- Quickstart no longer advertises `codex` as a working interactive `datus-agent configure` option

It also keeps the related Chinese and English docs aligned, and fixes the broken Chinese `thinking-delta` anchor in the Chat API docs.

## Root Cause

The docs had drifted behind recent CLI/config refactors:
- older setup wording still implied outdated init/config behavior
- the new examples mixed correct prose with an invalid top-level `models:` layout
- Codex appeared in the provider catalog, but the current interactive configure path is not yet functional end-to-end

## Validation

- `uv run --with mkdocs --with mkdocs-material --with mkdocs-static-i18n python -m mkdocs build --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded configuration guides with a refreshed provider catalog, new special-auth options, coding-plan providers, updated examples, and env-var/parameter override guidance.
  * Updated Quickstart and localized guides to use the configure-driven flow, revised CLI/setup examples, and clarified project initialization steps.
  * Fixed an intra-document anchor/link for the streaming section.
* **Tests**
  * Improved a duplicate-session async test for deterministic streaming behavior and more robust cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->