### PR TITLE
[Enhancement] Revamp tool call display and preserve mid-turn thinking

### DIFF
--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -132,9 +132,8 @@ class ActionContentGenerator(BaseActionContentGenerator):
                 pass
             else:
                 tc = self.tool_content_builder.build(action, verbose=False)
-                output_preview = ""
-                if tc.output_preview:
-                    output_preview = f"\n    {tc.output_preview}"
+                preview = tc.compact_result or tc.output_preview
+                output_preview = f"\n    {preview}" if preview else ""
                 text += f" - {tc.status_mark}{output_preview}{tc.duration_str}"
 
         return text
@@ -707,10 +706,19 @@ class ActionRenderer:
             return result
         else:
             status_dot = "[green]\u23fa[/green]" if action.status == ActionStatus.SUCCESS else "[red]\u23fa[/red]"
-            header = f"\U0001f527 {rich_escape(tc.label)} - {tc.status_mark}{tc.duration_str}"
-            if tc.output_preview:
-                header += f"\n    {rich_escape(tc.output_preview)}"
-            return [Text.from_markup(f"{status_dot} {header}")]
+            header = f"\U0001f527 {rich_escape(tc.label)}({rich_escape(tc.args_summary)})"
+            if action.status == ActionStatus.SUCCESS:
+                mark = "[green]\u2713[/green]"
+            else:
+                mark = "[red]\u00d7[/red]"
+            result_text = tc.compact_result or tc.output_preview
+            dur = tc.duration_str.strip()  # "(<0.1s)" or "(12.4s)"
+            dur_suffix = f" \u00b7 [dim]{dur.strip('()')}[/dim]" if dur else ""
+            if result_text:
+                body = f"  \u2514\u2500 {mark} {rich_escape(result_text)}{dur_suffix}"
+            else:
+                body = f"  \u2514\u2500 {mark}{dur_suffix}"
+            return [Text.from_markup(f"{status_dot} {header}\n{body}")]
 
     @staticmethod
     def _parse_task_tool_input(input_data: dict) -> tuple:

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -460,8 +460,9 @@ class ActionRenderer:
                     result.append(Text.from_markup(f"[dim]          {line}[/dim]"))
                 result.append(Text(""))
             else:
-                if tc.output_preview:
-                    result.append(Text.from_markup(f"[dim]          {rich_escape(tc.output_preview)}[/dim]"))
+                preview = tc.compact_result or tc.output_preview
+                if preview:
+                    result.append(Text.from_markup(f"[dim]          {rich_escape(preview)}[/dim]"))
             return result
         if action.role == ActionRole.ASSISTANT:
             content = _get_assistant_content(action)

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -28,9 +28,12 @@ class ToolCallContent:
     label: str  # tool identifier, e.g. "search_table"
     status_mark: str  # "✓" or "✗"
     duration_str: str  # " (1.2s)" or ""
-    output_preview: str = ""  # compact mode output summary
+    output_preview: str = ""  # legacy compact-mode summary; kept for back-compat
     args_lines: List[str] = field(default_factory=list)  # verbose: Rich markup formatted
     output_lines: List[str] = field(default_factory=list)  # verbose: Rich markup formatted
+    # Compact-mode fields used by the new header + └─ line layout:
+    args_summary: str = ""  # concise args for header, e.g. '"orders"' or 'pattern: "*.py"'
+    compact_result: str = ""  # concise result for └─ line, e.g. '3 tables: a, b, c'
 
 
 # Type alias for custom content builder functions
@@ -41,11 +44,229 @@ ToolCallContentFn = Callable[[ActionHistory, bool], ToolCallContent]
 
 
 def calc_duration(action: ActionHistory) -> str:
-    """Calculate duration string from action timestamps."""
+    """Calculate duration string from action timestamps.
+
+    Sub-tenth-of-a-second durations are rendered as ``(<0.1s)`` so they stay
+    visible without misleading rounding.
+    """
     if action.end_time and action.start_time:
         duration_sec = (action.end_time - action.start_time).total_seconds()
+        if duration_sec < 0.1:
+            return " (<0.1s)"
         return f" ({duration_sec:.1f}s)"
     return ""
+
+
+# ── Compact-layout helpers (header args + └─ result line) ──────────
+
+
+def _parse_args_dict(action: ActionHistory) -> dict:
+    """Return the tool's arguments as a dict, or an empty dict."""
+    if not action.input:
+        return {}
+    args = action.input.get("arguments")
+    if args is None:
+        return {}
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except Exception:
+            return {}
+    return args if isinstance(args, dict) else {}
+
+
+def _collapse_whitespace(text: str) -> str:
+    """Collapse any whitespace run (newlines, tabs, repeated spaces) into one space."""
+    return " ".join(str(text).split())
+
+
+def _truncate_middle(text: str, max_len: int = 60) -> str:
+    """Flatten whitespace, then truncate the middle if the result exceeds max_len."""
+    flat = _collapse_whitespace(text)
+    if len(flat) <= max_len:
+        return flat
+    keep = max(1, (max_len - 5) // 2)
+    return flat[:keep] + " ... " + flat[-keep:]
+
+
+def _format_positional(args: dict, *keys: str, max_len: int = 60) -> str:
+    """Pick the first non-empty key and format as a quoted positional arg."""
+    for key in keys:
+        val = args.get(key)
+        if val not in (None, "", [], {}):
+            return f'"{_truncate_middle(val, max_len)}"'
+    return ""
+
+
+def _format_kw(args: dict, *keys: str, max_len: int = 60) -> str:
+    """Format selected args as ``key: "value"`` pairs (only non-empty keys)."""
+    parts: List[str] = []
+    for key in keys:
+        val = args.get(key)
+        if val in (None, "", [], {}):
+            continue
+        parts.append(f'{key}: "{_truncate_middle(val, max_len)}"')
+    return ", ".join(parts)
+
+
+def _fallback_args_summary(args: dict, max_kv: int = 2, max_len: int = 40) -> str:
+    """Generic fallback: show the first few non-empty args as ``k: "v"``."""
+    parts: List[str] = []
+    for key, val in args.items():
+        if val in (None, "", [], {}):
+            continue
+        parts.append(f'{key}: "{_truncate_middle(val, max_len)}"')
+        if len(parts) >= max_kv:
+            break
+    return ", ".join(parts)
+
+
+def _extract_error_message(output_data) -> str:
+    """Return a concise error message from the tool output, or an empty string."""
+    data = parse_output_data(output_data)
+    if not data:
+        return ""
+    err = data.get("error")
+    if err and str(err) not in ("None", "null", ""):
+        return _truncate_middle(str(err), 80)
+    return ""
+
+
+def set_default_args_summary(tc: ToolCallContent, action: ActionHistory) -> None:
+    """Populate ``tc.args_summary`` from ``action.input`` using the fallback."""
+    if tc.args_summary:
+        return
+    args = _parse_args_dict(action)
+    if args:
+        tc.args_summary = _fallback_args_summary(args)
+
+
+def set_error_as_result(tc: ToolCallContent, action: ActionHistory) -> None:
+    """If the action failed, set ``compact_result`` to the error message."""
+    if action.status == ActionStatus.FAILED or (
+        isinstance(action.output, dict) and action.output.get("success") is False
+    ):
+        err = _extract_error_message(action.output)
+        if err:
+            tc.compact_result = err
+
+
+def _item_name(item) -> str:
+    """Best-effort extraction of a short name from a list item (str or dict)."""
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        for key in ("name", "table_name", "database", "schema", "identifier", "title", "id"):
+            val = item.get(key)
+            if val:
+                return str(val)
+    return ""
+
+
+def _fmt_count_with_preview(
+    count: int,
+    noun_singular: str,
+    noun_plural: str,
+    items: Optional[list] = None,
+    max_show: int = 3,
+) -> str:
+    """Format ``N nouns: item1, item2, item3`` when item names are available."""
+    noun = noun_singular if count == 1 else noun_plural
+    header = f"{count} {noun}"
+    if not items:
+        return header
+    names: List[str] = []
+    for item in items[:max_show]:
+        name = _item_name(item)
+        if name:
+            names.append(name)
+        if len(names) >= max_show:
+            break
+    if not names:
+        return header
+    preview = ", ".join(names)
+    if count > len(names):
+        preview += ", ..."
+    return f"{header}: {preview}"
+
+
+def _strip_legacy_preview(preview: str) -> str:
+    """Convert the legacy ``\u2713 xxx`` / ``\u2717 yyy`` preview into a bare result.
+
+    The renderer now draws the status mark on the ``\u2514\u2500`` line itself,
+    so per-builder previews must not prefix their own mark. When an older
+    builder still emits one, strip it to keep the output clean.
+    """
+    if not preview:
+        return ""
+    text = preview.strip()
+    for prefix in ("\u2713 ", "\u2717 ", "\u00d7 "):
+        if text.startswith(prefix):
+            return text[len(prefix) :].strip()
+    return text
+
+
+# ── Per-tool argument summary formatters ───────────────────────────
+#
+# Maps a function_name to a callable(args_dict) -> str that produces the
+# concise arg string rendered inside the ``tool(...)`` header. Only tools
+# listed here get a hand-tuned summary; others fall back to the generic
+# key:"value" pairs via ``set_default_args_summary``.
+_TOOL_ARGS_FORMATTERS: Dict[str, Callable[[dict], str]] = {
+    # DB tools
+    "list_tables": lambda a: _format_kw(a, "catalog", "schema_name"),
+    "describe_table": lambda a: _format_positional(a, "table_name", "name"),
+    "search_table": lambda a: _format_positional(a, "query_text", "query"),
+    "read_query": lambda a: _format_positional(a, "query", "sql"),
+    "query": lambda a: _format_positional(a, "query", "sql"),
+    "get_table_ddl": lambda a: _format_positional(a, "table_name", "name"),
+    "list_databases": lambda _a: "",
+    "list_schemas": lambda a: _format_positional(a, "database", "catalog"),
+    # Filesystem tools
+    "read_file": lambda a: _format_positional(a, "file_path", "path"),
+    "write_file": lambda a: _format_positional(a, "file_path", "path"),
+    "edit_file": lambda a: _format_positional(a, "file_path", "path"),
+    "glob": lambda a: _format_kw(a, "pattern", "path"),
+    "grep": lambda a: _format_kw(a, "pattern", "path"),
+    # Context search tools
+    "list_subject_tree": lambda _a: "",
+    "search_metrics": lambda a: _format_positional(a, "query", "query_text"),
+    "get_metrics": lambda a: _format_positional(a, "metric_name", "metric_id", "name"),
+    "search_reference_sql": lambda a: _format_positional(a, "query", "query_text"),
+    "get_reference_sql": lambda a: _format_positional(a, "ref_id", "sql_id", "name"),
+    "search_semantic_objects": lambda a: _format_positional(a, "query", "query_text"),
+    "search_knowledge": lambda a: _format_positional(a, "query", "query_text"),
+    "get_knowledge": lambda a: _format_positional(a, "doc_id", "id", "name"),
+    # Date parsing tools
+    "parse_temporal_expressions": lambda a: _format_positional(a, "expression", "text", "query"),
+    # Reference template tools
+    "search_reference_template": lambda a: _format_positional(a, "query", "query_text"),
+    "get_reference_template": lambda a: _format_positional(a, "template_id", "name"),
+    "render_reference_template": lambda a: _format_positional(a, "template_id", "name"),
+    "execute_reference_template": lambda a: _format_positional(a, "template_id", "name"),
+    # Platform document tools
+    "list_document_nav": lambda _a: "",
+    "get_document": lambda a: _format_positional(a, "doc_id", "doc_name", "name"),
+    "search_document": lambda a: _format_positional(a, "query", "query_text"),
+    "web_search_document": lambda a: _format_positional(a, "query", "query_text"),
+    # Skill tools
+    "load_skill": lambda a: _format_positional(a, "skill_name", "name"),
+    "skill_execute_command": lambda a: _format_kw(a, "skill_name", "command"),
+    "execute_command": lambda a: _format_kw(a, "skill_name", "command"),
+}
+
+
+def set_tool_specific_args_summary(tc: ToolCallContent, action: ActionHistory) -> None:
+    """Populate ``tc.args_summary`` using a per-tool formatter when available."""
+    if tc.args_summary:
+        return
+    function_name = action.input.get("function_name", "") if action.input else ""
+    formatter = _TOOL_ARGS_FORMATTERS.get(function_name)
+    if formatter is None:
+        return
+    summary = formatter(_parse_args_dict(action))
+    if summary:
+        tc.args_summary = summary
 
 
 def extract_args(action: ActionHistory) -> List[str]:
@@ -700,7 +921,7 @@ def _format_get_table_ddl_output_verbose(output_data) -> List[str]:
 
 
 def _build_list_tables(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """list_tables / table_overview: show table count."""
+    """list_tables / table_overview: show table count and first few names."""
     tc = make_base_content(action)
     if verbose:
         tc.args_lines = extract_args_markup(action)
@@ -709,7 +930,7 @@ def _build_list_tables(action: ActionHistory, verbose: bool) -> ToolCallContent:
     else:
         items = _get_items_from_output(action.output)
         if isinstance(items, list):
-            tc.output_preview = f"\u2713 {len(items)} tables"
+            tc.compact_result = _fmt_count_with_preview(len(items), "table", "tables", items)
     return tc
 
 
@@ -721,14 +942,25 @@ def _build_describe_table(action: ActionHistory, verbose: bool) -> ToolCallConte
         if action.output:
             tc.output_lines = _format_describe_table_output_markup(action.output)
     else:
-        items = _get_items_from_output(action.output)
-        if isinstance(items, list):
-            tc.output_preview = f"\u2713 {len(items)} columns"
+        data = parse_output_data(action.output)
+        columns = None
+        if isinstance(data, dict):
+            result = data.get("result")
+            if isinstance(result, dict) and isinstance(result.get("columns"), list):
+                columns = result["columns"]
+            elif isinstance(result, list):
+                columns = result
+        if columns is None:
+            items = _get_items_from_output(action.output)
+            if isinstance(items, list):
+                columns = items
+        if isinstance(columns, list):
+            tc.compact_result = f"{len(columns)} columns"
     return tc
 
 
 def _build_read_query(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """read_query / query: show row count."""
+    """read_query / query: show row × column count."""
     tc = make_base_content(action)
     if verbose:
         tc.args_lines = extract_args_markup(action)
@@ -737,18 +969,29 @@ def _build_read_query(action: ActionHistory, verbose: bool) -> ToolCallContent:
     else:
         data = parse_output_data(action.output)
         if data:
-            # Check top-level and nested result for original_rows
+            # Check top-level and nested result for rows / columns
             rows = data.get("original_rows")
+            cols = None
             if rows is None:
                 result = data.get("result")
                 if isinstance(result, dict):
                     rows = result.get("original_rows")
+                    cols = result.get("column_count")
+                    if cols is None:
+                        compressed = result.get("compressed_data")
+                        if isinstance(compressed, str) and compressed:
+                            first_line = compressed.split("\n", 1)[0]
+                            if first_line:
+                                cols = len(first_line.split(","))
             if rows is not None:
-                tc.output_preview = f"\u2713 {rows} rows"
+                if cols:
+                    tc.compact_result = f"{rows} \u00d7 {cols} result"
+                else:
+                    tc.compact_result = f"{rows} rows"
             else:
                 items = _get_items_from_output(action.output)
                 if isinstance(items, list):
-                    tc.output_preview = f"\u2713 {len(items)} items"
+                    tc.compact_result = f"{len(items)} items"
     return tc
 
 
@@ -770,7 +1013,7 @@ def _build_search_table(action: ActionHistory, verbose: bool) -> ToolCallContent
                 sample_count = len(sample_data)
             else:
                 sample_count = 0
-            tc.output_preview = f"\u2713 {metadata_count} tables and {sample_count} sample rows"
+            tc.compact_result = f"{metadata_count} tables and {sample_count} sample rows"
     return tc
 
 
@@ -804,12 +1047,12 @@ def _build_search_generic(action: ActionHistory, verbose: bool, unit: str) -> To
     else:
         items = _get_items_from_output(action.output)
         count = len(items) if isinstance(items, list) else 0
-        tc.output_preview = f"\u2713 {count} {unit}"
+        tc.compact_result = f"{count} {unit} matched"
     return tc
 
 
 def _build_get_table_ddl(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """get_table_ddl: show DDL definition."""
+    """get_table_ddl: show the table identifier and DDL size."""
     tc = make_base_content(action)
     if verbose:
         tc.args_lines = extract_args_markup(action)
@@ -821,7 +1064,16 @@ def _build_get_table_ddl(action: ActionHistory, verbose: bool) -> ToolCallConten
             result = data.get("result")
             if isinstance(result, dict):
                 identifier = result.get("identifier", "")
-                tc.output_preview = f"\u2713 {identifier}" if identifier else "\u2713 DDL retrieved"
+                definition = result.get("definition") or ""
+                chars = len(definition) if isinstance(definition, str) else 0
+                if identifier and chars:
+                    tc.compact_result = f"{identifier} \u00b7 {chars:,} chars"
+                elif chars:
+                    tc.compact_result = f"{chars:,} chars"
+                elif identifier:
+                    tc.compact_result = str(identifier)
+                else:
+                    tc.compact_result = "DDL retrieved"
     return tc
 
 
@@ -866,12 +1118,17 @@ def _build_edit_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
             tc.output_lines = _format_result_only_markup(action.output)
     else:
         data = parse_output_data(action.output)
+        args = _parse_args_dict(action)
+        edits_count = len(args.get("edits", [])) if isinstance(args.get("edits"), list) else 0
         if data:
             result = data.get("result")
-            if isinstance(result, str) and "edit" in result.lower():
-                tc.output_preview = f"\u2713 {result.split('(')[-1].rstrip(')')}" if "(" in result else "\u2713 Edited"
+            if edits_count:
+                noun = "occurrence" if edits_count == 1 else "occurrences"
+                tc.compact_result = f"{edits_count} {noun} replaced"
+            elif isinstance(result, str) and "edit" in result.lower():
+                tc.compact_result = result.split("(")[-1].rstrip(")") if "(" in result else "Edited"
             elif data.get("success"):
-                tc.output_preview = "\u2713 Edited"
+                tc.compact_result = "Edited"
     return tc
 
 
@@ -903,12 +1160,17 @@ def _build_write_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
             tc.output_lines = _format_result_only_markup(action.output)
     else:
         data = parse_output_data(action.output)
-        if data:
+        args = _parse_args_dict(action)
+        content = args.get("content")
+        if isinstance(content, str) and content:
+            line_count = len(content.splitlines()) or 1
+            tc.compact_result = f"wrote {line_count} lines"
+        elif data:
             result = data.get("result")
             if isinstance(result, str) and "success" in result.lower():
-                tc.output_preview = "\u2713 File written"
+                tc.compact_result = "File written"
             elif data.get("success"):
-                tc.output_preview = "\u2713 File written"
+                tc.compact_result = "File written"
     return tc
 
 
@@ -924,14 +1186,16 @@ def _build_simple_list(action: ActionHistory, verbose: bool, unit: str) -> ToolC
             tc.output_lines = _format_result_only_markup(action.output)
     else:
         data = parse_output_data(action.output)
+        items = None
         if data:
             result = data.get("result")
             if isinstance(result, list):
-                tc.output_preview = f"\u2713 {len(result)} {unit}"
-            else:
-                items = _get_items_from_output(action.output)
-                if isinstance(items, list):
-                    tc.output_preview = f"\u2713 {len(items)} {unit}"
+                items = result
+        if items is None:
+            items = _get_items_from_output(action.output)
+        if isinstance(items, list):
+            singular = unit[:-1] if unit.endswith("s") else unit
+            tc.compact_result = _fmt_count_with_preview(len(items), singular, unit, items)
     return tc
 
 
@@ -948,9 +1212,9 @@ def _build_get_detail(action: ActionHistory, verbose: bool) -> ToolCallContent:
             result = data.get("result")
             if isinstance(result, dict):
                 name = result.get("name", "")
-                tc.output_preview = f"\u2713 {name}" if name else "\u2713 Retrieved"
+                tc.compact_result = f"{name}" if name else "Retrieved"
             elif isinstance(result, str):
-                tc.output_preview = f"\u2713 {result[:50]}" if result else "\u2713 Retrieved"
+                tc.compact_result = f"{result[:50]}" if result else "Retrieved"
     return tc
 
 
@@ -965,9 +1229,9 @@ def _build_simple_action(action: ActionHistory, verbose: bool, success_label: st
         data = parse_output_data(action.output)
         if data:
             if action.status == ActionStatus.FAILED:
-                tc.output_preview = f"\u2717 {action.output if isinstance(action.output, str) else 'Failed'}"
+                tc.compact_result = f"{action.output if isinstance(action.output, str) else 'Failed'}"
             else:
-                tc.output_preview = f"\u2713 {success_label}"
+                tc.compact_result = f"{success_label}"
     return tc
 
 
@@ -984,11 +1248,11 @@ def _build_doc_search_result(action: ActionHistory, verbose: bool) -> ToolCallCo
             result = data.get("result")
             if isinstance(result, dict):
                 doc_count = result.get("doc_count", 0)
-                tc.output_preview = f"\u2713 {doc_count} docs found"
+                tc.compact_result = f"{doc_count} docs found"
             else:
                 items = _get_items_from_output(action.output)
                 count = len(items) if isinstance(items, list) else 0
-                tc.output_preview = f"\u2713 {count} docs found"
+                tc.compact_result = f"{count} docs found"
     return tc
 
 
@@ -1022,7 +1286,7 @@ def _build_list_subject_tree(action: ActionHistory, verbose: bool) -> ToolCallCo
         if data:
             result = data.get("result")
             if isinstance(result, dict):
-                tc.output_preview = f"\u2713 {len(result)} domains"
+                tc.compact_result = f"{len(result)} domains"
     return tc
 
 
@@ -1086,7 +1350,7 @@ def _build_render_reference_template(action: ActionHistory, verbose: bool) -> To
             result = data.get("result")
             if isinstance(result, dict):
                 name = result.get("template_name", "")
-                tc.output_preview = f"\u2713 {name}" if name else "\u2713 Rendered"
+                tc.compact_result = f"{name}" if name else "Rendered"
     return tc
 
 
@@ -1106,11 +1370,11 @@ def _build_execute_reference_template(action: ActionHistory, verbose: bool) -> T
                 if isinstance(query_result, dict):
                     rows = query_result.get("original_rows")
                     if rows is not None:
-                        tc.output_preview = f"\u2713 {rows} rows"
+                        tc.compact_result = f"{rows} rows"
                     else:
-                        tc.output_preview = "\u2713 Executed"
+                        tc.compact_result = "Executed"
                 else:
-                    tc.output_preview = "\u2713 Executed"
+                    tc.compact_result = "Executed"
     return tc
 
 
@@ -1125,8 +1389,8 @@ def _build_search_knowledge(action: ActionHistory, verbose: bool) -> ToolCallCon
 
 
 def _build_get_knowledge(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """get_knowledge: show knowledge entry count."""
-    return _build_search_generic(action, verbose, "knowledge entries")
+    """get_knowledge: show the fetched knowledge entry name."""
+    return _build_get_detail(action, verbose)
 
 
 def _build_list_metrics_semantic(action: ActionHistory, verbose: bool) -> ToolCallContent:
@@ -1166,11 +1430,11 @@ def _build_query_metrics(action: ActionHistory, verbose: bool) -> ToolCallConten
                 metadata = result.get("metadata", {})
                 row_count = metadata.get("row_count") if isinstance(metadata, dict) else None
                 if row_count is not None:
-                    tc.output_preview = f"\u2713 {row_count} rows"
+                    tc.compact_result = f"{row_count} rows"
                 else:
-                    tc.output_preview = "\u2713 Query completed"
+                    tc.compact_result = "Query completed"
             else:
-                tc.output_preview = "\u2713 Query completed"
+                tc.compact_result = "Query completed"
     return tc
 
 
@@ -1187,11 +1451,11 @@ def _build_validate_semantic(action: ActionHistory, verbose: bool) -> ToolCallCo
             result = data.get("result")
             if isinstance(result, dict):
                 if result.get("valid"):
-                    tc.output_preview = "\u2713 Valid"
+                    tc.compact_result = "Valid"
                 else:
                     issues = result.get("issues", [])
                     count = len(issues) if isinstance(issues, list) else 0
-                    tc.output_preview = f"\u2717 {count} validation errors"
+                    tc.compact_result = f"{count} validation errors"
     return tc
 
 
@@ -1209,7 +1473,7 @@ def _build_attribution_analyze(action: ActionHistory, verbose: bool) -> ToolCall
             if isinstance(result, dict):
                 dims = result.get("selected_dimensions") or result.get("dimension_ranking", [])
                 count = len(dims) if isinstance(dims, list) else 0
-                tc.output_preview = f"\u2713 {count} dimensions analyzed"
+                tc.compact_result = f"{count} dimensions analyzed"
     return tc
 
 
@@ -1237,13 +1501,63 @@ def _build_read_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
             else:
                 tc.output_lines = _format_result_only_markup(action.output)
     else:
-        data = parse_output_data(action.output)
-        if data:
-            result = data.get("result")
-            if isinstance(result, str):
-                line_count = len(result.split("\n"))
-                tc.output_preview = f"\u2713 {line_count} lines"
+        content = _extract_file_content(action.output)
+        if content is not None:
+            tc.compact_result = f"{len(content.splitlines()) or 1} lines"
+        else:
+            # Content pulled from another channel (e.g. summary) — just mark
+            # success so the user does not see an empty result line.
+            tc.compact_result = "read"
     return tc
+
+
+_FILE_BODY_KEYS = ("result", "content", "text", "body", "data", "output")
+
+
+def _extract_file_content(output_data) -> Optional[str]:
+    """Pull the raw file body out of a read_file action output.
+
+    Tries several known shapes because different SDKs / serializers wrap the
+    FuncToolResult differently:
+      - ``{"raw_output": {"result": "...body..."}}`` (FuncToolResult dict)
+      - ``{"raw_output": "{...json...}"}`` (pre-serialized FuncToolResult)
+      - ``{"raw_output": "body"}`` (raw file body already surfaced)
+      - ``{"result" | "content" | "text" | "body" | "data" | "output": "..."}``
+      - ``"body"`` (output_data itself is the body)
+    """
+    if output_data is None:
+        return None
+    if isinstance(output_data, str):
+        return output_data
+    if not isinstance(output_data, dict):
+        return None
+
+    # Direct string fields on the action output itself.
+    for key in _FILE_BODY_KEYS:
+        val = output_data.get(key)
+        if isinstance(val, str) and val:
+            return val
+
+    raw = output_data.get("raw_output")
+    if isinstance(raw, dict):
+        for key in _FILE_BODY_KEYS:
+            val = raw.get(key)
+            if isinstance(val, str):
+                return val
+        return None
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                for key in _FILE_BODY_KEYS:
+                    val = parsed.get(key)
+                    if isinstance(val, str):
+                        return val
+        except Exception:
+            pass
+        # Raw string that is not JSON — assume it is the file body itself.
+        return raw
+    return None
 
 
 def _build_glob(action: ActionHistory, verbose: bool) -> ToolCallContent:
@@ -1259,9 +1573,9 @@ def _build_glob(action: ActionHistory, verbose: bool) -> ToolCallContent:
             result = data.get("result")
             if isinstance(result, dict):
                 files = result.get("files", [])
-                tc.output_preview = f"\u2713 {len(files)} files found"
+                tc.compact_result = f"{len(files)} files found"
             elif isinstance(result, list):
-                tc.output_preview = f"\u2713 {len(result)} files found"
+                tc.compact_result = f"{len(result)} files found"
     return tc
 
 
@@ -1295,7 +1609,11 @@ def _build_grep(action: ActionHistory, verbose: bool) -> ToolCallContent:
             result = data.get("result")
             if isinstance(result, dict):
                 matches = result.get("matches", [])
-                tc.output_preview = f"\u2713 {len(matches)} matches"
+                file_count = len({m.get("file") for m in matches if isinstance(m, dict) and m.get("file")})
+                if file_count:
+                    tc.compact_result = f"{len(matches)} matches in {file_count} files"
+                else:
+                    tc.compact_result = f"{len(matches)} matches"
     return tc
 
 
@@ -1313,7 +1631,7 @@ def _build_list_document_nav(action: ActionHistory, verbose: bool) -> ToolCallCo
             if isinstance(result, dict):
                 platform = result.get("platform", "")
                 total_docs = result.get("total_docs", 0)
-                tc.output_preview = f"\u2713 {platform} \u2014 {total_docs} docs"
+                tc.compact_result = f"{platform} \u2014 {total_docs} docs"
     return tc
 
 
@@ -1331,7 +1649,7 @@ def _build_get_document(action: ActionHistory, verbose: bool) -> ToolCallContent
             if isinstance(result, dict):
                 title = result.get("title", "")
                 chunk_count = result.get("chunk_count", 0)
-                tc.output_preview = f"\u2713 {title} ({chunk_count} chunks)"
+                tc.compact_result = f"{title} ({chunk_count} chunks)"
     return tc
 
 
@@ -1348,7 +1666,7 @@ def _build_todo_read(action: ActionHistory, verbose: bool) -> ToolCallContent:
             result = data.get("result")
             if isinstance(result, dict):
                 total = result.get("total_lists", 0)
-                tc.output_preview = f"\u2713 {total} todo lists"
+                tc.compact_result = f"{total} todo lists"
     return tc
 
 
@@ -1371,7 +1689,7 @@ def _build_todo_update(action: ActionHistory, verbose: bool) -> ToolCallContent:
             if isinstance(result, dict):
                 item = result.get("updated_item", {})
                 status = item.get("status", "") if isinstance(item, dict) else ""
-                tc.output_preview = f"\u2713 {status}" if status else "\u2713 Updated"
+                tc.compact_result = f"{status}" if status else "Updated"
     return tc
 
 
@@ -1387,7 +1705,7 @@ def _build_check_exists(action: ActionHistory, verbose: bool) -> ToolCallContent
         if data:
             result = data.get("result")
             if isinstance(result, dict):
-                tc.output_preview = "\u2713 Exists" if result.get("exists") else "\u2713 Not found"
+                tc.compact_result = "Exists" if result.get("exists") else "Not found"
     return tc
 
 
@@ -1405,7 +1723,7 @@ def _build_end_generation(action: ActionHistory, verbose: bool) -> ToolCallConte
             if isinstance(result, dict):
                 files = result.get("semantic_model_files", [])
                 count = len(files) if isinstance(files, list) else 0
-                tc.output_preview = f"\u2713 {count} semantic models generated"
+                tc.compact_result = f"{count} semantic models generated"
     return tc
 
 
@@ -1420,7 +1738,7 @@ def _build_generate_sql_summary_id(action: ActionHistory, verbose: bool) -> Tool
 
 
 def _build_parse_dates(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """parse_temporal_expressions: show date expression count."""
+    """parse_temporal_expressions: show parsed date range when single, count otherwise."""
     tc = make_base_content(action)
     if verbose:
         tc.args_lines = extract_args_markup(action)
@@ -1432,8 +1750,19 @@ def _build_parse_dates(action: ActionHistory, verbose: bool) -> ToolCallContent:
             result = data.get("result")
             if isinstance(result, dict):
                 dates = result.get("extracted_dates", [])
-                count = len(dates) if isinstance(dates, list) else 0
-                tc.output_preview = f"\u2713 {count} date expressions"
+                if isinstance(dates, list) and len(dates) == 1 and isinstance(dates[0], dict):
+                    first = dates[0]
+                    start = first.get("start_date") or first.get("start") or first.get("date")
+                    end = first.get("end_date") or first.get("end")
+                    if start and end and start != end:
+                        tc.compact_result = f"{start} \u2192 {end}"
+                    elif start:
+                        tc.compact_result = str(start)
+                    else:
+                        tc.compact_result = "1 date expression"
+                else:
+                    count = len(dates) if isinstance(dates, list) else 0
+                    tc.compact_result = f"{count} date expressions"
     return tc
 
 
@@ -1451,7 +1780,7 @@ def _build_analyze_relationships(action: ActionHistory, verbose: bool) -> ToolCa
             if isinstance(result, dict):
                 rels = result.get("relationships", [])
                 count = len(rels) if isinstance(rels, list) else 0
-                tc.output_preview = f"\u2713 {count} relationships found"
+                tc.compact_result = f"{count} relationships found"
     return tc
 
 
@@ -1493,7 +1822,7 @@ def _build_get_multiple_ddl(action: ActionHistory, verbose: bool) -> ToolCallCon
         if data:
             result = data.get("result")
             if isinstance(result, list):
-                tc.output_preview = f"\u2713 {len(result)} DDLs retrieved"
+                tc.compact_result = f"{len(result)} DDLs retrieved"
     return tc
 
 
@@ -1511,7 +1840,7 @@ def _build_analyze_columns(action: ActionHistory, verbose: bool) -> ToolCallCont
             if isinstance(result, dict):
                 patterns = result.get("column_patterns", {})
                 count = len(patterns) if isinstance(patterns, dict) else 0
-                tc.output_preview = f"\u2713 {count} columns analyzed"
+                tc.compact_result = f"{count} columns analyzed"
     return tc
 
 
@@ -1585,13 +1914,13 @@ def _build_ask_user(action: ActionHistory, verbose: bool) -> ToolCallContent:
                     except Exception:
                         pass
                 if isinstance(result, list):
-                    tc.output_preview = f"\u2713 {len(result)} answer(s)"
+                    tc.compact_result = f"{len(result)} answer(s)"
                 else:
-                    tc.output_preview = "\u2713 Answered"
+                    tc.compact_result = "Answered"
             elif not data.get("success") and data.get("error"):
                 error = str(data["error"])
                 error = error[:50] + "..." if len(error) > 50 else error
-                tc.output_preview = f"\u2717 {error}"
+                tc.compact_result = f"{error}"
     return tc
 
 
@@ -1719,9 +2048,19 @@ class ToolCallContentBuilder:
         function_name = action.input.get("function_name", "") if action.input else ""
 
         if function_name in self._registry:
-            return self._registry[function_name](action, verbose)
+            tc = self._registry[function_name](action, verbose)
+        else:
+            tc = self._build_default(action, verbose)
 
-        return self._build_default(action, verbose)
+        if not verbose:
+            # Populate compact-layout fields if the per-tool builder skipped them.
+            set_tool_specific_args_summary(tc, action)
+            set_default_args_summary(tc, action)
+            if not tc.compact_result:
+                tc.compact_result = _strip_legacy_preview(tc.output_preview)
+            set_error_as_result(tc, action)
+
+        return tc
 
     def _build_default(self, action: ActionHistory, verbose: bool) -> ToolCallContent:
         """Default content building logic — no tool-specific knowledge."""

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -1013,31 +1013,44 @@ def _build_search_table(action: ActionHistory, verbose: bool) -> ToolCallContent
                 sample_count = len(sample_data)
             else:
                 sample_count = 0
-            tc.compact_result = f"{metadata_count} tables and {sample_count} sample rows"
+            tc.compact_result = (
+                f"{metadata_count} {_plural_unit(metadata_count, 'table', 'tables')} "
+                f"and {sample_count} {_plural_unit(sample_count, 'sample row', 'sample rows')}"
+            )
     return tc
 
 
 def _build_search_metrics(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """search_metrics: show metric count."""
-    return _build_search_generic(action, verbose, "metrics")
+    return _build_search_generic(action, verbose, "metric", "metrics")
 
 
 def _build_search_reference_sql(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """search_reference_sql: show reference SQL count."""
-    return _build_search_generic(action, verbose, "reference SQLs")
+    return _build_search_generic(action, verbose, "reference SQL", "reference SQLs")
 
 
 def _build_search_external_knowledge(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """search_external_knowledge / search_knowledge: show knowledge count."""
-    return _build_search_generic(action, verbose, "knowledge entries")
+    return _build_search_generic(action, verbose, "knowledge entry", "knowledge entries")
 
 
 def _build_search_documents(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """search_documents: show document count."""
-    return _build_search_generic(action, verbose, "documents")
+    return _build_search_generic(action, verbose, "document", "documents")
 
 
-def _build_search_generic(action: ActionHistory, verbose: bool, unit: str) -> ToolCallContent:
+def _plural_unit(count: int, singular: str, plural: str) -> str:
+    """Pick ``singular`` for ``count == 1``, ``plural`` otherwise."""
+    return singular if count == 1 else plural
+
+
+def _build_search_generic(
+    action: ActionHistory,
+    verbose: bool,
+    unit_singular: str,
+    unit_plural: str,
+) -> ToolCallContent:
     """Shared builder for search_* tools that count items from parsed output."""
     tc = make_base_content(action)
     if verbose:
@@ -1047,7 +1060,7 @@ def _build_search_generic(action: ActionHistory, verbose: bool, unit: str) -> To
     else:
         items = _get_items_from_output(action.output)
         count = len(items) if isinstance(items, list) else 0
-        tc.compact_result = f"{count} {unit} matched"
+        tc.compact_result = f"{count} {_plural_unit(count, unit_singular, unit_plural)} matched"
     return tc
 
 
@@ -1329,7 +1342,7 @@ def _build_get_reference_sql(action: ActionHistory, verbose: bool) -> ToolCallCo
 
 def _build_search_reference_template(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """search_reference_template: show template count."""
-    return _build_search_generic(action, verbose, "templates")
+    return _build_search_generic(action, verbose, "template", "templates")
 
 
 def _build_get_reference_template(action: ActionHistory, verbose: bool) -> ToolCallContent:
@@ -1380,12 +1393,12 @@ def _build_execute_reference_template(action: ActionHistory, verbose: bool) -> T
 
 def _build_search_semantic_objects(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """search_semantic_objects: show semantic object count."""
-    return _build_search_generic(action, verbose, "semantic objects")
+    return _build_search_generic(action, verbose, "semantic object", "semantic objects")
 
 
 def _build_search_knowledge(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """search_knowledge: show knowledge entry count."""
-    return _build_search_generic(action, verbose, "knowledge entries")
+    return _build_search_generic(action, verbose, "knowledge entry", "knowledge entries")
 
 
 def _build_get_knowledge(action: ActionHistory, verbose: bool) -> ToolCallContent:
@@ -1395,7 +1408,7 @@ def _build_get_knowledge(action: ActionHistory, verbose: bool) -> ToolCallConten
 
 def _build_list_metrics_semantic(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """list_metrics (SemanticTools): show metric count."""
-    return _build_search_generic(action, verbose, "metrics")
+    return _build_search_generic(action, verbose, "metric", "metrics")
 
 
 def _build_get_dimensions(action: ActionHistory, verbose: bool) -> ToolCallContent:
@@ -1511,19 +1524,30 @@ def _build_read_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
     return tc
 
 
+# Keys that typically hold the real file body inside a wrapper (FuncToolResult,
+# parsed JSON envelope, etc.). Ordered most-to-least specific.
 _FILE_BODY_KEYS = ("result", "content", "text", "body", "data", "output")
+
+# When falling back to top-level probing of the action.output dict, we narrow
+# the key set to avoid picking up JSON-encoded wrapper payloads that some SDKs
+# expose under generic names like ``text`` / ``data`` / ``output``.
+_FILE_BODY_STRICT_KEYS = ("result", "content", "body")
 
 
 def _extract_file_content(output_data) -> Optional[str]:
     """Pull the raw file body out of a read_file action output.
 
-    Tries several known shapes because different SDKs / serializers wrap the
-    FuncToolResult differently:
-      - ``{"raw_output": {"result": "...body..."}}`` (FuncToolResult dict)
-      - ``{"raw_output": "{...json...}"}`` (pre-serialized FuncToolResult)
-      - ``{"raw_output": "body"}`` (raw file body already surfaced)
-      - ``{"result" | "content" | "text" | "body" | "data" | "output": "..."}``
-      - ``"body"`` (output_data itself is the body)
+    Looks in the following order so we never accidentally return a JSON
+    envelope as the file body:
+
+    1. ``output_data.raw_output`` when it is a dict — the FuncToolResult shape.
+    2. ``output_data.raw_output`` when it is a string — parse JSON first, then
+       fall back to treating the string itself as the body.
+    3. ``output_data`` is a string — treat it as the body.
+    4. ``output_data`` top-level strict keys (``result`` / ``content`` /
+       ``body``) as a last resort. ``text`` / ``data`` / ``output`` are
+       intentionally excluded at the top level because MCP-style tools often
+       put a serialized wrapper under those names.
     """
     if output_data is None:
         return None
@@ -1532,20 +1556,13 @@ def _extract_file_content(output_data) -> Optional[str]:
     if not isinstance(output_data, dict):
         return None
 
-    # Direct string fields on the action output itself.
-    for key in _FILE_BODY_KEYS:
-        val = output_data.get(key)
-        if isinstance(val, str) and val:
-            return val
-
     raw = output_data.get("raw_output")
     if isinstance(raw, dict):
         for key in _FILE_BODY_KEYS:
             val = raw.get(key)
             if isinstance(val, str):
                 return val
-        return None
-    if isinstance(raw, str):
+    elif isinstance(raw, str):
         try:
             parsed = json.loads(raw)
             if isinstance(parsed, dict):
@@ -1557,6 +1574,12 @@ def _extract_file_content(output_data) -> Optional[str]:
             pass
         # Raw string that is not JSON — assume it is the file body itself.
         return raw
+
+    # Last-resort top-level probing using strict keys only.
+    for key in _FILE_BODY_STRICT_KEYS:
+        val = output_data.get(key)
+        if isinstance(val, str) and val:
+            return val
     return None
 
 

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -1214,7 +1214,7 @@ def _build_get_detail(action: ActionHistory, verbose: bool) -> ToolCallContent:
                 name = result.get("name", "")
                 tc.compact_result = f"{name}" if name else "Retrieved"
             elif isinstance(result, str):
-                tc.compact_result = f"{result[:50]}" if result else "Retrieved"
+                tc.compact_result = _truncate_middle(result, 50) if result else "Retrieved"
     return tc
 
 

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -1136,8 +1136,8 @@ def _build_edit_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
         if data:
             result = data.get("result")
             if edits_count:
-                noun = "occurrence" if edits_count == 1 else "occurrences"
-                tc.compact_result = f"{edits_count} {noun} replaced"
+                noun = "edit" if edits_count == 1 else "edits"
+                tc.compact_result = f"{edits_count} {noun} applied"
             elif isinstance(result, str) and "edit" in result.lower():
                 tc.compact_result = result.split("(")[-1].rstrip(")") if "(" in result else "Edited"
             elif data.get("success"):

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -37,6 +37,34 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _drop_if_matches_final(
+    pending: Optional[ActionHistory],
+    final_action: ActionHistory,
+    incremental_actions: list,
+) -> Optional[ActionHistory]:
+    """Reconcile a pending ASSISTANT action with an incoming *_response action.
+
+    The model layer tags the tail LLM text with is_thinking=False and the node
+    wraps the same text into a *_response action. When both are present we drop
+    the pending entry so the final response is not rendered twice. If the texts
+    differ (e.g. LLM emitted thinking before any tool call, then the node built
+    the final response from a later turn), flush the pending entry into the
+    incremental stream so the thinking is preserved.
+    """
+    if pending is None:
+        return None
+    pending_text = ""
+    if isinstance(pending.output, dict):
+        pending_text = (pending.output.get("raw_output") or "").strip()
+    final_text = ""
+    if isinstance(final_action.output, dict):
+        final_text = (final_action.output.get("response") or "").strip()
+    if pending_text and pending_text == final_text:
+        return None
+    incremental_actions.append(pending)
+    return None
+
+
 class ChatCommands:
     """Handles all chat-related commands and functionality."""
 
@@ -250,12 +278,18 @@ class ChatCommands:
             action_display = ActionHistoryDisplay(self.console)
             incremental_actions = []
             node_final_action = None  # Node's final ASSISTANT action (e.g. chat_response)
+            # Buffer for ASSISTANT text tagged as non-thinking by the model layer.
+            # Tail text often duplicates the node's *_response; defer rendering
+            # so we can drop it when the *_response arrives, but flush it on any
+            # other action so mid-turn thinking before a tool call is preserved.
+            pending_non_thinking = None
 
             if interactive:
                 self.console.print("[dim]Press ESC or Ctrl+C to interrupt[/dim]")
 
                 async def run_chat_stream():
                     """Run chat stream — INTERACTION actions flow into incremental_actions."""
+                    nonlocal node_final_action, pending_non_thinking
                     streaming_ctx.set_event_loop(asyncio.get_running_loop())
                     async for action in current_node.execute_stream_with_interactions(
                         action_history_manager=self.cli.actions
@@ -265,14 +299,6 @@ class ChatCommands:
                             continue
                         # Skip TOOL PROCESSING entries — SUCCESS version follows
                         if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
-                            continue
-                        # Skip non-thinking ASSISTANT actions (final output) —
-                        # rendered by the final response display below instead.
-                        if (
-                            action.role == ActionRole.ASSISTANT
-                            and isinstance(action.output, dict)
-                            and not action.output.get("is_thinking", True)
-                        ):
                             continue
                         # Node final actions (e.g. chat_response) — keep for
                         # final response rendering but skip streaming trace.
@@ -286,10 +312,30 @@ class ChatCommands:
                             and action.action_type.endswith("_response")
                             and action.depth == 0
                         ):
-                            nonlocal node_final_action
                             node_final_action = action
+                            pending_non_thinking = _drop_if_matches_final(
+                                pending_non_thinking, action, incremental_actions
+                            )
                             continue
+                        # Defer ASSISTANT text flagged as non-thinking — it may
+                        # be the tail text that duplicates the upcoming *_response.
+                        if (
+                            action.role == ActionRole.ASSISTANT
+                            and isinstance(action.output, dict)
+                            and not action.output.get("is_thinking", True)
+                        ):
+                            pending_non_thinking = action
+                            continue
+                        # Any other action: flush pending first to preserve order.
+                        if pending_non_thinking is not None:
+                            incremental_actions.append(pending_non_thinking)
+                            pending_non_thinking = None
                         incremental_actions.append(action)
+                    # Stream ended: flush remaining pending only when no node
+                    # final action captured it (otherwise it was already handled).
+                    if pending_non_thinking is not None and node_final_action is None:
+                        incremental_actions.append(pending_non_thinking)
+                        pending_non_thinking = None
 
                 streaming_ctx = action_display.display_streaming_actions(
                     incremental_actions,
@@ -315,7 +361,7 @@ class ChatCommands:
             else:
 
                 async def run_stream():
-                    nonlocal node_final_action
+                    nonlocal node_final_action, pending_non_thinking
                     async for action in current_node.execute_stream_with_interactions(
                         action_history_manager=self.cli.actions
                     ):
@@ -328,14 +374,6 @@ class ChatCommands:
                                     await auto_submit_interaction(broker, action)
                             continue
                         if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
-                            continue
-                        # Skip non-thinking ASSISTANT actions (final output) —
-                        # rendered by the final response display below instead.
-                        if (
-                            action.role == ActionRole.ASSISTANT
-                            and isinstance(action.output, dict)
-                            and not action.output.get("is_thinking", True)
-                        ):
                             continue
                         # Node final actions (e.g. chat_response) — keep for
                         # final response rendering but skip streaming trace.
@@ -350,8 +388,26 @@ class ChatCommands:
                             and action.depth == 0
                         ):
                             node_final_action = action
+                            pending_non_thinking = _drop_if_matches_final(
+                                pending_non_thinking, action, incremental_actions
+                            )
                             continue
+                        # Defer ASSISTANT text flagged as non-thinking — it may
+                        # be the tail text that duplicates the upcoming *_response.
+                        if (
+                            action.role == ActionRole.ASSISTANT
+                            and isinstance(action.output, dict)
+                            and not action.output.get("is_thinking", True)
+                        ):
+                            pending_non_thinking = action
+                            continue
+                        if pending_non_thinking is not None:
+                            incremental_actions.append(pending_non_thinking)
+                            pending_non_thinking = None
                         incremental_actions.append(action)
+                    if pending_non_thinking is not None and node_final_action is None:
+                        incremental_actions.append(pending_non_thinking)
+                        pending_non_thinking = None
 
                 with action_display.display_streaming_actions(incremental_actions):
                     try:

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -59,7 +59,9 @@ def _drop_if_matches_final(
     final_text = ""
     if isinstance(final_action.output, dict):
         final_text = (final_action.output.get("response") or "").strip()
-    if pending_text and pending_text == final_text:
+    # Drop the pending entry when it has nothing to contribute (empty text)
+    # or when its body duplicates the final response exactly.
+    if not pending_text or pending_text == final_text:
         return None
     incremental_actions.append(pending)
     return None
@@ -319,11 +321,15 @@ class ChatCommands:
                             continue
                         # Defer ASSISTANT text flagged as non-thinking — it may
                         # be the tail text that duplicates the upcoming *_response.
+                        # If a previous pending is still buffered, flush it first
+                        # so back-to-back non-thinking chunks are not dropped.
                         if (
                             action.role == ActionRole.ASSISTANT
                             and isinstance(action.output, dict)
                             and not action.output.get("is_thinking", True)
                         ):
+                            if pending_non_thinking is not None:
+                                incremental_actions.append(pending_non_thinking)
                             pending_non_thinking = action
                             continue
                         # Any other action: flush pending first to preserve order.
@@ -394,11 +400,15 @@ class ChatCommands:
                             continue
                         # Defer ASSISTANT text flagged as non-thinking — it may
                         # be the tail text that duplicates the upcoming *_response.
+                        # If a previous pending is still buffered, flush it first
+                        # so back-to-back non-thinking chunks are not dropped.
                         if (
                             action.role == ActionRole.ASSISTANT
                             and isinstance(action.output, dict)
                             and not action.output.get("is_thinking", True)
                         ):
+                            if pending_non_thinking is not None:
+                                incremental_actions.append(pending_non_thinking)
                             pending_non_thinking = action
                             continue
                         if pending_non_thinking is not None:

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -290,7 +290,7 @@ class TestBuildListTables:
             output_data={"result": [1, 2]},
         )
         tc = _build_list_tables(a, verbose=False)
-        assert "2 tables" in tc.output_preview
+        assert "2 tables" in tc.compact_result
 
     def test_verbose(self):
         a = _make(
@@ -318,7 +318,7 @@ class TestBuildDescribeTable:
             output_data={"result": ["c1", "c2", "c3"]},
         )
         tc = _build_describe_table(a, verbose=False)
-        assert "3 columns" in tc.output_preview
+        assert "3 columns" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -329,7 +329,7 @@ class TestBuildReadQuery:
             output_data={"original_rows": 42},
         )
         tc = _build_read_query(a, verbose=False)
-        assert "42 rows" in tc.output_preview
+        assert "42 rows" in tc.compact_result
 
     def test_compact_list_fallback(self):
         a = _make(
@@ -337,7 +337,7 @@ class TestBuildReadQuery:
             output_data={"result": [1, 2]},
         )
         tc = _build_read_query(a, verbose=False)
-        assert "2 items" in tc.output_preview
+        assert "2 items" in tc.compact_result
 
     def test_compact_no_data(self):
         a = _make(input_data={"function_name": "read_query"}, output_data={"k": "v"})
@@ -353,8 +353,8 @@ class TestBuildSearchTable:
             output_data={"metadata": [1, 2], "sample_data": [3]},
         )
         tc = _build_search_table(a, verbose=False)
-        assert "2 tables" in tc.output_preview
-        assert "1 sample rows" in tc.output_preview
+        assert "2 tables" in tc.compact_result
+        assert "1 sample rows" in tc.compact_result
 
     def test_compact_with_compressed_sample_data(self):
         a = _make(
@@ -372,8 +372,8 @@ class TestBuildSearchTable:
             },
         )
         tc = _build_search_table(a, verbose=False)
-        assert "2 tables" in tc.output_preview
-        assert "1 sample rows" in tc.output_preview
+        assert "2 tables" in tc.compact_result
+        assert "1 sample rows" in tc.compact_result
 
     def test_compact_no_data(self):
         a = _make(input_data={"function_name": "search_table"})
@@ -397,7 +397,7 @@ class TestBuildSearchGeneric:
     def test_compact_with_items(self, fn, builder, unit):
         a = _make(input_data={"function_name": fn}, output_data={"result": [1, 2, 3]})
         tc = builder(a, verbose=False)
-        assert f"3 {unit}" in tc.output_preview
+        assert f"3 {unit}" in tc.compact_result
 
     @pytest.mark.parametrize(
         "fn, builder",
@@ -409,7 +409,7 @@ class TestBuildSearchGeneric:
     def test_compact_no_items(self, fn, builder):
         a = _make(input_data={"function_name": fn}, output_data={"k": "v"})
         tc = builder(a, verbose=False)
-        assert "0 " in tc.output_preview
+        assert "0 " in tc.compact_result
 
 
 # ── Builder class ──────────────────────────────────────────────────
@@ -430,7 +430,7 @@ class TestToolCallContentBuilderDefault:
         builder = ToolCallContentBuilder()
         tc = builder.build(a, verbose=False)
         assert tc.label == "unknown_tool"
-        assert "Success" in tc.output_preview
+        assert "Success" in tc.compact_result
         assert "1.0s" in tc.duration_str
 
     def test_compact_failed_no_preview(self):
@@ -478,7 +478,7 @@ class TestToolCallContentBuilderRegistry:
         a = _make(input_data={"function_name": "brand_new_tool"}, output_data={"success": True})
         tc = ToolCallContentBuilder().build(a, verbose=False)
         assert tc.label == "brand_new_tool"
-        assert "Success" in tc.output_preview
+        assert "Success" in tc.compact_result
 
     def test_override_builtin(self):
         """Can override a built-in registration."""
@@ -494,7 +494,7 @@ class TestToolCallContentBuilderRegistry:
         """list_tables dispatched to _build_list_tables producing table count."""
         a = _make(input_data={"function_name": "list_tables"}, output_data={"result": [1, 2]})
         tc = ToolCallContentBuilder().build(a, verbose=False)
-        assert "2 tables" in tc.output_preview
+        assert "2 tables" in tc.compact_result
 
 
 # ── Parity: main/sub produce same content ──────────────────────────
@@ -784,16 +784,16 @@ class TestBuildGetTableDdl:
             },
         )
         tc = _build_get_table_ddl(a, verbose=False)
-        assert "catalog.db.my_table" in tc.output_preview
+        assert "catalog.db.my_table" in tc.compact_result
 
     def test_compact_no_identifier_fallback(self):
-        """Verify compact mode falls back to 'DDL retrieved' when no identifier."""
+        """When only the DDL body is present, show its character count."""
         a = _make(
             input_data={"function_name": "get_table_ddl"},
             output_data={"raw_output": '{"success": 1, "result": {"definition": "CREATE TABLE ..."}}'},
         )
         tc = _build_get_table_ddl(a, verbose=False)
-        assert "DDL retrieved" in tc.output_preview
+        assert tc.compact_result == "16 chars"
 
     def test_compact_no_data(self):
         """Verify compact mode produces empty preview with no output."""
@@ -831,7 +831,7 @@ class TestBuildWriteFile:
             output_data={"raw_output": '{"success": 1, "result": "File written successfully: /tmp/f.sql"}'},
         )
         tc = _build_write_file(a, verbose=False)
-        assert "File written" in tc.output_preview
+        assert "File written" in tc.compact_result
 
     def test_compact_success_with_success_flag(self):
         """Verify compact mode shows 'File written' when success flag is true."""
@@ -840,7 +840,7 @@ class TestBuildWriteFile:
             output_data={"raw_output": '{"success": 1, "result": {"path": "/tmp/f.sql"}}'},
         )
         tc = _build_write_file(a, verbose=False)
-        assert "File written" in tc.output_preview
+        assert "File written" in tc.compact_result
 
     def test_compact_no_data(self):
         """Verify compact mode with no output produces empty preview."""
@@ -912,7 +912,7 @@ class TestNewToolsRegistered:
             },
         )
         tc = ToolCallContentBuilder().build(a, verbose=False)
-        assert "db.t" in tc.output_preview
+        assert "db.t" in tc.compact_result
 
     def test_write_file_dispatches_correctly(self):
         """Verify write_file dispatched via builder produces correct output."""
@@ -921,7 +921,7 @@ class TestNewToolsRegistered:
             output_data={"raw_output": '{"success": 1, "result": "File written successfully"}'},
         )
         tc = ToolCallContentBuilder().build(a, verbose=False)
-        assert "File written" in tc.output_preview
+        assert "File written" in tc.compact_result
 
 
 # ── read_query compact: nested original_rows ──────────────────────
@@ -938,7 +938,8 @@ class TestBuildReadQueryNestedRows:
             output_data={"raw_output": '{"success": 1, "result": {"original_rows": 15, "compressed_data": "a\\n1"}}'},
         )
         tc = _build_read_query(a, verbose=False)
-        assert "15 rows" in tc.output_preview
+        # Column count is inferred from the compressed_data header line.
+        assert tc.compact_result == "15 \u00d7 1 result"
 
     def test_verbose_shows_only_data(self):
         """Verify verbose mode only shows CSV data preview with markup."""
@@ -1045,7 +1046,7 @@ class TestBuildSimpleList:
             output_data={"raw_output": '{"success": 1, "result": ["a", "b", "c"]}'},
         )
         tc = _build_simple_list(a, verbose=False, unit="items")
-        assert "3 items" in tc.output_preview
+        assert "3 items" in tc.compact_result
 
     def test_compact_no_list(self):
         a = _make(input_data={"function_name": "test"}, output_data={"raw_output": '{"success": 1}'})
@@ -1072,7 +1073,7 @@ class TestBuildGetDetail:
             output_data={"raw_output": '{"success": 1, "result": {"name": "my_metric", "description": "desc"}}'},
         )
         tc = _build_get_detail(a, verbose=False)
-        assert "my_metric" in tc.output_preview
+        assert "my_metric" in tc.compact_result
 
     def test_compact_no_name(self):
         a = _make(
@@ -1080,7 +1081,7 @@ class TestBuildGetDetail:
             output_data={"raw_output": '{"success": 1, "result": {"description": "no name"}}'},
         )
         tc = _build_get_detail(a, verbose=False)
-        assert "Retrieved" in tc.output_preview
+        assert "Retrieved" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1093,7 +1094,7 @@ class TestBuildSimpleAction:
             output_data={"raw_output": '{"success": 1, "result": "ok"}'},
         )
         tc = _build_simple_action(a, verbose=False, success_label="Done")
-        assert "Done" in tc.output_preview
+        assert "Done" in tc.compact_result
 
     def test_compact_no_data(self):
         a = _make(input_data={"function_name": "test"})
@@ -1111,7 +1112,7 @@ class TestBuildDocSearchResult:
             output_data={"raw_output": '{"success": 1, "result": {"docs": [], "doc_count": 5}}'},
         )
         tc = _build_doc_search_result(a, verbose=False)
-        assert "5 docs found" in tc.output_preview
+        assert "5 docs found" in tc.compact_result
 
     def test_compact_fallback_list(self):
         a = _make(
@@ -1119,7 +1120,7 @@ class TestBuildDocSearchResult:
             output_data={"result": [1, 2]},
         )
         tc = _build_doc_search_result(a, verbose=False)
-        assert "2 docs found" in tc.output_preview
+        assert "2 docs found" in tc.compact_result
 
 
 # ── Database tools ────────────────────────────────────────────────
@@ -1133,7 +1134,7 @@ class TestBuildListDatabases:
             output_data={"raw_output": '{"success": 1, "result": ["db1", "db2"]}'},
         )
         tc = _build_list_databases(a, verbose=False)
-        assert "2 databases" in tc.output_preview
+        assert "2 databases" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1144,7 +1145,7 @@ class TestBuildListSchemas:
             output_data={"raw_output": '{"success": 1, "result": ["public", "dbo"]}'},
         )
         tc = _build_list_schemas(a, verbose=False)
-        assert "2 schemas" in tc.output_preview
+        assert "2 schemas" in tc.compact_result
 
 
 # ── Context search tools ──────────────────────────────────────────
@@ -1158,7 +1159,7 @@ class TestBuildListSubjectTree:
             output_data={"raw_output": '{"success": 1, "result": {"domain1": {}, "domain2": {}}}'},
         )
         tc = _build_list_subject_tree(a, verbose=False)
-        assert "2 domains" in tc.output_preview
+        assert "2 domains" in tc.compact_result
 
     def test_compact_no_result(self):
         a = _make(input_data={"function_name": "list_subject_tree"})
@@ -1203,7 +1204,7 @@ class TestBuildGetMetrics:
             output_data={"raw_output": '{"success": 1, "result": {"name": "revenue", "description": "total"}}'},
         )
         tc = _build_get_metrics(a, verbose=False)
-        assert "revenue" in tc.output_preview
+        assert "revenue" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1214,7 +1215,7 @@ class TestBuildGetReferenceSQL:
             output_data={"raw_output": '{"success": 1, "result": {"name": "top_sales", "sql": "SELECT 1"}}'},
         )
         tc = _build_get_reference_sql(a, verbose=False)
-        assert "top_sales" in tc.output_preview
+        assert "top_sales" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1225,7 +1226,7 @@ class TestBuildSearchSemanticObjects:
             output_data={"result": [{"kind": "table", "name": "t1"}, {"kind": "metric", "name": "m1"}]},
         )
         tc = _build_search_semantic_objects(a, verbose=False)
-        assert "2 semantic objects" in tc.output_preview
+        assert "2 semantic objects" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1236,7 +1237,7 @@ class TestBuildSearchKnowledge:
             output_data={"result": [{"search_text": "q1", "explanation": "e1"}]},
         )
         tc = _build_search_knowledge(a, verbose=False)
-        assert "1 knowledge entries" in tc.output_preview
+        assert "1 knowledge entries" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1244,10 +1245,10 @@ class TestBuildGetKnowledge:
     def test_compact(self):
         a = _make(
             input_data={"function_name": "get_knowledge"},
-            output_data={"result": [{"search_text": "q1"}, {"search_text": "q2"}]},
+            output_data={"result": {"name": "sla_policy"}},
         )
         tc = _build_get_knowledge(a, verbose=False)
-        assert "2 knowledge entries" in tc.output_preview
+        assert "sla_policy" in tc.compact_result
 
 
 # ── Semantic tools ────────────────────────────────────────────────
@@ -1261,7 +1262,7 @@ class TestBuildListMetricsSemantic:
             output_data={"result": [{"name": "m1"}, {"name": "m2"}, {"name": "m3"}]},
         )
         tc = _build_list_metrics_semantic(a, verbose=False)
-        assert "3 metrics" in tc.output_preview
+        assert "3 metrics" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1272,7 +1273,7 @@ class TestBuildGetDimensions:
             output_data={"raw_output": '{"success": 1, "result": ["dim1", "dim2"]}'},
         )
         tc = _build_get_dimensions(a, verbose=False)
-        assert "2 dimensions" in tc.output_preview
+        assert "2 dimensions" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1286,7 +1287,7 @@ class TestBuildQueryMetrics:
             },
         )
         tc = _build_query_metrics(a, verbose=False)
-        assert "2 rows" in tc.output_preview
+        assert "2 rows" in tc.compact_result
 
     def test_compact_fallback(self):
         a = _make(
@@ -1294,7 +1295,7 @@ class TestBuildQueryMetrics:
             output_data={"raw_output": '{"success": 1, "result": {"columns": ["a"], "data": "a\\n1"}}'},
         )
         tc = _build_query_metrics(a, verbose=False)
-        assert "Query completed" in tc.output_preview
+        assert "Query completed" in tc.compact_result
 
     def test_verbose_csv_preview(self):
         a = _make(
@@ -1316,7 +1317,7 @@ class TestBuildValidateSemantic:
             output_data={"raw_output": '{"success": 1, "result": {"valid": true, "issues": []}}'},
         )
         tc = _build_validate_semantic(a, verbose=False)
-        assert "Valid" in tc.output_preview
+        assert "Valid" in tc.compact_result
 
     def test_compact_invalid(self):
         a = _make(
@@ -1327,7 +1328,7 @@ class TestBuildValidateSemantic:
             },
         )
         tc = _build_validate_semantic(a, verbose=False)
-        assert "2 validation errors" in tc.output_preview
+        assert "2 validation errors" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1341,7 +1342,7 @@ class TestBuildAttributionAnalyze:
             },
         )
         tc = _build_attribution_analyze(a, verbose=False)
-        assert "1 dimensions analyzed" in tc.output_preview
+        assert "1 dimensions analyzed" in tc.compact_result
 
 
 # ── Filesystem tools ──────────────────────────────────────────────
@@ -1355,7 +1356,7 @@ class TestBuildReadFile:
             output_data={"raw_output": '{"success": 1, "result": "line1\\nline2\\nline3"}'},
         )
         tc = _build_read_file(a, verbose=False)
-        assert "3 lines" in tc.output_preview
+        assert "3 lines" in tc.compact_result
 
     def test_verbose_truncates(self):
         content = "\\n".join([f"line {i}" for i in range(30)])
@@ -1375,7 +1376,7 @@ class TestBuildGlob:
             output_data={"raw_output": '{"success": 1, "result": {"files": ["/a.py", "/b.py"], "truncated": false}}'},
         )
         tc = _build_glob(a, verbose=False)
-        assert "2 files found" in tc.output_preview
+        assert "2 files found" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1389,7 +1390,7 @@ class TestBuildGrep:
             },
         )
         tc = _build_grep(a, verbose=False)
-        assert "1 matches" in tc.output_preview
+        assert "1 matches" in tc.compact_result
 
     def test_verbose_shows_matches(self):
         a = _make(
@@ -1417,8 +1418,8 @@ class TestBuildListDocumentNav:
             },
         )
         tc = _build_list_document_nav(a, verbose=False)
-        assert "spark" in tc.output_preview
-        assert "42 docs" in tc.output_preview
+        assert "spark" in tc.compact_result
+        assert "42 docs" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1432,8 +1433,8 @@ class TestBuildGetDocument:
             },
         )
         tc = _build_get_document(a, verbose=False)
-        assert "Overview" in tc.output_preview
-        assert "3 chunks" in tc.output_preview
+        assert "Overview" in tc.compact_result
+        assert "3 chunks" in tc.compact_result
 
 
 # ── Plan tools ────────────────────────────────────────────────────
@@ -1447,7 +1448,7 @@ class TestBuildTodoRead:
             output_data={"raw_output": '{"success": 1, "result": {"message": "ok", "lists": [], "total_lists": 3}}'},
         )
         tc = _build_todo_read(a, verbose=False)
-        assert "3 todo lists" in tc.output_preview
+        assert "3 todo lists" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1458,7 +1459,7 @@ class TestBuildTodoWrite:
             output_data={"raw_output": '{"success": 1, "result": {"message": "saved"}}'},
         )
         tc = _build_todo_write(a, verbose=False)
-        assert "Todo list updated" in tc.output_preview
+        assert "Todo list updated" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1472,7 +1473,7 @@ class TestBuildTodoUpdate:
             },
         )
         tc = _build_todo_update(a, verbose=False)
-        assert "completed" in tc.output_preview
+        assert "completed" in tc.compact_result
 
     def test_compact_no_status(self):
         a = _make(
@@ -1480,7 +1481,7 @@ class TestBuildTodoUpdate:
             output_data={"raw_output": '{"success": 1, "result": {"message": "ok", "updated_item": {}}}'},
         )
         tc = _build_todo_update(a, verbose=False)
-        assert "Updated" in tc.output_preview
+        assert "Updated" in tc.compact_result
 
 
 # ── Generation tools ──────────────────────────────────────────────
@@ -1494,7 +1495,7 @@ class TestBuildCheckExists:
             output_data={"raw_output": '{"success": 1, "result": {"exists": true, "name": "t1"}}'},
         )
         tc = _build_check_exists(a, verbose=False)
-        assert "Exists" in tc.output_preview
+        assert "Exists" in tc.compact_result
 
     def test_compact_not_found(self):
         a = _make(
@@ -1502,7 +1503,7 @@ class TestBuildCheckExists:
             output_data={"raw_output": '{"success": 1, "result": {"exists": false, "name": "t1"}}'},
         )
         tc = _build_check_exists(a, verbose=False)
-        assert "Not found" in tc.output_preview
+        assert "Not found" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1516,7 +1517,7 @@ class TestBuildEndGeneration:
             },
         )
         tc = _build_end_generation(a, verbose=False)
-        assert "2 semantic models generated" in tc.output_preview
+        assert "2 semantic models generated" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1527,7 +1528,7 @@ class TestBuildEndMetricGeneration:
             output_data={"raw_output": '{"success": 1, "result": {"message": "done"}}'},
         )
         tc = _build_end_metric_generation(a, verbose=False)
-        assert "Metric generated" in tc.output_preview
+        assert "Metric generated" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1538,7 +1539,7 @@ class TestBuildGenerateSqlSummaryId:
             output_data={"raw_output": '{"success": 1, "result": "abc123"}'},
         )
         tc = _build_generate_sql_summary_id(a, verbose=False)
-        assert "ID generated" in tc.output_preview
+        assert "ID generated" in tc.compact_result
 
 
 # ── Date parsing tools ────────────────────────────────────────────
@@ -1546,7 +1547,8 @@ class TestBuildGenerateSqlSummaryId:
 
 @pytest.mark.ci
 class TestBuildParseDates:
-    def test_compact(self):
+    def test_compact_single_date(self):
+        """Single extracted date with only a start → show the date itself."""
         a = _make(
             input_data={"function_name": "parse_temporal_expressions"},
             output_data={
@@ -1555,7 +1557,31 @@ class TestBuildParseDates:
             },
         )
         tc = _build_parse_dates(a, verbose=False)
-        assert "1 date expressions" in tc.output_preview
+        assert tc.compact_result == "2024-01-01"
+
+    def test_compact_date_range(self):
+        """Single extracted date with start + end → show ``start → end``."""
+        a = _make(
+            input_data={"function_name": "parse_temporal_expressions"},
+            output_data={
+                "raw_output": '{"success": 1, "result": {"extracted_dates": '
+                '[{"start_date": "2024-01-01", "end_date": "2024-12-31"}]}}'
+            },
+        )
+        tc = _build_parse_dates(a, verbose=False)
+        assert tc.compact_result == "2024-01-01 \u2192 2024-12-31"
+
+    def test_compact_multiple(self):
+        """Multiple extracted dates → fall back to the count summary."""
+        a = _make(
+            input_data={"function_name": "parse_temporal_expressions"},
+            output_data={
+                "raw_output": '{"success": 1, "result": {"extracted_dates": '
+                '[{"start_date": "2024-01-01"}, {"start_date": "2024-02-01"}]}}'
+            },
+        )
+        tc = _build_parse_dates(a, verbose=False)
+        assert tc.compact_result == "2 date expressions"
 
 
 # ── Semantic model generation tools ───────────────────────────────
@@ -1572,7 +1598,7 @@ class TestBuildAnalyzeRelationships:
             },
         )
         tc = _build_analyze_relationships(a, verbose=False)
-        assert "1 relationships found" in tc.output_preview
+        assert "1 relationships found" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1587,7 +1613,7 @@ class TestBuildGetMultipleDdl:
             },
         )
         tc = _build_get_multiple_ddl(a, verbose=False)
-        assert "2 DDLs retrieved" in tc.output_preview
+        assert "2 DDLs retrieved" in tc.compact_result
 
     def test_verbose_shows_ddl(self):
         a = _make(
@@ -1621,7 +1647,7 @@ class TestBuildAnalyzeColumns:
             },
         )
         tc = _build_analyze_columns(a, verbose=False)
-        assert "2 columns analyzed" in tc.output_preview
+        assert "2 columns analyzed" in tc.compact_result
 
 
 # ── Skill tools ───────────────────────────────────────────────────
@@ -1635,7 +1661,7 @@ class TestBuildExecuteCommand:
             output_data={"raw_output": '{"success": 1, "result": "output text"}'},
         )
         tc = _build_execute_command(a, verbose=False)
-        assert "Command executed" in tc.output_preview
+        assert "Command executed" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1646,7 +1672,7 @@ class TestBuildLoadSkill:
             output_data={"raw_output": '{"success": 1, "result": "skill content"}'},
         )
         tc = _build_load_skill(a, verbose=False)
-        assert "Skill loaded" in tc.output_preview
+        assert "Skill loaded" in tc.compact_result
 
 
 class TestBuildAskUser:
@@ -1660,7 +1686,7 @@ class TestBuildAskUser:
             output_data={"raw_output": json.dumps({"success": 1, "result": result_json})},
         )
         tc = _build_ask_user(a, verbose=False)
-        assert "1 answer" in tc.output_preview
+        assert "1 answer" in tc.compact_result
 
     def test_compact_error(self):
         a = _make(
@@ -1668,7 +1694,7 @@ class TestBuildAskUser:
             output_data={"raw_output": json.dumps({"success": 0, "error": "questions must be a non-empty list"})},
         )
         tc = _build_ask_user(a, verbose=False)
-        assert "non-empty" in tc.output_preview
+        assert "non-empty" in tc.compact_result
 
     def test_verbose_shows_formatted_questions(self):
         result_json = json.dumps(
@@ -1788,3 +1814,268 @@ class TestAllToolsRegistered:
     def test_registry_count(self):
         builder = ToolCallContentBuilder()
         assert len(builder._registry) >= len(self.EXPECTED_TOOLS)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Compact-layout helpers and per-tool formatters
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.ci
+class TestCompactHelpers:
+    """Coverage for the helpers that back the header + └─ compact layout."""
+
+    def test_collapse_whitespace_flattens_newlines_and_tabs(self):
+        from datus.cli.action_display.tool_content import _collapse_whitespace
+
+        assert _collapse_whitespace("a\n b\tc\r\nd") == "a b c d"
+        assert _collapse_whitespace("   ") == ""
+
+    def test_truncate_middle_short_stays_unchanged(self):
+        from datus.cli.action_display.tool_content import _truncate_middle
+
+        assert _truncate_middle("short", max_len=60) == "short"
+
+    def test_truncate_middle_long_gets_ellipsis(self):
+        from datus.cli.action_display.tool_content import _truncate_middle
+
+        result = _truncate_middle("x" * 100, max_len=20)
+        assert "..." in result
+        assert len(result) <= 20
+
+    def test_truncate_middle_flattens_embedded_newlines(self):
+        from datus.cli.action_display.tool_content import _truncate_middle
+
+        result = _truncate_middle("SELECT\n a,\n b\n FROM t", max_len=60)
+        assert "\n" not in result
+
+    def test_format_positional_picks_first_nonempty_key(self):
+        from datus.cli.action_display.tool_content import _format_positional
+
+        assert _format_positional({"x": "", "y": "val"}, "x", "y") == '"val"'
+        assert _format_positional({}, "x") == ""
+        # None / empty list / empty dict are all treated as missing.
+        assert _format_positional({"x": None, "y": [], "z": "v"}, "x", "y", "z") == '"v"'
+
+    def test_format_kw_joins_nonempty_pairs(self):
+        from datus.cli.action_display.tool_content import _format_kw
+
+        assert _format_kw({"pattern": "*.py", "path": "src"}, "pattern", "path") == ('pattern: "*.py", path: "src"')
+        assert _format_kw({"pattern": "*.py"}, "pattern", "path") == 'pattern: "*.py"'
+
+    def test_fallback_args_summary_limits_pairs(self):
+        from datus.cli.action_display.tool_content import _fallback_args_summary
+
+        args = {"a": "1", "b": "2", "c": "3"}
+        result = _fallback_args_summary(args, max_kv=2)
+        # Order follows dict iteration; only two pairs shown.
+        assert result.count(":") == 2
+
+    def test_extract_error_message_reads_error_field(self):
+        from datus.cli.action_display.tool_content import _extract_error_message
+
+        assert _extract_error_message({"raw_output": '{"error": "boom"}'}) == "boom"
+        assert _extract_error_message({"raw_output": "{}"}) == ""
+        assert _extract_error_message(None) == ""
+
+    def test_set_default_args_summary_uses_fallback(self):
+        from datus.cli.action_display.tool_content import (
+            ToolCallContent,
+            set_default_args_summary,
+        )
+
+        tc = ToolCallContent(label="x", status_mark="\u2713", duration_str="")
+        action = _make(input_data={"function_name": "custom", "arguments": {"pattern": "*.py"}})
+        set_default_args_summary(tc, action)
+        assert tc.args_summary == 'pattern: "*.py"'
+
+    def test_set_default_args_summary_noop_when_prefilled(self):
+        from datus.cli.action_display.tool_content import (
+            ToolCallContent,
+            set_default_args_summary,
+        )
+
+        tc = ToolCallContent(label="x", status_mark="\u2713", duration_str="", args_summary='"preset"')
+        action = _make(input_data={"function_name": "custom", "arguments": {"q": "v"}})
+        set_default_args_summary(tc, action)
+        assert tc.args_summary == '"preset"'
+
+    def test_set_error_as_result_populates_on_failure(self):
+        from datus.cli.action_display.tool_content import (
+            ToolCallContent,
+            set_error_as_result,
+        )
+
+        tc = ToolCallContent(label="x", status_mark="\u2717", duration_str="")
+        action = _make(output_data={"raw_output": '{"error": "file not found"}'})
+        action.status = ActionStatus.FAILED
+        set_error_as_result(tc, action)
+        assert "file not found" in tc.compact_result
+
+    def test_set_error_as_result_noop_on_success(self):
+        from datus.cli.action_display.tool_content import (
+            ToolCallContent,
+            set_error_as_result,
+        )
+
+        tc = ToolCallContent(label="x", status_mark="\u2713", duration_str="")
+        action = _make(output_data={"raw_output": '{"error": null}'})
+        set_error_as_result(tc, action)
+        assert tc.compact_result == ""
+
+    def test_strip_legacy_preview_removes_known_prefixes(self):
+        from datus.cli.action_display.tool_content import _strip_legacy_preview
+
+        assert _strip_legacy_preview("\u2713 3 tables") == "3 tables"
+        assert _strip_legacy_preview("\u2717 failed") == "failed"
+        assert _strip_legacy_preview("") == ""
+        assert _strip_legacy_preview("plain text") == "plain text"
+
+    def test_item_name_extracts_from_dict_or_str(self):
+        from datus.cli.action_display.tool_content import _item_name
+
+        assert _item_name("orders") == "orders"
+        assert _item_name({"name": "n1"}) == "n1"
+        assert _item_name({"table_name": "t1"}) == "t1"
+        assert _item_name({"other": "x"}) == ""
+
+    def test_fmt_count_with_preview_lists_first_items(self):
+        from datus.cli.action_display.tool_content import _fmt_count_with_preview
+
+        result = _fmt_count_with_preview(3, "table", "tables", ["orders", "customers", "products"])
+        assert result == "3 tables: orders, customers, products"
+
+    def test_fmt_count_with_preview_adds_ellipsis_when_truncated(self):
+        from datus.cli.action_display.tool_content import _fmt_count_with_preview
+
+        result = _fmt_count_with_preview(5, "table", "tables", ["a", "b", "c", "d", "e"], max_show=3)
+        assert result == "5 tables: a, b, c, ..."
+
+    def test_fmt_count_with_preview_singular_noun(self):
+        from datus.cli.action_display.tool_content import _fmt_count_with_preview
+
+        assert _fmt_count_with_preview(1, "table", "tables", ["solo"]) == "1 table: solo"
+
+    def test_fmt_count_with_preview_without_items(self):
+        from datus.cli.action_display.tool_content import _fmt_count_with_preview
+
+        assert _fmt_count_with_preview(7, "file", "files") == "7 files"
+
+
+@pytest.mark.ci
+class TestExtractFileContent:
+    """Coverage for the robust file-body extraction used by _build_read_file."""
+
+    def test_none_returns_none(self):
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        assert _extract_file_content(None) is None
+
+    def test_plain_string_is_body(self):
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        assert _extract_file_content("hello\nworld") == "hello\nworld"
+
+    def test_raw_output_dict_result_key(self):
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        out = {"raw_output": {"success": 1, "result": "abc\n"}}
+        assert _extract_file_content(out) == "abc\n"
+
+    def test_raw_output_json_string(self):
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        out = {"raw_output": '{"success": 1, "result": "line1\\nline2"}'}
+        assert _extract_file_content(out) == "line1\nline2"
+
+    def test_raw_output_plain_string(self):
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        out = {"raw_output": "not json, just content"}
+        assert _extract_file_content(out) == "not json, just content"
+
+    def test_top_level_content_key(self):
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        out = {"content": "body"}
+        assert _extract_file_content(out) == "body"
+
+    def test_non_dict_non_string_returns_none(self):
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        assert _extract_file_content(42) is None
+
+
+@pytest.mark.ci
+class TestToolArgsFormatters:
+    """Spot-check per-tool arg summary formatters registered in the table."""
+
+    def _args(self, **kwargs) -> dict:
+        return kwargs
+
+    def test_list_tables_kw_args(self):
+        from datus.cli.action_display.tool_content import _TOOL_ARGS_FORMATTERS
+
+        fmt = _TOOL_ARGS_FORMATTERS["list_tables"]
+        assert fmt(self._args(catalog="sales")) == 'catalog: "sales"'
+        assert fmt(self._args()) == ""
+
+    def test_describe_table_positional(self):
+        from datus.cli.action_display.tool_content import _TOOL_ARGS_FORMATTERS
+
+        fmt = _TOOL_ARGS_FORMATTERS["describe_table"]
+        assert fmt(self._args(table_name="orders")) == '"orders"'
+
+    def test_grep_kw_args(self):
+        from datus.cli.action_display.tool_content import _TOOL_ARGS_FORMATTERS
+
+        fmt = _TOOL_ARGS_FORMATTERS["grep"]
+        assert fmt(self._args(pattern="TODO", path="src")) == 'pattern: "TODO", path: "src"'
+
+    def test_list_databases_is_empty(self):
+        from datus.cli.action_display.tool_content import _TOOL_ARGS_FORMATTERS
+
+        fmt = _TOOL_ARGS_FORMATTERS["list_databases"]
+        assert fmt({}) == ""
+
+    def test_skill_execute_command_kw(self):
+        from datus.cli.action_display.tool_content import _TOOL_ARGS_FORMATTERS
+
+        fmt = _TOOL_ARGS_FORMATTERS["skill_execute_command"]
+        assert fmt(self._args(skill_name="s", command="c")) == 'skill_name: "s", command: "c"'
+
+
+@pytest.mark.ci
+class TestBuilderPostProcessing:
+    """End-to-end check that the registry populates args_summary / compact_result."""
+
+    def test_registered_tool_gets_custom_args_summary(self):
+        builder = ToolCallContentBuilder()
+        action = _make(
+            input_data={"function_name": "describe_table", "arguments": {"table_name": "orders"}},
+            output_data={"result": ["c1", "c2"]},
+        )
+        tc = builder.build(action, verbose=False)
+        assert tc.args_summary == '"orders"'
+        assert "2 columns" in tc.compact_result
+
+    def test_unknown_tool_falls_back_to_kv_pairs(self):
+        builder = ToolCallContentBuilder()
+        action = _make(
+            input_data={"function_name": "custom_tool", "arguments": {"x": "1", "y": "2"}},
+            output_data={"success": True},
+        )
+        tc = builder.build(action, verbose=False)
+        # Fallback: first two k:v pairs joined by ", "
+        assert 'x: "1"' in tc.args_summary
+        assert 'y: "2"' in tc.args_summary
+
+    def test_failed_action_sets_error_as_compact_result(self):
+        builder = ToolCallContentBuilder()
+        action = _make(
+            input_data={"function_name": "unknown_tool", "arguments": {}},
+            output_data={"raw_output": '{"error": "bad thing"}'},
+            status=ActionStatus.FAILED,
+        )
+        tc = builder.build(action, verbose=False)
+        assert "bad thing" in tc.compact_result

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -344,6 +344,20 @@ class TestBuildReadQuery:
         tc = _build_read_query(a, verbose=False)
         assert tc.output_preview == ""
 
+    def test_compact_infers_cols_from_compressed_data(self):
+        """When column_count is absent, infer column count from the first CSV header row."""
+        a = _make(
+            input_data={"function_name": "read_query"},
+            output_data={
+                "raw_output": (
+                    '{"success": 1, "result": {"original_rows": 7, '
+                    '"compressed_data": "id,name,created_at\\n1,a,2024\\n2,b,2025"}}'
+                )
+            },
+        )
+        tc = _build_read_query(a, verbose=False)
+        assert tc.compact_result == "7 \u00d7 3 result"
+
 
 @pytest.mark.ci
 class TestBuildSearchTable:
@@ -354,7 +368,7 @@ class TestBuildSearchTable:
         )
         tc = _build_search_table(a, verbose=False)
         assert "2 tables" in tc.compact_result
-        assert "1 sample rows" in tc.compact_result
+        assert "1 sample row" in tc.compact_result
 
     def test_compact_with_compressed_sample_data(self):
         a = _make(
@@ -373,7 +387,7 @@ class TestBuildSearchTable:
         )
         tc = _build_search_table(a, verbose=False)
         assert "2 tables" in tc.compact_result
-        assert "1 sample rows" in tc.compact_result
+        assert "1 sample row" in tc.compact_result
 
     def test_compact_no_data(self):
         a = _make(input_data={"function_name": "search_table"})
@@ -1237,7 +1251,7 @@ class TestBuildSearchKnowledge:
             output_data={"result": [{"search_text": "q1", "explanation": "e1"}]},
         )
         tc = _build_search_knowledge(a, verbose=False)
-        assert "1 knowledge entries" in tc.compact_result
+        assert "1 knowledge entry matched" in tc.compact_result
 
 
 @pytest.mark.ci
@@ -1999,6 +2013,26 @@ class TestExtractFileContent:
 
         out = {"content": "body"}
         assert _extract_file_content(out) == "body"
+
+    def test_top_level_generic_key_is_ignored(self):
+        """Top-level ``text`` / ``data`` / ``output`` often hold wrappers, not bodies."""
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        # ``text`` at the top level must not be mistaken for the file body.
+        assert _extract_file_content({"text": '{"success": 1}'}) is None
+        assert _extract_file_content({"data": "wrapper"}) is None
+        assert _extract_file_content({"output": "wrapper"}) is None
+
+    def test_raw_output_wins_over_top_level_text(self):
+        """When both a wrapper ``text`` field and ``raw_output`` are present,
+        the real body inside ``raw_output`` takes precedence."""
+        from datus.cli.action_display.tool_content import _extract_file_content
+
+        out = {
+            "text": '{"success": 1, "result": "envelope-only"}',
+            "raw_output": {"success": 1, "result": "real body"},
+        }
+        assert _extract_file_content(out) == "real body"
 
     def test_non_dict_non_string_returns_none(self):
         from datus.cli.action_display.tool_content import _extract_file_content

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -423,7 +423,9 @@ class TestBuildSearchGeneric:
     def test_compact_no_items(self, fn, builder):
         a = _make(input_data={"function_name": fn}, output_data={"k": "v"})
         tc = builder(a, verbose=False)
-        assert "0 " in tc.compact_result
+        # Shape-aware: "0 <noun(s)> matched" so a stray "0 " elsewhere won't pass.
+        assert tc.compact_result.startswith("0 ")
+        assert tc.compact_result.endswith(" matched")
 
 
 # ── Builder class ──────────────────────────────────────────────────

--- a/tests/unit_tests/cli/test_action_history_display.py
+++ b/tests/unit_tests/cli/test_action_history_display.py
@@ -2655,7 +2655,7 @@ class TestGetToolOutputPreview:
         )
         tc = _build_search_table(action, verbose=False)
         assert "2 tables" in tc.compact_result
-        assert "1 sample rows" in tc.compact_result
+        assert "1 sample row" in tc.compact_result
 
     def test_search_metrics_function(self):
         """search_metrics function shows metrics count via registered builder."""
@@ -2681,7 +2681,7 @@ class TestGetToolOutputPreview:
             output_data={"result": [1]},
         )
         tc = _build_search_reference_sql(action, verbose=False)
-        assert "reference SQLs" in tc.compact_result
+        assert "1 reference SQL matched" in tc.compact_result
 
     def test_search_external_knowledge_function(self):
         """search_external_knowledge function shows knowledge count via registered builder."""
@@ -2694,7 +2694,7 @@ class TestGetToolOutputPreview:
             output_data={"result": [1]},
         )
         tc = _build_search_external_knowledge(action, verbose=False)
-        assert "knowledge entries" in tc.compact_result
+        assert "1 knowledge entry matched" in tc.compact_result
 
     def test_search_documents_function(self):
         """search_documents function shows document count via registered builder."""
@@ -2707,7 +2707,7 @@ class TestGetToolOutputPreview:
             output_data={"result": [1]},
         )
         tc = _build_search_documents(action, verbose=False)
-        assert "documents" in tc.compact_result
+        assert "1 document matched" in tc.compact_result
 
     def test_generic_success_fallback(self):
         """Generic success output without items shows 'Success'."""

--- a/tests/unit_tests/cli/test_action_history_display.py
+++ b/tests/unit_tests/cli/test_action_history_display.py
@@ -2567,7 +2567,7 @@ class TestGetToolOutputPreview:
             output_data={"raw_output": '{"result": [{"name": "t1"}, {"name": "t2"}]}'},
         )
         tc = _build_list_tables(action, verbose=False)
-        assert "2 tables" in tc.output_preview
+        assert "2 tables" in tc.compact_result
 
     def test_describe_table_function(self):
         """describe_table function shows column count via registered builder."""
@@ -2580,7 +2580,7 @@ class TestGetToolOutputPreview:
             output_data={"raw_output": '{"result": [{"col": "a"}, {"col": "b"}, {"col": "c"}]}'},
         )
         tc = _build_describe_table(action, verbose=False)
-        assert "3 columns" in tc.output_preview
+        assert "3 columns" in tc.compact_result
 
     def test_error_output(self):
         """Failed output with error message shows failure."""
@@ -2641,7 +2641,7 @@ class TestGetToolOutputPreview:
             output_data={"raw_output": '{"original_rows": 42}'},
         )
         tc = _build_read_query(action, verbose=False)
-        assert "42 rows" in tc.output_preview
+        assert "42 rows" in tc.compact_result
 
     def test_search_table_function(self):
         """search_table function shows metadata and sample counts via registered builder."""
@@ -2654,8 +2654,8 @@ class TestGetToolOutputPreview:
             output_data={"raw_output": '{"metadata": [{"t": 1}, {"t": 2}], "sample_data": [{"r": 1}]}'},
         )
         tc = _build_search_table(action, verbose=False)
-        assert "2 tables" in tc.output_preview
-        assert "1 sample rows" in tc.output_preview
+        assert "2 tables" in tc.compact_result
+        assert "1 sample rows" in tc.compact_result
 
     def test_search_metrics_function(self):
         """search_metrics function shows metrics count via registered builder."""
@@ -2668,7 +2668,7 @@ class TestGetToolOutputPreview:
             output_data={"result": [1, 2]},
         )
         tc = _build_search_metrics(action, verbose=False)
-        assert "metrics" in tc.output_preview
+        assert "metrics" in tc.compact_result
 
     def test_search_reference_sql_function(self):
         """search_reference_sql function shows SQL count via registered builder."""
@@ -2681,7 +2681,7 @@ class TestGetToolOutputPreview:
             output_data={"result": [1]},
         )
         tc = _build_search_reference_sql(action, verbose=False)
-        assert "reference SQLs" in tc.output_preview
+        assert "reference SQLs" in tc.compact_result
 
     def test_search_external_knowledge_function(self):
         """search_external_knowledge function shows knowledge count via registered builder."""
@@ -2694,7 +2694,7 @@ class TestGetToolOutputPreview:
             output_data={"result": [1]},
         )
         tc = _build_search_external_knowledge(action, verbose=False)
-        assert "knowledge entries" in tc.output_preview
+        assert "knowledge entries" in tc.compact_result
 
     def test_search_documents_function(self):
         """search_documents function shows document count via registered builder."""
@@ -2707,7 +2707,7 @@ class TestGetToolOutputPreview:
             output_data={"result": [1]},
         )
         tc = _build_search_documents(action, verbose=False)
-        assert "documents" in tc.output_preview
+        assert "documents" in tc.compact_result
 
     def test_generic_success_fallback(self):
         """Generic success output without items shows 'Success'."""

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3847,8 +3847,8 @@ class TestDropIfMatchesFinal:
         assert result is None
         assert incremental == [pending]
 
-    def test_non_dict_outputs_still_flush(self):
-        """When either side's output is non-dict, be conservative and flush."""
+    def test_non_dict_pending_output_is_dropped(self):
+        """Non-dict pending output has no extractable text — drop it."""
         from datus.cli.chat_commands import _drop_if_matches_final
 
         incremental: list = []
@@ -3863,15 +3863,14 @@ class TestDropIfMatchesFinal:
         )
         final = self._final("anything")
         _drop_if_matches_final(pending, final, incremental)
-        assert incremental == [pending]
+        assert incremental == []
 
-    def test_empty_pending_text_flushes_without_match(self):
-        """Empty pending text should not accidentally match an empty final."""
+    def test_empty_pending_text_is_dropped(self):
+        """Empty pending text has nothing to contribute — drop it."""
         from datus.cli.chat_commands import _drop_if_matches_final
 
         incremental: list = []
         pending = self._assistant("")
-        final = self._final("")
+        final = self._final("anything")
         _drop_if_matches_final(pending, final, incremental)
-        # Both empty → no text to compare; flushed to stay safe.
-        assert incremental == [pending]
+        assert incremental == []

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3785,3 +3785,93 @@ class TestMakeInputCollector:
         action = self._make_action("request_batch", {"contents": ["Q1?", "Q2?"], "choices": [{}, {}]})
         result = collector(action, console)
         assert result is None
+
+
+# ===========================================================================
+# _drop_if_matches_final (thinking pending reconcile helper)
+# ===========================================================================
+
+
+@pytest.mark.ci
+class TestDropIfMatchesFinal:
+    """Unit tests for the helper that drops a deferred ASSISTANT text when its
+    content equals the node's final *_response body, or flushes it otherwise."""
+
+    def _assistant(self, raw: str) -> ActionHistory:
+        return ActionHistory(
+            action_id="a1",
+            role=ActionRole.ASSISTANT,
+            messages="",
+            action_type="response",
+            input={},
+            output={"raw_output": raw, "is_thinking": False},
+            status=ActionStatus.SUCCESS,
+        )
+
+    def _final(self, response: str) -> ActionHistory:
+        return ActionHistory(
+            action_id="f1",
+            role=ActionRole.ASSISTANT,
+            messages="",
+            action_type="chat_response",
+            input={},
+            output={"response": response},
+            status=ActionStatus.SUCCESS,
+        )
+
+    def test_pending_none_returns_none(self):
+        from datus.cli.chat_commands import _drop_if_matches_final
+
+        incremental: list = []
+        result = _drop_if_matches_final(None, self._final("hi"), incremental)
+        assert result is None
+        assert incremental == []
+
+    def test_texts_equal_drops_pending(self):
+        from datus.cli.chat_commands import _drop_if_matches_final
+
+        incremental: list = []
+        pending = self._assistant("  Hello world  ")
+        final = self._final("Hello world")
+        result = _drop_if_matches_final(pending, final, incremental)
+        assert result is None
+        assert incremental == []  # pending was NOT flushed
+
+    def test_texts_differ_flushes_pending(self):
+        from datus.cli.chat_commands import _drop_if_matches_final
+
+        incremental: list = []
+        pending = self._assistant("mid-turn thought")
+        final = self._final("actual final answer")
+        result = _drop_if_matches_final(pending, final, incremental)
+        assert result is None
+        assert incremental == [pending]
+
+    def test_non_dict_outputs_still_flush(self):
+        """When either side's output is non-dict, be conservative and flush."""
+        from datus.cli.chat_commands import _drop_if_matches_final
+
+        incremental: list = []
+        pending = ActionHistory(
+            action_id="a2",
+            role=ActionRole.ASSISTANT,
+            messages="raw",
+            action_type="response",
+            input={},
+            output="not a dict",
+            status=ActionStatus.SUCCESS,
+        )
+        final = self._final("anything")
+        _drop_if_matches_final(pending, final, incremental)
+        assert incremental == [pending]
+
+    def test_empty_pending_text_flushes_without_match(self):
+        """Empty pending text should not accidentally match an empty final."""
+        from datus.cli.chat_commands import _drop_if_matches_final
+
+        incremental: list = []
+        pending = self._assistant("")
+        final = self._final("")
+        _drop_if_matches_final(pending, final, incremental)
+        # Both empty → no text to compare; flushed to stay safe.
+        assert incremental == [pending]


### PR DESCRIPTION
## Why

Two related issues showed up while using the chat CLI:

1. **Mid-turn thinking text was lost.** The model layer tags the tail LLM
   text with `is_thinking=False`, and the CLI filtered every
   `is_thinking=False` ASSISTANT action out of the streaming trace. OpenAI
   Agents SDK happens to emit the reasoning text *before* the first
   `tool_call_item`, so the first chunk is always flagged `False` even
   when more tool calls follow. The result was a trace that jumped
   straight from one tool call to the next with no visible reasoning in
   between — exactly the thinking the user wanted to see.

2. **Tool calls were hard to scan.** The compact layout showed only the
   tool name (`🔧 list_tables - ✓ (12.4s)`), never the arguments, and
   every builder put its own `✓` prefix in a different place. Users had
   no way to tell at a glance *which* table the agent was reading or
   *what* pattern `glob` was matching without toggling Ctrl+O.

## Solution

Two separate commits, one per concern:

### `[BugFix] Preserve mid-turn thinking in streaming CLI display`

Replace the direct `is_thinking=False` filter in `chat_commands.py` with a
pending-buffer reconciliation:

- Non-thinking ASSISTANT actions are deferred (not appended immediately).
- Any subsequent non-ASSISTANT action flushes the pending entry so
  mid-turn thinking stays visible.
- When a node `*_response` arrives, compare the pending `raw_output` with
  the final response body; drop the pending entry only when it duplicates
  the final answer, otherwise flush it to the incremental stream.
- At end of stream, flush any remaining pending entry if no `*_response`
  was captured.

### `[Enhancement] Revamp tool call compact display layout`

Switch the non-verbose renderer to a concise two-line layout:

```
⏺ 🔧 tool_name(args)
  └─ ✓ concise result · duration
```

- `ToolCallContent` gains `args_summary` / `compact_result` fields.
  `output_preview` is kept as a legacy fallback.
- A `_TOOL_ARGS_FORMATTERS` table covers all 30+ tools `ChatAgenticNode`
  uses today — positional style for single-arg calls
  (`read_file(\"path\")`), key:value style for multi-arg calls
  (`grep(pattern: \"x\", path: \"y\")`), empty parens for no-arg calls.
- Whitespace in arg values is collapsed so multi-line SQL / file bodies
  don't wrap the header onto multiple lines.
- Durations under 0.1s render as `(<0.1s)` instead of rounding to `0.0s`.
- Per-tool builders now write `compact_result` directly; a helper strips
  legacy `✓`/`✗` prefixes if an older builder still emits one.
- `read_file`, `describe_table`, `get_table_ddl`, `write_file`,
  `edit_file`, `grep`, `list_tables` / `list_databases` / `list_schemas`,
  `search_*`, `parse_temporal_expressions`, and `read_query` now surface
  meaningful summaries (e.g. `245 lines`, `12 columns`,
  `3 matches in 2 files`, `15 × 3 result`, `2024-01-01 → 2024-12-31`).
- `get_knowledge` is reclassified from `search_generic` to `get_detail`
  semantics (single entry lookup).
- `_extract_file_content` probes several output shapes so `read_file`
  works whether the SDK returns a `FuncToolResult` dict, a JSON string,
  or the raw file body.
- Legacy `format_streaming_action` prefers `compact_result` when present
  so web / print-mode paths benefit from the same improvements.

Tradeoffs considered:
- **Keep vs. remove `is_thinking` field.** Kept it — SSE / API layers
  still use it to distinguish thinking deltas from final messages
  (`action_sse_converter`, `chat_task_manager`). Only the CLI filter
  semantic changed.
- **Emit thinking delta streaming vs. show full chunks.** Stuck with
  chunks for now. The `thinking_delta` events are still marked
  ''not supported yet'' in `streaming.py`; revisiting this is a larger
  UI change.

## Test Cases

New unit tests (all in `tests/unit_tests/cli/`):

- `TestDropIfMatchesFinal` — covers empty / matching / non-matching /
  non-dict / empty-both reconciliation cases for the thinking pending
  buffer.
- `TestCompactHelpers` — whitespace collapsing, middle-truncation,
  positional / kw / fallback arg summaries, error extraction,
  `set_default_args_summary`, `set_error_as_result`,
  `_strip_legacy_preview`, `_item_name`, `_fmt_count_with_preview`.
- `TestExtractFileContent` — every `read_file` output shape (dict,
  JSON string, raw string, top-level `content` key, non-dict fallback).
- `TestToolArgsFormatters` — spot-check of positional / kw / empty
  formatters across representative tools.
- `TestBuilderPostProcessing` — end-to-end: registry populates
  `args_summary` / `compact_result`, fallback kw pairs, failure paths.

Existing assertions that looked at the legacy `output_preview` field
were migrated to `compact_result` to match the new field responsibility.

Coverage after the change:
- Overall: **82.84%** (> 80% gate)
- Diff coverage vs upstream/main: **83%** (> 80% gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More compact, structured tool output: headers include tool + concise arg summary; bodies use a tree-style line with preferred compact result, status mark (✓/×), and duration; body always emitted even when no result text.
  * Per-tool concise summaries (rows×cols, DDL char counts, file/read/write counts, temporal ranges) and improved compact extraction for file reads.
  * Durations <0.1s display as "<0.1s".

* **Bug Fixes**
  * Avoided duplicate assistant streaming responses by reconciling buffered incremental and final assistant outputs.

* **Tests**
  * Updated and added tests for compact summaries, arg formatting, error extraction, file-content probing, and assistant-buffer reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->