### PR TITLE
[BugFix] Fix nightly test regressions (6 of 8 failures from run 24625864527)

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -13,9 +13,10 @@ asyncio.Task so that client disconnects do not cancel the computation.
 import json
 from typing import Annotated, Optional
 
-from fastapi import APIRouter, Path, Query
+from fastapi import APIRouter, HTTPException, Path, Query
 from fastapi.responses import StreamingResponse
 
+from datus.api.constants import BUILTIN_SUBAGENTS
 from datus.api.deps import AppContextDep, ServiceDep
 from datus.api.models.base_models import Result
 from datus.api.models.chat_models import (
@@ -39,6 +40,29 @@ from datus.utils.feedback_prompt import build_reaction_feedback_prompt
 router = APIRouter(prefix="/api/v1/chat", tags=["chat"])
 
 
+# Additional builtin subagents accepted by ``stream_chat`` beyond the canonical
+# ``BUILTIN_SUBAGENTS`` set — these are wired directly in
+# ``ChatTaskManager._create_node`` but are not listed as user-creatable agents
+# in ``datus.api.constants``. Keep this list in sync with the dispatch branches
+# in :meth:`ChatTaskManager._create_node`.
+_EXTRA_BUILTIN_SUBAGENTS = {"feedback"}
+
+
+def _is_valid_subagent_id(svc, subagent_id: str) -> bool:
+    """Return True if *subagent_id* resolves to a builtin or custom sub-agent."""
+    if subagent_id in BUILTIN_SUBAGENTS or subagent_id in _EXTRA_BUILTIN_SUBAGENTS:
+        return True
+    agentic_nodes = getattr(svc.agent_config, "agentic_nodes", None) or {}
+    if subagent_id in agentic_nodes:
+        return True
+    # Custom sub-agents may be keyed by sanitized node_name with the original
+    # UUID id stored under "id" — match either form.
+    for entry in agentic_nodes.values():
+        if isinstance(entry, dict) and entry.get("id") == subagent_id:
+            return True
+    return False
+
+
 # ========== Stream Chat ==========
 
 
@@ -54,6 +78,11 @@ async def stream_chat(
     ctx: AppContextDep,
 ):
     sub_agent_id = request.subagent_id
+    if sub_agent_id and not _is_valid_subagent_id(svc, sub_agent_id):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Subagent '{sub_agent_id}' not found",
+        )
 
     async def generate_sse():
         async for event in svc.chat.stream_chat(request, sub_agent_id=sub_agent_id, user_id=ctx.user_id):

--- a/datus/tools/func_tool/reference_template_tools.py
+++ b/datus/tools/func_tool/reference_template_tools.py
@@ -94,6 +94,7 @@ class ReferenceTemplateTools:
         Returns:
             FuncToolResult with list of matching templates, each containing:
                 - 'name': Template name
+                - 'template': The raw Jinja2 SQL template
                 - 'parameters': JSON string of parameter definitions with type metadata
                 - 'summary': Brief description of what the template does
                 - 'tags': Associated tags
@@ -104,7 +105,7 @@ class ReferenceTemplateTools:
                 query_text=query_text,
                 subject_path=subject_path,
                 top_n=top_n,
-                selected_fields=["name", "parameters", "summary", "tags"],
+                selected_fields=["name", "template", "parameters", "summary", "tags"],
             )
             return FuncToolResult(success=1, error=None, result=result)
         except Exception as e:

--- a/tests/integration/agent/test_gen_ext_knowledge_agentic.py
+++ b/tests/integration/agent/test_gen_ext_knowledge_agentic.py
@@ -47,8 +47,12 @@ class TestGenExtKnowledgeAgentic:
         # Should have context search tools
         assert node.context_search_tools is not None, "Context search tools should be initialized"
 
-        # verify_sql tool
-        assert "verify_sql" in tool_names, f"Missing verify_sql tool, got: {tool_names}"
+        # verify_sql is NOT registered at __init__: it is bound lazily inside
+        # execute_stream() only when a non-empty gold_sql is supplied and passes
+        # pre-validation (see GenExtKnowledgeAgenticNode._enable_verify_sql_tool).
+        assert "verify_sql" not in tool_names, (
+            f"verify_sql should be bound lazily when gold_sql is present, not at init. Got: {tool_names}"
+        )
 
         logger.info(f"Node initialized with {len(node.tools)} tools: {tool_names}")
 

--- a/tests/integration/agent/test_kb_path_e2e.py
+++ b/tests/integration/agent/test_kb_path_e2e.py
@@ -71,9 +71,12 @@ class TestKnowledgeBaseHomeE2E:
             execution_mode="workflow",
         )
 
-        # Sanity: the FilesystemFuncTool must be sandboxed at the new kb_home.
+        # Sanity: the FilesystemFuncTool is rooted at ``project_root`` (not
+        # ``subject/``) so the LLM can navigate all three KB subfolders via
+        # ``subject/<kind>/…`` relative paths. ``kb_home_tmp`` equals
+        # ``{project_root}/subject`` — the parent is the filesystem sandbox.
         assert node.filesystem_func_tool is not None
-        assert node.filesystem_func_tool.config.root_path == str(kb_home_tmp)
+        assert node.filesystem_func_tool.config.root_path == str(kb_home_tmp.parent)
 
         node.input = SemanticNodeInput(
             user_message=(

--- a/tests/integration/tools/test_reference_template.py
+++ b/tests/integration/tools/test_reference_template.py
@@ -31,7 +31,7 @@ class TestReferenceTemplateBootstrap:
     """Nightly: Bootstrap J2 template files into vector DB via LLM summary generation."""
 
     def test_bootstrap_overwrite(self, agent_config: AgentConfig):
-        """Bootstrap should process 3 J2 files (4 templates) and store to vector DB."""
+        """Bootstrap should process 4 J2 files (5 templates) and store to vector DB."""
         from datus.storage.reference_template.reference_template_init import init_reference_template
         from datus.storage.reference_template.store import ReferenceTemplateRAG
 
@@ -48,12 +48,13 @@ class TestReferenceTemplateBootstrap:
                 "california_schools/Charter/Zip",
                 "california_schools/SAT_Score/Phone",
                 "california_schools/Enrollment/Summary",
+                "california_schools/Stats/School_Count",
             ],
         )
 
         assert result["status"] == "success", f"Bootstrap failed: {result}"
-        assert result["valid_entries"] == 4, (
-            f"Expected 4 valid templates (3 files, 1 multi), got {result['valid_entries']}"
+        assert result["valid_entries"] == 5, (
+            f"Expected 5 valid templates (4 files, 1 multi — school_queries.j2), got {result['valid_entries']}"
         )
         assert result["processed_entries"] >= 1, f"Expected at least 1 processed, got {result['processed_entries']}"
         assert storage.get_reference_template_size() >= 1, "Storage should have at least 1 template after bootstrap"

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -8,9 +8,14 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import HTTPException
 
-from datus.api.models.cli_models import UserInteractionInput
-from datus.api.routes.chat_routes import submit_user_interaction
+from datus.api.models.cli_models import StreamChatInput, UserInteractionInput
+from datus.api.routes.chat_routes import (
+    _is_valid_subagent_id,
+    stream_chat,
+    submit_user_interaction,
+)
 
 
 def _mock_svc(task=None):
@@ -115,3 +120,84 @@ class TestSubmitUserInteractionConversion:
         result = await submit_user_interaction(request, svc)
 
         assert result.success is False
+
+
+def _mock_svc_with_nodes(agentic_nodes=None):
+    svc = MagicMock()
+    svc.agent_config.agentic_nodes = agentic_nodes or {}
+    return svc
+
+
+class TestIsValidSubagentId:
+    """Tests for the _is_valid_subagent_id helper used by stream_chat's 404 gate."""
+
+    def test_builtin_subagent(self):
+        svc = _mock_svc_with_nodes()
+        assert _is_valid_subagent_id(svc, "gen_sql") is True
+
+    def test_extra_builtin_feedback(self):
+        """feedback is dispatched by _create_node but not in BUILTIN_SUBAGENTS."""
+        svc = _mock_svc_with_nodes()
+        assert _is_valid_subagent_id(svc, "feedback") is True
+
+    def test_custom_node_by_name(self):
+        svc = _mock_svc_with_nodes({"my_custom_agent": {"id": "uuid-1", "model": "deepseek"}})
+        assert _is_valid_subagent_id(svc, "my_custom_agent") is True
+
+    def test_custom_node_by_uuid(self):
+        """Custom sub-agents may be looked up by the original UUID stored under 'id'."""
+        svc = _mock_svc_with_nodes({"my_custom_agent": {"id": "uuid-abc", "model": "deepseek"}})
+        assert _is_valid_subagent_id(svc, "uuid-abc") is True
+
+    def test_unknown_id_returns_false(self):
+        svc = _mock_svc_with_nodes({"existing_agent": {"id": "uuid-1"}})
+        assert _is_valid_subagent_id(svc, "nonexistent_xyz") is False
+
+    def test_agentic_nodes_missing_attribute(self):
+        """Missing ``agent_config.agentic_nodes`` falls through gracefully."""
+        svc = MagicMock()
+        svc.agent_config = MagicMock(spec=[])  # no agentic_nodes attribute
+        assert _is_valid_subagent_id(svc, "nonexistent") is False
+
+    def test_non_dict_node_entry_is_skipped(self):
+        """Non-dict entries in ``agentic_nodes`` are ignored during UUID lookup."""
+        svc = _mock_svc_with_nodes({"some_agent": "not_a_dict_value"})
+        assert _is_valid_subagent_id(svc, "not_a_dict_value") is False
+
+
+class TestStreamChat404Gate:
+    """Tests for the stream_chat 404 gate on invalid subagent_id."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_subagent_raises_404(self):
+        svc = _mock_svc_with_nodes()
+        ctx = MagicMock()
+        request = StreamChatInput(message="hi", subagent_id="nonexistent_xyz")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_chat(request, svc, ctx)
+
+        assert exc_info.value.status_code == 404
+        assert "nonexistent_xyz" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_none_subagent_bypasses_gate(self):
+        """Without a subagent_id the 404 gate is skipped — default routing handles it."""
+        svc = _mock_svc_with_nodes()
+        svc.chat.stream_chat = MagicMock(return_value=AsyncMock().__aiter__())
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="hi", subagent_id=None)
+
+        # Should not raise — returns a StreamingResponse.
+        response = await stream_chat(request, svc, ctx)
+        assert response is not None
+
+    @pytest.mark.asyncio
+    async def test_valid_builtin_passes_gate(self):
+        svc = _mock_svc_with_nodes()
+        svc.chat.stream_chat = MagicMock(return_value=AsyncMock().__aiter__())
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="hi", subagent_id="gen_sql")
+
+        response = await stream_chat(request, svc, ctx)
+        assert response is not None

--- a/tests/unit_tests/tools/func_tool/test_reference_template_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_reference_template_tools.py
@@ -79,7 +79,7 @@ class TestSearchReferenceTemplate:
             query_text="query",
             subject_path=["Sales", "Revenue"],
             top_n=5,
-            selected_fields=["name", "parameters", "summary", "tags"],
+            selected_fields=["name", "template", "parameters", "summary", "tags"],
         )
 
     def test_search_handles_exception(self, tools, mock_rag):


### PR DESCRIPTION
## Why

Nightly run [24625864527](https://github.com/Datus-ai/Datus-agent/actions/runs/24625864527) failed with 8 test failures. This PR addresses 6 of them — 2 production bugs and 4 tests that drifted out of sync with intentional refactors.

The remaining 2 are handled out-of-band:
- `test_bi_dashboard` × 2 — CI machine's Superset `kubectl port-forward` had died. Restarted it and installed a self-healing cron so it recovers automatically.
- `test_single_turn_chat` — LLM-behavior flakiness (agent returned a valid markdown summary without the literal `SELECT`). No production regression identified. Leaving as-is pending a separate test-hardening change (assert on `tools_used` rather than literal word).

## Solution

### Production fixes

1. **`datus/api/routes/chat_routes.py`** — add a 404 gate in `stream_chat`. Before: an unknown `subagent_id` fell through to the custom-subagent branch in `ChatTaskManager._create_node`, constructing a node for a nonexistent agent and streaming a partial SSE lifecycle back. Now: `_is_valid_subagent_id` validates against `BUILTIN_SUBAGENTS`, the `feedback` extra-builtin, and `agent_config.agentic_nodes` (by name **and** by UUID under `id`). Unknown IDs raise `HTTPException(404)` before any SSE is emitted.
2. **`datus/tools/func_tool/reference_template_tools.py`** — include `\"template\"` in `selected_fields` of `search_reference_template`. Previously callers had to make a second `get_reference_template` round-trip to get the template body — which contradicted the documented `execute_reference_template` workflow and was inconsistent with the sibling `search_reference_sql` contract.

### Test alignment (code intent confirmed; tests were stale)

3. **`tests/integration/agent/test_kb_path_e2e.py`** — `filesystem_func_tool` is rooted at `project_root`, not `subject/` (PR #588, so the LLM can navigate all three KB subfolders via `subject/<kind>/…`). Matches the existing unit test `test_filesystem_root_is_project_root`.
4. **`tests/integration/agent/test_gen_ext_knowledge_agentic.py`** — `verify_sql` is registered lazily in `execute_stream()` only when `gold_sql` passes pre-validation (PR #596), not at `__init__`. Matches the unit test `test_ext_knowledge_verify_sql_absent_at_init`.
5. **`tests/integration/tools/test_reference_template.py`** — `sample_data/california_schools/reference_template/` has 5 templates across 4 `.j2` files (`school_queries.j2` defines 2 templates separated by `;`). Updated the expected count and added the missing `subject_tree` entry (`california_schools/Stats/School_Count`).
6. **`tests/unit_tests/tools/func_tool/test_reference_template_tools.py`** — sync the `selected_fields` contract assertion with the new `\"template\"` inclusion.

### New unit tests

Added a `TestIsValidSubagentId` class and a `TestStreamChat404Gate` class in `tests/unit_tests/api/routes/test_chat_routes.py`, covering builtin / extra-builtin / by-name / by-UUID / missing-attribute / non-dict-entry paths. Diff coverage on `chat_routes.py` changes is 100%.

## Test Cases

- **New unit tests** (10 cases in `test_chat_routes.py`):
  - `TestIsValidSubagentId`: builtin, extra-builtin (feedback), custom node by name, custom node by UUID, unknown ID, missing `agentic_nodes` attribute, non-dict node entry.
  - `TestStreamChat404Gate`: invalid subagent raises 404, `None` subagent bypasses gate, valid builtin passes gate.
- **Nightly tests** (fixed, will be re-verified on the next nightly run):
  - `tests/integration/tools/test_reference_template.py::test_bootstrap_overwrite`
  - `tests/integration/tools/test_reference_template.py::test_search_reference_template`
  - `tests/integration/tools/test_reference_template.py::test_list_subject_tree_has_reference_template`
  - `tests/integration/agent/test_kb_path_e2e.py::test_semantic_model_lands_under_typed_subdir`
  - `tests/integration/agent/test_gen_ext_knowledge_agentic.py::test_node_initialization`
  - `tests/integration/api/test_api_chat.py::test_invalid_subagent_404`

### Verification

- `uv run ruff format . && uv run ruff check .` — clean.
- `uv run pytest tests/unit_tests/ --cov=datus --cov-fail-under=80` — 10158 passed, 7 skipped, 1 xfailed; overall coverage **82.99%**.
- `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` — diff coverage **100%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for subagent requests with improved error handling—invalid subagents now return a 404 error with details.
  * Reference template search results now include raw template content alongside metadata.

* **Improvements**
  * Enhanced support for both built-in and custom subagent identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->