### PR TITLE
[Refactor] Optimize FilesystemFuncTool

### DIFF
--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -30,10 +30,8 @@ logger = get_logger(__name__)
 # Read-only filesystem methods exposed to the explore agent
 READONLY_FILESYSTEM_METHODS = [
     "read_file",
-    "read_multiple_files",
-    "list_directory",
-    "directory_tree",
-    "search_files",
+    "glob",
+    "grep",
 ]
 
 

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -156,8 +156,7 @@ class GenExtKnowledgeAgenticNode(AgenticNode):
         self.tools = []
 
         # Hardcoded tool configuration: specific methods from generation_tools and filesystem_tools
-        # filesystem_tools.read_file, filesystem_tools.read_multiple_files, filesystem_tools.write_file,
-        # filesystem_tools.edit_file, filesystem_tools.list_directory
+        # filesystem_tools: read_file, write_file, edit_file
         # Chat node uses all available tools by default
         db_manager = db_manager_instance(self.agent_config.namespaces)
         self.conn = db_manager.get_conn(self.agent_config.current_database, self.agent_config.current_database)

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -129,21 +129,13 @@ class GenMetricsAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            from datus.tools.func_tool import trans_to_function_tool
-
             self.filesystem_func_tool = FilesystemFuncTool(
                 root_path=self.knowledge_base_dir,
                 path_normalizer=make_kb_path_normalizer(self.agent_config, default_kind="metric"),
             )
 
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.read_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.read_multiple_files))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.write_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.edit_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.list_directory))
-            logger.debug(
-                "Added filesystem tools: read_file, read_multiple_files, write_file, edit_file, list_directory"
-            )
+            self.tools.extend(self.filesystem_func_tool.available_tools())
+            logger.debug("Added filesystem tools: read_file, write_file, edit_file, glob, grep")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -188,21 +188,13 @@ class GenSemanticModelAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            from datus.tools.func_tool import trans_to_function_tool
-
             self.filesystem_func_tool = FilesystemFuncTool(
                 root_path=self.knowledge_base_dir,
                 path_normalizer=make_kb_path_normalizer(self.agent_config, default_kind="semantic"),
             )
 
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.read_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.read_multiple_files))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.write_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.edit_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.list_directory))
-            logger.debug(
-                "Added filesystem tools: read_file, read_multiple_files, write_file, edit_file, list_directory"
-            )
+            self.tools.extend(self.filesystem_func_tool.available_tools())
+            logger.debug("Added filesystem tools: read_file, write_file, edit_file, glob, grep")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -34,23 +34,17 @@ logger = get_logger(__name__)
 # Workspace filesystem methods (read-only, root = workspace)
 WORKSPACE_READONLY_METHODS = [
     "read_file",
-    "read_multiple_files",
-    "list_directory",
-    "directory_tree",
-    "search_files",
+    "glob",
+    "grep",
 ]
 
 # Skills filesystem methods (read + write, root = skills directory)
 SKILLS_ALL_METHODS = [
     "read_file",
-    "read_multiple_files",
-    "list_directory",
-    "directory_tree",
-    "search_files",
     "write_file",
     "edit_file",
-    "create_directory",
-    "move_file",
+    "glob",
+    "grep",
 ]
 
 

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -124,8 +124,7 @@ class SqlSummaryAgenticNode(AgenticNode):
 
         # Hardcoded tool configuration: specific methods from generation_tools and filesystem_tools
         # tools: generation_tools.generate_sql_summary_id,
-        # filesystem_tools.read_file, filesystem_tools.read_multiple_files, filesystem_tools.write_file,
-        # filesystem_tools.edit_file, filesystem_tools.list_directory
+        # filesystem_tools: read_file, write_file, edit_file, glob, grep
         self._setup_specific_generation_tools()
         self._setup_specific_filesystem_tool()
         if self.execution_mode == "interactive":
@@ -152,18 +151,12 @@ class SqlSummaryAgenticNode(AgenticNode):
     def _setup_specific_filesystem_tool(self):
         """Setup specific filesystem tools"""
         try:
-            from datus.tools.func_tool import trans_to_function_tool
-
             self.filesystem_func_tool = FilesystemFuncTool(
                 root_path=self.knowledge_base_dir,
                 path_normalizer=make_kb_path_normalizer(self.agent_config, default_kind="sql_summary"),
             )
 
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.read_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.read_multiple_files))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.write_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.edit_file))
-            self.tools.append(trans_to_function_tool(self.filesystem_func_tool.list_directory))
+            self.tools.extend(self.filesystem_func_tool.available_tools())
         except Exception as e:
             logger.error(f"Failed to setup specific filesystem tool: {e}")
 

--- a/datus/api/main.py
+++ b/datus/api/main.py
@@ -252,7 +252,7 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["web", "vscode"],
         help=(
             "Default proxy tool source shortcut. 'vscode' -> proxy filesystem_tools.*, "
-            "'web' -> proxy write_file/edit_file/move_file/create_directory. "
+            "'web' -> proxy write_file/edit_file. "
             "Overridable per request via ChatInput.source."
         ),
     )

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -30,14 +30,10 @@ VALID_TOOL_METHODS: dict[str, set[str]] = {
     "date_parsing_tools": {"parse_temporal_expressions"},
     "filesystem_tools": {
         "read_file",
-        "read_multiple_files",
         "write_file",
         "edit_file",
-        "create_directory",
-        "list_directory",
-        "directory_tree",
-        "move_file",
-        "search_files",
+        "glob",
+        "grep",
     },
     "platform_doc_tools": set(PlatformDocSearchTool.all_tools_name()),
 }

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -410,7 +410,7 @@ class ChatTaskManager:
             if effective_source == "vscode":
                 apply_proxy_tools(node, ["filesystem_tools.*"])
             elif effective_source == "web":
-                apply_proxy_tools(node, ["write_file", "edit_file", "move_file", "create_directory"])
+                apply_proxy_tools(node, ["write_file", "edit_file"])
             elif effective_source:
                 logger.warning("Unsupported source '%s'; skipping proxy shortcut", effective_source)
 

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -1246,8 +1246,27 @@ def _build_read_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
     return tc
 
 
-def _build_read_multiple_files(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """read_multiple_files: show file count."""
+def _build_glob(action: ActionHistory, verbose: bool) -> ToolCallContent:
+    """glob: show file count."""
+    tc = make_base_content(action)
+    if verbose:
+        tc.args_lines = extract_args_markup(action)
+        if action.output:
+            tc.output_lines = _format_result_only_markup(action.output)
+    else:
+        data = parse_output_data(action.output)
+        if data:
+            result = data.get("result")
+            if isinstance(result, dict):
+                files = result.get("files", [])
+                tc.output_preview = f"\u2713 {len(files)} files found"
+            elif isinstance(result, list):
+                tc.output_preview = f"\u2713 {len(result)} files found"
+    return tc
+
+
+def _build_grep(action: ActionHistory, verbose: bool) -> ToolCallContent:
+    """grep: show match count."""
     tc = make_base_content(action)
     if verbose:
         tc.args_lines = extract_args_markup(action)
@@ -1256,10 +1275,15 @@ def _build_read_multiple_files(action: ActionHistory, verbose: bool) -> ToolCall
             if data:
                 result = data.get("result")
                 if isinstance(result, dict):
+                    matches = result.get("matches", [])
                     lines: List[str] = []
-                    for path, content in result.items():
-                        line_count = len(content.split("\n")) if isinstance(content, str) else "?"
-                        lines.append(f"[bold]{_escape_markup(path)}[/bold]: [dim]{line_count} lines[/dim]")
+                    for m in matches[:30]:
+                        f = _escape_markup(str(m.get("file", "?")))
+                        ln = m.get("line", "?")
+                        content = _escape_markup(str(m.get("content", "")))
+                        lines.append(f"  [bold]{f}:{ln}[/bold]: [dim]{content}[/dim]")
+                    if len(matches) > 30:
+                        lines.append(f"  [dim]... ({len(matches) - 30} more matches)[/dim]")
                     tc.output_lines = lines
                 else:
                     tc.output_lines = _format_result_only_markup(action.output)
@@ -1270,82 +1294,9 @@ def _build_read_multiple_files(action: ActionHistory, verbose: bool) -> ToolCall
         if data:
             result = data.get("result")
             if isinstance(result, dict):
-                tc.output_preview = f"\u2713 {len(result)} files read"
+                matches = result.get("matches", [])
+                tc.output_preview = f"\u2713 {len(matches)} matches"
     return tc
-
-
-def _build_create_directory(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """create_directory: show success."""
-    return _build_simple_action(action, verbose, "Directory created")
-
-
-def _build_list_directory(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """list_directory: show item count."""
-    tc = make_base_content(action)
-    if verbose:
-        tc.args_lines = extract_args_markup(action)
-        if action.output:
-            data = parse_output_data(action.output)
-            if data:
-                result = data.get("result")
-                if isinstance(result, list):
-                    lines: List[str] = []
-                    for item in result:
-                        if isinstance(item, dict):
-                            name = item.get("name", "?")
-                            item_type = item.get("type", "")
-                            suffix = "/" if item_type == "directory" else ""
-                            lines.append(f"  {_escape_markup(name)}{suffix}")
-                        else:
-                            lines.append(f"  {_escape_markup(str(item))}")
-                    tc.output_lines = lines
-                else:
-                    tc.output_lines = _format_result_only_markup(action.output)
-            else:
-                tc.output_lines = _format_result_only_markup(action.output)
-    else:
-        data = parse_output_data(action.output)
-        if data:
-            result = data.get("result")
-            if isinstance(result, list):
-                tc.output_preview = f"\u2713 {len(result)} items"
-    return tc
-
-
-def _build_directory_tree(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """directory_tree: show tree."""
-    tc = make_base_content(action)
-    if verbose:
-        tc.args_lines = extract_args_markup(action)
-        if action.output:
-            data = parse_output_data(action.output)
-            if data:
-                result = data.get("result")
-                if isinstance(result, str):
-                    lines: List[str] = ["[bold]tree[/bold]:"]
-                    for tree_line in result.split("\n")[:30]:
-                        lines.append(f"  [dim]{_escape_markup(tree_line)}[/dim]")
-                    total = len(result.split("\n"))
-                    if total > 30:
-                        lines.append(f"  [dim]... ({total - 30} more lines)[/dim]")
-                    tc.output_lines = lines
-                else:
-                    tc.output_lines = _format_result_only_markup(action.output)
-            else:
-                tc.output_lines = _format_result_only_markup(action.output)
-    else:
-        tc.output_preview = "\u2713 Tree generated"
-    return tc
-
-
-def _build_move_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """move_file: show success."""
-    return _build_simple_action(action, verbose, "Moved")
-
-
-def _build_search_files(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """search_files: show file count."""
-    return _build_simple_list(action, verbose, "files found")
 
 
 def _build_list_document_nav(action: ActionHistory, verbose: bool) -> ToolCallContent:
@@ -1723,12 +1674,8 @@ class ToolCallContentBuilder:
         self._registry["edit_file"] = _build_edit_file
         self._registry["write_file"] = _build_write_file
         self._registry["read_file"] = _build_read_file
-        self._registry["read_multiple_files"] = _build_read_multiple_files
-        self._registry["create_directory"] = _build_create_directory
-        self._registry["list_directory"] = _build_list_directory
-        self._registry["directory_tree"] = _build_directory_tree
-        self._registry["move_file"] = _build_move_file
-        self._registry["search_files"] = _build_search_files
+        self._registry["glob"] = _build_glob
+        self._registry["grep"] = _build_grep
 
         # Platform document tools
         self._registry["list_document_nav"] = _build_list_document_nav

--- a/datus/prompts/prompt_templates/explore_system_1.0.j2
+++ b/datus/prompts/prompt_templates/explore_system_1.0.j2
@@ -30,9 +30,9 @@ You **MUST** use context search tools to gather domain knowledge before concludi
 {% endif -%}
 {% if has_filesystem_tools -%}
 ### Filesystem Tools (Read-Only)
-- Use `read_file`, `read_multiple_files` to read SQL files and documentation
-- Use `list_directory`, `directory_tree` to browse workspace structure
-- Use `search_files` to find relevant files by pattern (e.g., "**/*.sql")
+- Use `read_file` to read SQL files and documentation
+- Use `glob` to find files by pattern (e.g., "**/*.sql")
+- Use `grep` to search file contents by regex
 {% endif -%}
 {% if has_date_parsing_tools -%}
 ### Date Parsing Tools

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
@@ -110,7 +110,7 @@ Only include dimensions that are actually used in the SQL queries.
 
 ### Step 4: Find or Create Semantic Model
 
-1. Use `list_directory` to check for existing semantic model files
+1. Use `glob` to check for existing semantic model files
 2. If semantic model for the table exists:
    - Use `read_file` to read it
    - Verify measures and dimensions match what you extracted

--- a/datus/prompts/prompt_templates/skill_creator_system_1.0.j2
+++ b/datus/prompts/prompt_templates/skill_creator_system_1.0.j2
@@ -21,13 +21,12 @@ If unclear, use `ask_user` to clarify whether the user wants to create or optimi
 ## Available Tools
 {% if has_filesystem_tools -%}
 ### Workspace (read-only)
-- `read_file`, `list_directory`, `directory_tree`, `search_files` — browse project files
+- `read_file`, `glob`, `grep` — browse project files
 
 ### Skills Directory (read+write)
 All `skill_*` tools operate within the skills directory. Paths are relative.
-- `skill_create_directory`, `skill_write_file`, `skill_edit_file` — create/modify skills
-- `skill_read_file`, `skill_list_directory`, `skill_directory_tree` — browse skills
-- `skill_move_file` — reorganize
+- `skill_write_file`, `skill_edit_file` — create/modify skills
+- `skill_read_file`, `skill_glob`, `skill_grep` — browse skills
 {% endif -%}
 {% if has_db_tools -%}
 ### Database (research only)

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -195,52 +195,6 @@ class FilesystemFuncTool(BaseTool):
             logger.error(f"Error reading file {path}: {str(e)}")
             return FuncToolResult(success=0, error=str(e))
 
-    def read_multiple_files(self, paths: List[str]) -> FuncToolResult:
-        """
-        Read the contents of multiple files.
-
-        Args:
-            paths: List of file paths to read
-
-        Returns:
-            dict: A dictionary with the execution result, containing these keys:
-                  - 'success' (int): 1 for success, 0 for failure.
-                  - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[dict]): Dictionary mapping paths to their contents on success.
-        """
-        try:
-            results = {}
-
-            for raw_path in paths:
-                path = self._normalize(raw_path)
-                target_path = self._get_safe_path(path)
-                if not target_path or not target_path.exists():
-                    results[raw_path] = f"File not found: {raw_path}"
-                    continue
-
-                if not target_path.is_file():
-                    results[raw_path] = f"Path is not a file: {raw_path}"
-                    continue
-
-                if not self._is_allowed_file(target_path):
-                    results[raw_path] = f"File type not allowed: {raw_path}"
-                    continue
-
-                try:
-                    content = target_path.read_text(encoding="utf-8")
-                    results[raw_path] = content
-                except UnicodeDecodeError:
-                    results[raw_path] = f"Cannot read binary file: {raw_path}"
-                except PermissionError:
-                    results[raw_path] = f"Permission denied: {raw_path}"
-
-            return FuncToolResult(result=results)
-
-        except Exception as e:
-            logger.error(f"Error reading multiple files: {str(e)}")
-            return FuncToolResult(success=0, error=str(e))
-
-
     def write_file(self, path: str, content: str, file_type: str = "") -> FuncToolResult:
         """
         Create a new file or overwrite an existing file.

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -4,25 +4,18 @@
 
 import inspect
 import os
+import re
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, Iterator, List, Optional
 
 from agents import Tool
-from pydantic import BaseModel, Field
-from wcmatch import glob
+from wcmatch import glob as wc_glob
 
 from datus.tools import BaseTool
 from datus.tools.func_tool import FuncToolResult
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
-
-
-class EditOperation(BaseModel):
-    """Single edit operation for file editing"""
-
-    oldText: str = Field(description="The text to be replaced")
-    newText: str = Field(description="The text to replace with")
 
 
 class FilesystemConfig:
@@ -114,14 +107,10 @@ class FilesystemFuncTool(BaseTool):
         bound_tools = []
         methods_to_convert = [
             self.read_file,
-            self.read_multiple_files,
             self.write_file,
             self.edit_file,
-            self.create_directory,
-            self.list_directory,
-            self.directory_tree,
-            self.move_file,
-            self.search_files,
+            self.glob,
+            self.grep,
         ]
 
         for bound_method in methods_to_convert:
@@ -153,18 +142,21 @@ class FilesystemFuncTool(BaseTool):
             return True
         return file_path.suffix.lower() in self.config.allowed_extensions
 
-    def read_file(self, path: str) -> FuncToolResult:
+    def read_file(self, path: str, offset: int = 0, limit: int = 0) -> FuncToolResult:
         """
         Read the contents of a file.
 
         Args:
             path: Path to the file. Absolute paths are permitted for read-only operations.
+            offset: Line number to start reading from (1-based). 0 means start from beginning.
+            limit: Maximum number of lines to read. 0 means read all lines.
 
         Returns:
             dict: A dictionary with the execution result, containing these keys:
                   - 'success' (int): 1 for success, 0 for failure.
                   - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[str]): File contents on success.
+                  - 'result' (Optional[str]): File contents on success. When offset/limit are set,
+                    returns numbered lines in "N: line content" format.
         """
         try:
             path = self._normalize(path)
@@ -184,6 +176,15 @@ class FilesystemFuncTool(BaseTool):
 
             try:
                 content = target_path.read_text(encoding="utf-8")
+
+                if offset > 0 or limit > 0:
+                    lines = content.split("\n")
+                    start = max(0, offset - 1) if offset > 0 else 0
+                    end = start + limit if limit > 0 else len(lines)
+                    selected = lines[start:end]
+                    numbered = [f"{start + i + 1}: {line}" for i, line in enumerate(selected)]
+                    return FuncToolResult(result="\n".join(numbered))
+
                 return FuncToolResult(result=content)
             except UnicodeDecodeError:
                 return FuncToolResult(success=0, error=f"Cannot read binary file: {path}")
@@ -239,6 +240,7 @@ class FilesystemFuncTool(BaseTool):
             logger.error(f"Error reading multiple files: {str(e)}")
             return FuncToolResult(success=0, error=str(e))
 
+
     def write_file(self, path: str, content: str, file_type: str = "") -> FuncToolResult:
         """
         Create a new file or overwrite an existing file.
@@ -279,14 +281,15 @@ class FilesystemFuncTool(BaseTool):
             logger.error(f"Error writing file {path}: {str(e)}")
             return FuncToolResult(success=0, error=str(e))
 
-    def edit_file(self, path: str, edits: List[EditOperation]) -> FuncToolResult:
+    def edit_file(self, path: str, old_string: str, new_string: str) -> FuncToolResult:
         """
-        Make selective edits to a file.
+        Make a single edit to a file by replacing old_string with new_string.
 
         Args:
             path: Relative path within the workspace directory. Do NOT use absolute paths.
-            edits: List of edit operations. Each edit must be an object (not a string) with two properties
-                   Example: [{"oldText": "text to find", "newText": "text to replace"}]
+            old_string: The text to find and replace. Must match exactly once in the file.
+            new_string: The text to replace old_string with.
+
         Returns:
             dict: A dictionary with the execution result, containing these keys:
                   - 'success' (int): 1 for success, 0 for failure.
@@ -294,14 +297,8 @@ class FilesystemFuncTool(BaseTool):
                   - 'result' (Optional[str]): Success message on success.
         """
         try:
-            # Handle edits passed as JSON string from LLM
-            if isinstance(edits, str):
-                try:
-                    import json
-
-                    edits = json.loads(edits)
-                except json.JSONDecodeError as e:
-                    return FuncToolResult(success=0, error=f"Invalid JSON in edits parameter: {str(e)}")
+            if not old_string:
+                return FuncToolResult(success=0, error="old_string must not be empty")
 
             try:
                 path = self._normalize(path, strict=True)
@@ -320,34 +317,25 @@ class FilesystemFuncTool(BaseTool):
 
             try:
                 content = target_path.read_text(encoding="utf-8")
-                edits_applied = 0
+                match_count = content.count(old_string)
 
-                for edit in edits:
-                    # Handle both EditOperation objects and dictionaries
-                    if isinstance(edit, dict):
-                        old_text = edit.get("oldText", "")
-                        new_text = edit.get("newText", "")
-                    else:
-                        old_text = edit.oldText
-                        new_text = edit.newText
+                if match_count == 0:
+                    preview = old_string[:100] + "..." if len(old_string) > 100 else old_string
+                    return FuncToolResult(
+                        success=0,
+                        error=f"old_string not found in file. Looking for: {preview}",
+                    )
 
-                    # Check if old_text exists in content before replacing
-                    if old_text and old_text in content:
-                        content = content.replace(old_text, new_text)
-                        edits_applied += 1
-                    elif old_text:
-                        # old_text not found in file
-                        preview = old_text[:100] + "..." if len(old_text) > 100 else old_text
-                        return FuncToolResult(
-                            success=0,
-                            error=f"Text not found in file, cannot apply edit. Looking for: {preview}",
-                        )
+                if match_count > 1:
+                    return FuncToolResult(
+                        success=0,
+                        error=f"old_string matches {match_count} times in file. It must match exactly once. "
+                        "Provide more surrounding context to make the match unique.",
+                    )
 
-                if edits_applied == 0:
-                    return FuncToolResult(success=0, error="No edits were applied")
-
+                content = content.replace(old_string, new_string, 1)
                 target_path.write_text(content, encoding="utf-8")
-                return FuncToolResult(result=f"File edited successfully: {str(path)} ({edits_applied} edit(s) applied)")
+                return FuncToolResult(result=f"File edited successfully: {str(path)}")
             except UnicodeDecodeError:
                 return FuncToolResult(success=0, error=f"Cannot edit binary file: {path}")
             except PermissionError:
@@ -355,197 +343,6 @@ class FilesystemFuncTool(BaseTool):
 
         except Exception as e:
             logger.error(f"Error editing file {path}: {str(e)}")
-            return FuncToolResult(success=0, error=str(e))
-
-    def create_directory(self, path: str) -> FuncToolResult:
-        """
-        Create a new directory or ensure it exists.
-
-        Args:
-            path: Relative path within the workspace directory. Do NOT use absolute paths.
-
-        Returns:
-            dict: A dictionary with the execution result, containing these keys:
-                  - 'success' (int): 1 for success, 0 for failure.
-                  - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[str]): Success message on success.
-        """
-        try:
-            target_path = self._get_safe_path(path)
-
-            if not target_path:
-                return FuncToolResult(success=0, error=f"Invalid path: {path}")
-
-            try:
-                target_path.mkdir(parents=True, exist_ok=True)
-                return FuncToolResult(result=f"Directory created: {path}")
-            except PermissionError:
-                return FuncToolResult(success=0, error=f"Permission denied: {path}")
-
-        except Exception as e:
-            logger.error(f"Error creating directory {path}: {str(e)}")
-            return FuncToolResult(success=0, error=str(e))
-
-    def list_directory(self, path: str) -> FuncToolResult:
-        """
-        List the contents of a directory.
-
-        Args:
-            path: The path of the directory to list. Use "." to list the workspace root directory.
-                  Note: Only relative paths are allowed for security.
-
-        Returns:
-            dict: A dictionary with the execution result, containing these keys:
-                  - 'success' (int): 1 for success, 0 for failure.
-                  - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[List[Dict]]): List of items with 'name' and 'type' on success.
-        """
-        try:
-            target_path = self._get_safe_path(path)
-            logger.debug(f"target_path: {target_path}")
-
-            if not target_path or not target_path.exists():
-                return FuncToolResult(success=0, error=f"Directory not found: {path}")
-
-            if not target_path.is_dir():
-                return FuncToolResult(success=0, error=f"Path is not a directory: {path}")
-
-            try:
-                items = []
-                for item in sorted(target_path.iterdir()):
-                    item_info = {"name": item.name, "type": "directory" if item.is_dir() else "file"}
-                    items.append(item_info)
-
-                return FuncToolResult(result=items)
-            except PermissionError:
-                return FuncToolResult(success=0, error=f"Permission denied: {path}")
-
-        except Exception as e:
-            logger.error(f"Error listing directory {path}: {str(e)}")
-            return FuncToolResult(success=0, error=str(e))
-
-    def directory_tree(self, path: str, max_depth: int = 3, max_items: int = 1000) -> FuncToolResult:
-        """
-        Get a tree view of a directory with depth and item limits.
-
-        Args:
-            path: The path of the directory to analyze. Use "." for workspace root.
-            max_depth: Maximum depth to traverse (default: 3). Use -1 for unlimited depth.
-            max_items: Maximum number of items to display (default: 1000). Prevents context overflow.
-
-        Returns:
-            dict: A dictionary with the execution result, containing these keys:
-                  - 'success' (int): 1 for success, 0 for failure.
-                  - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[str]): Tree view string on success.
-        """
-        try:
-            target_path = self._get_safe_path(path)
-
-            if not target_path or not target_path.exists():
-                return FuncToolResult(success=0, error=f"Directory not found: {path}")
-
-            if not target_path.is_dir():
-                return FuncToolResult(success=0, error=f"Path is not a directory: {path}")
-
-            try:
-                item_count = {"count": 0}  # Mutable counter to track across recursion
-                truncated = {"flag": False}  # Track if output was truncated
-
-                def build_tree(dir_path: Path, prefix: str = "", depth: int = 0) -> List[str]:
-                    # Check depth limit
-                    if max_depth >= 0 and depth >= max_depth:
-                        return [f"{prefix}    ... (max depth {max_depth} reached)"]
-
-                    # Check item limit
-                    if item_count["count"] >= max_items:
-                        truncated["flag"] = True
-                        return [f"{prefix}    ... (max items {max_items} reached)"]
-
-                    lines = []
-                    try:
-                        items = sorted(dir_path.iterdir())
-                    except PermissionError:
-                        return [f"{prefix}    ... (permission denied)"]
-
-                    for i, item in enumerate(items):
-                        # Check item limit before processing
-                        if item_count["count"] >= max_items:
-                            truncated["flag"] = True
-                            lines.append(f"{prefix}    ... (truncated at {max_items} items)")
-                            break
-
-                        is_last = i == len(items) - 1
-                        current_prefix = "└── " if is_last else "├── "
-
-                        if item.is_dir():
-                            lines.append(f"{prefix}{current_prefix}{item.name}/")
-                            item_count["count"] += 1
-                            next_prefix = prefix + ("    " if is_last else "│   ")
-                            lines.extend(build_tree(item, next_prefix, depth + 1))
-                        else:
-                            try:
-                                size = item.stat().st_size
-                                lines.append(f"{prefix}{current_prefix}{item.name} ({size} bytes)")
-                            except Exception:
-                                lines.append(f"{prefix}{current_prefix}{item.name}")
-                            item_count["count"] += 1
-
-                    return lines
-
-                tree_lines = [f"{target_path.name}/"]
-                tree_lines.extend(build_tree(target_path))
-                tree_output = "\n".join(tree_lines)
-
-                # Add warning if truncated
-                if truncated["flag"]:
-                    tree_output += (
-                        f"\n\nOutput truncated: Reached limit of {max_items} items. "
-                        "Use smaller max_items or specify a subdirectory."
-                    )
-
-                return FuncToolResult(result=tree_output)
-            except PermissionError:
-                return FuncToolResult(success=0, error=f"Permission denied: {path}")
-
-        except Exception as e:
-            logger.error(f"Error building directory tree {path}: {str(e)}")
-            return FuncToolResult(success=0, error=str(e))
-
-    def move_file(self, source: str, destination: str) -> FuncToolResult:
-        """
-        Move or rename a file or directory.
-
-        Args:
-            source: The current path of the file or directory
-            destination: The new path for the file or directory
-
-        Returns:
-            dict: A dictionary with the execution result, containing these keys:
-                  - 'success' (int): 1 for success, 0 for failure.
-                  - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[str]): Success message on success.
-        """
-        try:
-            source_path = self._get_safe_path(source)
-            dest_path = self._get_safe_path(destination)
-
-            if not source_path or not source_path.exists():
-                return FuncToolResult(success=0, error=f"Source not found: {source}")
-
-            if not dest_path:
-                return FuncToolResult(success=0, error=f"Invalid destination: {destination}")
-
-            try:
-                source_path.rename(dest_path)
-                return FuncToolResult(result=f"Moved {source} to {destination}")
-            except PermissionError:
-                return FuncToolResult(success=0, error="Permission denied")
-            except OSError as e:
-                return FuncToolResult(success=0, error=f"Move failed: {str(e)}")
-
-        except Exception as e:
-            logger.error(f"Error moving file from {source} to {destination}: {str(e)}")
             return FuncToolResult(success=0, error=str(e))
 
     # Minimal fallback excludes when no .gitignore is found
@@ -607,28 +404,101 @@ class FilesystemFuncTool(BaseTool):
 
         return patterns
 
-    def search_files(
-        self, path: str, pattern: str, exclude_patterns: Optional[List[str]] = None, max_results: int = 200
-    ) -> FuncToolResult:
-        """
-        Recursively search for files and directories matching a pattern.
+    def _walk_files(self, path: str, include_pattern: str = "") -> Iterator[Path]:
+        """Walk directory tree yielding files, respecting gitignore, symlink safety, and sandbox.
 
         Args:
-            path: Starting directory to begin search
-            pattern: Glob-style pattern to match (e.g., "*.py", "**/*.yaml")
-            exclude_patterns: List of glob-style patterns to exclude from results
-            max_results: Maximum number of results to return (default 200). Use -1 for unlimited.
+            path: Starting directory path (relative to root).
+            include_pattern: Optional glob pattern to filter filenames (e.g., "*.py").
+
+        Yields:
+            Path objects for each matching file.
+        """
+        target_path = self._get_safe_path(path)
+        if not target_path or not target_path.exists() or not target_path.is_dir():
+            return
+
+        root_path_resolved = Path(self.config.root_path).resolve(strict=False)
+        target_path_resolved = target_path.resolve(strict=False)
+
+        try:
+            target_path_resolved.relative_to(root_path_resolved)
+        except ValueError:
+            return
+
+        exclude_patterns = self._load_gitignore_patterns(target_path)
+        visited_inodes = set()
+
+        def should_exclude(file_path: Path) -> bool:
+            relative_path = str(file_path.relative_to(target_path_resolved))
+            for exclude_pattern in exclude_patterns:
+                try:
+                    if wc_glob.globmatch(relative_path, exclude_pattern, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR):
+                        return True
+                except Exception:
+                    continue
+            return False
+
+        def walk_recursive(current_path: Path):
+            try:
+                try:
+                    current_inode = current_path.stat().st_ino
+                except OSError:
+                    return
+
+                if current_inode in visited_inodes:
+                    return
+                visited_inodes.add(current_inode)
+
+                for item in current_path.iterdir():
+                    try:
+                        if item.is_dir() and item.name == ".git":
+                            continue
+
+                        if should_exclude(item):
+                            continue
+
+                        item_resolved = item.resolve(strict=False)
+
+                        # Security: ensure resolved path stays within sandbox
+                        try:
+                            item_resolved.relative_to(root_path_resolved)
+                        except ValueError:
+                            continue
+
+                        if item.is_dir():
+                            yield from walk_recursive(item_resolved)
+                        elif item.is_file():
+                            if include_pattern:
+                                if not wc_glob.globmatch(
+                                    item.name, include_pattern, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR
+                                ):
+                                    continue
+                            yield item
+                    except OSError:
+                        continue
+            except OSError:
+                return
+
+        yield from walk_recursive(target_path_resolved)
+
+    def glob(self, pattern: str, path: str = ".") -> FuncToolResult:
+        """
+        Find files matching a glob pattern.
+
+        Args:
+            pattern: Glob pattern to match (e.g., "*.py", "**/*.yaml", "src/**/*.ts").
+            path: Starting directory for the search. Defaults to workspace root ".".
 
         Returns:
             dict: A dictionary with the execution result, containing these keys:
                   - 'success' (int): 1 for success, 0 for failure.
                   - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[List[str]]): List of matches whose paths are
-                    relative to ``root_path`` (so callers can feed them back to
-                    ``read_file`` / ``write_file`` without leaking absolute paths).
-                    Falls back to the absolute form only if a match somehow lands
-                    outside ``root_path``.
+                  - 'result' (Optional[dict]): Dict with 'files' (list of paths relative to
+                    ``root_path`` so callers can feed them back to ``read_file`` /
+                    ``write_file`` without leaking absolute paths) and 'truncated' (bool).
         """
+        max_results = 200
         try:
             target_path = self._get_safe_path(path)
 
@@ -638,114 +508,118 @@ class FilesystemFuncTool(BaseTool):
             if not target_path.is_dir():
                 return FuncToolResult(success=0, error=f"Path is not a directory: {path}")
 
-            # Merge user excludes with .gitignore patterns
-            gitignore_patterns = self._load_gitignore_patterns(target_path)
-            all_excludes = list(exclude_patterns or []) + gitignore_patterns
-            exclude_patterns = all_excludes
+            target_path_resolved = target_path.resolve(strict=False)
+            root_path_resolved = Path(self.config.root_path).resolve(strict=False)
+            matches = []
 
-            effective_max = max_results if max_results >= 0 else float("inf")
-
-            try:
-                matches = []
-                root_path_resolved = Path(self.config.root_path).resolve(strict=False)
-                target_path_resolved = target_path.resolve(strict=False)
-
-                # Ensure target path is within root path sandbox
+            for file_path in self._walk_files(path):
+                relative_path = str(file_path.relative_to(target_path_resolved))
+                # Report paths relative to root_path so the LLM can feed them
+                # back to read_file/write_file without leaking absolute paths.
                 try:
-                    target_path_resolved.relative_to(root_path_resolved)
+                    reported_path = str(file_path.relative_to(root_path_resolved))
                 except ValueError:
-                    return FuncToolResult(success=0, error=f"Path {path} is outside the allowed directory")
+                    reported_path = str(file_path)
+                try:
+                    if wc_glob.globmatch(relative_path, pattern, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR):
+                        matches.append(reported_path)
+                        if len(matches) >= max_results:
+                            break
+                except Exception:
+                    if file_path.name == pattern:
+                        matches.append(reported_path)
+                        if len(matches) >= max_results:
+                            break
 
-                # Track visited inodes to prevent symlink loops
-                visited_inodes = set()
-
-                def should_exclude(file_path: Path) -> bool:
-                    relative_path = str(file_path.relative_to(target_path_resolved))
-                    for exclude_pattern in exclude_patterns:
-                        try:
-                            # globmatch: minimatch-compatible with DOTGLOB (hidden files) and GLOBSTAR (**)
-                            if glob.globmatch(relative_path, exclude_pattern, flags=glob.DOTGLOB | glob.GLOBSTAR):
-                                return True
-                        except Exception:
-                            continue
-                    return False
-
-                def search_recursive(current_path: Path):
-                    try:
-                        try:
-                            current_inode = current_path.stat().st_ino
-                        except OSError:
-                            return
-
-                        if current_inode in visited_inodes:
-                            return
-
-                        visited_inodes.add(current_inode)
-
-                        for item in current_path.iterdir():
-                            try:
-                                if item.is_dir() and item.name == ".git":
-                                    continue
-
-                                if should_exclude(item):
-                                    continue
-
-                                item_resolved = item.resolve(strict=False)
-
-                                # Security: ensure resolved path stays within sandbox
-                                try:
-                                    item_resolved.relative_to(root_path_resolved)
-                                except ValueError:
-                                    continue
-
-                                relative_path = str(item.relative_to(target_path_resolved))
-                                # Report paths relative to root_path so the LLM can feed them
-                                # back to read_file/write_file without leaking absolute paths.
-                                try:
-                                    reported_path = str(item_resolved.relative_to(root_path_resolved))
-                                except ValueError:
-                                    reported_path = str(item_resolved)
-                                try:
-                                    if glob.globmatch(relative_path, pattern, flags=glob.DOTGLOB | glob.GLOBSTAR):
-                                        matches.append(reported_path)
-                                        if len(matches) >= effective_max:
-                                            return
-                                except Exception:
-                                    if item.name == pattern:
-                                        matches.append(reported_path)
-                                        if len(matches) >= effective_max:
-                                            return
-
-                                if item.is_dir():
-                                    search_recursive(item_resolved)
-                                    if len(matches) >= effective_max:
-                                        return
-
-                            except OSError:
-                                continue
-
-                    except OSError:
-                        return
-
-                search_recursive(target_path_resolved)
-
-                truncated = len(matches) >= effective_max
-                result_data = {
-                    "files": matches,
-                    "truncated": truncated,
-                }
-                if truncated:
-                    result_data["message"] = (
-                        f"Results truncated to {max_results}. "
-                        "Use a more specific pattern or exclude_patterns to narrow results."
-                    )
-                return FuncToolResult(result=result_data)
-
-            except PermissionError:
-                return FuncToolResult(success=0, error=f"Permission denied: {path}")
+            truncated = len(matches) >= max_results
+            result_data = {
+                "files": matches,
+                "truncated": truncated,
+            }
+            if truncated:
+                result_data["message"] = (
+                    f"Results truncated to {max_results}. Use a more specific pattern to narrow results."
+                )
+            return FuncToolResult(result=result_data)
 
         except Exception as e:
-            logger.exception(f"Error searching files in {path}")
+            logger.exception(f"Error in glob search for {pattern} in {path}")
+            return FuncToolResult(success=0, error=str(e))
+
+    def grep(self, pattern: str, path: str = ".", include: str = "", case_sensitive: bool = True) -> FuncToolResult:
+        """
+        Search file contents using a regular expression pattern.
+
+        Args:
+            pattern: Regular expression pattern to search for.
+            path: Starting directory for the search. Defaults to workspace root ".".
+            include: Optional glob pattern to filter files (e.g., "*.py", "*.sql").
+            case_sensitive: Whether the search is case-sensitive. Defaults to True.
+
+        Returns:
+            dict: A dictionary with the execution result, containing these keys:
+                  - 'success' (int): 1 for success, 0 for failure.
+                  - 'error' (Optional[str]): Error message on failure.
+                  - 'result' (Optional[dict]): Dict with 'matches' (list of {file, line, content}) and 'truncated'.
+        """
+        max_matches = 100
+        try:
+            target_path = self._get_safe_path(path)
+
+            if not target_path or not target_path.exists():
+                return FuncToolResult(success=0, error=f"Directory not found: {path}")
+
+            if not target_path.is_dir():
+                return FuncToolResult(success=0, error=f"Path is not a directory: {path}")
+
+            flags = 0 if case_sensitive else re.IGNORECASE
+            try:
+                compiled = re.compile(pattern, flags)
+            except re.error as e:
+                return FuncToolResult(success=0, error=f"Invalid regex pattern: {str(e)}")
+
+            matches = []
+
+            for file_path in self._walk_files(path, include_pattern=include):
+                if not self._is_allowed_file(file_path):
+                    continue
+
+                try:
+                    if file_path.stat().st_size > self.config.max_file_size:
+                        continue
+                except OSError:
+                    continue
+
+                try:
+                    content = file_path.read_text(encoding="utf-8")
+                except (UnicodeDecodeError, PermissionError, OSError):
+                    continue
+
+                for line_num, line in enumerate(content.split("\n"), start=1):
+                    if compiled.search(line):
+                        matches.append(
+                            {
+                                "file": str(file_path),
+                                "line": line_num,
+                                "content": line.rstrip(),
+                            }
+                        )
+                        if len(matches) >= max_matches:
+                            break
+
+                if len(matches) >= max_matches:
+                    break
+
+            truncated = len(matches) >= max_matches
+            return FuncToolResult(
+                result={
+                    "matches": matches,
+                    "truncated": truncated,
+                }
+            )
+
+        except Exception as e:
+            logger.exception(f"Error in grep search for {pattern} in {path}")
             return FuncToolResult(success=0, error=str(e))
 
 

--- a/datus/tools/mcp_tools/README.md
+++ b/datus/tools/mcp_tools/README.md
@@ -58,14 +58,14 @@ if result.success:
 # Call a tool
 result = mcp_tool.call_tool(
     "my-filesystem-server",
-    "list_directory",
-    {"path": "/tmp"}
+    "glob",
+    {"pattern": "*.py", "path": "/tmp"}
 )
 
 # Set up tool filtering (allow only specific tools)
 result = mcp_tool.set_tool_filter(
     "my-filesystem-server",
-    allowed_tools=["read_file", "write_file", "list_directory"],
+    allowed_tools=["read_file", "write_file", "glob"],
     blocked_tools=None,
     enabled=True
 )
@@ -194,7 +194,7 @@ Only specified tools are permitted. All other tools are blocked.
 # Allow only specific tools
 mcp_tool.set_tool_filter(
     "my-server",
-    allowed_tools=["read_file", "write_file", "list_directory"],
+    allowed_tools=["read_file", "write_file", "glob"],
     blocked_tools=None,  # Not used with allowlist
     enabled=True
 )
@@ -233,7 +233,7 @@ mcp_tool.set_tool_filter(
 # Basic allowlist
 result = mcp_tool.set_tool_filter(
     server_name="filesystem-server",
-    allowed_tools=["read_file", "write_file", "list_directory"],
+    allowed_tools=["read_file", "write_file", "glob"],
     enabled=True
 )
 
@@ -313,7 +313,7 @@ Tool filters are persisted in the configuration file:
       "command": "python",
       "args": ["-m", "my_server"],
       "tool_filter": {
-        "allowed_tool_names": ["read_file", "search_files"],
+        "allowed_tool_names": ["read_file", "glob"],
         "enabled": true
       }
     },

--- a/datus/tools/permission/permission_manager.py
+++ b/datus/tools/permission/permission_manager.py
@@ -294,8 +294,9 @@ class PermissionManager:
         elif tool_name.startswith("fs_") or tool_name in (
             "read_file",
             "write_file",
-            "list_files",
-            "list_directory",
+            "edit_file",
+            "glob",
+            "grep",
         ):
             return "filesystem_tools"
         elif tool_name.startswith("date_") or tool_name in ("parse_date", "parse_temporal_expressions"):

--- a/datus/utils/benchmark_utils.py
+++ b/datus/utils/benchmark_utils.py
@@ -482,7 +482,7 @@ def _extract_artifacts_from_action_history(
 
         output_payload = entry.get("output") or {}
         result_payload = _extract_result_payload(output_payload)
-        if function_name in {"write_file", "read_file", "read_multiple_files", "search_files"}:
+        if function_name in {"write_file", "read_file", "glob", "grep"}:
             _collect_file_artifacts(artifacts, result_payload)
         elif function_name in {"search_reference_sql", "get_reference_sql"}:
             _collect_reference_sql_artifacts(artifacts, result_payload)

--- a/docs/getting_started/Quickstart.md
+++ b/docs/getting_started/Quickstart.md
@@ -231,10 +231,10 @@ Datus will display its thinking process to show how it approaches the task, then
     +---------------------------------------------------------------------------------------------------------------------------------------+
     |                                                    Action Stream                                                                      |
     +=======================================================================================================================================+
-    | 🔧 Tool call - search_files('{"path": "~/.datus/workspace", "pattern": ...') - ✓                                            |
+    | 🔧 Tool call - glob('{"pattern": "*", "path": "~/.datus/workspace"}') - ✓                                                    |
     |     No matches found (0.5s)                                                                                                          |
     | 💬 Thinking: Let me check the directory structure to see what's available:                                                           |
-    | 🔧 Tool call - list_directory('{"path": "~/.datus/workspace"}') - ✓ (0.5s)                                                   |
+    | 🔧 Tool call - glob('{"pattern": "**/*", "path": "~/.datus/workspace"}') - ✓ (0.5s)                                          |
     | 💬 Thinking: Now let me analyze the gold-Bitcoin correlation by examining the data and performing a comprehensive correlation        |
     | analysis:                                                                                                                            |
     | 🔧 Tool call - read_query('{"sql": "SELECT \n    COUNT(*) as total_records,\n...') - ✓                                               |

--- a/docs/getting_started/Quickstart.zh.md
+++ b/docs/getting_started/Quickstart.zh.md
@@ -229,10 +229,10 @@ Datus 会展示其思考过程，说明分析步骤，并给出详细报告。
     +---------------------------------------------------------------------------------------------------------------------------------------+
     |                                                    Action Stream                                                                      |
     +=======================================================================================================================================+
-    | 🔧 Tool call - search_files('{"path": "/Users/yt/.datus/workspace", "pattern": ...') - ✓                                            |
+    | 🔧 Tool call - glob('{"pattern": "*", "path": "/Users/yt/.datus/workspace"}') - ✓                                                    |
     |     No matches found (0.5s)                                                                                                          |
     | 💬 Thinking: Let me check the directory structure to see what's available:                                                           |
-    | 🔧 Tool call - list_directory('{"path": "/Users/yt/.datus/workspace"}') - ✓ (0.5s)                                                   |
+    | 🔧 Tool call - glob('{"pattern": "**/*", "path": "/Users/yt/.datus/workspace"}') - ✓ (0.5s)                                          |
     | 💬 Thinking: Now let me analyze the gold-Bitcoin correlation by examining the data and performing a comprehensive correlation        |
     | analysis:                                                                                                                            |
     | 🔧 Tool call - read_query('{"sql": "SELECT \n    COUNT(*) as total_records,\n...') - ✓                                               |

--- a/docs/subagent/builtin_subagents.md
+++ b/docs/subagent/builtin_subagents.md
@@ -739,7 +739,7 @@ agent:
 |---------------|-------|---------|
 | Database | `list_databases`, `list_schemas`, `list_tables`, `search_table`, `describe_table`, `get_table_ddl`, `read_query` | Schema discovery and data sampling (read-only) |
 | Context Search | `search_metrics`, `search_reference_sql`, `search_knowledge`, `search_semantic_objects`, `list_subject_tree`, `get_metrics`, `get_reference_sql`, `get_knowledge` | Knowledge base retrieval |
-| Filesystem | `read_file`, `read_multiple_files`, `list_directory`, `directory_tree`, `search_files` | Read-only file browsing |
+| Filesystem | `read_file`, `glob`, `grep` | Read-only file browsing |
 | Date Parsing | `get_current_date`, `parse_temporal_expressions` | Date context |
 
 ### Output Format

--- a/docs/subagent/builtin_subagents.zh.md
+++ b/docs/subagent/builtin_subagents.zh.md
@@ -737,7 +737,7 @@ agent:
 |---------|------|------|
 | 数据库 | `list_databases`、`list_schemas`、`list_tables`、`search_table`、`describe_table`、`get_table_ddl`、`read_query` | Schema 发现和数据采样（只读） |
 | 上下文搜索 | `search_metrics`、`search_reference_sql`、`search_knowledge`、`search_semantic_objects`、`list_subject_tree`、`get_metrics`、`get_reference_sql`、`get_knowledge` | 知识库检索 |
-| 文件系统 | `read_file`、`read_multiple_files`、`list_directory`、`directory_tree`、`search_files` | 只读文件浏览 |
+| 文件系统 | `read_file`、`glob`、`grep` | 只读文件浏览 |
 | 日期解析 | `get_current_date`、`parse_temporal_expressions` | 日期上下文 |
 
 ### 输出格式

--- a/docs/subagent/gen_sql_summary.md
+++ b/docs/subagent/gen_sql_summary.md
@@ -84,7 +84,7 @@ agentic_nodes:
 ```
 
 **Built-in configurations** (automatically enabled):
-- **Tools**: Filesystem tools (`read_file`, `write_file`, `edit_file`, `list_directory`) and `generate_sql_summary_id`
+- **Tools**: Filesystem tools (`read_file`, `write_file`, `edit_file`, `glob`) and `generate_sql_summary_id`
 - **Hooks**: User confirmation workflow in interactive mode
 - **System Prompt**: Built-in template version 1.0
 - **Workspace**: `~/.datus/data/{namespace}/reference_sql`

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -18,7 +18,7 @@ Before asking the user anything, gather context silently:
 
 - If creating a data-related skill, **explore the database first**: use `list_tables`, `describe_table`, `read_query` (with LIMIT) to understand available tables, columns, data types, sample data, and time ranges.
 - If the conversation already contains a workflow the user wants to capture (e.g., "turn this into a skill"), extract the key steps, tools used, and patterns from the conversation history.
-- Check existing skills via `skill_list_directory` to avoid duplicates.
+- Check existing skills via `skill_glob` to avoid duplicates.
 
 This research informs your questions and your SKILL.md — it is NOT skill output.
 
@@ -94,13 +94,11 @@ skill-name/
 Use `skill_*` tools (paths relative to skills directory root):
 
 ```
-skill_create_directory(path="<skill-name>")
 skill_write_file(path="<skill-name>/SKILL.md", content=...)
 ```
 
 If the user explicitly requested scripts, also create scripts/:
 ```
-skill_create_directory(path="<skill-name>/scripts")
 skill_write_file(path="<skill-name>/scripts/<script>.py", content=...)
 ```
 

--- a/tests/integration/agent/test_gen_metrics_agentic.py
+++ b/tests/integration/agent/test_gen_metrics_agentic.py
@@ -37,7 +37,7 @@ class TestGenMetricsAgentic:
         tool_names = [tool.name for tool in node.tools]
         assert "read_file" in tool_names, f"Missing read_file tool, got: {tool_names}"
         assert "write_file" in tool_names, f"Missing write_file tool, got: {tool_names}"
-        assert "list_directory" in tool_names, f"Missing list_directory tool, got: {tool_names}"
+        assert "glob" in tool_names, f"Missing glob tool, got: {tool_names}"
         assert "check_semantic_object_exists" in tool_names, f"Missing check_semantic_object_exists, got: {tool_names}"
         assert "end_metric_generation" in tool_names, f"Missing end_metric_generation, got: {tool_names}"
 

--- a/tests/integration/agent/test_gen_semantic_model_agentic.py
+++ b/tests/integration/agent/test_gen_semantic_model_agentic.py
@@ -39,7 +39,7 @@ class TestGenSemanticModelAgentic:
         # Filesystem tools
         assert "read_file" in tool_names, f"Missing read_file, got: {tool_names}"
         assert "write_file" in tool_names, f"Missing write_file, got: {tool_names}"
-        assert "list_directory" in tool_names, f"Missing list_directory, got: {tool_names}"
+        assert "glob" in tool_names, f"Missing glob, got: {tool_names}"
 
         # Generation tools
         assert "check_semantic_object_exists" in tool_names, f"Missing check_semantic_object_exists, got: {tool_names}"

--- a/tests/integration/agent/test_sql_summary_agentic.py
+++ b/tests/integration/agent/test_sql_summary_agentic.py
@@ -40,9 +40,9 @@ class TestSqlSummaryAgentic:
         # Filesystem tools
         assert "read_file" in tool_names, f"Missing read_file, got: {tool_names}"
         assert "write_file" in tool_names, f"Missing write_file, got: {tool_names}"
-        assert "list_directory" in tool_names, f"Missing list_directory, got: {tool_names}"
         assert "edit_file" in tool_names, f"Missing edit_file, got: {tool_names}"
-        assert "read_multiple_files" in tool_names, f"Missing read_multiple_files, got: {tool_names}"
+        assert "glob" in tool_names, f"Missing glob, got: {tool_names}"
+        assert "grep" in tool_names, f"Missing grep, got: {tool_names}"
 
         # Generation tools
         assert "generate_sql_summary_id" in tool_names, f"Missing generate_sql_summary_id, got: {tool_names}"

--- a/tests/unit_tests/agent/node/test_explore_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_explore_agentic_node.py
@@ -124,10 +124,8 @@ class TestExploreAgenticNodeTools:
         tool_names = [t.name for t in node.tools]
         # Read-only tools should be present
         assert "read_file" in tool_names
-        assert "read_multiple_files" in tool_names
-        assert "list_directory" in tool_names
-        assert "directory_tree" in tool_names
-        assert "search_files" in tool_names
+        assert "glob" in tool_names
+        assert "grep" in tool_names
 
     def test_explore_excludes_write_tools(self, real_agent_config, mock_llm_create):
         """Node should NOT have write/edit/create/move filesystem tools."""
@@ -144,8 +142,6 @@ class TestExploreAgenticNodeTools:
         # Write tools should NOT be present
         assert "write_file" not in tool_names
         assert "edit_file" not in tool_names
-        assert "create_directory" not in tool_names
-        assert "move_file" not in tool_names
 
     def test_explore_has_date_parsing_tools(self, real_agent_config, mock_llm_create):
         """Node should have date parsing tools."""

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -69,9 +69,9 @@ class TestGenMetricsAgenticNodeInit:
         # Filesystem tools
         assert "read_file" in tool_names
         assert "write_file" in tool_names
-        assert "list_directory" in tool_names
         assert "edit_file" in tool_names
-        assert "read_multiple_files" in tool_names
+        assert "glob" in tool_names
+        assert "grep" in tool_names
 
         # Generation tools
         assert "check_semantic_object_exists" in tool_names

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -88,9 +88,9 @@ class TestGenSemanticModelAgenticNodeInit:
         # Filesystem tools
         assert "read_file" in tool_names
         assert "write_file" in tool_names
-        assert "list_directory" in tool_names
         assert "edit_file" in tool_names
-        assert "read_multiple_files" in tool_names
+        assert "glob" in tool_names
+        assert "grep" in tool_names
 
         # Generation tools
         assert "check_semantic_object_exists" in tool_names

--- a/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
@@ -108,8 +108,8 @@ class TestSkillCreatorAgenticNodeTools:
         tool_names = [t.name for t in node.tools]
         assert "skill_write_file" in tool_names
         assert "skill_edit_file" in tool_names
-        assert "skill_create_directory" in tool_names
-        assert "skill_move_file" in tool_names
+        assert "skill_glob" in tool_names
+        assert "skill_grep" in tool_names
 
     def test_has_workspace_read_tools(self, real_agent_config, mock_llm_create):
         """Node should have workspace read-only tools (unprefixed)."""
@@ -124,10 +124,8 @@ class TestSkillCreatorAgenticNodeTools:
         )
         tool_names = [t.name for t in node.tools]
         assert "read_file" in tool_names
-        assert "read_multiple_files" in tool_names
-        assert "list_directory" in tool_names
-        assert "directory_tree" in tool_names
-        assert "search_files" in tool_names
+        assert "glob" in tool_names
+        assert "grep" in tool_names
 
     def test_has_skills_read_tools(self, real_agent_config, mock_llm_create):
         """Node should have skill_* prefixed read tools for skills directory."""
@@ -142,8 +140,8 @@ class TestSkillCreatorAgenticNodeTools:
         )
         tool_names = [t.name for t in node.tools]
         assert "skill_read_file" in tool_names
-        assert "skill_list_directory" in tool_names
-        assert "skill_directory_tree" in tool_names
+        assert "skill_glob" in tool_names
+        assert "skill_grep" in tool_names
 
     def test_has_db_tools(self, real_agent_config, mock_llm_create):
         """Node should have database tools."""

--- a/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
@@ -71,8 +71,8 @@ class TestSqlSummaryAgenticNodeInit:
         assert "read_file" in tool_names
         assert "write_file" in tool_names
         assert "edit_file" in tool_names
-        assert "read_multiple_files" in tool_names
-        assert "list_directory" in tool_names
+        assert "glob" in tool_names
+        assert "grep" in tool_names
 
         # Tool instances should be initialized
         assert node.filesystem_func_tool is not None
@@ -148,8 +148,8 @@ class TestSqlSummaryAgenticNodeExecution:
                 build_tool_then_response(
                     tool_calls=[
                         MockToolCall(
-                            name="list_directory",
-                            arguments=json.dumps({"path": "."}),
+                            name="glob",
+                            arguments=json.dumps({"pattern": "*"}),
                         ),
                     ],
                     content=response_content,

--- a/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
@@ -169,7 +169,7 @@ class TestSqlSummaryAgenticNodeExecution:
 
         # Should include TOOL actions from real tool execution
         tool_actions = [a for a in actions if a.role == ActionRole.TOOL]
-        assert len(tool_actions) >= 2  # PROCESSING + SUCCESS for list_directory
+        assert len(tool_actions) >= 2  # PROCESSING + SUCCESS for glob
 
         # Verify tool was actually executed
         tool_success_actions = [a for a in tool_actions if a.status == ActionStatus.SUCCESS]

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -18,9 +18,7 @@ from datus.cli.action_display.tool_content import (
     _build_ask_user,
     _build_attribution_analyze,
     _build_check_exists,
-    _build_create_directory,
     _build_describe_table,
-    _build_directory_tree,
     _build_doc_search_result,
     _build_end_generation,
     _build_end_metric_generation,
@@ -34,23 +32,21 @@ from datus.cli.action_display.tool_content import (
     _build_get_multiple_ddl,
     _build_get_reference_sql,
     _build_get_table_ddl,
+    _build_glob,
+    _build_grep,
     _build_list_databases,
-    _build_list_directory,
     _build_list_document_nav,
     _build_list_metrics_semantic,
     _build_list_schemas,
     _build_list_subject_tree,
     _build_list_tables,
     _build_load_skill,
-    _build_move_file,
     _build_parse_dates,
     _build_query_metrics,
     _build_read_file,
-    _build_read_multiple_files,
     _build_read_query,
     _build_search_documents,
     _build_search_external_knowledge,
-    _build_search_files,
     _build_search_knowledge,
     _build_search_metrics,
     _build_search_reference_sql,
@@ -1372,96 +1368,39 @@ class TestBuildReadFile:
 
 
 @pytest.mark.ci
-class TestBuildReadMultipleFiles:
+class TestBuildGlob:
     def test_compact(self):
         a = _make(
-            input_data={"function_name": "read_multiple_files"},
-            output_data={"raw_output": '{"success": 1, "result": {"/a.py": "x", "/b.py": "y"}}'},
+            input_data={"function_name": "glob"},
+            output_data={"raw_output": '{"success": 1, "result": {"files": ["/a.py", "/b.py"], "truncated": false}}'},
         )
-        tc = _build_read_multiple_files(a, verbose=False)
-        assert "2 files read" in tc.output_preview
-
-    def test_verbose_shows_paths(self):
-        a = _make(
-            input_data={"function_name": "read_multiple_files", "arguments": {"paths": ["/a.py"]}},
-            output_data={"raw_output": '{"success": 1, "result": {"/a.py": "content"}}'},
-        )
-        tc = _build_read_multiple_files(a, verbose=True)
-        assert any("/a.py" in line for line in tc.output_lines)
+        tc = _build_glob(a, verbose=False)
+        assert "2 files found" in tc.output_preview
 
 
 @pytest.mark.ci
-class TestBuildCreateDirectory:
+class TestBuildGrep:
     def test_compact(self):
         a = _make(
-            input_data={"function_name": "create_directory"},
-            output_data={"raw_output": '{"success": 1, "result": "Directory created: /tmp/dir"}'},
-        )
-        tc = _build_create_directory(a, verbose=False)
-        assert "Directory created" in tc.output_preview
-
-
-@pytest.mark.ci
-class TestBuildListDirectory:
-    def test_compact(self):
-        a = _make(
-            input_data={"function_name": "list_directory"},
+            input_data={"function_name": "grep"},
             output_data={
-                "raw_output": '{"success": 1, "result": ['
-                '{"name": "src", "type": "directory"}, {"name": "readme.md", "type": "file"}]}'
+                "raw_output": '{"success": 1, "result": {"matches": ['
+                '{"file": "/a.py", "line": 1, "content": "hello"}], "truncated": false}}'
             },
         )
-        tc = _build_list_directory(a, verbose=False)
-        assert "2 items" in tc.output_preview
+        tc = _build_grep(a, verbose=False)
+        assert "1 matches" in tc.output_preview
 
-    def test_verbose_shows_dir_suffix(self):
+    def test_verbose_shows_matches(self):
         a = _make(
-            input_data={"function_name": "list_directory", "arguments": {"path": "/tmp"}},
-            output_data={"raw_output": '{"success": 1, "result": [{"name": "src", "type": "directory"}]}'},
+            input_data={"function_name": "grep", "arguments": {"pattern": "hello"}},
+            output_data={
+                "raw_output": '{"success": 1, "result": {"matches": ['
+                '{"file": "/a.py", "line": 1, "content": "hello world"}], "truncated": false}}'
+            },
         )
-        tc = _build_list_directory(a, verbose=True)
-        assert any("src/" in line for line in tc.output_lines)
-
-
-@pytest.mark.ci
-class TestBuildDirectoryTree:
-    def test_compact(self):
-        a = _make(
-            input_data={"function_name": "directory_tree"},
-            output_data={"raw_output": '{"success": 1, "result": ".\n├── src\n└── test"}'},
-        )
-        tc = _build_directory_tree(a, verbose=False)
-        assert "Tree generated" in tc.output_preview
-
-    def test_verbose(self):
-        a = _make(
-            input_data={"function_name": "directory_tree", "arguments": {"path": "/tmp"}},
-            output_data={"raw_output": '{"success": 1, "result": ".\\nsrc\\ntest"}'},
-        )
-        tc = _build_directory_tree(a, verbose=True)
-        assert any("tree" in line for line in tc.output_lines)
-
-
-@pytest.mark.ci
-class TestBuildMoveFile:
-    def test_compact(self):
-        a = _make(
-            input_data={"function_name": "move_file"},
-            output_data={"raw_output": '{"success": 1, "result": "Moved a to b"}'},
-        )
-        tc = _build_move_file(a, verbose=False)
-        assert "Moved" in tc.output_preview
-
-
-@pytest.mark.ci
-class TestBuildSearchFiles:
-    def test_compact(self):
-        a = _make(
-            input_data={"function_name": "search_files"},
-            output_data={"raw_output": '{"success": 1, "result": ["/a.py", "/b.py"]}'},
-        )
-        tc = _build_search_files(a, verbose=False)
-        assert "2 files found" in tc.output_preview
+        tc = _build_grep(a, verbose=True)
+        assert any("/a.py" in line for line in tc.output_lines)
 
 
 # ── Platform document tools ───────────────────────────────────────
@@ -1811,12 +1750,8 @@ class TestAllToolsRegistered:
         "edit_file",
         "write_file",
         "read_file",
-        "read_multiple_files",
-        "create_directory",
-        "list_directory",
-        "directory_tree",
-        "move_file",
-        "search_files",
+        "glob",
+        "grep",
         # Platform doc
         "list_document_nav",
         "get_document",

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from datus.cli.generation_hooks import make_kb_path_normalizer
-from datus.tools.func_tool.filesystem_tools import EditOperation, FilesystemConfig, FilesystemFuncTool
+from datus.tools.func_tool.filesystem_tools import FilesystemConfig, FilesystemFuncTool
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -156,41 +156,44 @@ class TestReadFile:
         result = tool.read_file("../../etc/passwd")
         assert result.success == 0
 
-
-# ---------------------------------------------------------------------------
-# FilesystemFuncTool - read_multiple_files
-# ---------------------------------------------------------------------------
-
-
-class TestReadMultipleFiles:
-    def test_read_multiple_success(self, tmp_path):
-        (tmp_path / "a.txt").write_text("content_a")
-        (tmp_path / "b.txt").write_text("content_b")
+    def test_read_file_with_offset_and_limit(self, tmp_path):
+        f = tmp_path / "lines.txt"
+        f.write_text("line1\nline2\nline3\nline4\nline5")
         tool = _make_tool(str(tmp_path))
-        result = tool.read_multiple_files(["a.txt", "b.txt"])
+        result = tool.read_file("lines.txt", offset=2, limit=2)
         assert result.success == 1
-        assert result.result["a.txt"] == "content_a"
-        assert result.result["b.txt"] == "content_b"
+        assert "2: line2" in result.result
+        assert "3: line3" in result.result
+        assert "line1" not in result.result
+        assert "line4" not in result.result
 
-    def test_read_multiple_partial_missing(self, tmp_path):
-        (tmp_path / "exists.txt").write_text("hi")
+    def test_read_file_with_offset_only(self, tmp_path):
+        f = tmp_path / "lines.txt"
+        f.write_text("line1\nline2\nline3")
         tool = _make_tool(str(tmp_path))
-        result = tool.read_multiple_files(["exists.txt", "missing.txt"])
+        result = tool.read_file("lines.txt", offset=2)
         assert result.success == 1
-        assert result.result["exists.txt"] == "hi"
-        assert "not found" in result.result["missing.txt"].lower()
+        assert "2: line2" in result.result
+        assert "3: line3" in result.result
+        assert "1: line1" not in result.result
 
-    def test_read_multiple_not_a_file(self, tmp_path):
-        (tmp_path / "mydir").mkdir()
+    def test_read_file_with_limit_only(self, tmp_path):
+        f = tmp_path / "lines.txt"
+        f.write_text("line1\nline2\nline3")
         tool = _make_tool(str(tmp_path))
-        result = tool.read_multiple_files(["mydir"])
-        assert "not a file" in result.result["mydir"].lower()
+        result = tool.read_file("lines.txt", limit=2)
+        assert result.success == 1
+        assert "1: line1" in result.result
+        assert "2: line2" in result.result
+        assert "line3" not in result.result
 
-    def test_read_multiple_disallowed_extension(self, tmp_path):
-        (tmp_path / "file.exe").write_bytes(b"binary")
+    def test_read_file_no_offset_limit_returns_full(self, tmp_path):
+        f = tmp_path / "lines.txt"
+        f.write_text("line1\nline2\nline3")
         tool = _make_tool(str(tmp_path))
-        result = tool.read_multiple_files(["file.exe"])
-        assert "not allowed" in result.result["file.exe"].lower()
+        result = tool.read_file("lines.txt")
+        assert result.success == 1
+        assert result.result == "line1\nline2\nline3"
 
 
 # ---------------------------------------------------------------------------
@@ -241,320 +244,104 @@ class TestEditFile:
         f = tmp_path / "code.py"
         f.write_text("hello world\nfoo bar")
         tool = _make_tool(str(tmp_path))
-        edits = [EditOperation(oldText="hello world", newText="goodbye world")]
-        result = tool.edit_file("code.py", edits)
+        result = tool.edit_file("code.py", "hello world", "goodbye world")
         assert result.success == 1
         assert "goodbye world" in f.read_text()
-
-    def test_edit_with_dict_list(self, tmp_path):
-        f = tmp_path / "code.py"
-        f.write_text("alpha beta gamma")
-        tool = _make_tool(str(tmp_path))
-        result = tool.edit_file("code.py", [{"oldText": "alpha", "newText": "delta"}])
-        assert result.success == 1
-        assert "delta" in f.read_text()
-
-    def test_edit_with_json_string(self, tmp_path):
-        f = tmp_path / "code.py"
-        f.write_text("foo bar")
-        tool = _make_tool(str(tmp_path))
-        import json
-
-        edits_json = json.dumps([{"oldText": "foo", "newText": "baz"}])
-        result = tool.edit_file("code.py", edits_json)
-        assert result.success == 1
-        assert "baz" in f.read_text()
-
-    def test_edit_invalid_json_string(self, tmp_path):
-        f = tmp_path / "code.py"
-        f.write_text("foo")
-        tool = _make_tool(str(tmp_path))
-        result = tool.edit_file("code.py", "not valid json{{")
-        assert result.success == 0
-        assert "invalid json" in result.error.lower()
 
     def test_edit_text_not_found(self, tmp_path):
         f = tmp_path / "code.py"
         f.write_text("foo bar")
         tool = _make_tool(str(tmp_path))
-        result = tool.edit_file("code.py", [EditOperation(oldText="nonexistent", newText="x")])
+        result = tool.edit_file("code.py", "nonexistent", "x")
         assert result.success == 0
         assert "not found" in result.error.lower()
 
+    def test_edit_multiple_matches_rejected(self, tmp_path):
+        f = tmp_path / "code.py"
+        f.write_text("hello hello hello")
+        tool = _make_tool(str(tmp_path))
+        result = tool.edit_file("code.py", "hello", "bye")
+        assert result.success == 0
+        assert "3 times" in result.error
+
+    def test_edit_empty_old_string_rejected(self, tmp_path):
+        f = tmp_path / "code.py"
+        f.write_text("content")
+        tool = _make_tool(str(tmp_path))
+        result = tool.edit_file("code.py", "", "x")
+        assert result.success == 0
+        assert "empty" in result.error.lower()
+
     def test_edit_file_not_found(self, tmp_path):
         tool = _make_tool(str(tmp_path))
-        result = tool.edit_file("missing.py", [EditOperation(oldText="x", newText="y")])
+        result = tool.edit_file("missing.py", "x", "y")
         assert result.success == 0
 
     def test_edit_disallowed_extension(self, tmp_path):
         f = tmp_path / "file.exe"
         f.write_bytes(b"binary")
         tool = _make_tool(str(tmp_path))
-        result = tool.edit_file("file.exe", [EditOperation(oldText="x", newText="y")])
-        assert result.success == 0
-
-    def test_edit_no_edits_applied(self, tmp_path):
-        f = tmp_path / "code.py"
-        f.write_text("content")
-        tool = _make_tool(str(tmp_path))
-        # Empty oldText means condition not met
-        result = tool.edit_file("code.py", [EditOperation(oldText="", newText="x")])
-        assert result.success == 0
-        assert "no edits" in result.error.lower()
-
-
-# ---------------------------------------------------------------------------
-# FilesystemFuncTool - create_directory
-# ---------------------------------------------------------------------------
-
-
-class TestCreateDirectory:
-    def test_create_new_directory(self, tmp_path):
-        tool = _make_tool(str(tmp_path))
-        result = tool.create_directory("newdir")
-        assert result.success == 1
-        assert (tmp_path / "newdir").is_dir()
-
-    def test_create_nested_directories(self, tmp_path):
-        tool = _make_tool(str(tmp_path))
-        result = tool.create_directory("a/b/c")
-        assert result.success == 1
-        assert (tmp_path / "a" / "b" / "c").is_dir()
-
-    def test_create_existing_directory_ok(self, tmp_path):
-        (tmp_path / "existing").mkdir()
-        tool = _make_tool(str(tmp_path))
-        result = tool.create_directory("existing")
-        assert result.success == 1
-
-    def test_create_directory_path_traversal(self, tmp_path):
-        tool = _make_tool(str(tmp_path))
-        result = tool.create_directory("../../evil_dir")
+        result = tool.edit_file("file.exe", "x", "y")
         assert result.success == 0
 
 
 # ---------------------------------------------------------------------------
-# FilesystemFuncTool - list_directory
+# FilesystemFuncTool - glob
 # ---------------------------------------------------------------------------
 
 
-class TestListDirectory:
-    def test_list_root_directory(self, tmp_path):
-        (tmp_path / "file1.txt").write_text("a")
-        (tmp_path / "subdir").mkdir()
-        tool = _make_tool(str(tmp_path))
-        result = tool.list_directory(".")
-        assert result.success == 1
-        names = [item["name"] for item in result.result]
-        assert "file1.txt" in names
-        assert "subdir" in names
-
-    def test_list_directory_types(self, tmp_path):
-        (tmp_path / "myfile.txt").write_text("x")
-        (tmp_path / "mydir").mkdir()
-        tool = _make_tool(str(tmp_path))
-        result = tool.list_directory(".")
-        items = {item["name"]: item["type"] for item in result.result}
-        assert items["myfile.txt"] == "file"
-        assert items["mydir"] == "directory"
-
-    def test_list_nonexistent_directory(self, tmp_path):
-        tool = _make_tool(str(tmp_path))
-        result = tool.list_directory("nonexistent")
-        assert result.success == 0
-        assert "not found" in result.error.lower()
-
-    def test_list_file_as_directory(self, tmp_path):
-        (tmp_path / "file.txt").write_text("x")
-        tool = _make_tool(str(tmp_path))
-        result = tool.list_directory("file.txt")
-        assert result.success == 0
-        assert "not a directory" in result.error.lower()
-
-
-# ---------------------------------------------------------------------------
-# FilesystemFuncTool - directory_tree
-# ---------------------------------------------------------------------------
-
-
-class TestDirectoryTree:
-    def test_tree_basic(self, tmp_path):
-        (tmp_path / "file.txt").write_text("hello")
-        (tmp_path / "subdir").mkdir()
-        (tmp_path / "subdir" / "nested.py").write_text("code")
-        tool = _make_tool(str(tmp_path))
-        result = tool.directory_tree(".")
-        assert result.success == 1
-        assert "file.txt" in result.result
-        assert "subdir" in result.result
-
-    def test_tree_max_depth_zero(self, tmp_path):
-        (tmp_path / "subdir").mkdir()
-        (tmp_path / "subdir" / "deep.txt").write_text("x")
-        tool = _make_tool(str(tmp_path))
-        result = tool.directory_tree(".", max_depth=0)
-        assert result.success == 1
-        assert "max depth" in result.result
-
-    def test_tree_nonexistent(self, tmp_path):
-        tool = _make_tool(str(tmp_path))
-        result = tool.directory_tree("nonexistent")
-        assert result.success == 0
-
-    def test_tree_file_as_directory(self, tmp_path):
-        (tmp_path / "file.txt").write_text("x")
-        tool = _make_tool(str(tmp_path))
-        result = tool.directory_tree("file.txt")
-        assert result.success == 0
-
-    def test_tree_max_items_truncated(self, tmp_path):
-        for i in range(10):
-            (tmp_path / f"file{i}.txt").write_text("x")
-        tool = _make_tool(str(tmp_path))
-        result = tool.directory_tree(".", max_items=3)
-        assert result.success == 1
-        assert "truncated" in result.result.lower() or "max items" in result.result
-
-    def test_tree_unlimited_depth(self, tmp_path):
-        d = tmp_path / "a" / "b" / "c"
-        d.mkdir(parents=True)
-        (d / "leaf.txt").write_text("x")
-        tool = _make_tool(str(tmp_path))
-        result = tool.directory_tree(".", max_depth=-1)
-        assert result.success == 1
-        assert "leaf.txt" in result.result
-
-
-# ---------------------------------------------------------------------------
-# FilesystemFuncTool - move_file
-# ---------------------------------------------------------------------------
-
-
-class TestMoveFile:
-    def test_move_file_success(self, tmp_path):
-        src = tmp_path / "source.txt"
-        src.write_text("content")
-        tool = _make_tool(str(tmp_path))
-        result = tool.move_file("source.txt", "dest.txt")
-        assert result.success == 1
-        assert not src.exists()
-        assert (tmp_path / "dest.txt").exists()
-
-    def test_move_source_not_found(self, tmp_path):
-        tool = _make_tool(str(tmp_path))
-        result = tool.move_file("nonexistent.txt", "dest.txt")
-        assert result.success == 0
-        assert "not found" in result.error.lower()
-
-    def test_move_invalid_destination(self, tmp_path):
-        src = tmp_path / "source.txt"
-        src.write_text("content")
-        tool = _make_tool(str(tmp_path))
-        result = tool.move_file("source.txt", "../../evil.txt")
-        assert result.success == 0
-
-    def test_move_rename_file(self, tmp_path):
-        src = tmp_path / "old_name.txt"
-        src.write_text("data")
-        tool = _make_tool(str(tmp_path))
-        result = tool.move_file("old_name.txt", "new_name.txt")
-        assert result.success == 1
-        assert (tmp_path / "new_name.txt").read_text() == "data"
-
-
-# ---------------------------------------------------------------------------
-# FilesystemFuncTool - search_files
-# ---------------------------------------------------------------------------
-
-
-class TestSearchFiles:
-    def test_search_finds_py_files(self, tmp_path):
+class TestGlobSearch:
+    def test_glob_finds_py_files(self, tmp_path):
         (tmp_path / "a.py").write_text("code")
         (tmp_path / "b.txt").write_text("text")
         (tmp_path / "sub").mkdir()
         (tmp_path / "sub" / "c.py").write_text("more code")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*.py")
+        result = tool.glob("*.py")
         assert result.success == 1
         py_files = [Path(p).name for p in result.result["files"]]
         assert "a.py" in py_files
 
-    def test_search_with_glob_star(self, tmp_path):
+    def test_glob_with_globstar(self, tmp_path):
         (tmp_path / "sub").mkdir()
         (tmp_path / "sub" / "deep.py").write_text("x")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "**/*.py")
+        result = tool.glob("**/*.py")
         assert result.success == 1
         names = [Path(p).name for p in result.result["files"]]
         assert "deep.py" in names
 
-    def test_search_nonexistent_directory(self, tmp_path):
+    def test_glob_nonexistent_directory(self, tmp_path):
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files("nonexistent", "*.py")
+        result = tool.glob("*.py", "nonexistent")
         assert result.success == 0
 
-    def test_search_file_as_directory(self, tmp_path):
+    def test_glob_file_as_directory(self, tmp_path):
         (tmp_path / "file.txt").write_text("x")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files("file.txt", "*.py")
+        result = tool.glob("*.py", "file.txt")
         assert result.success == 0
 
-    def test_search_with_exclude_patterns(self, tmp_path):
-        (tmp_path / "keep.py").write_text("x")
-        (tmp_path / "exclude.py").write_text("y")
-        tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*.py", exclude_patterns=["exclude.py"])
-        assert result.success == 1
-        names = [Path(p).name for p in result.result["files"]]
-        assert "keep.py" in names
-        assert "exclude.py" not in names
-
-    def test_search_ignores_git_directory(self, tmp_path):
+    def test_glob_ignores_git_directory(self, tmp_path):
         (tmp_path / ".git").mkdir()
         (tmp_path / ".git" / "config").write_text("git config")
-        (tmp_path / ".git" / "objects").mkdir()
-        (tmp_path / ".git" / "objects" / "pack.py").write_text("x")
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "main.py").write_text("code")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "**/*")
+        result = tool.glob("**/*")
         assert result.success == 1
         paths = [Path(p).name for p in result.result["files"]]
         assert "main.py" in paths
         assert "config" not in paths
-        assert "pack.py" not in paths
 
-    def test_search_empty_results(self, tmp_path):
+    def test_glob_empty_results(self, tmp_path):
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*.xyz_nonexistent")
+        result = tool.glob("*.xyz_nonexistent")
         assert result.success == 1
         assert result.result["files"] == []
         assert result.result["truncated"] is False
 
-    def test_search_max_results_truncates(self, tmp_path):
-        """Results are truncated when exceeding max_results."""
-        for i in range(10):
-            (tmp_path / f"file_{i}.py").write_text(f"code {i}")
-        tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*.py", max_results=3)
-        assert result.success == 1
-        assert isinstance(result.result, dict)
-        assert len(result.result["files"]) == 3
-        assert result.result["truncated"] is True
-
-    def test_search_max_results_no_truncate_when_under_limit(self, tmp_path):
-        """No truncation when results fit within max_results."""
-        (tmp_path / "a.py").write_text("code")
-        (tmp_path / "b.py").write_text("code")
-        tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*.py", max_results=10)
-        assert result.success == 1
-        assert isinstance(result.result, dict)
-        assert len(result.result["files"]) == 2
-        assert result.result["truncated"] is False
-
-    def test_search_excludes_gitignore_patterns(self, tmp_path):
-        """Patterns from .gitignore are excluded from search results."""
+    def test_glob_excludes_gitignore_patterns(self, tmp_path):
         (tmp_path / ".gitignore").write_text("*.log\nbuild/\n__pycache__\n")
         (tmp_path / "real.py").write_text("code")
         (tmp_path / "debug.log").write_text("log data")
@@ -563,82 +350,143 @@ class TestSearchFiles:
         (tmp_path / "__pycache__").mkdir()
         (tmp_path / "__pycache__" / "cached.py").write_text("bytecode")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*")
+        result = tool.glob("*")
         assert result.success == 1
         names = [Path(p).name for p in result.result["files"]]
         assert "real.py" in names
         assert "debug.log" not in names
         assert "output.py" not in names
         assert "cached.py" not in names
-        # Trailing-slash entry should also exclude the directory itself
-        assert "build" not in names
 
-    def test_search_excludes_git_dir_always(self, tmp_path):
-        """.git directory is always excluded even without .gitignore."""
-        (tmp_path / "real.py").write_text("code")
-        (tmp_path / ".git").mkdir()
-        (tmp_path / ".git" / "config").write_text("git config")
+    def test_glob_with_path_param(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "file.py").write_text("x")
+        (tmp_path / "other.py").write_text("y")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*")
+        result = tool.glob("*.py", "sub")
         assert result.success == 1
         names = [Path(p).name for p in result.result["files"]]
-        assert "real.py" in names
-        assert "config" not in names
+        assert "file.py" in names
+        assert "other.py" not in names
 
-    def test_search_fallback_excludes_without_gitignore(self, tmp_path):
-        """Without .gitignore, fallback excludes (.git, __pycache__, node_modules) apply."""
-        (tmp_path / "real.py").write_text("code")
-        (tmp_path / "__pycache__").mkdir()
-        (tmp_path / "__pycache__" / "cached.py").write_text("bytecode")
-        (tmp_path / "node_modules").mkdir()
-        (tmp_path / "node_modules" / "pkg.js").write_text("js")
-        tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*")
-        assert result.success == 1
-        names = [Path(p).name for p in result.result["files"]]
-        assert "real.py" in names
-        assert "cached.py" not in names
-        assert "pkg.js" not in names
-
-    def test_search_unlimited_with_negative_max(self, tmp_path):
-        """max_results=-1 returns all results without truncation."""
+    def test_glob_truncation(self, tmp_path):
+        """Results are truncated when exceeding max_results (200)."""
         for i in range(5):
-            (tmp_path / f"file_{i}.txt").write_text(f"text {i}")
+            (tmp_path / f"file_{i}.py").write_text(f"code {i}")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*.txt", max_results=-1)
+        result = tool.glob("*.py")
         assert result.success == 1
-        assert isinstance(result.result, dict)
-        assert len(result.result["files"]) == 5
         assert result.result["truncated"] is False
+        assert len(result.result["files"]) == 5
 
-    def test_search_negation_pattern_not_excluded(self, tmp_path):
-        """Gitignore negation patterns (!) should not cause exclusion."""
-        (tmp_path / ".gitignore").write_text("*.log\n!important.log\n")
-        (tmp_path / "debug.log").write_text("debug")
-        (tmp_path / "important.log").write_text("keep this")
-        (tmp_path / "code.py").write_text("code")
+
+# ---------------------------------------------------------------------------
+# FilesystemFuncTool - grep
+# ---------------------------------------------------------------------------
+
+
+class TestGrep:
+    def test_grep_finds_pattern(self, tmp_path):
+        (tmp_path / "hello.py").write_text("def hello():\n    return 'world'\n")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "*")
+        result = tool.grep("hello")
         assert result.success == 1
-        names = [Path(p).name for p in result.result["files"]]
-        assert "code.py" in names
-        # important.log is excluded by *.log (negation not fully supported),
-        # but crucially it must NOT be excluded by the ! line itself
-        assert "debug.log" not in names
+        assert len(result.result["matches"]) >= 1
+        assert result.result["matches"][0]["content"] == "def hello():"
 
-    def test_search_max_results_nested_dirs(self, tmp_path):
-        """Early termination propagates correctly through nested directories."""
-        for i in range(5):
-            d = tmp_path / f"dir_{i}"
-            d.mkdir()
-            for j in range(5):
-                (d / f"file_{j}.py").write_text(f"code {i}-{j}")
+    def test_grep_regex_pattern(self, tmp_path):
+        (tmp_path / "code.py").write_text("foo123\nbar456\nfoo789\n")
         tool = _make_tool(str(tmp_path))
-        result = tool.search_files(".", "**/*.py", max_results=3)
+        result = tool.grep(r"foo\d+")
+        assert result.success == 1
+        assert len(result.result["matches"]) == 2
+
+    def test_grep_case_insensitive(self, tmp_path):
+        (tmp_path / "data.txt").write_text("Hello\nhello\nHELLO\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("hello", case_sensitive=False)
+        assert result.success == 1
+        assert len(result.result["matches"]) == 3
+
+    def test_grep_case_sensitive_default(self, tmp_path):
+        (tmp_path / "data.txt").write_text("Hello\nhello\nHELLO\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("hello")
+        assert result.success == 1
+        assert len(result.result["matches"]) == 1
+
+    def test_grep_with_include_filter(self, tmp_path):
+        (tmp_path / "code.py").write_text("target line\n")
+        (tmp_path / "data.txt").write_text("target line\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("target", include="*.py")
+        assert result.success == 1
+        files = [m["file"] for m in result.result["matches"]]
+        assert any("code.py" in f for f in files)
+        assert not any("data.txt" in f for f in files)
+
+    def test_grep_skips_binary_files(self, tmp_path):
+        (tmp_path / "binary.txt").write_bytes(b"\xff\xfe\x00\x01target\x00")
+        (tmp_path / "text.txt").write_text("target line\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("target")
+        assert result.success == 1
+        files = [m["file"] for m in result.result["matches"]]
+        assert any("text.txt" in f for f in files)
+
+    def test_grep_invalid_regex(self, tmp_path):
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("[invalid")
+        assert result.success == 0
+        assert "invalid regex" in result.error.lower()
+
+    def test_grep_nonexistent_directory(self, tmp_path):
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("pattern", "nonexistent")
+        assert result.success == 0
+
+    def test_grep_returns_line_numbers(self, tmp_path):
+        (tmp_path / "code.py").write_text("line1\ntarget\nline3\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("target")
+        assert result.success == 1
+        assert result.result["matches"][0]["line"] == 2
+
+    def test_grep_respects_gitignore(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("*.log\n")
+        (tmp_path / "code.py").write_text("target\n")
+        (tmp_path / "debug.log").write_text("target\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("target")
+        assert result.success == 1
+        files = [m["file"] for m in result.result["matches"]]
+        assert any("code.py" in f for f in files)
+        assert not any("debug.log" in f for f in files)
+
+    def test_grep_truncation(self, tmp_path):
+        (tmp_path / "big.txt").write_text("\n".join([f"match line {i}" for i in range(150)]))
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("match")
         assert result.success == 1
         assert result.result["truncated"] is True
-        # With propagation fix, should be exactly max_results
-        assert len(result.result["files"]) == 3
+        assert len(result.result["matches"]) == 100
+
+
+# ---------------------------------------------------------------------------
+# FilesystemFuncTool - available_tools
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableTools:
+    def test_available_tools_returns_five(self, tmp_path):
+        tool = _make_tool(str(tmp_path))
+        tools = tool.available_tools()
+        names = [t.name for t in tools]
+        assert set(names) == {"read_file", "write_file", "edit_file", "glob", "grep"}
+
+    def test_available_tools_count(self, tmp_path):
+        tool = _make_tool(str(tmp_path))
+        assert len(tool.available_tools()) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -698,7 +546,7 @@ class TestFilesystemFuncToolKbNormalizerRoundTrip:
     def test_edit_file_after_naked_write(self, tmp_path):
         tool, _ = self._make(tmp_path, "sql_summary", "school_db")
         tool.write_file("q_001.yaml", "name: original\n", file_type="sql_summary")
-        edit_result = tool.edit_file("q_001.yaml", [{"oldText": "original", "newText": "edited"}])
+        edit_result = tool.edit_file("q_001.yaml", "original", "edited")
         assert edit_result.success == 1, edit_result.error
         assert tool.read_file("q_001.yaml").result == "name: edited\n"
 

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -531,18 +531,6 @@ class TestFilesystemFuncToolKbNormalizerRoundTrip:
         tool.write_file("orders.yml", "payload\n", file_type="semantic_model")
         assert tool.read_file("semantic_models/school_db/orders.yml").result == "payload\n"
 
-    def test_read_multiple_files_mixed_naked_and_prefixed(self, tmp_path):
-        """read_multiple_files applies the same normalizer to each path in the batch."""
-        tool, _ = self._make(tmp_path, "semantic", "school_db")
-        tool.write_file("orders.yml", "A\n", file_type="semantic_model")
-        tool.write_file("customers.yml", "B\n", file_type="semantic_model")
-
-        result = tool.read_multiple_files(["orders.yml", "semantic_models/school_db/customers.yml"])
-        assert result.success == 1
-        # Keyed by the caller's raw path so the LLM can correlate the response.
-        assert result.result["orders.yml"] == "A\n"
-        assert result.result["semantic_models/school_db/customers.yml"] == "B\n"
-
     def test_edit_file_after_naked_write(self, tmp_path):
         tool, _ = self._make(tmp_path, "sql_summary", "school_db")
         tool.write_file("q_001.yaml", "name: original\n", file_type="sql_summary")

--- a/tests/unit_tests/tools/mcp_tools/test_mcp_tools.py
+++ b/tests/unit_tests/tools/mcp_tools/test_mcp_tools.py
@@ -43,8 +43,8 @@ def test_parse_cmd():
 def test_tool_filtering():
     """Test tool filtering functionality."""
     # Test creating static tool filters
-    allowlist_filter = create_static_tool_filter(allowed_tool_names=["read_file", "write_file", "list_directory"])
-    assert allowlist_filter.allowed_tool_names == ["read_file", "write_file", "list_directory"]
+    allowlist_filter = create_static_tool_filter(allowed_tool_names=["read_file", "write_file", "glob"])
+    assert allowlist_filter.allowed_tool_names == ["read_file", "write_file", "glob"]
     assert allowlist_filter.blocked_tool_names is None
     assert allowlist_filter.enabled is True
 


### PR DESCRIPTION
Consolidate filesystem tools to minimize tool count while maintaining full coverage:
- Enhanced read_file with offset/limit for line-range reading
- Simplified edit_file to single old_string/new_string with uniqueness validation
- Added glob tool replacing search_files/list_directory/directory_tree
- Added grep tool for regex content search (previously missing)
- Removed redundant tools: read_multiple_files, create_directory, list_directory, directory_tree, move_file, search_files
- Updated all downstream nodes, services, prompts, and tests (28 files)

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added glob for pattern-based file discovery.
  * Added grep for regex-based content search.
  * read_file supports line-range slicing (offset & limit).

* **Changes**
  * edit_file simplified to a single-replacement operation requiring an exact single match.
  * Directory/list/search-style tools replaced by glob/grep across workflows, UIs, and tool registries.
  * Tool previews now show compact counts and detailed match listings for glob/grep.

* **Documentation**
  * CLI help, prompts, examples, and guides updated to reference glob/grep.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->