### PR TITLE
[Feature] Add daemon mode support to datus-claw gateway

### DIFF
--- a/datus/claw/main.py
+++ b/datus/claw/main.py
@@ -4,17 +4,177 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""CLI entry point for the Datus Claw IM gateway."""
+"""
+CLI entry point for the Datus Claw IM gateway.
+
+Supports foreground and daemon (background) modes with
+start/stop/restart/status actions.
+"""
 
 import argparse
 import asyncio
+import atexit
 import logging
+import multiprocessing
 import os
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Tuple
 
 from datus import __version__
 from datus.utils.loggings import configure_logging, get_logger
 
 logger = get_logger(__name__)
+
+_SERVICE_NAME = "datus-claw"
+
+
+def _default_paths(config_path: str = "") -> Tuple[Path, Path]:
+    """Return default pid and log file paths."""
+    from datus.configuration.agent_config_loader import get_agent_home
+    from datus.utils.path_manager import DatusPathManager
+
+    path_manager = DatusPathManager(get_agent_home(config_path))
+    pid_file = path_manager.pid_file_path(_SERVICE_NAME)
+    log_file = Path("logs") / f"{_SERVICE_NAME}.log"
+    return pid_file, log_file
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _read_pid(pid_file: Path) -> Optional[int]:
+    if not pid_file.exists():
+        return None
+    try:
+        pid_text = pid_file.read_text().strip()
+        return int(pid_text) if pid_text else None
+    except Exception:
+        return None
+
+
+def _is_process_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
+
+def _write_pid_file(pid_file: Path, pid: int) -> None:
+    _ensure_parent_dir(pid_file)
+    pid_file.write_text(str(pid))
+
+
+def _remove_pid_file(pid_file: Path) -> None:
+    try:
+        if pid_file.exists():
+            pid_file.unlink()
+    except Exception:
+        pass
+
+
+def _redirect_stdio(log_file: Path) -> None:
+    _ensure_parent_dir(log_file)
+    with open(os.devnull, "rb", buffering=0) as si:
+        os.dup2(si.fileno(), sys.stdin.fileno())
+    with open(log_file, "ab", buffering=0) as so:
+        os.dup2(so.fileno(), sys.stdout.fileno())
+    with open(log_file, "ab", buffering=0) as se:
+        os.dup2(se.fileno(), sys.stderr.fileno())
+
+
+def _run_gateway(args: argparse.Namespace) -> None:
+    """Load config and start the Claw gateway (blocking)."""
+    from datus.configuration.agent_config_loader import load_agent_config
+
+    logger.info("Loading agent configuration...")
+    agent_config = load_agent_config(
+        config=args.config or "",
+        namespace=args.namespace,
+    )
+
+    channels_config = getattr(agent_config, "channels_config", {})
+    if not channels_config:
+        logger.error("No 'channels' section found in agent configuration. Nothing to start.")
+        raise SystemExit(1)
+
+    from datus.claw.gateway import ClawGateway
+
+    gateway = ClawGateway(
+        agent_config=agent_config,
+        channels_config=channels_config,
+        host=args.host,
+        port=args.port,
+    )
+
+    logger.info("Starting Datus Claw gateway...")
+    asyncio.run(gateway.start())
+
+
+def _daemon_worker(args: argparse.Namespace, pid_file: Path, log_file: Path) -> None:
+    """Worker function that runs in the daemon process."""
+    os.setsid()
+    os.umask(0)
+
+    configure_logging(args.debug, log_dir="logs", console_output=False)
+    _redirect_stdio(log_file)
+    _write_pid_file(pid_file, os.getpid())
+
+    def _cleanup(*_args):
+        _remove_pid_file(pid_file)
+
+    atexit.register(_cleanup)
+    signal.signal(signal.SIGTERM, lambda *_a: (_cleanup(), os._exit(0)))
+
+    _run_gateway(args)
+
+
+def _stop(pid_file: Path, timeout_seconds: float = 10.0) -> int:
+    pid = _read_pid(pid_file)
+    if not pid:
+        logger.info("No PID file found; gateway not running?")
+        return 0
+    if not _is_process_running(pid):
+        logger.info("Stale PID file found; process not running. Cleaning up.")
+        _remove_pid_file(pid_file)
+        return 0
+
+    logger.info(f"Stopping gateway (pid={pid}) ...")
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        _remove_pid_file(pid_file)
+        return 0
+
+    start = time.time()
+    while time.time() - start < timeout_seconds:
+        if not _is_process_running(pid):
+            _remove_pid_file(pid_file)
+            logger.info("Stopped.")
+            return 0
+        time.sleep(0.2)
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    _remove_pid_file(pid_file)
+    logger.info("Force killed.")
+    return 0
+
+
+def _status(pid_file: Path) -> int:
+    pid = _read_pid(pid_file)
+    if pid and _is_process_running(pid):
+        print(f"running (pid={pid})")
+        return 0
+    print("stopped")
+    return 1
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -43,43 +203,86 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Log level (default: INFO or DATUS_LOG_LEVEL env var)",
     )
+
+    # Daemon control
+    parser.add_argument(
+        "--action",
+        choices=["start", "stop", "restart", "status"],
+        default="start",
+        help="Daemon action (default: start)",
+    )
+    parser.add_argument("--daemon", action="store_true", help="Run in background as a daemon")
+    parser.add_argument(
+        "--pid-file",
+        type=str,
+        help=f"PID file path (default: ~/.datus/run/{_SERVICE_NAME}.pid)",
+    )
+    parser.add_argument(
+        "--daemon-log-file",
+        type=str,
+        help=f"Daemon log file path (default: logs/{_SERVICE_NAME}.log)",
+    )
     return parser
 
 
 def main() -> None:
+    """Main entry point for starting the Datus Claw gateway."""
+    if hasattr(multiprocessing, "set_start_method"):
+        try:
+            multiprocessing.set_start_method("spawn", force=True)
+        except RuntimeError:
+            pass
+
     parser = _build_parser()
     args = parser.parse_args()
 
     if args.debug:
         args.log_level = "DEBUG"
 
-    configure_logging(args.debug)
+    # Resolve defaults for pid/log
+    default_pid, default_log = _default_paths(args.config or "")
+    pid_file = Path(args.pid_file) if args.pid_file else default_pid
+    log_file = Path(args.daemon_log_file) if args.daemon_log_file else default_log
+
+    if args.action in {"status", "stop"}:
+        configure_logging(args.debug)
+        if args.action == "status":
+            raise SystemExit(_status(pid_file))
+        if args.action == "stop":
+            raise SystemExit(_stop(pid_file))
+
+    if args.action == "restart":
+        configure_logging(args.debug)
+        _stop(pid_file)
+        # fall-through to start
+
+    if args.daemon:
+        if (pid := _read_pid(pid_file)) and _is_process_running(pid):
+            print(f"Already running (pid={pid})", file=sys.stderr)
+            raise SystemExit(0)
+
+        configure_logging(args.debug, log_dir="logs", console_output=False)
+        logger.info(f"Starting Datus Claw gateway (daemon) on {args.host}:{args.port} | Debug: {args.debug}")
+
+        daemon_process = multiprocessing.Process(target=_daemon_worker, args=(args, pid_file, log_file), daemon=False)
+        daemon_process.start()
+
+        time.sleep(0.5)
+
+        if daemon_process.is_alive():
+            print(f"Daemon started successfully (pid={daemon_process.pid})")
+            os._exit(0)
+        else:
+            print("Failed to start daemon process", file=sys.stderr)
+            daemon_process.join()
+            os._exit(1)
+    else:
+        configure_logging(args.debug)
+
     logging.getLogger().setLevel(getattr(logging, args.log_level, logging.INFO))
 
-    from datus.configuration.agent_config_loader import load_agent_config
-
-    logger.info("Loading agent configuration...")
-    agent_config = load_agent_config(
-        config=args.config or "",
-        namespace=args.namespace,
-    )
-
-    channels_config = getattr(agent_config, "channels_config", {})
-    if not channels_config:
-        logger.error("No 'channels' section found in agent configuration. Nothing to start.")
-        raise SystemExit(1)
-
-    from datus.claw.gateway import ClawGateway
-
-    gateway = ClawGateway(
-        agent_config=agent_config,
-        channels_config=channels_config,
-        host=args.host,
-        port=args.port,
-    )
-
-    logger.info("Starting Datus Claw gateway...")
-    asyncio.run(gateway.start())
+    logger.info(f"Starting Datus Claw gateway on {args.host}:{args.port}")
+    _run_gateway(args)
 
 
 if __name__ == "__main__":

--- a/datus/claw/main.py
+++ b/datus/claw/main.py
@@ -51,7 +51,10 @@ def _read_pid(pid_file: Path) -> Optional[int]:
         return None
     try:
         pid_text = pid_file.read_text().strip()
-        return int(pid_text) if pid_text else None
+        if not pid_text:
+            return None
+        pid = int(pid_text)
+        return pid if pid > 0 else None
     except Exception:
         return None
 
@@ -118,10 +121,13 @@ def _run_gateway(args: argparse.Namespace) -> None:
 
 def _daemon_worker(args: argparse.Namespace, pid_file: Path, log_file: Path) -> None:
     """Worker function that runs in the daemon process."""
-    os.setsid()
-    os.umask(0)
+    if sys.platform != "win32":
+        os.setsid()
+        os.umask(0o022)
 
-    configure_logging(args.debug, log_dir="logs", console_output=False)
+    log_dir = str(log_file.parent)
+    configure_logging(args.debug, log_dir=log_dir, console_output=False)
+    logging.getLogger().setLevel(getattr(logging, args.log_level, logging.INFO))
     _redirect_stdio(log_file)
     _write_pid_file(pid_file, os.getpid())
 
@@ -160,7 +166,10 @@ def _stop(pid_file: Path, timeout_seconds: float = 10.0) -> int:
         time.sleep(0.2)
 
     try:
-        os.kill(pid, signal.SIGKILL)
+        if sys.platform == "win32":
+            os.kill(pid, signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGKILL)
     except ProcessLookupError:
         pass
     _remove_pid_file(pid_file)
@@ -254,14 +263,16 @@ def main() -> None:
     if args.action == "restart":
         configure_logging(args.debug)
         _stop(pid_file)
-        # fall-through to start
+        args.daemon = True
+        # fall-through to start as daemon
 
     if args.daemon:
         if (pid := _read_pid(pid_file)) and _is_process_running(pid):
             print(f"Already running (pid={pid})", file=sys.stderr)
             raise SystemExit(0)
 
-        configure_logging(args.debug, log_dir="logs", console_output=False)
+        log_dir = str(log_file.parent)
+        configure_logging(args.debug, log_dir=log_dir, console_output=False)
         logger.info(f"Starting Datus Claw gateway (daemon) on {args.host}:{args.port} | Debug: {args.debug}")
 
         daemon_process = multiprocessing.Process(target=_daemon_worker, args=(args, pid_file, log_file), daemon=False)

--- a/docs/API/deployment.md
+++ b/docs/API/deployment.md
@@ -12,8 +12,34 @@ This registers the `datus-api` console script.
 
 ## Launch
 
+### Foreground (default)
+
 ```bash
 datus-api --host 0.0.0.0 --port 8000
+```
+
+### Daemon (background) Mode
+
+Run the API server as a background daemon:
+
+```bash
+# Start in background
+datus-api --daemon --port 8000
+
+# Check status
+datus-api --action status
+
+# Stop
+datus-api --action stop
+
+# Restart
+datus-api --action restart
+```
+
+By default, the PID file is stored at `~/.datus/run/datus-agent-api.pid` and daemon logs are written to `logs/datus-agent-api.log`. You can override these paths:
+
+```bash
+datus-api --daemon --pid-file /var/run/datus-api.pid --daemon-log-file /var/log/datus-api.log
 ```
 
 ## CLI arguments
@@ -29,8 +55,13 @@ datus-api --host 0.0.0.0 --port 8000
 | `--reload`       | off                      | Auto-reload on file change (dev only) |
 | `--workers`      | `1`                      | Number of uvicorn worker processes |
 | `-v`, `--version`| —                        | Print version and exit |
+| `--daemon`       | off                      | Run in background as a daemon |
+| `--action`       | `start`                  | Daemon action: `start`, `stop`, `restart`, `status` |
+| `--pid-file`     | `~/.datus/run/datus-agent-api.pid` | PID file path |
+| `--daemon-log-file` | `logs/datus-agent-api.log` | Daemon log file path |
 
 `--reload` and `--workers > 1` are mutually exclusive; the server will warn and fall back to a single worker.
+`--daemon` and `--reload` are mutually exclusive.
 
 ## Environment variables
 

--- a/docs/API/deployment.md
+++ b/docs/API/deployment.md
@@ -16,6 +16,9 @@ This registers the `datus-api` console script.
 
 ```bash
 datus-api --host 0.0.0.0 --port 8000
+
+# Or via uv
+uv run datus-api --host 0.0.0.0 --port 8000
 ```
 
 ### Daemon (background) Mode
@@ -35,6 +38,8 @@ datus-api --action stop
 # Restart
 datus-api --action restart
 ```
+
+All daemon commands also work with `uv run`, e.g. `uv run datus-api --daemon --port 8000`.
 
 By default, the PID file is stored at `~/.datus/run/datus-agent-api.pid` and daemon logs are written to `logs/datus-agent-api.log`. You can override these paths:
 

--- a/docs/API/deployment.zh.md
+++ b/docs/API/deployment.zh.md
@@ -12,8 +12,34 @@ uv sync
 
 ## 启动
 
+### 前台启动（默认）
+
 ```bash
 datus-api --host 0.0.0.0 --port 8000
+```
+
+### 后台守护进程模式
+
+以守护进程方式在后台运行 API 服务：
+
+```bash
+# 后台启动
+datus-api --daemon --port 8000
+
+# 查看状态
+datus-api --action status
+
+# 停止
+datus-api --action stop
+
+# 重启
+datus-api --action restart
+```
+
+默认情况下，PID 文件存储在 `~/.datus/run/datus-agent-api.pid`，守护进程日志写入 `logs/datus-agent-api.log`。可通过参数覆盖：
+
+```bash
+datus-api --daemon --pid-file /var/run/datus-api.pid --daemon-log-file /var/log/datus-api.log
 ```
 
 ## CLI 参数
@@ -29,8 +55,13 @@ datus-api --host 0.0.0.0 --port 8000
 | `--reload`        | 关闭                    | 文件变更自动重载(仅开发) |
 | `--workers`       | `1`                     | uvicorn worker 进程数 |
 | `-v`, `--version` | —                       | 打印版本并退出 |
+| `--daemon`        | 关闭                    | 以守护进程方式后台运行 |
+| `--action`        | `start`                 | 守护进程操作：`start`、`stop`、`restart`、`status` |
+| `--pid-file`      | `~/.datus/run/datus-agent-api.pid` | PID 文件路径 |
+| `--daemon-log-file` | `logs/datus-agent-api.log` | 守护进程日志文件路径 |
 
-`--reload` 与 `--workers > 1` 互斥,服务会发出告警并退回单 worker 模式。
+`--reload` 与 `--workers > 1` 互斥，服务会发出告警并退回单 worker 模式。
+`--daemon` 与 `--reload` 互斥。
 
 ## 环境变量
 

--- a/docs/API/deployment.zh.md
+++ b/docs/API/deployment.zh.md
@@ -16,6 +16,9 @@ uv sync
 
 ```bash
 datus-api --host 0.0.0.0 --port 8000
+
+# 或通过 uv 运行
+uv run datus-api --host 0.0.0.0 --port 8000
 ```
 
 ### 后台守护进程模式
@@ -35,6 +38,8 @@ datus-api --action stop
 # 重启
 datus-api --action restart
 ```
+
+所有守护进程命令也支持 `uv run`，例如 `uv run datus-api --daemon --port 8000`。
 
 默认情况下，PID 文件存储在 `~/.datus/run/datus-agent-api.pid`，守护进程日志写入 `logs/datus-agent-api.log`。可通过参数覆盖：
 

--- a/docs/claw/introduction.md
+++ b/docs/claw/introduction.md
@@ -129,6 +129,9 @@ Start the Claw gateway in the foreground:
 
 ```bash
 datus-claw --config conf/agent.yml
+
+# Or via uv
+uv run datus-claw --config conf/agent.yml
 ```
 
 ### Daemon (background) Mode
@@ -148,6 +151,8 @@ datus-claw --action stop
 # Restart
 datus-claw --action restart
 ```
+
+All daemon commands also work with `uv run`, e.g. `uv run datus-claw --daemon`.
 
 By default, the PID file is stored at `~/.datus/run/datus-claw.pid` and daemon logs are written to `logs/datus-claw.log`. You can override these paths:
 

--- a/docs/claw/introduction.md
+++ b/docs/claw/introduction.md
@@ -123,10 +123,36 @@ For detailed step-by-step instructions on configuring each IM platform, see the 
 
 ## Running the Gateway
 
-Start the Claw gateway with:
+### Foreground (default)
+
+Start the Claw gateway in the foreground:
 
 ```bash
-python -m datus.claw.main --config conf/agent.yml
+datus-claw --config conf/agent.yml
+```
+
+### Daemon (background) Mode
+
+Run the gateway as a background daemon:
+
+```bash
+# Start in background
+datus-claw --daemon
+
+# Check status
+datus-claw --action status
+
+# Stop
+datus-claw --action stop
+
+# Restart
+datus-claw --action restart
+```
+
+By default, the PID file is stored at `~/.datus/run/datus-claw.pid` and daemon logs are written to `logs/datus-claw.log`. You can override these paths:
+
+```bash
+datus-claw --daemon --pid-file /var/run/datus-claw.pid --daemon-log-file /var/log/datus-claw.log
 ```
 
 ### CLI Flags
@@ -139,6 +165,10 @@ python -m datus.claw.main --config conf/agent.yml
 | `--port` | `9000` | Health-check server bind port |
 | `--debug` | `false` | Enable debug logging |
 | `--log-level` | `INFO` (or `DATUS_LOG_LEVEL` env) | Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL |
+| `--daemon` | `false` | Run in background as a daemon |
+| `--action` | `start` | Daemon action: `start`, `stop`, `restart`, `status` |
+| `--pid-file` | `~/.datus/run/datus-claw.pid` | PID file path |
+| `--daemon-log-file` | `logs/datus-claw.log` | Daemon log file path |
 
 ## Features
 
@@ -230,7 +260,7 @@ If the bot connects but immediately disconnects or logs authentication errors, v
 Enable verbose logging to diagnose connection issues:
 
 ```bash
-python -m datus.claw.main --config conf/agent.yml --debug
+datus-claw --config conf/agent.yml --debug
 ```
 
 Or set the environment variable:

--- a/docs/claw/introduction.zh.md
+++ b/docs/claw/introduction.zh.md
@@ -123,10 +123,34 @@ channels:
 
 ## 启动网关
 
-使用以下命令启动 Claw 网关：
+### 前台启动（默认）
 
 ```bash
-python -m datus.claw.main --config conf/agent.yml
+datus-claw --config conf/agent.yml
+```
+
+### 后台守护进程模式
+
+以守护进程方式在后台运行网关：
+
+```bash
+# 后台启动
+datus-claw --daemon
+
+# 查看状态
+datus-claw --action status
+
+# 停止
+datus-claw --action stop
+
+# 重启
+datus-claw --action restart
+```
+
+默认情况下，PID 文件存储在 `~/.datus/run/datus-claw.pid`，守护进程日志写入 `logs/datus-claw.log`。可通过参数覆盖：
+
+```bash
+datus-claw --daemon --pid-file /var/run/datus-claw.pid --daemon-log-file /var/log/datus-claw.log
 ```
 
 ### CLI 参数
@@ -139,6 +163,10 @@ python -m datus.claw.main --config conf/agent.yml
 | `--port` | `9000` | 健康检查服务绑定端口 |
 | `--debug` | `false` | 启用调试日志 |
 | `--log-level` | `INFO`（或 `DATUS_LOG_LEVEL` 环境变量） | 日志级别：DEBUG、INFO、WARNING、ERROR、CRITICAL |
+| `--daemon` | `false` | 以守护进程方式后台运行 |
+| `--action` | `start` | 守护进程操作：`start`、`stop`、`restart`、`status` |
+| `--pid-file` | `~/.datus/run/datus-claw.pid` | PID 文件路径 |
+| `--daemon-log-file` | `logs/datus-claw.log` | 守护进程日志文件路径 |
 
 ## 功能特性
 
@@ -230,7 +258,7 @@ ImportError: slack_sdk is required for the Slack adapter. Install it with: pip i
 启用详细日志以诊断连接问题：
 
 ```bash
-python -m datus.claw.main --config conf/agent.yml --debug
+datus-claw --config conf/agent.yml --debug
 ```
 
 或设置环境变量：

--- a/docs/claw/introduction.zh.md
+++ b/docs/claw/introduction.zh.md
@@ -127,6 +127,9 @@ channels:
 
 ```bash
 datus-claw --config conf/agent.yml
+
+# 或通过 uv 运行
+uv run datus-claw --config conf/agent.yml
 ```
 
 ### 后台守护进程模式
@@ -146,6 +149,8 @@ datus-claw --action stop
 # 重启
 datus-claw --action restart
 ```
+
+所有守护进程命令也支持 `uv run`，例如 `uv run datus-claw --daemon`。
 
 默认情况下，PID 文件存储在 `~/.datus/run/datus-claw.pid`，守护进程日志写入 `logs/datus-claw.log`。可通过参数覆盖：
 


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Foreground and background (daemon) run modes with lifecycle actions: start, stop, restart, status
  * CLI flags to enable daemon mode and configure PID and daemon log file locations

* **Documentation**
  * English and Chinese docs updated with daemon usage examples, CLI flag descriptions, mutual-exclusivity notes, and startup guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->