### PR TITLE
[BugFix] Fix MagicMock session_dir creating garbage directories in project root

### DIFF
--- a/tests/unit_tests/claw/test_bridge.py
+++ b/tests/unit_tests/claw/test_bridge.py
@@ -1267,9 +1267,10 @@ class TestNonStreamingAdapter:
     """Tests that non-streaming adapters skip deltas and don't get stream_id."""
 
     @pytest_asyncio.fixture
-    async def setup(self):
+    async def setup(self, tmp_path):
         adapter = _StubAdapter()  # supports_streaming = False
         agent_config = MagicMock()
+        agent_config.session_dir = str(tmp_path / "sessions")
         task_manager = MagicMock()
         bridge = ChannelBridge(agent_config, task_manager)
         return bridge, adapter, task_manager
@@ -1319,9 +1320,10 @@ class TestStreamResponseConfig:
     """Tests that channel_config.stream_response=False disables streaming on capable adapters."""
 
     @pytest_asyncio.fixture
-    async def setup(self):
+    async def setup(self, tmp_path):
         adapter = _StreamingStubAdapter()  # supports_streaming = True
         agent_config = MagicMock()
+        agent_config.session_dir = str(tmp_path / "sessions")
         task_manager = MagicMock()
         bridge = ChannelBridge(agent_config, task_manager)
         return bridge, adapter, task_manager
@@ -1372,9 +1374,10 @@ class TestStreamMessageIdSeparator:
     """Tests that \\n\\n separator is prepended when SSE message_id changes during streaming."""
 
     @pytest_asyncio.fixture
-    async def setup(self):
+    async def setup(self, tmp_path):
         adapter = _StreamingStubAdapter()
         agent_config = MagicMock()
+        agent_config.session_dir = str(tmp_path / "sessions")
         task_manager = MagicMock()
         bridge = ChannelBridge(agent_config, task_manager)
         return bridge, adapter, task_manager
@@ -1473,8 +1476,9 @@ class TestVerboseOverride:
     """Tests for set_verbose / get_verbose per-conversation override."""
 
     @pytest.fixture
-    def bridge(self):
+    def bridge(self, tmp_path):
         agent_config = MagicMock()
+        agent_config.session_dir = str(tmp_path / "sessions")
         task_manager = MagicMock()
         return ChannelBridge(agent_config, task_manager)
 


### PR DESCRIPTION
## Why

Four test fixtures in `test_bridge.py` created `ChannelBridge` with a `MagicMock` agent_config without explicitly setting `session_dir`. When `bridge.clear_session()` or `handle_message()` created a `SessionManager`, `os.makedirs` received the MagicMock string representation as a path, creating garbage directories in the project root like:

```
<MagicMock name='mock.session_dir' id='5530317312'>
```

This was introduced in PR #559 (Add daemon mode support to datus-claw gateway).

## Solution

Add `tmp_path` parameter and set `agent_config.session_dir = str(tmp_path / "sessions")` in all 4 affected fixtures:

- `TestNonStreamingAdapter.setup` (line 1270)
- `TestStreamResponseConfig.setup` (line 1322)
- `TestStreamMessageIdSeparator.setup` (line 1375)
- `TestVerboseOverride.bridge` (line 1476)

## Test Cases

- [x] All 59 bridge tests pass
- [x] Verified with patched `os.makedirs` that no MagicMock directories are created
- [x] ruff format/check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by configuring temporary session directories for multiple test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->