### PR TITLE
[Feature] support claw/api feedback action

### DIFF
--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -191,6 +191,7 @@ def create_node_input(
     at_sqls=None,
     prompt_language: str = "en",
     plan_mode: bool = False,
+    source_session_id: Optional[str] = None,
 ):
     """Create node input based on node type.
 
@@ -205,6 +206,8 @@ def create_node_input(
         at_sqls: @-referenced SQL queries.
         prompt_language: Language for prompts (default "en").
         plan_mode: Whether to enable plan mode.
+        source_session_id: Source session the feedback node should copy from.
+            Only consumed by :class:`FeedbackAgenticNode`.
     """
     from datus.agent.node.gen_ext_knowledge_agentic_node import GenExtKnowledgeAgenticNode
     from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
@@ -311,10 +314,14 @@ def create_node_input(
     if isinstance(node, FeedbackAgenticNode):
         from datus.schemas.feedback_agentic_node_models import FeedbackNodeInput
 
-        # source_session_id is not needed here: the CLI's _copy_session_for_switch
-        # already seeds the feedback node's session, and caller_node_name carries
-        # the memory-routing semantics.
-        return FeedbackNodeInput(user_message=user_message, database=database)
+        # CLI path leaves source_session_id=None because _copy_session_for_switch
+        # seeds the feedback node's session directly. API/Claw paths pass a
+        # real source_session_id so the node copies the source session itself.
+        return FeedbackNodeInput(
+            user_message=user_message,
+            database=database,
+            source_session_id=source_session_id,
+        )
 
     else:
         from datus.schemas.chat_agentic_node_models import ChatNodeInput

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -261,6 +261,25 @@ class StreamChatInput(ChatInput):
     subagent_id: Optional[str] = Field(default=None, description="Subagent ID (builtin name or DB SubAgent id)")
     prompt_version: Optional[str] = Field(default=None, description="Prompt version")
     prompt_language: str = Field(default="en", description="Prompt language")
+    source_session_id: Optional[str] = Field(
+        default=None,
+        description="Source session to seed the agent with (currently used by feedback agent to copy history).",
+    )
+
+
+class FeedbackChatInput(ChatInput):
+    """Input for /chat/feedback — reaction-triggered feedback agent.
+
+    ``message`` is server-rendered from the reaction fields via
+    :func:`datus.utils.feedback_prompt.build_reaction_feedback_prompt`, so callers
+    can leave it empty.
+    """
+
+    message: str = Field(default="", description="Leave empty; server derives it from reaction fields")
+    source_session_id: str = Field(..., description="Session that produced the message being reacted to")
+    reaction_emoji: str = Field(..., description="Normalized emoji name (e.g. 'thumbsup')")
+    reference_msg: str = Field(..., description="Text of the bot message the user reacted to")
+    reaction_msg: Optional[str] = Field(default=None, description="Optional free-text comment attached to the reaction")
 
 
 class UserInteractionInput(BaseModel):

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -281,6 +281,14 @@ class FeedbackChatInput(ChatInput):
     reference_msg: str = Field(..., description="Text of the bot message the user reacted to")
     reaction_msg: Optional[str] = Field(default=None, description="Optional free-text comment attached to the reaction")
 
+    @field_validator("source_session_id", "reaction_emoji", "reference_msg")
+    @classmethod
+    def _reject_blank_required_field(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Feedback field must not be empty or whitespace-only")
+        return stripped
+
 
 class UserInteractionInput(BaseModel):
     """Input for user interaction submission."""

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -30,9 +30,11 @@ from datus.api.models.cli_models import (
     ChatSessionData,
     CompactSessionData,
     CompactSessionInput,
+    FeedbackChatInput,
     StreamChatInput,
     UserInteractionInput,
 )
+from datus.utils.feedback_prompt import build_reaction_feedback_prompt
 
 router = APIRouter(prefix="/api/v1/chat", tags=["chat"])
 
@@ -55,6 +57,43 @@ async def stream_chat(
 
     async def generate_sse():
         async for event in svc.chat.stream_chat(request, sub_agent_id=sub_agent_id, user_id=ctx.user_id):
+            yield f"id: {event.id}\nevent: {event.event}\ndata: {event.data.model_dump_json()}\n\n"
+
+    return StreamingResponse(generate_sse(), media_type="text/event-stream", headers=_sse_headers())
+
+
+# ========== Reaction-triggered Feedback ==========
+
+
+@router.post(
+    "/feedback",
+    summary="Stream Feedback Agent (reaction-triggered)",
+    description=(
+        "Trigger the feedback agent from a reaction event (IM emoji, UI thumbs, etc.). "
+        "The server builds the canonical user prompt from reaction_emoji/reference_msg/reaction_msg "
+        "and routes the request to the feedback sub-agent, which copies the source session and archives reusable knowledge."
+    ),
+)
+async def stream_chat_feedback(
+    request: FeedbackChatInput,
+    svc: ServiceDep,
+    ctx: AppContextDep,
+):
+    rendered_message = build_reaction_feedback_prompt(
+        reaction_emoji=request.reaction_emoji,
+        reference_msg=request.reference_msg,
+        reaction_msg=request.reaction_msg,
+    )
+    stream_input = StreamChatInput(
+        **request.model_dump(
+            exclude={"message", "reaction_emoji", "reference_msg", "reaction_msg"},
+        ),
+        message=rendered_message,
+        subagent_id="feedback",
+    )
+
+    async def generate_sse():
+        async for event in svc.chat.stream_chat(stream_input, sub_agent_id="feedback", user_id=ctx.user_id):
             yield f"id: {event.id}\nevent: {event.event}\ndata: {event.data.model_dump_json()}\n\n"
 
     return StreamingResponse(generate_sse(), media_type="text/event-stream", headers=_sse_headers())

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -33,6 +33,7 @@ from datus.schemas.action_history import ActionHistoryManager
 from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
 from datus.tools.proxy.proxy_tool import apply_proxy_tools
 from datus.utils.loggings import get_logger
+from datus.utils.path_manager import set_current_path_manager
 
 logger = get_logger(__name__)
 
@@ -348,6 +349,13 @@ class ChatTaskManager:
         """Execute the full agentic loop, pushing SSE events to the task buffer."""
         session_id = task.session_id
         event_id = 0
+
+        # Pin the path manager into this task's context. Required when the caller
+        # dispatched us from a thread that never inherited AgentConfig's ContextVar
+        # (e.g. claw bridge dispatching from an IM SDK worker thread via
+        # ``asyncio.run_coroutine_threadsafe``); otherwise downstream stores fall
+        # back to ``get_path_manager()`` and get an empty project_name.
+        set_current_path_manager(agent_config.path_manager)
 
         try:
             start_time = datetime.now()

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -374,7 +374,13 @@ class ChatTaskManager:
                     user_id=user_id,
                     interactive=interactive_enabled,
                 )
-                n.session_id = session_id
+                # Feedback runs triggered with a source_session_id must start with
+                # no session_id so FeedbackAgenticNode.execute_stream copies the
+                # source session into a fresh feedback_session_ id.
+                if sub_agent_id == "feedback" and request.source_session_id:
+                    n.session_id = None
+                else:
+                    n.session_id = session_id
                 return n
 
             node = await asyncio.to_thread(_init_node)
@@ -410,6 +416,7 @@ class ChatTaskManager:
                 database=request.database,
                 db_schema=request.db_schema,
                 plan_mode=request.plan_mode or False,
+                source_session_id=request.source_session_id,
             )
             node.input = node_input
 
@@ -601,6 +608,14 @@ class ChatTaskManager:
                     execution_mode=execution_mode,
                     scope=user_id,
                 )
+            elif subagent_id == "feedback":
+                from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
+
+                return FeedbackAgenticNode(
+                    agent_config=agent_config,
+                    execution_mode=execution_mode,
+                    scope=user_id,
+                )
             else:
                 # Custom sub_agent: agentic_nodes is keyed by sanitized node_name
                 # (not the UUID subagent_id). Each entry carries its original
@@ -650,13 +665,24 @@ class ChatTaskManager:
         database: Optional[str] = None,
         db_schema: Optional[str] = None,
         plan_mode: bool = False,
+        source_session_id: Optional[str] = None,
     ):
         """Create node input based on node type."""
+        from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
         from datus.agent.node.gen_ext_knowledge_agentic_node import GenExtKnowledgeAgenticNode
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
         from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
+
+        if isinstance(current_node, FeedbackAgenticNode):
+            from datus.schemas.feedback_agentic_node_models import FeedbackNodeInput
+
+            return FeedbackNodeInput(
+                user_message=user_message,
+                database=database,
+                source_session_id=source_session_id,
+            )
 
         if isinstance(current_node, (GenSemanticModelAgenticNode, GenMetricsAgenticNode)):
             from datus.schemas.semantic_agentic_node_models import SemanticNodeInput

--- a/datus/claw/bridge.py
+++ b/datus/claw/bridge.py
@@ -26,6 +26,7 @@ from datus.claw.models import (
 from datus.claw.richtext.parser import markdown_to_ir
 from datus.configuration.agent_config import AgentConfig
 from datus.models.session_manager import SessionManager
+from datus.utils.feedback_prompt import build_reaction_feedback_prompt
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -35,6 +36,9 @@ _STREAMABLE_TYPES = {"markdown", "code", "thinking", "error", "call-tool", "call
 
 # Maximum number of bot message IDs to track
 _MAX_BOT_MSG_MAP = 10000
+
+# Maximum number of bot messages to remember as already-reacted (dedup for reactions)
+_MAX_REACTED_MSG = 10000
 
 
 class ChannelBridge:
@@ -55,6 +59,9 @@ class ChannelBridge:
         self._verbose_overrides: Dict[str, Verbose] = {}
         # Track bot message IDs for reaction feedback: {bot_msg_id -> context}
         self._bot_message_map: OrderedDict[str, dict] = OrderedDict()
+        # Dedup reactions: a bot message only triggers feedback once, no matter
+        # how many emojis the user piles on afterwards.
+        self._reacted_bot_messages: OrderedDict[str, None] = OrderedDict()
         # Deduplication: recently seen message IDs
         self._seen_message_ids: OrderedDict[str, None] = OrderedDict()
         self._max_seen_ids: int = 1000
@@ -218,7 +225,7 @@ class ChannelBridge:
                                 continue
                             bot_msg_id = await adapter.send_message(outbound)
                             if bot_msg_id:
-                                await self._track_bot_message(bot_msg_id, session_id, msg)
+                                await self._track_bot_message(bot_msg_id, session_id, msg, outbound.text)
                             any_sent = True
 
             if not any_sent:
@@ -230,7 +237,7 @@ class ChannelBridge:
                 )
                 bot_msg_id = await adapter.send_message(fallback)
                 if bot_msg_id:
-                    await self._track_bot_message(bot_msg_id, session_id, msg)
+                    await self._track_bot_message(bot_msg_id, session_id, msg, fallback.text)
         except Exception:
             has_error = True
             raise
@@ -250,31 +257,98 @@ class ChannelBridge:
             except Exception as e:
                 logger.debug("Failed to add done reaction: %s", e)
 
-    async def _track_bot_message(self, bot_msg_id: str, session_id: str, msg: InboundMessage) -> None:
-        """Record a bot message ID for future reaction feedback tracking."""
+    async def _track_bot_message(
+        self,
+        bot_msg_id: str,
+        session_id: str,
+        msg: InboundMessage,
+        text: str = "",
+    ) -> None:
+        """Record a bot message ID for future reaction feedback tracking.
+
+        ``text`` is the bot's rendered reply — stored so that reaction handling
+        can quote it back to the feedback agent as the ``reference_msg``.
+        """
         async with self._lock:
+            existing = self._bot_message_map.get(bot_msg_id)
+            # Later fragments of a streamed reply share the same bot_msg_id; keep
+            # appending their text so the final reference captures the full reply.
+            accumulated_text = text or ""
+            if existing and existing.get("text"):
+                accumulated_text = f"{existing['text']}{accumulated_text}" if accumulated_text else existing["text"]
             self._bot_message_map[bot_msg_id] = {
                 "session_id": session_id,
                 "channel_id": msg.channel_id,
                 "conversation_id": msg.conversation_id,
                 "sender_id": msg.sender_id,
+                "text": accumulated_text,
             }
             # Evict oldest entries if over limit
             while len(self._bot_message_map) > _MAX_BOT_MSG_MAP:
                 self._bot_message_map.popitem(last=False)
 
     async def handle_reaction(self, event: ReactionEvent, adapter: ChannelAdapter) -> None:
-        """Process a reaction event on a bot message (feedback tracking)."""
+        """Trigger the feedback agent for the first reaction on a bot message.
+
+        Subsequent reactions on the same message (additional emojis, removed/re-added)
+        are ignored — we only care about the first signal.
+        Result is archived silently (no reply is posted back to the IM thread).
+        """
         context = self._bot_message_map.get(event.target_message_id)
         if not context:
             return
+
+        async with self._lock:
+            if event.target_message_id in self._reacted_bot_messages:
+                logger.debug(
+                    "Reaction on already-processed bot msg %s ignored (emoji=%s)",
+                    event.target_message_id,
+                    event.emoji,
+                )
+                return
+            self._reacted_bot_messages[event.target_message_id] = None
+            while len(self._reacted_bot_messages) > _MAX_REACTED_MSG:
+                self._reacted_bot_messages.popitem(last=False)
+
+        source_session_id = context.get("session_id")
+        reference_msg = context.get("text", "") or ""
         logger.info(
-            "Feedback: emoji=%s sender=%s session=%s msg=%s",
+            "Reaction feedback trigger: emoji=%s sender=%s session=%s msg=%s",
             event.emoji,
             event.sender_id,
-            context.get("session_id"),
+            source_session_id,
             event.target_message_id,
         )
+
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji=event.emoji,
+            reference_msg=reference_msg,
+        )
+        request = StreamChatInput(
+            message=prompt,
+            session_id=None,
+            source_session_id=source_session_id,
+            stream_response=False,
+        )
+
+        try:
+            task = await self._task_manager.start_chat(
+                self._agent_config,
+                request,
+                sub_agent_id="feedback",
+            )
+        except ValueError as exc:
+            logger.warning("Reaction feedback could not start: %s", exc)
+            return
+        except Exception:
+            logger.exception("Reaction feedback failed to start")
+            return
+
+        try:
+            async for _ in self._task_manager.consume_events(task):
+                pass
+        except Exception:
+            logger.exception("Reaction feedback stream errored")
 
     def _event_to_outbound(
         self,

--- a/datus/claw/bridge.py
+++ b/datus/claw/bridge.py
@@ -225,7 +225,11 @@ class ChannelBridge:
                                 continue
                             bot_msg_id = await adapter.send_message(outbound)
                             if bot_msg_id:
-                                await self._track_bot_message(bot_msg_id, session_id, msg, outbound.text)
+                                reference_text = outbound.text
+                                if outbound.sql:
+                                    sql_block = f"```sql\n{outbound.sql}\n```"
+                                    reference_text = f"{reference_text}\n\n{sql_block}" if reference_text else sql_block
+                                await self._track_bot_message(bot_msg_id, session_id, msg, reference_text)
                             any_sent = True
 
             if not any_sent:
@@ -338,9 +342,13 @@ class ChannelBridge:
                 sub_agent_id="feedback",
             )
         except ValueError as exc:
+            async with self._lock:
+                self._reacted_bot_messages.pop(event.target_message_id, None)
             logger.warning("Reaction feedback could not start: %s", exc)
             return
         except Exception:
+            async with self._lock:
+                self._reacted_bot_messages.pop(event.target_message_id, None)
             logger.exception("Reaction feedback failed to start")
             return
 

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -938,7 +938,21 @@ class SessionManager:
                         if msg_type == "function_call_output":
                             # Create a new SUCCESS action for the tool output
                             if current_actions:
-                                last_action = current_actions[-1]
+                                # Pair with the matching PROCESSING call by call_id so that
+                                # interleaved tool calls (multiple function_call messages
+                                # before any output) are matched correctly on resume.
+                                output_call_id = message_json.get("call_id")
+                                last_action = None
+                                if output_call_id:
+                                    for candidate in reversed(current_actions):
+                                        if (
+                                            candidate.action_id == output_call_id
+                                            and candidate.status == ActionStatus.PROCESSING
+                                        ):
+                                            last_action = candidate
+                                            break
+                                if last_action is None:
+                                    last_action = current_actions[-1]
 
                                 # Extract output directly from message_json
                                 output_text = message_json.get("output", "")

--- a/datus/utils/feedback_prompt.py
+++ b/datus/utils/feedback_prompt.py
@@ -12,7 +12,9 @@ _ELLIPSIS = "..."
 def _truncate(text: str, max_len: int) -> str:
     if max_len <= 0 or len(text) <= max_len:
         return text
-    keep = max(0, max_len - len(_ELLIPSIS))
+    if max_len <= len(_ELLIPSIS):
+        return _ELLIPSIS[:max_len]
+    keep = max_len - len(_ELLIPSIS)
     return text[:keep] + _ELLIPSIS
 
 

--- a/datus/utils/feedback_prompt.py
+++ b/datus/utils/feedback_prompt.py
@@ -1,0 +1,42 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Utilities for composing feedback-agent user prompts from reaction context."""
+
+from typing import Optional
+
+_ELLIPSIS = "..."
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if max_len <= 0 or len(text) <= max_len:
+        return text
+    keep = max(0, max_len - len(_ELLIPSIS))
+    return text[:keep] + _ELLIPSIS
+
+
+def build_reaction_feedback_prompt(
+    reaction_emoji: str,
+    reference_msg: str,
+    reaction_msg: Optional[str] = None,
+    max_ref_len: int = 500,
+) -> str:
+    """Build the canonical user prompt for reaction-triggered feedback.
+
+    Format:
+        [The user reacted to this message "{reference_msg}" with [{emoji}]] {reaction_msg}
+
+    Args:
+        reaction_emoji: Normalized emoji name (e.g. "thumbsup").
+        reference_msg: The bot message the user reacted to.
+        reaction_msg: Optional free-text comment the user attached to the reaction.
+        max_ref_len: Truncate ``reference_msg`` to this length; ``<= 0`` disables truncation.
+    """
+    emoji = (reaction_emoji or "").strip()
+    ref = _truncate((reference_msg or "").strip(), max_ref_len)
+    prompt = f'[The user reacted to this message "{ref}" with [{emoji}]]'
+    extra = (reaction_msg or "").strip()
+    if extra:
+        prompt = f"{prompt} {extra}"
+    return prompt

--- a/tests/unit_tests/agent/node/test_node_factory.py
+++ b/tests/unit_tests/agent/node/test_node_factory.py
@@ -273,3 +273,24 @@ class TestCreateNodeInput:
             assert getattr(result, attr) == expected_value, (
                 f"{node_class_name}: expected {attr}={expected_value!r}, got {getattr(result, attr)!r}"
             )
+
+    def test_feedback_source_session_id_wired(self):
+        """Feedback branch must forward source_session_id to FeedbackNodeInput."""
+        node_class = _load_node_class("datus.agent.node.feedback_agentic_node", "FeedbackAgenticNode")
+        node = MagicMock(spec=node_class)
+        result = create_node_input(
+            "analyze and archive",
+            node,
+            database="db",
+            source_session_id="chat_session_abc",
+        )
+        assert result.source_session_id == "chat_session_abc"
+        assert result.database == "db"
+        assert result.user_message == "analyze and archive"
+
+    def test_feedback_source_session_id_defaults_to_none(self):
+        """CLI callers leave source_session_id unset → FeedbackNodeInput carries None."""
+        node_class = _load_node_class("datus.agent.node.feedback_agentic_node", "FeedbackAgenticNode")
+        node = MagicMock(spec=node_class)
+        result = create_node_input("/feedback", node)
+        assert result.source_session_id is None

--- a/tests/unit_tests/api/routes/test_chat_routes_feedback.py
+++ b/tests/unit_tests/api/routes/test_chat_routes_feedback.py
@@ -1,0 +1,79 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for POST /api/v1/chat/feedback endpoint."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.api.models.cli_models import FeedbackChatInput, StreamChatInput
+from datus.api.routes.chat_routes import stream_chat_feedback
+
+
+def _build_svc():
+    svc = MagicMock()
+
+    async def _empty_stream(*args, **kwargs):
+        if False:
+            yield
+        return
+
+    svc.chat.stream_chat = MagicMock(side_effect=_empty_stream)
+    return svc
+
+
+def _build_ctx(user_id="tester"):
+    ctx = MagicMock()
+    ctx.user_id = user_id
+    return ctx
+
+
+async def _drain(response):
+    """Iterate a StreamingResponse body_iterator so the inner generator runs."""
+    async for _ in response.body_iterator:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_feedback_endpoint_renders_prompt_and_routes_to_feedback_subagent():
+    svc = _build_svc()
+    request = FeedbackChatInput(
+        source_session_id="chat_session_abc",
+        reaction_emoji="thumbsup",
+        reference_msg="Here is your SQL result",
+        database="sales_db",
+    )
+
+    response = await stream_chat_feedback(request, svc, _build_ctx())
+    await _drain(response)
+
+    svc.chat.stream_chat.assert_called_once()
+    call_args = svc.chat.stream_chat.call_args
+    stream_input: StreamChatInput = call_args.args[0]
+    assert isinstance(stream_input, StreamChatInput)
+    assert stream_input.subagent_id == "feedback"
+    assert stream_input.source_session_id == "chat_session_abc"
+    assert stream_input.database == "sales_db"
+    assert call_args.kwargs["sub_agent_id"] == "feedback"
+    assert call_args.kwargs["user_id"] == "tester"
+    assert stream_input.message == '[The user reacted to this message "Here is your SQL result" with [thumbsup]]'
+
+
+@pytest.mark.asyncio
+async def test_feedback_endpoint_appends_optional_reaction_msg():
+    svc = _build_svc()
+    request = FeedbackChatInput(
+        source_session_id="chat_session_abc",
+        reaction_emoji="thumbsdown",
+        reference_msg="Wrong answer",
+        reaction_msg="Please recheck the metric definition",
+    )
+
+    response = await stream_chat_feedback(request, svc, _build_ctx())
+    await _drain(response)
+
+    stream_input: StreamChatInput = svc.chat.stream_chat.call_args.args[0]
+    assert stream_input.message.endswith("Please recheck the metric definition")
+    assert "[thumbsdown]" in stream_input.message

--- a/tests/unit_tests/api/routes/test_chat_routes_feedback.py
+++ b/tests/unit_tests/api/routes/test_chat_routes_feedback.py
@@ -61,6 +61,35 @@ async def test_feedback_endpoint_renders_prompt_and_routes_to_feedback_subagent(
     assert stream_input.message == '[The user reacted to this message "Here is your SQL result" with [thumbsup]]'
 
 
+@pytest.mark.parametrize(
+    "field",
+    ["source_session_id", "reaction_emoji", "reference_msg"],
+)
+@pytest.mark.parametrize("blank_value", ["", "   ", "\t\n"])
+def test_feedback_input_rejects_blank_required_field(field, blank_value):
+    """Required feedback fields must reject empty / whitespace-only strings."""
+    kwargs = dict(
+        source_session_id="sess_1",
+        reaction_emoji="thumbsup",
+        reference_msg="hi",
+    )
+    kwargs[field] = blank_value
+    with pytest.raises(ValueError):
+        FeedbackChatInput(**kwargs)
+
+
+def test_feedback_input_strips_whitespace_on_required_fields():
+    """Surrounding whitespace on required fields should be stripped, not retained."""
+    inp = FeedbackChatInput(
+        source_session_id="  sess_1  ",
+        reaction_emoji="  thumbsup  ",
+        reference_msg="  hi  ",
+    )
+    assert inp.source_session_id == "sess_1"
+    assert inp.reaction_emoji == "thumbsup"
+    assert inp.reference_msg == "hi"
+
+
 @pytest.mark.asyncio
 async def test_feedback_endpoint_appends_optional_reaction_msg():
     svc = _build_svc()

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -747,6 +747,81 @@ class TestConsumeEventsCoalescing:
         assert task.consumer_offset == 3
 
 
+@pytest.mark.asyncio
+class TestRunLoopPathManagerContext:
+    """Regression: _run_loop must pin agent_config.path_manager into its own context.
+
+    The claw bridge dispatches messages from a Feishu SDK worker thread via
+    ``asyncio.run_coroutine_threadsafe``. That thread never inherited the
+    ContextVar set by ``AgentConfig.__init__``, so the spawned task starts
+    with an empty ``_current_path_manager`` and downstream stores
+    (``BaseSubjectEmbeddingStore`` -> ``get_subject_tree_store``) would fall
+    back to a path manager with empty ``project_name``, raising
+    ``create_rdb_for_store requires a non-empty project``.
+    """
+
+    async def test_run_loop_sets_path_manager_when_context_is_empty(self, real_agent_config, mock_llm_create):
+        """Even when the calling context has no path manager, _run_loop binds
+        agent_config.path_manager so downstream get_path_manager() callers see
+        the right project_name."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.utils.path_manager import (
+            _current_path_manager,
+            get_path_manager,
+            reset_path_manager,
+        )
+
+        captured: dict[str, str] = {}
+
+        original_create_node = ChatTaskManager._create_node
+
+        def _capturing_create_node(self, agent_config, subagent_id, session_id, **kwargs):
+            # Simulate what BaseSubjectEmbeddingStore.__init__ does at line 692:
+            # rely on the ambient ContextVar to find the project name.
+            captured["project_name"] = get_path_manager().project_name
+            return original_create_node(self, agent_config, subagent_id, session_id, **kwargs)
+
+        manager = ChatTaskManager()
+        manager._create_node = _capturing_create_node.__get__(manager, ChatTaskManager)  # type: ignore[method-assign]
+
+        # Wipe the ContextVar to mimic the Feishu-thread dispatch case. The
+        # task created by start_chat will inherit this empty context.
+        token = _current_path_manager.set(None)
+        try:
+            assert _current_path_manager.get() is None
+            request = StreamChatInput(message="hello", session_id="path-mgr-test")
+            task = await manager.start_chat(real_agent_config, request)
+            # Wait for the background loop to finish (mock LLM returns immediately).
+            await asyncio.wait_for(task.asyncio_task, timeout=5.0)
+        finally:
+            reset_path_manager(token)
+            await manager.shutdown()
+
+        expected = real_agent_config.project_name
+        assert expected, "real_agent_config.project_name must be non-empty for this test"
+        assert captured.get("project_name") == expected, (
+            f"_run_loop did not pin path_manager: got {captured.get('project_name')!r}, expected {expected!r}"
+        )
+
+    async def test_run_loop_does_not_leak_path_manager_to_caller(self, real_agent_config, mock_llm_create):
+        """The ContextVar.set inside _run_loop must stay scoped to its own task
+        and not bleed back into the calling context."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.utils.path_manager import _current_path_manager, reset_path_manager
+
+        manager = ChatTaskManager()
+        token = _current_path_manager.set(None)
+        try:
+            request = StreamChatInput(message="hello", session_id="leak-test")
+            task = await manager.start_chat(real_agent_config, request)
+            await asyncio.wait_for(task.asyncio_task, timeout=5.0)
+            # Caller's view stays untouched: the spawned task has its own context.
+            assert _current_path_manager.get() is None
+        finally:
+            reset_path_manager(token)
+            await manager.shutdown()
+
+
 class _StubGenSQLNode:
     def __init__(self, **kwargs):
         self.node_name = kwargs.get("node_name")

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -517,6 +517,28 @@ class TestCreateNodeInput:
         assert result.database == "db"
         assert result.db_schema == "schema"
 
+    def test_feedback_node_input_with_source_session(self, real_agent_config, mock_llm_create):
+        """_create_node_input for FeedbackAgenticNode carries source_session_id through."""
+        from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
+        from datus.schemas.feedback_agentic_node_models import FeedbackNodeInput
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "feedback", "test")
+        assert isinstance(node, FeedbackAgenticNode)
+
+        result = manager._create_node_input(
+            '[The user reacted to this message "reply" with [thumbsup]]',
+            node,
+            [],
+            [],
+            [],
+            database="db",
+            source_session_id="chat_session_xyz",
+        )
+        assert isinstance(result, FeedbackNodeInput)
+        assert result.source_session_id == "chat_session_xyz"
+        assert result.database == "db"
+
 
 # ---------------------------------------------------------------------------
 # Helpers for thinking-delta tests

--- a/tests/unit_tests/claw/test_bridge.py
+++ b/tests/unit_tests/claw/test_bridge.py
@@ -838,16 +838,27 @@ class TestReactionLifecycle:
         assert bot_msg_id.startswith("bot_msg_")
 
     @pytest.mark.asyncio
-    async def test_handle_reaction_known_message(self, setup):
-        """handle_reaction should log for known bot messages."""
-        bridge, adapter, _ = setup
+    async def test_handle_reaction_known_message_triggers_feedback(self, setup):
+        """A reaction on a tracked bot message should start a feedback subagent task."""
+        bridge, adapter, task_manager = setup
 
         bridge._bot_message_map["bot_123"] = {
             "session_id": "sess_1",
             "channel_id": "ch1",
             "conversation_id": "conv1",
             "sender_id": "user1",
+            "text": "Here is your result",
         }
+
+        mock_task = MagicMock()
+        task_manager.start_chat = AsyncMock(return_value=mock_task)
+
+        async def _fake_consume(task, start_from=None):
+            if False:
+                yield
+            return
+
+        task_manager.consume_events = _fake_consume
 
         event = ReactionEvent(
             channel_id="ch1",
@@ -857,13 +868,58 @@ class TestReactionLifecycle:
             emoji="thumbsup",
         )
 
-        # Should not raise
         await bridge.handle_reaction(event, adapter)
+
+        task_manager.start_chat.assert_awaited_once()
+        kwargs = task_manager.start_chat.await_args.kwargs
+        assert kwargs.get("sub_agent_id") == "feedback"
+        # Request is the second positional arg
+        request = task_manager.start_chat.await_args.args[1]
+        assert request.source_session_id == "sess_1"
+        assert request.session_id is None
+        assert request.subagent_id is None  # subagent_id passes via sub_agent_id kwarg
+        assert "thumbsup" in request.message
+        assert "Here is your result" in request.message
+
+    @pytest.mark.asyncio
+    async def test_handle_reaction_dedupes_same_message(self, setup):
+        """Only the first reaction on a bot message should trigger feedback."""
+        bridge, adapter, task_manager = setup
+
+        bridge._bot_message_map["bot_dup"] = {
+            "session_id": "sess_1",
+            "channel_id": "ch1",
+            "conversation_id": "conv1",
+            "sender_id": "user1",
+            "text": "Reply body",
+        }
+
+        task_manager.start_chat = AsyncMock(return_value=MagicMock())
+
+        async def _fake_consume(task, start_from=None):
+            if False:
+                yield
+            return
+
+        task_manager.consume_events = _fake_consume
+
+        base = dict(
+            channel_id="ch1",
+            sender_id="user2",
+            conversation_id="conv1",
+            target_message_id="bot_dup",
+        )
+        await bridge.handle_reaction(ReactionEvent(**base, emoji="thumbsup"), adapter)
+        await bridge.handle_reaction(ReactionEvent(**base, emoji="thumbsdown"), adapter)
+        await bridge.handle_reaction(ReactionEvent(**base, emoji="heart"), adapter)
+
+        assert task_manager.start_chat.await_count == 1
 
     @pytest.mark.asyncio
     async def test_handle_reaction_unknown_message(self, setup):
-        """handle_reaction should silently return for unknown messages."""
-        bridge, adapter, _ = setup
+        """Unknown bot messages should silently return without starting a task."""
+        bridge, adapter, task_manager = setup
+        task_manager.start_chat = AsyncMock()
 
         event = ReactionEvent(
             channel_id="ch1",
@@ -873,8 +929,31 @@ class TestReactionLifecycle:
             emoji="thumbsup",
         )
 
-        # Should not raise
         await bridge.handle_reaction(event, adapter)
+
+        task_manager.start_chat.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_track_bot_message_stores_text(self, setup):
+        """_track_bot_message should persist the bot reply text for later reference."""
+        bridge, _, _ = setup
+        msg = _make_inbound()
+
+        await bridge._track_bot_message("bot_1", "sess_1", msg, text="Hello world")
+
+        assert bridge._bot_message_map["bot_1"]["text"] == "Hello world"
+        assert bridge._bot_message_map["bot_1"]["session_id"] == "sess_1"
+
+    @pytest.mark.asyncio
+    async def test_track_bot_message_accumulates_streamed_text(self, setup):
+        """Repeated tracking for the same bot_msg_id should concat streamed fragments."""
+        bridge, _, _ = setup
+        msg = _make_inbound()
+
+        await bridge._track_bot_message("bot_1", "sess_1", msg, text="Hello ")
+        await bridge._track_bot_message("bot_1", "sess_1", msg, text="world")
+
+        assert bridge._bot_message_map["bot_1"]["text"] == "Hello world"
 
     @pytest.mark.asyncio
     async def test_bot_message_map_eviction(self, setup):

--- a/tests/unit_tests/claw/test_bridge.py
+++ b/tests/unit_tests/claw/test_bridge.py
@@ -934,6 +934,62 @@ class TestReactionLifecycle:
         task_manager.start_chat.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_tracked_reference_includes_sql_when_text_empty(self, setup):
+        """SQL-only replies (empty text, SQL in outbound.sql) must still populate reference text."""
+        bridge, adapter, task_manager = setup
+
+        mock_task = MagicMock()
+        task_manager.start_chat = AsyncMock(return_value=mock_task)
+
+        async def _fake_consume(task, start_from=None):
+            yield _make_sse_sql("SELECT 1")
+            yield _make_sse_end()
+
+        task_manager.consume_events = _fake_consume
+
+        await bridge.handle_message(_make_inbound("q"), adapter)
+
+        assert len(bridge._bot_message_map) == 1
+        tracked = next(iter(bridge._bot_message_map.values()))
+        assert tracked["text"] == "```sql\nSELECT 1\n```"
+
+    @pytest.mark.asyncio
+    async def test_tracked_reference_combines_text_and_sql(self, setup):
+        """When both markdown text and SQL are present, tracked reference should concat both."""
+        bridge, adapter, task_manager = setup
+
+        mock_task = MagicMock()
+        task_manager.start_chat = AsyncMock(return_value=mock_task)
+
+        combined_event = SSEEvent(
+            id=10,
+            event="message",
+            data=SSEMessageData(
+                type=SSEDataType.CREATE_MESSAGE,
+                payload=SSEMessagePayload(
+                    message_id="m10",
+                    role="assistant",
+                    content=[
+                        IMessageContent(type="markdown", payload={"content": "Here is the query"}),
+                        IMessageContent(type="code", payload={"content": "SELECT 2", "codeType": "sql"}),
+                    ],
+                ),
+            ),
+            timestamp=datetime.now().isoformat() + "Z",
+        )
+
+        async def _fake_consume(task, start_from=None):
+            yield combined_event
+            yield _make_sse_end()
+
+        task_manager.consume_events = _fake_consume
+
+        await bridge.handle_message(_make_inbound("q"), adapter)
+
+        tracked = next(iter(bridge._bot_message_map.values()))
+        assert tracked["text"] == "Here is the query\n\n```sql\nSELECT 2\n```"
+
+    @pytest.mark.asyncio
     async def test_track_bot_message_stores_text(self, setup):
         """_track_bot_message should persist the bot reply text for later reference."""
         bridge, _, _ = setup
@@ -954,6 +1010,75 @@ class TestReactionLifecycle:
         await bridge._track_bot_message("bot_1", "sess_1", msg, text="world")
 
         assert bridge._bot_message_map["bot_1"]["text"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_handle_reaction_rolls_back_dedup_on_start_chat_value_error(self, setup):
+        """If start_chat raises ValueError, the message should NOT stay marked as reacted."""
+        bridge, adapter, task_manager = setup
+
+        bridge._bot_message_map["bot_retry"] = {
+            "session_id": "sess_1",
+            "channel_id": "ch1",
+            "conversation_id": "conv1",
+            "sender_id": "user1",
+            "text": "Reply body",
+        }
+
+        task_manager.start_chat = AsyncMock(side_effect=ValueError("transient"))
+
+        event = ReactionEvent(
+            channel_id="ch1",
+            sender_id="user2",
+            conversation_id="conv1",
+            target_message_id="bot_retry",
+            emoji="thumbsup",
+        )
+
+        await bridge.handle_reaction(event, adapter)
+
+        # Dedup mark rolled back so a later reaction on the same message can retry
+        assert "bot_retry" not in bridge._reacted_bot_messages
+
+        # Second reaction should attempt start_chat again, not be silently skipped
+        task_manager.start_chat.reset_mock(return_value=True, side_effect=True)
+        task_manager.start_chat = AsyncMock(return_value=MagicMock())
+
+        async def _empty(task, start_from=None):
+            if False:
+                yield
+            return
+
+        task_manager.consume_events = _empty
+
+        await bridge.handle_reaction(event, adapter)
+        task_manager.start_chat.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_reaction_rolls_back_dedup_on_start_chat_unexpected_error(self, setup):
+        """Unexpected errors from start_chat must also roll back the dedup mark."""
+        bridge, adapter, task_manager = setup
+
+        bridge._bot_message_map["bot_boom"] = {
+            "session_id": "sess_1",
+            "channel_id": "ch1",
+            "conversation_id": "conv1",
+            "sender_id": "user1",
+            "text": "Reply body",
+        }
+
+        task_manager.start_chat = AsyncMock(side_effect=RuntimeError("boom"))
+
+        event = ReactionEvent(
+            channel_id="ch1",
+            sender_id="user2",
+            conversation_id="conv1",
+            target_message_id="bot_boom",
+            emoji="thumbsup",
+        )
+
+        await bridge.handle_reaction(event, adapter)
+
+        assert "bot_boom" not in bridge._reacted_bot_messages
 
     @pytest.mark.asyncio
     async def test_bot_message_map_eviction(self, setup):

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1214,6 +1214,80 @@ class TestGetSessionMessages:
         assert assistant_messages[0].get("sql") == "SELECT COUNT(*) FROM customer"
         assert assistant_messages[0]["content"] == "There are 30000 customers."
 
+    def test_interleaved_function_call_outputs_pair_by_call_id(self, sm):
+        """Parallel tool calls must be paired with their outputs via call_id on resume.
+
+        Regression for a bug where two function_call messages emitted back-to-back
+        (before any output) were paired with outputs by list order, causing the
+        SUCCESS action for the first call to inherit the input of the second call.
+        """
+        session_id = f"test_pair_{uuid.uuid4().hex[:8]}"
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+
+        call_id_a = "toolu_call_a"
+        call_id_b = "toolu_call_b"
+        args_a = json.dumps({"type": "gen_sql_summary", "description": "archive sql"})
+        args_b = json.dumps({"type": "gen_ext_knowledge", "description": "archive knowledge"})
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (session_id,))
+            rows = [
+                (
+                    json.dumps({"role": "user", "content": "go"}),
+                    "2025-01-01T00:00:00",
+                ),
+                (
+                    json.dumps({"type": "function_call", "call_id": call_id_a, "name": "task", "arguments": args_a}),
+                    "2025-01-01T00:00:01",
+                ),
+                (
+                    json.dumps({"type": "function_call", "call_id": call_id_b, "name": "task", "arguments": args_b}),
+                    "2025-01-01T00:00:02",
+                ),
+                (
+                    json.dumps(
+                        {
+                            "type": "function_call_output",
+                            "call_id": call_id_a,
+                            "output": "{'success': 1, 'result': 'ok'}",
+                        }
+                    ),
+                    "2025-01-01T00:00:03",
+                ),
+                (
+                    json.dumps(
+                        {
+                            "type": "function_call_output",
+                            "call_id": call_id_b,
+                            "output": "{'success': 0, 'error': 'Max turns (70) exceeded'}",
+                        }
+                    ),
+                    "2025-01-01T00:00:04",
+                ),
+            ]
+            conn.executemany(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                [(session_id, data, ts) for data, ts in rows],
+            )
+            conn.commit()
+
+        messages = sm.get_session_messages(session_id)
+        assistant_groups = [m for m in messages if m["role"] == "assistant"]
+        assert assistant_groups, "expected at least one assistant group"
+        actions = assistant_groups[0].get("actions", [])
+
+        success_by_call_id = {
+            a.action_id.removeprefix("complete_"): a for a in actions if a.action_id.startswith("complete_")
+        }
+        assert call_id_a in success_by_call_id, "SUCCESS action for call A missing"
+        assert call_id_b in success_by_call_id, "SUCCESS action for call B missing"
+
+        # Each SUCCESS action must inherit the input of its own call_id, not the
+        # most-recent PROCESSING action in insertion order.
+        assert success_by_call_id[call_id_a].input["arguments"] == args_a
+        assert success_by_call_id[call_id_b].input["arguments"] == args_b
+
 
 # ===========================================================================
 # TestParseOutputFromAction (migrated from test_session_loader.py)

--- a/tests/unit_tests/utils/test_feedback_prompt.py
+++ b/tests/unit_tests/utils/test_feedback_prompt.py
@@ -81,3 +81,18 @@ class TestBuildReactionFeedbackPrompt:
             reference_msg="",
         )
         assert prompt == '[The user reacted to this message "" with [thumbsup]]'
+
+    def test_truncate_respects_tiny_max_len(self):
+        """When max_len is smaller than the ellipsis, the quoted portion must still fit in max_len."""
+        long_ref = "a" * 100
+        for tiny in (1, 2, 3):
+            prompt = build_reaction_feedback_prompt(
+                reaction_emoji="x",
+                reference_msg=long_ref,
+                max_ref_len=tiny,
+            )
+            start = prompt.index('"') + 1
+            end = prompt.index('"', start)
+            quoted = prompt[start:end]
+            assert len(quoted) == tiny, f"max_len={tiny} produced {quoted!r}"
+            assert quoted == "..."[:tiny]

--- a/tests/unit_tests/utils/test_feedback_prompt.py
+++ b/tests/unit_tests/utils/test_feedback_prompt.py
@@ -1,0 +1,83 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/utils/feedback_prompt.py."""
+
+from datus.utils.feedback_prompt import build_reaction_feedback_prompt
+
+
+class TestBuildReactionFeedbackPrompt:
+    def test_basic_format(self):
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="thumbsup",
+            reference_msg="Sales for Q1 total 12345",
+        )
+        assert prompt == '[The user reacted to this message "Sales for Q1 total 12345" with [thumbsup]]'
+
+    def test_non_ascii_reference_passes_through(self):
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="thumbsdown",
+            reference_msg="这里是返回的表格数据",
+        )
+        assert "这里是返回的表格数据" in prompt
+        assert "[thumbsdown]" in prompt
+
+    def test_optional_reaction_msg_appended(self):
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="thumbsup",
+            reference_msg="hello",
+            reaction_msg="good job",
+        )
+        assert prompt.endswith("good job")
+        assert prompt.startswith("[The user reacted to this message")
+
+    def test_reaction_msg_whitespace_is_stripped(self):
+        """Blank/whitespace-only reaction_msg should not be appended."""
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="thumbsup",
+            reference_msg="hello",
+            reaction_msg="   ",
+        )
+        assert prompt == '[The user reacted to this message "hello" with [thumbsup]]'
+
+    def test_reference_msg_truncated_with_ellipsis(self):
+        """References longer than max_ref_len are truncated with '...' marker."""
+        long_ref = "a" * 1000
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="x",
+            reference_msg=long_ref,
+            max_ref_len=50,
+        )
+        # Extract quoted content between the first pair of '"'
+        start = prompt.index('"') + 1
+        end = prompt.index('"', start)
+        quoted = prompt[start:end]
+        assert len(quoted) == 50
+        assert quoted.endswith("...")
+        # Preserved prefix is 47 'a's (50 - len("..."))
+        assert quoted[:-3] == "a" * 47
+
+    def test_truncation_disabled_with_zero(self):
+        long_ref = "a" * 1000
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="x",
+            reference_msg=long_ref,
+            max_ref_len=0,
+        )
+        assert long_ref in prompt
+
+    def test_emoji_whitespace_trimmed(self):
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="  thumbsup  ",
+            reference_msg="hi",
+        )
+        assert "[thumbsup]" in prompt
+        assert "[  thumbsup  ]" not in prompt
+
+    def test_empty_reference(self):
+        prompt = build_reaction_feedback_prompt(
+            reaction_emoji="thumbsup",
+            reference_msg="",
+        )
+        assert prompt == '[The user reacted to this message "" with [thumbsup]]'


### PR DESCRIPTION
## Why

Datus's feedback subagent was previously only reachable via the CLI `/feedback` command. We need IM scenarios (Feishu/Slack via claw) and external frontends (Web UI / third-party integrations via API) to trigger the same feedback archival flow, closing the loop:

- **IM scenario**: when a user reacts to a bot message with an emoji (👍/👎), the feedback agent is automatically triggered to silently archive reusable knowledge, without the user having to copy/paste into the CLI.
- **API scenario**: expose `POST /api/v1/chat/feedback` so that when the frontend user clicks thumbs up/down (optionally with a comment), it sends the reaction context (emoji + the original message reacted to + optional comment) to the server, and the server renders the prompt and routes it to the feedback subagent uniformly.

This PR also fixes two upstream bugs exposed by these two new code paths:
1. When the Feishu SDK's worker thread dispatches messages through `asyncio.run_coroutine_threadsafe`, the `path_manager` ContextVar set by `AgentConfig` on the main thread cannot be inherited by the new task, which causes downstream `BaseSubjectEmbeddingStore` to receive an empty `project_name` and raise `create_rdb_for_store requires a non-empty project`.
2. `SessionManager.get_session_messages`, when resuming history with parallel tool calls, pairs `function_call_output` and `function_call` by list order, causing the SUCCESS action of the earlier-completed call to inherit arguments from a later call and distorting action history.

## Solution

### 1. Unified reaction prompt builder (`datus/utils/feedback_prompt.py`)

Added `build_reaction_feedback_prompt(reaction_emoji, reference_msg, reaction_msg=None, max_ref_len=500)`, which produces a fixed format:

```
[The user reacted to this message "{reference_msg}" with [{emoji}]] {reaction_msg?}
```

The claw bridge and the API route share the same rendering logic, ensuring the prompt fed to the feedback agent is identical on both paths. `reference_msg` is length-truncated (default 500 chars, with `...` marker) to prevent oversized IM replies from blowing up the context.

### 2. API endpoint (`datus/api/routes/chat_routes.py`)

Added `POST /api/v1/chat/feedback`, which accepts `FeedbackChatInput` (`reaction_emoji` / `reference_msg` / optional `reaction_msg` / required `source_session_id`). The server:
- Calls `build_reaction_feedback_prompt` to render the prompt
- Rebuilds it as `StreamChatInput(subagent_id="feedback", source_session_id=...)`
- Streams the response as SSE through the existing `ChatService.stream_chat` pipeline

The `message` field is documented as "leave empty, the server derives it", so the caller doesn't have to supply redundant text.

### 3. Claw bridge reaction trigger (`datus/claw/bridge.py`)

- `_track_bot_message` now takes a `text` argument and persists the bot reply text; for streaming chunks it incrementally accumulates so that the final `reference_msg` is the complete reply.
- `handle_reaction` changed from "log only" to: trigger the feedback subagent on first reaction, build `StreamChatInput(source_session_id=..., session_id=None)`, dispatch through `ChatTaskManager.start_chat`, and silently consume events (no IM write-back).
- Added `_reacted_bot_messages` OrderedDict (capped at 10000) for dedup: a given bot message only triggers once on the first reaction; subsequent emoji add/remove events are ignored to prevent spam.

### 4. `source_session_id` plumbing into the feedback node

- `node_factory.create_node_input` and `ChatTaskManager._create_node_input` added a `source_session_id` parameter and forward it to `FeedbackNodeInput`.
- `ChatTaskManager._init_node`: when `sub_agent_id == "feedback"` and `request.source_session_id` is non-empty, `node.session_id` is set to `None` so that `FeedbackAgenticNode.execute_stream` copies history from the source session into a fresh `feedback_session_*`, matching the CLI `_copy_session_for_switch` behavior (the CLI path is unchanged).

### 5. Bug fixes

- **`ChatTaskManager._run_loop`**: at the top of the loop, call `set_current_path_manager(agent_config.path_manager)` to explicitly pin the main-thread-initialized path manager into the current task's ContextVar. Because ContextVar mutations are invisible to the caller (tasks get an independent context copy), this does not leak to the outer scope.
- **`SessionManager.get_session_messages`**: when encountering a `function_call_output`, look up the matching `PROCESSING` action by `call_id` in reverse order, falling back to the original `current_actions[-1]` logic if not found. This fixes the pairing mismatch for parallel tool calls.

## Test Cases

All CI-level unit tests, zero external dependencies:

**New files**
- `tests/unit_tests/utils/test_feedback_prompt.py`: 8 cases covering basic format, non-ASCII, optional comment, whitespace comment stripping, truncation, truncation disabled (max_ref_len=0), emoji whitespace trimming, empty reference.
- `tests/unit_tests/api/routes/test_chat_routes_feedback.py`: 2 cases covering endpoint prompt rendering + routing to the feedback subagent + appending `reaction_msg`.

**Extended cases**
- `tests/unit_tests/agent/node/test_node_factory.py`: feedback branch `source_session_id` forward propagation + CLI path defaults to None.
- `tests/unit_tests/api/services/test_chat_task_manager.py`:
  - `_create_node_input` forwards `source_session_id` to `FeedbackAgenticNode`.
  - Added `TestRunLoopPathManagerContext`: under an empty ContextVar, `_run_loop` correctly pins the path manager + does not leak back to the caller (2 cases).
- `tests/unit_tests/claw/test_bridge.py`: reaction on a known bot message triggers feedback, repeated reactions on the same bot message are deduped, reactions on unknown bot messages return silently, `_track_bot_message` saves text, streaming text accumulates (5 new cases, the original `test_handle_reaction_known_message` upgraded to assert the trigger).
- `tests/unit_tests/models/test_session_manager.py`: added `test_interleaved_function_call_outputs_pair_by_call_id`, directly writing interleaved call_id history and asserting that the SUCCESS action's arguments map one-to-one to its call_id.

**Why no integration/nightly tests**
All changes can be covered by mocking the external boundaries (LLM / IM SDK / asyncio dispatch / SQLite session storage); no real LLM or database is required. The ChatTaskManager path_manager regression test uses `_current_path_manager.set(None)` directly to simulate the Feishu thread dispatch scenario, so there's no need to actually bring up the claw bridge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now react to assistant messages with emoji and optionally provide additional comments or context for their feedback.

* **Bug Fixes**
  * Improved session tracking to ensure function call outputs are correctly paired with their corresponding function calls during complex interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->