### PR TITLE
[Enhancement] Add manual docs deployment and replace namespace with database in CLI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,8 +60,17 @@ jobs:
               exit 1
             fi
             # Checkout the tag so docs content matches the version
-            git checkout "v${VERSION}" 2>/dev/null || git checkout "${VERSION}" 2>/dev/null || { echo "::error::Tag v${VERSION} or ${VERSION} not found"; exit 1; }
-            echo "DOCS_EDIT_URI=edit/v${VERSION}/docs/" >> "${GITHUB_ENV}"
+            if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+              git checkout "v${VERSION}"
+              CHECKED_OUT_REF="v${VERSION}"
+            elif git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+              git checkout "${VERSION}"
+              CHECKED_OUT_REF="${VERSION}"
+            else
+              echo "::error::Tag v${VERSION} or ${VERSION} not found"
+              exit 1
+            fi
+            echo "DOCS_EDIT_URI=edit/${CHECKED_OUT_REF}/docs/" >> "${GITHUB_ENV}"
             echo "DOCS_VERSION=${VERSION}" >> "${GITHUB_ENV}"
             echo "DOCS_ALIASES=" >> "${GITHUB_ENV}"
             echo "DOCS_SET_DEFAULT=" >> "${GITHUB_ENV}"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,12 @@ on:
     tags:
       - 'v*.*.*'
       - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g. v0.2.6). Uses the tag ref if empty.'
+        required: false
+        default: ''
 permissions:
   contents: write
 env:
@@ -45,7 +51,30 @@ jobs:
       - name: Resolve docs version metadata
         run: |
           echo "DOCS_SKIP_DEPLOY=false" >> "${GITHUB_ENV}"
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+          # workflow_dispatch with explicit version input
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+            VERSION="${VERSION#v}"
+            if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.+-]+)?$ ]]; then
+              echo "::error::Invalid version format: ${VERSION}"
+              exit 1
+            fi
+            # Checkout the tag so docs content matches the version
+            git checkout "v${VERSION}" 2>/dev/null || git checkout "${VERSION}" 2>/dev/null || { echo "::error::Tag v${VERSION} or ${VERSION} not found"; exit 1; }
+            echo "DOCS_EDIT_URI=edit/v${VERSION}/docs/" >> "${GITHUB_ENV}"
+            echo "DOCS_VERSION=${VERSION}" >> "${GITHUB_ENV}"
+            echo "DOCS_ALIASES=" >> "${GITHUB_ENV}"
+            echo "DOCS_SET_DEFAULT=" >> "${GITHUB_ENV}"
+            if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              SHOULD_PROMOTE_LATEST="$(
+                VERSION="${VERSION}" python -c 'import json, os, re, subprocess; from packaging.version import Version; current = Version(os.environ["VERSION"]); raw = subprocess.check_output(["mike", "list", "-j"], text=True) if True else "[]"; stable = [Version(str(item.get("version", ""))) for item in json.loads(raw or "[]") if re.fullmatch(r"\d+\.\d+\.\d+", str(item.get("version", "")))]; print("true" if not stable or current >= max(stable) else "false")' 2>/dev/null || echo "true"
+              )"
+              if [[ "${SHOULD_PROMOTE_LATEST}" == "true" ]]; then
+                echo "DOCS_ALIASES=latest" >> "${GITHUB_ENV}"
+                echo "DOCS_SET_DEFAULT=latest" >> "${GITHUB_ENV}"
+              fi
+            fi
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
             if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.+-]+)?$ ]]; then
               echo "DOCS_SKIP_DEPLOY=true" >> "${GITHUB_ENV}"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -49,11 +49,14 @@ jobs:
             echo "DOCS_HAS_PUBLISHED_VERSIONS=true" >> "${GITHUB_ENV}"
           fi
       - name: Resolve docs version metadata
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           echo "DOCS_SKIP_DEPLOY=false" >> "${GITHUB_ENV}"
           # workflow_dispatch with explicit version input
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && -n "${INPUT_VERSION}" ]]; then
+            VERSION="${INPUT_VERSION}"
             VERSION="${VERSION#v}"
             if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.+-]+)?$ ]]; then
               echo "::error::Invalid version format: ${VERSION}"
@@ -70,6 +73,8 @@ jobs:
               echo "::error::Tag v${VERSION} or ${VERSION} not found"
               exit 1
             fi
+            # Reinstall deps from the tag's requirements to match the checked-out version
+            pip install -r requirements-docs.txt
             echo "DOCS_EDIT_URI=edit/${CHECKED_OUT_REF}/docs/" >> "${GITHUB_ENV}"
             echo "DOCS_VERSION=${VERSION}" >> "${GITHUB_ENV}"
             echo "DOCS_ALIASES=" >> "${GITHUB_ENV}"

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -1063,12 +1063,15 @@ Type '.help' for a list of commands or '.exit' to quit.
 """
         self.console.print(welcome_text)
 
-        namespace = getattr(self.args, "namespace", "")
-        # TODO use default namespace if not set
-        if namespace:
-            self.console.print(f"Namespace [bold green]{namespace}[/] selected")
+        database = (
+            getattr(self.args, "database", "")
+            or getattr(self.args, "namespace", "")
+            or getattr(self.agent_config, "current_database", "")
+        )
+        if database:
+            self.console.print(f"Database [bold green]{database}[/] selected")
         else:
-            self.console.print("[yellow]Warning: No namespace selected, please use .namespace to select a namespace[/]")
+            self.console.print("[yellow]Warning: No database selected, please use .database to select a database[/]")
         # Display connection info
         if self.db_connector:
             db_info = f"Connected to [bold green]{self.agent_config.db_type}[/]"

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -722,3 +722,49 @@ class TestInitConnection:
 
         assert cli.cli_context.current_logic_db_name == "returned_db"
         assert cli.cli_context.current_db_name == "connector_db"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _print_welcome database fallback
+# ---------------------------------------------------------------------------
+
+
+class TestPrintWelcome:
+    """Test _print_welcome database fallback chain."""
+
+    def _get_output(self, cli):
+        """Call _print_welcome and return the console output."""
+        cli._print_welcome()
+        return cli.console.file.getvalue()
+
+    def test_database_from_args_database(self, real_agent_config):
+        """args.database takes highest priority."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="my_db", namespace="my_ns")
+        real_agent_config._current_database = "config_db"
+        output = self._get_output(cli)
+        assert "Database my_db selected" in output
+
+    def test_database_fallback_to_args_namespace(self, real_agent_config):
+        """Falls back to args.namespace when args.database is empty."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="", namespace="my_ns")
+        real_agent_config._current_database = ""
+        output = self._get_output(cli)
+        assert "Database my_ns selected" in output
+
+    def test_database_fallback_to_agent_config(self, real_agent_config):
+        """Falls back to agent_config.current_database when args are empty."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="", namespace="")
+        real_agent_config._current_database = "config_db"
+        output = self._get_output(cli)
+        assert "Database config_db selected" in output
+
+    def test_no_database_warning(self, real_agent_config):
+        """Shows warning when no database is available."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="", namespace="")
+        real_agent_config._current_database = ""
+        output = self._get_output(cli)
+        assert "No database selected" in output


### PR DESCRIPTION
## Why

1. The `v0.2.6` tag was pushed before the mike-based versioned docs workflow was added, so the `Deploy Docs` workflow never triggered for it — only `dev` appears in the version selector at docs.datus.ai.
2. The CLI welcome message still references "namespace" instead of the newer "database" terminology, and lacks a fallback chain for resolving the active database.

## Solution

1. **deploy-docs.yml**: Added a `workflow_dispatch` trigger with an optional `version` input. When triggered manually with a version (e.g. `v0.2.6`), it checks out the corresponding tag and deploys docs for that version via mike. This avoids the need to delete and re-push tags.
2. **repl.py**: Replaced the single `namespace` lookup with a fallback chain: `args.database` → `args.namespace` → `agent_config.current_database`. Updated user-facing messages from "namespace" to "database".

## Test Cases

- **deploy-docs.yml**: Workflow change — no unit tests applicable. Manual verification: trigger `Run workflow` in GitHub Actions with `version=v0.2.6` to confirm the version appears in the docs version selector.
- **repl.py**: The change is in the CLI welcome display logic. Existing CLI tests cover the welcome flow. No new integration tests needed for this string/fallback change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation deployment now supports manual triggers with an optional version input, validation, tag checkout, and conditional promotion of eligible stable versions to "latest".

* **Improvements**
  * CLI welcome now uses "Database" terminology, selects a sensible default from available sources, and shows clearer guidance when none is set.

* **Tests**
  * Added unit tests covering the CLI welcome behavior and database selection fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->