### PR TITLE
[BugFix] Drop stale {current_database} path level from KB generation templates

### DIFF
--- a/datus/agent/node/feedback_agentic_node.py
+++ b/datus/agent/node/feedback_agentic_node.py
@@ -135,7 +135,7 @@ class FeedbackAgenticNode(AgenticNode):
                 "native_tools": ", ".join([tool.name for tool in self.tools]) if self.tools else "None",
                 "has_task_tool": bool(self.sub_agent_task_tool),
                 "has_ask_user_tool": self.ask_user_tool is not None,
-                "knowledge_base_dir": str(self.agent_config.path_manager.knowledge_base_home),
+                "knowledge_base_dir": str(self.agent_config.path_manager.subject_dir),
                 "current_database": self.agent_config.current_database,
                 "workspace_root": self._resolve_workspace_root(),
             }

--- a/datus/prompts/prompt_templates/gen_ext_knowledge_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_ext_knowledge_system_1.0.j2
@@ -4,7 +4,7 @@ You are a business knowledge discovery expert.
 - Database tools: {{ native_tools }}
 - **verify_sql(sql)**: Validate your SQL against hidden reference. Returns `success` (0 or 1) and `suggestions` if failed.
 - **get_knowledge(paths)**: Get existing knowledge by paths. Each path is `[...subject_path, name]`
-- **write_file(path, content, file_type)**: Save files. Use `file_type="ext_knowledge"` for knowledge YAML, omit for SQL files. Always pass `path` as `{{ kind_subdir }}/{{ current_database }}/<filename>` (relative to the knowledge base root).
+- **write_file(path, content, file_type)**: Save files. Use `file_type="ext_knowledge"` for knowledge YAML, omit for SQL files. Always pass `path` as `{{ kind_subdir }}/<filename>` (relative to the knowledge base root).
 - **edit_file(filename, old_text, new_text)**: Apply targeted edits to an existing file (SQL or knowledge).
 - **read_file(filename)**: Read back file content (e.g., to pass SQL to `read_query` or `verify_sql`).
 {% if has_ask_user_tool %}
@@ -13,7 +13,7 @@ You are a business knowledge discovery expert.
 
 ## Workspace
 - Knowledge base root (`read_file` / `write_file` / `edit_file` operate inside this sandbox): {{ knowledge_base_dir }}
-- External knowledge directory for this database: `{{ kind_subdir }}/{{ current_database }}/`
+- External knowledge directory: `{{ kind_subdir }}/`
   (resolves to `{{ ext_knowledge_dir }}` on disk)
 
 {% if has_user_specified_subject %}
@@ -165,7 +165,7 @@ explanation: "When calculating GMV: (1) Use SUM(amount) to aggregate; (2) MUST f
    - **New knowledge**: Create new entry with unique subject_path
    - **Update existing**: If found knowledge is incomplete or incorrect, use SAME subject_path to update it
 3. Save: `write_file(path, yaml_content, file_type="ext_knowledge")`
-   - **Path Rule**: Always write under `{{ kind_subdir }}/{{ current_database }}/<filename>` (relative to the knowledge base root). Example: `{{ kind_subdir }}/{{ current_database }}/gmv_payment_filters.yaml`. Bare filenames are silently normalized but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also accepted.
+   - **Path Rule**: Always write under `{{ kind_subdir }}/<filename>` (relative to the knowledge base root). Example: `{{ kind_subdir }}/gmv_payment_filters.yaml`. Bare filenames are silently normalized but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also accepted.
 
 **Update Policy**: When you use the same `subject_path + name` as existing knowledge, it will be **updated** (not duplicated). Use this to:
 - Fix incorrect explanations

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
@@ -141,13 +141,13 @@ Skip any metric that already exists - do NOT update or overwrite.
 
 All `write_file` / `edit_file` / `read_file` paths are relative to the
 knowledge base root (`{{ knowledge_base_dir }}`). Always include the
-`{{ kind_subdir }}/{{ current_database }}/` prefix so the file lands in
+`{{ kind_subdir }}/` prefix so the file lands in
 the right namespace and is discoverable by downstream readers.
 
-1. **Semantic Model File**: `{{ kind_subdir }}/{{ current_database }}/{table_name}.yml`
+1. **Semantic Model File**: `{{ kind_subdir }}/{table_name}.yml`
    - Use `write_file` to save if new, or skip if exists and matches
 
-2. **Metrics File**: `{{ kind_subdir }}/{{ current_database }}/metrics/{table_name}_metrics.yml`
+2. **Metrics File**: `{{ kind_subdir }}/metrics/{table_name}_metrics.yml`
    - Create a NEW file for all core metrics
    - Use YAML document separator `---` between metrics
 
@@ -175,18 +175,18 @@ If `query_metrics` fails for a metric, use an empty string for that metric's SQL
 
 ### Step 10: Complete Generation
 
-After validation succeeds and SQLs are collected, MUST call `end_metric_generation` tool with the metric SQLs as a JSON string. `metric_file` and `semantic_model_file` are paths under the knowledge base root — use the same `{{ kind_subdir }}/{{ current_database }}/` prefix you wrote to:
+After validation succeeds and SQLs are collected, MUST call `end_metric_generation` tool with the metric SQLs as a JSON string. `metric_file` and `semantic_model_file` are paths under the knowledge base root — use the same `{{ kind_subdir }}/` prefix you wrote to:
 ```
 end_metric_generation(
-    metric_file="{{ kind_subdir }}/{{ current_database }}/metrics/users_metrics.yml",
-    semantic_model_file="{{ kind_subdir }}/{{ current_database }}/users.yml",
+    metric_file="{{ kind_subdir }}/metrics/users_metrics.yml",
+    semantic_model_file="{{ kind_subdir }}/users.yml",
     metric_sqls_json='{"metric1": "SELECT ...", "metric2": "SELECT ..."}'
 )
 ```
 
 ## Workspace
 - Knowledge base root (`read_file` / `write_file` / `edit_file` operate inside this sandbox): {{ knowledge_base_dir }}
-- Semantic model directory for this database: `{{ kind_subdir }}/{{ current_database }}/`
+- Semantic model directory: `{{ kind_subdir }}/`
 
 ## Output Format
 
@@ -194,14 +194,14 @@ end_metric_generation(
 
 ```json
 {
-  "semantic_model_file": "{{ kind_subdir }}/{{ current_database }}/users.yml",
-  "metric_file": "{{ kind_subdir }}/{{ current_database }}/metrics/users_metrics.yml",
+  "semantic_model_file": "{{ kind_subdir }}/users.yml",
+  "metric_file": "{{ kind_subdir }}/metrics/users_metrics.yml",
   "output": "markdown summary of extracted measures and generated metrics"
 }
 ```
 
-- `semantic_model_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/{{ current_database }}/users.yml"`
-- `metric_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/{{ current_database }}/metrics/users_metrics.yml"`
+- `semantic_model_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/users.yml"`
+- `metric_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/metrics/users_metrics.yml"`
 - `output`: Brief summary message
 
 **DO NOT** return markdown, plain text, or any other format. Return **ONLY** the JSON object.

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -113,9 +113,9 @@ Skip any metric that already exists — do NOT update or overwrite.
 
 ### Step 5: Write, Validate, and Dry-Run
 
-**File paths**: All `write_file` / `edit_file` / `read_file` calls — and the `metric_file` / `semantic_model_file` arguments to `end_metric_generation` — use paths relative to the **knowledge base root** (`{{ knowledge_base_dir }}`). Always include the `{{ kind_subdir }}/{{ current_database }}/` prefix:
-  - Semantic model: `{{ kind_subdir }}/{{ current_database }}/{table_name}.yml`
-  - Metric file: `{{ kind_subdir }}/{{ current_database }}/metrics/{table_name}_metrics.yml`
+**File paths**: All `write_file` / `edit_file` / `read_file` calls — and the `metric_file` / `semantic_model_file` arguments to `end_metric_generation` — use paths relative to the **knowledge base root** (`{{ knowledge_base_dir }}`). Always include the `{{ kind_subdir }}/` prefix:
+  - Semantic model: `{{ kind_subdir }}/{table_name}.yml`
+  - Metric file: `{{ kind_subdir }}/metrics/{table_name}_metrics.yml`
   Bare filenames are silently normalized by the host but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also tolerated.
 
 1. **Write files**: Use `write_file` to save metric YAML (and semantic model if newly created)
@@ -152,7 +152,7 @@ After ALL metrics have been reviewed one by one:
 
 ## Workspace
 - Knowledge base root (`read_file` / `write_file` / `edit_file` operate inside this sandbox): {{ knowledge_base_dir }}
-- Semantic model directory for this database: `{{ kind_subdir }}/{{ current_database }}/`
+- Semantic model directory: `{{ kind_subdir }}/`
   (resolves to `{{ semantic_model_dir }}` on disk)
 
 ## Output Format
@@ -161,14 +161,14 @@ After ALL metrics have been reviewed one by one:
 
 ```json
 {
-  "semantic_model_file": "{{ kind_subdir }}/{{ current_database }}/{table_name}.yml",
-  "metric_file": "{{ kind_subdir }}/{{ current_database }}/metrics/{table_name}_metrics.yml",
+  "semantic_model_file": "{{ kind_subdir }}/{table_name}.yml",
+  "metric_file": "{{ kind_subdir }}/metrics/{table_name}_metrics.yml",
   "output": "markdown summary of the metric definition"
 }
 ```
 
-- `semantic_model_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/{{ current_database }}/users.yml"`
-- `metric_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/{{ current_database }}/metrics/users_metrics.yml"`
+- `semantic_model_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/users.yml"`
+- `metric_file`: Path under the knowledge base root, e.g. `"{{ kind_subdir }}/metrics/users_metrics.yml"`
 - `output`: Brief summary message
 
 **DO NOT** return markdown, plain text, or any other format. Return **ONLY** the JSON object.

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
@@ -16,7 +16,7 @@ When user mentions multiple tables (e.g., "orders, customers, products"), you sh
 
 ## Workspace
 - Knowledge base root (`read_file` / `write_file` / `edit_file` operate inside this sandbox): {{ knowledge_base_dir }}
-- Semantic model directory for this database: `{{ kind_subdir }}/{{ current_database }}/`
+- Semantic model directory: `{{ kind_subdir }}/`
   (resolves to `{{ semantic_model_dir }}` on disk)
 
 ## Instructions
@@ -75,7 +75,7 @@ Please strictly follow the instructions below:
 
 5. **Save YAML file**:
    - Use `write_file` tool to store the semantic model
-   - **Path**: write under `{{ kind_subdir }}/{{ current_database }}/{table_name}.yml` (relative to the knowledge base root). Example: `{{ kind_subdir }}/{{ current_database }}/orders.yml`.
+   - **Path**: write under `{{ kind_subdir }}/{table_name}.yml` (relative to the knowledge base root). Example: `{{ kind_subdir }}/orders.yml`.
    - If you forget the prefix the host will silently normalize it, but always include it so subsequent `read_file` / `edit_file` use the same path.
    - If semantic model already exists, update it with `edit_file` if anything changed
 
@@ -95,8 +95,8 @@ Please strictly follow the instructions below:
 7. **Complete generation** (REQUIRED - ONLY AFTER VALIDATION PASSES):
    - **PREREQUISITE**: `validate_semantic` MUST have returned success. If not, go back to step 6.
    - If `end_semantic_model_generation` tool is available: Call it with the list of generated file paths
-     - **Path Rule**: Use the same path you passed to `write_file`, e.g. `{{ kind_subdir }}/{{ current_database }}/{table_name}.yml`. Absolute paths are also accepted; bare filenames (`orders.yml`) are silently normalized but the prefixed form is preferred for clarity.
-     - Example: `end_semantic_model_generation(semantic_model_files=["{{ kind_subdir }}/{{ current_database }}/orders.yml", "{{ kind_subdir }}/{{ current_database }}/customers.yml"])`
+     - **Path Rule**: Use the same path you passed to `write_file`, e.g. `{{ kind_subdir }}/{table_name}.yml`. Absolute paths are also accepted; bare filenames (`orders.yml`) are silently normalized but the prefixed form is preferred for clarity.
+     - Example: `end_semantic_model_generation(semantic_model_files=["{{ kind_subdir }}/orders.yml", "{{ kind_subdir }}/customers.yml"])`
    - **CRITICAL**: After all steps complete (including tool call if available), your final response MUST be a JSON object (see Output Format section)
 
 ## Multi-Table Generation Workflow
@@ -177,7 +177,7 @@ data_source:
 
 ### Step 7: Complete Generation (ONLY AFTER VALIDATION PASSES)
 - **PREREQUISITE**: `validate_semantic` MUST have returned success
-- If `end_semantic_model_generation` tool is available: Call it with **ALL generated file paths** using the form `{{ kind_subdir }}/{{ current_database }}/{table_name}.yml` (absolute paths are also accepted)
+- If `end_semantic_model_generation` tool is available: Call it with **ALL generated file paths** using the form `{{ kind_subdir }}/{table_name}.yml` (absolute paths are also accepted)
 - **CRITICAL**: Your final response MUST be a JSON object (see Output Format section)
 
 ## Relationship Discovery Strategy
@@ -213,7 +213,7 @@ Generate comprehensive, production-ready semantic models following MetricFlow be
 }
 ```
 
-- `semantic_model_files`: Array of generated file paths in the form `{{ kind_subdir }}/{{ current_database }}/{table_name}.yml` (e.g. `"{{ kind_subdir }}/{{ current_database }}/orders.yml"`). Absolute paths are also accepted and left unchanged.
+- `semantic_model_files`: Array of generated file paths in the form `{{ kind_subdir }}/{table_name}.yml` (e.g. `"{{ kind_subdir }}/orders.yml"`). Absolute paths are also accepted and left unchanged.
 - `output`: Markdown summary of generated semantic models
 
 The "output" should summarize:

--- a/datus/prompts/prompt_templates/gen_sql_summary_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_sql_summary_system_1.1.j2
@@ -8,7 +8,7 @@ You are a SQL analysis expert helping to analyze and summarize SQL queries for k
 
 ## Workspace
 - Knowledge base root (`read_file` / `write_file` / `edit_file` operate inside this sandbox): {{ knowledge_base_dir }}
-- SQL summary directory for this database: `{{ kind_subdir }}/{{ current_database }}/`
+- SQL summary directory: `{{ kind_subdir }}/`
   (resolves to `{{ sql_summary_dir }}` on disk)
 
 {% if has_subject_tree %}
@@ -58,7 +58,7 @@ Follow these steps to generate SQL summary:
    - This is a required tool call - the file will not be saved without it
    - where the `path` is the file path under the knowledge base root, and the `yaml_content` is the YAML content of the SQL summary
    - **Filename Rule**: MUST include the generated ID in filename to ensure uniqueness (e.g., `"sales_report_{id}.yaml"`)
-   - **Path Rule**: Always write under `{{ kind_subdir }}/{{ current_database }}/{name}_{id}.yaml`. Example: `{{ kind_subdir }}/{{ current_database }}/sales_report_{id}.yaml`. Bare filenames are silently normalized but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also accepted.
+   - **Path Rule**: Always write under `{{ kind_subdir }}/{name}_{id}.yaml`. Example: `{{ kind_subdir }}/sales_report_{id}.yaml`. Bare filenames are silently normalized but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also accepted.
    - Use the same path in the YAML's `filepath` field
 
 ## YAML Structure
@@ -151,7 +151,7 @@ Generate comprehensive SQL summaries that enable effective knowledge reuse and s
 **You MUST complete ALL tool calls before returning the final response:**
 
 1. First, call `generate_sql_summary_id(sql)` to get the unique ID
-2. Then, call `write_file(path, yaml_content, file_type="sql_summary")` to save the file. Use path `{{ kind_subdir }}/{{ current_database }}/{name}_{id}.yaml`.
+2. Then, call `write_file(path, yaml_content, file_type="sql_summary")` to save the file. Use path `{{ kind_subdir }}/{name}_{id}.yaml`.
 3. Only AFTER both tool calls succeed, return the final JSON response
 
 **DO NOT return the JSON response without completing the tool calls first. The file must be written to disk.**


### PR DESCRIPTION
Post fs-refactor, KB content is anchored to {project_root}/subject/{kind}/ without a per-database subdir, but the sql_summary / semantic_model / ext_knowledge / metrics prompt templates still instructed the LLM to write under {{ kind_subdir }}/{{ current_database }}/..., producing an extra {db}/ directory on disk. Also fix feedback_agentic_node referencing the removed path_manager.knowledge_base_home attribute (now subject_dir).

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured knowledge base file organization to simplify the directory hierarchy. Removed per-database subdirectory nesting from paths for semantic models, metrics, SQL summaries, and external knowledge artifacts. Generated files now organize directly within kind-level folders, providing a flatter structure and improved consistency in how knowledge base assets are stored and accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->