### PR TITLE
[BugFix] Replace scoped_context with typed catalogs and subjects fields

### DIFF
--- a/datus/api/models/agent_models.py
+++ b/datus/api/models/agent_models.py
@@ -107,7 +107,13 @@ class EditAgentInput(BaseModel):
     tools: Optional[List[str]] = None
     mcp: Optional[List[str]] = None
     skills: Optional[List[str]] = None
-    scoped_context: Optional[dict] = None
+    catalogs: Optional[List[str]] = Field(
+        default_factory=list,
+        description="Catalog access patterns (e.g., 'production_db.*', 'production_db.public.*')",
+    )
+    subjects: Optional[List[str]] = Field(
+        default_factory=list, description="Subject access patterns (e.g., 'Finance.Revenue.*')"
+    )
     permissions: Optional[dict] = None
     hooks: Optional[dict] = None
     rules: Optional[list[str]] = None


### PR DESCRIPTION
## Why

The `EditAgentInput` model used an untyped `scoped_context: Optional[dict]` field, which lacked clarity on its structure and purpose. This made it difficult to validate and document the expected input for catalog and subject access patterns.

## Solution

Replaced `scoped_context` with two strongly-typed fields:
- `catalogs: Optional[List[str]]` — for catalog access patterns (e.g., `'production_db.*'`, `'production_db.public.*'`)
- `subjects: Optional[List[str]]` — for subject access patterns (e.g., `'Finance.Revenue.*'`)

Both fields use `Field(default_factory=list)` with descriptive docstrings for better API documentation.

## Test Cases

This is a model-only change (Pydantic schema update) with no logic changes. Existing API tests cover serialization/deserialization of `EditAgentInput`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Agent configuration now accepts separate catalog and subject access patterns instead of a single scoped context field. This enables more granular control over agent permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->