### PR TITLE
[BugFix] Add missing catalogs and subjects fields to EditAgentInput

### DIFF
--- a/datus/api/models/agent_models.py
+++ b/datus/api/models/agent_models.py
@@ -110,11 +110,11 @@ class EditAgentInput(BaseModel):
     scoped_context: Optional[dict] = None
     permissions: Optional[dict] = None
     catalogs: Optional[List[str]] = Field(
-        default_factory=list,
+        default=None,
         description="Catalog access patterns (e.g., 'production_db.*', 'production_db.public.*')",
     )
     subjects: Optional[List[str]] = Field(
-        default_factory=list, description="Subject access patterns (e.g., 'Finance.Revenue.*')"
+        default=None, description="Subject access patterns (e.g., 'Finance.Revenue.*')"
     )
     hooks: Optional[dict] = None
     rules: Optional[list[str]] = None

--- a/datus/api/models/agent_models.py
+++ b/datus/api/models/agent_models.py
@@ -109,6 +109,13 @@ class EditAgentInput(BaseModel):
     skills: Optional[List[str]] = None
     scoped_context: Optional[dict] = None
     permissions: Optional[dict] = None
+    catalogs: Optional[List[str]] = Field(
+        default_factory=list,
+        description="Catalog access patterns (e.g., 'production_db.*', 'production_db.public.*')",
+    )
+    subjects: Optional[List[str]] = Field(
+        default_factory=list, description="Subject access patterns (e.g., 'Finance.Revenue.*')"
+    )
     hooks: Optional[dict] = None
     rules: Optional[list[str]] = None
     max_turns: Optional[int] = None


### PR DESCRIPTION
## Why

The `EditAgentInput` API model was missing the `catalogs` and `subjects` fields. This caused API requests containing these parameters to be silently ignored during agent editing, making it impossible to update catalog/subject access patterns via the API.

## Solution

Added `catalogs` and `subjects` optional fields to the `EditAgentInput` Pydantic model in `datus/api/models/agent_models.py`, matching the patterns already used in other agent models:
- `catalogs`: List of catalog access patterns (e.g., `'production_db.*'`)
- `subjects`: List of subject access patterns (e.g., `'Finance.Revenue.*'`)

Both fields default to empty lists and are optional to maintain backward compatibility.

## Test Cases

No new test cases added — this is a straightforward Pydantic model field addition. Existing API tests cover the `EditAgentInput` serialization path. The fields are optional with defaults, so no existing behavior is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent Edit API now accepts optional catalog and subject pattern lists when updating an agent. These fields are optional (can be omitted to leave existing values unchanged) and allow supplying one or more patterns to update the agent's catalog and subject pattern entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->