### PR TITLE
[Feature] Add GET /api/v1/chat/model to expose the active chat model

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -469,3 +469,16 @@ class ChatHistoryData(BaseModel):
     """Chat history data."""
 
     messages: List[SSEMessagePayload] = Field(default_factory=list, description="chat history messages")
+
+
+class ChatModelInfo(BaseModel):
+    """Chat model identity."""
+
+    type: str = Field(..., description="Model provider type (e.g., 'openai', 'claude')")
+    model: str = Field(..., description="Model identifier (e.g., 'gpt-4', 'claude-3-sonnet')")
+
+
+class ChatModelData(BaseModel):
+    """Current chat model data."""
+
+    current: ChatModelInfo = Field(..., description="The model currently active for chat")

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -26,6 +26,7 @@ from datus.api.models.chat_models import (
 )
 from datus.api.models.cli_models import (
     ChatHistoryData,
+    ChatModelData,
     ChatSessionData,
     CompactSessionData,
     CompactSessionInput,
@@ -169,6 +170,21 @@ async def get_chat_history(
     session_id: str = Query(..., description="Session ID to retrieve history for"),
 ) -> Result[ChatHistoryData]:
     return svc.chat.get_history(session_id, user_id=ctx.user_id)
+
+
+# ========== Current Chat Model ==========
+
+
+@router.get(
+    "/model",
+    response_model=Result[ChatModelData],
+    summary="Get Current Chat Model",
+    description="Return the active chat model identity (type and model)",
+)
+async def get_chat_model(
+    svc: ServiceDep,
+) -> Result[ChatModelData]:
+    return svc.chat.get_model()
 
 
 # ========== User Interaction ==========

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -14,6 +14,8 @@ from datus.agent.node.chat_agentic_node import ChatAgenticNode
 from datus.api.models.base_models import Result
 from datus.api.models.cli_models import (
     ChatHistoryData,
+    ChatModelData,
+    ChatModelInfo,
     ChatSessionData,
     ChatSessionItemInfo,
     CompactSessionData,
@@ -85,6 +87,20 @@ class ChatService:
         """Check if a session exists on disk."""
         session_mgr = SessionManager(session_dir=self._session_dir, scope=user_id)
         return session_mgr.session_exists(session_id)
+
+    def get_model(self) -> Result[ChatModelData]:
+        """Return the currently active chat model identity."""
+        try:
+            active = self.agent_config.active_model()
+            return Result[ChatModelData](
+                success=True,
+                data=ChatModelData(
+                    current=ChatModelInfo(type=active.type, model=active.model),
+                ),
+            )
+        except Exception as e:
+            logger.error(f"Failed to get active model: {e}")
+            return Result[ChatModelData](success=False, errorCode="MODEL_LOOKUP_ERROR", errorMessage=str(e))
 
     def list_sessions(self, user_id: Optional[str] = None) -> Result[ChatSessionData]:
         """List all chat sessions from disk."""

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -98,6 +98,42 @@ class TestChatServiceDeleteSession:
         assert chat_svc.session_exists("to-delete") is False
 
 
+class TestChatServiceGetModel:
+    """Tests for get_model."""
+
+    def test_get_model_returns_active_model_identity(self, chat_svc):
+        """get_model returns the active ModelConfig's type and model."""
+        result = chat_svc.get_model()
+        assert result.success is True
+        assert result.data is not None
+        assert result.data.current.type == "openai"
+        assert result.data.current.model == "mock-model"
+
+    def test_get_model_reflects_active_model_changes(self, chat_svc):
+        """get_model follows the AgentConfig.active_model() result."""
+        fake_active = MagicMock(type="claude", model="claude-3-sonnet")
+        with patch.object(chat_svc.agent_config, "active_model", return_value=fake_active):
+            result = chat_svc.get_model()
+
+        assert result.success is True
+        assert result.data.current.type == "claude"
+        assert result.data.current.model == "claude-3-sonnet"
+
+    def test_get_model_handles_lookup_error(self, chat_svc):
+        """get_model returns a typed error when active_model() raises."""
+        with patch.object(
+            chat_svc.agent_config,
+            "active_model",
+            side_effect=ValueError("no model"),
+        ):
+            result = chat_svc.get_model()
+
+        assert result.success is False
+        assert result.errorCode == "MODEL_LOOKUP_ERROR"
+        assert "no model" in (result.errorMessage or "")
+        assert result.data is None
+
+
 class TestChatServiceGetHistory:
     """Tests for get_history."""
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/chat/model` — returns the currently active chat model identity so clients can display which LLM is in use.
- Response shape: `Result[ChatModelData]` with `data: { current: { type, model } }`.
- Implementation resolves the active model via `AgentConfig.active_model()` (existing helper) from within a new `ChatService.get_model()` method.

## Changes
- `datus/api/models/cli_models.py`: adds `ChatModelInfo { type, model }` and `ChatModelData { current }`.
- `datus/api/services/chat_service.py`: adds `ChatService.get_model()` returning `Result[ChatModelData]`.
- `datus/api/routes/chat_routes.py`: registers the new `GET /model` route.

## Test plan
- [ ] `curl -s http://localhost:<port>/api/v1/chat/model` returns `{ success: true, data: { current: { type, model } } }` with values matching the active `ModelConfig`.
- [ ] If `active_model()` raises, the endpoint returns `success: false` with `errorCode: MODEL_LOOKUP_ERROR`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new schema types to represent chat model identity and an API endpoint to retrieve the currently active chat model (type and identifier), with robust error handling for lookup failures.
* **Tests**
  * Added unit tests covering successful retrieval, dynamic updates to the active model, and graceful failure behavior when model lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->