### PR TITLE
[Refactor] Unify filesystem tool around project_root with zone-based access policy

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1234,3 +1234,81 @@ class AgenticNode(Node):
         if expanded_path != workspace_root:
             logger.debug(f"Expanded workspace_root from '{workspace_root}' to '{expanded_path}'")
         return expanded_path
+
+    def _resolve_filesystem_strict(self) -> bool:
+        """Resolve the ``strict`` flag for this node's filesystem tool.
+
+        Source order:
+          1. ``self.node_config["filesystem_strict"]`` — per-node YAML.
+          2. ``self.agent_config.filesystem_strict`` — process-wide default
+             (set e.g. by API / claw bootstraps).
+          3. ``False`` — CLI default, falls back to broker-prompt behavior.
+        """
+        node_flag = self.node_config.get("filesystem_strict") if self.node_config else None
+        if node_flag is not None:
+            return bool(node_flag)
+        if self.agent_config is not None:
+            global_flag = getattr(self.agent_config, "filesystem_strict", None)
+            if global_flag is not None:
+                return bool(global_flag)
+        return False
+
+    def _make_filesystem_tool(self, **kwargs):
+        """Construct a ``FilesystemFuncTool`` with this node's identity baked in.
+
+        All production call sites go through this helper so ``root_path`` is
+        uniformly ``_resolve_workspace_root()`` and ``current_node`` matches
+        ``get_node_name()`` — the two inputs the path policy module expects to
+        classify ``.datus/memory/{current_node}/**`` as a whitelist subtree
+        for this node only. The ``strict`` flag is resolved from
+        ``node_config.filesystem_strict`` / ``agent_config.filesystem_strict``
+        so API / claw can opt out of interactive EXTERNAL prompts.
+        """
+        from datus.tools.func_tool import FilesystemFuncTool
+
+        root_path = kwargs.pop("root_path", None) or self._resolve_workspace_root()
+        datus_home = kwargs.pop("datus_home", None)
+        if datus_home is None and self.agent_config is not None:
+            path_manager = getattr(self.agent_config, "path_manager", None)
+            if path_manager is not None:
+                try:
+                    datus_home = str(path_manager.datus_home)
+                except Exception:
+                    datus_home = None
+        strict = kwargs.pop("strict", None)
+        if strict is None:
+            strict = self._resolve_filesystem_strict()
+        return FilesystemFuncTool(
+            root_path=root_path,
+            current_node=kwargs.pop("current_node", None) or self.get_node_name(),
+            datus_home=datus_home,
+            strict=strict,
+            **kwargs,
+        )
+
+    def _make_filesystem_policy(self):
+        """Build a :class:`FilesystemPolicy` for ``PermissionHooks`` construction.
+
+        Returns ``None`` when this node has no ``agent_config`` or the path
+        manager cannot be resolved, so callers can treat the policy as opt-in
+        and fall back to the pre-refactor category-level behavior.
+        """
+        if not self.agent_config:
+            return None
+        path_manager = getattr(self.agent_config, "path_manager", None)
+        if path_manager is None:
+            return None
+        try:
+            from pathlib import Path as _Path
+
+            from datus.tools.permission.permission_hooks import FilesystemPolicy
+
+            return FilesystemPolicy(
+                root_path=_Path(self._resolve_workspace_root()).resolve(strict=False),
+                current_node=self.get_node_name(),
+                datus_home=_Path(path_manager.datus_home),
+                strict=self._resolve_filesystem_strict(),
+            )
+        except Exception as e:
+            logger.debug(f"Failed to build FilesystemPolicy: {e}")
+            return None

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1238,20 +1238,13 @@ class AgenticNode(Node):
     def _resolve_filesystem_strict(self) -> bool:
         """Resolve the ``strict`` flag for this node's filesystem tool.
 
-        Source order:
-          1. ``self.node_config["filesystem_strict"]`` — per-node YAML.
-          2. ``self.agent_config.filesystem_strict`` — process-wide default
-             (set e.g. by API / claw bootstraps).
-          3. ``False`` — CLI default, falls back to broker-prompt behavior.
+        Reads ``self.agent_config.filesystem_strict`` (process-wide default set
+        by API / claw bootstraps). CLI leaves it unset so EXTERNAL access falls
+        back to broker-prompt behavior.
         """
-        node_flag = self.node_config.get("filesystem_strict") if self.node_config else None
-        if node_flag is not None:
-            return bool(node_flag)
-        if self.agent_config is not None:
-            global_flag = getattr(self.agent_config, "filesystem_strict", None)
-            if global_flag is not None:
-                return bool(global_flag)
-        return False
+        if self.agent_config is None:
+            return False
+        return bool(getattr(self.agent_config, "filesystem_strict", False))
 
     def _make_filesystem_tool(self, **kwargs):
         """Construct a ``FilesystemFuncTool`` with this node's identity baked in.
@@ -1261,8 +1254,8 @@ class AgenticNode(Node):
         ``get_node_name()`` — the two inputs the path policy module expects to
         classify ``.datus/memory/{current_node}/**`` as a whitelist subtree
         for this node only. The ``strict`` flag is resolved from
-        ``node_config.filesystem_strict`` / ``agent_config.filesystem_strict``
-        so API / claw can opt out of interactive EXTERNAL prompts.
+        ``agent_config.filesystem_strict`` so API / claw can opt out of
+        interactive EXTERNAL prompts.
         """
         from datus.tools.func_tool import FilesystemFuncTool
 

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -171,10 +171,9 @@ class ChatAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+            logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 
@@ -263,6 +262,7 @@ class ChatAgenticNode(AgenticNode):
                 permission_manager=self.permission_manager,
                 node_name=self.get_node_name(),
                 tool_registry=self.tool_registry,
+                fs_policy=self._make_filesystem_policy(),
             )
 
             logger.debug(f"Permission hooks setup with {len(self.tool_registry)} registered tools")

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -145,13 +145,12 @@ class ExploreAgenticNode(AgenticNode):
     def _setup_readonly_filesystem_tools(self):
         """Setup only read-only filesystem tools (no write/edit/create/move)."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.filesystem_func_tool = self._make_filesystem_tool()
             for method_name in READONLY_FILESYSTEM_METHODS:
                 if hasattr(self.filesystem_func_tool, method_name):
                     method = getattr(self.filesystem_func_tool, method_name)
                     self.tools.append(trans_to_function_tool(method))
-            logger.debug(f"Setup readonly filesystem tools with root path: {root_path}")
+            logger.debug(f"Setup readonly filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.warning(f"Failed to setup filesystem tools, continuing without: {e}")
 

--- a/datus/agent/node/feedback_agentic_node.py
+++ b/datus/agent/node/feedback_agentic_node.py
@@ -94,9 +94,8 @@ class FeedbackAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools for writing MEMORY.md and other files."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
-            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+            self.filesystem_func_tool = self._make_filesystem_tool()
+            logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 

--- a/datus/agent/node/feedback_agentic_node.py
+++ b/datus/agent/node/feedback_agentic_node.py
@@ -92,9 +92,16 @@ class FeedbackAgenticNode(AgenticNode):
         self._rebuild_tools()
 
     def _setup_filesystem_tools(self):
-        """Setup filesystem tools for writing MEMORY.md and other files."""
+        """Setup filesystem tools for writing MEMORY.md and other files.
+
+        The tool is rooted with ``current_node=self._resolve_caller_node_name()``
+        so ``.datus/memory/{caller}/**`` lands in the WHITELIST zone — the
+        whole point of this node is to update the caller's memory, so the
+        policy must permit writes under the caller's memory subtree rather
+        than feedback's own.
+        """
         try:
-            self.filesystem_func_tool = self._make_filesystem_tool()
+            self.filesystem_func_tool = self._make_filesystem_tool(current_node=self._resolve_caller_node_name())
             logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
@@ -108,6 +115,29 @@ class FeedbackAgenticNode(AgenticNode):
             self.tools.extend(self.sub_agent_task_tool.available_tools())
         if self.ask_user_tool:
             self.tools.extend(self.ask_user_tool.available_tools())
+
+    @property
+    def caller_node_name(self) -> Optional[str]:
+        """The node whose memory this feedback run should update.
+
+        Exposed as a property so assignment by the CLI (``node.caller_node_name
+        = "gen_sql"``) rebuilds the filesystem tool with the new caller —
+        otherwise the whitelist baked in at construction time (defaulting to
+        ``"chat"``) would keep the caller's memory path classified as HIDDEN.
+        """
+        return getattr(self, "_caller_node_name", None)
+
+    @caller_node_name.setter
+    def caller_node_name(self, value: Optional[str]) -> None:
+        self._caller_node_name = value
+        # Guard for the base class's __init__-time assignment: at that point
+        # ``filesystem_func_tool`` is still ``None`` and we must not rebuild.
+        if getattr(self, "filesystem_func_tool", None) is not None:
+            try:
+                self.filesystem_func_tool = self._make_filesystem_tool(current_node=self._resolve_caller_node_name())
+                self._rebuild_tools()
+            except Exception as e:
+                logger.debug(f"Could not rebuild filesystem tool on caller change: {e}")
 
     def _resolve_caller_node_name(self) -> str:
         """Return the caller node whose memory this feedback run should update.

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -469,7 +469,7 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
         """Setup hooks (hardcoded to generation_hooks)."""
         try:
             broker = self._get_or_create_broker()
-            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config, node_name=self.get_node_name())
+            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config)
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -18,7 +18,7 @@ import pandas as pd
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.compare_agentic_node import CompareAgenticNode
 from datus.cli.execution_state import ExecutionInterrupted
-from datus.cli.generation_hooks import GenerationHooks, make_kb_path_normalizer
+from datus.cli.generation_hooks import GenerationHooks
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.compare_node_models import CompareInput
@@ -458,10 +458,7 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
         try:
             from datus.tools.func_tool import trans_to_function_tool
 
-            self.filesystem_func_tool = FilesystemFuncTool(
-                root_path=self.knowledge_base_dir,
-                path_normalizer=make_kb_path_normalizer(default_kind="ext_knowledge"),
-            )
+            self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.append(trans_to_function_tool(self.filesystem_func_tool.read_file))
             self.tools.append(trans_to_function_tool(self.filesystem_func_tool.edit_file))
             self.tools.append(trans_to_function_tool(self.filesystem_func_tool.write_file))
@@ -472,7 +469,7 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
         """Setup hooks (hardcoded to generation_hooks)."""
         try:
             broker = self._get_or_create_broker()
-            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config)
+            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config, node_name=self.get_node_name())
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")
@@ -508,7 +505,8 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
         context["native_tools"] = ", ".join([tool.name for tool in self.tools]) if self.tools else "None"
         context["ext_knowledge_dir"] = self.ext_knowledge_dir
         context["knowledge_base_dir"] = self.knowledge_base_dir
-        context["kind_subdir"] = "ext_knowledge"
+        # Filesystem tool is rooted at project_root; full path required.
+        context["kind_subdir"] = "subject/ext_knowledge"
         context["current_database"] = self.agent_config.current_database
         context["has_filesystem_tools"] = bool(self.filesystem_func_tool)
         context["has_ask_user_tool"] = self.ask_user_tool is not None

--- a/datus/agent/node/gen_job_agentic_node.py
+++ b/datus/agent/node/gen_job_agentic_node.py
@@ -116,10 +116,9 @@ class GenJobAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+            logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -14,7 +14,6 @@ from typing import AsyncGenerator, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.cli.execution_state import ExecutionInterrupted
-from datus.cli.generation_hooks import make_kb_path_normalizer
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SemanticNodeResult
@@ -131,10 +130,7 @@ class GenMetricsAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            self.filesystem_func_tool = FilesystemFuncTool(
-                root_path=self.knowledge_base_dir,
-                path_normalizer=make_kb_path_normalizer(default_kind="metric"),
-            )
+            self.filesystem_func_tool = self._make_filesystem_tool()
 
             self.tools.extend(self.filesystem_func_tool.available_tools())
             logger.debug("Added filesystem tools: read_file, write_file, edit_file, glob, grep")
@@ -253,7 +249,8 @@ class GenMetricsAgenticNode(AgenticNode):
         context["mcp_tools"] = ", ".join(list(self.mcp_servers.keys())) if self.mcp_servers else "None"
         context["semantic_model_dir"] = self.metrics_dir
         context["knowledge_base_dir"] = self.knowledge_base_dir
-        context["kind_subdir"] = "semantic_models"
+        # Filesystem tool is rooted at project_root; full path required.
+        context["kind_subdir"] = "subject/semantic_models"
         context["current_database"] = self.agent_config.current_database
         context["has_ask_user_tool"] = self.ask_user_tool is not None
 

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -246,10 +246,9 @@ class GenReportAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+            logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 
@@ -283,8 +282,7 @@ class GenReportAgenticNode(AgenticNode):
                 tool_instance = self.context_search_tools
             elif tool_type == "filesystem_tools":
                 if not self.filesystem_func_tool:
-                    root_path = self._resolve_workspace_root()
-                    self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+                    self.filesystem_func_tool = self._make_filesystem_tool()
                 tool_instance = self.filesystem_func_tool
             else:
                 logger.warning(f"Unknown tool type: {tool_type}")

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -218,7 +218,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
         """Setup hooks for interactive mode."""
         try:
             broker = self._get_or_create_broker()
-            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config, node_name=self.get_node_name())
+            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config)
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -14,7 +14,7 @@ from typing import AsyncGenerator, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.cli.execution_state import ExecutionInterrupted
-from datus.cli.generation_hooks import GenerationHooks, make_kb_path_normalizer
+from datus.cli.generation_hooks import GenerationHooks
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SemanticNodeResult
@@ -193,10 +193,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            self.filesystem_func_tool = FilesystemFuncTool(
-                root_path=self.knowledge_base_dir,
-                path_normalizer=make_kb_path_normalizer(default_kind="semantic"),
-            )
+            self.filesystem_func_tool = self._make_filesystem_tool()
 
             self.tools.extend(self.filesystem_func_tool.available_tools())
             logger.debug("Added filesystem tools: read_file, write_file, edit_file, glob, grep")
@@ -221,7 +218,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
         """Setup hooks for interactive mode."""
         try:
             broker = self._get_or_create_broker()
-            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config)
+            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config, node_name=self.get_node_name())
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")
@@ -260,7 +257,9 @@ class GenSemanticModelAgenticNode(AgenticNode):
         context["mcp_tools"] = ", ".join(list(self.mcp_servers.keys())) if self.mcp_servers else "None"
         context["semantic_model_dir"] = self.semantic_model_dir
         context["knowledge_base_dir"] = self.knowledge_base_dir
-        context["kind_subdir"] = "semantic_models"
+        # Filesystem tool is now rooted at project_root (not subject/), so the
+        # LLM must pass the full ``subject/<kind>/…`` relative path.
+        context["kind_subdir"] = "subject/semantic_models"
         context["current_database"] = self.agent_config.current_database
         context["has_ask_user_tool"] = self.ask_user_tool is not None
 

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -116,19 +116,18 @@ class SkillCreatorAgenticNode(AgenticNode):
     def _setup_full_filesystem_tools(self):
         """Setup a single filesystem tool rooted at the project.
 
-        Reads see the whole workspace; writes land under ``.datus/skills/`` or
-        ``~/.datus/skills/`` via the WHITELIST zone in ``classify_path``. The
-        hard write-scope gate in ``GenerationHooks`` (``gen_skill`` entry in
-        ``NODE_WRITE_SCOPES``) enforces that writes outside those two roots
-        are rejected, so we no longer need a second sandboxed instance.
+        Visibility follows the zone classifier in ``classify_path``:
+        ``.datus/skills/`` and ``~/.datus/skills/`` are WHITELIST (writable),
+        the rest of the project tree is INTERNAL (also writable by this node),
+        ``.datus/`` internals other than skills are HIDDEN (invisible), and
+        anything outside the project root is EXTERNAL (the permission hook
+        prompts; strict mode rejects). There is no per-kind write gate — the
+        prompt is responsible for steering skill writes into the whitelist.
         """
         try:
             self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.info(
-                f"Setup filesystem tools rooted at: {self.filesystem_func_tool.root_path} "
-                "(writes restricted by GenerationHooks scope gate to .datus/skills/**)"
-            )
+            logger.info(f"Setup filesystem tools rooted at: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.warning(f"Failed to setup filesystem tools, continuing without: {e}")
 

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -11,12 +11,8 @@ database (optional), ask_user, and skill loading tools, running with a
 higher max_turns budget for extended multi-step interactions.
 """
 
-import os
 import re
-from pathlib import Path
 from typing import AsyncGenerator, Dict, List, Literal, Optional
-
-from agents import FunctionTool
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.workflow import Workflow
@@ -26,26 +22,9 @@ from datus.schemas.action_history import ActionHistory, ActionHistoryManager, Ac
 from datus.schemas.gen_skill_agentic_node_models import SkillCreatorNodeInput, SkillCreatorNodeResult
 from datus.tools.db_tools.db_manager import db_manager_instance
 from datus.tools.func_tool import DBFuncTool, FilesystemFuncTool
-from datus.tools.func_tool.base import trans_to_function_tool
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
-
-# Workspace filesystem methods (read-only, root = workspace)
-WORKSPACE_READONLY_METHODS = [
-    "read_file",
-    "glob",
-    "grep",
-]
-
-# Skills filesystem methods (read + write, root = skills directory)
-SKILLS_ALL_METHODS = [
-    "read_file",
-    "write_file",
-    "edit_file",
-    "glob",
-    "grep",
-]
 
 
 class SkillCreatorAgenticNode(AgenticNode):
@@ -87,7 +66,6 @@ class SkillCreatorAgenticNode(AgenticNode):
         # Initialize tool attributes before parent constructor
         self.db_func_tool: Optional[DBFuncTool] = None
         self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
-        self._skills_filesystem_tool: Optional[FilesystemFuncTool] = None
         self.skill_func_tool_instance = None
         self._session_search_tool = None
         self.skill_validate_tool = None
@@ -117,12 +95,12 @@ class SkillCreatorAgenticNode(AgenticNode):
 
         self.tools = []
         self._setup_full_filesystem_tools()
-        if not self._skills_filesystem_tool:
+        if not self.filesystem_func_tool:
             from datus.utils.exceptions import DatusException, ErrorCode
 
             raise DatusException(
                 code=ErrorCode.COMMON_CONFIG_ERROR,
-                message_args={"config_error": "Failed to setup skills filesystem tools — cannot create skills"},
+                message_args={"config_error": "Failed to setup filesystem tools — cannot create skills"},
             )
         self._setup_db_tools()
         if self.execution_mode == "interactive":
@@ -135,58 +113,22 @@ class SkillCreatorAgenticNode(AgenticNode):
 
         logger.debug(f"Setup {len(self.tools)} skill creator tools: {[tool.name for tool in self.tools]}")
 
-    def _resolve_skills_write_root(self) -> str:
-        """Resolve the root path for write operations — restricted to the first skills directory.
-
-        Relative paths are anchored to the workspace root (not process CWD)
-        to prevent the sandbox from drifting outside the project.
-        """
-        if self.agent_config:
-            skills_config = getattr(self.agent_config, "skills_config", None)
-            if skills_config and hasattr(skills_config, "directories") and skills_config.directories:
-                first_dir = skills_config.directories[0]
-                expanded = os.path.expanduser(first_dir)
-                # Anchor relative paths to workspace root, not CWD
-                if not os.path.isabs(expanded):
-                    workspace = self._resolve_workspace_root()
-                    expanded = os.path.join(workspace, expanded)
-                resolved = str(Path(expanded).resolve())
-                Path(resolved).mkdir(parents=True, exist_ok=True)
-                return resolved
-        # Fallback: ~/.datus/skills/
-        fallback = os.path.expanduser("~/.datus/skills")
-        Path(fallback).mkdir(parents=True, exist_ok=True)
-        return fallback
-
     def _setup_full_filesystem_tools(self):
-        """Setup two filesystem tool sets: workspace (read-only) and skills (read+write)."""
-        try:
-            # Workspace tools — read-only, rooted at workspace
-            read_root = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=read_root)
-            for method_name in WORKSPACE_READONLY_METHODS:
-                if hasattr(self.filesystem_func_tool, method_name):
-                    method = getattr(self.filesystem_func_tool, method_name)
-                    self.tools.append(trans_to_function_tool(method))
-            logger.debug(f"Setup workspace read-only tools with root: {read_root}")
+        """Setup a single filesystem tool rooted at the project.
 
-            # Skills tools — read+write, rooted at skills directory, prefixed with skill_
-            skills_root = self._resolve_skills_write_root()
-            self._skills_filesystem_tool = FilesystemFuncTool(root_path=skills_root)
-            for method_name in SKILLS_ALL_METHODS:
-                if hasattr(self._skills_filesystem_tool, method_name):
-                    method = getattr(self._skills_filesystem_tool, method_name)
-                    tool = trans_to_function_tool(method)
-                    # Prefix with skill_ to distinguish from workspace tools
-                    tool = FunctionTool(
-                        name=f"skill_{tool.name}",
-                        description=f"[Skills directory: {skills_root}] {tool.description}",
-                        params_json_schema=tool.params_json_schema,
-                        on_invoke_tool=tool.on_invoke_tool,
-                        strict_json_schema=False,
-                    )
-                    self.tools.append(tool)
-            logger.info(f"Setup skills filesystem tools (skill_*) restricted to: {skills_root}")
+        Reads see the whole workspace; writes land under ``.datus/skills/`` or
+        ``~/.datus/skills/`` via the WHITELIST zone in ``classify_path``. The
+        hard write-scope gate in ``GenerationHooks`` (``gen_skill`` entry in
+        ``NODE_WRITE_SCOPES``) enforces that writes outside those two roots
+        are rejected, so we no longer need a second sandboxed instance.
+        """
+        try:
+            self.filesystem_func_tool = self._make_filesystem_tool()
+            self.tools.extend(self.filesystem_func_tool.available_tools())
+            logger.info(
+                f"Setup filesystem tools rooted at: {self.filesystem_func_tool.root_path} "
+                "(writes restricted by GenerationHooks scope gate to .datus/skills/**)"
+            )
         except Exception as e:
             logger.warning(f"Failed to setup filesystem tools, continuing without: {e}")
 

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -381,10 +381,9 @@ class GenSQLAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools (all available tools)."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+            logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 
@@ -469,8 +468,7 @@ class GenSQLAgenticNode(AgenticNode):
                 tool_instance = self.date_parsing_tools
             elif tool_type == "filesystem_tools":
                 if not self.filesystem_func_tool:
-                    root_path = self._resolve_workspace_root()
-                    self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+                    self.filesystem_func_tool = self._make_filesystem_tool()
                 tool_instance = self.filesystem_func_tool
             elif tool_type == "platform_doc_tools":
                 if not self._platform_doc_tool:

--- a/datus/agent/node/gen_table_agentic_node.py
+++ b/datus/agent/node/gen_table_agentic_node.py
@@ -116,10 +116,9 @@ class GenTableAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+            logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 

--- a/datus/agent/node/migration_agentic_node.py
+++ b/datus/agent/node/migration_agentic_node.py
@@ -119,10 +119,9 @@ class MigrationAgenticNode(AgenticNode):
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            root_path = self._resolve_workspace_root()
-            self.filesystem_func_tool = FilesystemFuncTool(root_path=root_path)
+            self.filesystem_func_tool = self._make_filesystem_tool()
             self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.debug(f"Setup filesystem tools with root path: {root_path}")
+            logger.debug(f"Setup filesystem tools with root path: {self.filesystem_func_tool.root_path}")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -14,7 +14,7 @@ from typing import AsyncGenerator, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.cli.execution_state import ExecutionInterrupted
-from datus.cli.generation_hooks import GenerationHooks, make_kb_path_normalizer
+from datus.cli.generation_hooks import GenerationHooks
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.sql_summary_agentic_node_models import SqlSummaryNodeInput, SqlSummaryNodeResult
@@ -153,10 +153,7 @@ class SqlSummaryAgenticNode(AgenticNode):
     def _setup_specific_filesystem_tool(self):
         """Setup specific filesystem tools"""
         try:
-            self.filesystem_func_tool = FilesystemFuncTool(
-                root_path=self.knowledge_base_dir,
-                path_normalizer=make_kb_path_normalizer(default_kind="sql_summary"),
-            )
+            self.filesystem_func_tool = self._make_filesystem_tool()
 
             self.tools.extend(self.filesystem_func_tool.available_tools())
         except Exception as e:
@@ -166,7 +163,7 @@ class SqlSummaryAgenticNode(AgenticNode):
         """Setup hooks (hardcoded to generation_hooks)."""
         try:
             broker = self._get_or_create_broker()
-            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config)
+            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config, node_name=self.get_node_name())
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")
@@ -245,7 +242,8 @@ class SqlSummaryAgenticNode(AgenticNode):
         context["native_tools"] = ", ".join([tool.name for tool in self.tools]) if self.tools else "None"
         context["sql_summary_dir"] = self.sql_summary_dir
         context["knowledge_base_dir"] = self.knowledge_base_dir
-        context["kind_subdir"] = "sql_summaries"
+        # Filesystem tool is rooted at project_root; full path required.
+        context["kind_subdir"] = "subject/sql_summaries"
         context["current_database"] = self.agent_config.current_database
         context["has_ask_user_tool"] = self.ask_user_tool is not None
 

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -163,7 +163,7 @@ class SqlSummaryAgenticNode(AgenticNode):
         """Setup hooks (hardcoded to generation_hooks)."""
         try:
             broker = self._get_or_create_broker()
-            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config, node_name=self.get_node_name())
+            self.hooks = GenerationHooks(broker=broker, agent_config=self.agent_config)
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -222,6 +222,10 @@ class ChatTaskManager:
         """
         # Clone config to avoid cross-request mutation of shared AgentConfig
         agent_config = copy.deepcopy(agent_config)
+        # API surface has no interactive broker to confirm EXTERNAL file
+        # access, so force filesystem strict mode — every node constructed
+        # below reads this flag via AgenticNode._resolve_filesystem_strict().
+        agent_config.filesystem_strict = True
         _fill_database_context(
             agent_config,
             catalog=request.catalog,

--- a/datus/claw/main.py
+++ b/datus/claw/main.py
@@ -100,6 +100,10 @@ def _run_gateway(args: argparse.Namespace) -> None:
         config=args.config or "",
         namespace=args.namespace,
     )
+    # Claw runs non-interactively — no broker to confirm out-of-workspace
+    # file access. Force filesystem strict mode so nodes reject EXTERNAL
+    # paths instead of hanging on a prompt.
+    agent_config.filesystem_strict = True
 
     channels_config = getattr(agent_config, "channels_config", {})
     if not channels_config:

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -9,13 +9,11 @@ import asyncio
 import json
 import os
 from datetime import datetime
-from pathlib import Path
 from typing import Optional
 
 import yaml
 from agents.lifecycle import AgentHooks
 from datus_storage_base.conditions import And, eq
-from wcmatch import glob as wc_glob
 
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
 from datus.configuration.agent_config import AgentConfig
@@ -23,8 +21,6 @@ from datus.storage.metric.store import MetricRAG
 from datus.storage.reference_sql.store import ReferenceSqlRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.db_tools import connector_registry
-from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
-from datus.tools.permission.permission_hooks import PermissionDeniedException
 from datus.utils.constants import DBType
 from datus.utils.loggings import get_logger
 
@@ -42,28 +38,6 @@ _KIND_TO_SUBDIR = {
     "metric": "semantic_models",
     "sql_summary": "sql_summaries",
     "ext_knowledge": "ext_knowledge",
-}
-
-
-# Per-node filesystem write scopes (glob patterns rooted at ``project_root`` or
-# ``~``). Enforced by :meth:`GenerationHooks.on_tool_start` — any ``write_file``
-# or ``edit_file`` whose resolved display form does not match one of the
-# patterns is rejected with ``PermissionDeniedException``.  Nodes whose
-# ``node_name`` is absent from the map are unconstrained (e.g. ``chat``,
-# ``explore``, ``gen_report``).
-#
-# Design note: we intentionally keep this hard-coded rather than in
-# ``agent.yml`` until more call sites start requesting overrides. Prompts do
-# the *guidance*; this map does the *guardrail*.
-NODE_WRITE_SCOPES: dict[str, list[str]] = {
-    "gen_semantic_model": ["subject/semantic_models/**"],
-    "gen_metrics": ["subject/semantic_models/**"],
-    "sql_summary": ["subject/sql_summaries/**"],
-    "gen_ext_knowledge": ["subject/ext_knowledge/**"],
-    "gen_skill": [".datus/skills/**", "~/.datus/skills/**"],
-    "migration": ["subject/**"],
-    "gen_job": ["subject/**"],
-    "gen_table": ["subject/**"],
 }
 
 
@@ -148,29 +122,6 @@ def resolve_kb_sandbox_path(
     return candidate
 
 
-def _path_matches_scope(display: str, scope: str) -> bool:
-    """Match a display-form path against a scope glob.
-
-    ``display`` comes from :class:`~datus.tools.func_tool.fs_path_policy.ResolvedPath`:
-    project-relative for ``INTERNAL``/``WHITELIST`` and absolute for everything
-    else. ``scope`` patterns mirror that: relative patterns (``subject/**``)
-    match project-relative displays, while ``~/.datus/skills/**`` matches the
-    home-whitelist ``~/...`` display. The matching itself uses wcmatch's
-    gitignore-style semantics via ``DOTGLOB | GLOBSTAR``.
-    """
-    if not scope:
-        return False
-    try:
-        return wc_glob.globmatch(display, scope, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR)
-    except Exception:
-        return False
-
-
-def path_matches_any_scope(display: str, scopes: list[str]) -> bool:
-    """Return ``True`` if ``display`` matches any of ``scopes``."""
-    return any(_path_matches_scope(display, pattern) for pattern in scopes)
-
-
 class GenerationHooks(AgentHooks):
     """Hooks for handling generation tool results and user interaction."""
 
@@ -182,13 +133,7 @@ class GenerationHooks(AgentHooks):
         "ext_knowledge": "ext_knowledge_path",
     }
 
-    def __init__(
-        self,
-        broker: InteractionBroker,
-        agent_config: AgentConfig = None,
-        *,
-        node_name: Optional[str] = None,
-    ):
+    def __init__(self, broker: InteractionBroker, agent_config: AgentConfig = None):
         """
         Initialize generation hooks.
 
@@ -198,15 +143,9 @@ class GenerationHooks(AgentHooks):
                 for relative path resolution are looked up on this config at call
                 time so sub-agent namespace switches take effect without rebuilding
                 the hook.
-            node_name: Name of the owning node (e.g. ``gen_semantic_model``).
-                Used to look up :data:`NODE_WRITE_SCOPES` for the hard
-                write-scope gate. When ``None`` the gate falls back to
-                ``agent.name`` at call time; if that is also missing no gating
-                applies.
         """
         self.broker = broker
         self.agent_config = agent_config
-        self.node_name = node_name
         self.processed_files = set()  # Track files that have been processed to avoid duplicates
         logger.debug(f"GenerationHooks initialized with config: {agent_config is not None}")
 
@@ -307,110 +246,7 @@ class GenerationHooks(AgentHooks):
                 await self._handle_ext_knowledge_result(result)
 
     async def on_tool_start(self, context, agent, tool) -> None:
-        """Hard write-scope gate for ``write_file`` / ``edit_file``.
-
-        The gate ensures a ``gen_*`` node can only write under its designated
-        subdirectory. This is belt-and-braces with the prompts — prompts tell
-        the LLM *where* to write; this check enforces it so a prompt drift
-        does not corrupt the KB.
-
-        Paths outside the scope raise ``PermissionDeniedException`` (same type
-        the OpenAI Agents SDK framework already understands from
-        ``PermissionHooks``), which the framework surfaces to the LLM as a
-        tool failure so the next turn can correct the path.
-        """
-        tool_name = getattr(tool, "name", getattr(tool, "__name__", ""))
-        if tool_name not in ("write_file", "edit_file"):
-            return
-
-        node_name = self._resolve_node_name(agent)
-        scopes = NODE_WRITE_SCOPES.get(node_name or "")
-        if not scopes:
-            return
-
-        path_arg = self._extract_path_arg(context)
-        if not path_arg:
-            return
-
-        root_path = self._project_root()
-        if root_path is None:
-            return
-
-        datus_home = self._datus_home()
-        resolved = classify_path(
-            path_arg,
-            root_path=root_path,
-            current_node=node_name,
-            datus_home=datus_home,
-        )
-
-        # EXTERNAL / HIDDEN immediately fail the scope gate — neither home
-        # whitelist nor project-internal, so no gen_* scope could ever match.
-        if resolved.zone == PathZone.EXTERNAL:
-            logger.info("Scope gate: %s rejected external write to %s", node_name, resolved.display)
-            raise PermissionDeniedException(
-                f"Node '{node_name}' may not write outside its scope {scopes}; got external path {resolved.display}",
-                tool_category="filesystem_tools",
-                tool_name=tool_name,
-            )
-
-        if not path_matches_any_scope(resolved.display, scopes):
-            logger.info(
-                "Scope gate: %s rejected write to %s (allowed scopes: %s)",
-                node_name,
-                resolved.display,
-                scopes,
-            )
-            raise PermissionDeniedException(
-                f"Node '{node_name}' may only write under {scopes}; got {resolved.display}",
-                tool_category="filesystem_tools",
-                tool_name=tool_name,
-            )
-
-    def _resolve_node_name(self, agent) -> Optional[str]:
-        """Resolve the owning node name, preferring the explicit constructor arg."""
-        if self.node_name:
-            return self.node_name
-        agent_name = getattr(agent, "name", None)
-        if isinstance(agent_name, str) and agent_name:
-            return agent_name
-        return None
-
-    def _extract_path_arg(self, context) -> str:
-        try:
-            raw = getattr(context, "tool_arguments", "{}")
-            data = json.loads(raw) if isinstance(raw, str) else raw
-            if isinstance(data, dict):
-                value = data.get("path", "")
-                if isinstance(value, str):
-                    return value
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.debug(f"Failed to parse tool_arguments for scope gate: {e}")
-        return ""
-
-    def _project_root(self) -> Optional[Path]:
-        if not self.agent_config:
-            return None
-        path_manager = getattr(self.agent_config, "path_manager", None)
-        if path_manager is None:
-            return None
-        try:
-            return Path(path_manager.project_root)
-        except Exception as e:
-            logger.debug(f"Failed to read project_root from path_manager: {e}")
-            return None
-
-    def _datus_home(self) -> Optional[Path]:
-        if not self.agent_config:
-            return None
-        path_manager = getattr(self.agent_config, "path_manager", None)
-        if path_manager is None:
-            return None
-        try:
-            return Path(path_manager.datus_home)
-        except Exception as e:
-            logger.debug(f"Failed to read datus_home from path_manager: {e}")
-            return None
+        pass
 
     async def on_handoff(self, context, agent, source) -> None:
         pass

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -9,11 +9,13 @@ import asyncio
 import json
 import os
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import yaml
 from agents.lifecycle import AgentHooks
 from datus_storage_base.conditions import And, eq
+from wcmatch import glob as wc_glob
 
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
 from datus.configuration.agent_config import AgentConfig
@@ -21,8 +23,9 @@ from datus.storage.metric.store import MetricRAG
 from datus.storage.reference_sql.store import ReferenceSqlRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.db_tools import connector_registry
+from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
+from datus.tools.permission.permission_hooks import PermissionDeniedException
 from datus.utils.constants import DBType
-from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -41,14 +44,26 @@ _KIND_TO_SUBDIR = {
     "ext_knowledge": "ext_knowledge",
 }
 
-# write_file `file_type` argument values used by the LLM mapped to internal kinds.
-_FILE_TYPE_ALIASES = {
-    "semantic": "semantic",
-    "semantic_model": "semantic",
-    "metric": "metric",
-    "metrics": "metric",
-    "sql_summary": "sql_summary",
-    "ext_knowledge": "ext_knowledge",
+
+# Per-node filesystem write scopes (glob patterns rooted at ``project_root`` or
+# ``~``). Enforced by :meth:`GenerationHooks.on_tool_start` — any ``write_file``
+# or ``edit_file`` whose resolved display form does not match one of the
+# patterns is rejected with ``PermissionDeniedException``.  Nodes whose
+# ``node_name`` is absent from the map are unconstrained (e.g. ``chat``,
+# ``explore``, ``gen_report``).
+#
+# Design note: we intentionally keep this hard-coded rather than in
+# ``agent.yml`` until more call sites start requesting overrides. Prompts do
+# the *guidance*; this map does the *guardrail*.
+NODE_WRITE_SCOPES: dict[str, list[str]] = {
+    "gen_semantic_model": ["subject/semantic_models/**"],
+    "gen_metrics": ["subject/semantic_models/**"],
+    "sql_summary": ["subject/sql_summaries/**"],
+    "gen_ext_knowledge": ["subject/ext_knowledge/**"],
+    "gen_skill": [".datus/skills/**", "~/.datus/skills/**"],
+    "migration": ["subject/**"],
+    "gen_job": ["subject/**"],
+    "gen_table": ["subject/**"],
 }
 
 
@@ -77,12 +92,20 @@ def normalize_kb_relative_path(path: str, kind: Optional[str]) -> str:
         return path
     if parts[0] == "..":
         return path
+    # After the ``subject/`` relocation, prompts emit fully-qualified paths
+    # like ``subject/semantic_models/orders.yml``. ``_resolve_path`` joins the
+    # result with ``kb_home`` (``{project_root}/subject``), so strip a leading
+    # ``subject/`` segment first to avoid ``subject/subject/...`` drift.
+    if parts[0] == "subject":
+        parts = parts[1:]
+        if not parts:
+            return path
     subdir = _KIND_TO_SUBDIR.get(kind or "")
     if not subdir:
-        return path
+        return "/".join(parts)
     head = parts[0]
     if head in set(_KIND_TO_SUBDIR.values()):
-        return path
+        return "/".join(parts)
     return f"{subdir}/{'/'.join(parts)}"
 
 
@@ -125,38 +148,27 @@ def resolve_kb_sandbox_path(
     return candidate
 
 
-def make_kb_path_normalizer(default_kind: Optional[str] = None):
+def _path_matches_scope(display: str, scope: str) -> bool:
+    """Match a display-form path against a scope glob.
+
+    ``display`` comes from :class:`~datus.tools.func_tool.fs_path_policy.ResolvedPath`:
+    project-relative for ``INTERNAL``/``WHITELIST`` and absolute for everything
+    else. ``scope`` patterns mirror that: relative patterns (``subject/**``)
+    match project-relative displays, while ``~/.datus/skills/**`` matches the
+    home-whitelist ``~/...`` display. The matching itself uses wcmatch's
+    gitignore-style semantics via ``DOTGLOB | GLOBSTAR``.
     """
-    Build a ``FilesystemFuncTool.path_normalizer`` closure that silently prefixes
-    relative paths with the correct KB subdir under ``subject/``.
+    if not scope:
+        return False
+    try:
+        return wc_glob.globmatch(display, scope, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR)
+    except Exception:
+        return False
 
-    The closure accepts an optional ``strict_kind`` kwarg. When set (used for
-    mutating tool ops — ``write_file`` / ``edit_file``), cross-kind writes are
-    rejected: a node whose ``default_kind`` is ``semantic`` cannot write to a
-    path already prefixed with ``sql_summaries/`` or ``ext_knowledge/``. Reads
-    stay lax so the LLM can still browse peer KB artifacts.
-    """
-    expected_subdir = _KIND_TO_SUBDIR.get(default_kind or "")
-    known_subdirs = set(_KIND_TO_SUBDIR.values())
 
-    def _normalize(path: str, file_type: Optional[str], *, strict_kind: bool = False) -> str:
-        if strict_kind and expected_subdir and path and not os.path.isabs(path):
-            parts = [p for p in path.replace("\\", "/").split("/") if p]
-            head = parts[0] if parts else ""
-            if head in known_subdirs and head != expected_subdir:
-                raise DatusException(
-                    code=ErrorCode.TOOL_INVALID_INPUT,
-                    message=(
-                        f"Write to '{head}/' is not allowed from a {default_kind!r} node; "
-                        f"this node may only write under '{expected_subdir}/'."
-                    ),
-                )
-            kind = default_kind
-        else:
-            kind = _FILE_TYPE_ALIASES.get(file_type or "", default_kind)
-        return normalize_kb_relative_path(path, kind)
-
-    return _normalize
+def path_matches_any_scope(display: str, scopes: list[str]) -> bool:
+    """Return ``True`` if ``display`` matches any of ``scopes``."""
+    return any(_path_matches_scope(display, pattern) for pattern in scopes)
 
 
 class GenerationHooks(AgentHooks):
@@ -170,7 +182,13 @@ class GenerationHooks(AgentHooks):
         "ext_knowledge": "ext_knowledge_path",
     }
 
-    def __init__(self, broker: InteractionBroker, agent_config: AgentConfig = None):
+    def __init__(
+        self,
+        broker: InteractionBroker,
+        agent_config: AgentConfig = None,
+        *,
+        node_name: Optional[str] = None,
+    ):
         """
         Initialize generation hooks.
 
@@ -180,9 +198,15 @@ class GenerationHooks(AgentHooks):
                 for relative path resolution are looked up on this config at call
                 time so sub-agent namespace switches take effect without rebuilding
                 the hook.
+            node_name: Name of the owning node (e.g. ``gen_semantic_model``).
+                Used to look up :data:`NODE_WRITE_SCOPES` for the hard
+                write-scope gate. When ``None`` the gate falls back to
+                ``agent.name`` at call time; if that is also missing no gating
+                applies.
         """
         self.broker = broker
         self.agent_config = agent_config
+        self.node_name = node_name
         self.processed_files = set()  # Track files that have been processed to avoid duplicates
         logger.debug(f"GenerationHooks initialized with config: {agent_config is not None}")
 
@@ -283,7 +307,110 @@ class GenerationHooks(AgentHooks):
                 await self._handle_ext_knowledge_result(result)
 
     async def on_tool_start(self, context, agent, tool) -> None:
-        pass
+        """Hard write-scope gate for ``write_file`` / ``edit_file``.
+
+        The gate ensures a ``gen_*`` node can only write under its designated
+        subdirectory. This is belt-and-braces with the prompts — prompts tell
+        the LLM *where* to write; this check enforces it so a prompt drift
+        does not corrupt the KB.
+
+        Paths outside the scope raise ``PermissionDeniedException`` (same type
+        the OpenAI Agents SDK framework already understands from
+        ``PermissionHooks``), which the framework surfaces to the LLM as a
+        tool failure so the next turn can correct the path.
+        """
+        tool_name = getattr(tool, "name", getattr(tool, "__name__", ""))
+        if tool_name not in ("write_file", "edit_file"):
+            return
+
+        node_name = self._resolve_node_name(agent)
+        scopes = NODE_WRITE_SCOPES.get(node_name or "")
+        if not scopes:
+            return
+
+        path_arg = self._extract_path_arg(context)
+        if not path_arg:
+            return
+
+        root_path = self._project_root()
+        if root_path is None:
+            return
+
+        datus_home = self._datus_home()
+        resolved = classify_path(
+            path_arg,
+            root_path=root_path,
+            current_node=node_name,
+            datus_home=datus_home,
+        )
+
+        # EXTERNAL / HIDDEN immediately fail the scope gate — neither home
+        # whitelist nor project-internal, so no gen_* scope could ever match.
+        if resolved.zone == PathZone.EXTERNAL:
+            logger.info("Scope gate: %s rejected external write to %s", node_name, resolved.display)
+            raise PermissionDeniedException(
+                f"Node '{node_name}' may not write outside its scope {scopes}; got external path {resolved.display}",
+                tool_category="filesystem_tools",
+                tool_name=tool_name,
+            )
+
+        if not path_matches_any_scope(resolved.display, scopes):
+            logger.info(
+                "Scope gate: %s rejected write to %s (allowed scopes: %s)",
+                node_name,
+                resolved.display,
+                scopes,
+            )
+            raise PermissionDeniedException(
+                f"Node '{node_name}' may only write under {scopes}; got {resolved.display}",
+                tool_category="filesystem_tools",
+                tool_name=tool_name,
+            )
+
+    def _resolve_node_name(self, agent) -> Optional[str]:
+        """Resolve the owning node name, preferring the explicit constructor arg."""
+        if self.node_name:
+            return self.node_name
+        agent_name = getattr(agent, "name", None)
+        if isinstance(agent_name, str) and agent_name:
+            return agent_name
+        return None
+
+    def _extract_path_arg(self, context) -> str:
+        try:
+            raw = getattr(context, "tool_arguments", "{}")
+            data = json.loads(raw) if isinstance(raw, str) else raw
+            if isinstance(data, dict):
+                value = data.get("path", "")
+                if isinstance(value, str):
+                    return value
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.debug(f"Failed to parse tool_arguments for scope gate: {e}")
+        return ""
+
+    def _project_root(self) -> Optional[Path]:
+        if not self.agent_config:
+            return None
+        path_manager = getattr(self.agent_config, "path_manager", None)
+        if path_manager is None:
+            return None
+        try:
+            return Path(path_manager.project_root)
+        except Exception as e:
+            logger.debug(f"Failed to read project_root from path_manager: {e}")
+            return None
+
+    def _datus_home(self) -> Optional[Path]:
+        if not self.agent_config:
+            return None
+        path_manager = getattr(self.agent_config, "path_manager", None)
+        if path_manager is None:
+            return None
+        try:
+            return Path(path_manager.datus_home)
+        except Exception as e:
+            logger.debug(f"Failed to read datus_home from path_manager: {e}")
+            return None
 
     async def on_handoff(self, context, agent, source) -> None:
         pass

--- a/datus/prompts/prompt_templates/skill_creator_system_1.0.j2
+++ b/datus/prompts/prompt_templates/skill_creator_system_1.0.j2
@@ -11,7 +11,11 @@ If unclear, use `ask_user` to clarify whether the user wants to create or optimi
 ## Critical Rules
 
 1. **You create/optimize skills — never perform the task itself.** "Create a skill for bitcoin analysis" means write a SKILL.md that teaches agents how to analyze bitcoin, not analyze bitcoin yourself.
-2. **All skill files go in the skills directory only.** Use `skill_*` tools for all skill file operations. Paths are relative to the skills directory root.
+2. **All skill files MUST be written under a skills directory.** Valid write prefixes are:
+   - `.datus/skills/<skill-name>/...` — project-local skill (preferred for repo-scoped skills)
+   - `~/.datus/skills/<skill-name>/...` — global skill (shared across projects)
+
+   Any `write_file` / `edit_file` call targeting a path outside these prefixes is out of scope for this node. If the user requests a write elsewhere, refuse and explain.
 3. **Research FIRST, then ask_user ONCE.** Explore the database/context silently before asking. Then call `ask_user` exactly once with all questions. Do NOT call ask_user again to "confirm" — the user's answers are final, proceed to writing immediately.
 4. **ALWAYS call `validate_skill` after writing SKILL.md** to verify correctness.
 {% if has_db_tools %}
@@ -20,13 +24,11 @@ If unclear, use `ask_user` to clarify whether the user wants to create or optimi
 
 ## Available Tools
 {% if has_filesystem_tools -%}
-### Workspace (read-only)
-- `read_file`, `glob`, `grep` — browse project files
+### Filesystem
+A single unified filesystem tool covers both browsing the project and writing skill files.
 
-### Skills Directory (read+write)
-All `skill_*` tools operate within the skills directory. Paths are relative.
-- `skill_write_file`, `skill_edit_file` — create/modify skills
-- `skill_read_file`, `skill_glob`, `skill_grep` — browse skills
+- `read_file`, `glob`, `grep` — browse any project file (use to research existing code, schema, docs before creating a skill)
+- `write_file`, `edit_file` — create or modify files. **Only write under `.datus/skills/...` or `~/.datus/skills/...`** (see Critical Rule #2). Paths can be relative to the project root (e.g. `.datus/skills/my-skill/SKILL.md`) or `~`-prefixed for the global skills dir.
 {% endif -%}
 {% if has_db_tools -%}
 ### Database (research only)

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -2,17 +2,22 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import inspect
 import os
 import re
 from pathlib import Path
-from typing import Callable, Iterator, List, Optional
+from typing import Iterator, List, Optional
 
 from agents import Tool
 from wcmatch import glob as wc_glob
 
 from datus.tools import BaseTool
 from datus.tools.func_tool import FuncToolResult
+from datus.tools.func_tool.fs_path_policy import (
+    PathZone,
+    ResolvedPath,
+    classify_path,
+    whitelist_anchors,
+)
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -46,59 +51,51 @@ class FilesystemConfig:
         self.max_file_size = max_file_size
 
 
-PathNormalizer = Callable[[str, Optional[str]], str]
-
-
 class FilesystemFuncTool(BaseTool):
-    """Function tool wrapper for filesystem operations"""
+    """Function tool wrapper for filesystem operations.
+
+    Path resolution is centralized in :func:`classify_path`. Every operation
+    runs the same classifier and then branches on the resulting zone:
+
+    * ``INTERNAL`` / ``WHITELIST`` — proceed.
+    * ``HIDDEN`` — return a ``File not found`` style error for reads/writes
+      and prune the subtree in walks, so ``.datus/sessions`` etc. stay
+      invisible to the LLM.
+    * ``EXTERNAL`` — proceed at the tool level; the ``PermissionHooks`` layer
+      is responsible for asking the user first.
+    """
 
     def __init__(
         self,
         root_path: str = None,
         *,
-        path_normalizer: Optional[PathNormalizer] = None,
+        current_node: Optional[str] = None,
+        datus_home: Optional[str] = None,
+        strict: bool = False,
         **kwargs,
     ):
+        """
+        Args:
+            strict: When ``True``, ``EXTERNAL`` paths (anything outside the
+                project root and its whitelist) are rejected at the tool layer
+                with the same "not found" semantics as ``HIDDEN``. This is the
+                mode the API / claw surfaces run in — the agent has no
+                interactive broker to confirm external access, so we fail
+                closed instead of ever touching the host filesystem.
+                ``False`` (the CLI default) lets ``PermissionHooks`` prompt
+                the user.
+        """
         super().__init__(**kwargs)
         self.root_path = root_path or os.getenv("FILESYSTEM_MCP_PATH", os.path.expanduser("~"))
-        self.config = FilesystemConfig(root_path=root_path)
-        self._path_normalizer = path_normalizer
-        # Detect strict_kind support via signature inspection up front so a
-        # TypeError raised *inside* the normalizer can't be mistaken for a
-        # legacy 2-arg signature and silently drop the strict flag.
-        self._normalizer_accepts_strict_kind = False
-        if path_normalizer is not None:
-            try:
-                params = inspect.signature(path_normalizer).parameters
-                self._normalizer_accepts_strict_kind = "strict_kind" in params or any(
-                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-                )
-            except (TypeError, ValueError):
-                pass
+        self.config = FilesystemConfig(root_path=self.root_path)
+        self._current_node = current_node
+        self._datus_home = Path(datus_home).expanduser().resolve(strict=False) if datus_home else None
+        self._root_resolved = Path(self.root_path).expanduser().resolve(strict=False)
+        self._strict = strict
 
-    def _normalize(self, path: str, file_type: Optional[str] = None, *, strict: bool = False) -> str:
-        """
-        Apply the configured path normalizer (if any) before sandbox resolution.
-
-        With ``strict=False`` (default, read-side), normalizer errors are logged
-        and the original path is returned so the downstream sandbox check can
-        fail naturally. With ``strict=True`` (write-side), the exception is
-        re-raised so callers don't silently land a mutation at a mis-normalized
-        location. ``strict=True`` is also forwarded to the normalizer as the
-        ``strict_kind`` kwarg so KB normalizers can enforce cross-kind write
-        restrictions on mutating ops while keeping reads lax.
-        """
-        if self._path_normalizer is None or not path:
-            return path
-        try:
-            if self._normalizer_accepts_strict_kind:
-                return self._path_normalizer(path, file_type, strict_kind=strict)
-            return self._path_normalizer(path, file_type)
-        except Exception as e:
-            logger.warning(f"path_normalizer raised on path={path!r} file_type={file_type!r}: {e}")
-            if strict:
-                raise
-            return path
+    @property
+    def strict(self) -> bool:
+        return self._strict
 
     def available_tools(self) -> List[Tool]:
         """Get all available filesystem tools"""
@@ -117,24 +114,50 @@ class FilesystemFuncTool(BaseTool):
             bound_tools.append(trans_to_function_tool(bound_method))
         return bound_tools
 
-    def _get_safe_path(self, path: str) -> Optional[Path]:
-        """Get a safe path within the root directory.
+    # ------------------------------------------------------------------ zones
 
-        Uses ``Path.relative_to`` instead of string ``startswith`` so that
-        sibling directories whose names share the root's prefix (e.g. a
-        ``subject_backup`` sitting next to ``subject``) can't be mistaken
-        for an in-sandbox path via ``../`` traversal.
+    def _classify(self, path: str) -> ResolvedPath:
+        return classify_path(
+            path,
+            root_path=self._root_resolved,
+            current_node=self._current_node,
+            datus_home=self._datus_home,
+        )
+
+    def _not_found(self, resolved: ResolvedPath) -> FuncToolResult:
+        """Uniform ``File not found`` response for hidden zones.
+
+        We deliberately do not distinguish between "really missing" and
+        "hidden by policy" — leaking that ``.datus/sessions`` exists would
+        defeat the invisibility guarantee.
         """
-        try:
-            root = Path(self.config.root_path).resolve()
-            target = (root / path).resolve()
-            try:
-                target.relative_to(root)
-            except ValueError:
-                return None
-            return target
-        except Exception:
+        return FuncToolResult(success=0, error=f"File not found: {resolved.display}")
+
+    def _strict_reject(self, resolved: ResolvedPath) -> FuncToolResult:
+        """Error response for ``EXTERNAL`` paths in strict mode.
+
+        Unlike ``_not_found``, this is explicit: the caller **asked** for a
+        path outside the workspace, so hiding the rejection would be
+        confusing. The error message names the path so the LLM can fix it
+        on the next turn. Used by the API / claw surfaces that have no
+        interactive broker to prompt the user.
+        """
+        return FuncToolResult(
+            success=0,
+            error=f"Path outside workspace is not allowed in strict mode: {resolved.display}",
+        )
+
+    def _get_safe_path(self, path: str) -> Optional[Path]:
+        """Deprecated sandbox helper kept for backward compat.
+
+        Delegates to :meth:`_classify`; returns ``None`` for ``HIDDEN`` or
+        ``EXTERNAL`` to preserve the historical "reject out-of-sandbox"
+        semantics used by a handful of callers outside this class.
+        """
+        resolved = self._classify(path)
+        if resolved.zone in (PathZone.HIDDEN, PathZone.EXTERNAL):
             return None
+        return resolved.resolved
 
     def _is_allowed_file(self, file_path: Path) -> bool:
         """Check if file extension is allowed"""
@@ -142,12 +165,16 @@ class FilesystemFuncTool(BaseTool):
             return True
         return file_path.suffix.lower() in self.config.allowed_extensions
 
+    # ------------------------------------------------------------- read/write
+
     def read_file(self, path: str, offset: int = 0, limit: int = 0) -> FuncToolResult:
         """
         Read the contents of a file.
 
         Args:
-            path: Path to the file. Absolute paths are permitted for read-only operations.
+            path: Path to the file. Relative paths are resolved under the
+                project root; absolute paths are permitted but the permission
+                layer will prompt the user when they fall outside the project.
             offset: Line number to start reading from (1-based). 0 means start from beginning.
             limit: Maximum number of lines to read. 0 means read all lines.
 
@@ -159,20 +186,24 @@ class FilesystemFuncTool(BaseTool):
                     returns numbered lines in "N: line content" format.
         """
         try:
-            path = self._normalize(path)
-            target_path = self._get_safe_path(path)
+            resolved = self._classify(path)
+            if resolved.zone == PathZone.HIDDEN:
+                return self._not_found(resolved)
+            if self._strict and resolved.zone == PathZone.EXTERNAL:
+                return self._strict_reject(resolved)
 
-            if not target_path or not target_path.exists():
-                return FuncToolResult(success=0, error=f"File not found: {path}")
+            target_path = resolved.resolved
+            if not target_path.exists():
+                return FuncToolResult(success=0, error=f"File not found: {resolved.display}")
 
             if not target_path.is_file():
-                return FuncToolResult(success=0, error=f"Path is not a file: {path}")
+                return FuncToolResult(success=0, error=f"Path is not a file: {resolved.display}")
 
             if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {path}")
+                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
 
             if target_path.stat().st_size > self.config.max_file_size:
-                return FuncToolResult(success=0, error=f"File too large: {path}")
+                return FuncToolResult(success=0, error=f"File too large: {resolved.display}")
 
             try:
                 content = target_path.read_text(encoding="utf-8")
@@ -187,9 +218,9 @@ class FilesystemFuncTool(BaseTool):
 
                 return FuncToolResult(result=content)
             except UnicodeDecodeError:
-                return FuncToolResult(success=0, error=f"Cannot read binary file: {path}")
+                return FuncToolResult(success=0, error=f"Cannot read binary file: {resolved.display}")
             except PermissionError:
-                return FuncToolResult(success=0, error=f"Permission denied: {path}")
+                return FuncToolResult(success=0, error=f"Permission denied: {resolved.display}")
 
         except Exception as e:
             logger.error(f"Error reading file {path}: {str(e)}")
@@ -200,10 +231,14 @@ class FilesystemFuncTool(BaseTool):
         Create a new file or overwrite an existing file.
 
         Args:
-            path: Relative path within the workspace directory. Do NOT use absolute paths.
-            content: The content to write to the file
-            file_type: Type of file being written (e.g., "reference_sql", "semantic_model").
-                       Used by hooks for special handling.
+            path: Target path. Relative paths are resolved under the project
+                root. Absolute paths require user confirmation via the
+                permission hook.
+            content: The content to write to the file.
+            file_type: Optional tag consumed by ``GenerationHooks`` for
+                post-write sync-to-DB routing; has no effect on where the
+                file lands. The prompt is responsible for supplying the
+                correct directory in ``path``.
 
         Returns:
             dict: A dictionary with the execution result, containing these keys:
@@ -211,25 +246,24 @@ class FilesystemFuncTool(BaseTool):
                   - 'error' (Optional[str]): Error message on failure.
                   - 'result' (Optional[str]): Success message on success.
         """
+        del file_type
         try:
-            try:
-                path = self._normalize(path, file_type, strict=True)
-            except Exception as e:
-                return FuncToolResult(success=0, error=f"Path normalization failed: {e}")
-            target_path = self._get_safe_path(path)
+            resolved = self._classify(path)
+            if resolved.zone == PathZone.HIDDEN:
+                return self._not_found(resolved)
+            if self._strict and resolved.zone == PathZone.EXTERNAL:
+                return self._strict_reject(resolved)
 
-            if not target_path:
-                return FuncToolResult(success=0, error=f"Invalid path: {path}")
-
+            target_path = resolved.resolved
             if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {path}")
+                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
 
             try:
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 target_path.write_text(content, encoding="utf-8")
-                return FuncToolResult(result=f"File written successfully: {str(path)}")
+                return FuncToolResult(result=f"File written successfully: {resolved.display}")
             except PermissionError:
-                return FuncToolResult(success=0, error=f"Permission denied: {path}")
+                return FuncToolResult(success=0, error=f"Permission denied: {resolved.display}")
 
         except Exception as e:
             logger.error(f"Error writing file {path}: {str(e)}")
@@ -240,7 +274,7 @@ class FilesystemFuncTool(BaseTool):
         Make a single edit to a file by replacing old_string with new_string.
 
         Args:
-            path: Relative path within the workspace directory. Do NOT use absolute paths.
+            path: Target path, resolved the same way as ``write_file``.
             old_string: The text to find and replace. Must match exactly once in the file.
             new_string: The text to replace old_string with.
 
@@ -254,20 +288,21 @@ class FilesystemFuncTool(BaseTool):
             if not old_string:
                 return FuncToolResult(success=0, error="old_string must not be empty")
 
-            try:
-                path = self._normalize(path, strict=True)
-            except Exception as e:
-                return FuncToolResult(success=0, error=f"Path normalization failed: {e}")
-            target_path = self._get_safe_path(path)
+            resolved = self._classify(path)
+            if resolved.zone == PathZone.HIDDEN:
+                return self._not_found(resolved)
+            if self._strict and resolved.zone == PathZone.EXTERNAL:
+                return self._strict_reject(resolved)
 
-            if not target_path or not target_path.exists():
-                return FuncToolResult(success=0, error=f"File not found: {path}")
+            target_path = resolved.resolved
+            if not target_path.exists():
+                return FuncToolResult(success=0, error=f"File not found: {resolved.display}")
 
             if not target_path.is_file():
-                return FuncToolResult(success=0, error=f"Path is not a file: {path}")
+                return FuncToolResult(success=0, error=f"Path is not a file: {resolved.display}")
 
             if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {path}")
+                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
 
             try:
                 content = target_path.read_text(encoding="utf-8")
@@ -289,15 +324,17 @@ class FilesystemFuncTool(BaseTool):
 
                 content = content.replace(old_string, new_string, 1)
                 target_path.write_text(content, encoding="utf-8")
-                return FuncToolResult(result=f"File edited successfully: {str(path)}")
+                return FuncToolResult(result=f"File edited successfully: {resolved.display}")
             except UnicodeDecodeError:
-                return FuncToolResult(success=0, error=f"Cannot edit binary file: {path}")
+                return FuncToolResult(success=0, error=f"Cannot edit binary file: {resolved.display}")
             except PermissionError:
-                return FuncToolResult(success=0, error=f"Permission denied: {path}")
+                return FuncToolResult(success=0, error=f"Permission denied: {resolved.display}")
 
         except Exception as e:
             logger.error(f"Error editing file {path}: {str(e)}")
             return FuncToolResult(success=0, error=str(e))
+
+    # ------------------------------------------------------------------ walks
 
     # Minimal fallback excludes when no .gitignore is found
     _FALLBACK_EXCLUDE_DIRS = {".git", "__pycache__", "node_modules"}
@@ -311,7 +348,6 @@ class FilesystemFuncTool(BaseTool):
         """
         patterns = [".git", ".git/**", "**/.git/**"]
 
-        # Search for .gitignore from search_root up to root_path
         root_resolved = Path(self.config.root_path).resolve(strict=False)
         current = search_root.resolve(strict=False)
         gitignore_path = None
@@ -325,7 +361,6 @@ class FilesystemFuncTool(BaseTool):
             current = current.parent
 
         if not gitignore_path:
-            # No .gitignore found, use fallback
             for d in self._FALLBACK_EXCLUDE_DIRS:
                 patterns.extend([d, f"{d}/**", f"**/{d}/**"])
             return patterns
@@ -336,21 +371,16 @@ class FilesystemFuncTool(BaseTool):
                     line = line.strip()
                     if not line or line.startswith("#"):
                         continue
-                    # Skip negation patterns (not supported in this simplified parser)
                     if line.startswith("!"):
                         continue
-                    # Strip leading / (gitignore root-relative marker)
                     entry = line.lstrip("/")
-                    # Handle trailing-slash directory entries: also match the dir name itself
                     if entry.endswith("/"):
                         dir_name = entry.rstrip("/")
                         patterns.append(dir_name)
                         patterns.append(f"**/{dir_name}")
                     patterns.append(entry)
-                    # Ensure directory entries also match contents
                     if not entry.endswith("/**"):
                         patterns.append(f"{entry}/**")
-                    # Ensure patterns match at any depth unless already prefixed
                     if not entry.startswith("**/"):
                         patterns.append(f"**/{entry}")
         except Exception as e:
@@ -358,33 +388,58 @@ class FilesystemFuncTool(BaseTool):
 
         return patterns
 
-    def _walk_files(self, path: str, include_pattern: str = "") -> Iterator[Path]:
-        """Walk directory tree yielding files, respecting gitignore, symlink safety, and sandbox.
+    def _walk_files(self, seed: ResolvedPath, include_pattern: str = "") -> Iterator[Path]:
+        """Walk a directory tree yielding files.
 
-        Args:
-            path: Starting directory path (relative to root).
-            include_pattern: Optional glob pattern to filter filenames (e.g., "*.py").
+        Traversal honors:
 
-        Yields:
-            Path objects for each matching file.
+        * Gitignore entries under the seed.
+        * Symlink safety: a symlink target outside the project root is only
+          followed when the seed itself was ``EXTERNAL`` (the hook confirmed
+          it). For ``INTERNAL``/``WHITELIST`` seeds we re-classify each
+          resolved item so a symlink pointing at ``~/secrets`` is skipped.
+        * ``HIDDEN`` prune: every entry is classified; ``HIDDEN`` subtrees
+          are skipped entirely, which keeps ``.datus/sessions`` etc. invisible
+          even if the LLM happens to search from project root.
         """
-        target_path = self._get_safe_path(path)
-        if not target_path or not target_path.exists() or not target_path.is_dir():
+        target_path = seed.resolved
+        if seed.zone == PathZone.HIDDEN or not target_path.exists() or not target_path.is_dir():
             return
 
-        root_path_resolved = Path(self.config.root_path).resolve(strict=False)
-        target_path_resolved = target_path.resolve(strict=False)
-
-        try:
-            target_path_resolved.relative_to(root_path_resolved)
-        except ValueError:
-            return
-
+        seed_is_project_relative = seed.zone in (PathZone.INTERNAL, PathZone.WHITELIST)
         exclude_patterns = self._load_gitignore_patterns(target_path)
         visited_inodes = set()
+        anchors = whitelist_anchors(
+            root_path=self._root_resolved,
+            current_node=self._current_node,
+            datus_home=self._datus_home,
+        )
 
-        def should_exclude(file_path: Path) -> bool:
-            relative_path = str(file_path.relative_to(target_path_resolved))
+        def has_whitelisted_descendant(directory: Path) -> bool:
+            """Is any whitelist anchor strictly underneath ``directory``?
+
+            Needed because ``.datus/`` itself classifies HIDDEN even though
+            ``.datus/skills/`` inside it is WHITELIST — we still have to
+            descend into the HIDDEN parent to reach the visible subtree.
+            """
+            try:
+                for anchor in anchors:
+                    if anchor == directory:
+                        return True
+                    try:
+                        anchor.relative_to(directory)
+                        return True
+                    except ValueError:
+                        continue
+            except Exception:
+                return False
+            return False
+
+        def should_gitignore_exclude(file_path: Path) -> bool:
+            try:
+                relative_path = str(file_path.relative_to(target_path))
+            except ValueError:
+                return False
             for exclude_pattern in exclude_patterns:
                 try:
                     if wc_glob.globmatch(relative_path, exclude_pattern, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR):
@@ -406,35 +461,48 @@ class FilesystemFuncTool(BaseTool):
 
                 for item in current_path.iterdir():
                     try:
-                        if item.is_dir() and item.name == ".git":
-                            continue
-
-                        if should_exclude(item):
+                        if should_gitignore_exclude(item):
                             continue
 
                         item_resolved = item.resolve(strict=False)
 
-                        # Security: ensure resolved path stays within sandbox
-                        try:
-                            item_resolved.relative_to(root_path_resolved)
-                        except ValueError:
-                            continue
+                        # Classify every resolved item; HIDDEN subtrees are
+                        # pruned regardless of where the walk started, unless
+                        # they contain a whitelist anchor further inside (in
+                        # which case we descend but never yield at the HIDDEN
+                        # level itself).
+                        item_is_hidden = False
+                        if seed_is_project_relative:
+                            item_zone = classify_path(
+                                str(item_resolved),
+                                root_path=self._root_resolved,
+                                current_node=self._current_node,
+                                datus_home=self._datus_home,
+                            ).zone
+                            if item_zone == PathZone.EXTERNAL:
+                                # Symlink escape from project tree; skip.
+                                continue
+                            if item_zone == PathZone.HIDDEN:
+                                if item_resolved.is_dir() and has_whitelisted_descendant(item_resolved):
+                                    item_is_hidden = True  # descend but don't yield files here
+                                else:
+                                    continue
 
-                        if item.is_dir():
+                        if item_resolved.is_dir():
                             yield from walk_recursive(item_resolved)
-                        elif item.is_file():
+                        elif item_resolved.is_file() and not item_is_hidden:
                             if include_pattern:
                                 if not wc_glob.globmatch(
                                     item.name, include_pattern, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR
                                 ):
                                     continue
-                            yield item
+                            yield item_resolved
                     except OSError:
                         continue
             except OSError:
                 return
 
-        yield from walk_recursive(target_path_resolved)
+        yield from walk_recursive(target_path)
 
     def glob(self, pattern: str, path: str = ".") -> FuncToolResult:
         """
@@ -448,48 +516,61 @@ class FilesystemFuncTool(BaseTool):
             dict: A dictionary with the execution result, containing these keys:
                   - 'success' (int): 1 for success, 0 for failure.
                   - 'error' (Optional[str]): Error message on failure.
-                  - 'result' (Optional[dict]): Dict with 'files' (list of paths relative to
-                    ``root_path`` so callers can feed them back to ``read_file`` /
-                    ``write_file`` without leaking absolute paths) and 'truncated' (bool).
+                  - 'result' (Optional[dict]): Dict with 'files' (list of paths), 'truncated' (bool),
+                    and — when the search seed fell outside the project root — ``'external': True``
+                    so the caller knows reported paths are absolute.
         """
         max_results = 200
         try:
-            target_path = self._get_safe_path(path)
+            seed = self._classify(path)
+            if seed.zone == PathZone.HIDDEN:
+                return FuncToolResult(result={"files": [], "truncated": False})
+            if self._strict and seed.zone == PathZone.EXTERNAL:
+                return self._strict_reject(seed)
 
-            if not target_path or not target_path.exists():
-                return FuncToolResult(success=0, error=f"Directory not found: {path}")
-
+            target_path = seed.resolved
+            if not target_path.exists():
+                return FuncToolResult(success=0, error=f"Directory not found: {seed.display}")
             if not target_path.is_dir():
-                return FuncToolResult(success=0, error=f"Path is not a directory: {path}")
+                return FuncToolResult(success=0, error=f"Path is not a directory: {seed.display}")
 
-            target_path_resolved = target_path.resolve(strict=False)
-            root_path_resolved = Path(self.config.root_path).resolve(strict=False)
-            matches = []
+            report_relative_to: Optional[Path] = None
+            if seed.zone in (PathZone.INTERNAL, PathZone.WHITELIST):
+                report_relative_to = self._root_resolved
 
-            for file_path in self._walk_files(path):
-                relative_path = str(file_path.relative_to(target_path_resolved))
-                # Report paths relative to root_path so the LLM can feed them
-                # back to read_file/write_file without leaking absolute paths.
+            matches: List[str] = []
+            for file_path in self._walk_files(seed):
                 try:
-                    reported_path = str(file_path.relative_to(root_path_resolved))
+                    match_rel = str(file_path.relative_to(target_path))
                 except ValueError:
-                    reported_path = str(file_path)
+                    match_rel = str(file_path)
+
                 try:
-                    if wc_glob.globmatch(relative_path, pattern, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR):
-                        matches.append(reported_path)
-                        if len(matches) >= max_results:
-                            break
+                    matched = wc_glob.globmatch(match_rel, pattern, flags=wc_glob.DOTGLOB | wc_glob.GLOBSTAR)
                 except Exception:
-                    if file_path.name == pattern:
-                        matches.append(reported_path)
-                        if len(matches) >= max_results:
-                            break
+                    matched = file_path.name == pattern
+
+                if not matched:
+                    continue
+
+                if report_relative_to is not None:
+                    try:
+                        reported = str(file_path.relative_to(report_relative_to))
+                    except ValueError:
+                        reported = str(file_path)
+                else:
+                    reported = str(file_path)
+                matches.append(reported)
+                if len(matches) >= max_results:
+                    break
 
             truncated = len(matches) >= max_results
-            result_data = {
+            result_data: dict = {
                 "files": matches,
                 "truncated": truncated,
             }
+            if seed.zone == PathZone.EXTERNAL:
+                result_data["external"] = True
             if truncated:
                 result_data["message"] = (
                     f"Results truncated to {max_results}. Use a more specific pattern to narrow results."
@@ -518,13 +599,17 @@ class FilesystemFuncTool(BaseTool):
         """
         max_matches = 100
         try:
-            target_path = self._get_safe_path(path)
+            seed = self._classify(path)
+            if seed.zone == PathZone.HIDDEN:
+                return FuncToolResult(result={"matches": [], "truncated": False})
+            if self._strict and seed.zone == PathZone.EXTERNAL:
+                return self._strict_reject(seed)
 
-            if not target_path or not target_path.exists():
-                return FuncToolResult(success=0, error=f"Directory not found: {path}")
-
+            target_path = seed.resolved
+            if not target_path.exists():
+                return FuncToolResult(success=0, error=f"Directory not found: {seed.display}")
             if not target_path.is_dir():
-                return FuncToolResult(success=0, error=f"Path is not a directory: {path}")
+                return FuncToolResult(success=0, error=f"Path is not a directory: {seed.display}")
 
             flags = 0 if case_sensitive else re.IGNORECASE
             try:
@@ -532,9 +617,12 @@ class FilesystemFuncTool(BaseTool):
             except re.error as e:
                 return FuncToolResult(success=0, error=f"Invalid regex pattern: {str(e)}")
 
-            matches = []
+            report_relative_to: Optional[Path] = None
+            if seed.zone in (PathZone.INTERNAL, PathZone.WHITELIST):
+                report_relative_to = self._root_resolved
 
-            for file_path in self._walk_files(path, include_pattern=include):
+            matches: List[dict] = []
+            for file_path in self._walk_files(seed, include_pattern=include):
                 if not self._is_allowed_file(file_path):
                     continue
 
@@ -549,11 +637,19 @@ class FilesystemFuncTool(BaseTool):
                 except (UnicodeDecodeError, PermissionError, OSError):
                     continue
 
+                if report_relative_to is not None:
+                    try:
+                        reported_file = str(file_path.relative_to(report_relative_to))
+                    except ValueError:
+                        reported_file = str(file_path)
+                else:
+                    reported_file = str(file_path)
+
                 for line_num, line in enumerate(content.split("\n"), start=1):
                     if compiled.search(line):
                         matches.append(
                             {
-                                "file": str(file_path),
+                                "file": reported_file,
                                 "line": line_num,
                                 "content": line.rstrip(),
                             }
@@ -565,18 +661,24 @@ class FilesystemFuncTool(BaseTool):
                     break
 
             truncated = len(matches) >= max_matches
-            return FuncToolResult(
-                result={
-                    "matches": matches,
-                    "truncated": truncated,
-                }
-            )
+            result_data: dict = {
+                "matches": matches,
+                "truncated": truncated,
+            }
+            if seed.zone == PathZone.EXTERNAL:
+                result_data["external"] = True
+            return FuncToolResult(result=result_data)
 
         except Exception as e:
             logger.exception(f"Error in grep search for {pattern} in {path}")
             return FuncToolResult(success=0, error=str(e))
 
 
-def filesystem_function_tools(root_path: str = None) -> List[Tool]:
+def filesystem_function_tools(
+    root_path: str = None,
+    *,
+    current_node: Optional[str] = None,
+    strict: bool = False,
+) -> List[Tool]:
     """Get filesystem function tools"""
-    return FilesystemFuncTool(root_path=root_path).available_tools()
+    return FilesystemFuncTool(root_path=root_path, current_node=current_node, strict=strict).available_tools()

--- a/datus/tools/func_tool/fs_path_policy.py
+++ b/datus/tools/func_tool/fs_path_policy.py
@@ -1,0 +1,217 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Path classification policy shared between ``FilesystemFuncTool`` and the
+permission / generation hooks.
+
+A single ``classify_path()`` pure function assigns every filesystem path the
+tool sees to one of four zones (``INTERNAL``/``WHITELIST``/``HIDDEN``/
+``EXTERNAL``). The same classification is then enforced in two places:
+
+1. ``FilesystemFuncTool`` — visibility and early-return for ``HIDDEN``/bounds.
+2. ``PermissionHooks`` — force ``ASK`` for ``EXTERNAL`` and short-circuit
+   ``INTERNAL``/``WHITELIST`` against any ``check_permission`` verdict.
+
+Keeping the function pure (no IO beyond ``Path.resolve(strict=False)``) lets
+both layers share behavior without coupling them to each other.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class PathZone(str, Enum):
+    """Classification of a filesystem path relative to the project root."""
+
+    INTERNAL = "internal"
+    WHITELIST = "whitelist"
+    HIDDEN = "hidden"
+    EXTERNAL = "external"
+
+
+@dataclass(frozen=True)
+class ResolvedPath:
+    """Result of ``classify_path``.
+
+    Attributes:
+        raw: Caller-supplied path string, unmodified.
+        resolved: Absolute, symlink-resolved ``Path`` (``strict=False`` so the
+            target may not exist yet — needed for write ops).
+        zone: Which ``PathZone`` the resolved path belongs to.
+        display: Human/LLM-friendly rendering. Relative to ``root_path`` for
+            ``INTERNAL``/``WHITELIST``-in-project, ``~``-prefixed for home
+            whitelist, absolute for ``EXTERNAL``/``HIDDEN``.
+    """
+
+    raw: str
+    resolved: Path
+    zone: PathZone
+    display: str
+
+
+def _is_relative_to(candidate: Path, anchor: Path) -> bool:
+    """Python 3.12 has ``Path.is_relative_to`` but guarded with a try/except for
+    non-Path comparisons. Kept as a small helper for readability and so tests
+    can mock or extend it without touching ``Path``.
+    """
+    try:
+        candidate.relative_to(anchor)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_home(datus_home: Optional[Path]) -> Path:
+    """Resolve the effective ``~/.datus`` root for whitelist anchors."""
+    if datus_home is not None:
+        return Path(datus_home).expanduser().resolve(strict=False)
+    return (Path.home() / ".datus").resolve(strict=False)
+
+
+def classify_path(
+    path: str,
+    *,
+    root_path: Path,
+    current_node: Optional[str],
+    datus_home: Optional[Path] = None,
+) -> ResolvedPath:
+    """Classify ``path`` into a ``PathZone`` relative to ``root_path``.
+
+    Args:
+        path: The raw path string as reported by the LLM / caller. May be
+            relative, absolute, or ``~``-prefixed. Empty or ``.`` is treated
+            as the project root itself.
+        root_path: The project root (used as the base for relative paths and
+            as the anchor for ``INTERNAL`` / project-side whitelist checks).
+            Will be ``resolve()``'d internally, so symlinks in the root are
+            normalized up front.
+        current_node: Name of the currently executing node. Only then does
+            ``{root_path}/.datus/memory/{current_node}/**`` qualify as
+            ``WHITELIST``. ``None`` causes the memory anchor to be dropped,
+            which demotes every ``.datus/memory/**`` path to ``HIDDEN``.
+        datus_home: Override for ``~/.datus``. Primarily a test hook; when
+            ``None`` the classifier uses the real home directory.
+
+    Returns:
+        A ``ResolvedPath`` with the computed zone and display form. Never
+        raises — callers can rely on getting some ``PathZone`` back.
+    """
+    raw = path
+    root_resolved = Path(root_path).expanduser().resolve(strict=False)
+    home_resolved = _resolve_home(datus_home)
+
+    candidate_input = path.strip() if path else ""
+    if candidate_input in ("", ".", "./"):
+        expanded = root_resolved
+    else:
+        expanded = Path(os.path.expanduser(candidate_input))
+        if not expanded.is_absolute():
+            expanded = root_resolved / expanded
+
+    resolved = expanded.resolve(strict=False)
+
+    # Anchor order matters: project-side anchors are matched before the home
+    # anchor so a project that happens to live under ``~/.datus`` still
+    # classifies ``{project_root}/.datus/skills/x`` as the project's own skill
+    # rather than the global one. See Decision Order step 4 in the plan.
+    project_dot_datus = (root_resolved / ".datus").resolve(strict=False)
+    project_skills = (project_dot_datus / "skills").resolve(strict=False)
+    project_memory_node: Optional[Path] = None
+    if current_node:
+        project_memory_node = (project_dot_datus / "memory" / current_node).resolve(strict=False)
+    global_skills = (home_resolved / "skills").resolve(strict=False)
+
+    whitelist_anchors = [project_skills]
+    if project_memory_node is not None:
+        whitelist_anchors.append(project_memory_node)
+    whitelist_anchors.append(global_skills)
+
+    zone: PathZone
+    display: str
+    if any(_is_relative_to(resolved, anchor) for anchor in whitelist_anchors):
+        zone = PathZone.WHITELIST
+        if _is_relative_to(resolved, root_resolved):
+            display = str(resolved.relative_to(root_resolved))
+        elif _is_relative_to(resolved, home_resolved):
+            # ``home_resolved`` already *is* the ``.datus`` directory, so we
+            # rebuild the display with the canonical ``~/.datus/`` prefix the
+            # LLM can feed back unambiguously. Without this we would show
+            # ``~/skills/foo`` and lose which home we meant.
+            display = "~/.datus/" + str(resolved.relative_to(home_resolved))
+        else:
+            display = str(resolved)
+    elif _is_relative_to(resolved, project_dot_datus):
+        zone = PathZone.HIDDEN
+        if _is_relative_to(resolved, root_resolved):
+            display = str(resolved.relative_to(root_resolved))
+        else:
+            display = str(resolved)
+    elif _is_relative_to(resolved, root_resolved):
+        zone = PathZone.INTERNAL
+        display = str(resolved.relative_to(root_resolved)) or "."
+    else:
+        zone = PathZone.EXTERNAL
+        display = str(resolved)
+
+    return ResolvedPath(raw=raw, resolved=resolved, zone=zone, display=display)
+
+
+def whitelist_anchors(
+    *,
+    root_path: Path,
+    current_node: Optional[str],
+    datus_home: Optional[Path] = None,
+) -> list[Path]:
+    """Return the resolved whitelist anchor directories for a given node.
+
+    Used by walkers that need to answer "is there a whitelisted subtree
+    underneath this HIDDEN directory?" without re-running ``classify_path``
+    for every descendant. The order mirrors ``classify_path`` (project-side
+    first) so longer prefixes win.
+    """
+    root_resolved = Path(root_path).expanduser().resolve(strict=False)
+    home_resolved = _resolve_home(datus_home)
+    project_dot_datus = (root_resolved / ".datus").resolve(strict=False)
+    anchors = [(project_dot_datus / "skills").resolve(strict=False)]
+    if current_node:
+        anchors.append((project_dot_datus / "memory" / current_node).resolve(strict=False))
+    anchors.append((home_resolved / "skills").resolve(strict=False))
+    return anchors
+
+
+def build_walk_patterns(
+    *,
+    root_path: Path,
+    current_node: Optional[str],
+) -> tuple[list[str], list[str]]:
+    """Build the (exclude, re-include) glob pattern pair used by the walker.
+
+    The tool feeds these into ``wcmatch`` so ``HIDDEN`` subtrees are pruned
+    before any per-entry work, mirroring Claude Code's ``--glob !{pattern}``
+    ripgrep trick. Re-includes win over excludes, so the two whitelisted
+    subtrees under ``.datus/`` stay visible.
+
+    Args:
+        root_path: Project root (unused beyond documentation today; accepted
+            for forward-compat so callers that later want root-relative
+            patterns don't need to change signature).
+        current_node: Same semantics as ``classify_path``; ``None`` leaves
+            the memory subtree excluded.
+
+    Returns:
+        ``(excludes, re_includes)`` — both are glob patterns rooted at
+        ``root_path`` (no leading ``/``).
+    """
+    del root_path  # reserved for future use; keeps API stable.
+    excludes = [".datus", ".datus/**"]
+    re_includes = [".datus/skills/**"]
+    if current_node:
+        re_includes.append(f".datus/memory/{current_node}/**")
+    return excludes, re_includes

--- a/datus/tools/func_tool/fs_path_policy.py
+++ b/datus/tools/func_tool/fs_path_policy.py
@@ -135,27 +135,32 @@ def classify_path(
 
     zone: PathZone
     display: str
+    # Relative displays use ``.as_posix()`` instead of ``str()`` so the forward-
+    # slash-shaped scope globs used downstream (e.g. ``subject/**`` matched
+    # with ``wcmatch.globmatch``) still work on Windows. ``str(Path)`` yields
+    # backslashes on Windows, which ``wcmatch`` does not normalize — it would
+    # silently reject valid writes.
     if any(_is_relative_to(resolved, anchor) for anchor in whitelist_anchors):
         zone = PathZone.WHITELIST
         if _is_relative_to(resolved, root_resolved):
-            display = str(resolved.relative_to(root_resolved))
+            display = resolved.relative_to(root_resolved).as_posix()
         elif _is_relative_to(resolved, home_resolved):
             # ``home_resolved`` already *is* the ``.datus`` directory, so we
             # rebuild the display with the canonical ``~/.datus/`` prefix the
             # LLM can feed back unambiguously. Without this we would show
             # ``~/skills/foo`` and lose which home we meant.
-            display = "~/.datus/" + str(resolved.relative_to(home_resolved))
+            display = "~/.datus/" + resolved.relative_to(home_resolved).as_posix()
         else:
             display = str(resolved)
     elif _is_relative_to(resolved, project_dot_datus):
         zone = PathZone.HIDDEN
         if _is_relative_to(resolved, root_resolved):
-            display = str(resolved.relative_to(root_resolved))
+            display = resolved.relative_to(root_resolved).as_posix()
         else:
             display = str(resolved)
     elif _is_relative_to(resolved, root_resolved):
         zone = PathZone.INTERNAL
-        display = str(resolved.relative_to(root_resolved)) or "."
+        display = resolved.relative_to(root_resolved).as_posix() or "."
     else:
         zone = PathZone.EXTERNAL
         display = str(resolved)

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -261,6 +261,17 @@ class PermissionHooks(AgentHooks):
         policy = self.fs_policy
         assert policy is not None  # guarded by caller
         args = self._parse_tool_args(context)
+        # ``_parse_tool_args`` deliberately returns whatever the JSON decoder
+        # produced, so malformed tool_arguments (list, string, number) would
+        # otherwise blow up on ``.get()``. Treat non-object payloads as
+        # "no path provided" and fall back to the category-level rule check.
+        if not isinstance(args, dict):
+            logger.debug(
+                "Filesystem permission check received non-object tool arguments for %s: %r",
+                tool_name,
+                args,
+            )
+            return False
         path_arg = args.get("path", "")
         try:
             resolved = classify_path(

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -18,11 +18,14 @@ when prompting users for permission confirmation.
 import asyncio
 import json
 import logging
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from agents.lifecycle import AgentHooks
 
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
+from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
 from datus.tools.permission.permission_config import PermissionLevel
 from datus.tools.registry.tool_registry import ToolRegistry
 
@@ -42,6 +45,30 @@ class PermissionDeniedException(Exception):
         super().__init__(message)
         self.tool_category = tool_category
         self.tool_name = tool_name
+
+
+@dataclass(frozen=True)
+class FilesystemPolicy:
+    """Per-node filesystem policy passed to :class:`PermissionHooks`.
+
+    Carries the information the hook needs to run
+    :func:`datus.tools.func_tool.fs_path_policy.classify_path` on every
+    filesystem tool call. Leaving this ``None`` on construction keeps the
+    old category/tool-level permission behavior (no zone-based overrides).
+
+    ``strict`` mirrors :attr:`FilesystemFuncTool.strict` so the hook and the
+    tool agree on what to do with ``EXTERNAL`` paths. When ``True``, the
+    hook denies them up front (no broker prompt) because the API / claw
+    surfaces have no interactive broker attached — prompting would hang the
+    request. The tool-level ``strict`` is still the source of truth, but
+    having the same flag in the policy lets the hook fail fast before the
+    tool even gets invoked.
+    """
+
+    root_path: Path
+    current_node: Optional[str]
+    datus_home: Optional[Path] = None
+    strict: bool = False
 
 
 class CompositeHooks(AgentHooks):
@@ -118,6 +145,8 @@ class PermissionHooks(AgentHooks):
         permission_manager: "PermissionManager",
         node_name: str,
         tool_registry: ToolRegistry,
+        *,
+        fs_policy: Optional[FilesystemPolicy] = None,
     ):
         """Initialize the permission hooks.
 
@@ -126,11 +155,19 @@ class PermissionHooks(AgentHooks):
             permission_manager: PermissionManager for checking permissions
             node_name: Name of the current agentic node (e.g., "chat")
             tool_registry: Shared ToolRegistry instance (from AgenticNode)
+            fs_policy: Optional per-node filesystem policy. When provided,
+                ``filesystem_tools`` calls are routed through
+                :func:`classify_path` first so ``EXTERNAL`` paths force a user
+                prompt regardless of category rules, and ``HIDDEN`` paths fall
+                through silently (the tool itself returns ``File not found``).
+                Leaving this ``None`` preserves the old tool/category-level
+                behavior for tests and legacy callers.
         """
         self.broker = broker
         self.permission_manager = permission_manager
         self.node_name = node_name
         self.tool_registry = tool_registry
+        self.fs_policy = fs_policy
 
     async def on_tool_start(self, context, agent, tool) -> None:
         """Intercept ALL tool calls for permission checking.
@@ -156,6 +193,15 @@ class PermissionHooks(AgentHooks):
         category, pattern_name = self._get_category_and_pattern(tool_name, context)
 
         logger.debug(f"Permission check for tool '{tool_name}': category='{category}', pattern='{pattern_name}'")
+
+        # Filesystem tools: zone-based policy overrides rules.
+        #   INTERNAL/WHITELIST → bypass, HIDDEN → bypass (tool returns not-found),
+        #   EXTERNAL → force ASK with a path-keyed session cache so approving
+        #   /Users/foo/secret does not cascade to /Users/foo/other.
+        if self.fs_policy is not None and category == "filesystem_tools":
+            handled = await self._handle_filesystem_zone(context, tool_name, pattern_name)
+            if handled:
+                return
 
         # Check permission
         permission = self.permission_manager.check_permission(category, pattern_name, self.node_name)
@@ -201,6 +247,127 @@ class PermissionHooks(AgentHooks):
                     )
 
                 logger.info(f"User approved tool '{tool_name}'")
+
+    async def _handle_filesystem_zone(self, context: Any, tool_name: str, pattern_name: str) -> bool:
+        """Zone-based gating for ``filesystem_tools.*`` calls.
+
+        Returns ``True`` when the call has been fully handled (either allowed
+        through or rejected) and ``False`` to let the normal category-level
+        permission check run. ``EXTERNAL`` zones always land in the ``ASK``
+        branch here regardless of what the category rule says — that is the
+        whole point of zones, otherwise a session-level ``allow`` on
+        ``filesystem_tools`` would silently grant ``/etc/passwd`` access.
+        """
+        policy = self.fs_policy
+        assert policy is not None  # guarded by caller
+        args = self._parse_tool_args(context)
+        path_arg = args.get("path", "")
+        try:
+            resolved = classify_path(
+                path_arg,
+                root_path=policy.root_path,
+                current_node=policy.current_node,
+                datus_home=policy.datus_home,
+            )
+        except Exception as e:
+            logger.debug(f"classify_path failed for {tool_name} path={path_arg!r}: {e}")
+            return False
+
+        if resolved.zone in (PathZone.INTERNAL, PathZone.WHITELIST):
+            logger.debug(
+                "Filesystem zone %s: allowing %s on %s without prompt",
+                resolved.zone.value,
+                tool_name,
+                resolved.display,
+            )
+            return True
+
+        if resolved.zone == PathZone.HIDDEN:
+            # Let the tool itself return the uniform ``File not found`` so the
+            # LLM cannot distinguish "hidden by policy" from "does not exist".
+            logger.debug("Filesystem zone HIDDEN: letting tool return not-found for %s", resolved.display)
+            return True
+
+        # EXTERNAL in strict mode → deny up front, no broker prompt. Mirrors
+        # FilesystemFuncTool.strict so callers without an interactive broker
+        # (API / claw) fail fast instead of hanging waiting for user input.
+        if policy.strict:
+            logger.info(
+                "Filesystem strict mode: rejecting EXTERNAL access to %s (tool=%s)",
+                resolved.resolved,
+                tool_name,
+            )
+            raise PermissionDeniedException(
+                f"Filesystem strict mode: path outside workspace is not allowed: {resolved.resolved}",
+                tool_category="filesystem_tools",
+                tool_name=pattern_name,
+            )
+
+        # EXTERNAL: force ASK, keyed by absolute path to prevent broad auto-approval.
+        cache_key = f"filesystem_tools.external::{resolved.resolved}"
+        if self.permission_manager._session_approvals.get(cache_key):
+            logger.debug("External path %s already approved for session", resolved.resolved)
+            return True
+
+        async with _permission_prompt_lock:
+            if self.permission_manager._session_approvals.get(cache_key):
+                return True
+
+            approved = await self._request_external_confirmation(tool_name, pattern_name, resolved.resolved)
+            if not approved:
+                logger.info("User rejected external filesystem access to %s", resolved.resolved)
+                raise PermissionDeniedException(
+                    f"User rejected external filesystem access to {resolved.resolved}",
+                    tool_category="filesystem_tools",
+                    tool_name=pattern_name,
+                )
+            logger.info("User approved external filesystem access to %s", resolved.resolved)
+            return True
+
+    async def _request_external_confirmation(
+        self,
+        tool_name: str,
+        pattern_name: str,
+        abs_path: Path,
+    ) -> bool:
+        """Prompt the user for an EXTERNAL filesystem access.
+
+        Approval is narrow: the ``a`` (always-allow) choice caches this exact
+        absolute path, not the whole tool or category.
+        """
+        content = (
+            "### External Filesystem Access\n\n"
+            f"**Tool:** `filesystem_tools.{pattern_name}`\n"
+            f"**Path:** `{abs_path}`  _(outside project root)_\n"
+        )
+        try:
+            choice, callback = await self.broker.request(
+                contents=[content],
+                choices=[
+                    {
+                        "y": "Allow (once)",
+                        "a": "Always allow (this path, session)",
+                        "n": "Deny",
+                    }
+                ],
+                default_choices=["n"],
+            )
+
+            if choice == "a":
+                cache_key = f"external::{abs_path}"
+                self.permission_manager.approve_for_session("filesystem_tools", cache_key)
+                await callback(f"**{abs_path}** approved for session")
+                return True
+            if choice == "y":
+                await callback("**Approved**")
+                return True
+            await callback("**Denied**")
+            return False
+        except InteractionCancelled:
+            return False
+        except Exception as e:
+            logger.error(f"Error in external filesystem confirmation for {tool_name}: {e}")
+            return False
 
     def _get_category_and_pattern(self, tool_name: str, context: Any) -> Tuple[str, str]:
         """Get tool category and pattern name for permission checking.

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -174,6 +174,53 @@ class TestChatAgenticNodeToolSetup:
 
         assert node.filesystem_func_tool is not None
 
+    def test_filesystem_strict_from_agent_config(self, real_agent_config, mock_llm_create):
+        """agent_config.filesystem_strict = True propagates into the tool
+        and the permission-hook policy. This is how API / claw bootstraps
+        force strict mode for every node they spawn."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        real_agent_config.filesystem_strict = True
+        try:
+            node = ChatAgenticNode(
+                node_id="test_fs_strict",
+                description="Test fs strict",
+                node_type=NodeType.TYPE_CHAT,
+                agent_config=real_agent_config,
+            )
+            assert node.filesystem_func_tool.strict is True
+            if node.permission_hooks and node.permission_hooks.fs_policy:
+                assert node.permission_hooks.fs_policy.strict is True
+        finally:
+            real_agent_config.filesystem_strict = False
+
+    def test_filesystem_root_from_node_config_workspace(self, real_agent_config, mock_llm_create, tmp_path):
+        """``node_config.workspace_root`` replaces the fs tool root so a node
+        can be scoped to a directory outside the project root. Verified via
+        ``_resolve_workspace_root`` -> ``_make_filesystem_tool``."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        custom_workspace = tmp_path / "node_ws"
+        custom_workspace.mkdir()
+
+        if not getattr(real_agent_config, "agentic_nodes", None):
+            real_agent_config.agentic_nodes = {}
+        prev = real_agent_config.agentic_nodes.get("chat")
+        real_agent_config.agentic_nodes["chat"] = {"workspace_root": str(custom_workspace)}
+        try:
+            node = ChatAgenticNode(
+                node_id="test_node_ws",
+                description="Test node workspace",
+                node_type=NodeType.TYPE_CHAT,
+                agent_config=real_agent_config,
+            )
+            assert node.filesystem_func_tool.root_path == str(custom_workspace)
+        finally:
+            if prev is not None:
+                real_agent_config.agentic_nodes["chat"] = prev
+            else:
+                real_agent_config.agentic_nodes.pop("chat", None)
+
     def test_has_date_parsing_tools(self, real_agent_config, mock_llm_create):
         """Chat node has date parsing tools."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -208,7 +208,12 @@ class TestChatAgenticNodeToolSetup:
         custom_workspace = tmp_path / "node_ws"
         custom_workspace.mkdir()
 
-        if not getattr(real_agent_config, "agentic_nodes", None):
+        # Snapshot the whole container, not just the "chat" key — if the
+        # fixture started with ``agentic_nodes = None`` we must restore that
+        # exact state, otherwise downstream tests that assert ``is None`` see
+        # a stray ``{}``.
+        prev_container = getattr(real_agent_config, "agentic_nodes", None)
+        if not prev_container:
             real_agent_config.agentic_nodes = {}
         prev = real_agent_config.agentic_nodes.get("chat")
         real_agent_config.agentic_nodes["chat"] = {"workspace_root": str(custom_workspace)}
@@ -225,6 +230,8 @@ class TestChatAgenticNodeToolSetup:
                 real_agent_config.agentic_nodes["chat"] = prev
             else:
                 real_agent_config.agentic_nodes.pop("chat", None)
+            if not prev_container:
+                real_agent_config.agentic_nodes = prev_container
 
     def test_has_date_parsing_tools(self, real_agent_config, mock_llm_create):
         """Chat node has date parsing tools."""

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -180,6 +180,7 @@ class TestChatAgenticNodeToolSetup:
         force strict mode for every node they spawn."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode
 
+        previous_strict = getattr(real_agent_config, "filesystem_strict", False)
         real_agent_config.filesystem_strict = True
         try:
             node = ChatAgenticNode(
@@ -189,10 +190,14 @@ class TestChatAgenticNodeToolSetup:
                 agent_config=real_agent_config,
             )
             assert node.filesystem_func_tool.strict is True
-            if node.permission_hooks and node.permission_hooks.fs_policy:
-                assert node.permission_hooks.fs_policy.strict is True
+            # Contract is mandatory: strict mode must reach the hook policy,
+            # otherwise EXTERNAL paths would still trigger broker prompts in
+            # non-interactive bootstraps (the whole point of strict mode).
+            assert node.permission_hooks is not None
+            assert node.permission_hooks.fs_policy is not None
+            assert node.permission_hooks.fs_policy.strict is True
         finally:
-            real_agent_config.filesystem_strict = False
+            real_agent_config.filesystem_strict = previous_strict
 
     def test_filesystem_root_from_node_config_workspace(self, real_agent_config, mock_llm_create, tmp_path):
         """``node_config.workspace_root`` replaces the fs tool root so a node

--- a/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
@@ -11,6 +11,7 @@ via the conftest mock_llm_create fixture.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -453,14 +454,11 @@ class TestGenExtKnowledgeSaveToDbSandbox:
 
 
 class TestGenExtKnowledgeFilesystemRootPath:
-    """FilesystemFuncTool is sandboxed to subject_dir (not the type-specific subdir)."""
+    """FilesystemFuncTool now uses project_root; scope enforcement moved to GenerationHooks."""
 
-    def test_filesystem_root_is_subject_dir(self, real_agent_config, mock_llm_create):
+    def test_filesystem_root_is_project_root(self, real_agent_config, mock_llm_create):
         node = _create_node(real_agent_config)
-        expected = str(real_agent_config.path_manager.subject_dir)
+        expected = str(Path(real_agent_config.project_root).expanduser())
 
         assert node.filesystem_func_tool is not None
-        assert node.filesystem_func_tool.config.root_path == expected
-        assert node.filesystem_func_tool._path_normalizer is not None
-
-        assert node.filesystem_func_tool._path_normalizer("notes.yaml", None) == "ext_knowledge/notes.yaml"
+        assert node.filesystem_func_tool.root_path == expected

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -672,20 +672,15 @@ class TestExecuteStreamGenMetricsError:
 
 
 class TestGenMetricsFilesystemRootPath:
-    """FilesystemFuncTool is sandboxed to subject_dir (not the type-specific subdir)."""
+    """FilesystemFuncTool now uses project_root; write-scope enforcement moved to GenerationHooks."""
 
-    def test_filesystem_root_is_subject_dir(self, real_agent_config, mock_llm_create):
+    def test_filesystem_root_is_project_root(self, real_agent_config, mock_llm_create):
+        from pathlib import Path
+
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        expected = str(real_agent_config.path_manager.subject_dir)
+        expected = str(Path(real_agent_config.project_root).expanduser())
 
         assert node.filesystem_func_tool is not None
-        assert node.filesystem_func_tool.config.root_path == expected
-        assert node.filesystem_func_tool._path_normalizer is not None
-
-        # metric kind co-locates under semantic_models/
-        assert (
-            node.filesystem_func_tool._path_normalizer("metrics/orders.yaml", None)
-            == "semantic_models/metrics/orders.yaml"
-        )
+        assert node.filesystem_func_tool.root_path == expected

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -609,16 +609,15 @@ class TestSaveToDb:
 
 
 class TestGenSemanticModelFilesystemRootPath:
-    """FilesystemFuncTool is sandboxed to subject_dir (not the type-specific subdir)."""
+    """FilesystemFuncTool now uses project_root; write-scope enforcement moved to GenerationHooks."""
 
-    def test_filesystem_root_is_subject_dir(self, real_agent_config, mock_llm_create):
+    def test_filesystem_root_is_project_root(self, real_agent_config, mock_llm_create):
+        from pathlib import Path
+
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 
         node = GenSemanticModelAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        expected = str(real_agent_config.path_manager.subject_dir)
+        expected = str(Path(real_agent_config.project_root).expanduser())
 
         assert node.filesystem_func_tool is not None
-        assert node.filesystem_func_tool.config.root_path == expected
-        assert node.filesystem_func_tool._path_normalizer is not None
-
-        assert node.filesystem_func_tool._path_normalizer("orders.yml", None) == "semantic_models/orders.yml"
+        assert node.filesystem_func_tool.root_path == expected

--- a/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
@@ -94,8 +94,11 @@ class TestSkillCreatorAgenticNodeInit:
 class TestSkillCreatorAgenticNodeTools:
     """Tests for SkillCreatorAgenticNode tool setup."""
 
-    def test_has_skills_write_tools(self, real_agent_config, mock_llm_create):
-        """Node should have skill_* prefixed write tools for skills directory."""
+    def test_has_unified_filesystem_tools(self, real_agent_config, mock_llm_create):
+        """Node exposes a single unified filesystem tool — write scope is
+        enforced by GenerationHooks (``.datus/skills/**``), not by a separate
+        prefixed instance.
+        """
         from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
 
         node = SkillCreatorAgenticNode(
@@ -106,13 +109,12 @@ class TestSkillCreatorAgenticNodeTools:
             node_name="gen_skill",
         )
         tool_names = [t.name for t in node.tools]
-        assert "skill_write_file" in tool_names
-        assert "skill_edit_file" in tool_names
-        assert "skill_glob" in tool_names
-        assert "skill_grep" in tool_names
+        assert {"read_file", "write_file", "edit_file", "glob", "grep"}.issubset(tool_names)
+        # No skill_* prefixed duplicates anymore.
+        assert not any(name.startswith("skill_") and name.endswith(("_file", "glob", "grep")) for name in tool_names)
 
     def test_has_workspace_read_tools(self, real_agent_config, mock_llm_create):
-        """Node should have workspace read-only tools (unprefixed)."""
+        """Node has the unified read tools rooted at project workspace."""
         from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
 
         node = SkillCreatorAgenticNode(
@@ -126,22 +128,6 @@ class TestSkillCreatorAgenticNodeTools:
         assert "read_file" in tool_names
         assert "glob" in tool_names
         assert "grep" in tool_names
-
-    def test_has_skills_read_tools(self, real_agent_config, mock_llm_create):
-        """Node should have skill_* prefixed read tools for skills directory."""
-        from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
-
-        node = SkillCreatorAgenticNode(
-            node_id="test_skill_creator_tools_2b",
-            description="Test gen_skill node",
-            node_type=NodeType.TYPE_GEN_SKILL,
-            agent_config=real_agent_config,
-            node_name="gen_skill",
-        )
-        tool_names = [t.name for t in node.tools]
-        assert "skill_read_file" in tool_names
-        assert "skill_glob" in tool_names
-        assert "skill_grep" in tool_names
 
     def test_has_db_tools(self, real_agent_config, mock_llm_create):
         """Node should have database tools."""

--- a/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
@@ -350,14 +350,13 @@ class TestSqlSummarySaveToDbSandbox:
 
 
 class TestSqlSummaryFilesystemRootPath:
-    """FilesystemFuncTool is sandboxed to subject_dir (not the type-specific subdir)."""
+    """FilesystemFuncTool now uses project_root; write-scope enforcement moved to GenerationHooks."""
 
-    def test_filesystem_root_is_subject_dir(self, real_agent_config, mock_llm_create):
+    def test_filesystem_root_is_project_root(self, real_agent_config, mock_llm_create):
+        from pathlib import Path
+
         node = _create_node(real_agent_config)
-        expected = str(real_agent_config.path_manager.subject_dir)
+        expected = str(Path(real_agent_config.project_root).expanduser())
 
         assert node.filesystem_func_tool is not None
-        assert node.filesystem_func_tool.config.root_path == expected
-        assert node.filesystem_func_tool._path_normalizer is not None
-
-        assert node.filesystem_func_tool._path_normalizer("q_001.yaml", None) == "sql_summaries/q_001.yaml"
+        assert node.filesystem_func_tool.root_path == expected

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -24,15 +24,12 @@ import pytest
 
 from datus.cli.execution_state import InteractionCancelled
 from datus.cli.generation_hooks import (
-    NODE_WRITE_SCOPES,
     GenerationCancelledException,
     GenerationHooks,
     normalize_kb_relative_path,
-    path_matches_any_scope,
     resolve_kb_sandbox_path,
 )
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool  # noqa: F401
-from datus.tools.permission.permission_hooks import PermissionDeniedException
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1514,140 +1511,6 @@ class TestNormalizeKbRelativePath:
 
     def test_unknown_kind_unchanged(self):
         assert normalize_kb_relative_path("orders.yaml", "unknown") == "orders.yaml"
-
-
-# ---------------------------------------------------------------------------
-# Tests: NODE_WRITE_SCOPES hard gate on on_tool_start
-# ---------------------------------------------------------------------------
-
-
-class _FakeTool:
-    def __init__(self, name):
-        self.name = name
-
-
-class _FakeContext:
-    def __init__(self, path):
-        self.tool_arguments = json.dumps({"path": path, "content": "x"})
-
-
-class _FakeAgent:
-    def __init__(self, name):
-        self.name = name
-
-
-class TestNodeWriteScopes:
-    def test_scope_map_covers_expected_nodes(self):
-        expected = {
-            "gen_semantic_model",
-            "gen_metrics",
-            "sql_summary",
-            "gen_ext_knowledge",
-            "gen_skill",
-            "migration",
-            "gen_job",
-            "gen_table",
-        }
-        assert set(NODE_WRITE_SCOPES) == expected
-
-    def test_path_matches_any_scope_accepts_relative_subject(self):
-        assert path_matches_any_scope("subject/semantic_models/x.yaml", ["subject/semantic_models/**"])
-
-    def test_path_matches_any_scope_rejects_wrong_subdir(self):
-        assert not path_matches_any_scope("subject/sql_summaries/x.yaml", ["subject/semantic_models/**"])
-
-    @pytest.mark.asyncio
-    async def test_gate_allows_write_in_scope(self, real_agent_config):
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
-        tool = _FakeTool("write_file")
-        ctx = _FakeContext("subject/semantic_models/x.yaml")
-        # Should not raise
-        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_rejects_write_outside_scope(self, real_agent_config):
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
-        tool = _FakeTool("write_file")
-        ctx = _FakeContext("subject/sql_summaries/x.yaml")
-        with pytest.raises(PermissionDeniedException):
-            await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_skips_unknown_node(self, real_agent_config):
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="chat")
-        tool = _FakeTool("write_file")
-        ctx = _FakeContext("subject/sql_summaries/x.yaml")
-        # ``chat`` is not in NODE_WRITE_SCOPES so the gate is a no-op.
-        await hooks.on_tool_start(ctx, _FakeAgent("chat"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_ignores_non_write_tools(self, real_agent_config):
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
-        tool = _FakeTool("read_file")
-        ctx = _FakeContext("subject/sql_summaries/x.yaml")
-        # Read-side calls are never gated — the gate is write/edit only.
-        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_rejects_external_absolute(self, real_agent_config):
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
-        tool = _FakeTool("write_file")
-        ctx = _FakeContext("/tmp/escape.yaml")
-        with pytest.raises(PermissionDeniedException):
-            await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_falls_back_to_agent_name(self, real_agent_config):
-        """When node_name is not passed to the constructor, the gate reads
-        ``agent.name`` at call time so the scope is still resolvable."""
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config)
-        tool = _FakeTool("write_file")
-        ctx = _FakeContext("subject/sql_summaries/x.yaml")
-        with pytest.raises(PermissionDeniedException):
-            await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_missing_path_arg_is_noop(self, real_agent_config):
-        """No ``path`` kwarg → gate cannot classify → skip rather than raise."""
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
-        tool = _FakeTool("write_file")
-        ctx = MagicMock()
-        ctx.tool_arguments = json.dumps({"content": "no path here"})
-        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_malformed_tool_arguments(self, real_agent_config):
-        """Malformed JSON in tool_arguments → ``_extract_path_arg`` swallows
-        the decode error and the gate skips. Regression guard against crashing
-        on LLM-malformed payloads.
-        """
-        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
-        tool = _FakeTool("write_file")
-        ctx = MagicMock()
-        ctx.tool_arguments = "{not valid json"
-        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    @pytest.mark.asyncio
-    async def test_gate_noop_without_agent_config(self):
-        """No agent_config → ``_project_root`` returns None → the gate
-        short-circuits rather than attempting to classify the path."""
-        hooks = GenerationHooks(broker=None, agent_config=None, node_name="gen_semantic_model")
-        tool = _FakeTool("write_file")
-        ctx = _FakeContext("subject/semantic_models/x.yaml")
-        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
-
-    def test_resolve_node_name_prefers_constructor(self):
-        hooks = GenerationHooks(broker=None, agent_config=None, node_name="chat")
-        assert hooks._resolve_node_name(_FakeAgent("something_else")) == "chat"
-
-    def test_resolve_node_name_falls_back_to_agent(self):
-        hooks = GenerationHooks(broker=None, agent_config=None)
-        assert hooks._resolve_node_name(_FakeAgent("chat")) == "chat"
-
-    def test_resolve_node_name_returns_none_when_missing(self):
-        hooks = GenerationHooks(broker=None, agent_config=None)
-        agent = MagicMock(spec=[])  # no ``name`` attribute
-        assert hooks._resolve_node_name(agent) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -24,13 +24,15 @@ import pytest
 
 from datus.cli.execution_state import InteractionCancelled
 from datus.cli.generation_hooks import (
+    NODE_WRITE_SCOPES,
     GenerationCancelledException,
     GenerationHooks,
-    make_kb_path_normalizer,
     normalize_kb_relative_path,
+    path_matches_any_scope,
     resolve_kb_sandbox_path,
 )
-from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
+from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool  # noqa: F401
+from datus.tools.permission.permission_hooks import PermissionDeniedException
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1515,71 +1517,164 @@ class TestNormalizeKbRelativePath:
 
 
 # ---------------------------------------------------------------------------
-# Tests: make_kb_path_normalizer factory
+# Tests: NODE_WRITE_SCOPES hard gate on on_tool_start
 # ---------------------------------------------------------------------------
 
 
-class TestMakeKbPathNormalizer:
-    def test_uses_default_kind_when_file_type_missing(self):
-        normalizer = make_kb_path_normalizer(default_kind="semantic")
-        assert normalizer("orders.yaml", None) == "semantic_models/orders.yaml"
+class _FakeTool:
+    def __init__(self, name):
+        self.name = name
 
-    def test_file_type_overrides_default_kind(self):
-        normalizer = make_kb_path_normalizer(default_kind="semantic")
-        assert normalizer("q_001.yaml", "sql_summary") == "sql_summaries/q_001.yaml"
 
-    def test_file_type_aliases_recognized(self):
-        normalizer = make_kb_path_normalizer(default_kind=None)
-        assert normalizer("orders.yaml", "semantic_model") == "semantic_models/orders.yaml"
-        assert normalizer("metrics/x.yaml", "metric") == "semantic_models/metrics/x.yaml"
-        assert normalizer("notes.yaml", "ext_knowledge") == "ext_knowledge/notes.yaml"
+class _FakeContext:
+    def __init__(self, path):
+        self.tool_arguments = json.dumps({"path": path, "content": "x"})
 
-    def test_strict_kind_rejects_cross_kind_write(self):
-        """Mutating ops (strict_kind=True) must reject writes to peer kinds' subdirs."""
-        from datus.utils.exceptions import DatusException, ErrorCode
 
-        normalizer = make_kb_path_normalizer(default_kind="semantic")
-        # Read-lax: cross-kind reads still allowed.
-        assert normalizer("sql_summaries/q.yaml", None) == "sql_summaries/q.yaml"
-        # Write-strict: the same cross-kind path is refused.
-        with pytest.raises(DatusException) as exc_info:
-            normalizer("sql_summaries/q.yaml", None, strict_kind=True)
-        assert exc_info.value.code == ErrorCode.TOOL_INVALID_INPUT
-        assert "Write to 'sql_summaries/' is not allowed" in str(exc_info.value)
+class _FakeAgent:
+    def __init__(self, name):
+        self.name = name
 
-    def test_strict_kind_ignores_file_type_override(self):
-        """In strict mode, file_type cannot be used to switch kinds."""
-        normalizer = make_kb_path_normalizer(default_kind="semantic")
-        # Without strict: file_type override is honored.
-        assert normalizer("q.yaml", "sql_summary") == "sql_summaries/q.yaml"
-        # With strict: override is ignored; default_kind wins.
-        assert normalizer("q.yaml", "sql_summary", strict_kind=True) == "semantic_models/q.yaml"
 
-    def test_strict_kind_allows_own_kind_prefix(self):
-        """Own-kind prefix is accepted in strict mode."""
-        normalizer = make_kb_path_normalizer(default_kind="semantic")
-        assert normalizer("semantic_models/orders.yml", None, strict_kind=True) == "semantic_models/orders.yml"
+class TestNodeWriteScopes:
+    def test_scope_map_covers_expected_nodes(self):
+        expected = {
+            "gen_semantic_model",
+            "gen_metrics",
+            "sql_summary",
+            "gen_ext_knowledge",
+            "gen_skill",
+            "migration",
+            "gen_job",
+            "gen_table",
+        }
+        assert set(NODE_WRITE_SCOPES) == expected
+
+    def test_path_matches_any_scope_accepts_relative_subject(self):
+        assert path_matches_any_scope("subject/semantic_models/x.yaml", ["subject/semantic_models/**"])
+
+    def test_path_matches_any_scope_rejects_wrong_subdir(self):
+        assert not path_matches_any_scope("subject/sql_summaries/x.yaml", ["subject/semantic_models/**"])
+
+    @pytest.mark.asyncio
+    async def test_gate_allows_write_in_scope(self, real_agent_config):
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
+        tool = _FakeTool("write_file")
+        ctx = _FakeContext("subject/semantic_models/x.yaml")
+        # Should not raise
+        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_rejects_write_outside_scope(self, real_agent_config):
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
+        tool = _FakeTool("write_file")
+        ctx = _FakeContext("subject/sql_summaries/x.yaml")
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_skips_unknown_node(self, real_agent_config):
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="chat")
+        tool = _FakeTool("write_file")
+        ctx = _FakeContext("subject/sql_summaries/x.yaml")
+        # ``chat`` is not in NODE_WRITE_SCOPES so the gate is a no-op.
+        await hooks.on_tool_start(ctx, _FakeAgent("chat"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_ignores_non_write_tools(self, real_agent_config):
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
+        tool = _FakeTool("read_file")
+        ctx = _FakeContext("subject/sql_summaries/x.yaml")
+        # Read-side calls are never gated — the gate is write/edit only.
+        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_rejects_external_absolute(self, real_agent_config):
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
+        tool = _FakeTool("write_file")
+        ctx = _FakeContext("/tmp/escape.yaml")
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_falls_back_to_agent_name(self, real_agent_config):
+        """When node_name is not passed to the constructor, the gate reads
+        ``agent.name`` at call time so the scope is still resolvable."""
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config)
+        tool = _FakeTool("write_file")
+        ctx = _FakeContext("subject/sql_summaries/x.yaml")
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_missing_path_arg_is_noop(self, real_agent_config):
+        """No ``path`` kwarg → gate cannot classify → skip rather than raise."""
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
+        tool = _FakeTool("write_file")
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps({"content": "no path here"})
+        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_malformed_tool_arguments(self, real_agent_config):
+        """Malformed JSON in tool_arguments → ``_extract_path_arg`` swallows
+        the decode error and the gate skips. Regression guard against crashing
+        on LLM-malformed payloads.
+        """
+        hooks = GenerationHooks(broker=None, agent_config=real_agent_config, node_name="gen_semantic_model")
+        tool = _FakeTool("write_file")
+        ctx = MagicMock()
+        ctx.tool_arguments = "{not valid json"
+        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    @pytest.mark.asyncio
+    async def test_gate_noop_without_agent_config(self):
+        """No agent_config → ``_project_root`` returns None → the gate
+        short-circuits rather than attempting to classify the path."""
+        hooks = GenerationHooks(broker=None, agent_config=None, node_name="gen_semantic_model")
+        tool = _FakeTool("write_file")
+        ctx = _FakeContext("subject/semantic_models/x.yaml")
+        await hooks.on_tool_start(ctx, _FakeAgent("gen_semantic_model"), tool)
+
+    def test_resolve_node_name_prefers_constructor(self):
+        hooks = GenerationHooks(broker=None, agent_config=None, node_name="chat")
+        assert hooks._resolve_node_name(_FakeAgent("something_else")) == "chat"
+
+    def test_resolve_node_name_falls_back_to_agent(self):
+        hooks = GenerationHooks(broker=None, agent_config=None)
+        assert hooks._resolve_node_name(_FakeAgent("chat")) == "chat"
+
+    def test_resolve_node_name_returns_none_when_missing(self):
+        hooks = GenerationHooks(broker=None, agent_config=None)
+        agent = MagicMock(spec=[])  # no ``name`` attribute
+        assert hooks._resolve_node_name(agent) is None
 
 
 # ---------------------------------------------------------------------------
-# Tests: hook + tool agreement — _resolve_path finds files written via the
-# same normalizer regardless of whether the LLM emitted a naked filename.
+# Tests: hook + tool agreement — _resolve_path finds files written by the
+# tool (naked filename path was a normalizer concern; with normalizer gone
+# the LLM writes the full prefix, so the hook resolver must keep returning
+# the same absolute path regardless of which form the caller uses).
 # ---------------------------------------------------------------------------
 
 
 class TestHookAndToolPathAgreement:
-    def test_resolve_path_finds_naked_file_after_normalized_write(self, tmp_path, real_agent_config):
-        """FilesystemFuncTool writes orders.yml → hook resolves 'orders.yml' to the same on-disk path."""
+    def test_resolve_path_finds_file_written_with_full_prefix(self, tmp_path, real_agent_config):
+        """FilesystemFuncTool writes subject/semantic_models/orders.yml → hook resolves the same on-disk path."""
         subject_root = Path(str(real_agent_config.path_manager.subject_dir))
+        project_root = subject_root.parent
 
         tool = FilesystemFuncTool(
-            root_path=str(subject_root),
-            path_normalizer=make_kb_path_normalizer(default_kind="semantic"),
+            root_path=str(project_root),
+            current_node="gen_semantic_model",
         )
-        write_result = tool.write_file("orders.yml", "id: orders\n", file_type="semantic_model")
+        write_result = tool.write_file("subject/semantic_models/orders.yml", "id: orders\n")
         assert write_result.success == 1
 
         hooks = GenerationHooks(broker=None, agent_config=real_agent_config)
+        # Hook's legacy resolver still accepts naked filenames via
+        # normalize_kb_relative_path; the resolver path is decoupled from
+        # the fs tool.
         resolved = hooks._resolve_path("orders.yml", "semantic")
 
         on_disk = subject_root / "semantic_models" / "orders.yml"

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -7,16 +7,16 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-from datus.cli.generation_hooks import make_kb_path_normalizer
 from datus.tools.func_tool.filesystem_tools import FilesystemConfig, FilesystemFuncTool
+from datus.tools.func_tool.fs_path_policy import PathZone
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_tool(root_path: str) -> FilesystemFuncTool:
-    return FilesystemFuncTool(root_path=root_path)
+def _make_tool(root_path: str, *, current_node: str = "test_node") -> FilesystemFuncTool:
+    return FilesystemFuncTool(root_path=root_path, current_node=current_node)
 
 
 # ---------------------------------------------------------------------------
@@ -60,17 +60,24 @@ class TestFilesystemConfig:
 
 
 class TestGetSafePath:
+    """``_get_safe_path`` is the deprecated shim over ``classify_path``. It
+    returns ``None`` for EXTERNAL/HIDDEN zones so legacy callers continue to
+    see the original "out-of-sandbox" reject behavior.
+    """
+
     def test_valid_relative_path(self, tmp_path):
         tool = _make_tool(str(tmp_path))
         result = tool._get_safe_path("subdir/file.txt")
         assert result is not None
         assert str(result).startswith(str(tmp_path.resolve()))
 
-    def test_path_traversal_blocked(self, tmp_path):
+    def test_path_traversal_returns_none(self, tmp_path):
+        # Escape via `..` lands in EXTERNAL → shim returns None for parity
+        # with the pre-refactor contract. The tool itself would allow the
+        # read (hook is responsible for the user prompt), but this shim
+        # exists only for the handful of external callers.
         tool = _make_tool(str(tmp_path))
-        # Try to escape root via ..
-        result = tool._get_safe_path("../../etc/passwd")
-        assert result is None
+        assert tool._get_safe_path("../../etc/passwd") is None
 
     def test_dot_path_returns_root(self, tmp_path):
         tool = _make_tool(str(tmp_path))
@@ -151,10 +158,14 @@ class TestReadFile:
         result = tool.read_file("data.txt")
         assert result.success == 0
 
-    def test_read_file_path_traversal_blocked(self, tmp_path):
+    def test_read_file_path_traversal_classified_external(self, tmp_path):
+        """``../`` escape lands in EXTERNAL. The tool does not hard-reject
+        (the permission hook is responsible for asking the user), but the
+        zone classifier must flag it so the hook can see it.
+        """
         tool = _make_tool(str(tmp_path))
-        result = tool.read_file("../../etc/passwd")
-        assert result.success == 0
+        resolved = tool._classify("../../etc/passwd")
+        assert resolved.zone == PathZone.EXTERNAL
 
     def test_read_file_with_offset_and_limit(self, tmp_path):
         f = tmp_path / "lines.txt"
@@ -220,10 +231,12 @@ class TestWriteFile:
         assert result.success == 0
         assert "not allowed" in result.error.lower()
 
-    def test_write_path_traversal_blocked(self, tmp_path):
+    def test_write_path_traversal_classified_external(self, tmp_path):
+        """Write with ``../`` escape also classifies EXTERNAL — gating lives
+        in the permission hook, not in the tool."""
         tool = _make_tool(str(tmp_path))
-        result = tool.write_file("../../evil.txt", "evil")
-        assert result.success == 0
+        resolved = tool._classify("../../evil.txt")
+        assert resolved.zone == PathZone.EXTERNAL
 
     def test_write_overwrites_existing(self, tmp_path):
         f = tmp_path / "existing.txt"
@@ -490,101 +503,154 @@ class TestAvailableTools:
 
 
 # ---------------------------------------------------------------------------
-# KB path_normalizer round-trip: write/read/edit with the silent prefix
-# normalizer (covers the project-scoped ``subject/`` layout contract).
+# Zone-based visibility contract: .datus/ invisible except skills/memory
+# whitelist; absolute-path reads allowed at the tool layer (permission hook
+# is responsible for prompting the user outside the project).
 # ---------------------------------------------------------------------------
 
 
-class TestFilesystemFuncToolKbNormalizerRoundTrip:
-    """Contract tests for FilesystemFuncTool + KB path_normalizer."""
+class TestPathZones:
+    """Covers the four classification zones on read/write/edit/glob."""
 
-    def _make(self, tmp_path: Path, kind: str):
-        kb_root = tmp_path / "kb"
-        kb_root.mkdir()
-        tool = FilesystemFuncTool(
-            root_path=str(kb_root),
-            path_normalizer=make_kb_path_normalizer(default_kind=kind),
-        )
-        return tool, kb_root
+    def test_internal_relative_path_allowed(self, tmp_path):
+        (tmp_path / "hello.md").write_text("hi")
+        tool = _make_tool(str(tmp_path))
+        resolved = tool._classify("hello.md")
+        assert resolved.zone == PathZone.INTERNAL
+        assert tool.read_file("hello.md").result == "hi"
 
-    def test_naked_filename_lands_in_typed_subdir(self, tmp_path):
-        tool, kb_root = self._make(tmp_path, "semantic")
-        result = tool.write_file("orders.yml", "id: orders\n", file_type="semantic_model")
-        assert result.success == 1
-        on_disk = kb_root / "semantic_models" / "orders.yml"
-        assert on_disk.is_file()
-        assert on_disk.read_text() == "id: orders\n"
-
-    def test_read_naked_filename_after_naked_write(self, tmp_path):
-        """LLM forgets prefix on both write and subsequent read — both must succeed."""
-        tool, _ = self._make(tmp_path, "semantic")
-        tool.write_file("orders.yml", "payload\n", file_type="semantic_model")
-        assert tool.read_file("orders.yml").result == "payload\n"
-
-    def test_read_with_full_prefix_after_naked_write(self, tmp_path):
-        tool, _ = self._make(tmp_path, "semantic")
-        tool.write_file("orders.yml", "payload\n", file_type="semantic_model")
-        assert tool.read_file("semantic_models/orders.yml").result == "payload\n"
-
-    def test_edit_file_after_naked_write(self, tmp_path):
-        tool, _ = self._make(tmp_path, "sql_summary")
-        tool.write_file("q_001.yaml", "name: original\n", file_type="sql_summary")
-        edit_result = tool.edit_file("q_001.yaml", "original", "edited")
-        assert edit_result.success == 1, edit_result.error
-        assert tool.read_file("q_001.yaml").result == "name: edited\n"
-
-    def test_write_with_full_prefix_does_not_double_prefix(self, tmp_path):
-        tool, kb_root = self._make(tmp_path, "semantic")
-        tool.write_file(
-            "semantic_models/customers.yml",
-            "id: customers\n",
-            file_type="semantic_model",
-        )
-        assert (kb_root / "semantic_models" / "customers.yml").is_file()
-        assert not (kb_root / "semantic_models" / "semantic_models").exists()
-
-    def test_cross_kind_read_works(self, tmp_path):
-        """A semantic-mode tool must still read peer sql_summaries by full path."""
-        tool, kb_root = self._make(tmp_path, "semantic")
-        peer = kb_root / "sql_summaries" / "q_001.yaml"
-        peer.parent.mkdir(parents=True)
-        peer.write_text("peer content\n")
-        assert tool.read_file("sql_summaries/q_001.yaml").result == "peer content\n"
-
-    def test_cross_kind_write_is_rejected_under_strict(self, tmp_path):
-        """Writing to a peer kind's subdir must fail closed (sandbox enforcement)."""
-        tool, _ = self._make(tmp_path, "semantic")
-        result = tool.write_file(
-            "sql_summaries/q_001.yaml",
-            "bad\n",
-            file_type="semantic_model",
-        )
+    def test_hidden_dot_datus_invisible_on_read(self, tmp_path):
+        secret = tmp_path / ".datus" / "sessions" / "x.db"
+        secret.parent.mkdir(parents=True)
+        secret.write_text("secret")
+        tool = _make_tool(str(tmp_path))
+        resolved = tool._classify(".datus/sessions/x.db")
+        assert resolved.zone == PathZone.HIDDEN
+        result = tool.read_file(".datus/sessions/x.db")
+        # Same "File not found" whether the file exists or not.
         assert result.success == 0
-        assert "not allowed" in (result.error or "").lower()
+        assert "file not found" in (result.error or "").lower()
 
-    def test_normalizer_exception_fails_write(self, tmp_path):
-        """If the path_normalizer raises, write_file must fail instead of
-        silently landing the mutation at an unnormalized path."""
-
-        def _boom(path, file_type, *, strict_kind=False):
-            raise RuntimeError("normalizer error")
-
-        tool = FilesystemFuncTool(root_path=str(tmp_path), path_normalizer=_boom)
-        result = tool.write_file("orders.yml", "data\n")
+    def test_hidden_dot_datus_invisible_on_write(self, tmp_path):
+        tool = _make_tool(str(tmp_path))
+        result = tool.write_file(".datus/sessions/new.md", "payload")
         assert result.success == 0
-        assert "normalization failed" in (result.error or "").lower()
-        # And no file should have been created.
-        assert not any(tmp_path.rglob("orders.yml"))
+        assert "file not found" in (result.error or "").lower()
+        assert not (tmp_path / ".datus" / "sessions" / "new.md").exists()
 
-    def test_normalizer_exception_does_not_fail_read(self, tmp_path):
-        """Reads stay lax: on normalizer error, fall back to the original path
-        and let the sandbox check fail naturally."""
+    def test_whitelist_project_skills_readable_and_writable(self, tmp_path):
+        tool = _make_tool(str(tmp_path))
+        resolved = tool._classify(".datus/skills/my_skill/SKILL.md")
+        assert resolved.zone == PathZone.WHITELIST
+        assert tool.write_file(".datus/skills/my_skill/SKILL.md", "# skill\n").success == 1
+        assert tool.read_file(".datus/skills/my_skill/SKILL.md").result == "# skill\n"
 
-        def _boom(path, file_type, *, strict_kind=False):
-            raise RuntimeError("normalizer error")
+    def test_whitelist_per_node_memory_isolated(self, tmp_path):
+        tool = _make_tool(str(tmp_path), current_node="gen_sql")
+        own_zone = tool._classify(".datus/memory/gen_sql/MEMORY.md").zone
+        other_zone = tool._classify(".datus/memory/chat/MEMORY.md").zone
+        assert own_zone == PathZone.WHITELIST
+        assert other_zone == PathZone.HIDDEN
 
-        (tmp_path / "orders.yml").write_text("data\n")
-        tool = FilesystemFuncTool(root_path=str(tmp_path), path_normalizer=_boom)
-        result = tool.read_file("orders.yml")
+    def test_current_node_none_degrades_memory_to_hidden(self, tmp_path):
+        tool = FilesystemFuncTool(root_path=str(tmp_path), current_node=None)
+        zone = tool._classify(".datus/memory/anything/MEMORY.md").zone
+        assert zone == PathZone.HIDDEN
+
+    def test_external_absolute_allowed_at_tool_layer(self, tmp_path):
+        """Without a hook, the tool allows EXTERNAL reads. This documents the
+        contract: the hook owns user confirmation, the tool owns visibility.
+        """
+        outside = tmp_path.parent / "outside.md"
+        try:
+            outside.write_text("out-of-project")
+            # Fresh project root is an empty subdir so absolute access is external.
+            project = tmp_path / "proj"
+            project.mkdir()
+            tool = _make_tool(str(project))
+            zone = tool._classify(str(outside)).zone
+            assert zone == PathZone.EXTERNAL
+            assert tool.read_file(str(outside)).result == "out-of-project"
+        finally:
+            if outside.exists():
+                outside.unlink()
+
+    def test_glob_prunes_hidden_subtree(self, tmp_path):
+        (tmp_path / "keep.md").write_text("visible")
+        skill_dir = tmp_path / ".datus" / "skills" / "foo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("skill")
+        hidden = tmp_path / ".datus" / "sessions"
+        hidden.mkdir(parents=True)
+        (hidden / "a.md").write_text("hidden")
+        tool = _make_tool(str(tmp_path))
+        names = {Path(p).name for p in tool.glob("**/*.md").result["files"]}
+        assert "keep.md" in names
+        assert "SKILL.md" in names
+        assert "a.md" not in names
+
+    def test_strict_rejects_external_read(self, tmp_path):
+        """Strict mode fails closed on EXTERNAL: reads never touch the host fs.
+
+        Used by API / claw where there's no broker to ask the user. We do
+        not fall through to an ``exists()`` probe either, so a missing
+        external path and an existing one produce the same rejection.
+        """
+        outside = tmp_path.parent / "strict_outside.md"
+        outside.write_text("secret")
+        project = tmp_path / "proj"
+        project.mkdir()
+        tool = FilesystemFuncTool(root_path=str(project), current_node="chat", strict=True)
+        try:
+            result = tool.read_file(str(outside))
+            assert result.success == 0
+            assert "not allowed in strict mode" in (result.error or "").lower()
+            assert str(outside) in (result.error or "")
+        finally:
+            if outside.exists():
+                outside.unlink()
+
+    def test_strict_rejects_external_write(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        target = tmp_path / "elsewhere.md"
+        tool = FilesystemFuncTool(root_path=str(project), current_node="chat", strict=True)
+        result = tool.write_file(str(target), "payload")
+        assert result.success == 0
+        assert "not allowed in strict mode" in (result.error or "").lower()
+        assert not target.exists()
+
+    def test_strict_rejects_external_glob(self, tmp_path):
+        other = tmp_path / "other"
+        other.mkdir()
+        (other / "x.md").write_text("x")
+        project = tmp_path / "proj"
+        project.mkdir()
+        tool = FilesystemFuncTool(root_path=str(project), current_node="chat", strict=True)
+        result = tool.glob("*.md", str(other))
+        assert result.success == 0
+        assert "not allowed in strict mode" in (result.error or "").lower()
+
+    def test_strict_allows_internal_and_whitelist(self, tmp_path):
+        """Strict mode must NOT break project-internal / whitelist access —
+        otherwise the API surface could not read its own files."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "hello.md").write_text("hi")
+        tool = FilesystemFuncTool(root_path=str(project), current_node="chat", strict=True)
+        assert tool.read_file("hello.md").result == "hi"
+        assert tool.write_file(".datus/skills/x/SKILL.md", "# skill\n").success == 1
+
+    def test_glob_external_seed_returns_absolute_paths(self, tmp_path):
+        other = tmp_path / "other"
+        other.mkdir()
+        (other / "x.md").write_text("body")
+        project = tmp_path / "proj"
+        project.mkdir()
+        tool = _make_tool(str(project))
+        result = tool.glob("*.md", str(other))
         assert result.success == 1
-        assert result.result == "data\n"
+        assert result.result.get("external") is True
+        files = result.result["files"]
+        assert files
+        assert all(Path(p).is_absolute() for p in files)

--- a/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
+++ b/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
@@ -9,6 +9,7 @@ import pytest
 
 from datus.tools.func_tool.fs_path_policy import (
     PathZone,
+    build_walk_patterns,
     classify_path,
     whitelist_anchors,
 )
@@ -136,3 +137,37 @@ class TestWhitelistAnchors:
         expected_suffixes = {(".datus", "skills")}
         seen = {(a.parent.name, a.name) for a in anchors}
         assert seen == expected_suffixes
+
+
+class TestBuildWalkPatterns:
+    """The walker relies on these patterns to prune ``HIDDEN`` subtrees cheaply
+    — ``wcmatch`` is fed ``excludes`` first and then applies ``re_includes`` so
+    the two allowed subtrees under ``.datus/`` (skills + per-node memory) stay
+    visible. The glob strings below are the contract that the filesystem tool
+    expects, so they are pinned here.
+    """
+
+    def test_excludes_prune_entire_dot_datus(self, project):
+        excludes, _ = build_walk_patterns(root_path=project, current_node="chat")
+        # Both the directory itself and its contents must be excluded,
+        # otherwise ``.datus`` survives the first-level match.
+        assert excludes == [".datus", ".datus/**"]
+
+    def test_re_includes_default_to_skills_only(self, project):
+        _, re_includes = build_walk_patterns(root_path=project, current_node=None)
+        # Without a current_node we cannot scope a memory subtree — only the
+        # project-local skills directory gets re-included.
+        assert re_includes == [".datus/skills/**"]
+
+    def test_re_includes_add_node_memory(self, project):
+        _, re_includes = build_walk_patterns(root_path=project, current_node="gen_sql")
+        # Skills stays first (longest-prefix-wins isn't used here, but the
+        # downstream walker iterates in list order for determinism).
+        assert re_includes == [".datus/skills/**", ".datus/memory/gen_sql/**"]
+
+    def test_patterns_are_posix_for_wcmatch(self, project):
+        """All generated patterns are POSIX slashes; wcmatch does not normalize
+        separators, so a Windows-style backslash would break globmatch."""
+        excludes, re_includes = build_walk_patterns(root_path=project, current_node="chat")
+        for pattern in excludes + re_includes:
+            assert "\\" not in pattern

--- a/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
+++ b/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
@@ -1,0 +1,138 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for datus/tools/func_tool/fs_path_policy.py"""
+
+from pathlib import Path
+
+import pytest
+
+from datus.tools.func_tool.fs_path_policy import (
+    PathZone,
+    classify_path,
+    whitelist_anchors,
+)
+
+
+@pytest.fixture
+def project(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def fake_home(tmp_path):
+    home = tmp_path / "fake_home" / ".datus"
+    (home / "skills").mkdir(parents=True)
+    return home
+
+
+class TestClassifyInternal:
+    def test_relative_inside_root(self, project):
+        r = classify_path("src/main.py", root_path=project, current_node="chat")
+        assert r.zone == PathZone.INTERNAL
+        assert r.display == "src/main.py"
+
+    def test_dot_maps_to_root(self, project):
+        r = classify_path(".", root_path=project, current_node="chat")
+        assert r.zone == PathZone.INTERNAL
+        assert r.display == "."
+
+    def test_absolute_inside_root_is_internal(self, project):
+        r = classify_path(str(project / "a.md"), root_path=project, current_node="chat")
+        assert r.zone == PathZone.INTERNAL
+
+
+class TestClassifyHidden:
+    def test_datus_subdir_is_hidden(self, project):
+        r = classify_path(".datus/sessions/foo.db", root_path=project, current_node="chat")
+        assert r.zone == PathZone.HIDDEN
+
+    def test_datus_root_itself_is_hidden(self, project):
+        r = classify_path(".datus", root_path=project, current_node="chat")
+        assert r.zone == PathZone.HIDDEN
+
+
+class TestClassifyWhitelist:
+    def test_project_skills_whitelisted(self, project):
+        r = classify_path(".datus/skills/foo/SKILL.md", root_path=project, current_node="chat")
+        assert r.zone == PathZone.WHITELIST
+        assert r.display.startswith(".datus/skills/")
+
+    def test_own_memory_dir_is_whitelist(self, project):
+        r = classify_path(".datus/memory/gen_sql/MEMORY.md", root_path=project, current_node="gen_sql")
+        assert r.zone == PathZone.WHITELIST
+
+    def test_other_node_memory_is_hidden(self, project):
+        r = classify_path(".datus/memory/chat/MEMORY.md", root_path=project, current_node="gen_sql")
+        assert r.zone == PathZone.HIDDEN
+
+    def test_none_node_disables_memory_whitelist(self, project):
+        r = classify_path(".datus/memory/any/MEMORY.md", root_path=project, current_node=None)
+        assert r.zone == PathZone.HIDDEN
+
+    def test_home_skills_whitelist(self, project, fake_home):
+        r = classify_path(
+            str(fake_home / "skills" / "global" / "SKILL.md"),
+            root_path=project,
+            current_node="chat",
+            datus_home=fake_home,
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.display.startswith("~/.datus/skills/")
+
+
+class TestClassifyExternal:
+    def test_relative_escape_goes_external(self, project):
+        r = classify_path("../other/secret.txt", root_path=project, current_node="chat")
+        assert r.zone == PathZone.EXTERNAL
+        assert Path(r.display).is_absolute()
+
+    def test_absolute_outside_root_is_external(self, project, tmp_path):
+        elsewhere = tmp_path / "other"
+        elsewhere.mkdir()
+        target = elsewhere / "x.md"
+        r = classify_path(str(target), root_path=project, current_node="chat")
+        assert r.zone == PathZone.EXTERNAL
+
+
+class TestRootUnderHome:
+    """If the project happens to live under ``~/.datus`` — e.g. someone runs
+    ``datus`` inside ``~/.datus/workspace/demo`` — project anchors must still
+    beat the global ``~/.datus/skills`` anchor so file visibility matches the
+    user's intent ("writing to my project's skills dir, not the global one").
+    """
+
+    def test_project_skills_wins_over_global(self, tmp_path):
+        home = tmp_path / ".datus"
+        home.mkdir()
+        (home / "skills").mkdir()
+        project = home / "workspace" / "demo"
+        project.mkdir(parents=True)
+        r = classify_path(
+            ".datus/skills/foo/SKILL.md",
+            root_path=project,
+            current_node="chat",
+            datus_home=home,
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.display.startswith(".datus/skills/")
+
+
+class TestWhitelistAnchors:
+    def test_anchor_list_contains_project_and_home(self, project, fake_home):
+        anchors = whitelist_anchors(root_path=project, current_node="chat", datus_home=fake_home)
+        # project_skills, home_skills (no memory since current_node without memory dir) — but current_node="chat" still adds memory anchor.
+        assert (project / ".datus" / "skills").resolve(strict=False) in anchors
+        assert (project / ".datus" / "memory" / "chat").resolve(strict=False) in anchors
+        assert (fake_home / "skills").resolve(strict=False) in anchors
+
+    def test_anchors_skip_memory_when_node_none(self, project, fake_home):
+        anchors = whitelist_anchors(root_path=project, current_node=None, datus_home=fake_home)
+        # Expect exactly two anchors: project .datus/skills and home .datus/skills.
+        # No per-node memory anchor because current_node is None.
+        assert len(anchors) == 2
+        expected_suffixes = {(".datus", "skills")}
+        seen = {(a.parent.name, a.name) for a in anchors}
+        assert seen == expected_suffixes

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -10,7 +10,12 @@ import pytest
 
 from datus.cli.execution_state import InteractionBroker
 from datus.tools.permission.permission_config import PermissionConfig, PermissionLevel, PermissionRule
-from datus.tools.permission.permission_hooks import CompositeHooks, PermissionDeniedException, PermissionHooks
+from datus.tools.permission.permission_hooks import (
+    CompositeHooks,
+    FilesystemPolicy,
+    PermissionDeniedException,
+    PermissionHooks,
+)
 from datus.tools.permission.permission_manager import PermissionManager
 from datus.tools.registry.tool_registry import ToolRegistry
 
@@ -423,3 +428,200 @@ class TestPermissionHooksIntegration:
         assert hooks.tool_registry.get("list_tables") == "db_tools"
         assert hooks.tool_registry.get("load_skill") == "skills"
         assert hooks.tool_registry.get("read_file") == "filesystem_tools"
+
+
+class TestFilesystemZoneBranch:
+    """``fs_policy`` routes filesystem_tools calls through path zones.
+
+    INTERNAL/WHITELIST bypass the normal rule, HIDDEN falls through silently
+    (the tool returns not-found), EXTERNAL forces an ASK keyed by absolute
+    path so approval never leaks across targets.
+    """
+
+    def _build(self, broker, tmp_path, rules=None, *, strict=False):
+        registry = ToolRegistry()
+        fs_tool = MagicMock()
+        fs_tool.name = "read_file"
+        registry.register_tools("filesystem_tools", [fs_tool])
+
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ALLOW,
+            rules=rules or [],
+        )
+        manager = PermissionManager(global_config=config)
+        project = tmp_path / "proj"
+        project.mkdir()
+        hooks = PermissionHooks(
+            broker=broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            fs_policy=FilesystemPolicy(root_path=project, current_node="chat", strict=strict),
+        )
+        return hooks, manager, project
+
+    @pytest.mark.asyncio
+    async def test_internal_bypasses_ask_rule(self, mock_broker, tmp_path):
+        hooks, _, project = self._build(
+            mock_broker,
+            tmp_path,
+            rules=[PermissionRule(tool="filesystem_tools", pattern="*", permission=PermissionLevel.ASK)],
+        )
+        ctx = MagicMock()
+        ctx.tool_arguments = '{"path": "src/main.py"}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        # Even though the rule says ASK, INTERNAL zone bypasses the prompt.
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hidden_returns_without_prompt(self, mock_broker, tmp_path):
+        hooks, _, project = self._build(mock_broker, tmp_path)
+        ctx = MagicMock()
+        ctx.tool_arguments = '{"path": ".datus/sessions/foo.db"}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        # HIDDEN short-circuits with no broker interaction; tool layer returns
+        # the uniform "File not found".
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_external_forces_ask_and_caches_by_abs_path(self, mock_broker, tmp_path):
+        hooks, manager, project = self._build(mock_broker, tmp_path)
+        target_dir = tmp_path / "other"
+        target_dir.mkdir()
+        target = target_dir / "secret.md"
+        target.write_text("x")
+
+        # Broker returns "a" (approve for session) on first call, should not be
+        # called again on the second.
+        callback = AsyncMock()
+        mock_broker.request = AsyncMock(return_value=("a", callback))
+
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{target}"}}'
+        tool = MagicMock()
+        tool.name = "read_file"
+
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
+        assert mock_broker.request.await_count == 1
+
+        # Second call with same abs path must NOT prompt.
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
+        assert mock_broker.request.await_count == 1
+        # Cache key is path-keyed, not category-keyed.
+        assert any(f"external::{target.resolve()}" in k for k in manager._session_approvals)
+
+    @pytest.mark.asyncio
+    async def test_external_deny_raises(self, mock_broker, tmp_path):
+        hooks, _, _ = self._build(mock_broker, tmp_path)
+        target = tmp_path / "other.md"
+        target.write_text("x")
+
+        callback = AsyncMock()
+        mock_broker.request = AsyncMock(return_value=("n", callback))
+
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{target}"}}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(ctx, MagicMock(), tool)
+
+    @pytest.mark.asyncio
+    async def test_strict_external_denies_without_broker(self, mock_broker, tmp_path):
+        """Strict policy → EXTERNAL is rejected with PermissionDenied and the
+        broker is never touched. Regression guard for API/claw flows that
+        have no interactive prompt — they must fail fast, not hang."""
+        hooks, _, _ = self._build(mock_broker, tmp_path, strict=True)
+        target = tmp_path / "elsewhere.md"
+        target.write_text("x")
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{target}"}}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        with pytest.raises(PermissionDeniedException) as exc_info:
+            await hooks.on_tool_start(ctx, MagicMock(), tool)
+        assert "strict mode" in str(exc_info.value).lower()
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_strict_internal_still_passes(self, mock_broker, tmp_path):
+        """Strict must not affect INTERNAL/WHITELIST paths — those are the
+        whole point of having a workspace at all."""
+        hooks, _, project = self._build(mock_broker, tmp_path, strict=True)
+        (project / "hello.md").write_text("hi")
+        ctx = MagicMock()
+        ctx.tool_arguments = '{"path": "hello.md"}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_external_broker_cancel_denies(self, mock_broker, tmp_path):
+        """``InteractionCancelled`` from the broker must surface as a denial
+        (not a silent approval). Guards the catch-block in
+        ``_request_external_confirmation``."""
+        from datus.cli.execution_state import InteractionCancelled
+
+        hooks, _, _ = self._build(mock_broker, tmp_path)
+        target = tmp_path / "cancel.md"
+        target.write_text("x")
+        mock_broker.request = AsyncMock(side_effect=InteractionCancelled())
+
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{target}"}}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(ctx, MagicMock(), tool)
+
+    @pytest.mark.asyncio
+    async def test_external_broker_unexpected_error_denies(self, mock_broker, tmp_path):
+        """A non-``InteractionCancelled`` exception from the broker should
+        also default to denial. Guards the generic ``except Exception`` arm."""
+        hooks, _, _ = self._build(mock_broker, tmp_path)
+        target = tmp_path / "boom.md"
+        target.write_text("x")
+        mock_broker.request = AsyncMock(side_effect=RuntimeError("broker explosion"))
+
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{target}"}}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(ctx, MagicMock(), tool)
+
+    @pytest.mark.asyncio
+    async def test_legacy_null_fs_policy_preserves_rules(self, mock_broker, tmp_path):
+        """Without fs_policy, behavior must match the pre-refactor contract
+        (rules drive everything). Regression guard for existing tests."""
+        registry = ToolRegistry()
+        fs_tool = MagicMock()
+        fs_tool.name = "read_file"
+        registry.register_tools("filesystem_tools", [fs_tool])
+        manager = PermissionManager(
+            global_config=PermissionConfig(
+                default_permission=PermissionLevel.ALLOW,
+                rules=[
+                    PermissionRule(tool="filesystem_tools", pattern="read_file", permission=PermissionLevel.DENY),
+                ],
+            )
+        )
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            fs_policy=None,
+        )
+        ctx = MagicMock()
+        # Path is INTERNAL-looking, but without fs_policy we do not short-circuit.
+        ctx.tool_arguments = '{"path": "src/main.py"}'
+        tool = MagicMock()
+        tool.name = "read_file"
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(ctx, MagicMock(), tool)


### PR DESCRIPTION


Move every AgenticNode to a single FilesystemFuncTool construction path (project_root + current_node) and replace the old per-kind sandbox with a shared PathZone classifier. The tool now distinguishes INTERNAL, WHITELIST (~/.datus/skills, .datus/skills, .datus/memory/{current_node}), HIDDEN (the rest of .datus — invisible so sessions/data/conf don't leak), and EXTERNAL (absolute paths outside the project) so the permission hook can prompt for user confirmation instead of the tool silently rejecting.

Add a strict mode for non-interactive surfaces: FilesystemFuncTool(strict=True) and FilesystemPolicy(strict=True) hard-reject EXTERNAL paths without touching the broker, wired through agent_config.filesystem_strict in the API (chat_task_manager) and claw (main._run_gateway) bootstraps so those entry points never hang on a missing prompt.

Move write-scope enforcement into GenerationHooks via NODE_WRITE_SCOPES + hard PermissionDeniedException on on_tool_start, drop make_kb_path_normalizer, and update gen_* prompts' kind_subdir to include the full `subject/` prefix so the LLM writes fully-qualified paths that match the project-rooted tool.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filesystem zoning introduced (internal, whitelist, hidden, external) with per-node memory isolation; external accesses may require approval or be blocked in strict mode.
  * Gateway/chat now enable strict filesystem mode by default.

* **Refactor**
  * Unified filesystem tool creation and permission wiring across agent nodes; tool roots now use project-root semantics, and generation flows expect fully-qualified subject/... paths.

* **Documentation**
  * Skill prompts/templates clarify and enforce restricted write locations under approved skills directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->