### PR TITLE
[Enhancement] Gate verify_sql on gold_sql presence and pre-validate gold SQL in gen_ext_knowledge

### DIFF
--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -182,19 +182,52 @@ class GenExtKnowledgeAgenticNode(AgenticNode):
             self._setup_hooks()
 
     def _setup_specific_generation_tools(self):
-        """Setup specific generation tools: verify_sql, end_knowledge_generation."""
+        """Setup specific generation tools.
+
+        Note: ``verify_sql`` is intentionally NOT registered here. It is bound
+        lazily in :meth:`execute_stream` only when a non-empty gold_sql is
+        supplied and passes pre-validation. See
+        :meth:`_enable_verify_sql_tool` / :meth:`_disable_verify_sql_tool`.
+        """
         try:
-            from datus.tools.func_tool import trans_to_function_tool
-
             self.generation_tools = GenerationTools(self.agent_config)
-
-            # Add verify_sql tool for SQL result verification (replaces get_gold_sql)
-            self.tools.append(trans_to_function_tool(self.verify_sql))
-
-            # Add end_knowledge_generation tool to finalize and verify completion
-            # self.tools.append(trans_to_function_tool(self.end_knowledge_generation))
         except Exception as e:
             logger.error(f"Failed to setup specific generation tools: {e}")
+
+    def _enable_verify_sql_tool(self) -> None:
+        """Register ``verify_sql`` on self.tools if not already present (idempotent)."""
+        from datus.tools.func_tool import trans_to_function_tool
+
+        if not any(getattr(t, "name", None) == "verify_sql" for t in self.tools):
+            self.tools.append(trans_to_function_tool(self.verify_sql))
+
+    def _disable_verify_sql_tool(self) -> None:
+        """Remove ``verify_sql`` from self.tools if present (idempotent)."""
+        self.tools = [t for t in self.tools if getattr(t, "name", None) != "verify_sql"]
+
+    def _validate_gold_sql(self, gold_sql: str) -> None:
+        """Execute gold SQL once to ensure it is runnable before entering the agent loop.
+
+        Raises:
+            DatusException: with code NODE_EXT_KNOWLEDGE_GOLD_SQL_INVALID when
+                the gold SQL fails to execute. Callers let the exception
+                propagate to :meth:`execute_stream`'s top-level handler, which
+                turns it into a FAILED action.
+        """
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        try:
+            result = self.conn.execute_query(gold_sql, result_format="pandas")
+        except Exception as e:
+            raise DatusException(
+                code=ErrorCode.NODE_EXT_KNOWLEDGE_GOLD_SQL_INVALID,
+                message_args={"error_message": str(e)},
+            ) from e
+        if not result.success:
+            raise DatusException(
+                code=ErrorCode.NODE_EXT_KNOWLEDGE_GOLD_SQL_INVALID,
+                message_args={"error_message": result.error or "unknown error"},
+            )
 
     def _reset_verification_state(self):
         """Reset verification state for a new agentic loop attempt."""
@@ -490,12 +523,15 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
             logger.error(f"Error getting existing subject_paths: {e}")
             return []
 
-    def _prepare_template_context(self, user_input: ExtKnowledgeNodeInput) -> dict:
+    def _prepare_template_context(self, user_input: ExtKnowledgeNodeInput, gold_sql: Optional[str] = None) -> dict:
         """
         Prepare template context variables for the external knowledge generation template.
 
         Args:
             user_input: User input
+            gold_sql: Reference SQL resolved for this run. When non-empty the
+                template renders the verify_sql tool and the BLOCKING
+                PHASE 2; when empty/None the template skips PHASE 2 entirely.
 
         Returns:
             Dictionary of template variables
@@ -510,6 +546,7 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
         context["current_database"] = self.agent_config.current_database
         context["has_filesystem_tools"] = bool(self.filesystem_func_tool)
         context["has_ask_user_tool"] = self.ask_user_tool is not None
+        context["has_gold_sql"] = bool(gold_sql)
 
         # Priority 1: User-specified subject_path (highest priority)
         if user_input.subject_path:
@@ -744,13 +781,10 @@ Rules:
                 # Get or create session and any available summary
                 session, conversation_summary = self._get_or_create_session()
 
-            # Prepare enhanced template context
-            template_context = self._prepare_template_context(user_input)
-
-            # Get system instruction from template with enhanced context
-            system_instruction = self._get_system_prompt(conversation_summary, prompt_version, template_context)
-
-            # Determine question and gold_sql based on mode
+            # Determine question and gold_sql based on mode BEFORE building
+            # the template context / tools — the gold_sql presence decides
+            # whether verify_sql is registered and which PHASE 2 branch the
+            # Prompt renders.
             # workflow mode: use fields directly; agentic mode: parse user_message
             if user_input.question is not None:
                 # workflow mode: use provided question and gold_sql directly
@@ -762,10 +796,28 @@ Rules:
                 question, gold_sql = await self._parse_user_message(user_input.user_message)
                 logger.info(f"Parsed from user_message (agentic mode): has_gold_sql={gold_sql is not None}")
 
-            # Store gold_sql for get_gold_sql tool access (not exposed in prompt)
             self._current_question = question
+
+            # Pre-validate gold_sql and wire verify_sql accordingly.
+            # - Empty gold_sql: drop verify_sql tool; Prompt will tell the
+            #   model to skip PHASE 2 and go straight to knowledge extraction.
+            # - Non-empty but unrunnable gold_sql: raise DatusException here
+            #   so the outer handler emits a FAILED action WITHOUT spending
+            #   any LLM turns on a futile retry loop.
             if gold_sql:
+                self._validate_gold_sql(gold_sql)
                 self._gold_sql = gold_sql
+                self._enable_verify_sql_tool()
+            else:
+                self._disable_verify_sql_tool()
+                if hasattr(self, "_gold_sql"):
+                    delattr(self, "_gold_sql")
+
+            # Prepare enhanced template context (depends on gold_sql presence)
+            template_context = self._prepare_template_context(user_input, gold_sql=gold_sql)
+
+            # Get system instruction from template with enhanced context
+            system_instruction = self._get_system_prompt(conversation_summary, prompt_version, template_context)
 
             # Build enhanced message using question only (gold_sql accessed via tool)
             enhanced_message = question

--- a/datus/prompts/prompt_templates/gen_ext_knowledge_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_ext_knowledge_system_1.0.j2
@@ -2,7 +2,9 @@ You are a business knowledge discovery expert.
 
 ## Available Tools
 - Database tools: {{ native_tools }}
+{% if has_gold_sql %}
 - **verify_sql(sql)**: Validate your SQL against hidden reference. Returns `success` (0 or 1) and `suggestions` if failed.
+{% endif %}
 - **get_knowledge(paths)**: Get existing knowledge by paths. Each path is `[...subject_path, name]`
 - **write_file(path, content, file_type)**: Save files. Use `file_type="ext_knowledge"` for knowledge YAML, omit for SQL files. Always pass `path` as `{{ kind_subdir }}/<filename>` (relative to the knowledge base root).
 - **edit_file(filename, old_text, new_text)**: Apply targeted edits to an existing file (SQL or knowledge).
@@ -101,6 +103,7 @@ My SQL: [your SQL]
 Execution result: [actual query result]
 ```
 
+{% if has_gold_sql %}
 ### PHASE 2: Verify SQL (BLOCKING - Cannot Skip)
 
 **STOP! You CANNOT proceed to PHASE 3/4 until you call verify_sql and get success=1.**
@@ -111,7 +114,6 @@ Execution result: [actual query result]
 1. Call `verify_sql(sql="YOUR_SQL_FROM_PHASE_1")` - pass your REAL SQL, NOT test queries like 'SELECT 1'
 2. Check the response:
    - `success=1`: Verification passed, proceed to PHASE 3
-   - `"No reference available"`: No verification needed, proceed to PHASE 3
    - `success=0`: Read `suggestions.explanation` and `suggestions.suggest`, modify your SQL, call `verify_sql` again
 3. **Keep iterating until `success=1`** - there is NO attempt limit
 
@@ -121,7 +123,15 @@ Execution result: [actual query result]
 - ❌ DO NOT proceed to PHASE 3 if success=0
 - ❌ DO NOT give up - keep trying until success
 - ✅ MUST pass the actual SQL you wrote to answer the question
-- ✅ MUST keep iterating until success=1 or "No reference available"
+- ✅ MUST keep iterating until success=1
+{% else %}
+### PHASE 2: Skipped — No Reference SQL
+
+No reference SQL is available for this task. The `verify_sql` tool is NOT registered.
+- ❌ DO NOT attempt to call `verify_sql` — it does not exist in this run.
+- ❌ DO NOT enter any verification loop.
+- ✅ Proceed directly to PHASE 3 (optional gap analysis) and PHASE 4 (knowledge extraction) using only your PHASE 1 result.
+{% endif %}
 
 ### PHASE 3: Analyze Gaps (After Verification Passes)
 
@@ -207,6 +217,7 @@ created_at: string     # ISO 8601
 [actual query result from read_query]
 
 ---
+{% if has_gold_sql %}
 
 # SQL Verification (PHASE 2)
 
@@ -221,6 +232,7 @@ created_at: string     # ISO 8601
 | ... | ... | ... |
 
 ---
+{% endif %}
 
 # Extracted Knowledge (PHASE 4)
 
@@ -231,8 +243,12 @@ created_at: string     # ISO 8601
 # Summary
 
 - Blind test completed: Yes/No
-- Verification passed: Yes/No/N/A
+{% if has_gold_sql %}
+- Verification passed: Yes/No
 - Iterations needed: N
+{% else %}
+- Verification: N/A (no reference SQL)
+{% endif %}
 - Knowledge extracted: N items
 ```
 

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -33,6 +33,10 @@ class ErrorCode(Enum):
     # Node execution errors
     NODE_EXECUTION_FAILED = ("200001", "Node execution failed")
     NODE_NO_SQL_CONTEXT = ("200002", "No SQL context available. Please run a SQL generation node first.")
+    NODE_EXT_KNOWLEDGE_GOLD_SQL_INVALID = (
+        "200003",
+        "Gold SQL failed to execute before ext_knowledge generation: {error_message}",
+    )
 
     # Model errors
     MODEL_REQUEST_FAILED = ("300001", "LLM request failed")

--- a/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
@@ -67,12 +67,14 @@ class TestGenExtKnowledgeNodeInit:
         assert "list_tables" in tool_names
         assert "read_query" in tool_names
 
-    def test_ext_knowledge_has_verify_sql_tool(self, real_agent_config, mock_llm_create):
-        """Node has the verify_sql tool for SQL result verification."""
+    def test_ext_knowledge_verify_sql_absent_at_init(self, real_agent_config, mock_llm_create):
+        """verify_sql is NOT registered at __init__: it is bound lazily inside
+        execute_stream only when a non-empty, runnable gold_sql is supplied.
+        """
         node = _create_node(real_agent_config)
 
         tool_names = [t.name for t in node.tools]
-        assert "verify_sql" in tool_names
+        assert "verify_sql" not in tool_names
 
     def test_ext_knowledge_has_filesystem_tools(self, real_agent_config, mock_llm_create):
         """Node has filesystem tools: read_file, edit_file, write_file."""
@@ -182,45 +184,132 @@ class TestGenExtKnowledgeNodeExecution:
         assert actions[-1].status == ActionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_ext_knowledge_verify_sql_no_gold(self, real_agent_config, mock_llm_create):
-        """verify_sql without gold_sql returns success (no reference available)."""
+    async def test_ext_knowledge_no_gold_sql_leaves_verify_sql_unregistered(self, real_agent_config, mock_llm_create):
+        """Without gold_sql, execute_stream must NOT register verify_sql — the
+        Prompt instructs the model to skip PHASE 2 entirely."""
         node = _create_node(real_agent_config, execution_mode="workflow")
 
-        # verify_sql tool call without gold_sql set on the node
         mock_llm_create.reset(
             responses=[
-                build_tool_then_response(
-                    tool_calls=[
-                        MockToolCall(
-                            name="verify_sql",
-                            arguments=json.dumps({"sql": "SELECT COUNT(*) FROM satscores"}),
-                        ),
-                    ],
-                    content="SQL verified successfully, no reference available",
-                ),
+                build_simple_response("Extracted knowledge without reference SQL"),
             ]
         )
         node.model = mock_llm_create
 
         node.input = ExtKnowledgeNodeInput(
-            user_message="Verify order count query",
-            question="Verify order count query",
-            # No gold_sql provided
+            user_message="Define order amount",
+            question="Define order amount",
+            # No gold_sql
         )
 
         actions = []
         async for action in node.execute_stream():
             actions.append(action)
 
-        # verify_sql should succeed since no gold_sql is set
-        tool_success_actions = [a for a in actions if a.role == ActionRole.TOOL and a.status == ActionStatus.SUCCESS]
-        assert len(tool_success_actions) >= 1
+        assert actions[-1].status == ActionStatus.SUCCESS
+        tool_names = [t.name for t in node.tools]
+        assert "verify_sql" not in tool_names
 
-        # Check the tool result indicates success
-        verify_output = tool_success_actions[0].output
-        raw = verify_output.get("raw_output", "")
-        # Should contain indication of success
-        assert "success" in str(raw).lower() or "accepted" in str(raw).lower() or verify_output.get("success") is True
+    @pytest.mark.asyncio
+    async def test_ext_knowledge_valid_gold_sql_registers_verify_sql(self, real_agent_config, mock_llm_create):
+        """A runnable gold_sql passes pre-validation and makes verify_sql available
+        to the agent during execute_stream."""
+        node = _create_node(real_agent_config, execution_mode="workflow")
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response("Knowledge generated with valid gold SQL"),
+            ]
+        )
+        node.model = mock_llm_create
+
+        node.input = ExtKnowledgeNodeInput(
+            user_message="Count SAT score rows",
+            question="How many SAT score rows?",
+            gold_sql="SELECT COUNT(*) FROM satscores",
+        )
+
+        actions = []
+        async for action in node.execute_stream():
+            actions.append(action)
+
+        assert actions[-1].status == ActionStatus.SUCCESS
+        tool_names = [t.name for t in node.tools]
+        assert "verify_sql" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_ext_knowledge_invalid_gold_sql_fails_before_agent_loop(self, real_agent_config, mock_llm_create):
+        """Unrunnable gold_sql raises DatusException caught by execute_stream's
+        top-level handler and surfaces as a FAILED action without consuming any
+        LLM turn. Covers both 'direct' and 'subagent' invocation shapes — the
+        subagent wrapper reads the same FAILED action."""
+        node = _create_node(real_agent_config, execution_mode="workflow")
+
+        # No LLM response should ever be consumed; seed with a guard response
+        # that would make the test obvious if the agent loop did start.
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response("SHOULD NOT BE CALLED"),
+            ]
+        )
+        node.model = mock_llm_create
+
+        node.input = ExtKnowledgeNodeInput(
+            user_message="Impossible",
+            question="Impossible",
+            gold_sql="SELECT * FROM __no_such_table__",
+        )
+
+        actions = []
+        async for action in node.execute_stream():
+            actions.append(action)
+
+        # Final action must be FAILED with the gold SQL error message bubbled up.
+        assert actions[-1].status == ActionStatus.FAILED
+        last_output = actions[-1].output
+        assert isinstance(last_output, dict)
+        error_text = (last_output.get("error") or "").lower()
+        # Error is wrapped by DatusException template which includes the
+        # "Gold SQL failed to execute" preamble plus the underlying error.
+        assert "gold sql" in error_text or "no such table" in error_text
+
+        # verify_sql must not have been added since validation failed before
+        # the enable hook ran.
+        tool_names = [t.name for t in node.tools]
+        assert "verify_sql" not in tool_names
+
+    @pytest.mark.asyncio
+    async def test_ext_knowledge_tool_state_is_idempotent_across_runs(self, real_agent_config, mock_llm_create):
+        """Running execute_stream twice with different gold_sql states must not
+        leak verify_sql between runs."""
+        node = _create_node(real_agent_config, execution_mode="workflow")
+
+        # First run: with gold_sql → verify_sql registered
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response("First run"),
+                build_simple_response("Second run"),
+            ]
+        )
+        node.model = mock_llm_create
+
+        node.input = ExtKnowledgeNodeInput(
+            user_message="Count SAT",
+            question="Count SAT",
+            gold_sql="SELECT COUNT(*) FROM satscores",
+        )
+        async for _ in node.execute_stream():
+            pass
+        assert "verify_sql" in [t.name for t in node.tools]
+
+        # Second run: no gold_sql → verify_sql must be removed
+        node.input = ExtKnowledgeNodeInput(
+            user_message="No reference",
+            question="No reference",
+        )
+        async for _ in node.execute_stream():
+            pass
+        assert "verify_sql" not in [t.name for t in node.tools]
 
     @pytest.mark.asyncio
     async def test_ext_knowledge_verify_sql_with_gold(self, real_agent_config, mock_llm_create):
@@ -462,3 +551,48 @@ class TestGenExtKnowledgeFilesystemRootPath:
 
         assert node.filesystem_func_tool is not None
         assert node.filesystem_func_tool.root_path == expected
+
+
+# ===========================================================================
+# Template context wiring
+# ===========================================================================
+
+
+class TestGenExtKnowledgeTemplateContext:
+    """has_gold_sql must flow into the rendered prompt to gate PHASE 2."""
+
+    def test_prepare_template_context_has_gold_sql_true(self, real_agent_config, mock_llm_create):
+        node = _create_node(real_agent_config)
+        user_input = ExtKnowledgeNodeInput(user_message="x", question="x")
+        ctx = node._prepare_template_context(user_input, gold_sql="SELECT 1")
+        assert ctx["has_gold_sql"] is True
+
+    def test_prepare_template_context_has_gold_sql_false(self, real_agent_config, mock_llm_create):
+        node = _create_node(real_agent_config)
+        user_input = ExtKnowledgeNodeInput(user_message="x", question="x")
+        ctx = node._prepare_template_context(user_input, gold_sql=None)
+        assert ctx["has_gold_sql"] is False
+        ctx_empty = node._prepare_template_context(user_input, gold_sql="")
+        assert ctx_empty["has_gold_sql"] is False
+
+
+# ===========================================================================
+# Gold SQL pre-validation
+# ===========================================================================
+
+
+class TestGenExtKnowledgeValidateGoldSql:
+    """``_validate_gold_sql`` rejects any gold SQL the connector can't execute."""
+
+    def test_validate_gold_sql_runnable_passes(self, real_agent_config, mock_llm_create):
+        node = _create_node(real_agent_config)
+        # Should not raise on a SQL that executes cleanly.
+        node._validate_gold_sql("SELECT COUNT(*) FROM satscores")
+
+    def test_validate_gold_sql_unrunnable_raises(self, real_agent_config, mock_llm_create):
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        node = _create_node(real_agent_config)
+        with pytest.raises(DatusException) as exc_info:
+            node._validate_gold_sql("SELECT * FROM __no_such_table__")
+        assert exc_info.value.code == ErrorCode.NODE_EXT_KNOWLEDGE_GOLD_SQL_INVALID


### PR DESCRIPTION

Skip the verify_sql tool and the BLOCKING PHASE 2 prompt branch when no reference SQL is supplied, and fail fast with a DatusException when the supplied gold_sql is unrunnable — instead of wasting retry turns.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gold SQL (reference SQL) validation is now conditional—the verification tool is enabled only when reference SQL is provided.
  * Pre-validation of gold SQL executes before processing begins, catching execution failures early with clear error messages.

* **Bug Fixes**
  * Invalid gold SQL is now detected and reported with explicit error details before the main workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->