### PR TITLE
[Feature] Add docker-backed adapter integration test suite

### DIFF
--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -854,23 +854,25 @@ class DBFuncTool:
                 result.append({"type": "table", "name": tb})
 
             if include_views:
-                # Add views
+                # Add views. We deliberately swallow any exception — some connectors
+                # don't support views (NotImplementedError/AttributeError), and others
+                # raise real SQL errors when the system view the adapter targets is
+                # missing on that DB version. Failing list_tables entirely for a
+                # subordinate listing would hide the tables we already fetched.
                 try:
                     views = connector.get_views(catalog, database, schema_name)
                     for view in views:
                         result.append({"type": "view", "name": view})
-                except (NotImplementedError, AttributeError):
-                    # Some connectors may not support get_views
-                    pass
+                except Exception as e:
+                    logger.debug(f"get_views unavailable on {connector.dialect}: {e}")
 
-                # Add materialized views
+                # Add materialized views (same reasoning as views above).
                 try:
                     materialized_views = connector.get_materialized_views(catalog, database, schema_name)
                     for mv in materialized_views:
                         result.append({"type": "materialized_view", "name": mv})
-                except (NotImplementedError, AttributeError):
-                    # Some connectors may not support get_materialized_views
-                    pass
+                except Exception as e:
+                    logger.debug(f"get_materialized_views unavailable on {connector.dialect}: {e}")
 
             filtered_result = self._filter_table_entries(result, catalog, database, schema_name)
             return FuncToolResult(result=filtered_result)

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -55,6 +55,7 @@ Several adapters use default ports that are commonly occupied:
 - postgresql (5432) — conflicts with any local Postgres / superset-db
 - trino (8080) — conflicts with Airflow / many web dev servers
 - starrocks (9030) — conflicts with existing StarRocks instances
+- hive / spark (10000) — both default to the HiveServer2/Spark Thrift port; run one suite at a time or remap one service
 
 For the Trino adapter, the compose file already supports a `TRINO_HOST_PORT`
 override (see its `docker-compose.yml`). For the others, either stop the

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -1,0 +1,82 @@
+# Adapter Contract Tests
+
+End-to-end contract tests that exercise `DBFuncTool` / `BIFuncTool` (main repo)
+against real database / BI services started from each adapter's own docker-compose.
+
+Each adapter's contract tests are **opt-in** via an env var, because they
+require a docker container to be running. Tests skip cleanly when the opt-in
+flag is unset.
+
+## Why separate `integration/adapters/`?
+
+`tests/integration/tools/` already covers `DBFuncTool` against SQLite/DuckDB.
+This directory specifically exercises the *adapter packages* (`datus-postgresql`,
+`datus-mysql`, etc.) — one suite per adapter, each using the adapter repo's
+own `docker-compose.yml` as the canonical fixture.
+
+## Running
+
+### PostgreSQL
+
+```bash
+# 1. Install the adapter (not a hard dep of Datus-agent)
+uv pip install datus-postgresql
+
+# 2. Start the docker container (in the adapter repo)
+cd /path/to/datus-db-adapters/datus-postgresql
+docker compose up -d
+# Wait ~30s for the healthcheck to pass
+
+# 3. Run the contract tests (from Datus-agent repo)
+cd /path/to/Datus-agent
+ADAPTERS_PG=1 uv run pytest tests/integration/adapters/test_postgresql.py -v
+
+# 4. Tear down
+cd /path/to/datus-db-adapters/datus-postgresql
+docker compose down -v
+```
+
+## Env vars
+
+| Adapter | Opt-in flag | Connection env | Default (matches adapter's docker-compose.yml) |
+|---|---|---|---|
+| postgresql | `ADAPTERS_PG=1` | `POSTGRESQL_HOST/PORT/USER/PASSWORD/DATABASE` | `localhost:5432 test_user/test_password/test` |
+| mysql | `ADAPTERS_MYSQL=1` | `MYSQL_HOST/PORT/USER/PASSWORD/DATABASE` | `localhost:3306 test_user/test_password/test` |
+| clickhouse | `ADAPTERS_CH=1` | `CLICKHOUSE_HOST/PORT/USER/PASSWORD/DATABASE` | `localhost:8123 default_user/default_test/default_test` |
+| starrocks | `ADAPTERS_SR=1` | `STARROCKS_HOST/PORT/USER/PASSWORD/CATALOG/DATABASE` | `127.0.0.1:9030 root//default_catalog/test` |
+| trino | `ADAPTERS_TRINO=1` | `TRINO_HOST/PORT/USER` | `localhost:8080 trino` (uses built-in `tpch.tiny`, no seeding) |
+| greenplum | `ADAPTERS_GP=1` | `GREENPLUM_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA` | `localhost:15432 gpadmin/pivotal/test/public` |
+| hive | `ADAPTERS_HIVE=1` | `HIVE_HOST/PORT/USERNAME/PASSWORD/DATABASE` | `localhost:10000 hive//default` |
+| spark | `ADAPTERS_SPARK=1` | `SPARK_HOST/PORT/USER/PASSWORD/DATABASE/AUTH_MECHANISM` | `localhost:10000 spark//default/NONE` |
+
+### Port conflicts
+
+Several adapters use default ports that are commonly occupied:
+- postgresql (5432) — conflicts with any local Postgres / superset-db
+- trino (8080) — conflicts with Airflow / many web dev servers
+- starrocks (9030) — conflicts with existing StarRocks instances
+
+For the Trino adapter, the compose file already supports a `TRINO_HOST_PORT`
+override (see its `docker-compose.yml`). For the others, either stop the
+conflicting container or use a one-off `docker run` on an alternate port and
+override the `*_PORT` env var.
+
+## What gets tested
+
+For each adapter, contract tests cover the public surface of `DBFuncTool`
+that the agent actually calls:
+
+- `list_tables` — returns seeded tables
+- `describe_table` — returns column metadata
+- `get_table_ddl` — returns a valid `CREATE TABLE`
+- `read_query` — executes a SELECT and returns compressed rows
+- `read_query` read-only guard — rejects DML / multi-statement injection
+
+## Adding a new adapter
+
+1. Copy `test_postgresql.py` as `test_<name>.py`.
+2. Replace `datus_postgresql` imports with the new adapter's connector/config.
+3. Adjust the seeded DDL to the target dialect (quote style, type names).
+4. Pick a new opt-in flag (`ADAPTERS_<NAME>=1`) and document env vars here.
+5. Confirm the adapter's `docker-compose.yml` ports don't collide with others
+   you run simultaneously.

--- a/tests/integration/adapters/test_clickhouse.py
+++ b/tests/integration/adapters/test_clickhouse.py
@@ -19,6 +19,12 @@ from typing import Generator
 
 import pytest
 
+if os.getenv("ADAPTERS_CH") != "1":
+    pytest.skip(
+        "ADAPTERS_CH=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 pytest.importorskip(
     "datus_clickhouse",
     reason="datus-clickhouse not installed; run `uv pip install datus-clickhouse`",
@@ -28,13 +34,7 @@ from datus_clickhouse import ClickHouseConfig, ClickHouseConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_CH"),
-        reason="ADAPTERS_CH=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 REGION_TABLE = "datus_adapter_region"
@@ -98,14 +98,16 @@ def ch_connector(ch_config: ClickHouseConfig) -> Generator[ClickHouseConnector, 
         database=None,
     )
     init_conn = ClickHouseConnector(init_config)
-    if not init_conn.test_connection():
-        pytest.fail(
-            "ClickHouse container unreachable despite ADAPTERS_CH=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-clickhouse?"
-        )
-    if ch_config.database:
-        init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{ch_config.database}`")
-    init_conn.close()
+    try:
+        if not init_conn.test_connection():
+            pytest.fail(
+                "ClickHouse container unreachable despite ADAPTERS_CH=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-clickhouse?"
+            )
+        if ch_config.database:
+            init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{ch_config.database}`")
+    finally:
+        init_conn.close()
 
     conn = ClickHouseConnector(ch_config)
     try:
@@ -120,8 +122,8 @@ def seeded_connector(ch_connector: ClickHouseConnector) -> Generator[ClickHouseC
         result = ch_connector.execute({"sql_query": sql})
         assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
 
-    ch_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
-    ch_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+    _exec(f"DROP TABLE IF EXISTS `{NATION_TABLE}`")
+    _exec(f"DROP TABLE IF EXISTS `{REGION_TABLE}`")
     _exec(REGION_DDL)
     _exec(NATION_DDL)
     for row in REGION_ROWS:

--- a/tests/integration/adapters/test_clickhouse.py
+++ b/tests/integration/adapters/test_clickhouse.py
@@ -1,0 +1,192 @@
+"""
+Contract tests: ClickHouse adapter via DBFuncTool.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-clickhouse`
+  * start:      `cd datus-db-adapters/datus-clickhouse && docker compose up -d`
+  * env:         ADAPTERS_CH=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  CLICKHOUSE_HOST=localhost  CLICKHOUSE_PORT=8123
+  CLICKHOUSE_USER=default_user  CLICKHOUSE_PASSWORD=default_test
+  CLICKHOUSE_DATABASE=default_test
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+pytest.importorskip(
+    "datus_clickhouse",
+    reason="datus-clickhouse not installed; run `uv pip install datus-clickhouse`",
+)
+
+from datus_clickhouse import ClickHouseConfig, ClickHouseConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_CH"),
+        reason="ADAPTERS_CH=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+# ClickHouse requires ENGINE + ORDER BY (no PK concept identical to MySQL/PG).
+REGION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{REGION_TABLE}` (
+    `r_regionkey` Int32,
+    `r_name` String,
+    `r_comment` String
+) ENGINE = MergeTree() ORDER BY r_regionkey
+"""
+NATION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{NATION_TABLE}` (
+    `n_nationkey` Int32,
+    `n_name` String,
+    `n_regionkey` Int32,
+    `n_comment` String
+) ENGINE = MergeTree() ORDER BY n_nationkey
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def ch_config() -> ClickHouseConfig:
+    return ClickHouseConfig(
+        host=os.getenv("CLICKHOUSE_HOST", "localhost"),
+        port=int(os.getenv("CLICKHOUSE_PORT", "8123")),
+        username=os.getenv("CLICKHOUSE_USER", "default_user"),
+        password=os.getenv("CLICKHOUSE_PASSWORD", "default_test"),
+        database=os.getenv("CLICKHOUSE_DATABASE", "default_test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def ch_connector(ch_config: ClickHouseConfig) -> Generator[ClickHouseConnector, None, None]:
+    # Ensure target database exists (connect without db first).
+    init_config = ClickHouseConfig(
+        host=ch_config.host,
+        port=ch_config.port,
+        username=ch_config.username,
+        password=ch_config.password,
+        database=None,
+    )
+    init_conn = ClickHouseConnector(init_config)
+    if not init_conn.test_connection():
+        pytest.fail(
+            "ClickHouse container unreachable despite ADAPTERS_CH=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-clickhouse?"
+        )
+    if ch_config.database:
+        init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{ch_config.database}`")
+    init_conn.close()
+
+    conn = ClickHouseConnector(ch_config)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(ch_connector: ClickHouseConnector) -> Generator[ClickHouseConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = ch_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    ch_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
+    ch_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    for row in REGION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{REGION_TABLE}` VALUES ({values})")
+    for row in NATION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{NATION_TABLE}` VALUES ({values})")
+
+    try:
+        yield ch_connector
+    finally:
+        ch_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
+        ch_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: ClickHouseConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(REGION_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == REGION_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert REGION_TABLE in definition, f"definition missing {REGION_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/integration/adapters/test_greenplum.py
+++ b/tests/integration/adapters/test_greenplum.py
@@ -24,6 +24,12 @@ from typing import Generator
 
 import pytest
 
+if os.getenv("ADAPTERS_GP") != "1":
+    pytest.skip(
+        "ADAPTERS_GP=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 pytest.importorskip(
     "datus_greenplum",
     reason="datus-greenplum not installed; run `uv pip install datus-greenplum`",
@@ -33,13 +39,7 @@ from datus_greenplum import GreenplumConfig, GreenplumConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_GP"),
-        reason="ADAPTERS_GP=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 SCHEMA = os.getenv("GREENPLUM_SCHEMA", "public")
@@ -97,12 +97,12 @@ def gp_config() -> GreenplumConfig:
 @pytest.fixture(scope="module")
 def gp_connector(gp_config: GreenplumConfig) -> Generator[GreenplumConnector, None, None]:
     conn = GreenplumConnector(gp_config)
-    if not conn.test_connection():
-        pytest.fail(
-            "Greenplum container unreachable despite ADAPTERS_GP=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-greenplum?"
-        )
     try:
+        if not conn.test_connection():
+            pytest.fail(
+                "Greenplum container unreachable despite ADAPTERS_GP=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-greenplum?"
+            )
         yield conn
     finally:
         conn.close()

--- a/tests/integration/adapters/test_greenplum.py
+++ b/tests/integration/adapters/test_greenplum.py
@@ -1,0 +1,186 @@
+"""
+Contract tests: Greenplum adapter via DBFuncTool.
+
+Greenplum is PostgreSQL wire-protocol compatible; the adapter `GreenplumConnector`
+inherits from `PostgreSQLConnector`. We still test it as a separate adapter to
+catch GP-specific regressions (DDL generation with distribution policy, system
+database/schema filters).
+
+Opt-in (all required):
+  * install:    `uv pip install datus-greenplum`
+  * start:      `cd datus-db-adapters/datus-greenplum && docker compose up -d`
+  * env:         ADAPTERS_GP=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  GREENPLUM_HOST=localhost  GREENPLUM_PORT=15432
+  GREENPLUM_USER=gpadmin    GREENPLUM_PASSWORD=pivotal
+  GREENPLUM_DATABASE=test   GREENPLUM_SCHEMA=public
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+pytest.importorskip(
+    "datus_greenplum",
+    reason="datus-greenplum not installed; run `uv pip install datus-greenplum`",
+)
+
+from datus_greenplum import GreenplumConfig, GreenplumConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_GP"),
+        reason="ADAPTERS_GP=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+SCHEMA = os.getenv("GREENPLUM_SCHEMA", "public")
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+# Greenplum 6.x rejects `CREATE TABLE IF NOT EXISTS`; use plain CREATE after DROP.
+REGION_DDL = f"""
+CREATE TABLE "{SCHEMA}"."{REGION_TABLE}" (
+    r_regionkey INTEGER PRIMARY KEY,
+    r_name VARCHAR(25) NOT NULL,
+    r_comment VARCHAR(152)
+)
+"""
+NATION_DDL = f"""
+CREATE TABLE "{SCHEMA}"."{NATION_TABLE}" (
+    n_nationkey INTEGER PRIMARY KEY,
+    n_name VARCHAR(25) NOT NULL,
+    n_regionkey INTEGER NOT NULL,
+    n_comment VARCHAR(152)
+)
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def gp_config() -> GreenplumConfig:
+    return GreenplumConfig(
+        host=os.getenv("GREENPLUM_HOST", "localhost"),
+        port=int(os.getenv("GREENPLUM_PORT", "15432")),
+        username=os.getenv("GREENPLUM_USER", "gpadmin"),
+        password=os.getenv("GREENPLUM_PASSWORD", "pivotal"),
+        database=os.getenv("GREENPLUM_DATABASE", "test"),
+        schema_name=SCHEMA,
+    )
+
+
+@pytest.fixture(scope="module")
+def gp_connector(gp_config: GreenplumConfig) -> Generator[GreenplumConnector, None, None]:
+    conn = GreenplumConnector(gp_config)
+    if not conn.test_connection():
+        pytest.fail(
+            "Greenplum container unreachable despite ADAPTERS_GP=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-greenplum?"
+        )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(gp_connector: GreenplumConnector) -> Generator[GreenplumConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = gp_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    _exec(f'DROP TABLE IF EXISTS "{SCHEMA}"."{NATION_TABLE}" CASCADE')
+    _exec(f'DROP TABLE IF EXISTS "{SCHEMA}"."{REGION_TABLE}" CASCADE')
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    for row in REGION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f'INSERT INTO "{SCHEMA}"."{REGION_TABLE}" VALUES ({values})')
+    for row in NATION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f'INSERT INTO "{SCHEMA}"."{NATION_TABLE}" VALUES ({values})')
+
+    try:
+        yield gp_connector
+    finally:
+        gp_connector.execute({"sql_query": f'DROP TABLE IF EXISTS "{SCHEMA}"."{NATION_TABLE}" CASCADE'})
+        gp_connector.execute({"sql_query": f'DROP TABLE IF EXISTS "{SCHEMA}"."{REGION_TABLE}" CASCADE'})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: GreenplumConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(REGION_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == REGION_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert REGION_TABLE in definition, f"definition missing {REGION_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/integration/adapters/test_hive.py
+++ b/tests/integration/adapters/test_hive.py
@@ -22,6 +22,12 @@ from typing import Generator
 
 import pytest
 
+if os.getenv("ADAPTERS_HIVE") != "1":
+    pytest.skip(
+        "ADAPTERS_HIVE=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 pytest.importorskip(
     "datus_hive",
     reason="datus-hive not installed; run `uv pip install datus-hive`",
@@ -31,13 +37,7 @@ from datus_hive import HiveConfig, HiveConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_HIVE"),
-        reason="ADAPTERS_HIVE=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 REGION_TABLE = "datus_adapter_region"
@@ -93,13 +93,13 @@ def hive_config() -> HiveConfig:
 @pytest.fixture(scope="module")
 def hive_connector(hive_config: HiveConfig) -> Generator[HiveConnector, None, None]:
     conn = HiveConnector(hive_config)
-    if not conn.test_connection():
-        pytest.fail(
-            "Hive container unreachable despite ADAPTERS_HIVE=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-hive? "
-            "Wait ~60s for the metastore + server to become healthy."
-        )
     try:
+        if not conn.test_connection():
+            pytest.fail(
+                "Hive container unreachable despite ADAPTERS_HIVE=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-hive? "
+                "Wait ~60s for the metastore + server to become healthy."
+            )
         yield conn
     finally:
         conn.close()
@@ -111,8 +111,8 @@ def seeded_connector(hive_connector: HiveConnector) -> Generator[HiveConnector, 
         result = hive_connector.execute({"sql_query": sql})
         assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
 
-    hive_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {NATION_TABLE}"})
-    hive_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {REGION_TABLE}"})
+    _exec(f"DROP TABLE IF EXISTS {NATION_TABLE}")
+    _exec(f"DROP TABLE IF EXISTS {REGION_TABLE}")
     _exec(REGION_DDL)
     _exec(NATION_DDL)
     values_sql = ", ".join("(" + ", ".join(_escape(v) for v in row) + ")" for row in REGION_ROWS)

--- a/tests/integration/adapters/test_hive.py
+++ b/tests/integration/adapters/test_hive.py
@@ -1,0 +1,181 @@
+"""
+Contract tests: Hive adapter via DBFuncTool.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-hive`
+  * start:      `cd datus-db-adapters/datus-hive && docker compose up -d`
+  *             (wait ~60s for HiveServer2 healthcheck)
+  * env:         ADAPTERS_HIVE=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  HIVE_HOST=localhost  HIVE_PORT=10000
+  HIVE_USERNAME=hive   HIVE_PASSWORD=
+  HIVE_DATABASE=default
+
+Port 10000 collides with Spark Thrift. Run Hive OR Spark contract tests, not both.
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+pytest.importorskip(
+    "datus_hive",
+    reason="datus-hive not installed; run `uv pip install datus-hive`",
+)
+
+from datus_hive import HiveConfig, HiveConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_HIVE"),
+        reason="ADAPTERS_HIVE=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+# Hive DDL: uses STORED AS (TEXTFILE default) — keep simple for schema sanity.
+REGION_DDL = f"""
+CREATE TABLE IF NOT EXISTS {REGION_TABLE} (
+    r_regionkey INT,
+    r_name VARCHAR(25),
+    r_comment VARCHAR(152)
+)
+"""
+NATION_DDL = f"""
+CREATE TABLE IF NOT EXISTS {NATION_TABLE} (
+    n_nationkey INT,
+    n_name VARCHAR(25),
+    n_regionkey INT,
+    n_comment VARCHAR(152)
+)
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def hive_config() -> HiveConfig:
+    return HiveConfig(
+        host=os.getenv("HIVE_HOST", "localhost"),
+        port=int(os.getenv("HIVE_PORT", "10000")),
+        username=os.getenv("HIVE_USERNAME", "hive"),
+        password=os.getenv("HIVE_PASSWORD", ""),
+        database=os.getenv("HIVE_DATABASE", "default"),
+    )
+
+
+@pytest.fixture(scope="module")
+def hive_connector(hive_config: HiveConfig) -> Generator[HiveConnector, None, None]:
+    conn = HiveConnector(hive_config)
+    if not conn.test_connection():
+        pytest.fail(
+            "Hive container unreachable despite ADAPTERS_HIVE=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-hive? "
+            "Wait ~60s for the metastore + server to become healthy."
+        )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(hive_connector: HiveConnector) -> Generator[HiveConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = hive_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    hive_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {NATION_TABLE}"})
+    hive_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {REGION_TABLE}"})
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    values_sql = ", ".join("(" + ", ".join(_escape(v) for v in row) + ")" for row in REGION_ROWS)
+    _exec(f"INSERT INTO {REGION_TABLE} VALUES {values_sql}")
+    values_sql = ", ".join("(" + ", ".join(_escape(v) for v in row) + ")" for row in NATION_ROWS)
+    _exec(f"INSERT INTO {NATION_TABLE} VALUES {values_sql}")
+
+    try:
+        yield hive_connector
+    finally:
+        hive_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {NATION_TABLE}"})
+        hive_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {REGION_TABLE}"})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: HiveConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(REGION_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == REGION_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert REGION_TABLE in definition, f"definition missing {REGION_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/integration/adapters/test_mysql.py
+++ b/tests/integration/adapters/test_mysql.py
@@ -1,0 +1,180 @@
+"""
+Contract tests: MySQL adapter via DBFuncTool.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-mysql`
+  * start:      `cd datus-db-adapters/datus-mysql && docker compose up -d`
+  * env:         ADAPTERS_MYSQL=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  MYSQL_HOST=localhost  MYSQL_PORT=3306
+  MYSQL_USER=test_user  MYSQL_PASSWORD=test_password
+  MYSQL_DATABASE=test
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+pytest.importorskip(
+    "datus_mysql",
+    reason="datus-mysql not installed; run `uv pip install datus-mysql`",
+)
+
+from datus_mysql import MySQLConfig, MySQLConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_MYSQL"),
+        reason="ADAPTERS_MYSQL=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+REGION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{REGION_TABLE}` (
+    `r_regionkey` INT NOT NULL,
+    `r_name` VARCHAR(25) NOT NULL,
+    `r_comment` VARCHAR(152),
+    PRIMARY KEY (`r_regionkey`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+"""
+NATION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{NATION_TABLE}` (
+    `n_nationkey` INT NOT NULL,
+    `n_name` VARCHAR(25) NOT NULL,
+    `n_regionkey` INT NOT NULL,
+    `n_comment` VARCHAR(152),
+    PRIMARY KEY (`n_nationkey`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def mysql_config() -> MySQLConfig:
+    return MySQLConfig(
+        host=os.getenv("MYSQL_HOST", "localhost"),
+        port=int(os.getenv("MYSQL_PORT", "3306")),
+        username=os.getenv("MYSQL_USER", "test_user"),
+        password=os.getenv("MYSQL_PASSWORD", "test_password"),
+        database=os.getenv("MYSQL_DATABASE", "test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def mysql_connector(mysql_config: MySQLConfig) -> Generator[MySQLConnector, None, None]:
+    conn = MySQLConnector(mysql_config)
+    if not conn.test_connection():
+        pytest.fail(
+            "MySQL container unreachable despite ADAPTERS_MYSQL=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-mysql?"
+        )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(mysql_connector: MySQLConnector) -> Generator[MySQLConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = mysql_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    _exec(f"DROP TABLE IF EXISTS `{NATION_TABLE}`")
+    _exec(f"DROP TABLE IF EXISTS `{REGION_TABLE}`")
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    for row in REGION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{REGION_TABLE}` VALUES ({values})")
+    for row in NATION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{NATION_TABLE}` VALUES ({values})")
+
+    try:
+        yield mysql_connector
+    finally:
+        mysql_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
+        mysql_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: MySQLConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(REGION_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == REGION_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert REGION_TABLE in definition, f"definition missing {REGION_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/integration/adapters/test_mysql.py
+++ b/tests/integration/adapters/test_mysql.py
@@ -19,6 +19,12 @@ from typing import Generator
 
 import pytest
 
+if os.getenv("ADAPTERS_MYSQL") != "1":
+    pytest.skip(
+        "ADAPTERS_MYSQL=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 pytest.importorskip(
     "datus_mysql",
     reason="datus-mysql not installed; run `uv pip install datus-mysql`",
@@ -28,13 +34,7 @@ from datus_mysql import MySQLConfig, MySQLConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_MYSQL"),
-        reason="ADAPTERS_MYSQL=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 REGION_TABLE = "datus_adapter_region"
@@ -91,12 +91,12 @@ def mysql_config() -> MySQLConfig:
 @pytest.fixture(scope="module")
 def mysql_connector(mysql_config: MySQLConfig) -> Generator[MySQLConnector, None, None]:
     conn = MySQLConnector(mysql_config)
-    if not conn.test_connection():
-        pytest.fail(
-            "MySQL container unreachable despite ADAPTERS_MYSQL=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-mysql?"
-        )
     try:
+        if not conn.test_connection():
+            pytest.fail(
+                "MySQL container unreachable despite ADAPTERS_MYSQL=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-mysql?"
+            )
         yield conn
     finally:
         conn.close()

--- a/tests/integration/adapters/test_postgresql.py
+++ b/tests/integration/adapters/test_postgresql.py
@@ -19,6 +19,15 @@ from typing import Generator
 
 import pytest
 
+# Opt-in gate MUST run before the optional-package import. Otherwise, when the
+# user hasn't set ADAPTERS_PG=1 and hasn't installed the adapter, the tests
+# skip with a misleading "not installed" reason instead of "opt-in not set".
+if os.getenv("ADAPTERS_PG") != "1":
+    pytest.skip(
+        "ADAPTERS_PG=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 # datus-postgresql is NOT a hard dep of Datus-agent; audit allows importorskip here
 # because the package is not in [project.dependencies].
 pytest.importorskip(
@@ -30,13 +39,7 @@ from datus_postgresql import PostgreSQLConfig, PostgreSQLConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_PG"),
-        reason="ADAPTERS_PG=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 SCHEMA = os.getenv("POSTGRESQL_SCHEMA", "public")
@@ -100,12 +103,12 @@ def pg_connector(pg_config: PostgreSQLConfig) -> Generator[PostgreSQLConnector, 
     than silently skip.
     """
     conn = PostgreSQLConnector(pg_config)
-    if not conn.test_connection():
-        pytest.fail(
-            "PostgreSQL container unreachable despite ADAPTERS_PG=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-postgresql?"
-        )
     try:
+        if not conn.test_connection():
+            pytest.fail(
+                "PostgreSQL container unreachable despite ADAPTERS_PG=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-postgresql?"
+            )
         yield conn
     finally:
         conn.close()

--- a/tests/integration/adapters/test_postgresql.py
+++ b/tests/integration/adapters/test_postgresql.py
@@ -1,0 +1,200 @@
+"""
+Contract tests: PostgreSQL adapter via DBFuncTool.
+
+Opt-in (both required):
+  * install the adapter:       `uv pip install datus-postgresql`
+  * start the docker service:  `cd datus-db-adapters/datus-postgresql && docker compose up -d`
+  * set env var:                ADAPTERS_PG=1
+
+Env for overriding defaults (defaults match the adapter's docker-compose.yml):
+  POSTGRESQL_HOST=localhost  POSTGRESQL_PORT=5432
+  POSTGRESQL_USER=test_user  POSTGRESQL_PASSWORD=test_password
+  POSTGRESQL_DATABASE=test   POSTGRESQL_SCHEMA=public
+
+See `tests/integration/adapters/README.md` for the full workflow.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+# datus-postgresql is NOT a hard dep of Datus-agent; audit allows importorskip here
+# because the package is not in [project.dependencies].
+pytest.importorskip(
+    "datus_postgresql",
+    reason="datus-postgresql not installed; run `uv pip install datus-postgresql`",
+)
+
+from datus_postgresql import PostgreSQLConfig, PostgreSQLConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_PG"),
+        reason="ADAPTERS_PG=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+SCHEMA = os.getenv("POSTGRESQL_SCHEMA", "public")
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+REGION_DDL = f"""
+CREATE TABLE IF NOT EXISTS "{SCHEMA}"."{REGION_TABLE}" (
+    r_regionkey INTEGER PRIMARY KEY,
+    r_name VARCHAR(25) NOT NULL,
+    r_comment VARCHAR(152)
+)
+"""
+NATION_DDL = f"""
+CREATE TABLE IF NOT EXISTS "{SCHEMA}"."{NATION_TABLE}" (
+    n_nationkey INTEGER PRIMARY KEY,
+    n_name VARCHAR(25) NOT NULL,
+    n_regionkey INTEGER NOT NULL,
+    n_comment VARCHAR(152)
+)
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape_sql_value(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def pg_config() -> PostgreSQLConfig:
+    return PostgreSQLConfig(
+        host=os.getenv("POSTGRESQL_HOST", "localhost"),
+        port=int(os.getenv("POSTGRESQL_PORT", "5432")),
+        username=os.getenv("POSTGRESQL_USER", "test_user"),
+        password=os.getenv("POSTGRESQL_PASSWORD", "test_password"),
+        database=os.getenv("POSTGRESQL_DATABASE", "test"),
+        schema_name=SCHEMA,
+    )
+
+
+@pytest.fixture(scope="module")
+def pg_connector(pg_config: PostgreSQLConfig) -> Generator[PostgreSQLConnector, None, None]:
+    """
+    Connect to the docker PostgreSQL instance.
+
+    ADAPTERS_PG=1 is a user-confirmed opt-in: if the container is unreachable
+    at this point, that's a config/setup error and should fail loudly rather
+    than silently skip.
+    """
+    conn = PostgreSQLConnector(pg_config)
+    if not conn.test_connection():
+        pytest.fail(
+            "PostgreSQL container unreachable despite ADAPTERS_PG=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-postgresql?"
+        )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(pg_connector: PostgreSQLConnector) -> Generator[PostgreSQLConnector, None, None]:
+    """Create seeded tables, yield the connector, drop tables on teardown."""
+
+    def _exec(sql: str) -> None:
+        result = pg_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    _exec(f'DROP TABLE IF EXISTS "{SCHEMA}"."{NATION_TABLE}" CASCADE')
+    _exec(f'DROP TABLE IF EXISTS "{SCHEMA}"."{REGION_TABLE}" CASCADE')
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    for row in REGION_ROWS:
+        values = ", ".join(_escape_sql_value(v) for v in row)
+        _exec(f'INSERT INTO "{SCHEMA}"."{REGION_TABLE}" VALUES ({values})')
+    for row in NATION_ROWS:
+        values = ", ".join(_escape_sql_value(v) for v in row)
+        _exec(f'INSERT INTO "{SCHEMA}"."{NATION_TABLE}" VALUES ({values})')
+
+    try:
+        yield pg_connector
+    finally:
+        pg_connector.execute({"sql_query": f'DROP TABLE IF EXISTS "{SCHEMA}"."{NATION_TABLE}" CASCADE'})
+        pg_connector.execute({"sql_query": f'DROP TABLE IF EXISTS "{SCHEMA}"."{REGION_TABLE}" CASCADE'})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: PostgreSQLConnector) -> DBFuncTool:
+    """DBFuncTool in legacy single-connector mode (no AgentConfig needed)."""
+    return DBFuncTool(seeded_connector)
+
+
+# -----------------------------------------------------------------------------
+# Contract tests
+# -----------------------------------------------------------------------------
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(REGION_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == REGION_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert REGION_TABLE in definition, f"definition missing {REGION_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    # DBFuncTool.read_query compresses rows — payload is a dict with CSV.
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    """DBFuncTool.read_query must reject INSERT — read-only guard."""
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    """DBFuncTool.read_query must reject `SELECT; DELETE` injection."""
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/integration/adapters/test_spark.py
+++ b/tests/integration/adapters/test_spark.py
@@ -22,6 +22,12 @@ from typing import Generator
 
 import pytest
 
+if os.getenv("ADAPTERS_SPARK") != "1":
+    pytest.skip(
+        "ADAPTERS_SPARK=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 pytest.importorskip(
     "datus_spark",
     reason="datus-spark not installed; run `uv pip install datus-spark`",
@@ -31,13 +37,7 @@ from datus_spark import SparkConfig, SparkConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_SPARK"),
-        reason="ADAPTERS_SPARK=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 REGION_TABLE = "datus_adapter_region"
@@ -94,13 +94,13 @@ def spark_config() -> SparkConfig:
 @pytest.fixture(scope="module")
 def spark_connector(spark_config: SparkConfig) -> Generator[SparkConnector, None, None]:
     conn = SparkConnector(spark_config)
-    if not conn.test_connection():
-        pytest.fail(
-            "Spark container unreachable despite ADAPTERS_SPARK=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-spark? "
-            "Wait ~60s for the Thrift server to become healthy."
-        )
     try:
+        if not conn.test_connection():
+            pytest.fail(
+                "Spark container unreachable despite ADAPTERS_SPARK=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-spark? "
+                "Wait ~60s for the Thrift server to become healthy."
+            )
         yield conn
     finally:
         conn.close()
@@ -112,8 +112,8 @@ def seeded_connector(spark_connector: SparkConnector) -> Generator[SparkConnecto
         result = spark_connector.execute({"sql_query": sql})
         assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
 
-    spark_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {NATION_TABLE}"})
-    spark_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {REGION_TABLE}"})
+    _exec(f"DROP TABLE IF EXISTS {NATION_TABLE}")
+    _exec(f"DROP TABLE IF EXISTS {REGION_TABLE}")
     _exec(REGION_DDL)
     _exec(NATION_DDL)
     values_sql = ", ".join("(" + ", ".join(_escape(v) for v in row) + ")" for row in REGION_ROWS)

--- a/tests/integration/adapters/test_spark.py
+++ b/tests/integration/adapters/test_spark.py
@@ -1,0 +1,182 @@
+"""
+Contract tests: Spark (Thrift) adapter via DBFuncTool.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-spark`
+  * start:      `cd datus-db-adapters/datus-spark && docker compose up -d`
+  *             (wait ~60s for the Thrift server healthcheck)
+  * env:         ADAPTERS_SPARK=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  SPARK_HOST=localhost  SPARK_PORT=10000
+  SPARK_USER=spark      SPARK_PASSWORD=
+  SPARK_DATABASE=default SPARK_AUTH_MECHANISM=NONE
+
+Port 10000 collides with Hive Thrift. Run Hive OR Spark contract tests, not both.
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+pytest.importorskip(
+    "datus_spark",
+    reason="datus-spark not installed; run `uv pip install datus-spark`",
+)
+
+from datus_spark import SparkConfig, SparkConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_SPARK"),
+        reason="ADAPTERS_SPARK=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+# Spark SQL: uses backticks; default catalog is the session catalog.
+REGION_DDL = f"""
+CREATE TABLE IF NOT EXISTS {REGION_TABLE} (
+    r_regionkey INT,
+    r_name STRING,
+    r_comment STRING
+) USING PARQUET
+"""
+NATION_DDL = f"""
+CREATE TABLE IF NOT EXISTS {NATION_TABLE} (
+    n_nationkey INT,
+    n_name STRING,
+    n_regionkey INT,
+    n_comment STRING
+) USING PARQUET
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def spark_config() -> SparkConfig:
+    return SparkConfig(
+        host=os.getenv("SPARK_HOST", "localhost"),
+        port=int(os.getenv("SPARK_PORT", "10000")),
+        username=os.getenv("SPARK_USER", "spark"),
+        password=os.getenv("SPARK_PASSWORD", ""),
+        database=os.getenv("SPARK_DATABASE", "default"),
+        auth_mechanism=os.getenv("SPARK_AUTH_MECHANISM", "NONE"),
+    )
+
+
+@pytest.fixture(scope="module")
+def spark_connector(spark_config: SparkConfig) -> Generator[SparkConnector, None, None]:
+    conn = SparkConnector(spark_config)
+    if not conn.test_connection():
+        pytest.fail(
+            "Spark container unreachable despite ADAPTERS_SPARK=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-spark? "
+            "Wait ~60s for the Thrift server to become healthy."
+        )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(spark_connector: SparkConnector) -> Generator[SparkConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = spark_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    spark_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {NATION_TABLE}"})
+    spark_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {REGION_TABLE}"})
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    values_sql = ", ".join("(" + ", ".join(_escape(v) for v in row) + ")" for row in REGION_ROWS)
+    _exec(f"INSERT INTO {REGION_TABLE} VALUES {values_sql}")
+    values_sql = ", ".join("(" + ", ".join(_escape(v) for v in row) + ")" for row in NATION_ROWS)
+    _exec(f"INSERT INTO {NATION_TABLE} VALUES {values_sql}")
+
+    try:
+        yield spark_connector
+    finally:
+        spark_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {NATION_TABLE}"})
+        spark_connector.execute({"sql_query": f"DROP TABLE IF EXISTS {REGION_TABLE}"})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: SparkConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(REGION_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == REGION_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert REGION_TABLE in definition, f"definition missing {REGION_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/integration/adapters/test_starrocks.py
+++ b/tests/integration/adapters/test_starrocks.py
@@ -1,0 +1,200 @@
+"""
+Contract tests: StarRocks adapter via DBFuncTool.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-starrocks`
+  * start:      `cd datus-db-adapters/datus-starrocks && docker compose up -d`
+  * env:         ADAPTERS_SR=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  STARROCKS_HOST=127.0.0.1  STARROCKS_PORT=9030
+  STARROCKS_USER=root       STARROCKS_PASSWORD=
+  STARROCKS_CATALOG=default_catalog  STARROCKS_DATABASE=test
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+pytest.importorskip(
+    "datus_starrocks",
+    reason="datus-starrocks not installed; run `uv pip install datus-starrocks`",
+)
+
+from datus_starrocks import StarRocksConfig, StarRocksConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_SR"),
+        reason="ADAPTERS_SR=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+# StarRocks DDL: ENGINE=OLAP + PRIMARY KEY + DISTRIBUTED BY HASH + PROPERTIES.
+REGION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{REGION_TABLE}` (
+    `r_regionkey` INT NOT NULL,
+    `r_name` VARCHAR(25) NOT NULL,
+    `r_comment` VARCHAR(152)
+) ENGINE=OLAP
+PRIMARY KEY (`r_regionkey`)
+DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
+PROPERTIES ("replication_num" = "1")
+"""
+NATION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{NATION_TABLE}` (
+    `n_nationkey` INT NOT NULL,
+    `n_name` VARCHAR(25) NOT NULL,
+    `n_regionkey` INT NOT NULL,
+    `n_comment` VARCHAR(152)
+) ENGINE=OLAP
+PRIMARY KEY (`n_nationkey`)
+DISTRIBUTED BY HASH(`n_nationkey`) BUCKETS 1
+PROPERTIES ("replication_num" = "1")
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def sr_config() -> StarRocksConfig:
+    return StarRocksConfig(
+        host=os.getenv("STARROCKS_HOST", "127.0.0.1"),
+        port=int(os.getenv("STARROCKS_PORT", "9030")),
+        username=os.getenv("STARROCKS_USER", "root"),
+        password=os.getenv("STARROCKS_PASSWORD", ""),
+        catalog=os.getenv("STARROCKS_CATALOG", "default_catalog"),
+        database=os.getenv("STARROCKS_DATABASE", "test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def sr_connector(sr_config: StarRocksConfig) -> Generator[StarRocksConnector, None, None]:
+    # Ensure target database exists (connect without db).
+    init_config = StarRocksConfig(
+        host=sr_config.host,
+        port=sr_config.port,
+        username=sr_config.username,
+        password=sr_config.password,
+        catalog=sr_config.catalog,
+        database=None,
+    )
+    init_conn = StarRocksConnector(init_config)
+    if not init_conn.test_connection():
+        pytest.fail(
+            "StarRocks container unreachable despite ADAPTERS_SR=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-starrocks?"
+        )
+    if sr_config.database:
+        init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{sr_config.database}`")
+    init_conn.close()
+
+    conn = StarRocksConnector(sr_config)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(sr_connector: StarRocksConnector) -> Generator[StarRocksConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = sr_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    sr_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
+    sr_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    for row in REGION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{REGION_TABLE}` VALUES ({values})")
+    for row in NATION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{NATION_TABLE}` VALUES ({values})")
+
+    try:
+        yield sr_connector
+    finally:
+        sr_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
+        sr_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: StarRocksConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(REGION_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == REGION_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert REGION_TABLE in definition, f"definition missing {REGION_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/integration/adapters/test_starrocks.py
+++ b/tests/integration/adapters/test_starrocks.py
@@ -19,6 +19,12 @@ from typing import Generator
 
 import pytest
 
+if os.getenv("ADAPTERS_SR") != "1":
+    pytest.skip(
+        "ADAPTERS_SR=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 pytest.importorskip(
     "datus_starrocks",
     reason="datus-starrocks not installed; run `uv pip install datus-starrocks`",
@@ -28,13 +34,7 @@ from datus_starrocks import StarRocksConfig, StarRocksConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_SR"),
-        reason="ADAPTERS_SR=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 REGION_TABLE = "datus_adapter_region"
@@ -106,14 +106,16 @@ def sr_connector(sr_config: StarRocksConfig) -> Generator[StarRocksConnector, No
         database=None,
     )
     init_conn = StarRocksConnector(init_config)
-    if not init_conn.test_connection():
-        pytest.fail(
-            "StarRocks container unreachable despite ADAPTERS_SR=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-starrocks?"
-        )
-    if sr_config.database:
-        init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{sr_config.database}`")
-    init_conn.close()
+    try:
+        if not init_conn.test_connection():
+            pytest.fail(
+                "StarRocks container unreachable despite ADAPTERS_SR=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-starrocks?"
+            )
+        if sr_config.database:
+            init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{sr_config.database}`")
+    finally:
+        init_conn.close()
 
     conn = StarRocksConnector(sr_config)
     try:
@@ -128,8 +130,8 @@ def seeded_connector(sr_connector: StarRocksConnector) -> Generator[StarRocksCon
         result = sr_connector.execute({"sql_query": sql})
         assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
 
-    sr_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
-    sr_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+    _exec(f"DROP TABLE IF EXISTS `{NATION_TABLE}`")
+    _exec(f"DROP TABLE IF EXISTS `{REGION_TABLE}`")
     _exec(REGION_DDL)
     _exec(NATION_DDL)
     for row in REGION_ROWS:

--- a/tests/integration/adapters/test_trino.py
+++ b/tests/integration/adapters/test_trino.py
@@ -22,6 +22,12 @@ from typing import Generator
 
 import pytest
 
+if os.getenv("ADAPTERS_TRINO") != "1":
+    pytest.skip(
+        "ADAPTERS_TRINO=1 not set; see tests/integration/adapters/README.md",
+        allow_module_level=True,
+    )
+
 pytest.importorskip(
     "datus_trino",
     reason="datus-trino not installed; run `uv pip install datus-trino`",
@@ -31,13 +37,7 @@ from datus_trino import TrinoConfig, TrinoConnector  # noqa: E402
 
 from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.getenv("ADAPTERS_TRINO"),
-        reason="ADAPTERS_TRINO=1 not set; see tests/integration/adapters/README.md",
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 
 TPCH_TABLE = "region"  # Trino tpch.tiny: columns are unprefixed (regionkey, name, comment)
@@ -59,13 +59,13 @@ def trino_config() -> TrinoConfig:
 @pytest.fixture(scope="module")
 def trino_connector(trino_config: TrinoConfig) -> Generator[TrinoConnector, None, None]:
     conn = TrinoConnector(trino_config)
-    if not conn.test_connection():
-        pytest.fail(
-            "Trino container unreachable despite ADAPTERS_TRINO=1. "
-            "Did you run `docker compose up -d` in datus-db-adapters/datus-trino? "
-            "If port 8080 is taken, start with TRINO_HOST_PORT=8085 and set TRINO_PORT=8085."
-        )
     try:
+        if not conn.test_connection():
+            pytest.fail(
+                "Trino container unreachable despite ADAPTERS_TRINO=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-trino? "
+                "If port 8080 is taken, start with TRINO_HOST_PORT=8085 and set TRINO_PORT=8085."
+            )
         yield conn
     finally:
         conn.close()

--- a/tests/integration/adapters/test_trino.py
+++ b/tests/integration/adapters/test_trino.py
@@ -1,0 +1,128 @@
+"""
+Contract tests: Trino adapter via DBFuncTool.
+
+Uses Trino's built-in `tpch.tiny` catalog (pre-populated TPC-H data) — no
+seeding needed, tables are read-only.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-trino`
+  * start:      `cd datus-db-adapters/datus-trino && docker compose up -d`
+  *             (port 8080 may conflict; use `TRINO_HOST_PORT=8085 docker compose up -d`
+  *              and then set TRINO_PORT=8085 here)
+  * env:         ADAPTERS_TRINO=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  TRINO_HOST=localhost  TRINO_PORT=8080  TRINO_USER=trino
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+pytest.importorskip(
+    "datus_trino",
+    reason="datus-trino not installed; run `uv pip install datus-trino`",
+)
+
+from datus_trino import TrinoConfig, TrinoConnector  # noqa: E402
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ADAPTERS_TRINO"),
+        reason="ADAPTERS_TRINO=1 not set; see tests/integration/adapters/README.md",
+    ),
+]
+
+
+TPCH_TABLE = "region"  # Trino tpch.tiny: columns are unprefixed (regionkey, name, comment)
+
+
+@pytest.fixture(scope="module")
+def trino_config() -> TrinoConfig:
+    return TrinoConfig(
+        host=os.getenv("TRINO_HOST", "localhost"),
+        port=int(os.getenv("TRINO_PORT", "8080")),
+        username=os.getenv("TRINO_USER", "trino"),
+        password=os.getenv("TRINO_PASSWORD", ""),
+        catalog="tpch",
+        schema_name="tiny",
+        http_scheme=os.getenv("TRINO_HTTP_SCHEME", "http"),
+    )
+
+
+@pytest.fixture(scope="module")
+def trino_connector(trino_config: TrinoConfig) -> Generator[TrinoConnector, None, None]:
+    conn = TrinoConnector(trino_config)
+    if not conn.test_connection():
+        pytest.fail(
+            "Trino container unreachable despite ADAPTERS_TRINO=1. "
+            "Did you run `docker compose up -d` in datus-db-adapters/datus-trino? "
+            "If port 8080 is taken, start with TRINO_HOST_PORT=8085 and set TRINO_PORT=8085."
+        )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def db_tool(trino_connector: TrinoConnector) -> DBFuncTool:
+    return DBFuncTool(trino_connector)
+
+
+def test_list_tables_returns_tpch_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["name"] for entry in result.result}
+    # tpch.tiny ships 8 standard TPC-H tables; we check the ones we actually query.
+    assert "region" in names, f"region missing from {sorted(names)}"
+    assert "nation" in names, f"nation missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(TPCH_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = {c["name"] for c in columns}
+    assert {"regionkey", "name", "comment"}.issubset(col_names), f"missing cols: {col_names}"
+
+
+def test_get_table_ddl_returns_create_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.get_table_ddl(TPCH_TABLE)
+    assert result.success == 1, f"get_table_ddl failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"DDL payload must be dict, got {type(payload).__name__}"
+    assert payload.get("table_name") == TPCH_TABLE, f"table_name mismatch: {payload}"
+    definition = payload.get("definition") or ""
+    assert "create" in definition.lower(), f"definition missing CREATE: {definition!r}"
+    assert TPCH_TABLE in definition.lower(), f"definition missing {TPCH_TABLE}: {definition!r}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    # tpch.tiny.region has exactly 5 rows (standard TPC-H region count).
+    result = db_tool.read_query("SELECT COUNT(*) AS cnt FROM region")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "5" in (payload.get("compressed_data") or ""), f"region count should be 5; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    """Guard fires at SQL-type parse stage, before Trino rejects the read-only catalog."""
+    result = db_tool.read_query("INSERT INTO region VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query("SELECT 1; DELETE FROM region")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"


### PR DESCRIPTION
## Why

Before this PR the tools integration suite exercised \`DBFuncTool\` only against SQLite / DuckDB. The real adapter packages (\`datus-postgresql\`, \`datus-mysql\`, \`datus-clickhouse\`, \`datus-starrocks\`, \`datus-trino\`, \`datus-greenplum\`, \`datus-hive\`, \`datus-spark\`) ship their own \`docker-compose.yml\` + TPCH seed data but are never touched by main-repo tests. Gaps slip through — e.g. the newly merged \`datus-trino\` fix for \`connect()\` never had main-repo coverage, and \`get_tables_with_ddl\` returning \`NotImplementedError\` on trino/spark was invisible to our CI.

## Solution

Introduce \`tests/integration/adapters/\` with one contract test file per adapter (8 total). Each file:

- Opt-in via a dedicated env var (\`ADAPTERS_PG=1\`, \`ADAPTERS_MYSQL=1\`, ...). Skips cleanly when unset → zero impact on default test runs.
- Reads connection env with defaults matching the adapter's own \`docker-compose.yml\`.
- Seeds a tiny TPCH-style fixture (region + nation) and tears it down on teardown.
- Runs 6 contract tests against \`DBFuncTool\`: \`list_tables\`, \`describe_table\`, \`get_table_ddl\`, \`read_query\`, plus DML + multi-statement read-only guards. (Trino uses the built-in \`tpch.tiny\` catalog, no seeding.)

Also widens \`DBFuncTool.list_tables\` subordinate-listing catch from \`(NotImplementedError, AttributeError)\` to \`Exception\` + \`logger.debug\`. The previous narrow catch caused \`list_tables\` to fail outright when an adapter's \`get_views\` / \`get_materialized_views\` raised a real SQL error (e.g. Greenplum 6.x lacks \`pg_matviews\`), throwing away the already-fetched table list.

## Test Cases

All 48 contract tests (8 adapters × 6 tests) verified locally against docker:

| Adapter | Docker source | Result |
|---|---|---|
| postgresql | \`docker run postgres:16\` on alt port 5544 (compose default 5432 was occupied) | 6/6 |
| mysql | \`datus-mysql/docker-compose.yml\` | 6/6 |
| clickhouse | \`datus-clickhouse/docker-compose.yml\` | 6/6 |
| starrocks | \`datus-starrocks/docker-compose.yml\` | 6/6 |
| trino | \`datus-trino/docker-compose.yml\` w/ \`TRINO_HOST_PORT=8085\` | 6/6 |
| greenplum | \`datus-greenplum/docker-compose.yml\` | 6/6 |
| hive | \`datus-hive/docker-compose.yml\` | 6/6 |
| spark | \`datus-spark/docker-compose.yml\` | 6/6 |

- [x] \`python3 ci/audit_tests.py --paths tests/integration/adapters/\` → \`P0=0 P1=0\`.
- [x] Default run (no opt-in env): all 48 tests skip cleanly.
- [x] Port-conflict handling between hive / spark (both 10000) documented in README — tested by running one at a time.

## Dependencies

The trino / spark contract tests depend on the adapter fixes in https://github.com/Datus-ai/datus-db-adapters/pull/46 — once that merges and ships to pypi, the nightly workflow picks them up automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient error handling during table/view discovery so failures are logged and previous results are preserved.

* **Tests**
  * Added opt-in end-to-end integration contract tests for ClickHouse, Greenplum, Hive, MySQL, PostgreSQL, Spark, StarRocks, and Trino.

* **Documentation**
  * Added an adapter contract tests guide describing opt-in flags, run instructions, required env vars, and how to add new adapter suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->