### PR TITLE
[BugFix] Sanitize metadata in query_metrics to prevent serialization errors

### DIFF
--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -9,6 +9,7 @@ Provides unified interface to semantic layer services through adapters.
 Tools delegate to registered semantic adapters while leveraging unified storage for performance.
 """
 
+import json
 from typing import List, Optional
 
 from agents import Tool
@@ -407,11 +408,21 @@ class SemanticTools:
                 )
             )
 
-            # Format result
+            # Format result — sanitize metadata to ensure JSON-serializable
+            # Adapters (e.g. MetricFlow) may put non-serializable objects
+            # like DataflowPlan into metadata; convert them to strings.
+            safe_metadata = {}
+            for k, v in (result.metadata or {}).items():
+                try:
+                    json.dumps(v)
+                    safe_metadata[k] = v
+                except (TypeError, ValueError):
+                    safe_metadata[k] = str(v)
+
             result_dict = {
                 "columns": result.columns,
                 "data": self.compressor.compress(result.data),
-                "metadata": result.metadata,
+                "metadata": safe_metadata,
             }
 
             return FuncToolResult(

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -193,6 +193,30 @@ class TestQueryMetricsCompression:
         assert result.result["columns"] == ["metric_time__day", "revenue", "cost"]
         assert result.result["metadata"] == {"sql": "SELECT ...", "row_count": 1}
 
+    def test_query_metrics_sanitizes_non_serializable_metadata(self, semantic_tools):
+        """Test that non-JSON-serializable metadata values are converted to strings."""
+
+        class FakePlan:
+            def __str__(self):
+                return "<FakePlan: node1 -> node2>"
+
+        query_result = QueryResult(
+            columns=["revenue"],
+            data=[{"revenue": 100}],
+            metadata={"dataflow_plan": FakePlan(), "sql": "SELECT 1", "count": 42},
+        )
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=query_result):
+            result = semantic_tools.query_metrics(metrics=["revenue"])
+
+        assert result.success == 1
+        meta = result.result["metadata"]
+        # Non-serializable object should be converted to str
+        assert meta["dataflow_plan"] == "<FakePlan: node1 -> node2>"
+        # Serializable values should be preserved as-is
+        assert meta["sql"] == "SELECT 1"
+        assert meta["count"] == 42
+
     def test_query_metrics_compressed_data_contains_original_columns(self, semantic_tools):
         """Test that compressed result includes original column names."""
         query_result = QueryResult(


### PR DESCRIPTION
## Why

After #526 changed `FuncToolResult.model_dump()` to `model_dump(mode="json")` in `base.py`, `query_metrics` started failing with `PydanticSerializationError: Unable to serialize unknown type: <class 'metricflow.dataflow.dataflow_plan.DataflowPlan'>`.

The MetricFlow adapter puts raw `DataflowPlan` objects into `QueryResult.metadata`. Previously `model_dump()` (without `mode="json"`) left these objects in the dict for the OpenAI Agents SDK to handle. With strict JSON mode, Pydantic rejects non-serializable types.

## Solution

Sanitize `result.metadata` values in `query_metrics` before constructing `FuncToolResult`. Each value is tested with `json.dumps()`; non-serializable values are converted to `str()`. This is a defense-in-depth approach — adapters may return arbitrary objects in metadata, and the tool layer should guarantee JSON-safe output regardless.

## Test Cases

- Existing 53 unit tests in `test_semantic_tools.py` all pass (no regression).
- No new integration tests needed — this is a serialization guard, not a behavior change. The underlying adapter-side fix (converting `DataflowPlan` to a serializable form) should be done in `datus-semantic-metricflow`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metric query results now sanitize metadata values so non-JSON-serializable entries are converted to safe string forms, ensuring consistent formatting and preventing serialization errors.

* **Tests**
  * Added a unit test verifying metadata sanitization preserves serializable fields and converts non-serializable values to strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->