### PR TITLE
[Feature] Make SubAgentTaskTool configurable for all AgenticNode types

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -392,8 +392,18 @@ class AgenticNode(Node):
             logger.debug("Skipped compaction for ephemeral session")
             return {"success": False, "summary": "", "summary_token": 0}
 
-        if not self.model or not self._session:
-            logger.warning("Cannot compact: no model or session available")
+        if not self.model:
+            logger.warning("Cannot compact: no model available")
+            return {"success": False, "summary": "", "summary_token": 0}
+
+        # Lazily materialize the SQLite session when only session_id is known.
+        # This happens after .resume, which sets self.session_id but leaves
+        # self._session as None until the first execute call.
+        if self._session is None and self.session_id:
+            self._get_or_create_session()
+
+        if not self._session:
+            logger.warning("Cannot compact: no session available")
             return {"success": False, "summary": "", "summary_token": 0}
 
         try:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -692,22 +692,26 @@ class AgenticNode(Node):
     def _setup_sub_agent_task_tool(self):
         """Setup SubAgentTaskTool based on subagents config or node default.
 
-        Skipped when ``_is_subagent`` is True (nodes created by SubAgentTaskTool)
+        Skipped when ``is_subagent`` is True (nodes created by SubAgentTaskTool)
         to enforce strict 2-level depth — subagent nodes never get their own task tool.
         """
         if self._is_subagent:
             return
 
+        from datus.schemas.agent_models import SubAgentConfig
+
         subagents_str = self.node_config.get("subagents")
         if subagents_str is None:
             subagents_str = self.DEFAULT_SUBAGENTS
 
-        if subagents_str == "*":
+        parsed = SubAgentConfig(subagents=subagents_str).subagent_list
+        if not parsed:
+            return  # Empty = no task tool
+
+        if parsed == ["*"]:
             allowed = None  # None = SubAgentTaskTool discovers all types
         else:
-            allowed = [s.strip() for s in subagents_str.split(",") if s.strip()]
-            if not allowed:
-                return  # Empty = no task tool
+            allowed = parsed
 
         try:
             from datus.tools.func_tool.sub_agent_task_tool import SubAgentTaskTool

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -372,8 +372,8 @@ class AgenticNode(Node):
                     last_turn = turn_usage[-1] if isinstance(turn_usage, list) else turn_usage
                     if isinstance(last_turn, dict):
                         return last_turn.get("total_tokens", 0)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Failed to get turn usage for token counting: {e}")
 
         return 0
 
@@ -692,7 +692,7 @@ class AgenticNode(Node):
     def _setup_sub_agent_task_tool(self):
         """Setup SubAgentTaskTool based on subagents config or node default.
 
-        Skipped when ``_as_subagent`` is True (nodes created by SubAgentTaskTool)
+        Skipped when ``_is_subagent`` is True (nodes created by SubAgentTaskTool)
         to enforce strict 2-level depth — subagent nodes never get their own task tool.
         """
         if self._is_subagent:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -45,6 +45,8 @@ class AgenticNode(Node):
     with tool integration and automatic context management.
     """
 
+    DEFAULT_SUBAGENTS = "explore"
+
     def __init__(
         self,
         node_id: str,
@@ -55,6 +57,7 @@ class AgenticNode(Node):
         tools: Optional[List[Tool]] = None,
         mcp_servers: Optional[Dict[str, MCPServerStdio]] = None,
         scope: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize the agentic node.
@@ -68,6 +71,7 @@ class AgenticNode(Node):
             tools: List of function tools available to this node
             mcp_servers: Dictionary of MCP servers available to this node
             scope: Optional session scope for directory isolation
+            is_subagent: When True, skip SubAgentTaskTool setup (2-level depth enforcement)
         """
         # Initialize Node base class
         super().__init__(node_id, description, node_type, input_data, agent_config, tools)
@@ -87,6 +91,8 @@ class AgenticNode(Node):
         self.skill_manager: Optional["SkillManager"] = None
         self.skill_func_tool = None
         self.ask_user_tool = None
+        self.sub_agent_task_tool = None
+        self._is_subagent = is_subagent
         self._permission_callback: Optional[Callable[[str, str, Dict[str, Any]], Awaitable[bool]]] = None
 
         # ActionBus - merges tool sub-actions into the main action stream
@@ -335,25 +341,41 @@ class AgenticNode(Node):
 
     async def _count_session_tokens(self) -> int:
         """
-        Count the total tokens in the current session.
+        Estimate current context window usage in tokens.
 
-        Reads from session's turn_usage table first. Falls back to summing
-        usage from action history (for native API paths that bypass the SDK).
+        Returns the last API call's input_tokens from the most recent execute,
+        which represents the actual conversation size in the context window.
+        Falls back to the last turn's total_tokens from turn_usage table.
 
         Returns:
-            Total token count in the session
+            Estimated context window token usage
         """
-        if self._session and hasattr(self._session, "get_session_usage"):
-            usage = await self._session.get_session_usage()
-            total = usage.get("total_tokens", 0) if usage else 0
-            if total > 0:
-                return total
-        # Fallback: sum usage from action history (native Anthropic API path)
-        total_from_actions = 0
-        for action in self.actions:
-            if isinstance(action.output, dict) and "usage" in action.output:
-                total_from_actions += action.output["usage"].get("total_tokens", 0)
-        return total_from_actions
+        # Primary: get last_call_input_tokens from the most recent assistant action
+        for action in reversed(self.actions):
+            if isinstance(action.output, dict) and isinstance(action.output.get("usage"), dict):
+                usage = action.output["usage"]
+                last_call = usage.get("last_call_input_tokens", 0)
+                if last_call > 0:
+                    return last_call
+                # Fallback within action: use input_tokens (still per-turn, not cumulative sum)
+                input_tokens = usage.get("input_tokens", 0)
+                if input_tokens > 0:
+                    return input_tokens
+                break
+
+        # Fallback: get the latest turn's total_tokens from turn_usage table
+        if self._session and hasattr(self._session, "get_turn_usage"):
+            try:
+                turn_usage = await self._session.get_turn_usage()
+                if turn_usage:
+                    # turn_usage is a list of per-turn records; use the last one
+                    last_turn = turn_usage[-1] if isinstance(turn_usage, list) else turn_usage
+                    if isinstance(last_turn, dict):
+                        return last_turn.get("total_tokens", 0)
+            except Exception:
+                pass
+
+        return 0
 
     async def _manual_compact(self) -> dict:
         """
@@ -508,6 +530,7 @@ class AgenticNode(Node):
             "sql_file_threshold",
             "sql_preview_lines",
             "bi_platform",
+            "subagents",
         ]
         for attr in direct_attributes:
             # Handle both dict and object access patterns
@@ -665,6 +688,41 @@ class AgenticNode(Node):
         except Exception as e:
             logger.error(f"Failed to setup ask_user tool: {e}")
             self.ask_user_tool = None
+
+    def _setup_sub_agent_task_tool(self):
+        """Setup SubAgentTaskTool based on subagents config or node default.
+
+        Skipped when ``_as_subagent`` is True (nodes created by SubAgentTaskTool)
+        to enforce strict 2-level depth — subagent nodes never get their own task tool.
+        """
+        if self._is_subagent:
+            return
+
+        subagents_str = self.node_config.get("subagents")
+        if subagents_str is None:
+            subagents_str = self.DEFAULT_SUBAGENTS
+
+        if subagents_str == "*":
+            allowed = None  # None = SubAgentTaskTool discovers all types
+        else:
+            allowed = [s.strip() for s in subagents_str.split(",") if s.strip()]
+            if not allowed:
+                return  # Empty = no task tool
+
+        try:
+            from datus.tools.func_tool.sub_agent_task_tool import SubAgentTaskTool
+
+            self.sub_agent_task_tool = SubAgentTaskTool(
+                agent_config=self.agent_config,
+                allowed_subagents=allowed,
+                parent_node_name=self.get_node_name(),
+            )
+            self.sub_agent_task_tool.set_action_bus(self.action_bus)
+            self.sub_agent_task_tool.set_interaction_broker(self.interaction_broker)
+            self.sub_agent_task_tool.set_parent_node(self)
+        except Exception as e:
+            logger.error(f"Failed to setup SubAgent task tool: {e}")
+            self.sub_agent_task_tool = None
 
     def _ensure_skill_tools_in_tools(self) -> None:
         """

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -350,9 +350,19 @@ class AgenticNode(Node):
         Returns:
             Estimated context window token usage
         """
-        # Primary: get last_call_input_tokens from the most recent assistant action
+        # Primary: get last_call_input_tokens from the most recent root assistant action.
+        # Scope to root-level actions (depth == 0) so child/tool usage from sub-agents
+        # doesn't leak into the parent session's context estimate.
         for action in reversed(self.actions):
-            if isinstance(action.output, dict) and isinstance(action.output.get("usage"), dict):
+            # Stop at the last root-level user message to scope to the current turn
+            if action.role == ActionRole.USER and action.depth == 0:
+                break
+            if (
+                action.role == ActionRole.ASSISTANT
+                and action.depth == 0
+                and isinstance(action.output, dict)
+                and isinstance(action.output.get("usage"), dict)
+            ):
                 usage = action.output["usage"]
                 last_call = usage.get("last_call_input_tokens", 0)
                 if last_call > 0:

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -54,6 +54,8 @@ class ChatAgenticNode(AgenticNode):
     - Session-based conversation management with MCP server integration
     """
 
+    DEFAULT_SUBAGENTS = "*"
+
     def __init__(
         self,
         node_id: str,
@@ -64,6 +66,7 @@ class ChatAgenticNode(AgenticNode):
         tools: Optional[list] = None,
         scope: Optional[str] = None,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
+        is_subagent: bool = False,
     ):
         """
         Initialize the ChatAgenticNode.
@@ -97,9 +100,6 @@ class ChatAgenticNode(AgenticNode):
         self._platform_doc_tool: Optional[PlatformDocSearchTool] = None
         self.reference_template_tools: Optional[ReferenceTemplateTools] = None
 
-        # SubAgent task delegation tool
-        self.sub_agent_task_tool = None
-
         # Plan mode attributes
         self.plan_mode_active = False
         self.plan_hooks = None
@@ -117,6 +117,7 @@ class ChatAgenticNode(AgenticNode):
             tools=tools or [],
             mcp_servers={},
             scope=scope,
+            is_subagent=is_subagent,
         )
 
         # Execution mode: "interactive" enables ask_user tool; "workflow"
@@ -226,21 +227,6 @@ class ChatAgenticNode(AgenticNode):
             logger.debug(f"Setup skill tools: {self.skill_manager.get_skill_count()} skills discovered")
         except Exception as e:
             logger.error(f"Failed to setup skill tools: {e}")
-
-    def _setup_sub_agent_task_tool(self):
-        """Setup SubAgent task delegation tool."""
-        try:
-            from datus.tools.func_tool.sub_agent_task_tool import SubAgentTaskTool
-
-            self.sub_agent_task_tool = SubAgentTaskTool(
-                agent_config=self.agent_config,
-            )
-            self.sub_agent_task_tool.set_action_bus(self.action_bus)
-            self.sub_agent_task_tool.set_interaction_broker(self.interaction_broker)
-            self.sub_agent_task_tool.set_parent_node(self)
-        except Exception as e:
-            logger.error(f"Failed to setup SubAgent task tool: {e}")
-            self.sub_agent_task_tool = None
 
     def _setup_permission_hooks(self):
         """Setup permission hooks and register all tool categories."""

--- a/datus/agent/node/compare_agentic_node.py
+++ b/datus/agent/node/compare_agentic_node.py
@@ -30,6 +30,7 @@ class CompareAgenticNode(AgenticNode):
         self,
         node_name: str = "compare",
         agent_config: Optional[AgentConfig] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize CompareAgenticNode.
@@ -37,6 +38,7 @@ class CompareAgenticNode(AgenticNode):
         Args:
             node_name: Name of the node configuration in agent.yml (default: "compare")
             agent_config: Agent configuration
+            is_subagent: When True, skip SubAgentTaskTool setup (2-level depth enforcement)
         """
         self.configured_node_name = node_name
 
@@ -54,6 +56,7 @@ class CompareAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=[],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         # Get max_turns from agentic_nodes configuration, default to 30

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -53,6 +53,7 @@ class ExploreAgenticNode(AgenticNode):
         agent_config: Optional[AgentConfig] = None,
         tools: Optional[list] = None,
         node_name: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         self.configured_node_name = node_name
 
@@ -77,6 +78,7 @@ class ExploreAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=tools or [],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         # Setup read-only tools. When input_data is None (e.g. factory path),

--- a/datus/agent/node/gen_dashboard_agentic_node.py
+++ b/datus/agent/node/gen_dashboard_agentic_node.py
@@ -42,6 +42,7 @@ class GenDashboardAgenticNode(AgenticNode):
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         node_id: Optional[str] = None,
         node_name: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         self.execution_mode = execution_mode
         # Support custom node_name for alias subagents (e.g. my_dashboard: {node_class: gen_dashboard})
@@ -64,6 +65,7 @@ class GenDashboardAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=[],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         self.bi_func_tool = None

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -71,6 +71,7 @@ class GenExtKnowledgeAgenticNode(AgenticNode):
         build_mode: str = "incremental",
         subject_tree: Optional[list] = None,
         scope: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize the GenExtKnowledgeAgenticNode.
@@ -123,6 +124,7 @@ class GenExtKnowledgeAgenticNode(AgenticNode):
             tools=[],
             mcp_servers={},
             scope=scope,
+            is_subagent=is_subagent,
         )
 
         # Initialize external knowledge storage for context queries

--- a/datus/agent/node/gen_job_agentic_node.py
+++ b/datus/agent/node/gen_job_agentic_node.py
@@ -47,6 +47,7 @@ class GenJobAgenticNode(AgenticNode):
         self,
         agent_config: AgentConfig,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
+        is_subagent: bool = False,
     ):
         self.execution_mode = execution_mode
 
@@ -66,6 +67,7 @@ class GenJobAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=[],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         self.db_func_tool: Optional[DBFuncTool] = None

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -48,6 +48,7 @@ class GenMetricsAgenticNode(AgenticNode):
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         subject_tree: Optional[list] = None,
         scope: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize the GenMetricsAgenticNode.
@@ -84,6 +85,7 @@ class GenMetricsAgenticNode(AgenticNode):
             tools=[],
             mcp_servers={},
             scope=scope,
+            is_subagent=is_subagent,
         )
 
         # Initialize metrics storage for context queries

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -102,17 +102,12 @@ class GenReportAgenticNode(AgenticNode):
             is_subagent=is_subagent,
         )
 
-        # Setup tools based on configuration
+        # Setup tools based on configuration (includes subagent task tool wiring)
         self.setup_tools()
 
         # Setup ask_user tool for clarification questions (interactive mode only)
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
-
-        # Setup subagent task tool based on configuration (default: explore)
-        self._setup_sub_agent_task_tool()
-        if self.sub_agent_task_tool:
-            self.tools.extend(self.sub_agent_task_tool.available_tools())
 
         logger.debug(f"GenReportAgenticNode tools: {len(self.tools)} tools - {[tool.name for tool in self.tools]}")
 
@@ -149,6 +144,13 @@ class GenReportAgenticNode(AgenticNode):
         # Ensure filesystem tools are always available (required for memory and file operations)
         if not self.filesystem_func_tool:
             self._setup_filesystem_tools()
+
+        # Rebuild subagent task tool so repeated setup_tools() calls (e.g. via
+        # ChatCommands.update_chat_node_tools after a namespace switch) keep the
+        # "task" tool available for delegation.
+        self._setup_sub_agent_task_tool()
+        if self.sub_agent_task_tool:
+            self.tools.extend(self.sub_agent_task_tool.available_tools())
 
         logger.info(f"Setup {len(self.tools)} tools: {[tool.name for tool in self.tools]}")
 

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -55,6 +55,7 @@ class GenReportAgenticNode(AgenticNode):
         node_name: Optional[str] = None,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         scope: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize the GenReportAgenticNode.
@@ -68,6 +69,7 @@ class GenReportAgenticNode(AgenticNode):
             tools: List of tools (will be populated in setup_tools)
             node_name: Name of the node configuration in agent.yml
             execution_mode: Execution mode - "interactive" (default) or "workflow"
+            is_subagent: When True, skip SubAgentTaskTool setup (2-level depth enforcement)
         """
         self.execution_mode = execution_mode
         # Determine node name from node_type if not provided
@@ -97,6 +99,7 @@ class GenReportAgenticNode(AgenticNode):
             tools=tools or [],
             mcp_servers={},  # No MCP servers for report nodes by default
             scope=scope,
+            is_subagent=is_subagent,
         )
 
         # Setup tools based on configuration
@@ -105,6 +108,11 @@ class GenReportAgenticNode(AgenticNode):
         # Setup ask_user tool for clarification questions (interactive mode only)
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
+
+        # Setup subagent task tool based on configuration (default: explore)
+        self._setup_sub_agent_task_tool()
+        if self.sub_agent_task_tool:
+            self.tools.extend(self.sub_agent_task_tool.available_tools())
 
         logger.debug(f"GenReportAgenticNode tools: {len(self.tools)} tools - {[tool.name for tool in self.tools]}")
 
@@ -310,6 +318,7 @@ class GenReportAgenticNode(AgenticNode):
             "has_semantic_tools": bool(self.semantic_tools),
             "has_db_tools": bool(self.db_func_tool),
             "has_ask_user_tool": self.ask_user_tool is not None,
+            "has_task_tool": bool(self.sub_agent_task_tool),
             "agent_config": self.agent_config,
             "conversation_summary": conversation_summary,
         }

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -50,6 +50,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
         agent_config: AgentConfig,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         scope: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize the GenSemanticModelAgenticNode.
@@ -84,6 +85,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
             tools=[],
             mcp_servers={},
             scope=scope,
+            is_subagent=is_subagent,
         )
 
         # Setup tools

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -68,6 +68,7 @@ class SkillCreatorAgenticNode(AgenticNode):
         tools: Optional[list] = None,
         node_name: Optional[str] = None,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
+        is_subagent: bool = False,
     ):
         self.configured_node_name = node_name
         self.execution_mode = execution_mode
@@ -99,6 +100,7 @@ class SkillCreatorAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=tools or [],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         # Setup tools

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -128,17 +128,12 @@ class GenSQLAgenticNode(AgenticNode):
             f"GenSQLAgenticNode final mcp_servers: {len(self.mcp_servers)} servers - {list(self.mcp_servers.keys())}"
         )
 
-        # Setup tools based on configuration
+        # Setup tools based on configuration (includes subagent task tool wiring)
         self.setup_tools()
 
         # Setup ask_user tool for clarification questions (interactive mode only)
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
-
-        # Setup subagent task tool based on configuration (default: explore)
-        self._setup_sub_agent_task_tool()
-        if self.sub_agent_task_tool:
-            self.tools.extend(self.sub_agent_task_tool.available_tools())
 
         logger.debug(f"GenSQLAgenticNode tools: {len(self.tools)} tools - {[tool.name for tool in self.tools]}")
 
@@ -268,6 +263,13 @@ class GenSQLAgenticNode(AgenticNode):
         # Ensure filesystem tools are always available (required for memory and file operations)
         if not self.filesystem_func_tool:
             self._setup_filesystem_tools()
+
+        # Rebuild subagent task tool so repeated setup_tools() calls (e.g. via
+        # ChatCommands.update_chat_node_tools after a namespace switch) keep the
+        # "task" tool available for delegation.
+        self._setup_sub_agent_task_tool()
+        if self.sub_agent_task_tool:
+            self.tools.extend(self.sub_agent_task_tool.available_tools())
 
         logger.debug(f"Setup {len(self.tools)} tools: {[tool.name for tool in self.tools]}")
 

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -63,6 +63,7 @@ class GenSQLAgenticNode(AgenticNode):
         node_name: Optional[str] = None,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         scope: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize the GenSQLAgenticNode as a workflow-compatible node.
@@ -76,6 +77,7 @@ class GenSQLAgenticNode(AgenticNode):
             tools: List of tools (will be populated in setup_tools)
             node_name: Name of the node configuration in agent.yml (e.g., "gensql", "gen_sql")
             execution_mode: Execution mode - "interactive" (default) or "workflow"
+            is_subagent: When True, skip SubAgentTaskTool setup (2-level depth enforcement)
         """
         self.execution_mode = execution_mode
         # Determine node name from node_type if not provided
@@ -115,6 +117,7 @@ class GenSQLAgenticNode(AgenticNode):
             tools=tools or [],
             mcp_servers={},  # Initialize empty, will setup after parent init
             scope=scope,
+            is_subagent=is_subagent,
         )
 
         # Initialize MCP servers based on configuration (after node_config is available)
@@ -131,6 +134,11 @@ class GenSQLAgenticNode(AgenticNode):
         # Setup ask_user tool for clarification questions (interactive mode only)
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
+
+        # Setup subagent task tool based on configuration (default: explore)
+        self._setup_sub_agent_task_tool()
+        if self.sub_agent_task_tool:
+            self.tools.extend(self.sub_agent_task_tool.available_tools())
 
         logger.debug(f"GenSQLAgenticNode tools: {len(self.tools)} tools - {[tool.name for tool in self.tools]}")
 
@@ -237,6 +245,8 @@ class GenSQLAgenticNode(AgenticNode):
             self.tools.extend(self._platform_doc_tool.available_tools())
         if self.ask_user_tool:
             self.tools.extend(self.ask_user_tool.available_tools())
+        if self.sub_agent_task_tool:
+            self.tools.extend(self.sub_agent_task_tool.available_tools())
 
     # Default tools when not configured in agent.yml
     DEFAULT_TOOLS = "db_tools.*, filesystem_tools.*"
@@ -617,6 +627,7 @@ class GenSQLAgenticNode(AgenticNode):
         )
         context["conversation_summary"] = conversation_summary
         context["has_ask_user_tool"] = self.ask_user_tool is not None
+        context["has_task_tool"] = bool(self.sub_agent_task_tool)
         from datus.utils.time_utils import get_default_current_date
 
         ref = self.date_parsing_tools.reference_date if self.date_parsing_tools else None

--- a/datus/agent/node/gen_table_agentic_node.py
+++ b/datus/agent/node/gen_table_agentic_node.py
@@ -47,6 +47,7 @@ class GenTableAgenticNode(AgenticNode):
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         node_id: Optional[str] = None,
         node_name: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         self.execution_mode = execution_mode
         # Support custom node_name for alias subagents (e.g. my_table: {node_class: gen_table})
@@ -69,6 +70,7 @@ class GenTableAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=[],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         self.db_func_tool: Optional[DBFuncTool] = None

--- a/datus/agent/node/migration_agentic_node.py
+++ b/datus/agent/node/migration_agentic_node.py
@@ -47,6 +47,7 @@ class MigrationAgenticNode(AgenticNode):
         self,
         agent_config: AgentConfig,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
+        is_subagent: bool = False,
     ):
         self.execution_mode = execution_mode
 
@@ -66,6 +67,7 @@ class MigrationAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=[],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         self.db_func_tool: Optional[DBFuncTool] = None

--- a/datus/agent/node/node.py
+++ b/datus/agent/node/node.py
@@ -57,6 +57,7 @@ class Node(ABC):
         agent_config: Optional[AgentConfig] = None,
         tools: Optional[List[Tool]] = None,
         node_name: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         from datus.agent.node import (
             BeginNode,
@@ -113,17 +114,40 @@ class Node(ABC):
             return DateParserNode(node_id, description, node_type, input_data, agent_config)
         elif node_type == NodeType.TYPE_CHAT:
             return ChatAgenticNode(
-                node_id, description, node_type, input_data, agent_config, tools, execution_mode="workflow"
+                node_id,
+                description,
+                node_type,
+                input_data,
+                agent_config,
+                tools,
+                execution_mode="workflow",
+                is_subagent=is_subagent,
             )
         elif node_type == NodeType.TYPE_GENSQL:
             return GenSQLAgenticNode(
-                node_id, description, node_type, input_data, agent_config, tools, node_name, execution_mode="workflow"
+                node_id,
+                description,
+                node_type,
+                input_data,
+                agent_config,
+                tools,
+                node_name,
+                execution_mode="workflow",
+                is_subagent=is_subagent,
             )
         elif node_type == NodeType.TYPE_GEN_REPORT:
             from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
 
             return GenReportAgenticNode(
-                node_id, description, node_type, input_data, agent_config, tools, node_name, execution_mode="workflow"
+                node_id,
+                description,
+                node_type,
+                input_data,
+                agent_config,
+                tools,
+                node_name,
+                execution_mode="workflow",
+                is_subagent=is_subagent,
             )
         elif node_type == NodeType.TYPE_EXPLORE:
             from datus.agent.node.explore_agentic_node import ExploreAgenticNode

--- a/datus/agent/node/node.py
+++ b/datus/agent/node/node.py
@@ -152,12 +152,25 @@ class Node(ABC):
         elif node_type == NodeType.TYPE_EXPLORE:
             from datus.agent.node.explore_agentic_node import ExploreAgenticNode
 
-            return ExploreAgenticNode(node_id, description, node_type, input_data, agent_config, tools, node_name)
+            return ExploreAgenticNode(
+                node_id,
+                description,
+                node_type,
+                input_data,
+                agent_config,
+                tools,
+                node_name,
+                is_subagent=is_subagent,
+            )
         elif node_type == NodeType.TYPE_GEN_TABLE:
             from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
 
             node = GenTableAgenticNode(
-                agent_config=agent_config, execution_mode="workflow", node_id=node_id, node_name=node_name
+                agent_config=agent_config,
+                execution_mode="workflow",
+                node_id=node_id,
+                node_name=node_name,
+                is_subagent=is_subagent,
             )
             if input_data is not None:
                 node.input = input_data
@@ -165,26 +178,39 @@ class Node(ABC):
         elif node_type == NodeType.TYPE_GEN_JOB:
             from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
 
-            node = GenJobAgenticNode(agent_config=agent_config, execution_mode="workflow")
+            node = GenJobAgenticNode(agent_config=agent_config, execution_mode="workflow", is_subagent=is_subagent)
             if input_data is not None:
                 node.input = input_data
             return node
         elif node_type == NodeType.TYPE_MIGRATION:
             from datus.agent.node.migration_agentic_node import MigrationAgenticNode
 
-            node = MigrationAgenticNode(agent_config=agent_config, execution_mode="workflow")
+            node = MigrationAgenticNode(agent_config=agent_config, execution_mode="workflow", is_subagent=is_subagent)
             if input_data is not None:
                 node.input = input_data
             return node
         elif node_type == NodeType.TYPE_GEN_SKILL:
             from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
 
-            return SkillCreatorAgenticNode(node_id, description, node_type, input_data, agent_config, tools, node_name)
+            return SkillCreatorAgenticNode(
+                node_id,
+                description,
+                node_type,
+                input_data,
+                agent_config,
+                tools,
+                node_name,
+                is_subagent=is_subagent,
+            )
         elif node_type == NodeType.TYPE_GEN_DASHBOARD:
             from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
 
             node = GenDashboardAgenticNode(
-                agent_config=agent_config, execution_mode="workflow", node_id=node_id, node_name=node_name
+                agent_config=agent_config,
+                execution_mode="workflow",
+                node_id=node_id,
+                node_name=node_name,
+                is_subagent=is_subagent,
             )
             if input_data is not None:
                 node.input = input_data
@@ -193,7 +219,11 @@ class Node(ABC):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
             node = SchedulerAgenticNode(
-                agent_config=agent_config, execution_mode="workflow", node_id=node_id, node_name=node_name
+                agent_config=agent_config,
+                execution_mode="workflow",
+                node_id=node_id,
+                node_name=node_name,
+                is_subagent=is_subagent,
             )
             if input_data is not None:
                 node.input = input_data

--- a/datus/agent/node/scheduler_agentic_node.py
+++ b/datus/agent/node/scheduler_agentic_node.py
@@ -41,6 +41,7 @@ class SchedulerAgenticNode(AgenticNode):
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         node_id: Optional[str] = None,
         node_name: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         self.execution_mode = execution_mode
         # Support custom node_name for alias subagents (e.g. my_scheduler: {node_class: scheduler})
@@ -63,6 +64,7 @@ class SchedulerAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=[],
             mcp_servers={},
+            is_subagent=is_subagent,
         )
 
         self.scheduler_tools = None

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -48,6 +48,7 @@ class SqlSummaryAgenticNode(AgenticNode):
         subject_tree: Optional[list] = None,
         storage_type: str = "reference_sql",
         scope: Optional[str] = None,
+        is_subagent: bool = False,
     ):
         """
         Initialize the SqlSummaryAgenticNode.
@@ -90,6 +91,7 @@ class SqlSummaryAgenticNode(AgenticNode):
             tools=[],
             mcp_servers={},
             scope=scope,
+            is_subagent=is_subagent,
         )
 
         # Initialize reference SQL storage for context queries

--- a/datus/cli/_cli_utils.py
+++ b/datus/cli/_cli_utils.py
@@ -93,6 +93,8 @@ def select_choice(
                 is_sel = i == selected[0]
                 if key == _FREE_TEXT_SENTINEL:
                     label = f"  [/] {display}"
+                elif key == display:
+                    label = f"  {display}"
                 else:
                     label = f"  [{key}] {display}"
                 if is_sel:

--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -213,6 +213,7 @@ class SQLCompleter(Completer):
             # ".show": None,
             ".namespace": None,
             ".mcp": None,
+            ".agent": None,
             ".subagent": None,
             ".subagent list": None,
             ".subagent add": None,
@@ -1059,6 +1060,7 @@ class SubagentCompleter(Completer):
     def _load_subagents(self) -> List[str]:
         """Load available subagents from configuration and include built-in subagents."""
         subagents = list(SYS_SUB_AGENTS)
+        subagents.append("chat")
         if hasattr(self.agent_config, "agentic_nodes") and self.agent_config.agentic_nodes:
             for name, sub_config in self.agent_config.agentic_nodes.items():
                 if name != "chat" and name not in SYS_SUB_AGENTS:  # Exclude default chat and avoid duplicates

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -74,37 +74,13 @@ class ChatCommands:
             # Create new node only if switching from subagent to regular
             return bool(self.current_subagent_name)
 
-    def _trigger_compact_for_current_node(self):
-        """Trigger compact on current node before switching."""
-        if self.current_node and hasattr(self.current_node, "_manual_compact"):
-            try:
-
-                async def _get_info():
-                    return await self.current_node.get_session_info()
-
-                session_info = asyncio.run(_get_info())
-                if session_info.get("session_id"):
-                    self.console.print("[yellow]Switching node, compacting current session...[/]")
-
-                    async def run_compact():
-                        return await self.current_node._manual_compact()
-
-                    result = asyncio.run(run_compact())
-
-                    if result.get("success"):
-                        self.console.print("[green]✓ Session compacted successfully![/]")
-                        logger.info(
-                            f"Session compact details - New Token Count: {result.get('new_token_count', 'N/A')}"
-                            f"Tokens Saved: {result.get('tokens_saved', 'N/A')}"
-                            f"Compression Ratio: {result.get('compression_ratio', 'N/A')}"
-                        )
-                    else:
-                        error_msg = result.get("error", "Unknown error occurred")
-                        self.console.print(f"[bold red]✗ Failed to compact session:[/] {error_msg}")
-
-            except Exception as e:
-                logger.error(f"Compact error during node switch: {e}")
-                self.console.print(f"[bold red]Compact error:[/] {str(e)}")
+    def _is_agent_switch(self, subagent_name: str = None) -> bool:
+        """Check if this is a node type switch (not a fresh start)."""
+        if self.current_node is None:
+            return False
+        effective_current = self.current_subagent_name or ""
+        effective_new = subagent_name or ""
+        return effective_current != effective_new
 
     def _create_new_node(self, subagent_name: str = None):
         """Create new node based on subagent_name and configuration.
@@ -153,14 +129,12 @@ class ChatCommands:
         message: str,
         plan_mode: bool = False,
         subagent_name: Optional[str] = None,
-        compact_when_new_subagent: bool = True,
     ):
         """Execute a chat command in interactive REPL mode."""
         self._execute_chat(
             message,
             plan_mode=plan_mode,
             subagent_name=subagent_name,
-            compact_when_new_subagent=compact_when_new_subagent,
             interactive=True,
         )
 
@@ -200,7 +174,6 @@ class ChatCommands:
         message: str,
         plan_mode: bool = False,
         subagent_name: Optional[str] = None,
-        compact_when_new_subagent: bool = True,
         interactive: bool = True,
     ):
         """Core chat execution logic shared by interactive and non-interactive modes."""
@@ -214,23 +187,27 @@ class ChatCommands:
             if interactive:
                 # Decision logic: determine if we need to create a new node
                 need_new_node = self._should_create_new_node(subagent_name)
-
-                # If creating new node and have existing node, trigger compact
-                if need_new_node and self.current_node is not None and compact_when_new_subagent:
-                    self._trigger_compact_for_current_node()
+                is_switch = self._is_agent_switch(subagent_name)
 
                 # Get or create node
                 if need_new_node:
+                    # Carry over session_id when switching agents to preserve conversation
+                    prev_session_id = None
+                    if is_switch and self.current_node and hasattr(self.current_node, "session_id"):
+                        prev_session_id = self.current_node.session_id
                     self.current_node = self._create_new_node(subagent_name)
+                    if prev_session_id:
+                        self.current_node.session_id = prev_session_id
                     self.current_subagent_name = subagent_name if subagent_name else None
-                    self.all_turn_actions = []
+                    if not is_switch:
+                        self.all_turn_actions = []
                     if not subagent_name:
                         self.chat_node = self.current_node
 
                 current_node = self.current_node
 
                 # Show session info for existing session
-                if not need_new_node:
+                if not need_new_node or is_switch:
                     session_info = asyncio.run(current_node.get_session_info())
                     if session_info.get("session_id"):
                         session_display = (

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -82,6 +82,25 @@ class ChatCommands:
         effective_new = subagent_name or ""
         return effective_current != effective_new
 
+    def _copy_session_for_switch(self, prev_session_id: str, new_node) -> str:
+        """Copy session data from the previous node to a new session matching the new node's name prefix.
+
+        Uses :meth:`SessionManager.copy_session` so that the new session_id prefix
+        matches ``new_node.get_node_name()`` and :meth:`_extract_node_type_from_session_id`
+        resolves the correct type on ``.resume``.
+
+        Returns:
+            New session_id with the correct node-name prefix.
+        """
+        from datus.models.session_manager import SessionManager
+
+        try:
+            session_manager = SessionManager(self.cli.agent_config.session_dir, scope=self.cli.scope)
+            return session_manager.copy_session(prev_session_id, new_node.get_node_name())
+        except Exception as e:
+            logger.warning(f"Failed to copy session on agent switch, starting fresh: {e}")
+            return new_node.session_id  # fall back to whatever the node already has (None → auto-generate)
+
     def _create_new_node(self, subagent_name: str = None):
         """Create new node based on subagent_name and configuration.
 
@@ -191,13 +210,14 @@ class ChatCommands:
 
                 # Get or create node
                 if need_new_node:
-                    # Carry over session_id when switching agents to preserve conversation
+                    # Copy session when switching agents to preserve conversation
+                    # while keeping the session_id prefix consistent with the new node type.
                     prev_session_id = None
                     if is_switch and self.current_node and hasattr(self.current_node, "session_id"):
                         prev_session_id = self.current_node.session_id
                     self.current_node = self._create_new_node(subagent_name)
                     if prev_session_id:
-                        self.current_node.session_id = prev_session_id
+                        self.current_node.session_id = self._copy_session_for_switch(prev_session_id, self.current_node)
                     self.current_subagent_name = subagent_name if subagent_name else None
                     if not is_switch:
                         self.all_turn_actions = []

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -583,10 +583,7 @@ class DatusCLI:
         if not args:
             # Interactive selector
             current_default = self.default_agent or "chat"
-            choices = {
-                name: (f"{name}  [current]" if name == current_default else name)
-                for name in sorted(self.available_subagents)
-            }
+            choices = {name: name for name in sorted(self.available_subagents)}
             self.console.print("[bold]Select default agent:[/] (Up/Down to navigate, Enter to confirm)")
             selected = select_choice(self.console, choices, default=current_default)
             if selected == current_default:

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 from datus_db_core import BaseSqlConnector
 
-from datus.cli._cli_utils import prompt_input
+from datus.cli._cli_utils import prompt_input, select_choice
 from datus.cli.agent_commands import AgentCommands
 from datus.cli.autocomplete import AtReferenceCompleter, CustomPygmentsStyle, CustomSqlLexer, SubagentCompleter
 from datus.cli.bi_dashboard import BiDashboardCommands
@@ -88,6 +88,8 @@ class DatusCLI:
 
         # Plan mode support
         self.plan_mode_active = False
+        # Default agent for /message routing ("" = chat node)
+        self.default_agent = ""
 
         # Load agent config first so path-dependent helpers use the configured home.
         self.agent_config = load_agent_config(**vars(self.args))
@@ -103,6 +105,7 @@ class DatusCLI:
 
         # Initialize available subagents early (needed by autocomplete)
         self.available_subagents = set(SYS_SUB_AGENTS)
+        self.available_subagents.add("chat")
         if hasattr(self.agent_config, "agentic_nodes") and self.agent_config.agentic_nodes:
             self.available_subagents.update(name for name in self.agent_config.agentic_nodes.keys() if name != "chat")
 
@@ -174,6 +177,7 @@ class DatusCLI:
             ".table_schema": self.metadata_commands.cmd_table_schema,
             ".indexes": self.metadata_commands.cmd_indexes,
             ".namespace": self._cmd_switch_namespace,
+            ".agent": self._cmd_agent,
             ".subagent": self.sub_agent_commands.cmd,
             ".mcp": self._cmd_mcp,
             ".skill": self._cmd_skill,
@@ -275,11 +279,12 @@ class DatusCLI:
         self.console.print(echoed)
 
     def _get_prompt_text(self):
-        """Get the current prompt text based on mode"""
+        """Get the current prompt text based on mode and default agent"""
         if self.plan_mode_active:
             return "[PLAN MODE] Datus> "
-        else:
-            return "Datus> "
+        if self.default_agent:
+            return f"Datus ({self.default_agent})> "
+        return "Datus> "
 
     def _update_prompt(self):
         """Update the prompt display (called when mode changes)"""
@@ -568,6 +573,39 @@ class DatusCLI:
             # Perhaps we should reload the data here.
             self.at_completer.reload_data()
 
+    def _cmd_agent(self, args: str):
+        """Set or show the default agent for message routing.
+
+        No args  -> interactive selector (up/down + Enter)
+        <name>   -> set directly
+        """
+        args = args.strip()
+        if not args:
+            # Interactive selector
+            current_default = self.default_agent or "chat"
+            choices = {
+                name: (f"{name}  [current]" if name == current_default else name)
+                for name in sorted(self.available_subagents)
+            }
+            self.console.print("[bold]Select default agent:[/] (Up/Down to navigate, Enter to confirm)")
+            selected = select_choice(self.console, choices, default=current_default)
+            if selected == current_default:
+                self.console.print(f"[dim]Default agent unchanged: {current_default}[/]")
+                return
+            args = selected
+
+        if args not in self.available_subagents:
+            self.console.print(f"[bold red]Error:[/] Unknown agent '{args}'. Run '.agent' to see available agents.")
+            return
+
+        # "chat" resets to empty string (the chat node)
+        if args == "chat":
+            self.default_agent = ""
+            self.console.print("[bold green]Default agent reset to: chat[/]")
+        else:
+            self.default_agent = args
+            self.console.print(f"[bold green]Default agent set to: {args}[/]")
+
     def _cmd_switch_namespace(self, args: str):
         if args.strip() == "":
             self._cmd_list_namespaces()
@@ -635,15 +673,16 @@ class DatusCLI:
                 potential_subagent = parts[0]
                 if potential_subagent in self.available_subagents:
                     # Sub-agent syntax: /subagent_name message
-                    subagent_name = potential_subagent
+                    # "/chat message" explicitly routes to the chat node
+                    subagent_name = "" if potential_subagent == "chat" else potential_subagent
                     actual_message = parts[1]
                     return CommandType.CHAT, subagent_name, actual_message
                 else:
                     # Regular chat: /message (first part is not a valid subagent)
-                    return CommandType.CHAT, "", message
+                    return CommandType.CHAT, self.default_agent, message
             else:
                 # Regular chat: /message
-                return CommandType.CHAT, "", message
+                return CommandType.CHAT, self.default_agent, message
 
         # Internal commands (.prefix)
         if text.startswith("."):
@@ -662,10 +701,10 @@ class DatusCLI:
             if sql_type != SQLType.UNKNOWN:
                 return CommandType.SQL, "", text
             else:
-                return CommandType.CHAT, "", text.strip()
+                return CommandType.CHAT, self.default_agent, text.strip()
         except Exception:
             # If any exception occurs, treat as chat
-            return CommandType.CHAT, "", text.strip()
+            return CommandType.CHAT, self.default_agent, text.strip()
 
     def _execute_sql(self, sql: str, system: bool = False):
         """Execute a SQL query and display results."""
@@ -956,7 +995,9 @@ class DatusCLI:
 
         lines.append("[bold]Chat Commands (/ prefix):[/]")
         chat_cmds = [
-            ("/<message>", "Chat with the AI assistant"),
+            ("/<message>", "Chat with the AI assistant (uses default agent)"),
+            ("/chat <message>", "Chat with the chat node explicitly"),
+            ("/<agent> <message>", "Chat with a specific agent"),
         ]
         for cmd, desc in chat_cmds:
             lines.append(f"    {cmd:<{CMD_WIDTH}}{desc}")
@@ -980,6 +1021,9 @@ class DatusCLI:
             (".schema schema_name", "Switch current schema"),
             (".table_schema table_name", "Show table field details"),
             (".indexes table_name", "Show indexes for a table"),
+            (".agent", "Interactive selector to switch default agent"),
+            ("     .agent <name>", "Set default agent directly (e.g., .agent gen_sql)"),
+            ("     .agent chat", "Reset default agent to chat node"),
             (".namespace namespace", "Switch current namespace"),
             (".mcp", "Manage MCP (Model Configuration Protocol) servers"),
             ("     .mcp list", "List all MCP servers"),

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -1022,7 +1022,7 @@ class DatusCLI:
             (".table_schema table_name", "Show table field details"),
             (".indexes table_name", "Show indexes for a table"),
             (".agent", "Interactive selector to switch default agent"),
-            ("     .agent <name>", "Set default agent directly (e.g., .agent gen_sql)"),
+            ("     .agent <name>", "Set default agent directly (e.g., .agent gensql)"),
             ("     .agent chat", "Reset default agent to chat node"),
             (".namespace namespace", "Switch current namespace"),
             (".mcp", "Manage MCP (Model Configuration Protocol) servers"),

--- a/datus/cli/sub_agent_commands.py
+++ b/datus/cli/sub_agent_commands.py
@@ -42,6 +42,7 @@ class SubAgentCommands:
             # Also update available_subagents set for command parsing
             if hasattr(self.cli_instance, "available_subagents"):
                 self.cli_instance.available_subagents = set(SYS_SUB_AGENTS)
+                self.cli_instance.available_subagents.add("chat")
                 if self.cli_instance.agent_config.agentic_nodes:
                     self.cli_instance.available_subagents.update(
                         name for name in self.cli_instance.agent_config.agentic_nodes.keys() if name != "chat"

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -194,16 +194,32 @@ class SessionManager:
             # No persisted session data to copy; return new id so the node starts fresh
             return new_session_id
 
-        # Read all messages from source
+        # Read all messages, message_structure, and turn_usage from source.
+        # We must preserve agent_messages.id so that message_structure.message_id
+        # references remain valid in the new DB; AdvancedSQLiteSession.get_items()
+        # relies on a JOIN between agent_messages and message_structure, so copying
+        # agent_messages alone would result in an empty conversation history.
         with sqlite3.connect(source_db_path, timeout=5.0) as src_conn:
             cursor = src_conn.cursor()
             cursor.execute(
-                "SELECT message_data, created_at FROM agent_messages WHERE session_id = ? ORDER BY created_at, id",
+                "SELECT id, message_data, created_at FROM agent_messages "
+                "WHERE session_id = ? ORDER BY id",
                 (source_session_id,),
             )
             message_rows = cursor.fetchall()
 
-            # Read turn_usage if the table exists
+            structure_rows: list = []
+            try:
+                cursor.execute(
+                    "SELECT message_id, branch_id, message_type, sequence_number, "
+                    "user_turn_number, branch_turn_number, tool_name, created_at "
+                    "FROM message_structure WHERE session_id = ? ORDER BY sequence_number",
+                    (source_session_id,),
+                )
+                structure_rows = cursor.fetchall()
+            except sqlite3.OperationalError:
+                pass
+
             turn_usage_rows: list = []
             try:
                 cursor.execute(
@@ -227,10 +243,39 @@ class SessionManager:
                 "INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)",
                 (new_session_id,),
             )
-            for message_data, created_at in message_rows:
+            # Preserve id to keep message_structure.message_id references valid.
+            for msg_id, message_data, created_at in message_rows:
                 new_conn.execute(
-                    "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
-                    (new_session_id, message_data, created_at),
+                    "INSERT INTO agent_messages (id, session_id, message_data, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (msg_id, new_session_id, message_data, created_at),
+                )
+            for (
+                message_id,
+                branch_id,
+                message_type,
+                sequence_number,
+                user_turn_number,
+                branch_turn_number,
+                tool_name,
+                created_at,
+            ) in structure_rows:
+                new_conn.execute(
+                    "INSERT INTO message_structure "
+                    "(session_id, message_id, branch_id, message_type, sequence_number, "
+                    "user_turn_number, branch_turn_number, tool_name, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        new_session_id,
+                        message_id,
+                        branch_id,
+                        message_type,
+                        sequence_number,
+                        user_turn_number,
+                        branch_turn_number,
+                        tool_name,
+                        created_at,
+                    ),
                 )
             for usage_row in turn_usage_rows:
                 new_conn.execute(
@@ -245,7 +290,8 @@ class SessionManager:
 
         logger.info(
             f"Copied session {source_session_id} -> {new_session_id} "
-            f"({len(message_rows)} messages, {len(turn_usage_rows)} turn_usage rows)"
+            f"({len(message_rows)} messages, {len(structure_rows)} structure rows, "
+            f"{len(turn_usage_rows)} turn_usage rows)"
         )
         return new_session_id
 
@@ -326,17 +372,22 @@ class SessionManager:
         if not kept_rows:
             raise ValueError(f"No messages to keep for turn {up_to_user_turn}")
 
+        kept_message_ids = {row[0] for row in kept_rows}
+
         # Create the new session database
         new_db_path = os.path.join(self.session_dir, f"{new_session_id}.db")
         new_session = AdvancedSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
         # Store in cache
         self._sessions[new_session_id] = new_session
 
-        # Read turn_usage rows for kept turns from source DB
-        turn_usage_rows = []
+        # Read turn_usage and message_structure rows for kept turns from source DB.
+        # message_structure must be copied so that AdvancedSQLiteSession.get_items()
+        # (which JOINs agent_messages with message_structure) returns the rewound history.
+        turn_usage_rows: list = []
+        structure_rows: list = []
         with sqlite3.connect(source_db_path, timeout=5.0) as src_conn:
+            cursor = src_conn.cursor()
             try:
-                cursor = src_conn.cursor()
                 cursor.execute(
                     "SELECT branch_id, user_turn_number, requests, input_tokens, "
                     "output_tokens, total_tokens, input_tokens_details, "
@@ -349,16 +400,56 @@ class SessionManager:
                 # turn_usage table may not exist in older databases
                 pass
 
-        # Insert session record, messages, and turn_usage into the new DB
+            try:
+                cursor.execute(
+                    "SELECT message_id, branch_id, message_type, sequence_number, "
+                    "user_turn_number, branch_turn_number, tool_name, created_at "
+                    "FROM message_structure WHERE session_id = ? ORDER BY sequence_number",
+                    (source_session_id,),
+                )
+                structure_rows = [row for row in cursor.fetchall() if row[0] in kept_message_ids]
+            except sqlite3.OperationalError:
+                pass
+
+        # Insert session record, messages, message_structure, and turn_usage into the new DB.
+        # Preserve agent_messages.id so message_structure.message_id references remain valid.
         with sqlite3.connect(new_db_path, timeout=5.0) as new_conn:
             new_conn.execute(
                 "INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)",
                 (new_session_id,),
             )
-            for _, _, message_data, created_at in kept_rows:
+            for msg_id, _, message_data, created_at in kept_rows:
                 new_conn.execute(
-                    "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
-                    (new_session_id, message_data, created_at),
+                    "INSERT INTO agent_messages (id, session_id, message_data, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (msg_id, new_session_id, message_data, created_at),
+                )
+            for (
+                message_id,
+                branch_id,
+                message_type,
+                sequence_number,
+                user_turn_number,
+                branch_turn_number,
+                tool_name,
+                created_at,
+            ) in structure_rows:
+                new_conn.execute(
+                    "INSERT INTO message_structure "
+                    "(session_id, message_id, branch_id, message_type, sequence_number, "
+                    "user_turn_number, branch_turn_number, tool_name, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        new_session_id,
+                        message_id,
+                        branch_id,
+                        message_type,
+                        sequence_number,
+                        user_turn_number,
+                        branch_turn_number,
+                        tool_name,
+                        created_at,
+                    ),
                 )
             for usage_row in turn_usage_rows:
                 new_conn.execute(

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -170,6 +170,85 @@ class SessionManager:
         else:
             logger.warning(f"Attempted to delete non-existent session: {session_id}")
 
+    def copy_session(self, source_session_id: str, target_node_name: str) -> str:
+        """Copy a session to a new one with a different node-name prefix.
+
+        All messages and turn_usage rows are copied.  The new session_id uses
+        ``target_node_name`` as prefix so that
+        :meth:`ChatCommands._extract_node_type_from_session_id` resolves the
+        correct node type.
+
+        Args:
+            source_session_id: The session to copy from.
+            target_node_name: Node name for the new session_id prefix
+                (e.g. ``"gensql"``, ``"chat"``).
+
+        Returns:
+            The new session ID.
+        """
+        self._validate_session_id(source_session_id)
+        new_session_id = f"{target_node_name}_session_{uuid.uuid4().hex[:8]}"
+
+        source_db_path = os.path.join(self.session_dir, f"{source_session_id}.db")
+        if not os.path.exists(source_db_path):
+            # No persisted session data to copy; return new id so the node starts fresh
+            return new_session_id
+
+        # Read all messages from source
+        with sqlite3.connect(source_db_path, timeout=5.0) as src_conn:
+            cursor = src_conn.cursor()
+            cursor.execute(
+                "SELECT message_data, created_at FROM agent_messages WHERE session_id = ? ORDER BY created_at, id",
+                (source_session_id,),
+            )
+            message_rows = cursor.fetchall()
+
+            # Read turn_usage if the table exists
+            turn_usage_rows: list = []
+            try:
+                cursor.execute(
+                    "SELECT branch_id, user_turn_number, requests, input_tokens, "
+                    "output_tokens, total_tokens, input_tokens_details, "
+                    "output_tokens_details, created_at "
+                    "FROM turn_usage WHERE session_id = ?",
+                    (source_session_id,),
+                )
+                turn_usage_rows = cursor.fetchall()
+            except sqlite3.OperationalError:
+                pass
+
+        # Create new session DB
+        new_db_path = os.path.join(self.session_dir, f"{new_session_id}.db")
+        new_session = AdvancedSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
+        self._sessions[new_session_id] = new_session
+
+        with sqlite3.connect(new_db_path, timeout=5.0) as new_conn:
+            new_conn.execute(
+                "INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)",
+                (new_session_id,),
+            )
+            for message_data, created_at in message_rows:
+                new_conn.execute(
+                    "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                    (new_session_id, message_data, created_at),
+                )
+            for usage_row in turn_usage_rows:
+                new_conn.execute(
+                    "INSERT OR IGNORE INTO turn_usage "
+                    "(session_id, branch_id, user_turn_number, requests, input_tokens, "
+                    "output_tokens, total_tokens, input_tokens_details, "
+                    "output_tokens_details, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (new_session_id, *usage_row),
+                )
+            new_conn.commit()
+
+        logger.info(
+            f"Copied session {source_session_id} -> {new_session_id} "
+            f"({len(message_rows)} messages, {len(turn_usage_rows)} turn_usage rows)"
+        )
+        return new_session_id
+
     def rewind_session(
         self,
         source_session_id: str,

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -232,10 +232,12 @@ class SessionManager:
             except sqlite3.OperationalError:
                 pass
 
-        # Create new session DB
+        # Materialize tables in the new DB first (short-lived session is released
+        # before bulk inserts), then use a single raw connection with executemany
+        # for all writes. Avoids two concurrent connections on the same file and
+        # is substantially faster for long histories.
         new_db_path = os.path.join(self.session_dir, f"{new_session_id}.db")
-        new_session = AdvancedSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
-        self._sessions[new_session_id] = new_session
+        AdvancedSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
 
         with sqlite3.connect(new_db_path, timeout=5.0) as new_conn:
             new_conn.execute(
@@ -243,48 +245,34 @@ class SessionManager:
                 (new_session_id,),
             )
             # Preserve id to keep message_structure.message_id references valid.
-            for msg_id, message_data, created_at in message_rows:
-                new_conn.execute(
-                    "INSERT INTO agent_messages (id, session_id, message_data, created_at) VALUES (?, ?, ?, ?)",
-                    (msg_id, new_session_id, message_data, created_at),
-                )
-            for (
-                message_id,
-                branch_id,
-                message_type,
-                sequence_number,
-                user_turn_number,
-                branch_turn_number,
-                tool_name,
-                created_at,
-            ) in structure_rows:
-                new_conn.execute(
-                    "INSERT INTO message_structure "
-                    "(session_id, message_id, branch_id, message_type, sequence_number, "
-                    "user_turn_number, branch_turn_number, tool_name, created_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        new_session_id,
-                        message_id,
-                        branch_id,
-                        message_type,
-                        sequence_number,
-                        user_turn_number,
-                        branch_turn_number,
-                        tool_name,
-                        created_at,
-                    ),
-                )
-            for usage_row in turn_usage_rows:
-                new_conn.execute(
-                    "INSERT OR IGNORE INTO turn_usage "
-                    "(session_id, branch_id, user_turn_number, requests, input_tokens, "
-                    "output_tokens, total_tokens, input_tokens_details, "
-                    "output_tokens_details, created_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (new_session_id, *usage_row),
-                )
+            new_conn.executemany(
+                "INSERT INTO agent_messages (id, session_id, message_data, created_at) VALUES (?, ?, ?, ?)",
+                [
+                    (msg_id, new_session_id, message_data, created_at)
+                    for msg_id, message_data, created_at in message_rows
+                ],
+            )
+            new_conn.executemany(
+                "INSERT INTO message_structure "
+                "(session_id, message_id, branch_id, message_type, sequence_number, "
+                "user_turn_number, branch_turn_number, tool_name, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [(new_session_id, *row) for row in structure_rows],
+            )
+            new_conn.executemany(
+                "INSERT OR IGNORE INTO turn_usage "
+                "(session_id, branch_id, user_turn_number, requests, input_tokens, "
+                "output_tokens, total_tokens, input_tokens_details, "
+                "output_tokens_details, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [(new_session_id, *row) for row in turn_usage_rows],
+            )
             new_conn.commit()
+
+        # Cache a fresh session pointing at the populated DB (tables already exist).
+        self._sessions[new_session_id] = AdvancedSQLiteSession(
+            session_id=new_session_id, db_path=new_db_path, create_tables=False
+        )
 
         logger.info(
             f"Copied session {source_session_id} -> {new_session_id} "

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -202,8 +202,7 @@ class SessionManager:
         with sqlite3.connect(source_db_path, timeout=5.0) as src_conn:
             cursor = src_conn.cursor()
             cursor.execute(
-                "SELECT id, message_data, created_at FROM agent_messages "
-                "WHERE session_id = ? ORDER BY id",
+                "SELECT id, message_data, created_at FROM agent_messages WHERE session_id = ? ORDER BY id",
                 (source_session_id,),
             )
             message_rows = cursor.fetchall()
@@ -246,8 +245,7 @@ class SessionManager:
             # Preserve id to keep message_structure.message_id references valid.
             for msg_id, message_data, created_at in message_rows:
                 new_conn.execute(
-                    "INSERT INTO agent_messages (id, session_id, message_data, created_at) "
-                    "VALUES (?, ?, ?, ?)",
+                    "INSERT INTO agent_messages (id, session_id, message_data, created_at) VALUES (?, ?, ?, ?)",
                     (msg_id, new_session_id, message_data, created_at),
                 )
             for (
@@ -420,8 +418,7 @@ class SessionManager:
             )
             for msg_id, _, message_data, created_at in kept_rows:
                 new_conn.execute(
-                    "INSERT INTO agent_messages (id, session_id, message_data, created_at) "
-                    "VALUES (?, ?, ?, ?)",
+                    "INSERT INTO agent_messages (id, session_id, message_data, created_at) VALUES (?, ?, ?, ?)",
                     (msg_id, new_session_id, message_data, created_at),
                 )
             for (

--- a/datus/schemas/agent_models.py
+++ b/datus/schemas/agent_models.py
@@ -68,6 +68,9 @@ class SubAgentConfig(BaseModel):
     prompt_version: Optional[str] = Field(default="1.0", init=True, description="System Prompt version")
     prompt_language: str = Field(default="en", init=True, description="System Prompt language")
     scoped_kb_path: Optional[str] = Field(default=None, init=True, description="Path to scoped KB storage")
+    subagents: Optional[str] = Field(
+        default=None, description="Comma-separated subagent types, or '*' for all (excluding self)"
+    )
 
     class Config:
         populate_by_name = True
@@ -97,6 +100,9 @@ class SubAgentConfig(BaseModel):
         if self.node_class:
             payload["node_class"] = self.node_class
 
+        if self.subagents is not None:
+            payload["subagents"] = self.subagents
+
         # scoped_kb_path is deprecated: sub-agents now use the shared global
         # storage with WHERE filters, so we no longer persist this field.
 
@@ -112,3 +118,10 @@ class SubAgentConfig(BaseModel):
         if not self.tools or not self.tools.strip():
             return []
         return [tool.strip() for tool in self.tools.split(",") if tool.strip()]
+
+    @property
+    def subagent_list(self) -> List[str]:
+        """Parse subagents field into a list. Returns empty list for None/empty, ['*'] for '*'."""
+        if not self.subagents or not self.subagents.strip():
+            return []
+        return [s.strip() for s in self.subagents.split(",") if s.strip()]

--- a/datus/schemas/agent_models.py
+++ b/datus/schemas/agent_models.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ScopedContextLists(BaseModel):
@@ -74,6 +74,37 @@ class SubAgentConfig(BaseModel):
 
     class Config:
         populate_by_name = True
+
+    @field_validator("subagents", mode="before")
+    @classmethod
+    def _normalize_subagents(cls, value: Any) -> Optional[str]:
+        """Normalize the subagents field.
+
+        - ``None`` / empty / blank strings collapse to ``None``.
+        - Leading/trailing whitespace and duplicate entries are stripped.
+        - If ``*`` appears anywhere, it is collapsed to the single canonical
+          wildcard ``"*"`` (``*, foo`` -> ``"*"``).
+        """
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError("subagents must be a string")
+        stripped = value.strip()
+        if not stripped:
+            return None
+        tokens: List[str] = []
+        seen: set = set()
+        for raw in stripped.split(","):
+            tok = raw.strip()
+            if not tok or tok in seen:
+                continue
+            seen.add(tok)
+            tokens.append(tok)
+        if not tokens:
+            return None
+        if "*" in tokens:
+            return "*"
+        return ",".join(tokens)
 
     def has_scoped_context(self) -> bool:
         return self.scoped_context and not self.scoped_context.is_empty

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -284,7 +284,7 @@ class SubAgentTaskTool:
         """Create a new AgenticNode instance for the given subagent type.
 
         Builtin types (SYS_SUB_AGENTS + gen_sql/gen_report/explore) are created
-        via ``_create_builtin_node`` with ``_as_subagent=True`` so their
+        via ``_create_builtin_node`` with ``is_subagent=True`` so their
         constructors skip SubAgentTaskTool setup entirely.
 
         Custom agents go through ``Node.new_instance`` which doesn't support

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -288,7 +288,7 @@ class SubAgentTaskTool:
         constructors skip SubAgentTaskTool setup entirely.
 
         Custom agents go through ``Node.new_instance`` which doesn't support
-        ``_as_subagent``, so we strip the task tool post-construction.
+        ``is_subagent``, so we strip the task tool post-construction.
         """
         # Builtin system subagents have non-standard constructors
         if subagent_type in SYS_SUB_AGENTS:
@@ -309,7 +309,7 @@ class SubAgentTaskTool:
         )
 
         # Custom agents go through Node.new_instance which can't pass
-        # _as_subagent, so strip any nested task tool post-construction.
+        # is_subagent, so strip any nested task tool post-construction.
         nested_tool = getattr(node, "sub_agent_task_tool", None)
         if isinstance(nested_tool, SubAgentTaskTool):
             if node.tools:

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -283,12 +283,10 @@ class SubAgentTaskTool:
     def _create_node(self, subagent_type: str):
         """Create a new AgenticNode instance for the given subagent type.
 
-        Builtin types (SYS_SUB_AGENTS + gen_sql/gen_report/explore) are created
-        via ``_create_builtin_node`` with ``is_subagent=True`` so their
-        constructors skip SubAgentTaskTool setup entirely.
-
-        Custom agents go through ``Node.new_instance`` which doesn't support
-        ``is_subagent``, so we strip the task tool post-construction.
+        Both builtin (SYS_SUB_AGENTS) and custom agents propagate
+        ``is_subagent=True`` so the child's constructor skips SubAgentTaskTool
+        setup entirely — enforcing strict 2-level depth at the source rather
+        than stripping tools post-construction.
         """
         # Builtin system subagents have non-standard constructors
         if subagent_type in SYS_SUB_AGENTS:
@@ -300,24 +298,14 @@ class SubAgentTaskTool:
 
         from datus.agent.node.node import Node
 
-        node = Node.new_instance(
+        return Node.new_instance(
             node_id=node_id,
             description=description,
             node_type=node_type,
             agent_config=self.agent_config,
             node_name=node_name,
+            is_subagent=True,
         )
-
-        # Custom agents go through Node.new_instance which can't pass
-        # is_subagent, so strip any nested task tool post-construction.
-        nested_tool = getattr(node, "sub_agent_task_tool", None)
-        if isinstance(nested_tool, SubAgentTaskTool):
-            if node.tools:
-                task_tool_names = {t.name for t in nested_tool.available_tools()}
-                node.tools = [t for t in node.tools if t.name not in task_tool_names]
-            node.sub_agent_task_tool = None
-
-        return node
 
     def _resolve_execution_mode(self) -> Literal["interactive", "workflow"]:
         """Resolve execution_mode from the parent node, defaulting to 'interactive'."""
@@ -394,6 +382,7 @@ class SubAgentTaskTool:
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
                 node_id=f"task_gen_table_{uuid.uuid4().hex[:8]}",
+                is_subagent=True,
             )
         elif subagent_type == "gen_job":
             from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
@@ -421,6 +410,7 @@ class SubAgentTaskTool:
                 tools=None,
                 node_name="gen_skill",
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_dashboard":
             from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
@@ -940,15 +930,36 @@ class SubAgentTaskTool:
         return "\n".join(lines)
 
     def _get_available_types(self) -> List[str]:
-        """Discover available subagent types, filtered by allowed_subagents and excluding self."""
+        """Discover available subagent types, filtered by allowed_subagents and excluding self.
+
+        In explicit list mode, unknown types are filtered out with a warning so
+        that a misconfigured ``subagents: "foo, bar"`` surfaces as a log message
+        instead of a cryptic ``_create_node`` failure at runtime.
+        """
         if self._allowed_subagents is not None:
-            # Explicit list mode: return only those types, exclude self
-            return [t for t in self._allowed_subagents if t != self._parent_node_name]
+            # Explicit list mode: filter against the discoverable universe,
+            # warn on unknown names, and exclude self.
+            discoverable = self._discover_all_types()
+            result: List[str] = []
+            for t in self._allowed_subagents:
+                if t == self._parent_node_name:
+                    continue
+                if t not in discoverable:
+                    logger.warning(
+                        f"Subagent type '{t}' in allowed_subagents is not a known type "
+                        f"(parent={self._parent_node_name}); skipping. "
+                        f"Known types: {sorted(discoverable)}"
+                    )
+                    continue
+                result.append(t)
+            return result
 
-        # Wildcard mode (*): discover all types, exclude self
+        # Wildcard mode (*): all discovered types, excluding self.
+        return [t for t in self._discover_all_types() if t != self._parent_node_name]
+
+    def _discover_all_types(self) -> List[str]:
+        """Return every subagent type that can currently be instantiated."""
         types = ["explore"]
-
-        # Add built-in system subagents (always available)
         types.extend(sorted(SYS_SUB_AGENTS))
 
         if self.agent_config and hasattr(self.agent_config, "agentic_nodes"):
@@ -969,4 +980,4 @@ class SubAgentTaskTool:
 
                 types.append(name)
 
-        return [t for t in types if t != self._parent_node_name]
+        return types

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -323,6 +323,7 @@ class SubAgentTaskTool:
             return GenSemanticModelAgenticNode(
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_metrics":
             from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
@@ -330,6 +331,7 @@ class SubAgentTaskTool:
             return GenMetricsAgenticNode(
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_sql_summary":
             from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
@@ -338,6 +340,7 @@ class SubAgentTaskTool:
                 node_name="gen_sql_summary",
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_ext_knowledge":
             from datus.agent.node.gen_ext_knowledge_agentic_node import GenExtKnowledgeAgenticNode
@@ -346,6 +349,7 @@ class SubAgentTaskTool:
                 node_name="gen_ext_knowledge",
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_sql":
             from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
@@ -390,6 +394,7 @@ class SubAgentTaskTool:
             return GenJobAgenticNode(
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "migration":
             from datus.agent.node.migration_agentic_node import MigrationAgenticNode
@@ -397,6 +402,7 @@ class SubAgentTaskTool:
             return MigrationAgenticNode(
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_skill":
             from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
@@ -419,6 +425,7 @@ class SubAgentTaskTool:
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
                 node_id=f"task_gen_dashboard_{uuid.uuid4().hex[:8]}",
+                is_subagent=True,
             )
         elif subagent_type == "scheduler":
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
@@ -427,6 +434,7 @@ class SubAgentTaskTool:
                 agent_config=self.agent_config,
                 execution_mode=self._resolve_execution_mode(),
                 node_id=f"task_scheduler_{uuid.uuid4().hex[:8]}",
+                is_subagent=True,
             )
         else:
             raise ValueError(f"Unknown builtin subagent type: {subagent_type}")

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -184,8 +184,15 @@ class SubAgentTaskTool:
     for every task invocation to ensure fully independent context.
     """
 
-    def __init__(self, agent_config: AgentConfig):
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        allowed_subagents: Optional[List[str]] = None,
+        parent_node_name: Optional[str] = None,
+    ):
         self.agent_config = agent_config
+        self._allowed_subagents = allowed_subagents
+        self._parent_node_name = parent_node_name
         self._action_bus: Optional["ActionBus"] = None
         self._interaction_broker: Optional["InteractionBroker"] = None
         self._parent_node: Optional["AgenticNode"] = None
@@ -274,7 +281,15 @@ class SubAgentTaskTool:
     # ── node creation ─────────────────────────────────────────────────
 
     def _create_node(self, subagent_type: str):
-        """Create a new AgenticNode instance for the given subagent type."""
+        """Create a new AgenticNode instance for the given subagent type.
+
+        Builtin types (SYS_SUB_AGENTS + gen_sql/gen_report/explore) are created
+        via ``_create_builtin_node`` with ``_as_subagent=True`` so their
+        constructors skip SubAgentTaskTool setup entirely.
+
+        Custom agents go through ``Node.new_instance`` which doesn't support
+        ``_as_subagent``, so we strip the task tool post-construction.
+        """
         # Builtin system subagents have non-standard constructors
         if subagent_type in SYS_SUB_AGENTS:
             return self._create_builtin_node(subagent_type)
@@ -285,13 +300,24 @@ class SubAgentTaskTool:
 
         from datus.agent.node.node import Node
 
-        return Node.new_instance(
+        node = Node.new_instance(
             node_id=node_id,
             description=description,
             node_type=node_type,
             agent_config=self.agent_config,
             node_name=node_name,
         )
+
+        # Custom agents go through Node.new_instance which can't pass
+        # _as_subagent, so strip any nested task tool post-construction.
+        nested_tool = getattr(node, "sub_agent_task_tool", None)
+        if isinstance(nested_tool, SubAgentTaskTool):
+            if node.tools:
+                task_tool_names = {t.name for t in nested_tool.available_tools()}
+                node.tools = [t for t in node.tools if t.name not in task_tool_names]
+            node.sub_agent_task_tool = None
+
+        return node
 
     def _resolve_execution_mode(self) -> Literal["interactive", "workflow"]:
         """Resolve execution_mode from the parent node, defaulting to 'interactive'."""
@@ -345,6 +371,7 @@ class SubAgentTaskTool:
                 tools=None,
                 node_name="gen_sql",
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_report":
             from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
@@ -358,6 +385,7 @@ class SubAgentTaskTool:
                 tools=None,
                 node_name="gen_report",
                 execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
             )
         elif subagent_type == "gen_table":
             from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
@@ -912,30 +940,33 @@ class SubAgentTaskTool:
         return "\n".join(lines)
 
     def _get_available_types(self) -> List[str]:
-        """Discover available subagent types."""
+        """Discover available subagent types, filtered by allowed_subagents and excluding self."""
+        if self._allowed_subagents is not None:
+            # Explicit list mode: return only those types, exclude self
+            return [t for t in self._allowed_subagents if t != self._parent_node_name]
+
+        # Wildcard mode (*): discover all types, exclude self
         types = ["explore"]
 
         # Add built-in system subagents (always available)
         types.extend(sorted(SYS_SUB_AGENTS))
 
-        if not self.agent_config or not hasattr(self.agent_config, "agentic_nodes"):
-            return types
+        if self.agent_config and hasattr(self.agent_config, "agentic_nodes"):
+            current_database = self.agent_config.current_database
 
-        current_database = self.agent_config.current_database
-
-        for name, config in self.agent_config.agentic_nodes.items():
-            if name in ("chat", "explore") or name in SYS_SUB_AGENTS:
-                continue
-
-            # If scoped_context is configured, namespace must match current namespace
-            try:
-                sub_config = SubAgentConfig.model_validate(config)
-                if sub_config.has_scoped_context() and not sub_config.is_in_namespace(current_database):
+            for name, config in self.agent_config.agentic_nodes.items():
+                if name in ("chat", "explore") or name in SYS_SUB_AGENTS:
                     continue
-            except Exception as e:
-                logger.debug(f"Skipping invalid subagent config '{name}': {e}")
-                continue
 
-            types.append(name)
+                # If scoped_context is configured, namespace must match current namespace
+                try:
+                    sub_config = SubAgentConfig.model_validate(config)
+                    if sub_config.has_scoped_context() and not sub_config.is_in_namespace(current_database):
+                        continue
+                except Exception as e:
+                    logger.debug(f"Skipping invalid subagent config '{name}': {e}")
+                    continue
 
-        return types
+                types.append(name)
+
+        return [t for t in types if t != self._parent_node_name]

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -648,6 +648,73 @@ class TestCountSessionTokens:
         result = await node._count_session_tokens()
         assert result == 0
 
+    @pytest.mark.asyncio
+    async def test_count_tokens_ignores_subagent_depth_actions(self):
+        """Sub-agent (depth>0) ASSISTANT actions must not pollute parent context estimate.
+
+        Regression: the scan must skip child/tool usage so that only root-level
+        (depth == 0) assistant actions contribute to the context window estimate.
+        Here the only depth>0 assistant has large usage; the parent's estimate
+        should fall back to turn_usage (or 0) instead of reading the child's.
+        """
+        node = _make_node()
+        subagent_action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat",
+            messages="sub",
+            input_data={},
+            output_data={"usage": {"last_call_input_tokens": 99999, "input_tokens": 99999, "total_tokens": 99999}},
+            status=ActionStatus.SUCCESS,
+        )
+        subagent_action.depth = 1  # simulate sub-agent nesting
+        node.actions.append(subagent_action)
+
+        mock_session = MagicMock()
+        mock_session.get_turn_usage = AsyncMock(return_value=[{"user_turn_number": 1, "total_tokens": 321}])
+        node._session = mock_session
+
+        result = await node._count_session_tokens()
+        # Must NOT return 99999 from the depth>0 action; fall back to turn_usage's 321.
+        assert result == 321
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_breaks_at_root_user_message(self):
+        """Scan stops at the most recent root-level USER action to scope to the current turn.
+
+        An older ASSISTANT action preceding the latest root USER message must
+        NOT be used, even if it has usage. This guards against bleed-over from
+        the previous turn's usage into the current turn's estimate.
+        """
+        node = _make_node()
+        # Older turn's assistant reply with usage (should be ignored after USER break).
+        old_assistant = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat",
+            messages="old",
+            input_data={},
+            output_data={"usage": {"last_call_input_tokens": 7777}},
+            status=ActionStatus.SUCCESS,
+        )
+        old_assistant.depth = 0
+        # Latest root user message marks the boundary of the current turn.
+        latest_user = ActionHistory.create_action(
+            role=ActionRole.USER,
+            action_type="chat",
+            messages="new question",
+            input_data={},
+            status=ActionStatus.SUCCESS,
+        )
+        latest_user.depth = 0
+        node.actions.extend([old_assistant, latest_user])
+
+        mock_session = MagicMock()
+        mock_session.get_turn_usage = AsyncMock(return_value=[{"user_turn_number": 1, "total_tokens": 111}])
+        node._session = mock_session
+
+        result = await node._count_session_tokens()
+        # Reverse scan hits latest_user first -> break -> fall back to turn_usage (111).
+        assert result == 111
+
 
 # ---------------------------------------------------------------------------
 # Concrete subclass for testing

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -559,26 +559,64 @@ class TestManualCompact:
 
 class TestCountSessionTokens:
     @pytest.mark.asyncio
-    async def test_count_tokens_no_session(self):
+    async def test_count_tokens_no_actions_no_session(self):
         node = _make_node()
         node._session = None
         result = await node._count_session_tokens()
         assert result == 0
 
     @pytest.mark.asyncio
-    async def test_count_tokens_with_session(self):
+    async def test_count_tokens_uses_last_call_input_tokens(self):
+        """Primary path: last_call_input_tokens from the most recent action's usage."""
+        node = _make_node()
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat",
+            messages="ok",
+            input_data={},
+            output_data={"usage": {"last_call_input_tokens": 5000, "input_tokens": 8000, "total_tokens": 12000}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions.append(action)
+        result = await node._count_session_tokens()
+        assert result == 5000
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_falls_back_to_input_tokens(self):
+        """When last_call_input_tokens is 0, fall back to input_tokens."""
+        node = _make_node()
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat",
+            messages="ok",
+            input_data={},
+            output_data={"usage": {"last_call_input_tokens": 0, "input_tokens": 8000, "total_tokens": 12000}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions.append(action)
+        result = await node._count_session_tokens()
+        assert result == 8000
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_falls_back_to_turn_usage(self):
+        """When actions have no usage, fall back to last turn in turn_usage table."""
         node = _make_node()
         mock_session = MagicMock()
-        mock_session.get_session_usage = AsyncMock(return_value={"total_tokens": 1234})
+        mock_session.get_turn_usage = AsyncMock(
+            return_value=[
+                {"user_turn_number": 1, "total_tokens": 500},
+                {"user_turn_number": 2, "total_tokens": 1234},
+            ]
+        )
         node._session = mock_session
         result = await node._count_session_tokens()
         assert result == 1234
 
     @pytest.mark.asyncio
-    async def test_count_tokens_empty_usage(self):
+    async def test_count_tokens_empty_actions_empty_turn_usage(self):
         node = _make_node()
         mock_session = MagicMock()
-        mock_session.get_session_usage = AsyncMock(return_value={})
+        mock_session.get_turn_usage = AsyncMock(return_value=[])
         node._session = mock_session
         result = await node._count_session_tokens()
         assert result == 0
@@ -854,8 +892,17 @@ class TestGetSessionInfoExtended:
         node = _make_simple_node()
         node.session_id = "sess_x"
         node._session = MagicMock()
-        node._session.get_session_usage = AsyncMock(return_value={"total_tokens": 500})
         node.context_length = 4000
+        # Provide usage via actions (primary path for _count_session_tokens)
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat",
+            messages="ok",
+            input_data={},
+            output_data={"usage": {"last_call_input_tokens": 500, "input_tokens": 800, "total_tokens": 1200}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions.append(action)
 
         result = asyncio.run(node.get_session_info())
         assert result["session_id"] == "sess_x"
@@ -1104,8 +1151,16 @@ class TestAutoCompactExtended:
         node = _make_simple_node()
         node.model = MagicMock()
         node.context_length = 10000
-        node._session = MagicMock()
-        node._session.get_session_usage = AsyncMock(return_value={"total_tokens": 100})
+        # Provide usage via actions (primary path for _count_session_tokens)
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat",
+            messages="ok",
+            input_data={},
+            output_data={"usage": {"last_call_input_tokens": 100, "input_tokens": 200, "total_tokens": 300}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions.append(action)
 
         result = asyncio.run(node._auto_compact())
         assert result is False
@@ -1115,7 +1170,16 @@ class TestAutoCompactExtended:
         node.model = MagicMock()
         node.context_length = 1000
         node._session = MagicMock()
-        node._session.get_session_usage = AsyncMock(return_value={"total_tokens": 950})
+        # Provide usage via actions
+        action = ActionHistory.create_action(
+            role=ActionRole.ASSISTANT,
+            action_type="chat",
+            messages="ok",
+            input_data={},
+            output_data={"usage": {"last_call_input_tokens": 950, "input_tokens": 1500, "total_tokens": 2000}},
+            status=ActionStatus.SUCCESS,
+        )
+        node.actions.append(action)
         node.model.generate_with_tools = AsyncMock(return_value={"content": "summary", "usage": {"output_tokens": 50}})
         node.model.delete_session = MagicMock()
         node.session_id = "sess_auto"

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -551,6 +551,33 @@ class TestManualCompact:
         assert node._session is None
         assert node.session_id is None
 
+    @pytest.mark.asyncio
+    async def test_manual_compact_lazy_loads_session_after_resume(self):
+        """After .resume sets session_id but leaves _session None, compact must still work.
+
+        Regression: previously _manual_compact aborted with
+        "Cannot compact: no model or session available" because resume does not
+        eagerly open the SQLite session.
+        """
+        node = _make_node()
+        node.ephemeral = False
+        node.session_id = "resumed_session"
+        node._session = None  # Simulate post-resume state
+        mock_model = MagicMock()
+        mock_model.generate_with_tools = AsyncMock(
+            return_value={"content": "Resumed summary", "usage": {"output_tokens": 50}}
+        )
+        # create_session is what _get_or_create_session will call via self.model.
+        mock_model.create_session = MagicMock(return_value=MagicMock())
+        node.model = mock_model
+
+        result = await node._manual_compact()
+
+        # _get_or_create_session should have been invoked to materialize the session.
+        mock_model.create_session.assert_called_once_with("resumed_session")
+        assert result["success"] is True
+        assert result["summary"] == "Resumed summary"
+
 
 # ---------------------------------------------------------------------------
 # TestCountSessionTokens

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -2146,6 +2146,7 @@ class TestRebuildTools:
         node.filesystem_func_tool = None
         node._platform_doc_tool = None
         node.ask_user_tool = None
+        node.sub_agent_task_tool = None
 
         node._rebuild_tools()
 
@@ -2164,6 +2165,7 @@ class TestRebuildTools:
         node.date_parsing_tools = None
         node.filesystem_func_tool = None
         node._platform_doc_tool = None
+        node.sub_agent_task_tool = None
         # ask_user_tool is set up by _make_node via setup_tools; keep it
 
         node._rebuild_tools()
@@ -2181,6 +2183,7 @@ class TestRebuildTools:
         node.filesystem_func_tool = None
         node._platform_doc_tool = None
         node.ask_user_tool = None
+        node.sub_agent_task_tool = None
 
         node._rebuild_tools()
 

--- a/tests/unit_tests/cli/test_autocomplete.py
+++ b/tests/unit_tests/cli/test_autocomplete.py
@@ -47,11 +47,11 @@ class TestSubagentCompleterInit:
         for sys_sub in SYS_SUB_AGENTS:
             assert sys_sub in completer._available_subagents
 
-    def test_loaded_subagents_exclude_chat(self, real_agent_config):
-        """Loaded subagents exclude the 'chat' node."""
+    def test_loaded_subagents_include_chat(self, real_agent_config):
+        """Loaded subagents include 'chat' for explicit /chat routing."""
         completer = SubagentCompleter(real_agent_config)
 
-        assert "chat" not in completer._available_subagents
+        assert "chat" in completer._available_subagents
 
     def test_loaded_subagents_include_custom_nodes(self, real_agent_config):
         """Custom agentic_nodes not in SYS_SUB_AGENTS and not 'chat' are included."""

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3368,8 +3368,8 @@ class TestIsAgentSwitch:
 
 
 class TestSessionPreservationOnSwitch:
-    def test_session_id_carried_over_on_switch(self, chat_cmd):
-        """When switching agents, session_id from old node is carried to new node."""
+    def test_session_copied_on_switch_with_correct_prefix(self, chat_cmd):
+        """When switching agents, session is copied and new id has the target node prefix."""
         old_node = MagicMock()
         old_node.session_id = "chat_session_abc123"
         chat_cmd.current_node = old_node
@@ -3377,7 +3377,11 @@ class TestSessionPreservationOnSwitch:
 
         new_node = MagicMock()
         new_node.session_id = None
+        new_node.get_node_name.return_value = "gensql"
         chat_cmd._create_new_node = MagicMock(return_value=new_node)
+
+        # Mock _copy_session_for_switch to return a properly-prefixed session_id
+        chat_cmd._copy_session_for_switch = MagicMock(return_value="gensql_session_def456")
 
         # Simulate _execute_chat logic for agent switch
         subagent_name = "gensql"
@@ -3387,15 +3391,41 @@ class TestSessionPreservationOnSwitch:
         assert need_new_node is True
         assert is_switch is True
 
-        # Carry over session_id
         prev_session_id = None
         if is_switch and chat_cmd.current_node and hasattr(chat_cmd.current_node, "session_id"):
             prev_session_id = chat_cmd.current_node.session_id
         chat_cmd.current_node = chat_cmd._create_new_node(subagent_name)
         if prev_session_id:
-            chat_cmd.current_node.session_id = prev_session_id
+            chat_cmd.current_node.session_id = chat_cmd._copy_session_for_switch(prev_session_id, chat_cmd.current_node)
 
-        assert chat_cmd.current_node.session_id == "chat_session_abc123"
+        # Verify the new session_id has the target node prefix, not the source prefix
+        assert chat_cmd.current_node.session_id == "gensql_session_def456"
+        chat_cmd._copy_session_for_switch.assert_called_once_with("chat_session_abc123", new_node)
+
+    def test_copy_session_delegates_to_session_manager(self, chat_cmd):
+        """_copy_session_for_switch delegates to SessionManager.copy_session."""
+        new_node = MagicMock()
+        new_node.get_node_name.return_value = "gensql"
+
+        with patch("datus.models.session_manager.SessionManager") as mock_sm_cls:
+            mock_sm = mock_sm_cls.return_value
+            mock_sm.copy_session.return_value = "gensql_session_xyz789"
+
+            result = chat_cmd._copy_session_for_switch("chat_session_abc123", new_node)
+
+        assert result == "gensql_session_xyz789"
+        mock_sm.copy_session.assert_called_once_with("chat_session_abc123", "gensql")
+
+    def test_copy_session_fallback_on_error(self, chat_cmd):
+        """If copy_session fails, fall back to the node's existing session_id."""
+        new_node = MagicMock()
+        new_node.session_id = "fallback_session_id"
+        new_node.get_node_name.return_value = "gensql"
+
+        with patch("datus.models.session_manager.SessionManager", side_effect=Exception("no dir")):
+            result = chat_cmd._copy_session_for_switch("chat_session_abc123", new_node)
+
+        assert result == "fallback_session_id"
 
     def test_session_id_not_carried_on_fresh_start(self, chat_cmd):
         """First node creation (no previous node) does not carry session_id."""

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -31,7 +31,7 @@ import json
 import os
 import sqlite3
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from rich.console import Console

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -1423,46 +1423,6 @@ class TestEdgeCases:
 # ===========================================================================
 
 
-class TestTriggerCompact:
-    """Tests for _trigger_compact_for_current_node."""
-
-    def test_trigger_compact_no_node(self, real_agent_config, mock_llm_create):
-        """No-op when current_node is None."""
-        cmds = _make_chat_commands(real_agent_config)
-        cmds.current_node = None
-
-        # Should not raise
-        cmds._trigger_compact_for_current_node()
-        assert cmds.current_node is None
-
-    def test_trigger_compact_node_without_compact_method(self, real_agent_config, mock_llm_create):
-        """No-op when node does not have _manual_compact."""
-        console = Console(file=io.StringIO(), no_color=True)
-        cmds = _make_chat_commands(real_agent_config, console=console)
-        # Use a minimal object without _manual_compact
-        cmds.current_node = object()
-
-        # Should not raise
-        cmds._trigger_compact_for_current_node()
-        output = _get_console_output(console)
-        assert "compacted" not in output.lower()
-        assert cmds.current_node is not None
-
-    def test_trigger_compact_with_node_no_session(self, real_agent_config, mock_llm_create):
-        """Node with _manual_compact but no active session does not print compact messages."""
-        console = Console(file=io.StringIO(), no_color=True)
-        cmds = _make_chat_commands(real_agent_config, console=console)
-        node = cmds._create_new_node()
-        cmds.current_node = node
-
-        # Node exists but has no session_id set, so get_session_info returns no session_id
-        cmds._trigger_compact_for_current_node()
-
-        output = _get_console_output(console)
-        # Should not contain compact success/failure messages (no active session)
-        assert "Session compacted successfully" not in output
-
-
 # ===========================================================================
 # TestCmdCompact
 # ===========================================================================
@@ -1709,7 +1669,7 @@ class TestExecuteChatCommandResponseProcessing:
         cmds.execute_chat_command("Hello", subagent_name=None)
         first_node = cmds.current_node
 
-        cmds.execute_chat_command("Generate SQL", subagent_name="gensql", compact_when_new_subagent=False)
+        cmds.execute_chat_command("Generate SQL", subagent_name="gensql")
         second_node = cmds.current_node
 
         assert first_node is not second_node
@@ -2156,42 +2116,6 @@ class TestCmdListSessionsWithData:
         assert len(output) > 0
         # Either shows sessions table or "No chat sessions found"
         assert "Session" in output or "No chat sessions" in output
-
-
-# ===========================================================================
-# TestTriggerCompactWithSession — _trigger_compact 带活跃 session
-# ===========================================================================
-
-
-class TestTriggerCompactWithSession:
-    """Tests for _trigger_compact_for_current_node with an active session."""
-
-    def test_trigger_compact_before_subagent_switch(self, real_agent_config, mock_llm_create):
-        """Switching subagent with compact_when_new_subagent=True triggers compact."""
-        from tests.unit_tests.mock_llm_model import build_simple_response
-
-        console = Console(file=io.StringIO(), no_color=True)
-        cmds = _make_chat_commands(real_agent_config, console=console)
-
-        mock_llm_create.reset(
-            responses=[
-                build_simple_response("Chat reply"),
-                build_simple_response("Summary"),  # for compact
-                build_simple_response("SQL reply"),  # for subagent
-            ]
-        )
-
-        # First: create a chat session
-        cmds.execute_chat_command("Hello")
-        assert cmds.current_node is not None
-
-        # Second: switch to subagent with compact (exercises line 314)
-        console.file = io.StringIO()
-        cmds.execute_chat_command("Generate SQL", subagent_name="gensql", compact_when_new_subagent=True)
-
-        output = _get_console_output(console)
-        assert cmds.current_subagent_name == "gensql"
-        assert len(output) > 0
 
 
 # ===========================================================================
@@ -3397,6 +3321,100 @@ class TestShouldCreateNewNodeExtended:
 
 
 # ---------------------------------------------------------------------------
+# Tests: _is_agent_switch
+# ---------------------------------------------------------------------------
+
+
+class TestIsAgentSwitch:
+    def test_no_current_node_is_not_switch(self, chat_cmd):
+        """No current node means this is not a switch."""
+        chat_cmd.current_node = None
+        assert chat_cmd._is_agent_switch("gensql") is False
+
+    def test_same_subagent_is_not_switch(self, chat_cmd):
+        """Same subagent is not a switch."""
+        chat_cmd.current_node = MagicMock()
+        chat_cmd.current_subagent_name = "gensql"
+        assert chat_cmd._is_agent_switch("gensql") is False
+
+    def test_different_subagent_is_switch(self, chat_cmd):
+        """Different subagent is a switch."""
+        chat_cmd.current_node = MagicMock()
+        chat_cmd.current_subagent_name = "gensql"
+        assert chat_cmd._is_agent_switch("compare") is True
+
+    def test_chat_to_subagent_is_switch(self, chat_cmd):
+        """Switching from chat to subagent is a switch."""
+        chat_cmd.current_node = MagicMock()
+        chat_cmd.current_subagent_name = None
+        assert chat_cmd._is_agent_switch("gensql") is True
+
+    def test_subagent_to_chat_is_switch(self, chat_cmd):
+        """Switching from subagent to chat is a switch."""
+        chat_cmd.current_node = MagicMock()
+        chat_cmd.current_subagent_name = "gensql"
+        assert chat_cmd._is_agent_switch(None) is True
+
+    def test_chat_to_chat_is_not_switch(self, chat_cmd):
+        """Staying on chat is not a switch."""
+        chat_cmd.current_node = MagicMock()
+        chat_cmd.current_subagent_name = None
+        assert chat_cmd._is_agent_switch(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: session_id preservation on agent switch
+# ---------------------------------------------------------------------------
+
+
+class TestSessionPreservationOnSwitch:
+    def test_session_id_carried_over_on_switch(self, chat_cmd):
+        """When switching agents, session_id from old node is carried to new node."""
+        old_node = MagicMock()
+        old_node.session_id = "chat_session_abc123"
+        chat_cmd.current_node = old_node
+        chat_cmd.current_subagent_name = None  # was on chat
+
+        new_node = MagicMock()
+        new_node.session_id = None
+        chat_cmd._create_new_node = MagicMock(return_value=new_node)
+
+        # Simulate _execute_chat logic for agent switch
+        subagent_name = "gensql"
+        need_new_node = chat_cmd._should_create_new_node(subagent_name)
+        is_switch = chat_cmd._is_agent_switch(subagent_name)
+
+        assert need_new_node is True
+        assert is_switch is True
+
+        # Carry over session_id
+        prev_session_id = None
+        if is_switch and chat_cmd.current_node and hasattr(chat_cmd.current_node, "session_id"):
+            prev_session_id = chat_cmd.current_node.session_id
+        chat_cmd.current_node = chat_cmd._create_new_node(subagent_name)
+        if prev_session_id:
+            chat_cmd.current_node.session_id = prev_session_id
+
+        assert chat_cmd.current_node.session_id == "chat_session_abc123"
+
+    def test_session_id_not_carried_on_fresh_start(self, chat_cmd):
+        """First node creation (no previous node) does not carry session_id."""
+        chat_cmd.current_node = None
+        chat_cmd.current_subagent_name = None
+
+        new_node = MagicMock()
+        new_node.session_id = None
+        chat_cmd._create_new_node = MagicMock(return_value=new_node)
+
+        is_switch = chat_cmd._is_agent_switch("gensql")
+        assert is_switch is False
+
+        chat_cmd.current_node = chat_cmd._create_new_node("gensql")
+        # session_id remains None (will be auto-generated on first use)
+        assert chat_cmd.current_node.session_id is None
+
+
+# ---------------------------------------------------------------------------
 # Tests: update_chat_node_tools
 # ---------------------------------------------------------------------------
 
@@ -3431,65 +3449,6 @@ class TestCmdClearChatExtended:
 
         # After clear, state should be reset
         assert chat_cmd.chat_history == [] or chat_cmd.current_node is None
-
-
-# ---------------------------------------------------------------------------
-# Tests: _trigger_compact_for_current_node
-# ---------------------------------------------------------------------------
-
-
-class TestTriggerCompactExtended:
-    def test_no_current_node_does_nothing(self, chat_cmd):
-        chat_cmd.current_node = None
-        chat_cmd._trigger_compact_for_current_node()  # should not raise
-
-    def test_compact_success(self, chat_cmd):
-        mock_node = MagicMock()
-        mock_node._manual_compact = AsyncMock(
-            return_value={
-                "success": True,
-                "new_token_count": 100,
-                "tokens_saved": 50,
-                "compression_ratio": 0.5,
-            }
-        )
-
-        async def mock_get_info():
-            return {"session_id": "abc123"}
-
-        mock_node.get_session_info = mock_get_info
-        chat_cmd.current_node = mock_node
-
-        chat_cmd._trigger_compact_for_current_node()
-        output = chat_cmd.console.file.getvalue()
-        # Should print success message
-        assert len(output) > 0, "Should have printed compact result"
-
-    def test_compact_failure_logged(self, chat_cmd):
-        mock_node = MagicMock()
-        mock_node._manual_compact = AsyncMock(return_value={"success": False, "error": "Compact failed"})
-
-        async def mock_get_info():
-            return {"session_id": "abc123"}
-
-        mock_node.get_session_info = mock_get_info
-        chat_cmd.current_node = mock_node
-
-        chat_cmd._trigger_compact_for_current_node()
-        output = chat_cmd.console.file.getvalue()
-        assert "Failed" in output or "compact" in output.lower(), f"Expected failure message, got: {output[:200]}"
-
-    def test_exception_during_compact_handled(self, chat_cmd):
-        mock_node = MagicMock()
-
-        async def mock_get_info():
-            raise RuntimeError("session error")
-
-        mock_node.get_session_info = mock_get_info
-        chat_cmd.current_node = mock_node
-
-        # Should not propagate exception
-        chat_cmd._trigger_compact_for_current_node()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -47,6 +47,7 @@ def _make_cli(agent_config, available_subagents=None):
     cli.agent_ready = False
     cli.agent_initializing = False
     cli.plan_mode_active = False
+    cli.default_agent = ""
     cli.at_completer = MagicMock()
     cli.db_connector = MagicMock()
     cli.db_manager = MagicMock()
@@ -768,3 +769,150 @@ class TestPrintWelcome:
         real_agent_config._current_database = ""
         output = self._get_output(cli)
         assert "No database selected" in output
+
+
+# ---------------------------------------------------------------------------
+# Tests: _cmd_agent
+# ---------------------------------------------------------------------------
+
+
+class TestCmdAgent:
+    def test_cmd_agent_set_valid(self, cli):
+        """'.agent gen_sql' sets default_agent to gen_sql."""
+        cli.available_subagents = {"chat", "gen_sql", "gen_report"}
+        cli._cmd_agent("gen_sql")
+        assert cli.default_agent == "gen_sql"
+        output = cli.console.file.getvalue()
+        assert "gen_sql" in output
+
+    def test_cmd_agent_set_chat_resets(self, cli):
+        """'.agent chat' resets default_agent to empty string."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = "gen_sql"
+        cli._cmd_agent("chat")
+        assert cli.default_agent == ""
+        output = cli.console.file.getvalue()
+        assert "chat" in output
+
+    def test_cmd_agent_set_invalid(self, cli):
+        """'.agent nonexistent' prints error and doesn't change default."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = ""
+        cli._cmd_agent("nonexistent")
+        assert cli.default_agent == ""
+        output = cli.console.file.getvalue()
+        assert "Unknown agent" in output
+
+    def test_cmd_agent_no_args_interactive(self, cli):
+        """'.agent' (no args) calls select_choice for interactive selection."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = ""
+        with patch("datus.cli.repl.select_choice", return_value="gen_sql") as mock_select:
+            cli._cmd_agent("")
+        mock_select.assert_called_once()
+        assert cli.default_agent == "gen_sql"
+
+    def test_cmd_agent_interactive_no_change(self, cli):
+        """Interactive selection of same agent prints 'unchanged'."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = ""
+        with patch("datus.cli.repl.select_choice", return_value="chat"):
+            cli._cmd_agent("")
+        assert cli.default_agent == ""
+        output = cli.console.file.getvalue()
+        assert "unchanged" in output
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_command with default_agent routing
+# ---------------------------------------------------------------------------
+
+
+class TestParseCommandDefaultAgent:
+    def test_slash_message_uses_default_agent(self, cli):
+        """'/message' uses default_agent when no explicit subagent prefix."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = "gen_sql"
+        cmd_type, cmd, args = cli._parse_command("/show revenue")
+        assert cmd_type == CommandType.CHAT
+        assert cmd == "gen_sql"
+        assert args == "show revenue"
+
+    def test_explicit_subagent_overrides_default(self, cli):
+        """'/gen_report msg' uses gen_report even when default is gen_sql."""
+        cli.available_subagents = {"chat", "gen_sql", "gen_report"}
+        cli.default_agent = "gen_sql"
+        cmd_type, cmd, args = cli._parse_command("/gen_report show revenue")
+        assert cmd_type == CommandType.CHAT
+        assert cmd == "gen_report"
+        assert args == "show revenue"
+
+    def test_chat_explicit_maps_to_empty(self, cli):
+        """'/chat msg' always maps subagent_name to '' regardless of default."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = "gen_sql"
+        cmd_type, cmd, args = cli._parse_command("/chat show revenue")
+        assert cmd_type == CommandType.CHAT
+        assert cmd == ""
+        assert args == "show revenue"
+
+    def test_bare_text_uses_default_agent(self, cli):
+        """Bare natural language text uses default_agent."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = "gen_sql"
+        with patch("datus.cli.repl.parse_sql_type") as mock_parse:
+            from datus.utils.constants import SQLType
+
+            mock_parse.return_value = SQLType.UNKNOWN
+            cmd_type, cmd, args = cli._parse_command("show me the revenue")
+        assert cmd_type == CommandType.CHAT
+        assert cmd == "gen_sql"
+
+    def test_bare_text_default_chat(self, cli):
+        """Bare text with default_agent='' routes to chat."""
+        cli.default_agent = ""
+        with patch("datus.cli.repl.parse_sql_type") as mock_parse:
+            from datus.utils.constants import SQLType
+
+            mock_parse.return_value = SQLType.UNKNOWN
+            cmd_type, cmd, args = cli._parse_command("hello world")
+        assert cmd_type == CommandType.CHAT
+        assert cmd == ""
+
+    def test_single_word_slash_uses_default(self, cli):
+        """'/message' (single word, not a subagent) uses default_agent."""
+        cli.available_subagents = {"chat", "gen_sql"}
+        cli.default_agent = "gen_sql"
+        cmd_type, cmd, args = cli._parse_command("/hello")
+        assert cmd_type == CommandType.CHAT
+        assert cmd == "gen_sql"
+        assert args == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_prompt_text with default_agent
+# ---------------------------------------------------------------------------
+
+
+class TestGetPromptTextWithAgent:
+    def test_prompt_shows_default_agent(self, cli):
+        """Prompt displays agent name when default_agent is set."""
+        cli.default_agent = "gen_sql"
+        cli.plan_mode_active = False
+        text = cli._get_prompt_text()
+        assert "gen_sql" in text
+        assert "Datus" in text
+
+    def test_prompt_normal_when_no_default(self, cli):
+        """Prompt shows normal 'Datus>' when default_agent is empty."""
+        cli.default_agent = ""
+        cli.plan_mode_active = False
+        text = cli._get_prompt_text()
+        assert text == "Datus> "
+
+    def test_plan_mode_overrides_agent_prompt(self, cli):
+        """Plan mode prompt takes precedence over agent prompt."""
+        cli.default_agent = "gen_sql"
+        cli.plan_mode_active = True
+        text = cli._get_prompt_text()
+        assert "PLAN" in text

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -949,14 +949,12 @@ class TestGenerateWithToolsRouting:
 
 class TestCountSessionTokensFallback:
     @pytest.mark.asyncio
-    async def test_fallback_to_action_history(self):
-        """When session turn_usage returns 0, fall back to action history usage."""
+    async def test_uses_last_call_input_tokens_from_latest_action(self):
+        """Primary: uses last_call_input_tokens from the most recent action with usage."""
         from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 
-        # Create a mock agentic node
         mock_node = MagicMock()
         mock_node._session = MagicMock()
-        mock_node._session.get_session_usage = AsyncMock(return_value={"total_tokens": 0})
         mock_node.actions = [
             ActionHistory(
                 action_id="a1",
@@ -964,7 +962,7 @@ class TestCountSessionTokensFallback:
                 messages="ok",
                 action_type="final_response",
                 status=ActionStatus.SUCCESS,
-                output={"raw_output": "answer", "usage": {"total_tokens": 500}},
+                output={"raw_output": "answer", "usage": {"last_call_input_tokens": 500, "input_tokens": 800, "total_tokens": 1200}},
             ),
             ActionHistory(
                 action_id="a2",
@@ -972,23 +970,23 @@ class TestCountSessionTokensFallback:
                 messages="ok2",
                 action_type="final_response",
                 status=ActionStatus.SUCCESS,
-                output={"raw_output": "answer2", "usage": {"total_tokens": 300}},
+                output={"raw_output": "answer2", "usage": {"last_call_input_tokens": 900, "input_tokens": 1500, "total_tokens": 2000}},
             ),
         ]
 
         from datus.agent.node.agentic_node import AgenticNode
 
         result = await AgenticNode._count_session_tokens(mock_node)
-        assert result == 800
+        # Should return last_call_input_tokens from the LAST action (900), not sum
+        assert result == 900
 
     @pytest.mark.asyncio
-    async def test_session_usage_preferred_over_fallback(self):
-        """When session turn_usage returns >0, use that instead of fallback."""
+    async def test_falls_back_to_input_tokens_when_no_last_call(self):
+        """When last_call_input_tokens is 0, fall back to input_tokens."""
         from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 
         mock_node = MagicMock()
         mock_node._session = MagicMock()
-        mock_node._session.get_session_usage = AsyncMock(return_value={"total_tokens": 1234})
         mock_node.actions = [
             ActionHistory(
                 action_id="a1",
@@ -996,14 +994,14 @@ class TestCountSessionTokensFallback:
                 messages="ok",
                 action_type="final_response",
                 status=ActionStatus.SUCCESS,
-                output={"usage": {"total_tokens": 999}},
+                output={"usage": {"last_call_input_tokens": 0, "input_tokens": 999, "total_tokens": 1500}},
             ),
         ]
 
         from datus.agent.node.agentic_node import AgenticNode
 
         result = await AgenticNode._count_session_tokens(mock_node)
-        assert result == 1234
+        assert result == 999
 
 
 class TestInjectOAuthHeaders:

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -962,7 +962,10 @@ class TestCountSessionTokensFallback:
                 messages="ok",
                 action_type="final_response",
                 status=ActionStatus.SUCCESS,
-                output={"raw_output": "answer", "usage": {"last_call_input_tokens": 500, "input_tokens": 800, "total_tokens": 1200}},
+                output={
+                    "raw_output": "answer",
+                    "usage": {"last_call_input_tokens": 500, "input_tokens": 800, "total_tokens": 1200},
+                },
             ),
             ActionHistory(
                 action_id="a2",
@@ -970,7 +973,10 @@ class TestCountSessionTokensFallback:
                 messages="ok2",
                 action_type="final_response",
                 status=ActionStatus.SUCCESS,
-                output={"raw_output": "answer2", "usage": {"last_call_input_tokens": 900, "input_tokens": 1500, "total_tokens": 2000}},
+                output={
+                    "raw_output": "answer2",
+                    "usage": {"last_call_input_tokens": 900, "input_tokens": 1500, "total_tokens": 2000},
+                },
             ),
         ]
 

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1662,3 +1662,36 @@ class TestCopySession:
         assert len(rows) == 1
         assert rows[0][0] == new_id
         assert rows[0][1] == 150
+
+    def test_copy_session_get_items_returns_copied_messages(self, sm):
+        """Copied session must return history via AdvancedSQLiteSession.get_items().
+
+        Regression for the bug where switching agents printed
+        "Copied session ... (N messages, ...)" but the new agent's LLM call
+        did not include the history.  AdvancedSQLiteSession.get_items() joins
+        agent_messages with message_structure, so copy_session must preserve
+        message_structure rows and agent_messages.id references.
+        """
+        import asyncio
+
+        source_id = "chat_session_items"
+        # Populate via AdvancedSQLiteSession.add_items so message_structure is
+        # created by the SDK exactly as in production.
+        source_db = os.path.join(sm.session_dir, f"{source_id}.db")
+        source = AdvancedSQLiteSession(session_id=source_id, db_path=source_db, create_tables=True)
+        items = [
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+            {"role": "user", "content": "Q2"},
+            {"role": "assistant", "content": "A2"},
+        ]
+        asyncio.run(source.add_items(items))
+
+        new_id = sm.copy_session(source_id, "gensql")
+
+        # Open via the SDK class to exercise the real read path.
+        new_db = os.path.join(sm.session_dir, f"{new_id}.db")
+        new_session = AdvancedSQLiteSession(session_id=new_id, db_path=new_db, create_tables=True)
+        read_items = asyncio.run(new_session.get_items())
+        assert len(read_items) == 4
+        assert [it.get("content") for it in read_items] == ["Q1", "A1", "Q2", "A2"]

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1519,3 +1519,146 @@ class TestGetDetailedUsage:
             assert "legacy-session" in sessions
         finally:
             manager.close_all_sessions()
+
+
+# ---------------------------------------------------------------------------
+# Tests: copy_session
+# ---------------------------------------------------------------------------
+
+
+class TestCopySession:
+    """Tests for SessionManager.copy_session with real SQLite data."""
+
+    def _setup_source_session(self, sm, session_id, messages):
+        """Create a source session and populate it with messages."""
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (session_id,))
+            for idx, msg in enumerate(messages):
+                created_at = msg.get("created_at", f"2025-01-01T00:00:{idx:02d}")
+                msg_copy = {k: v for k, v in msg.items() if k != "created_at"}
+                conn.execute(
+                    "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                    (session_id, json.dumps(msg_copy), created_at),
+                )
+            conn.commit()
+
+    def test_copy_session_changes_prefix(self, sm):
+        """Copied session_id uses target_node_name prefix, not the source prefix."""
+        source_id = "chat_session_abc12345"
+        self._setup_source_session(
+            sm,
+            source_id,
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+            ],
+        )
+
+        new_id = sm.copy_session(source_id, "gensql")
+
+        assert new_id.startswith("gensql_session_")
+        assert new_id != source_id
+
+    def test_copy_session_preserves_all_messages(self, sm):
+        """All messages from the source session are copied to the new session."""
+        source_id = "chat_session_copy1"
+        self._setup_source_session(
+            sm,
+            source_id,
+            [
+                {"role": "user", "content": "Q1", "created_at": "2025-01-01T00:00:00"},
+                {"role": "assistant", "content": "A1", "created_at": "2025-01-01T00:00:01"},
+                {"role": "user", "content": "Q2", "created_at": "2025-01-01T00:00:02"},
+                {"role": "assistant", "content": "A2", "created_at": "2025-01-01T00:00:03"},
+            ],
+        )
+
+        new_id = sm.copy_session(source_id, "gen_report")
+
+        msgs = _read_messages(sm.session_dir, new_id)
+        assert len(msgs) == 4
+        assert msgs[0]["content"] == "Q1"
+        assert msgs[1]["content"] == "A1"
+        assert msgs[2]["content"] == "Q2"
+        assert msgs[3]["content"] == "A2"
+
+    def test_copy_session_new_db_file_created(self, sm):
+        """A separate .db file is created for the new session."""
+        source_id = "chat_session_dbcheck"
+        self._setup_source_session(sm, source_id, [{"role": "user", "content": "test"}])
+
+        new_id = sm.copy_session(source_id, "explore")
+
+        new_db = os.path.join(sm.session_dir, f"{new_id}.db")
+        assert os.path.exists(new_db)
+        # Source DB should still exist untouched
+        source_db = os.path.join(sm.session_dir, f"{source_id}.db")
+        assert os.path.exists(source_db)
+
+    def test_copy_session_cached(self, sm):
+        """The new session should be cached in SessionManager._sessions."""
+        source_id = "chat_session_cached"
+        self._setup_source_session(sm, source_id, [{"role": "user", "content": "test"}])
+
+        new_id = sm.copy_session(source_id, "gensql")
+
+        assert new_id in sm._sessions
+
+    def test_copy_nonexistent_source_returns_fresh_id(self, sm):
+        """When source DB doesn't exist, return a fresh session_id (no crash)."""
+        new_id = sm.copy_session("nonexistent_session_xxx", "gensql")
+
+        assert new_id.startswith("gensql_session_")
+        # No DB file should be created since there was nothing to copy
+        new_db = os.path.join(sm.session_dir, f"{new_id}.db")
+        assert not os.path.exists(new_db)
+
+    def test_copy_session_copies_turn_usage(self, sm):
+        """turn_usage rows are also copied to the new session."""
+        source_id = "chat_session_usage"
+        # Create session via get_session so the DB file exists with base tables
+        sm.get_session(source_id)
+        db_path = os.path.join(sm.session_dir, f"{source_id}.db")
+
+        # Populate messages and turn_usage directly
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (source_id,))
+            conn.execute(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                (source_id, json.dumps({"role": "user", "content": "test"}), "2025-01-01T00:00:00"),
+            )
+            # turn_usage may or may not already exist; create if missing
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS turn_usage ("
+                "session_id TEXT NOT NULL, branch_id TEXT NOT NULL DEFAULT 'main', "
+                "user_turn_number INTEGER NOT NULL, requests INTEGER DEFAULT 0, "
+                "input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0, "
+                "total_tokens INTEGER DEFAULT 0, input_tokens_details TEXT, "
+                "output_tokens_details TEXT, created_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO turn_usage "
+                "(session_id, branch_id, user_turn_number, requests, input_tokens, "
+                "output_tokens, total_tokens, input_tokens_details, output_tokens_details, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (source_id, "main", 1, 2, 100, 50, 150, "{}", "{}", "2025-01-01T00:00:00"),
+            )
+            conn.commit()
+
+        # Verify source turn_usage exists before copy
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.execute("SELECT COUNT(*) FROM turn_usage WHERE session_id = ?", (source_id,))
+            assert cursor.fetchone()[0] == 1
+
+        new_id = sm.copy_session(source_id, "gensql")
+
+        # Verify turn_usage was copied
+        new_db = os.path.join(sm.session_dir, f"{new_id}.db")
+        with sqlite3.connect(new_db) as conn:
+            cursor = conn.execute("SELECT session_id, total_tokens FROM turn_usage WHERE session_id = ?", (new_id,))
+            rows = cursor.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == new_id
+        assert rows[0][1] == 150

--- a/tests/unit_tests/schemas/test_agent_models.py
+++ b/tests/unit_tests/schemas/test_agent_models.py
@@ -1,0 +1,81 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.schemas.agent_models.SubAgentConfig``.
+
+Primary focus: the ``subagents`` field normalization validator.
+"""
+
+import pytest
+
+from datus.schemas.agent_models import SubAgentConfig
+
+
+@pytest.mark.ci
+class TestSubAgentsFieldNormalization:
+    """Tests for the ``subagents`` field validator / normalizer."""
+
+    def test_none_stays_none(self):
+        cfg = SubAgentConfig(subagents=None)
+        assert cfg.subagents is None
+        assert cfg.subagent_list == []
+
+    def test_empty_string_collapses_to_none(self):
+        cfg = SubAgentConfig(subagents="")
+        assert cfg.subagents is None
+        assert cfg.subagent_list == []
+
+    def test_whitespace_only_collapses_to_none(self):
+        cfg = SubAgentConfig(subagents="   ")
+        assert cfg.subagents is None
+
+    def test_wildcard_alone(self):
+        cfg = SubAgentConfig(subagents="*")
+        assert cfg.subagents == "*"
+        assert cfg.subagent_list == ["*"]
+
+    def test_wildcard_mixed_collapses_to_wildcard(self):
+        """``*, foo, bar`` is ambiguous -> collapse to the canonical ``*``."""
+        cfg = SubAgentConfig(subagents="*, gen_sql, explore")
+        assert cfg.subagents == "*"
+        assert cfg.subagent_list == ["*"]
+
+    def test_wildcard_at_end_mixed_still_collapses(self):
+        cfg = SubAgentConfig(subagents="gen_sql, *")
+        assert cfg.subagents == "*"
+
+    def test_explicit_list(self):
+        cfg = SubAgentConfig(subagents="gen_sql, explore")
+        assert cfg.subagents == "gen_sql,explore"
+        assert cfg.subagent_list == ["gen_sql", "explore"]
+
+    def test_duplicates_removed(self):
+        cfg = SubAgentConfig(subagents="gen_sql, gen_sql, explore, gen_sql")
+        assert cfg.subagent_list == ["gen_sql", "explore"]
+
+    def test_stray_whitespace_and_empty_tokens_stripped(self):
+        cfg = SubAgentConfig(subagents="  gen_sql , , explore ,")
+        assert cfg.subagent_list == ["gen_sql", "explore"]
+
+    def test_single_entry(self):
+        cfg = SubAgentConfig(subagents="explore")
+        assert cfg.subagents == "explore"
+        assert cfg.subagent_list == ["explore"]
+
+    def test_non_string_rejected(self):
+        """Non-string values must fail validation — ``subagents`` is a string field."""
+        from pydantic import ValidationError
+
+        with pytest.raises((ValidationError, TypeError)):
+            SubAgentConfig(subagents=["gen_sql"])
+
+    def test_as_payload_omits_subagents_when_none(self):
+        cfg = SubAgentConfig(system_prompt="x", subagents=None)
+        payload = cfg.as_payload()
+        assert "subagents" not in payload
+
+    def test_as_payload_includes_subagents_when_set(self):
+        cfg = SubAgentConfig(system_prompt="x", subagents="gen_sql, explore")
+        payload = cfg.as_payload()
+        assert payload["subagents"] == "gen_sql,explore"

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -154,6 +154,41 @@ class TestGetAvailableTypes:
         types = tool._get_available_types()
         assert "global_agent" in types
 
+    def test_explicit_list_filters_out_unknown_types(self, caplog):
+        """Unknown types in explicit allowed_subagents are skipped with a warning."""
+        config = Mock(spec=AgentConfig)
+        config.current_database = "default"
+        config.agentic_nodes = {"chat": {"model": "default"}}
+        tool = SubAgentTaskTool(
+            agent_config=config,
+            allowed_subagents=["gen_sql", "nonexistent_foo", "explore"],
+            parent_node_name="chat",
+        )
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="datus.tools.func_tool.sub_agent_task_tool"):
+            types = tool._get_available_types()
+
+        assert "gen_sql" in types
+        assert "explore" in types
+        assert "nonexistent_foo" not in types
+        assert any("nonexistent_foo" in rec.message for rec in caplog.records)
+
+    def test_explicit_list_excludes_self(self):
+        """The parent node name is excluded even if listed in allowed_subagents."""
+        config = Mock(spec=AgentConfig)
+        config.current_database = "default"
+        config.agentic_nodes = {"chat": {"model": "default"}}
+        tool = SubAgentTaskTool(
+            agent_config=config,
+            allowed_subagents=["gen_sql", "explore"],
+            parent_node_name="gen_sql",
+        )
+        types = tool._get_available_types()
+        assert "gen_sql" not in types
+        assert "explore" in types
+
 
 # ── _resolve_node_type ─────────────────────────────────────────────
 
@@ -901,6 +936,7 @@ class TestCreateBuiltinNode:
             agent_config=task_tool.agent_config,
             execution_mode="interactive",
             node_id=ANY,
+            is_subagent=True,
         )
 
     def test_unknown_builtin_raises(self, task_tool):
@@ -912,6 +948,20 @@ class TestCreateBuiltinNode:
         with patch.object(task_tool, "_create_builtin_node", return_value=Mock()) as mock_builtin:
             task_tool._create_node("gen_semantic_model")
             mock_builtin.assert_called_once_with("gen_semantic_model")
+
+    def test_create_node_custom_passes_is_subagent_true(self, task_tool):
+        """Custom agents must receive ``is_subagent=True`` via Node.new_instance.
+
+        This enforces 2-level depth at the source: the child never constructs a
+        SubAgentTaskTool, so there is nothing to strip post-construction.
+        """
+        with patch("datus.agent.node.node.Node.new_instance", return_value=Mock()) as mock_new_instance:
+            task_tool._create_node("sales_analyst")
+
+        mock_new_instance.assert_called_once()
+        call_kwargs = mock_new_instance.call_args.kwargs
+        assert call_kwargs["is_subagent"] is True
+        assert call_kwargs["node_name"] == "sales_analyst"
 
 
 # ── _resolve_execution_mode ─────────────────────────────────────────

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -899,6 +899,7 @@ class TestCreateBuiltinNode:
         mock_init.assert_called_once_with(
             agent_config=task_tool.agent_config,
             execution_mode="interactive",
+            is_subagent=True,
         )
 
     @patch("datus.agent.node.gen_metrics_agentic_node.GenMetricsAgenticNode.__init__", return_value=None)
@@ -907,6 +908,7 @@ class TestCreateBuiltinNode:
         mock_init.assert_called_once_with(
             agent_config=task_tool.agent_config,
             execution_mode="interactive",
+            is_subagent=True,
         )
 
     @patch("datus.agent.node.sql_summary_agentic_node.SqlSummaryAgenticNode.__init__", return_value=None)
@@ -916,6 +918,7 @@ class TestCreateBuiltinNode:
             node_name="gen_sql_summary",
             agent_config=task_tool.agent_config,
             execution_mode="interactive",
+            is_subagent=True,
         )
 
     @patch("datus.agent.node.gen_ext_knowledge_agentic_node.GenExtKnowledgeAgenticNode.__init__", return_value=None)
@@ -925,6 +928,7 @@ class TestCreateBuiltinNode:
             node_name="gen_ext_knowledge",
             agent_config=task_tool.agent_config,
             execution_mode="interactive",
+            is_subagent=True,
         )
 
     @patch("datus.agent.node.gen_table_agentic_node.GenTableAgenticNode.__init__", return_value=None)
@@ -932,6 +936,48 @@ class TestCreateBuiltinNode:
         from unittest.mock import ANY
 
         task_tool._create_builtin_node("gen_table")
+        mock_init.assert_called_once_with(
+            agent_config=task_tool.agent_config,
+            execution_mode="interactive",
+            node_id=ANY,
+            is_subagent=True,
+        )
+
+    @patch("datus.agent.node.gen_job_agentic_node.GenJobAgenticNode.__init__", return_value=None)
+    def test_gen_job(self, mock_init, task_tool):
+        task_tool._create_builtin_node("gen_job")
+        mock_init.assert_called_once_with(
+            agent_config=task_tool.agent_config,
+            execution_mode="interactive",
+            is_subagent=True,
+        )
+
+    @patch("datus.agent.node.migration_agentic_node.MigrationAgenticNode.__init__", return_value=None)
+    def test_migration(self, mock_init, task_tool):
+        task_tool._create_builtin_node("migration")
+        mock_init.assert_called_once_with(
+            agent_config=task_tool.agent_config,
+            execution_mode="interactive",
+            is_subagent=True,
+        )
+
+    @patch("datus.agent.node.gen_dashboard_agentic_node.GenDashboardAgenticNode.__init__", return_value=None)
+    def test_gen_dashboard(self, mock_init, task_tool):
+        from unittest.mock import ANY
+
+        task_tool._create_builtin_node("gen_dashboard")
+        mock_init.assert_called_once_with(
+            agent_config=task_tool.agent_config,
+            execution_mode="interactive",
+            node_id=ANY,
+            is_subagent=True,
+        )
+
+    @patch("datus.agent.node.scheduler_agentic_node.SchedulerAgenticNode.__init__", return_value=None)
+    def test_scheduler(self, mock_init, task_tool):
+        from unittest.mock import ANY
+
+        task_tool._create_builtin_node("scheduler")
         mock_init.assert_called_once_with(
             agent_config=task_tool.agent_config,
             execution_mode="interactive",


### PR DESCRIPTION
Add a `subagents` config field to SubAgentConfig and AgenticNode, enabling any AgenticNode subclass to delegate tasks to subagents. Chat defaults to '*' (all types), other nodes (GenSQL, GenReport) default to 'explore'. SubAgentTaskTool now supports allowed_subagents filtering, self-exclusion, and strict 2-level depth enforcement (child nodes get their task tool stripped).

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI .agent command and prompt badge to set a default agent for routing; /chat still forces chat.
  * Sub-agent task tooling can be discovered and surfaced to nodes when enabled.

* **Improvements**
  * Session switching now preserves sessions by copying session data when possible.
  * Token counting now estimates usage from recent action-level data.
  * Subagent discovery now always includes "chat"; autocomplete offers .agent/chat suggestions.

* **Bug Fixes**
  * Removed automatic session compaction on agent switches.

* **Tests**
  * Expanded tests for routing, session copying, token counting, autocomplete, and subagent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->