### PR TITLE
[Enhancement] Filter session list/resume by current agent

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -11,7 +11,7 @@ asyncio.Task so that client disconnects do not cancel the computation.
 """
 
 import json
-from typing import Annotated
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Path, Query
 from fastapi.responses import StreamingResponse
@@ -132,13 +132,21 @@ async def compact_chat_session(
     "/sessions",
     response_model=Result[ChatSessionData],
     summary="List Chat Sessions",
-    description="List all chat sessions",
+    description=(
+        "List chat sessions. Pass subagent_id to filter by agent "
+        "(use 'chat' for the default chat agent, or any builtin/custom subagent id). "
+        "Omit to return every session for the user."
+    ),
 )
 async def list_sessions(
     svc: ServiceDep,
     ctx: AppContextDep,
+    subagent_id: Optional[str] = Query(
+        default=None,
+        description="Filter by subagent id; 'chat' selects the default chat agent",
+    ),
 ) -> Result[ChatSessionData]:
-    return svc.chat.list_sessions(user_id=ctx.user_id)
+    return svc.chat.list_sessions(user_id=ctx.user_id, subagent_id=subagent_id)
 
 
 @router.delete(

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -28,7 +28,7 @@ from datus.api.models.cli_models import (
 )
 from datus.api.services.action_sse_converter import action_to_sse_event
 from datus.configuration.agent_config import AgentConfig
-from datus.models.session_manager import SessionManager
+from datus.models.session_manager import SessionManager, session_matches_agent
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -102,11 +102,23 @@ class ChatService:
             logger.error(f"Failed to get active model: {e}")
             return Result[ChatModelData](success=False, errorCode="MODEL_LOOKUP_ERROR", errorMessage=str(e))
 
-    def list_sessions(self, user_id: Optional[str] = None) -> Result[ChatSessionData]:
-        """List all chat sessions from disk."""
+    def list_sessions(
+        self,
+        user_id: Optional[str] = None,
+        subagent_id: Optional[str] = None,
+    ) -> Result[ChatSessionData]:
+        """List chat sessions from disk, optionally filtered by agent.
+
+        When ``subagent_id`` is ``None`` every session for *user_id* is
+        returned. When set, only sessions whose id prefix encodes that agent
+        are returned; the sentinel ``"chat"`` selects the default chat agent
+        (including legacy prefix-less sessions).
+        """
         try:
             session_mgr = SessionManager(session_dir=self._session_dir, scope=user_id)
             all_ids = session_mgr.list_sessions()
+            if subagent_id is not None:
+                all_ids = [sid for sid in all_ids if session_matches_agent(sid, subagent_id)]
             sessions = []
 
             for sid in all_ids:

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -1139,16 +1139,18 @@ class ChatCommands:
                 self.last_actions = last_assistant_actions
 
     def cmd_list_sessions(self, args: str):
-        """List all available chat sessions."""
+        """List chat sessions for the active agent."""
         try:
             # Create a session manager directly (don't rely on chat_node)
-            from datus.models.session_manager import SessionManager
+            from datus.models.session_manager import SessionManager, session_matches_agent
 
             session_manager = SessionManager(self.cli.agent_config.session_dir, scope=self.cli.scope)
             sessions = session_manager.list_sessions()
+            sessions = [s for s in sessions if session_matches_agent(s, self.current_subagent_name)]
 
+            agent_label = self.current_subagent_name or "chat"
             if not sessions:
-                self.console.print("[yellow]No chat sessions found.[/]")
+                self.console.print(f"[yellow]No chat sessions found for agent '{agent_label}'.[/]")
                 return
 
             # Get current session ID for highlighting (if current_node exists)
@@ -1158,17 +1160,20 @@ class ChatCommands:
 
             # Get session info for all sessions first to enable sorting
             sessions_with_info = []
-            for session_data in sessions:
-                session_id = session_data["session_id"]
+            for session_id in sessions:
+                session_data = {"session_id": session_id}
                 try:
-                    # Get detailed session info if available
+                    info = session_manager.get_session_info(session_id)
+                    if info.get("exists"):
+                        session_data["created_at"] = info.get("created_at") or ""
+                        session_data["last_updated"] = info.get("updated_at") or info.get("latest_message_at") or ""
+                        session_data["total_turns"] = info.get("message_count", 0)
                     if self.current_node and hasattr(self.current_node, "_get_session_details"):
                         detailed_info = self.current_node._get_session_details(session_id)
                         session_data.update(detailed_info)
-                    sessions_with_info.append(session_data)
                 except Exception as e:
                     logger.debug(f"Could not get detailed info for session {session_id}: {e}")
-                    sessions_with_info.append(session_data)
+                sessions_with_info.append(session_data)
 
             # Sort by last_updated (most recent first)
             sessions_with_info.sort(
@@ -1209,26 +1214,28 @@ class ChatCommands:
     @staticmethod
     def _extract_node_type_from_session_id(session_id: str) -> str:
         """Extract node type from session_id format {node_name}_session_{uuid}."""
-        if "_session_" in session_id:
-            return session_id.rsplit("_session_", 1)[0]
-        return "chat"
+        from datus.models.session_manager import extract_agent_from_session_id
+
+        return extract_agent_from_session_id(session_id)
 
     def cmd_resume(self, args: str):
-        """Resume a previous chat session."""
+        """Resume a previous chat session for the active agent."""
         from datus.cli._cli_utils import select_list
-        from datus.models.session_manager import SessionManager
+        from datus.models.session_manager import SessionManager, session_matches_agent
 
         try:
             session_manager = SessionManager(self.cli.agent_config.session_dir, scope=self.cli.scope)
 
             # If session_id provided directly, use it
             target_session_id = args.strip() if args else None
+            agent_label = self.current_subagent_name or "chat"
 
             if not target_session_id:
-                # List all sessions for user to choose
+                # List sessions for the current agent only
                 sessions = session_manager.list_sessions(sort_by_modified=True)
+                sessions = [sid for sid in sessions if session_matches_agent(sid, self.current_subagent_name)]
                 if not sessions:
-                    self.console.print("[yellow]No sessions found.[/]")
+                    self.console.print(f"[yellow]No sessions found for agent '{agent_label}'.[/]")
                     return
 
                 # Get session info and filter empty sessions
@@ -1239,7 +1246,7 @@ class ChatCommands:
                         session_infos.append(info)
 
                 if not session_infos:
-                    self.console.print("[yellow]No sessions with messages found.[/]")
+                    self.console.print(f"[yellow]No sessions with messages found for agent '{agent_label}'.[/]")
                     return
 
                 # Sort by updated_at descending (newest first)

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -29,6 +29,31 @@ if TYPE_CHECKING:
     from datus.utils.path_manager import DatusPathManager
 
 
+DEFAULT_CHAT_AGENT = "chat"
+
+
+def extract_agent_from_session_id(session_id: str) -> str:
+    """Return the agent name encoded in *session_id*.
+
+    Session IDs produced by the CLI and API follow the pattern
+    ``{agent_name}_session_{uuid}``. Legacy IDs that lack the ``_session_``
+    delimiter are treated as belonging to the default chat agent.
+    """
+    if "_session_" in session_id:
+        return session_id.rsplit("_session_", 1)[0]
+    return DEFAULT_CHAT_AGENT
+
+
+def session_matches_agent(session_id: str, agent_name: Optional[str]) -> bool:
+    """True when *session_id* belongs to *agent_name*.
+
+    ``None`` / empty / ``"chat"`` all resolve to the default chat agent, so
+    legacy (prefix-less) sessions are surfaced under chat.
+    """
+    target = agent_name or DEFAULT_CHAT_AGENT
+    return extract_agent_from_session_id(session_id) == target
+
+
 class SessionManager:
     """
     Manages sessions for multi-turn conversations across LLM models.

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -79,6 +79,41 @@ class TestChatServiceListSessions:
         session_ids = [s.session_id for s in result.data.sessions]
         assert "test-list-session" in session_ids
 
+    def test_list_sessions_filters_by_subagent_id(self, chat_svc):
+        """subagent_id='gen_metrics' keeps only sessions whose prefix matches."""
+        sm = SessionManager(session_dir=chat_svc._session_dir)
+        sm.create_session("chat_session_a")
+        sm.create_session("gen_metrics_session_a")
+        sm.create_session("gen_metrics_session_b")
+
+        result = chat_svc.list_sessions(subagent_id="gen_metrics")
+        assert result.success is True
+        session_ids = {s.session_id for s in result.data.sessions}
+        assert session_ids == {"gen_metrics_session_a", "gen_metrics_session_b"}
+
+    def test_list_sessions_filter_chat_includes_legacy(self, chat_svc):
+        """subagent_id='chat' returns chat-prefixed and legacy (no-prefix) ids, but not subagents."""
+        sm = SessionManager(session_dir=chat_svc._session_dir)
+        sm.create_session("chat_session_a")
+        sm.create_session("legacy-id-1")
+        sm.create_session("gen_metrics_session_a")
+
+        result = chat_svc.list_sessions(subagent_id="chat")
+        assert result.success is True
+        session_ids = {s.session_id for s in result.data.sessions}
+        assert session_ids == {"chat_session_a", "legacy-id-1"}
+
+    def test_list_sessions_no_filter_returns_all(self, chat_svc):
+        """subagent_id=None returns sessions for every agent."""
+        sm = SessionManager(session_dir=chat_svc._session_dir)
+        sm.create_session("chat_session_a")
+        sm.create_session("gen_metrics_session_a")
+
+        result = chat_svc.list_sessions()
+        assert result.success is True
+        session_ids = {s.session_id for s in result.data.sessions}
+        assert {"chat_session_a", "gen_metrics_session_a"} <= session_ids
+
 
 class TestChatServiceDeleteSession:
     """Tests for delete_session."""

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3909,3 +3909,75 @@ class TestDropIfMatchesFinal:
         final = self._final("anything")
         _drop_if_matches_final(pending, final, incremental)
         assert incremental == []
+
+
+# ===========================================================================
+# TestSessionFilterByAgent — cmd_list_sessions/cmd_resume filter by active agent
+# ===========================================================================
+
+
+class TestSessionFilterByAgent:
+    """cmd_list_sessions and cmd_resume only surface sessions for the active agent."""
+
+    def _seed_mixed_sessions(self):
+        """Seed disk with sessions for chat, gensql, gen_metrics, plus a legacy id."""
+        _create_session_on_disk("chat_session_a", [("user", "hi")])
+        _create_session_on_disk("gensql_session_a", [("user", "gen sql")])
+        _create_session_on_disk("gen_metrics_session_a", [("user", "metrics")])
+        _create_session_on_disk("legacy-session-1", [("user", "legacy")])
+
+    def test_list_sessions_chat_hides_subagent_ids(self, real_agent_config, mock_llm_create):
+        """Chat agent sees chat-prefixed and legacy ids, not subagent sessions."""
+        console = Console(file=io.StringIO(), no_color=True)
+        cmds = _make_chat_commands(real_agent_config, console=console)
+        cmds.current_subagent_name = None
+
+        self._seed_mixed_sessions()
+        cmds.cmd_list_sessions("")
+
+        output = _get_console_output(console)
+        assert "chat_session_a" in output
+        assert "legacy-session-1" in output
+        assert "gensql_session_a" not in output
+        assert "gen_metrics_session_a" not in output
+
+    def test_list_sessions_subagent_scope(self, real_agent_config, mock_llm_create):
+        """gen_metrics agent only sees its own sessions."""
+        console = Console(file=io.StringIO(), no_color=True)
+        cmds = _make_chat_commands(real_agent_config, console=console)
+        cmds.current_subagent_name = "gen_metrics"
+
+        self._seed_mixed_sessions()
+        cmds.cmd_list_sessions("")
+
+        output = _get_console_output(console)
+        assert "gen_metrics_session_a" in output
+        assert "chat_session_a" not in output
+        assert "gensql_session_a" not in output
+        assert "legacy-session-1" not in output
+
+    def test_list_sessions_agent_with_no_sessions(self, real_agent_config, mock_llm_create):
+        """Empty message references the current agent label."""
+        console = Console(file=io.StringIO(), no_color=True)
+        cmds = _make_chat_commands(real_agent_config, console=console)
+        cmds.current_subagent_name = "gen_metrics"
+
+        _create_session_on_disk("chat_session_a", [("user", "hi")])
+        cmds.cmd_list_sessions("")
+
+        output = _get_console_output(console)
+        assert "gen_metrics" in output
+        assert "no chat sessions found" in output.lower()
+
+    def test_resume_interactive_empty_when_agent_has_no_sessions(self, real_agent_config, mock_llm_create):
+        """cmd_resume with no args filters by current agent; empty result message mentions agent."""
+        console = Console(file=io.StringIO(), no_color=True)
+        cmds = _make_chat_commands(real_agent_config, console=console)
+        cmds.current_subagent_name = "gen_metrics"
+
+        _create_session_on_disk("chat_session_a", [("user", "hi")])
+        cmds.cmd_resume("")
+
+        output = _get_console_output(console)
+        assert "gen_metrics" in output
+        assert cmds.current_node is None

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -30,7 +30,11 @@ from types import SimpleNamespace
 import pytest
 from agents.extensions.memory import AdvancedSQLiteSession
 
-from datus.models.session_manager import SessionManager
+from datus.models.session_manager import (
+    SessionManager,
+    extract_agent_from_session_id,
+    session_matches_agent,
+)
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.utils.exceptions import DatusException
 from datus.utils.path_manager import DatusPathManager
@@ -1702,3 +1706,64 @@ class TestCopySession:
         read_items = asyncio.run(new_session.get_items())
         assert len(read_items) == 4
         assert [it.get("content") for it in read_items] == ["Q1", "A1", "Q2", "A2"]
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers: extract_agent_from_session_id, session_matches_agent
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAgentFromSessionId:
+    """Tests for extract_agent_from_session_id."""
+
+    def test_chat_prefix(self):
+        """Default chat-prefixed ids resolve to 'chat'."""
+        assert extract_agent_from_session_id("chat_session_abc123") == "chat"
+
+    def test_subagent_prefix(self):
+        """Subagent-prefixed ids return the subagent name."""
+        assert extract_agent_from_session_id("gen_metrics_session_abc123") == "gen_metrics"
+
+    def test_multi_underscore_prefix(self):
+        """Splits on the last '_session_' so underscores in the agent name survive."""
+        assert extract_agent_from_session_id("my_custom_agent_session_x") == "my_custom_agent"
+
+    def test_legacy_no_prefix_defaults_to_chat(self):
+        """Session IDs without the _session_ delimiter fall back to chat."""
+        assert extract_agent_from_session_id("legacy-session-id") == "chat"
+        assert extract_agent_from_session_id("abc123") == "chat"
+
+
+class TestSessionMatchesAgent:
+    """Tests for session_matches_agent."""
+
+    def test_chat_session_matches_none(self):
+        """None agent selects the default chat agent."""
+        assert session_matches_agent("chat_session_1", None) is True
+
+    def test_chat_session_matches_chat_string(self):
+        """Explicit 'chat' matches chat-prefixed sessions."""
+        assert session_matches_agent("chat_session_1", "chat") is True
+
+    def test_chat_session_matches_empty_string(self):
+        """Empty-string agent_name is treated as the chat agent."""
+        assert session_matches_agent("chat_session_1", "") is True
+
+    def test_subagent_match(self):
+        """Subagent session matches its own name."""
+        assert session_matches_agent("gen_metrics_session_1", "gen_metrics") is True
+
+    def test_subagent_does_not_match_chat(self):
+        """Subagent session must not surface under the chat filter."""
+        assert session_matches_agent("gen_metrics_session_1", None) is False
+        assert session_matches_agent("gen_metrics_session_1", "chat") is False
+
+    def test_chat_does_not_match_subagent(self):
+        """Chat session must not surface under a subagent filter."""
+        assert session_matches_agent("chat_session_1", "gen_metrics") is False
+
+    def test_legacy_session_matches_chat(self):
+        """Legacy prefix-less sessions are visible to the chat agent."""
+        assert session_matches_agent("legacy-id", None) is True
+        assert session_matches_agent("legacy-id", "chat") is True
+        assert session_matches_agent("legacy-id", "gen_metrics") is False


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

Session ids already encode the owning agent via `{agent_name}_session_{uuid}`, but the CLI `.sessions` / `.resume` commands and the `GET /api/v1/chat/sessions` endpoint surfaced every id in the project scope. When a user switched to a subagent (e.g. `gen_metrics`) and ran `.sessions`, they saw every chat / gensql / other-subagent session too, and had to scroll through unrelated ids to find theirs.

There was also a pre-existing rendering bug in `cmd_list_sessions`: `SessionManager.list_sessions()` returns `list[str]`, but the CLI treated each entry as a dict (`session_data["session_id"]`), which would raise as soon as the loop body was exercised end-to-end.

## Solution

- Promote the session-id decoding to two module-level helpers in `datus/models/session_manager.py`:
  - `extract_agent_from_session_id(session_id)` — splits on the last `_session_` delimiter; legacy prefix-less ids resolve to the default chat agent.
  - `session_matches_agent(session_id, agent_name)` — `None` / `""` / `"chat"` all map to the default chat agent, so legacy ids stay visible under chat.
- CLI (`datus/cli/chat_commands.py`):
  - `cmd_list_sessions` and `cmd_resume` now filter by `self.current_subagent_name` before rendering / prompting.
  - Empty-state messages name the active agent (`No chat sessions found for agent '<name>'.`) so users know the scope.
  - Fix the `list[str]` vs `list[dict]` bug: iterate ids as strings and build the display dict inline, populating `created_at` / `last_updated` / `total_turns` from `session_manager.get_session_info()`.
  - `_extract_node_type_from_session_id` delegates to the new helper for consistency.
- API (`datus/api/routes/chat_routes.py`, `datus/api/services/chat_service.py`):
  - `GET /api/v1/chat/sessions` accepts a new optional `subagent_id` query parameter. Omit it for the full list; pass `"chat"` for the default chat agent (including legacy ids); pass a subagent id to scope to that agent only.
  - `ChatService.list_sessions` accepts `subagent_id` and applies `session_matches_agent` when provided.

Key design decisions / tradeoffs:

- **Single sentinel for the default agent.** Using `"chat"` / `None` / `""` interchangeably keeps the CLI (`current_subagent_name` is `None` when on the default chat agent) and API (`subagent_id=chat`) call sites aligned without a separate enum.
- **Centralized decoding.** Both call sites go through `session_matches_agent`, so the id format only needs to change in one place if we ever re-encode agent ownership out-of-band (e.g. metadata file alongside the session db).
- **`rsplit("_session_", 1)`** — agent names can legally contain underscores (`gen_metrics`, `my_custom_agent`), so splitting on the last delimiter is required for correctness.

## Test Cases

All tests are CI-tier (no external deps, deterministic). Added:

- `tests/unit_tests/models/test_session_manager.py`
  - `TestExtractAgentFromSessionId`: chat prefix, subagent prefix, multi-underscore agent names, legacy prefix-less ids.
  - `TestSessionMatchesAgent`: `None` / `""` / `"chat"` all match chat + legacy ids, subagent does not leak into chat filter, chat does not leak into subagent filter.
- `tests/unit_tests/api/services/test_chat_service.py`
  - `test_list_sessions_filters_by_subagent_id` — `subagent_id="gen_metrics"` returns only gen_metrics sessions.
  - `test_list_sessions_filter_chat_includes_legacy` — `subagent_id="chat"` returns chat-prefixed and legacy ids, excludes subagent ids.
  - `test_list_sessions_no_filter_returns_all` — omitted filter returns every session.
- `tests/unit_tests/cli/test_chat_commands.py::TestSessionFilterByAgent`
  - Chat scope hides subagent ids but surfaces chat + legacy ids.
  - `gen_metrics` scope only shows its own sessions.
  - Empty-state message references the active agent label.
  - `cmd_resume` with no args filters by current agent and does not activate a node when the agent has no sessions.

No integration or nightly tests were added: the change is pure id-string filtering + CLI rendering, with no new LLM calls, database connections, or cross-process behavior to exercise.