### PR TITLE
[Enhancement] Sync reference templates and align test config defaults

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -45,8 +45,9 @@ jobs:
         run: |
           DATUS_TEST_HOME="${GITHUB_WORKSPACE}/.datus_test_data"
           echo "DATUS_TEST_HOME=$DATUS_TEST_HOME" >> $GITHUB_ENV
-          sed -i "s|home: ~/.datus/tests|home: $DATUS_TEST_HOME|g" tests/conf/agent.yml
-          sed -i "s|workspace_root: ~/.datus/tests/workspace|workspace_root: $DATUS_TEST_HOME/workspace|g" tests/conf/agent.yml
+          sed -i "s|home: .datus_test_data|home: $DATUS_TEST_HOME|g" tests/conf/agent.yml
+          sed -i "s|workspace_root: .datus_test_data/workspace|workspace_root: $DATUS_TEST_HOME/workspace|g" tests/conf/agent.yml
+          sed -i "s|knowledge_base_home: .datus_test_data/knowledge_base|knowledge_base_home: $DATUS_TEST_HOME/knowledge_base|g" tests/conf/agent.yml
 
       - name: Load environment variables
         run: |

--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -48,8 +48,9 @@ jobs:
         run: |
           DATUS_TEST_HOME="${GITHUB_WORKSPACE}/.datus_test_data"
           echo "DATUS_TEST_HOME=$DATUS_TEST_HOME" >> $GITHUB_ENV
-          sed -i "s|home: ~/.datus/tests|home: $DATUS_TEST_HOME|g" tests/conf/agent.yml
-          sed -i "s|workspace_root: ~/.datus/tests/workspace|workspace_root: $DATUS_TEST_HOME/workspace|g" tests/conf/agent.yml
+          sed -i "s|home: .datus_test_data|home: $DATUS_TEST_HOME|g" tests/conf/agent.yml
+          sed -i "s|workspace_root: .datus_test_data/workspace|workspace_root: $DATUS_TEST_HOME/workspace|g" tests/conf/agent.yml
+          sed -i "s|knowledge_base_home: .datus_test_data/knowledge_base|knowledge_base_home: $DATUS_TEST_HOME/knowledge_base|g" tests/conf/agent.yml
 
       - name: Load environment variables
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ test.py
 evaluation_details.json
 conf/agent.yml.bak
 .gstack/
+/.datus_test_data

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -61,11 +61,11 @@ class GenMetricsAgenticNode(AgenticNode):
         self.subject_tree = subject_tree
 
         # Get max_turns from agentic_nodes configuration, default to 30
-        self.max_turns = 30
+        self.max_turns = 40
         if agent_config and hasattr(agent_config, "agentic_nodes") and self.NODE_NAME in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[self.NODE_NAME]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 40)
 
         self.metrics_dir = str(agent_config.path_manager.semantic_model_path(agent_config.current_database))
         self.knowledge_base_dir = str(agent_config.path_manager.knowledge_base_home)

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -61,11 +61,11 @@ class GenSemanticModelAgenticNode(AgenticNode):
         self.execution_mode = execution_mode
 
         # Get max_turns from agentic_nodes configuration, default to 30
-        self.max_turns = 30
+        self.max_turns = 40
         if agent_config and hasattr(agent_config, "agentic_nodes") and self.NODE_NAME in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[self.NODE_NAME]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 40)
 
         self.semantic_model_dir = str(agent_config.path_manager.semantic_model_path(agent_config.current_database))
         self.knowledge_base_dir = str(agent_config.path_manager.knowledge_base_home)

--- a/datus/agent/node/search_metrics_node.py
+++ b/datus/agent/node/search_metrics_node.py
@@ -85,7 +85,7 @@ class SearchMetricsNode(Node):
         logger.debug(f"Checking if rag storage path exists: {path}")
         if not os.path.exists(path):
             logger.info("RAG storage path does not exist.")
-            return self.get_bad_result("RAG storage path does not exist.")
+            return self.get_bad_result(f"RAG storage path `{path}` does not exist.")
         else:
             try:
                 result = self._search_metrics()

--- a/datus/agent/node/search_metrics_node.py
+++ b/datus/agent/node/search_metrics_node.py
@@ -85,7 +85,7 @@ class SearchMetricsNode(Node):
         logger.debug(f"Checking if rag storage path exists: {path}")
         if not os.path.exists(path):
             logger.info("RAG storage path does not exist.")
-            return self.get_bad_result(f"RAG storage path `{path}` does not exist.")
+            return self.get_bad_result("RAG storage path does not exist.")
         else:
             try:
                 result = self._search_metrics()

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1403,6 +1403,8 @@ class GenerationHooks(AgentHooks):
 
             # The template content is stored in the "sql" field by SqlSummaryAgenticNode
             template_content = reference_template_data.get("sql", "")
+            if not isinstance(template_content, str) or not template_content.strip():
+                return {"success": False, "error": "Reference template 'sql' must be a non-empty string"}
             comment = reference_template_data.get("comment", "")
             item_id = reference_template_data.get("id", "")
 

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1380,6 +1380,82 @@ class GenerationHooks(AgentHooks):
             return {"success": False, "error": str(e)}
 
     @staticmethod
+    def _sync_reference_template_to_db(
+        file_path: str, agent_config: AgentConfig, build_mode: str = "incremental"
+    ) -> dict:
+        """
+        Sync reference template YAML file to Knowledge Base.
+        """
+        try:
+            from datus.storage.reference_template.init_utils import (
+                exists_reference_templates,
+                gen_reference_template_id,
+            )
+            from datus.storage.reference_template.store import ReferenceTemplateRAG
+
+            with open(file_path, "r", encoding="utf-8") as f:
+                doc = yaml.safe_load(f)
+
+            if isinstance(doc, dict) and "sql" in doc:
+                reference_template_data = doc
+            else:
+                return {"success": False, "error": "No reference_template data found in YAML file"}
+
+            # The template content is stored in the "sql" field by SqlSummaryAgenticNode
+            template_content = reference_template_data.get("sql", "")
+            comment = reference_template_data.get("comment", "")
+            item_id = reference_template_data.get("id", "")
+
+            if not item_id or item_id == "auto_generated":
+                item_id = gen_reference_template_id(template_content)
+                reference_template_data["id"] = item_id
+
+            storage = ReferenceTemplateRAG(agent_config)
+            existing_ids = exists_reference_templates(storage, build_mode=build_mode)
+
+            if item_id in existing_ids:
+                logger.info(f"Reference template {item_id} already exists in Knowledge Base, skipping")
+                return {
+                    "success": True,
+                    "message": f"Reference template '{reference_template_data.get('name', '')}' already exists, skipped",
+                }
+
+            subject_path = []
+            subject_tree_str = reference_template_data.get("subject_tree", "")
+            if subject_tree_str:
+                parts = subject_tree_str.split("/")
+                subject_path = [part.strip() for part in parts if part.strip()]
+
+            # Extract parameters from template content
+            import json
+
+            from datus.storage.reference_template.template_file_processor import extract_template_parameters
+
+            parameters = extract_template_parameters(template_content)
+
+            reference_template_dict = {
+                "id": item_id,
+                "name": reference_template_data.get("name", ""),
+                "template": template_content,
+                "parameters": json.dumps(parameters),
+                "comment": comment,
+                "summary": reference_template_data.get("summary", ""),
+                "search_text": reference_template_data.get("search_text", ""),
+                "filepath": file_path,
+                "subject_path": subject_path,
+                "tags": reference_template_data.get("tags", ""),
+            }
+
+            storage.upsert_batch([reference_template_dict])
+
+            logger.info(f"Successfully synced reference template {item_id} to Knowledge Base")
+            return {"success": True, "message": f"Synced reference template: {reference_template_dict['name']}"}
+
+        except Exception as e:
+            logger.error(f"Error syncing reference template to DB: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
+
+    @staticmethod
     def _sync_reference_sql_to_db(file_path: str, agent_config: AgentConfig, build_mode: str = "incremental") -> dict:
         """
         Sync reference SQL YAML file to Knowledge Base.

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -897,10 +897,6 @@ class AgentConfig:
         """Base document storage directory: {home}/data/document/"""
         return os.path.join(self.rag_base_path, "document")
 
-    def sub_agent_storage_path(self, sub_agent_name: str):
-        """Deprecated: sub-agents now use the shared global storage with datasource_id field isolation."""
-        return os.path.join(self.rag_base_path, "sub_agents", sub_agent_name)
-
     def _is_file_based_vector_backend(self) -> bool:
         """Return True if the vector backend stores data in local files (e.g. LanceDB).
 

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -1,10 +1,11 @@
 agent:
   # Set home to tests directory so data paths resolve to tests/data instead of ~/.datus/data
   # Using relative path for portability across different environments
-  home: ~/.datus/tests
+  home: .datus_test_data
   target: deepseek
-  workspace_root: ~/.datus/tests/workspace
-  knowledge_base_home: ~/.datus/tests/workspace/knowledge_base # Configuration to simulate real-world scenarios
+  workspace_root: .datus_test_data/workspace
+
+  knowledge_base_home: .datus_test_data/knowledge_base # Configuration to simulate real-world scenarios
   models:
     deepseek:
       type: deepseek

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -104,7 +104,7 @@ class TestGenMetricsAgenticNodeInit:
                 agent_config=real_agent_config,
                 execution_mode="workflow",
             )
-            assert node.max_turns == 30
+            assert node.max_turns == 40
         finally:
             if original is not None:
                 real_agent_config.agentic_nodes["gen_metrics"] = original

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -122,7 +122,7 @@ class TestGenSemanticModelAgenticNodeInit:
                 agent_config=real_agent_config,
                 execution_mode="workflow",
             )
-            assert node.max_turns == 30
+            assert node.max_turns == 40
         finally:
             if original is not None:
                 real_agent_config.agentic_nodes["gen_semantic_model"] = original

--- a/tests/unit_tests/agent/node/test_node.py
+++ b/tests/unit_tests/agent/node/test_node.py
@@ -125,6 +125,7 @@ def agent_config() -> AgentConfig:
     agent_config = load_acceptance_config(namespace="bird_sqlite")
     if not agent_config.current_database and agent_config.service.databases:
         agent_config.current_database = "california_schools"
+    Path(agent_config.rag_storage_path()).mkdir(parents=True, exist_ok=True)
     return agent_config
 
 
@@ -637,8 +638,6 @@ class TestNode:
         """Test schema linking node"""
         # Take first test case from the list
         _current_database = agent_config.current_database
-        print("$$$$", agent_config)
-        print("$$$$", search_metrics_input)
         try:
             for case in search_metrics_input:
                 input_data = SearchMetricsInput(**case["input"])
@@ -652,7 +651,6 @@ class TestNode:
                 assert node.type == NodeType.TYPE_SEARCH_METRICS
                 assert isinstance(node.input, SearchMetricsInput)
                 result = node.run()
-                print("$$$$", result)
                 logger.debug(f"Search metrics node result: {result}")
                 assert node.status == "completed", f"Node execution failed with status: {node.status}, {node.result}"
                 assert isinstance(result, SearchMetricsResult), "Result type mismatch"

--- a/tests/unit_tests/agent/node/test_node.py
+++ b/tests/unit_tests/agent/node/test_node.py
@@ -637,6 +637,8 @@ class TestNode:
         """Test schema linking node"""
         # Take first test case from the list
         _current_database = agent_config.current_database
+        print("$$$$", agent_config)
+        print("$$$$", search_metrics_input)
         try:
             for case in search_metrics_input:
                 input_data = SearchMetricsInput(**case["input"])
@@ -650,8 +652,9 @@ class TestNode:
                 assert node.type == NodeType.TYPE_SEARCH_METRICS
                 assert isinstance(node.input, SearchMetricsInput)
                 result = node.run()
+                print("$$$$", result)
                 logger.debug(f"Search metrics node result: {result}")
-                assert node.status == "completed", f"Node execution failed with status: {node.status}"
+                assert node.status == "completed", f"Node execution failed with status: {node.status}, {node.result}"
                 assert isinstance(result, SearchMetricsResult), "Result type mismatch"
                 assert result.success is True, f"Node execution failed: {result}"
         except Exception as e:

--- a/tests/unit_tests/agent/node/test_node.py
+++ b/tests/unit_tests/agent/node/test_node.py
@@ -2,7 +2,6 @@ import glob
 import json
 from pathlib import Path
 from typing import Any, Dict, List
-from unittest.mock import patch
 
 import duckdb
 import pytest
@@ -132,13 +131,6 @@ def agent_config() -> AgentConfig:
 @pytest.fixture
 def function_tools(agent_config: AgentConfig) -> List[Tool]:
     return db_function_tools(agent_config)
-
-
-@pytest.fixture
-def search_metrics_agent_config(tmp_path) -> AgentConfig:
-    agent_config = load_acceptance_config(namespace="duckdb", home=str(tmp_path))
-    agent_config.current_database = "duckdb"
-    return agent_config
 
 
 def save_to_yaml(content: BaseModel, filename: str):
@@ -641,10 +633,9 @@ class TestNode:
             logger.error(f"Doc search node test failed: {str(e)}")
             raise
 
-    def test_search_metrics_node(self, search_metrics_input, search_metrics_agent_config: AgentConfig):
+    def test_search_metrics_node(self, search_metrics_input, agent_config: AgentConfig):
         """Test schema linking node"""
         # Take first test case from the list
-        agent_config = search_metrics_agent_config
         _current_database = agent_config.current_database
         try:
             for case in search_metrics_input:
@@ -658,15 +649,7 @@ class TestNode:
                 )
                 assert node.type == NodeType.TYPE_SEARCH_METRICS
                 assert isinstance(node.input, SearchMetricsInput)
-                good_result = SearchMetricsResult(
-                    success=True,
-                    error=None,
-                    sql_task=input_data.sql_task,
-                    metrics=[],
-                    metrics_count=0,
-                )
-                with patch.object(node, "_execute_search_metrics", return_value=good_result):
-                    result = node.run()
+                result = node.run()
                 logger.debug(f"Search metrics node result: {result}")
                 assert node.status == "completed", f"Node execution failed with status: {node.status}"
                 assert isinstance(result, SearchMetricsResult), "Result type mismatch"

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -768,11 +768,11 @@ class TestSyncToStorage:
 
 
 # ---------------------------------------------------------------------------
-# Tests: _sync_reference_sql_to_db
+# Tests: _sync_reference_sql_to_db / _sync_reference_template_to_db
 # ---------------------------------------------------------------------------
 
 
-class TestSyncReferenceTemplateToDb:
+class TestSyncReferenceSqlToDb:
     def test_valid_template_yaml(self, tmp_path):
         import yaml
 
@@ -849,6 +849,140 @@ class TestSyncReferenceTemplateToDb:
 
         assert result["success"] is True
         assert "already exists" in result["message"]
+
+
+class TestSyncReferenceTemplateToDb:
+    def test_valid_template_yaml(self, tmp_path):
+        import yaml
+
+        yaml_file = tmp_path / "tpl.yaml"
+        yaml_file.write_text(
+            yaml.dump(
+                {
+                    "sql": "SELECT * FROM t WHERE x = '{{val}}'",
+                    "name": "test_reference_template",
+                    "summary": "Test reference template",
+                    "search_text": "test reference template val",
+                    "subject_tree": "Sales/Revenue",
+                    "comment": "Helpful template",
+                    "tags": "test",
+                }
+            )
+        )
+
+        mock_config = MagicMock()
+
+        with (
+            patch("datus.storage.reference_template.store.ReferenceTemplateRAG") as mock_rag_cls,
+            patch(
+                "datus.storage.reference_template.init_utils.exists_reference_templates",
+                return_value=set(),
+            ),
+            patch(
+                "datus.storage.reference_template.init_utils.gen_reference_template_id",
+                return_value="new_tpl_id",
+            ),
+            patch(
+                "datus.storage.reference_template.template_file_processor.extract_template_parameters",
+                return_value=[{"name": "val", "type": "string"}],
+            ),
+        ):
+            mock_rag = mock_rag_cls.return_value
+            mock_rag.upsert_batch = MagicMock()
+
+            result = GenerationHooks._sync_reference_template_to_db(str(yaml_file), mock_config)
+
+        assert result["success"] is True
+        assert "Synced reference template" in result["message"]
+        mock_rag.upsert_batch.assert_called_once()
+        stored = mock_rag.upsert_batch.call_args.args[0][0]
+        assert stored == {
+            "id": "new_tpl_id",
+            "name": "test_reference_template",
+            "template": "SELECT * FROM t WHERE x = '{{val}}'",
+            "parameters": json.dumps([{"name": "val", "type": "string"}]),
+            "comment": "Helpful template",
+            "summary": "Test reference template",
+            "search_text": "test reference template val",
+            "filepath": str(yaml_file),
+            "subject_path": ["Sales", "Revenue"],
+            "tags": "test",
+        }
+
+    def test_missing_sql_field(self, tmp_path):
+        import yaml
+
+        yaml_file = tmp_path / "bad.yaml"
+        yaml_file.write_text(yaml.dump({"name": "no_sql"}))
+
+        result = GenerationHooks._sync_reference_template_to_db(str(yaml_file), MagicMock())
+
+        assert result["success"] is False
+        assert "No reference_template data" in result["error"]
+
+    def test_blank_sql_returns_error(self, tmp_path):
+        import yaml
+
+        yaml_file = tmp_path / "blank.yaml"
+        yaml_file.write_text(yaml.dump({"sql": "   ", "name": "blank"}))
+
+        result = GenerationHooks._sync_reference_template_to_db(str(yaml_file), MagicMock())
+
+        assert result["success"] is False
+        assert "non-empty string" in result["error"]
+
+    def test_duplicate_skipped(self, tmp_path):
+        import yaml
+
+        yaml_file = tmp_path / "dup.yaml"
+        yaml_file.write_text(yaml.dump({"sql": "SELECT 1", "name": "dup_tpl"}))
+
+        mock_config = MagicMock()
+        with (
+            patch("datus.storage.reference_template.store.ReferenceTemplateRAG"),
+            patch(
+                "datus.storage.reference_template.init_utils.exists_reference_templates",
+                return_value={"existing_tpl_id"},
+            ),
+            patch(
+                "datus.storage.reference_template.init_utils.gen_reference_template_id",
+                return_value="existing_tpl_id",
+            ),
+        ):
+            result = GenerationHooks._sync_reference_template_to_db(str(yaml_file), mock_config)
+
+        assert result["success"] is True
+        assert "already exists" in result["message"]
+
+    def test_storage_error_returns_failure(self, tmp_path):
+        import yaml
+
+        yaml_file = tmp_path / "boom.yaml"
+        yaml_file.write_text(yaml.dump({"sql": "SELECT 1", "name": "boom_tpl"}))
+
+        mock_config = MagicMock()
+        with (
+            patch("datus.storage.reference_template.store.ReferenceTemplateRAG") as mock_rag_cls,
+            patch(
+                "datus.storage.reference_template.init_utils.exists_reference_templates",
+                return_value=set(),
+            ),
+            patch(
+                "datus.storage.reference_template.init_utils.gen_reference_template_id",
+                return_value="boom_id",
+            ),
+            patch(
+                "datus.storage.reference_template.template_file_processor.extract_template_parameters",
+                return_value=[],
+            ),
+        ):
+            mock_rag = mock_rag_cls.return_value
+            mock_rag.upsert_batch.side_effect = RuntimeError("boom")
+
+            result = GenerationHooks._sync_reference_template_to_db(str(yaml_file), mock_config)
+
+        assert result["success"] is False
+        assert result["error"] == "boom"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

- Generated reference templates were not being synced into the knowledge base from GenerationHooks, so follow-up retrieval could miss newly created templates.
- The branch also aligns several test and local config defaults to make workspace-relative test data handling more consistent.

## Solution

- Added reference-template YAML sync support in GenerationHooks, including id generation, duplicate checks, subject-path parsing, parameter extraction, and KB upsert.
- Increased the default max_turns for semantic-model and metrics agentic nodes from 30 to 40.
- Removed the deprecated sub_agent_storage_path helper from AgentConfig.
- Switched test config paths to workspace-relative .datus_test_data locations and ignored that directory in Git.
- Adjusted tests/unit_tests/agent/node/test_node.py to use the current config and test flow.

## Test Cases

- Modified tests/unit_tests/agent/node/test_node.py to match the updated config behavior.
- No new integration or nightly cases were added in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI can sync reference templates into the template database.

* **Chores**
  * Added a top-level test data directory to .gitignore and switched tests to use it.
  * Removed a deprecated per-sub-agent storage accessor.

* **Tests**
  * Simplified fixtures and updated unit expectations to reflect real node behavior.

* **Configuration**
  * Increased default max iterations for certain agent nodes (30 → 40).

* **Bug Fixes**
  * Error message now includes the resolved storage path when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->