### PR TITLE
[BugFix] Fix group chat replying to non-bot threads triggering bot response

### DIFF
--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -128,7 +128,7 @@ class AgentService:
                 errorCode="INVALID_AGENT_TYPE",
                 errorMessage=f"Unknown agent_type '{agent_type}'. Must be one of: {', '.join(SUBAGENT_TOOL_REFERENCE)}",
             )
-        return Result(success=True, data=SUBAGENT_TOOL_REFERENCE[agent_type])
+        return Result(success=True, data={"tools": SUBAGENT_TOOL_REFERENCE[agent_type]})
 
     async def get_agent(
         self,

--- a/datus/claw/adapters/feishu.py
+++ b/datus/claw/adapters/feishu.py
@@ -435,12 +435,9 @@ class FeishuAdapter(ChannelAdapter):
             return await self._start_stream(message, text)
         else:
             # Subsequent message — append content to existing card
-            # Delta chunks (token-level) are concatenated directly;
-            # complete messages are separated by blank lines.
-            if message.is_delta:
-                state.accumulated += text
-            else:
-                state.accumulated += f"\n\n{text}"
+            # Concatenate directly — separators between different LLM messages
+            # are already prepended by the bridge layer.
+            state.accumulated += text
             await self._update_card_content(stream_id)
             return None
 

--- a/datus/claw/bridge.py
+++ b/datus/claw/bridge.py
@@ -172,6 +172,8 @@ class ChannelBridge:
         stream_id = f"{msg.channel_id}_{msg.message_id}"
         # Per-request pending tool calls to avoid cross-message contamination
         pending_tool_calls: Dict[str, dict] = {}
+        # Track LLM message_id changes within a single stream to insert separators
+        last_message_id: Optional[str] = None
 
         try:
             # Stream each SSE event to the IM channel as it arrives
@@ -202,6 +204,18 @@ class ChannelBridge:
                                 if is_update:
                                     continue
                                 outbound.stream_id = stream_id
+                                # Insert separator when LLM message_id changes within a stream
+                                current_message_id = getattr(
+                                    getattr(event.data, "payload", None), "message_id", None
+                                )
+                                if (
+                                    current_message_id
+                                    and last_message_id is not None
+                                    and current_message_id != last_message_id
+                                ):
+                                    outbound.text = f"\n\n{outbound.text}"
+                                if current_message_id:
+                                    last_message_id = current_message_id
                             elif outbound.is_delta:
                                 continue
                             bot_msg_id = await adapter.send_message(outbound)

--- a/datus/claw/bridge.py
+++ b/datus/claw/bridge.py
@@ -108,10 +108,17 @@ class ChannelBridge:
             while len(self._seen_message_ids) > self._max_seen_ids:
                 self._seen_message_ids.popitem(last=False)
 
-        # In group chats, only respond to @bot messages or thread replies
-        if msg.chat_type == "group" and not msg.mentions_bot and not msg.thread_id:
-            logger.debug("Ignoring non-mention group message in %s", msg.conversation_id)
-            return
+        # In group chats, only respond to @bot messages or replies in bot-active threads
+        if msg.chat_type == "group" and not msg.mentions_bot:
+            if not msg.thread_id:
+                logger.debug("Ignoring non-mention group message in %s", msg.conversation_id)
+                return
+            # Check if bot has an existing session for this thread
+            session_id = self.build_session_id(msg)
+            session_mgr = SessionManager(session_dir=self._agent_config.session_dir)
+            if not session_mgr.session_exists(session_id):
+                logger.debug("Ignoring reply to unknown thread %s in %s", msg.thread_id, msg.conversation_id)
+                return
 
         # In group chats without an existing thread, use message_id as thread_id
         # so each @bot message gets its own thread (independent session)
@@ -319,7 +326,7 @@ class ChannelBridge:
                 if code_text:
                     text_parts.append(f"```{code_type}\n{code_text}\n```")
 
-        combined_text = "\n".join(text_parts).strip()
+        combined_text = "\n\n".join(text_parts).strip()
         if not combined_text and not sql:
             return None
 

--- a/datus/claw/bridge.py
+++ b/datus/claw/bridge.py
@@ -205,9 +205,7 @@ class ChannelBridge:
                                     continue
                                 outbound.stream_id = stream_id
                                 # Insert separator when LLM message_id changes within a stream
-                                current_message_id = getattr(
-                                    getattr(event.data, "payload", None), "message_id", None
-                                )
+                                current_message_id = getattr(getattr(event.data, "payload", None), "message_id", None)
                                 if (
                                     current_message_id
                                     and last_message_id is not None

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -112,8 +112,10 @@ class TestGetUseTools:
         """get_use_tools returns tools for known agent type."""
         result = AgentService.get_use_tools("gen_sql")
         assert result.success is True
-        assert isinstance(result.data, list)
-        assert len(result.data) > 0
+        assert isinstance(result.data, dict)
+        assert "tools" in result.data
+        assert isinstance(result.data["tools"], list)
+        assert len(result.data["tools"]) > 0
 
     def test_unknown_agent_type_returns_error(self):
         """get_use_tools returns error for unknown agent type."""
@@ -126,7 +128,8 @@ class TestGetUseTools:
         """get_use_tools returns tools for gen_report."""
         result = AgentService.get_use_tools("gen_report")
         assert result.success is True
-        assert len(result.data) > 0
+        assert isinstance(result.data, dict)
+        assert len(result.data["tools"]) > 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/claw/adapters/test_feishu.py
+++ b/tests/unit_tests/claw/adapters/test_feishu.py
@@ -362,7 +362,7 @@ async def test_streaming_subsequent_message_updates_card():
 
     # Card element content should have been called for the update
     assert adapter._lark_client.cardkit.v1.card_element.content.call_count == 1
-    assert "chunk1\n\nchunk2" in adapter._streams["stream_1"].accumulated
+    assert adapter._streams["stream_1"].accumulated == "chunk1chunk2"
     assert adapter._streams["stream_1"].seq == 2
 
 
@@ -400,8 +400,8 @@ async def test_streaming_delta_concatenates_directly():
 
 
 @pytest.mark.asyncio
-async def test_streaming_non_delta_uses_separator():
-    """Non-delta messages should use \\n\\n separator."""
+async def test_streaming_non_delta_concatenates_directly():
+    """Non-delta messages should be concatenated directly (separator added by bridge)."""
     adapter = _make_adapter()
     adapter._lark_client = _mock_lark_client(message_id="msg_nd", card_id="card_nd")
 
@@ -412,7 +412,7 @@ async def test_streaming_non_delta_uses_separator():
     msg2 = _make_streaming_message("second")
     await adapter.send_message(msg2)
 
-    assert adapter._streams["stream_1"].accumulated == "first\n\nsecond"
+    assert adapter._streams["stream_1"].accumulated == "firstsecond"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/claw/test_bridge.py
+++ b/tests/unit_tests/claw/test_bridge.py
@@ -500,7 +500,7 @@ class TestChannelBridge:
 
     @pytest.mark.asyncio
     async def test_group_thread_reply_without_mention_processed(self, setup):
-        """Thread replies in group chats should be processed without @bot."""
+        """Thread replies in bot-active threads should be processed without @bot."""
         bridge, adapter, task_manager = setup
 
         mock_task = MagicMock()
@@ -513,10 +513,30 @@ class TestChannelBridge:
         task_manager.consume_events = _fake_consume
 
         msg = _make_inbound("more details please", chat_type="group", mentions_bot=False, thread_id="existing_thread")
-        await bridge.handle_message(msg, adapter)
+        with patch("datus.claw.bridge.SessionManager") as mock_sm_cls:
+            mock_sm = MagicMock()
+            mock_sm.session_exists.return_value = True
+            mock_sm_cls.return_value = mock_sm
+            await bridge.handle_message(msg, adapter)
 
         assert len(adapter.sent) == 1
         assert adapter.sent[0].thread_id == "existing_thread"
+
+    @pytest.mark.asyncio
+    async def test_group_thread_reply_to_unknown_thread_ignored(self, setup):
+        """Thread replies in non-bot threads should be ignored."""
+        bridge, adapter, task_manager = setup
+        task_manager.start_chat = AsyncMock()
+
+        msg = _make_inbound("more details please", chat_type="group", mentions_bot=False, thread_id="other_thread")
+        with patch("datus.claw.bridge.SessionManager") as mock_sm_cls:
+            mock_sm = MagicMock()
+            mock_sm.session_exists.return_value = False
+            mock_sm_cls.return_value = mock_sm
+            await bridge.handle_message(msg, adapter)
+
+        task_manager.start_chat.assert_not_called()
+        assert len(adapter.sent) == 0
 
     @pytest.mark.asyncio
     async def test_dm_always_processed(self, setup):

--- a/tests/unit_tests/claw/test_bridge.py
+++ b/tests/unit_tests/claw/test_bridge.py
@@ -86,14 +86,14 @@ def _make_inbound(
     )
 
 
-def _make_sse_message(content_text: str, content_type: str = "markdown") -> SSEEvent:
+def _make_sse_message(content_text: str, content_type: str = "markdown", message_id: str = "m1") -> SSEEvent:
     return SSEEvent(
         id=1,
         event="message",
         data=SSEMessageData(
             type=SSEDataType.CREATE_MESSAGE,
             payload=SSEMessagePayload(
-                message_id="m1",
+                message_id=message_id,
                 role="assistant",
                 content=[IMessageContent(type=content_type, payload={"content": content_text})],
             ),
@@ -1328,6 +1328,107 @@ class TestStreamResponseConfig:
 
         assert len(adapter.sent) == 1
         assert "final result" in adapter.sent[0].text
+
+
+class TestStreamMessageIdSeparator:
+    """Tests that \\n\\n separator is prepended when SSE message_id changes during streaming."""
+
+    @pytest_asyncio.fixture
+    async def setup(self):
+        adapter = _StreamingStubAdapter()
+        agent_config = MagicMock()
+        task_manager = MagicMock()
+        bridge = ChannelBridge(agent_config, task_manager)
+        return bridge, adapter, task_manager
+
+    @pytest.mark.asyncio
+    async def test_separator_prepended_on_message_id_change(self, setup):
+        """When message_id changes, the outbound text should be prepended with \\n\\n."""
+        bridge, adapter, task_manager = setup
+
+        mock_task = MagicMock()
+        task_manager.start_chat = AsyncMock(return_value=mock_task)
+
+        async def _fake_consume(task, start_from=None):
+            yield _make_sse_message("first part", message_id="msg_a")
+            yield _make_sse_message("second part", message_id="msg_b")
+            yield _make_sse_end()
+
+        task_manager.consume_events = _fake_consume
+
+        await bridge.handle_message(_make_inbound("q"), adapter)
+
+        assert len(adapter.sent) == 2
+        # First message: no separator (first message_id seen)
+        assert adapter.sent[0].text == "first part"
+        # Second message: prepended with \n\n because message_id changed
+        assert adapter.sent[1].text == "\n\nsecond part"
+
+    @pytest.mark.asyncio
+    async def test_no_separator_when_message_id_unchanged(self, setup):
+        """When message_id stays the same, no separator should be added."""
+        bridge, adapter, task_manager = setup
+
+        mock_task = MagicMock()
+        task_manager.start_chat = AsyncMock(return_value=mock_task)
+
+        async def _fake_consume(task, start_from=None):
+            yield _make_sse_message("chunk1", message_id="msg_a")
+            yield _make_sse_message("chunk2", message_id="msg_a")
+            yield _make_sse_end()
+
+        task_manager.consume_events = _fake_consume
+
+        await bridge.handle_message(_make_inbound("q"), adapter)
+
+        assert len(adapter.sent) == 2
+        assert adapter.sent[0].text == "chunk1"
+        assert adapter.sent[1].text == "chunk2"
+
+    @pytest.mark.asyncio
+    async def test_separator_only_in_streaming_mode(self, setup):
+        """Non-streaming adapters should not get separators."""
+        bridge, _, task_manager = setup
+        non_stream_adapter = _StubAdapter()
+
+        mock_task = MagicMock()
+        task_manager.start_chat = AsyncMock(return_value=mock_task)
+
+        async def _fake_consume(task, start_from=None):
+            yield _make_sse_message("first", message_id="msg_a")
+            yield _make_sse_message("second", message_id="msg_b")
+            yield _make_sse_end()
+
+        task_manager.consume_events = _fake_consume
+
+        await bridge.handle_message(_make_inbound("q"), non_stream_adapter)
+
+        assert len(non_stream_adapter.sent) == 2
+        assert non_stream_adapter.sent[0].text == "first"
+        assert non_stream_adapter.sent[1].text == "second"
+
+    @pytest.mark.asyncio
+    async def test_multiple_message_id_changes(self, setup):
+        """Multiple message_id transitions should each get a separator."""
+        bridge, adapter, task_manager = setup
+
+        mock_task = MagicMock()
+        task_manager.start_chat = AsyncMock(return_value=mock_task)
+
+        async def _fake_consume(task, start_from=None):
+            yield _make_sse_message("a", message_id="id1")
+            yield _make_sse_message("b", message_id="id2")
+            yield _make_sse_message("c", message_id="id3")
+            yield _make_sse_end()
+
+        task_manager.consume_events = _fake_consume
+
+        await bridge.handle_message(_make_inbound("q"), adapter)
+
+        assert len(adapter.sent) == 3
+        assert adapter.sent[0].text == "a"
+        assert adapter.sent[1].text == "\n\nb"
+        assert adapter.sent[2].text == "\n\nc"
 
 
 class TestVerboseOverride:


### PR DESCRIPTION
Use SessionManager.session_exists() to check thread ownership before processing group thread replies without @bot mention. This prevents the bot from responding to replies in threads it never participated in.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group-chat thread replies now ignore unknown threads unless an active bot session exists, preventing unintended processing.

* **Improvements**
  * Tool availability responses now return a structured object with a "tools" field.
  * Streamed message formatting refined: separators are inserted when stream segments change; some channels now concatenate streamed chunks without extra blank lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->