### PR TITLE
[Enhancement] Promote filesystem_strict to a first-class AgentConfig field 

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1239,12 +1239,13 @@ class AgenticNode(Node):
         """Resolve the ``strict`` flag for this node's filesystem tool.
 
         Reads ``self.agent_config.filesystem_strict`` (process-wide default set
-        by API / claw bootstraps). CLI leaves it unset so EXTERNAL access falls
-        back to broker-prompt behavior.
+        by API / claw bootstraps, or by ``agent.filesystem.strict`` / the
+        ``--filesystem-strict`` CLI flag). CLI leaves it unset so EXTERNAL
+        access falls back to broker-prompt behavior.
         """
         if self.agent_config is None:
             return False
-        return bool(getattr(self.agent_config, "filesystem_strict", False))
+        return bool(self.agent_config.filesystem_strict)
 
     def _make_filesystem_tool(self, **kwargs):
         """Construct a ``FilesystemFuncTool`` with this node's identity baked in.

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -73,6 +73,26 @@ class ArgumentParser:
             help="Enable saving LLM input/output traces to YAML files",
         )
 
+        # Filesystem strict mode: fail-closed for paths outside the project
+        # root instead of prompting the broker. ``default=None`` preserves
+        # ``agent.filesystem.strict`` in YAML when neither flag is passed.
+        filesystem_strict_group = self.parser.add_mutually_exclusive_group()
+        filesystem_strict_group.add_argument(
+            "--filesystem-strict",
+            dest="filesystem_strict",
+            action="store_true",
+            default=None,
+            help="Reject filesystem reads/writes outside the project root at the "
+            "tool layer (fail-closed; no interactive prompt). Overrides "
+            "agent.filesystem.strict from YAML.",
+        )
+        filesystem_strict_group.add_argument(
+            "--no-filesystem-strict",
+            dest="filesystem_strict",
+            action="store_false",
+            help="Force-disable filesystem strict mode even if agent.filesystem.strict is true in YAML.",
+        )
+
         # Execution mode: --web and --print are mutually exclusive
         mode_group = self.parser.add_mutually_exclusive_group()
         mode_group.add_argument(

--- a/datus/cli/provider_model_catalog.py
+++ b/datus/cli/provider_model_catalog.py
@@ -87,6 +87,8 @@ def _bucket_by_vendor(raw_models: List[Dict[str, Any]]) -> Dict[str, List[str]]:
         provider_key = OPENROUTER_VENDOR_MAP.get(vendor.strip().lower())
         if provider_key is None:
             continue
+        if provider_key == "claude":
+            slug = slug.replace(".", "-")
         buckets.setdefault(provider_key, {})[slug] = None
     return {k: list(v.keys()) for k, v in buckets.items()}
 

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -438,6 +438,13 @@ class AgentConfig:
         self.target = kwargs["target"]
         self.models = {name: load_model_config(cfg) for name, cfg in models_raw.items()}
         self._benchmark_config_dict = kwargs.get("benchmark", {})
+        # ``filesystem_strict`` is a process-wide safety switch that makes
+        # ``FilesystemFuncTool`` fail-closed for EXTERNAL paths (outside the
+        # project root) instead of prompting the broker. Set via
+        # ``agent.filesystem.strict`` in YAML, ``--filesystem-strict`` on the
+        # CLI, or direct assignment from API/claw bootstraps.
+        filesystem_raw = kwargs.get("filesystem") or {}
+        self._filesystem_strict = bool(filesystem_raw.get("strict", False))
         self._current_database = ""
         self.nodes = nodes
         self.export_config: Dict[str, Any] = kwargs.get("export", {})
@@ -553,6 +560,24 @@ class AgentConfig:
                     f"Only alphanumeric characters, underscores, and hyphens are allowed.",
                 )
             self.document_configs[name] = DocumentConfig.from_dict(cfg)
+
+    @property
+    def filesystem_strict(self) -> bool:
+        """Whether ``FilesystemFuncTool`` rejects EXTERNAL paths at the tool layer.
+
+        ``True``: fail-closed — the tool returns a "not allowed in strict mode"
+        error for any path outside the project root / whitelist. Used by the
+        API and claw surfaces, which have no interactive broker to confirm
+        out-of-workspace access.
+
+        ``False`` (default): ``PermissionHooks`` prompts the user via the
+        broker on EXTERNAL access. Used by the CLI.
+        """
+        return self._filesystem_strict
+
+    @filesystem_strict.setter
+    def filesystem_strict(self, value: bool) -> None:
+        self._filesystem_strict = bool(value)
 
     @property
     def current_database(self):
@@ -917,6 +942,11 @@ class AgentConfig:
             # Update all model configs to enable tracing if command line flag is set
             for model_config in self.models.values():
                 model_config.save_llm_trace = True
+        # --filesystem-strict / --no-filesystem-strict land here as a tri-state:
+        # ``None`` means "CLI didn't say, keep YAML value"; explicit True/False
+        # overrides whatever ``agent.filesystem.strict`` set at construction.
+        if kwargs.get("filesystem_strict") is not None:
+            self.filesystem_strict = kwargs["filesystem_strict"]
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -32,7 +32,7 @@ class FilesystemConfig:
         allowed_extensions: List[str] = None,
         max_file_size: int = 1024 * 1024,
     ):
-        self.root_path = root_path or os.getenv("FILESYSTEM_MCP_PATH", os.path.expanduser("~"))
+        self.root_path = root_path or os.getcwd()
         self.allowed_extensions = allowed_extensions or [
             ".txt",
             ".md",
@@ -86,7 +86,7 @@ class FilesystemFuncTool(BaseTool):
                 the user.
         """
         super().__init__(**kwargs)
-        self.root_path = root_path or os.getenv("FILESYSTEM_MCP_PATH", os.path.expanduser("~"))
+        self.root_path = root_path or os.getcwd()
         self.config = FilesystemConfig(root_path=self.root_path)
         self._current_node = current_node
         self._datus_home = Path(datus_home).expanduser().resolve(strict=False) if datus_home else None

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -18,6 +18,7 @@ when prompting users for permission confirmation.
 import asyncio
 import json
 import logging
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
@@ -34,8 +35,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Global lock to prevent multiple permission prompts at once
-_permission_prompt_lock = asyncio.Lock()
+# Per-event-loop locks to serialize permission prompts within a single loop.
+# A module-level ``asyncio.Lock()`` binds to the loop running on first ``await``
+# and then raises ``Lock is bound to a different event loop`` on every
+# subsequent ``asyncio.run()`` (the CLI creates a fresh loop per turn via
+# ``chat_commands.py``). Key the lock by the running loop so each turn gets its
+# own, while still serializing prompts from parallel tool calls inside one loop.
+_permission_prompt_locks: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _get_permission_prompt_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _permission_prompt_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _permission_prompt_locks[loop] = lock
+    return lock
 
 
 class PermissionDeniedException(Exception):
@@ -228,7 +245,7 @@ class PermissionHooks(AgentHooks):
                     return
 
             # Use lock to prevent multiple prompts at once (for parallel tool calls)
-            async with _permission_prompt_lock:
+            async with _get_permission_prompt_lock():
                 # Re-check cache after acquiring lock (another prompt may have approved it)
                 for cache_key in cache_keys:
                     if self.permission_manager._session_approvals.get(cache_key):
@@ -320,7 +337,7 @@ class PermissionHooks(AgentHooks):
             logger.debug("External path %s already approved for session", resolved.resolved)
             return True
 
-        async with _permission_prompt_lock:
+        async with _get_permission_prompt_lock():
             if self.permission_manager._session_approvals.get(cache_key):
                 return True
 

--- a/tests/unit_tests/api/test_main.py
+++ b/tests/unit_tests/api/test_main.py
@@ -249,10 +249,18 @@ class TestRedirectStdio:
 
 
 class TestDefaultPaths:
-    def test_returns_pid_and_log_paths(self):
-        pid_file, log_file = _default_paths()
+    def test_returns_pid_and_log_paths(self, tmp_path):
+        with patch(
+            "datus.configuration.agent_config_loader.get_agent_home",
+            return_value=str(tmp_path),
+        ), patch("datus.utils.path_manager.DatusPathManager") as mock_pm_cls:
+            mock_pm = mock_pm_cls.return_value
+            mock_pm.pid_file_path.return_value = tmp_path / "datus-agent-api.pid"
+            mock_pm.logs_dir = tmp_path / "logs"
+            pid_file, log_file = _default_paths()
         assert isinstance(pid_file, Path)
         assert isinstance(log_file, Path)
+        assert log_file.name == "datus-agent-api.log"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -540,3 +540,89 @@ class TestAgentConfigProjectLayout:
 
         with pytest.raises(DatusException):
             self._make(tmp_path, project_name="a" * (_PROJECT_NAME_MAX_LEN + 1), project_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# AgentConfig.filesystem_strict
+# ---------------------------------------------------------------------------
+
+
+class TestAgentConfigFilesystemStrict:
+    """``filesystem_strict`` is the process-wide fail-closed switch for
+    FilesystemFuncTool EXTERNAL access. It has three input channels
+    (``agent.filesystem.strict`` in YAML, ``--filesystem-strict`` CLI flag
+    via ``override_by_args``, direct setter from API/claw bootstraps) and
+    all three must land on the same underlying property.
+    """
+
+    def _make(self, tmp_path, **extra_kwargs):
+        from datus.configuration.agent_config import AgentConfig, NodeConfig
+
+        kwargs = dict(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            skip_init_dirs=True,
+        )
+        kwargs.update(extra_kwargs)
+        return AgentConfig(**kwargs)
+
+    def test_default_false(self, tmp_path):
+        cfg = self._make(tmp_path)
+        assert cfg.filesystem_strict is False
+
+    def test_from_yaml_true(self, tmp_path):
+        cfg = self._make(tmp_path, filesystem={"strict": True})
+        assert cfg.filesystem_strict is True
+
+    def test_from_yaml_false_explicit(self, tmp_path):
+        cfg = self._make(tmp_path, filesystem={"strict": False})
+        assert cfg.filesystem_strict is False
+
+    def test_from_yaml_missing_key_defaults_false(self, tmp_path):
+        # ``agent.filesystem: {}`` (empty dict) must still default to False,
+        # not crash on a missing ``strict`` key.
+        cfg = self._make(tmp_path, filesystem={})
+        assert cfg.filesystem_strict is False
+
+    def test_setter_coerces_to_bool(self, tmp_path):
+        cfg = self._make(tmp_path)
+        cfg.filesystem_strict = 1
+        assert cfg.filesystem_strict is True
+        cfg.filesystem_strict = 0
+        assert cfg.filesystem_strict is False
+        cfg.filesystem_strict = True
+        assert cfg.filesystem_strict is True
+
+    def test_override_by_args_true_flips(self, tmp_path):
+        cfg = self._make(tmp_path, filesystem={"strict": False})
+        cfg.override_by_args(filesystem_strict=True)
+        assert cfg.filesystem_strict is True
+
+    def test_override_by_args_false_flips(self, tmp_path):
+        # --no-filesystem-strict must be able to override a YAML True.
+        cfg = self._make(tmp_path, filesystem={"strict": True})
+        cfg.override_by_args(filesystem_strict=False)
+        assert cfg.filesystem_strict is False
+
+    def test_override_by_args_none_preserves_yaml(self, tmp_path):
+        # When neither CLI flag is passed, argparse leaves filesystem_strict=None
+        # and the YAML-derived value must survive.
+        cfg = self._make(tmp_path, filesystem={"strict": True})
+        cfg.override_by_args(filesystem_strict=None)
+        assert cfg.filesystem_strict is True
+
+    def test_override_by_args_missing_preserves_yaml(self, tmp_path):
+        # override_by_args is also called without a filesystem_strict key
+        # (e.g. in non-CLI code paths). That must not reset the flag.
+        cfg = self._make(tmp_path, filesystem={"strict": True})
+        cfg.override_by_args()
+        assert cfg.filesystem_strict is True

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -27,6 +27,33 @@ from datus.configuration.agent_config import AgentConfig, NodeConfig
 from tests.unit_tests.mock_llm_model import MockLLMModel
 
 
+@pytest.fixture(autouse=True)
+def _isolate_project_cwd(monkeypatch, tmp_path):
+    """Run every unit test in a per-test isolated working directory.
+
+    Two effects:
+
+    1. ``load_project_override`` (see ``agent_config_loader._apply_project_override``)
+       reads ``{cwd}/.datus/config.yml`` unconditionally. On a developer workstation
+       that file typically pins ``target:`` to whatever model the human is using,
+       which will not be present in the stub ``agent.yml`` fixtures the tests load.
+       Without this isolation every test that reaches ``load_agent_config`` crashes
+       with ``Unexcepted value of target``.
+
+    2. ``AgentConfig.__init__`` derives ``project_root`` from ``os.getcwd()`` when
+       the caller doesn't pass one. Pinning CWD to a fresh tmp dir keeps
+       implicit ``{project_root}/subject`` paths, sharded session/data
+       directories, and similar from leaking the real repo into a test's
+       storage layout.
+
+    The fixture is function-scoped so each test gets its own clean dir and
+    monkeypatch restores the original CWD on teardown. ``tests/data`` and
+    ``tests/conf`` loaders in this suite already resolve via
+    ``Path(__file__).resolve().parents[...]``, so they're unaffected.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _disable_langsmith_tracing():
     """Disable LangSmith/LangChain tracing for the unit test session only.

--- a/tests/unit_tests/tools/db_tools/test_connector_duckdb.py
+++ b/tests/unit_tests/tools/db_tools/test_connector_duckdb.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -6,10 +7,16 @@ from datus.tools.db_tools.config import DuckDBConfig
 from datus.tools.db_tools.duckdb_connector import DuckdbConnector
 from datus.utils.exceptions import DatusException, ErrorCode
 
+# Resolve the sample duckdb path against the repo root rather than CWD. The
+# unit-test harness chdirs every test into a per-test tmp dir for project
+# override isolation, so relative paths would miss the real ``sample_data/``
+# directory shipped with the repo.
+_DUCKDB_SAMPLE_PATH = Path(__file__).resolve().parents[4] / "sample_data" / "duckdb-demo.duckdb"
+
 
 @pytest.fixture
 def duckdb_connector() -> DuckdbConnector:
-    config = DuckDBConfig(db_path="sample_data/duckdb-demo.duckdb")
+    config = DuckDBConfig(db_path=str(_DUCKDB_SAMPLE_PATH))
     return DuckdbConnector(config)
 
 

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -3,9 +3,7 @@
 
 """Unit tests for datus/tools/func_tool/filesystem_tools.py"""
 
-import os
 from pathlib import Path
-from unittest.mock import patch
 
 from datus.tools.func_tool.filesystem_tools import FilesystemConfig, FilesystemFuncTool
 from datus.tools.func_tool.fs_path_policy import PathZone
@@ -25,14 +23,14 @@ def _make_tool(root_path: str, *, current_node: str = "test_node") -> Filesystem
 
 
 class TestFilesystemConfig:
-    def test_default_root_path(self):
-        with patch.dict(os.environ, {}, clear=True):
-            # Remove env var if set
-            os.environ.pop("FILESYSTEM_MCP_PATH", None)
-            cfg = FilesystemConfig()
-        # os.path.expanduser("~") is the only portable way to get the home directory
-        # at test time — it matches the same call in FilesystemConfig's default_factory.
-        assert cfg.root_path == os.path.expanduser("~")
+    def test_default_root_path(self, tmp_path, monkeypatch):
+        # Production call sites always pass an explicit ``root_path`` via
+        # ``_make_filesystem_tool``; the ``os.getcwd()`` fallback only kicks
+        # in for direct construction (tests, scripts). We chdir so the
+        # assertion is deterministic regardless of where pytest was invoked.
+        monkeypatch.chdir(tmp_path)
+        cfg = FilesystemConfig()
+        assert cfg.root_path == str(tmp_path)
 
     def test_explicit_root_path(self, tmp_path):
         cfg = FilesystemConfig(root_path=str(tmp_path))
@@ -47,11 +45,6 @@ class TestFilesystemConfig:
     def test_custom_allowed_extensions(self):
         cfg = FilesystemConfig(allowed_extensions=[".py"])
         assert cfg.allowed_extensions == [".py"]
-
-    def test_env_var_sets_root_path(self, tmp_path):
-        with patch.dict(os.environ, {"FILESYSTEM_MCP_PATH": str(tmp_path)}):
-            cfg = FilesystemConfig()
-        assert cfg.root_path == str(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -4,11 +4,13 @@
 
 """Tests for the permission hooks module."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from datus.cli.execution_state import InteractionBroker
+from datus.tools.permission import permission_hooks as permission_hooks_module
 from datus.tools.permission.permission_config import PermissionConfig, PermissionLevel, PermissionRule
 from datus.tools.permission.permission_hooks import (
     CompositeHooks,
@@ -625,3 +627,79 @@ class TestFilesystemZoneBranch:
         tool.name = "read_file"
         with pytest.raises(PermissionDeniedException):
             await hooks.on_tool_start(ctx, MagicMock(), tool)
+
+
+class TestPermissionPromptLockPerLoop:
+    """Regression guard: the prompt lock must not bleed across event loops.
+
+    A module-level ``asyncio.Lock()`` used to bind to whichever loop first
+    awaited it, then raised ``Lock is bound to a different event loop`` on
+    every subsequent ``asyncio.run()`` call (the CLI creates a fresh loop per
+    chat turn). These tests exercise the per-loop lock helper to make sure
+    the bug cannot silently regress.
+    """
+
+    def test_separate_asyncio_run_calls_do_not_reuse_lock(self):
+        async def _acquire_once():
+            lock = permission_hooks_module._get_permission_prompt_lock()
+            async with lock:
+                return lock
+
+        lock_a = asyncio.run(_acquire_once())
+        lock_b = asyncio.run(_acquire_once())
+
+        # Each ``asyncio.run`` has its own loop, so it must receive its own
+        # lock — reusing the first one would raise "bound to a different event
+        # loop" on acquisition.
+        assert lock_a is not lock_b
+
+    def test_same_loop_returns_same_lock(self):
+        async def _collect():
+            first = permission_hooks_module._get_permission_prompt_lock()
+            second = permission_hooks_module._get_permission_prompt_lock()
+            return first, second
+
+        first, second = asyncio.run(_collect())
+        # Within a single loop, concurrent tool calls must share one lock so
+        # the "one prompt at a time" invariant still holds.
+        assert first is second
+
+    def test_external_prompt_succeeds_across_separate_asyncio_runs(self, mock_broker, tmp_path):
+        """End-to-end: two consecutive ``asyncio.run`` turns, each hitting the
+        EXTERNAL-path prompt code path, must both succeed. Before the fix the
+        second turn raised ``Lock is bound to a different event loop``."""
+        registry = ToolRegistry()
+        fs_tool = MagicMock()
+        fs_tool.name = "read_file"
+        registry.register_tools("filesystem_tools", [fs_tool])
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        target = tmp_path / "outside.md"
+        target.write_text("x")
+
+        async def _one_turn():
+            # Fresh manager per turn to mirror the CLI re-initializing state.
+            manager = PermissionManager(
+                global_config=PermissionConfig(default_permission=PermissionLevel.ALLOW, rules=[])
+            )
+            hooks = PermissionHooks(
+                broker=mock_broker,
+                permission_manager=manager,
+                node_name="chat",
+                tool_registry=registry,
+                fs_policy=FilesystemPolicy(root_path=project, current_node="chat"),
+            )
+            # Rebind broker inside the coroutine so the AsyncMock is bound to
+            # the currently-running loop.
+            mock_broker.request = AsyncMock(return_value=("n", AsyncMock()))
+            ctx = MagicMock()
+            ctx.tool_arguments = f'{{"path": "{target}"}}'
+            tool = MagicMock()
+            tool.name = "read_file"
+            with pytest.raises(PermissionDeniedException):
+                await hooks.on_tool_start(ctx, MagicMock(), tool)
+
+        asyncio.run(_one_turn())
+        # Second turn: a brand-new loop. Must not raise the loop-binding error.
+        asyncio.run(_one_turn())


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to explicitly enable or disable filesystem strictness (tri-state: true/false/unspecified).

* **Improvements**
  * Default filesystem root now resolves to the current working directory.
  * Permission prompts use per-event-loop locking to avoid async loop conflicts.
  * Provider model IDs normalized (dots -> dashes) for consistent bucketing.

* **Tests**
  * Added/updated tests for filesystem strictness, permission-prompt locking, and deterministic path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->