### PR TITLE
[BugFix] Fix nightly config and multi-db routing

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync
-          uv pip install --upgrade --no-cache-dir datus-semantic-metricflow>=0.1.3 datus-postgresql datus-bi-superset
+          uv pip install --upgrade --no-cache-dir "datus-semantic-metricflow>=0.1.3" datus-postgresql datus-bi-superset
 
       - name: Setup config file
         run: |

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync
-          uv pip install --upgrade --no-cache-dir datus-semantic-metricflow>=0.1.3 datus-postgresql
+          uv pip install --upgrade --no-cache-dir datus-semantic-metricflow>=0.1.3 datus-postgresql datus-bi-superset
 
       - name: Setup config file
         run: |

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -99,6 +99,7 @@ class GenMetricsAgenticNode(AgenticNode):
         self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
         self.generation_tools: Optional[GenerationTools] = None
         self.ask_user_tool = None
+        self.hooks = None
         self.setup_tools()
 
     def get_node_name(self) -> str:
@@ -423,7 +424,7 @@ class GenMetricsAgenticNode(AgenticNode):
                 tools=self.tools,
                 mcp_servers=self.mcp_servers,
                 instruction=system_instruction,
-                max_turns=self.max_turns,
+                max_turns=user_input.max_turns if user_input.max_turns else self.max_turns,
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=None,

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -470,6 +470,14 @@ class DBFuncTool:
         if explicit:
             return self._normalize_identifier_part(explicit)
 
+        # In multi-connector mode, the logical routing database is the configured
+        # service database key, not the engine-internal database name exposed by
+        # the connector (e.g. "SSB"). Using the physical name here breaks
+        # follow-up routing for describe_table/list_tables when no explicit
+        # database argument is provided.
+        if field == "database" and self._is_multi_connector:
+            return self._normalize_identifier_part(self._default_database)
+
         fallback_attr_map = {
             "catalog": "catalog_name",
             "database": "database_name",

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -114,6 +114,7 @@ agent:
     gen_metrics:
       max_turns: 30
       system_prompt: gen_metrics
+      prompt_version: "1.1"
     gen_ext_knowledge:
       max_turns: 30
       system_prompt: gen_ext_knowledge

--- a/tests/integration/agent/test_gen_metrics_agentic.py
+++ b/tests/integration/agent/test_gen_metrics_agentic.py
@@ -69,7 +69,6 @@ class TestGenMetricsAgentic:
                 "Read frpm.yml first to understand the existing data source, then create the metric. "
                 "Use the end_metric_generation tool when done."
             ),
-            max_turns=5,
         )
 
         action_manager = ActionHistoryManager()
@@ -103,7 +102,6 @@ class TestGenMetricsAgentic:
                 "The frpm data source has a measure called total_frpm_count_k12 with SUM aggregation. "
                 "Use the end_metric_generation tool when done."
             ),
-            max_turns=5,
         )
 
         action_manager = ActionHistoryManager()

--- a/tests/integration/api/test_api_chat.py
+++ b/tests/integration/api/test_api_chat.py
@@ -124,22 +124,23 @@ async def chat_client(chat_agent_config, chat_datus_service):
         deps_mod._default_interactive,
         deps_mod._stream_thinking,
     )
-    mod.service = DatusAPIService(agent_args)
-
     cache = DatusServiceCache(max_size=4)
-    init_deps(NoAuthProvider(), cache, namespace="bird_school")
 
     async def _factory():
         return chat_datus_service
 
-    await cache.get_or_create("default", _factory)
-
+    # Enter try/finally BEFORE mutating globals so failures during setup
+    # (DatusAPIService, init_deps, cache.get_or_create) still unwind the
+    # patched module state and shut the cache down cleanly.
     try:
+        mod.service = DatusAPIService(agent_args)
+        init_deps(NoAuthProvider(), cache, namespace="bird_school")
+        await cache.get_or_create("default", _factory)
+
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=120.0) as c:
             yield c
     finally:
         mod.service = saved
-        await cache.shutdown()
         (
             deps_mod._auth_provider,
             deps_mod._service_cache,
@@ -148,6 +149,8 @@ async def chat_client(chat_agent_config, chat_datus_service):
             deps_mod._default_interactive,
             deps_mod._stream_thinking,
         ) = saved_deps
+        # Shut the cache down last so if it raises the globals are already restored.
+        await cache.shutdown()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/api/test_api_chat.py
+++ b/tests/integration/api/test_api_chat.py
@@ -98,6 +98,7 @@ def chat_datus_service(chat_agent_config):
 @pytest_asyncio.fixture(scope="module")
 async def chat_client(chat_agent_config, chat_datus_service):
     """AsyncClient wired to the full FastAPI app with real DatusService."""
+    import datus.api.deps as deps_mod
     from datus.api.auth import NoAuthProvider
     from datus.api.deps import init_deps
     from datus.api.service import DatusAPIService, create_app
@@ -115,16 +116,23 @@ async def chat_client(chat_agent_config, chat_datus_service):
 
     mod = _svc_mod()
     saved = mod.service
+    saved_deps = (
+        deps_mod._auth_provider,
+        deps_mod._service_cache,
+        deps_mod._namespace,
+        deps_mod._default_source,
+        deps_mod._default_interactive,
+        deps_mod._stream_thinking,
+    )
     mod.service = DatusAPIService(agent_args)
 
-    ns = "bird_school"
     cache = DatusServiceCache(max_size=4)
-    init_deps(NoAuthProvider(namespace=ns), cache, namespace=ns)
+    init_deps(NoAuthProvider(), cache, namespace="bird_school")
 
     async def _factory():
         return chat_datus_service
 
-    await cache.get_or_create(ns, _factory)
+    await cache.get_or_create("default", _factory)
 
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=120.0) as c:
@@ -132,6 +140,14 @@ async def chat_client(chat_agent_config, chat_datus_service):
     finally:
         mod.service = saved
         await cache.shutdown()
+        (
+            deps_mod._auth_provider,
+            deps_mod._service_cache,
+            deps_mod._namespace,
+            deps_mod._default_source,
+            deps_mod._default_interactive,
+            deps_mod._stream_thinking,
+        ) = saved_deps
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/api/test_api_chat.py
+++ b/tests/integration/api/test_api_chat.py
@@ -241,8 +241,10 @@ class TestAPIChatN9:
                 events = parse_sse_body(resp.text)
                 assert len(events) >= 1
                 ids = [e["id"] for e in events if e.get("id", -1) >= 0]
-                if len(ids) >= 2:
-                    assert ids[0] == 0
+                # Resume must replay numbered events as a contiguous sequence
+                # starting at id=0. Empty list matches list(range(0)) == [],
+                # so the check is unconditional — no hidden skip branch.
+                assert ids == list(range(len(ids))), f"resume events must be a contiguous 0..N sequence, got {ids}"
             else:
                 assert resp.json().get("errorCode") == "TASK_NOT_FOUND"
         finally:
@@ -298,14 +300,25 @@ class TestAPIChatN9:
             "stop_sess",
         )
         try:
+            # If the task is still running when we arrive, send /stop and wait
+            # for it to terminate. If it already finished on its own (fast
+            # LLM / small workload), we skip the stop call — the terminal-
+            # state assert below still fires, so the test never silently passes.
+            stop_success: bool | None = None
             if task.status == "running":
                 body = (await chat_client.post("/api/v1/chat/stop", json={"session_id": "stop_sess"})).json()
-                assert body["success"] is True
+                stop_success = body["success"]
                 for _ in range(20):
                     await asyncio.sleep(0.5)
                     if task.status != "running":
                         break
-                assert task.status in ("cancelled", "completed", "error")
+            # Unconditional terminal-state check — applies whether we stopped
+            # the task or it finished on its own.
+            assert task.status in ("cancelled", "completed", "error"), (
+                f"task should reach a terminal state, got {task.status}"
+            )
+            # Only assert stop-endpoint success if we actually called it.
+            assert stop_success in (None, True), f"chat/stop must report success when invoked, got {stop_success}"
         finally:
             await _cleanup_task(chat_datus_service, task)
 

--- a/tests/integration/tools/test_func_tools_db.py
+++ b/tests/integration/tools/test_func_tools_db.py
@@ -116,10 +116,10 @@ class TestDBFuncToolIntegrationReal:
 class TestSqliteMultiConnector:
     @pytest.fixture
     def agent_config(self):
-        """Load SSB SQLite namespace configuration."""
+        """Load acceptance config using a valid current database."""
         from tests.conftest import load_acceptance_config
 
-        return load_acceptance_config(namespace="bird_sqlite", home="tests")
+        return load_acceptance_config(namespace="california_schools", home="tests")
 
     @pytest.fixture
     def db_tool(self, agent_config):
@@ -134,13 +134,15 @@ class TestSqliteMultiConnector:
         """Test that multi-connector mode initializes correctly."""
 
         assert db_tool._db_manager is not None
-        assert db_tool._namespace == "bird_sqlite"
+        assert db_tool._namespace == "california_schools"
+        assert db_tool._default_database == "california_schools"
         assert db_tool._connector_cache_size > 1
 
     def test_database(self, db_tool):
         result = db_tool.list_databases()
         assert result.success == 1
-        assert len(result.result) > 1
+        available_names = {item["name"] for item in result.result if item.get("available")}
+        assert {"california_schools", "card_games"}.issubset(available_names)
 
     def test_tables(self, db_tool):
         result = db_tool.list_tables(database="california_schools")

--- a/tests/integration/tools/test_mcp_server.py
+++ b/tests/integration/tools/test_mcp_server.py
@@ -598,7 +598,7 @@ class TestMCPToolRegistration:
     @pytest.fixture
     def server(self):
         """Create a test server instance."""
-        server = create_server(namespace="bird_sqlite", config_path=CONFIG_PATH)
+        server = create_server(namespace="ssb_sqlite", config_path=CONFIG_PATH)
         yield server
         server.close()
 
@@ -628,7 +628,7 @@ class TestMCPToolExecution:
     @pytest.fixture
     def server(self):
         """Create a test server instance."""
-        server = create_server(namespace="bird_sqlite", config_path=CONFIG_PATH)
+        server = create_server(namespace="ssb_sqlite", config_path=CONFIG_PATH)
         yield server
         server.close()
 

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -24,7 +24,7 @@ Design principle: NO mock except LLM.
 """
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -52,7 +52,7 @@ class TestGenMetricsAgenticNodeInit:
         assert node.get_node_name() == "gen_metrics"
         assert node.id == "gen_metrics_node"
         assert node.execution_mode == "workflow"
-        assert not hasattr(node, "hooks")  # hooks removed from gen_metrics
+        assert node.hooks is None
 
     def test_metrics_has_tools(self, real_agent_config, mock_llm_create):
         """Test that the node has filesystem and generation tools."""
@@ -220,7 +220,7 @@ class TestGenMetricsAgenticNodeExecution:
             execution_mode="workflow",
         )
 
-        assert not hasattr(node, "hooks")  # hooks removed from gen_metrics
+        assert node.hooks is None
         assert node.execution_mode == "workflow"
 
         node.input = SemanticNodeInput(user_message="Generate metrics")
@@ -590,6 +590,34 @@ class TestPrepareTemplateContext:
 
         assert "native_tools" in context
         assert "mcp_tools" in context
+
+
+class TestGetSystemPrompt:
+    def test_workflow_uses_prompt_version_from_config(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate metrics")
+
+        with patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_pm:
+            mock_pm.return_value.render_template.return_value = "test prompt"
+
+            node._get_system_prompt(template_context={})
+
+            call_kwargs = mock_pm.return_value.render_template.call_args
+            version = call_kwargs.kwargs.get("version")
+            assert version == "1.1", f"Expected configured version '1.1', got '{version}'"
+
+    def test_input_prompt_version_overrides_config(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate metrics", prompt_version="1.2")
+
+        with patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_pm:
+            mock_pm.return_value.render_template.return_value = "test prompt"
+
+            node._get_system_prompt(template_context={})
+
+            call_kwargs = mock_pm.return_value.render_template.call_args
+            version = call_kwargs.kwargs.get("version")
+            assert version == "1.2", f"Expected explicit version '1.2', got '{version}'"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -185,6 +185,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
             "gen_metrics": {
                 "system_prompt": "gen_metrics",
                 "max_turns": 5,
+                "prompt_version": "1.1",
             },
             "gen_semantic_model": {
                 "system_prompt": "gen_semantic_model",

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -638,6 +638,41 @@ class TestGetConnectorRouting:
         assert conn_target is mock_target
         assert conn_source is not conn_target
 
+    def test_multi_connector_defaults_coordinate_database_to_logical_name(self):
+        """When database is omitted, table coordinates should use the logical default database key."""
+        from datus.tools.db_tools.db_manager import DBManager
+
+        mock_source = Mock()
+        mock_source.dialect = "duckdb"
+        mock_source.database_name = "PHYSICAL_DB"
+        mock_source.get_databases.return_value = []
+
+        mock_db_manager = Mock(spec=DBManager)
+        mock_db_manager.get_conn.return_value = mock_source
+        mock_db_manager.first_conn.return_value = mock_source
+
+        mock_config = Mock()
+        mock_config.active_model.return_value.model = "gpt-5.4"
+        mock_config.current_database = "duckdb"
+        mock_config.current_db_configs.return_value = {"duckdb": Mock(), "greenplum": Mock()}
+
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            tool = DBFuncTool(
+                mock_db_manager,
+                agent_config=mock_config,
+                default_database="duckdb",
+            )
+
+        coordinate = tool._build_table_coordinate("orders")
+
+        assert tool._is_multi_connector is True
+        assert coordinate.database == "duckdb"
+
     def test_explicit_database_raises_when_not_configured(self):
         """When caller explicitly passes a database that doesn't exist, raise DatusException (no silent fallback)."""
         from datus.tools.db_tools.db_manager import DBManager


### PR DESCRIPTION
## What changed

- make `gen_metrics` prompt selection config-driven via `agentic_nodes.gen_metrics.prompt_version`, initialize `hooks`, and honor explicit `user_input.max_turns`
- fix `DBFuncTool` multi-connector default routing to use configured logical database keys instead of connector-internal database names
- update nightly-facing integration tests to use current database keys and adapt the chat API fixture to the current auth/cache behavior
- install `datus-bi-superset` in the nightly workflow dependency step

## Why it changed

Nightly started failing after the `namespace` to `service.databases` migration and the newer prompt/template behavior.

The main regressions were:

- multi-database tools defaulted to physical connector names like `SSB` instead of logical routing keys like `ssb_sqlite`
- `gen_metrics` workflow runs needed a pinned prompt version from config rather than implicitly taking the latest template
- the chat API test fixture still assumed the old `NoAuthProvider` signature and stale cache/dependency state leaked across tests
- the nightly workflow did not install the Superset BI adapter required by dashboard coverage

## Impact

- nightly runs now line up with the current config model
- multi-connector `list_tables` and `describe_table` calls route correctly when no explicit `database` argument is provided
- `gen_metrics` uses configuration, not a code constant, to select its prompt version
- the chat API test fixture no longer pollutes later tests in the same process

## Validation

- `uv run pytest tests/integration/agent/test_gen_metrics_agentic.py::TestGenMetricsAgentic::test_execute_stream_generates_metric tests/integration/agent/test_gen_metrics_agentic.py::TestGenMetricsAgentic::test_execute_stream_uses_tools -q`
- `uv run pytest tests/integration/api/test_api_chat.py::TestAPIChatN9::test_stop_running_chat tests/integration/api/test_api_chat.py::TestAPIChatN9::test_ask_user_interaction tests/integration/api/test_api_chat.py::TestAPIChatN9::test_error_paths -q -o log_cli=false`
- `uv run pytest tests/integration/tools/test_mcp_server.py::TestMCPToolRegistration::test_list_tools tests/integration/tools/test_mcp_server.py::TestMCPToolExecution::test_call_list_tables tests/integration/tools/test_mcp_server.py::TestStaticModeHTTPStreamable::test_list_tables -q`
- `uv run pytest tests/integration/tools/test_func_tools_db.py::TestSqliteMultiConnector::test_connector_mode_initialization tests/integration/tools/test_func_tools_db.py::TestSqliteMultiConnector::test_database tests/integration/tools/test_func_tools_db.py::TestSqliteMultiConnector::test_tables tests/integration/tools/test_func_tools_db.py::TestScopedTables::test_describe_table_blocked_by_scope -q`
- `uv run pytest tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py::TestGetSystemPrompt::test_workflow_uses_prompt_version_from_config tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py::TestGetSystemPrompt::test_input_prompt_version_overrides_config tests/unit_tests/storage/metric/test_metric_init.py::TestInitSuccessStoryMetricsAsync::test_batch_flow_pins_prompt_version_1_1 -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable prompt version support for agentic nodes

* **Bug Fixes**
  * Default database routing now uses logical database keys in multi-connector mode
  * Agent turn-limit handling now respects user-provided limits
  * Agent hooks initialized consistently

* **Tests**
  * Expanded and adjusted tests for agent behavior, database routing, fixtures, integration namespaces, and streaming/assertion behavior

* **Chores**
  * Nightly workflow updated to install an additional package and adjust install formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->