### PR TITLE
[BugFix] Fix args.namespace AttributeError in web chatbot after CLI rename to database

### DIFF
--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -45,7 +45,7 @@ def _build_agent_args(args: argparse.Namespace) -> argparse.Namespace:
     ``create_app`` / ``DatusAPIService``.
     """
     agent_args = argparse.Namespace(
-        namespace=args.namespace,
+        namespace=args.database,
         config=getattr(args, "config", None),
         debug=getattr(args, "debug", False),
         # Fields expected by DatusAPIService but not present in CLI args
@@ -179,7 +179,7 @@ def run_web_interface(args: argparse.Namespace) -> None:
         url += f"/?subagent={args.subagent}"
 
     logger.info("Starting Datus Web Interface...")
-    logger.info(f"Namespace: {args.namespace}")
+    logger.info(f"Database: {args.database}")
     logger.info(f"Server URL: {url}")
 
     app = create_web_app(args)


### PR DESCRIPTION
## Why

After #557 renamed the CLI flag from `--namespace` to `--database` (with `dest="database"`), running `datus --web --namespace <name>` crashes with `AttributeError: 'Namespace' object has no attribute 'namespace'` because `chatbot.py` still referenced `args.namespace`.

## Solution

Updated two references in `datus/cli/web/chatbot.py`:
- `_build_agent_args`: `args.namespace` → `args.database` (mapped to `namespace=` for downstream API compatibility)
- `run_web_interface`: log message updated from `args.namespace` to `args.database`

## Test Cases

No new tests needed — this is a one-line attribute name fix caught by runtime crash. Existing web chatbot tests cover the corrected code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration parameter handling in the web interface to ensure the proper database setting is applied.
  * Updated logging output to display "Database" instead of "Namespace" for clearer configuration reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->