### PR TITLE
[Enhancement] Fix function_tool schema: correct required fields and simplify Optional type definitions

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -68,6 +68,10 @@ def trans_to_function_tool(bound_method: Callable) -> FunctionTool:
         if prop_name in corrected_schema.get("required", []):
             continue
 
+        param = sig.parameters.get(prop_name)
+        if param is None or param.default is not None:
+            continue
+
         anyof = prop_schema.get("anyOf")
         if not isinstance(anyof, list) or len(anyof) != 2:
             continue

--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -51,6 +51,34 @@ def trans_to_function_tool(bound_method: Callable) -> FunctionTool:
     if "self" in corrected_schema.get("required", []):
         corrected_schema["required"].remove("self")
 
+    # Remove params with default values from 'required' — the agents SDK marks
+    # every parameter as required regardless of Python default values.
+    sig = inspect.signature(bound_method)
+    params_with_defaults = {
+        name for name, param in sig.parameters.items() if param.default is not inspect.Parameter.empty
+    }
+    required = corrected_schema.get("required", [])
+    corrected_schema["required"] = [p for p in required if p not in params_with_defaults]
+
+    # Simplify anyOf[type, null] → type for optional params that are not required.
+    # Since the param is already excluded from 'required', the null branch is redundant
+    # and confusing for the LLM.
+    properties = corrected_schema.get("properties", {})
+    for prop_name, prop_schema in properties.items():
+        if prop_name in corrected_schema.get("required", []):
+            continue
+
+        anyof = prop_schema.get("anyOf")
+        if not isinstance(anyof, list) or len(anyof) != 2:
+            continue
+
+        non_null_types = [t for t in anyof if t.get("type") != "null"]
+        if len(non_null_types) != 1:
+            continue
+
+        prop_schema.clear()
+        prop_schema.update(non_null_types[0])
+
     # The invoker MUST be an 'async' function.
     # We define a closure to correctly capture the 'bound_method' for each iteration.
     def create_async_invoker(method_to_call: Callable) -> Callable:
@@ -114,6 +142,7 @@ def trans_to_function_tool(bound_method: Callable) -> FunctionTool:
         name=tool_template.name,
         description=tool_template.description,
         params_json_schema=corrected_schema,
-        on_invoke_tool=async_invoker,  # <--- Assign the async function
+        on_invoke_tool=async_invoker,
+        strict_json_schema=False,  # Prevent agents SDK from regenerating 'required'
     )
     return final_tool

--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -142,7 +142,7 @@ def trans_to_function_tool(bound_method: Callable) -> FunctionTool:
         name=tool_template.name,
         description=tool_template.description,
         params_json_schema=corrected_schema,
-        on_invoke_tool=async_invoker,
-        strict_json_schema=False,  # Prevent agents SDK from regenerating 'required'
+        on_invoke_tool=async_invoker,  # <--- Assign the async function
+        strict_json_schema=False,  # Prevent agents SDK from regenerating 'required' as it has been applied in tool_template
     )
     return final_tool

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -178,6 +178,7 @@ class TestTransToFunctionTool:
                 opt_str: str | None = None,
                 opt_int: int | None = None,
                 opt_list: list[str] | None = None,
+                opt_str_with_default_not_none: str | None = "auto",
             ) -> FuncToolResult:
                 return FuncToolResult()
 
@@ -192,6 +193,7 @@ class TestTransToFunctionTool:
         assert props["opt_int"]["type"] == "integer"
         assert "anyOf" not in props["opt_list"]
         assert props["opt_list"]["type"] == "array"
+        assert "anyOf" in props["opt_str_with_default_not_none"]
 
     def test_required_param_keeps_anyof_untouched(self):
         """Required parameters should not have their schema modified."""

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -100,3 +100,109 @@ class TestTransToFunctionTool:
 
         assert result["success"] == 1
         assert result["result"] == "test"
+
+    def test_required_excludes_params_with_defaults(self):
+        """Parameters with default values should not be in the 'required' list."""
+
+        class FakeTool:
+            def method(
+                self,
+                req: str,
+                opt: str | None = None,
+                with_default: int = 100,
+                opt_str: str | None = None,
+            ) -> FuncToolResult:
+                return FuncToolResult(result=req)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.method)
+
+        assert tool.params_json_schema.get("required") == ["req"]
+
+    def test_required_all_params_required(self):
+        """All params without defaults should be in 'required'."""
+
+        class FakeTool:
+            def method(self, a: str, b: int, c: float) -> FuncToolResult:
+                return FuncToolResult(result=a)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.method)
+
+        assert set(tool.params_json_schema.get("required", [])) == {"a", "b", "c"}
+
+    def test_required_no_params(self):
+        """Methods with no parameters should have empty 'required' list."""
+
+        class FakeTool:
+            def method(self) -> FuncToolResult:
+                return FuncToolResult(result="ok")
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.method)
+
+        assert tool.params_json_schema.get("required", []) == []
+
+    def test_required_all_optional(self):
+        """All optional params should result in empty 'required' list."""
+
+        class FakeTool:
+            def method(self, a: str | None = None, b: int = 0) -> FuncToolResult:
+                return FuncToolResult(result="ok")
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.method)
+
+        assert tool.params_json_schema.get("required", []) == []
+
+    def test_required_self_not_in_list(self):
+        """The 'self' parameter should never appear in 'required' or 'properties'."""
+
+        class FakeTool:
+            def method(self, name: str, opt: str | None = None) -> FuncToolResult:
+                return FuncToolResult(result=name)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.method)
+
+        assert "self" not in tool.params_json_schema.get("properties", {})
+        assert "self" not in tool.params_json_schema.get("required", [])
+        assert tool.params_json_schema.get("required") == ["name"]
+
+    def test_optional_type_simplifies_anyof_to_plain_type(self):
+        """Optional[str] should produce {\"type\": \"string\"} not anyOf[str, null]."""
+
+        class FakeTool:
+            def method(
+                self,
+                opt_str: str | None = None,
+                opt_int: int | None = None,
+                opt_list: list[str] | None = None,
+            ) -> FuncToolResult:
+                return FuncToolResult()
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.method)
+
+        props = tool.params_json_schema["properties"]
+        # All three should have a plain "type" key, not "anyOf"
+        assert "anyOf" not in props["opt_str"]
+        assert props["opt_str"]["type"] == "string"
+        assert "anyOf" not in props["opt_int"]
+        assert props["opt_int"]["type"] == "integer"
+        assert "anyOf" not in props["opt_list"]
+        assert props["opt_list"]["type"] == "array"
+
+    def test_required_param_keeps_anyof_untouched(self):
+        """Required parameters should not have their schema modified."""
+
+        class FakeTool:
+            def method(self, req_opt: str | None) -> FuncToolResult:
+                return FuncToolResult()
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.method)
+
+        assert tool.params_json_schema.get("required") == ["req_opt"]
+        # Required Optional params keep the anyOf since they are in required
+        assert "anyOf" in tool.params_json_schema["properties"]["req_opt"]


### PR DESCRIPTION
## Why

The agents SDK's `function_tool` generates JSON schemas where every parameter is placed in the `required` array, regardless of whether it has a Python default value. Additionally, `Optional[T]` parameters are represented as `anyOf[{type: T}, {type: "null"}]`. This causes two problems:

1. **Incorrect `required` field**: Parameters like `time_start: Optional[str] = None` end up required, so the LLM must provide them even though the function handles the absence gracefully.
2. **Confusing `anyOf` types**: `Optional[str]` becomes `{"anyOf": [{"type": "string"}, {"type": "null"}]}` which is redundant once the parameter is correctly marked as optional, and confuses the LLM about whether it should pass `null` explicitly.

## Solution

Three corrections applied in `trans_to_function_tool` ([base.py:48-74](datus/tools/func_tool/base.py#L48-L74)):

1. **Filter `required` using the function's actual signature** — inspect each parameter's default value and remove those with defaults from the `required` array.
2. **Simplify `anyOf[type, null]` → plain `type`** — for parameters excluded from `required`, replace the `anyOf` schema with the single non-null type branch. `Optional[List[str]]` becomes `{"type": "array", "items": {"type": "string"}}`. Required `Optional` params (e.g. `req: Optional[str]` with no default) retain `anyOf`.
3. **Set `strict_json_schema=False`** on the `FunctionTool` — the SDK's `ensure_strict_json_schema` regenerates `required` from all properties that have a `default` key, undoing corrections 1 and 2. Disabling strict mode preserves our corrected schema.

## Test Cases

Added 7 new unit tests in [test_base.py](tests/unit_tests/tools/func_tool/test_base.py):

- `test_required_excludes_params_with_defaults` — verifies mixed params produce correct `required`
- `test_required_all_params_required` — params without defaults all stay required
- `test_required_no_params` — no-param methods have empty `required`
- `test_required_all_optional` — all-default methods have empty `required`
- `test_required_self_not_in_list` — `self` never appears in `required` or `properties`
- `test_optional_type_simplifies_anyof_to_plain_type` — `Optional[str]`, `Optional[int]`, `Optional[List[str]]` all produce plain `type` without `anyOf`
- `test_required_param_keeps_anyof_untouched` — required `Optional` params retain `anyOf`

No integration/nightly tests needed — this is a pure schema normalization change with no external dependencies. All 12 tests in `test_base.py` pass, and existing semantic_tools tests (54 tests) continue to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter JSON-schema generation: parameters with defaults are no longer marked required; optional-type schemas are simplified to remove redundant anyOf/null branches when appropriate, while nullable-required parameters retain explicit nullability.

* **Tests**
  * Added comprehensive tests for defaulted parameters, required vs optional typing, omission of bound self, and no-parameter scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->