### PR TITLE
[BugFix] session compact result persistence

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -450,6 +450,7 @@ class AgenticNode(Node):
                 await self._session.add_items(
                     [
                         {
+                            "type": "message",
                             "role": "user",
                             "content": "[Previous conversation was compacted to save context. Summary below.]",
                         },

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -458,6 +458,7 @@ class AgenticNode(Node):
                             "content": "[Previous conversation was compacted to save context. Summary below.]",
                         },
                         {
+                            "type": "message",
                             "role": "assistant",
                             "content": [{"type": "output_text", "text": summary}],
                         },

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -83,7 +83,6 @@ class AgenticNode(Node):
         self.session_id: Optional[str] = None
         self._session: Optional[AdvancedSQLiteSession] = None
         self.ephemeral: bool = False  # When True, use in-memory session (no SQLite persistence)
-        self.last_summary: Optional[str] = None
         self.context_length: Optional[int] = None
 
         # Permission and skill management
@@ -306,11 +305,11 @@ class AgenticNode(Node):
         Get or create the session for this node.
 
         Returns:
-            Tuple of (session, summary) where summary is the conversation summary
-            from previous compact (if any), None otherwise
+            Tuple of (session, summary). The summary slot is always None now
+            that compaction persists the summary directly into the session
+            history; it is kept in the return type for backward compatibility
+            with existing call sites that unpack two values.
         """
-        summary = None
-
         if self._session is None:
             if self.session_id is None:
                 self.session_id = self._generate_session_id()
@@ -329,15 +328,7 @@ class AgenticNode(Node):
                     self._session = self.model.create_session(self.session_id)
                     logger.debug(f"Created session: {self.session_id}")
 
-                # If we have a summary from previous compact, return it
-                if self.last_summary:
-                    summary = self.last_summary
-                    logger.debug(f"Returning summary from previous compact: {len(summary)} chars")
-
-                    # Clear the summary after using it once
-                    self.last_summary = None
-
-        return self._session, summary
+        return self._session, None
 
     async def _count_session_tokens(self) -> int:
         """
@@ -390,7 +381,12 @@ class AgenticNode(Node):
     async def _manual_compact(self) -> dict:
         """
         Manually compact the session by summarizing conversation history.
-        This clears the session and stores summary for next session creation.
+
+        Generates an LLM summary of the current session, clears the session's
+        history, then writes a `user marker + assistant summary` pair back
+        into the SAME session so subsequent LLM requests and UI history reads
+        see the summary as the new visible turn. The session_id / .db file
+        are preserved; no new session is created.
 
         Returns:
             Dict with success, summary, and summary_token count
@@ -467,11 +463,6 @@ class AgenticNode(Node):
             except Exception as persist_err:
                 logger.error(f"Failed to persist compact summary: {persist_err}")
                 return {"success": False, "summary": "", "summary_token": 0}
-
-            # Keep last_summary for backward compatibility with any callers that
-            # still read the attribute directly. The summary now lives in the
-            # session itself, so this is no longer the source of truth.
-            self.last_summary = summary
 
             logger.info(
                 f"Manual compacting completed. Session {self.session_id} cleared and "

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -419,9 +419,6 @@ class AgenticNode(Node):
         try:
             logger.info(f"Starting manual compacting for session {self.session_id}")
 
-            # Store old session info for logging
-            old_session_id = self.session_id
-
             # 1. Generate summary using LLM with existing session
             summarization_prompt = (
                 "Summarize our conversation up to this point. The summary should be a concise yet comprehensive "
@@ -447,24 +444,37 @@ class AgenticNode(Node):
                 logger.error(f"Failed to generate summary with LLM: {e}")
                 return {"success": False, "summary": "", "summary_token": 0}
 
-            # 2. Store summary for next session creation
+            # 2. Persist summary back into the session: clear the existing history
+            #    and append a user/assistant pair so the summary becomes the new
+            #    visible turn. Subsequent LLM requests will pick it up as context
+            #    via the OpenAI Agents SDK session, and UI history reads will
+            #    surface the summary instead of an empty session.
+            try:
+                await self._session.clear_session()
+                await self._session.add_items(
+                    [
+                        {
+                            "role": "user",
+                            "content": "[Previous conversation was compacted to save context. Summary below.]",
+                        },
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": summary}],
+                        },
+                    ]
+                )
+            except Exception as persist_err:
+                logger.error(f"Failed to persist compact summary: {persist_err}")
+                return {"success": False, "summary": "", "summary_token": 0}
+
+            # Keep last_summary for backward compatibility with any callers that
+            # still read the attribute directly. The summary now lives in the
+            # session itself, so this is no longer the source of truth.
             self.last_summary = summary
-            logger.info(f"Stored summary for next session: {len(summary)} characters")
-
-            # 3. Clear current session
-            if old_session_id:
-                try:
-                    self.model.delete_session(old_session_id)
-                    logger.debug(f"Deleted old session: {old_session_id}")
-                except Exception as e:
-                    logger.warning(f"Failed to delete old session {old_session_id}: {e}")
-
-            # Clear session references
-            self.session_id = None
-            self._session = None
 
             logger.info(
-                f"Manual compacting completed. Cleared session: {old_session_id}, Summary stored: {len(summary)} chars"
+                f"Manual compacting completed. Session {self.session_id} cleared and "
+                f"summary persisted ({len(summary)} chars, {summary_token} output tokens)"
             )
             return {"success": True, "summary": summary, "summary_token": summary_token}
 

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -1038,6 +1038,9 @@ class ChatCommands:
                 self.console.print(f"  New Token Count: {result.get('new_token_count', 'N/A')}")
                 self.console.print(f"  Tokens Saved: {result.get('tokens_saved', 'N/A')}")
                 self.console.print(f"  Compression Ratio: {result.get('compression_ratio', 'N/A')}")
+
+                # Reload in-memory state from the compacted session
+                self._reload_state_from_session()
             else:
                 error_msg = result.get("error", "Unknown error occurred")
                 self.console.print(f"[bold red]✗ Failed to compact session:[/] {error_msg}")
@@ -1045,6 +1048,64 @@ class ChatCommands:
         except Exception as e:
             logger.error(f"Error during manual compact: {e}")
             self.console.print(f"[bold red]Error:[/] {str(e)}")
+
+    def _reload_state_from_session(self):
+        """Reload in-memory state from the current session after compaction.
+
+        Clears accumulated action/chat history and rebuilds it from the
+        persisted session messages, then re-renders the conversation on
+        screen so the CLI display matches the compacted DB state.
+        """
+        from datus.models.session_manager import SessionManager
+
+        session_id = self.current_node.session_id
+        session_manager = SessionManager(self.cli.agent_config.session_dir, scope=self.cli.scope)
+        messages = session_manager.get_session_messages(session_id)
+
+        # Reset in-memory state
+        self.all_turn_actions = []
+        self.last_actions = []
+        self.chat_history = []
+        self._trace_verbose = False
+        if self.current_node:
+            self.current_node.actions = []
+
+        # Rebuild state from session messages
+        if messages:
+            from rich.rule import Rule
+
+            self.console.print()
+            action_display = ActionHistoryDisplay(self.console)
+            last_assistant_actions = []
+            current_user_msg = ""
+
+            for msg in messages:
+                role = msg.get("role", "unknown")
+                content = msg.get("content", "")
+                if role == "user":
+                    current_user_msg = content
+                    self.console.print(f"[bold blue]You:[/] {content}")
+                else:
+                    actions = msg.get("actions")
+                    if actions:
+                        action_display.render_action_history(actions)
+                        last_assistant_actions = actions
+                    sql = msg.get("sql")
+                    if sql:
+                        self._display_sql_with_copy(sql)
+                    if content:
+                        stripped = content.strip()
+                        is_json = stripped.startswith("{") and stripped.endswith("}")
+                        if not (is_json and (sql or actions)):
+                            self._display_markdown_response(content)
+                    # Rebuild all_turn_actions
+                    if actions and current_user_msg:
+                        self.all_turn_actions.append((current_user_msg, actions))
+                    current_user_msg = ""
+                self.console.print(Rule(style="dim"))
+
+            if last_assistant_actions:
+                self.last_actions = last_assistant_actions
 
     def cmd_list_sessions(self, args: str):
         """List all available chat sessions."""

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -1301,15 +1301,6 @@ class ChatCommands:
                             self.all_turn_actions.append((current_user_msg, actions))
                         current_user_msg = ""
 
-            # Get session info to check token usage
-            info = session_manager.get_session_info(target_session_id)
-            total_tokens = info.get("total_tokens", 0)
-            if total_tokens > 50000:
-                self.console.print(
-                    "[yellow]Note: This session has high token usage. "
-                    "Consider using .compact to reduce context size.[/]"
-                )
-
             self.console.print("[green]You can now continue the conversation.[/]")
 
         except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,25 @@ TEST_DATA_DIR = Path(__file__).parent / "data"
 TEST_CONF_DIR = Path(__file__).parent / "conf"
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _disable_langsmith_tracing():
+    """Disable LangSmith/LangChain tracing for the entire test session.
+
+    Overrides any inherited env vars so UT runs never upload traces, even when
+    the developer's shell has LANGSMITH_TRACING=true or an API key set.
+    """
+    for key in (
+        "LANGCHAIN_API_KEY",
+        "LANGSMITH_API_KEY",
+        "LANGCHAIN_ENDPOINT",
+        "LANGSMITH_ENDPOINT",
+    ):
+        os.environ.pop(key, None)
+    os.environ["LANGSMITH_TRACING"] = "false"
+    os.environ["LANGCHAIN_TRACING_V2"] = "false"
+    yield
+
+
 @pytest.fixture
 def mock_args():
     """Create a mock arguments object for testing."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,25 +17,6 @@ TEST_DATA_DIR = Path(__file__).parent / "data"
 TEST_CONF_DIR = Path(__file__).parent / "conf"
 
 
-@pytest.fixture(autouse=True, scope="session")
-def _disable_langsmith_tracing():
-    """Disable LangSmith/LangChain tracing for the entire test session.
-
-    Overrides any inherited env vars so UT runs never upload traces, even when
-    the developer's shell has LANGSMITH_TRACING=true or an API key set.
-    """
-    for key in (
-        "LANGCHAIN_API_KEY",
-        "LANGSMITH_API_KEY",
-        "LANGCHAIN_ENDPOINT",
-        "LANGSMITH_ENDPOINT",
-    ):
-        os.environ.pop(key, None)
-    os.environ["LANGSMITH_TRACING"] = "false"
-    os.environ["LANGCHAIN_TRACING_V2"] = "false"
-    yield
-
-
 @pytest.fixture
 def mock_args():
     """Create a mock arguments object for testing."""

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -625,6 +625,7 @@ class TestManualCompact:
         assert len(items) == 2
         assert items[0]["role"] == "user"
         assert "compacted" in items[0]["content"].lower()
+        assert items[1]["type"] == "message"
         assert items[1]["role"] == "assistant"
         assert isinstance(items[1]["content"], list)
         assert items[1]["content"][0]["type"] == "output_text"

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -43,6 +43,19 @@ class _ConcreteAgenticNode(AgenticNode):
         yield action
 
 
+def _make_async_session_mock() -> MagicMock:
+    """Build a session-like mock whose async methods are AsyncMocks.
+
+    Used by _manual_compact tests because the production code now awaits
+    `clear_session` and `add_items` on `self._session` after generating the
+    summary.
+    """
+    sess = MagicMock()
+    sess.clear_session = AsyncMock()
+    sess.add_items = AsyncMock()
+    return sess
+
+
 def _make_node(agent_config=None, **overrides):
     """Create a node with __init__ bypassed for targeted testing."""
     with patch.object(AgenticNode, "__init__", lambda self, *a, **kw: None):
@@ -536,7 +549,8 @@ class TestManualCompact:
         node = _make_node()
         node.ephemeral = False
         node.session_id = "compact_test"
-        node._session = MagicMock()
+        mock_session = _make_async_session_mock()
+        node._session = mock_session
         mock_model = MagicMock()
         mock_model.generate_with_tools = AsyncMock(
             return_value={"content": "Summary of conversation", "usage": {"output_tokens": 100}}
@@ -547,9 +561,13 @@ class TestManualCompact:
 
         assert result["success"] is True
         assert "Summary" in result["summary"]
-        # Session should be cleared
-        assert node._session is None
-        assert node.session_id is None
+        # Session is preserved — summary is persisted into the same session,
+        # not a new one. The .db file (and session_id) must remain alive.
+        assert node._session is mock_session
+        assert node.session_id == "compact_test"
+        mock_session.clear_session.assert_awaited_once()
+        mock_session.add_items.assert_awaited_once()
+        mock_model.delete_session.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_manual_compact_lazy_loads_session_after_resume(self):
@@ -568,7 +586,8 @@ class TestManualCompact:
             return_value={"content": "Resumed summary", "usage": {"output_tokens": 50}}
         )
         # create_session is what _get_or_create_session will call via self.model.
-        mock_model.create_session = MagicMock(return_value=MagicMock())
+        # Return a session whose async methods can be awaited by the persist step.
+        mock_model.create_session = MagicMock(return_value=_make_async_session_mock())
         node.model = mock_model
 
         result = await node._manual_compact()
@@ -577,6 +596,61 @@ class TestManualCompact:
         mock_model.create_session.assert_called_once_with("resumed_session")
         assert result["success"] is True
         assert result["summary"] == "Resumed summary"
+        # Session id is preserved so the same .db keeps holding the summary.
+        assert node.session_id == "resumed_session"
+
+    @pytest.mark.asyncio
+    async def test_manual_compact_persists_summary_pair(self):
+        """After summary generation, a user marker + assistant summary pair
+        must be appended to the SAME session via add_items so subsequent LLM
+        turns and history reads see the summary."""
+        node = _make_node()
+        node.ephemeral = False
+        node.session_id = "persist_test"
+        mock_session = _make_async_session_mock()
+        node._session = mock_session
+        mock_model = MagicMock()
+        mock_model.generate_with_tools = AsyncMock(
+            return_value={"content": "summary text", "usage": {"output_tokens": 100}}
+        )
+        node.model = mock_model
+
+        result = await node._manual_compact()
+
+        assert result["success"] is True
+        # clear_session must run before add_items (no rollback if add fails).
+        mock_session.clear_session.assert_awaited_once()
+        mock_session.add_items.assert_awaited_once()
+        items = mock_session.add_items.await_args.args[0]
+        assert len(items) == 2
+        assert items[0]["role"] == "user"
+        assert "compacted" in items[0]["content"].lower()
+        assert items[1]["role"] == "assistant"
+        assert isinstance(items[1]["content"], list)
+        assert items[1]["content"][0]["type"] == "output_text"
+        assert items[1]["content"][0]["text"] == "summary text"
+
+    @pytest.mark.asyncio
+    async def test_manual_compact_add_items_failure_returns_failure(self):
+        """If add_items raises after clear_session succeeds, surface a
+        failure result without rolling back (simple-fail strategy)."""
+        node = _make_node()
+        node.ephemeral = False
+        node.session_id = "fail_test"
+        mock_session = _make_async_session_mock()
+        mock_session.add_items.side_effect = RuntimeError("write failed")
+        node._session = mock_session
+        mock_model = MagicMock()
+        mock_model.generate_with_tools = AsyncMock(return_value={"content": "summary", "usage": {"output_tokens": 10}})
+        node.model = mock_model
+
+        result = await node._manual_compact()
+
+        assert result["success"] is False
+        assert result["summary"] == ""
+        assert result["summary_token"] == 0
+        mock_session.clear_session.assert_awaited_once()
+        mock_session.add_items.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1204,7 +1278,7 @@ class TestManualCompactExtended:
     def test_success_stores_summary(self):
         node = _make_simple_node()
         mock_model = MagicMock()
-        mock_session = MagicMock()
+        mock_session = _make_async_session_mock()
         node.model = mock_model
         node._session = mock_session
         node.session_id = "sess_compact"
@@ -1212,16 +1286,19 @@ class TestManualCompactExtended:
         mock_model.generate_with_tools = AsyncMock(
             return_value={"content": "summary text", "usage": {"output_tokens": 100}}
         )
-        mock_model.delete_session = MagicMock()
 
         result = asyncio.run(node._manual_compact())
         assert result["success"] is True
         assert result["summary"] == "summary text"
+        # last_summary kept for backward compatibility with legacy callers.
         assert node.last_summary == "summary text"
-        assert node._session is None
-        assert node.session_id is None
+        # Session must be preserved — summary now lives inside the session.
+        assert node._session is mock_session
+        assert node.session_id == "sess_compact"
         mock_model.generate_with_tools.assert_awaited_once()
         assert mock_model.generate_with_tools.await_args.kwargs["agent_name"] == node.get_node_name()
+        mock_session.clear_session.assert_awaited_once()
+        mock_session.add_items.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1263,7 +1340,7 @@ class TestAutoCompactExtended:
         node = _make_simple_node()
         node.model = MagicMock()
         node.context_length = 1000
-        node._session = MagicMock()
+        node._session = _make_async_session_mock()
         # Provide usage via actions
         action = ActionHistory.create_action(
             role=ActionRole.ASSISTANT,
@@ -1275,7 +1352,6 @@ class TestAutoCompactExtended:
         )
         node.actions.append(action)
         node.model.generate_with_tools = AsyncMock(return_value={"content": "summary", "usage": {"output_tokens": 50}})
-        node.model.delete_session = MagicMock()
         node.session_id = "sess_auto"
 
         result = asyncio.run(node._auto_compact())

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -64,7 +64,6 @@ def _make_node(agent_config=None, **overrides):
     node._session = None
     node.ephemeral = False
     node.session_id = None
-    node.last_summary = None
     node.model = None
     node.tools = []
     node.mcp_servers = {}
@@ -821,7 +820,6 @@ def _make_simple_node(**overrides):
     node._session = None
     node.ephemeral = False
     node.session_id = None
-    node.last_summary = None
     node.model = None
     node.tools = []
     node.mcp_servers = {}
@@ -1132,18 +1130,19 @@ class TestGetOrCreateSession:
         call_kwargs = mock_sqlite_cls.call_args
         assert call_kwargs[1].get("db_path") == ":memory:" or ":memory:" in str(call_kwargs)
 
-    def test_returns_last_summary_and_clears_it(self):
+    def test_summary_is_no_longer_returned_via_get_or_create_session(self):
+        """Compacted summary now lives inside the session history itself, not
+        on a node attribute. _get_or_create_session must always return None
+        for the summary slot."""
         node = _make_simple_node()
         mock_model = MagicMock()
         mock_session = MagicMock()
         mock_model.create_session.return_value = mock_session
         node.model = mock_model
         node.session_id = "s"
-        node.last_summary = "previous conversation summary"
 
         _, summary = node._get_or_create_session()
-        assert summary == "previous conversation summary"
-        assert node.last_summary is None
+        assert summary is None
 
 
 # ---------------------------------------------------------------------------
@@ -1291,8 +1290,6 @@ class TestManualCompactExtended:
         result = asyncio.run(node._manual_compact())
         assert result["success"] is True
         assert result["summary"] == "summary text"
-        # last_summary kept for backward compatibility with legacy callers.
-        assert node.last_summary == "summary text"
         # Session must be preserved — summary now lives inside the session.
         assert node._session is mock_session
         assert node.session_id == "sess_compact"

--- a/tests/unit_tests/agent/node/test_agentic_node_ephemeral.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_ephemeral.py
@@ -33,7 +33,6 @@ def _make_node(**overrides):
     node._session = None
     node.ephemeral = False
     node.session_id = None
-    node.last_summary = None
     node.model = None
     # Apply overrides
     for k, v in overrides.items():
@@ -101,19 +100,19 @@ class TestEphemeralSession:
         mock_model.create_session.assert_called_once_with("normal_session_456")
         assert session is mock_session
 
-    def test_ephemeral_session_with_last_summary(self):
-        """Ephemeral session returns and clears last_summary just like normal sessions."""
+    def test_ephemeral_session_summary_slot_is_none(self):
+        """After the compact-persistence refactor, _get_or_create_session
+        no longer carries forward a compacted summary through a node
+        attribute; the summary slot must always be None."""
         node = _make_node(
             ephemeral=True,
             session_id="eph_summary_001",
-            last_summary="Previous conversation summary",
             model=MagicMock(),
         )
 
         session, summary = node._get_or_create_session()
 
-        assert summary == "Previous conversation summary"
-        assert node.last_summary is None
+        assert summary is None
         assert session is not None
 
 

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -2566,7 +2566,6 @@ def _make_gensql_node(node_config=None, agent_config=None):
     node._session = None
     node.ephemeral = False
     node.session_id = None
-    node.last_summary = None
     node.model = None
     node.tools = []
     node.mcp_servers = {}

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -175,6 +175,79 @@ class TestChatServiceCompactSession:
         # Should handle gracefully
         assert result is not None
 
+    async def test_compact_persists_summary_into_session(self, real_agent_config, mock_llm_create):
+        """End-to-end: compact must keep the .db alive and write a
+        user-marker + assistant-summary pair back into the same session.
+
+        This is the regression coverage for the original bug where compact
+        deleted the .db and stored the summary only in the discarded node's
+        memory, so UI history reads got an empty session and the next
+        chat turn had no summary context.
+        """
+        from datus.api.models.cli_models import CompactSessionInput
+
+        svc = ChatService(
+            agent_config=real_agent_config,
+            task_manager=ChatTaskManager(),
+            project_id="test-proj",
+        )
+
+        # Route the mock LLM's session manager to the real on-disk session_dir
+        # so that ChatAgenticNode._get_or_create_session loads the same .db
+        # we pre-populate below.
+        real_sm = SessionManager(session_dir=svc._session_dir)
+        mock_llm_create._session_manager = real_sm
+
+        # Pre-create a real chat session with two Q/A pairs.
+        session_id = "chat_session_compact_test"
+        seeded = real_sm.create_session(session_id)
+        await seeded.add_items(
+            [
+                {"role": "user", "content": "What tables are there?"},
+                {"role": "assistant", "content": [{"type": "output_text", "text": "Tables: schools, frpm"}]},
+                {"role": "user", "content": "Describe schools."},
+                {"role": "assistant", "content": [{"type": "output_text", "text": "schools has cols a, b, c"}]},
+            ]
+        )
+
+        # Patch the mock LLM's generate_with_tools to return a deterministic
+        # summary for the summarization prompt issued inside _manual_compact.
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        mock_llm_create.generate_with_tools = _AsyncMock(
+            return_value={"content": "Summary of conversation", "usage": {"output_tokens": 42}}
+        )
+
+        request = CompactSessionInput(session_id=session_id)
+        result = await svc.compact_session(request)
+
+        assert result.success is True
+        assert result.data.success is True
+
+        # The .db file must still exist — compact no longer deletes it.
+        import os
+
+        db_path = os.path.join(svc._session_dir, f"{session_id}.db")
+        assert os.path.exists(db_path), "Session .db must be preserved after compact"
+
+        # Re-open the session via a fresh SessionManager to bypass any
+        # in-memory caches and verify on-disk state.
+        verify_sm = SessionManager(session_dir=svc._session_dir)
+        verify_session = verify_sm.get_session(session_id)
+        items = await verify_session.get_items()
+
+        # After compact, the session must contain exactly the user-marker
+        # and assistant-summary pair we wrote in _manual_compact.
+        assert len(items) == 2
+        assert items[0]["role"] == "user"
+        assert "compacted" in items[0]["content"].lower()
+        assert items[1]["role"] == "assistant"
+        # Assistant content is a list of typed parts; the first part is the summary text.
+        content = items[1]["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "output_text"
+        assert content[0]["text"] == "Summary of conversation"
+
 
 @pytest.mark.asyncio
 class TestChatServiceStreamChat:

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -2090,6 +2090,42 @@ class TestCmdCompactWithSession:
             or "Error" in output
         )
 
+    def test_compact_resets_in_memory_state(self, real_agent_config, mock_llm_create):
+        """After successful compact, in-memory state is reset via _reload_state_from_session."""
+        from tests.unit_tests.mock_llm_model import build_simple_response
+
+        console = Console(file=io.StringIO(), no_color=True)
+        cmds = _make_chat_commands(real_agent_config, console=console)
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response("First reply"),
+                build_simple_response("Second reply"),
+                # compact summary response
+                build_simple_response("Summary of conversation"),
+            ]
+        )
+
+        # Two rounds of chat to accumulate history
+        cmds.execute_chat_command("First question")
+        cmds.execute_chat_command("Second question")
+
+        # Verify pre-compact state has accumulated data
+        assert len(cmds.all_turn_actions) == 2
+        assert len(cmds.chat_history) == 2
+        assert len(cmds.last_actions) > 0
+
+        console.file = io.StringIO()
+        cmds.cmd_compact("")
+
+        output = _get_console_output(console)
+        if "compacted successfully" in output.lower():
+            # After successful compact, accumulated pre-compact history should be cleared
+            # _reload_state_from_session rebuilds from the compacted session
+            # which contains only the summary pair, not the original turn actions
+            assert cmds._trace_verbose is False
+            assert cmds.current_node.actions == []
+
 
 # ===========================================================================
 # TestCmdListSessionsWithData — cmd_list_sessions 有 session 数据

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -2303,44 +2303,6 @@ class TestCmdResumeWithSession:
         # Should show "You:" for user messages
         assert "you:" in output.lower() or "message" in output.lower()
 
-    def test_resume_high_token_warning(self, real_agent_config, mock_llm_create):
-        """cmd_resume shows high token warning when session has > 50000 tokens."""
-        console = Console(file=io.StringIO(), no_color=True)
-        cmds = _make_chat_commands(real_agent_config, console=console)
-
-        session_id = "chat_session_resume05"
-        _create_session_on_disk(session_id)
-
-        # Insert token usage > 50000 into turn_usage table
-        from datus.utils.path_manager import get_path_manager
-
-        db_path = os.path.join(str(get_path_manager().sessions_dir), f"{session_id}.db")
-        with sqlite3.connect(db_path) as conn:
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS turn_usage ("
-                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                "session_id TEXT NOT NULL, "
-                "branch_id TEXT DEFAULT 'main', "
-                "user_turn_number INTEGER NOT NULL, "
-                "requests INTEGER DEFAULT 0, "
-                "input_tokens INTEGER DEFAULT 0, "
-                "output_tokens INTEGER DEFAULT 0, "
-                "total_tokens INTEGER DEFAULT 0, "
-                "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
-            )
-            conn.execute(
-                "INSERT INTO turn_usage (session_id, user_turn_number, total_tokens) VALUES (?, ?, ?)",
-                (session_id, 1, 60000),
-            )
-            conn.commit()
-
-        cmds.cmd_resume(session_id)
-
-        output = _get_console_output(console)
-        assert cmds.current_node is not None
-        # Should show high token warning
-        assert "token" in output.lower() or "compact" in output.lower()
-
 
 # ===========================================================================
 # TestCmdRewindWithSession — cmd_rewind with active session + disk session

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -2119,12 +2119,15 @@ class TestCmdCompactWithSession:
         cmds.cmd_compact("")
 
         output = _get_console_output(console)
-        if "compacted successfully" in output.lower():
-            # After successful compact, accumulated pre-compact history should be cleared
-            # _reload_state_from_session rebuilds from the compacted session
-            # which contains only the summary pair, not the original turn actions
-            assert cmds._trace_verbose is False
-            assert cmds.current_node.actions == []
+        # Compact must succeed; this is the precondition for the reload behavior
+        # under test. A silent failure here would have previously made the
+        # remaining assertions vacuous.
+        assert "compacted successfully" in output.lower(), f"compact did not succeed; output={output!r}"
+        # After successful compact, _reload_state_from_session rebuilds from
+        # the compacted session (which contains only the summary pair), so
+        # pre-compact accumulated turn actions must be cleared.
+        assert cmds._trace_verbose is False
+        assert cmds.current_node.actions == []
 
 
 # ===========================================================================

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -26,6 +26,41 @@ import pytest
 from datus.configuration.agent_config import AgentConfig, NodeConfig
 from tests.unit_tests.mock_llm_model import MockLLMModel
 
+
+@pytest.fixture(autouse=True, scope="session")
+def _disable_langsmith_tracing():
+    """Disable LangSmith/LangChain tracing for the unit test session only.
+
+    Scoped to tests/unit_tests/ so integration/nightly/regression suites that
+    intentionally exercise real tracing pipelines remain unaffected.
+    Overrides any inherited env vars so UT runs never upload traces, even when
+    the developer's shell has LANGSMITH_TRACING=true or an API key set.
+    """
+    saved = {
+        k: os.environ.get(k)
+        for k in (
+            "LANGCHAIN_API_KEY",
+            "LANGSMITH_API_KEY",
+            "LANGCHAIN_ENDPOINT",
+            "LANGSMITH_ENDPOINT",
+            "LANGSMITH_TRACING",
+            "LANGCHAIN_TRACING_V2",
+        )
+    }
+    for key in ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_ENDPOINT", "LANGSMITH_ENDPOINT"):
+        os.environ.pop(key, None)
+    os.environ["LANGSMITH_TRACING"] = "false"
+    os.environ["LANGCHAIN_TRACING_V2"] = "false"
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
 # ---------------------------------------------------------------------------
 # Singleton cleanup
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compaction now preserves the session DB and writes the generated summary back into the same session; failures to persist return failure. Session-creation no longer surfaces a prior compacted summary. CLI refreshes in-memory conversation state after compaction; resume no longer emits a high-token warning. Logging now reports token counts and persistence outcomes.

* **Tests**
  * Updated compaction tests to verify in-session summary persistence and failure behavior; added async-capable session mocks.

* **Chores**
  * Added an autouse fixture to disable external tracing during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->