### PR TITLE
[UT] Stop unit tests from writing under cwd

### DIFF
--- a/tests/integration/tools/test_tools.py
+++ b/tests/integration/tools/test_tools.py
@@ -68,10 +68,20 @@ class TestLineageTools:
     """Test suite for lineage graph functionality"""
 
     @pytest.fixture
-    def agent_config(self) -> AgentConfig:
-        # Use test config file which has bird_sqlite namespace defined
+    def agent_config(self, tmp_path, monkeypatch) -> AgentConfig:
+        # Use test config file which has bird_sqlite namespace defined.
+        # The yml points ``home`` at the relative path ``.datus_test_data``,
+        # which ``Path.resolve()`` anchors to the current cwd. Switch cwd to
+        # ``tmp_path`` so every derived path (path_manager, storage data_dir,
+        # etc.) lands inside the pytest-managed tmp dir — safe under xdist and
+        # free of repo-root pollution.
+        monkeypatch.chdir(tmp_path)
         test_conf_path = Path(__file__).parent.parent.parent / "conf" / "agent.yml"
-        return load_agent_config(config=str(test_conf_path), namespace="bird_sqlite")
+        return load_agent_config(
+            config=str(test_conf_path),
+            namespace="bird_sqlite",
+            home=str(tmp_path),
+        )
 
     @pytest.fixture
     def setup_lineage_tool(self, agent_config: AgentConfig):

--- a/tests/integration/tools/test_tools_output.py
+++ b/tests/integration/tools/test_tools_output.py
@@ -21,8 +21,12 @@ logger = get_logger(__name__)
 
 class TestBirdDevOutput:
     @pytest.fixture
-    def global_config(self) -> AgentConfig:
-        return load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"))
+    def global_config(self, tmp_path, monkeypatch) -> AgentConfig:
+        # chdir to tmp_path so the yml's ``home: .datus_test_data`` relative
+        # path resolves inside tmp_path instead of repo cwd, keeping the
+        # fixture safe under xdist.
+        monkeypatch.chdir(tmp_path)
+        return load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), home=str(tmp_path))
 
     @pytest.fixture
     def test_data(self, tmp_path) -> dict:

--- a/tests/unit_tests/cli/test_namespace_manager.py
+++ b/tests/unit_tests/cli/test_namespace_manager.py
@@ -9,8 +9,12 @@ from tests.conftest import TEST_CONF_DIR
 
 
 @pytest.fixture
-def agent_config() -> AgentConfig:
-    return load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), reload=True)
+def agent_config(tmp_path) -> AgentConfig:
+    # ``home=tmp_path`` pins every derived path inside the pytest-managed
+    # tmp dir. The session-level ``_isolate_project_cwd`` autouse fixture
+    # already chdir-s into tmp_path, so the yml's relative paths never
+    # resolve under the repo root.
+    return load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), home=str(tmp_path), reload=True)
 
 
 @pytest.fixture

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -10,11 +10,15 @@ from tests.conftest import TEST_CONF_DIR
 
 
 @pytest.fixture
-def agent_config() -> AgentConfig:
-    return load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), reload=True)
+def agent_config(tmp_path) -> AgentConfig:
+    # ``home=tmp_path`` pins every derived path inside the pytest-managed tmp
+    # dir. The unit-tests autouse ``_isolate_project_cwd`` fixture already
+    # chdir-s into tmp_path, so the yml's relative paths never resolve under
+    # the repo root.
+    return load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), home=str(tmp_path), reload=True)
 
 
-def test_config_exception():
+def test_config_exception(tmp_path):
     with pytest.raises(DatusException, match="Agent configuration file not found: not_found.yml"):
         load_agent_config(config="not_found.yml", reload=True)
 
@@ -22,9 +26,9 @@ def test_config_exception():
         DatusException,
         match="Unexcepted value of Node Type, excepted value:",
     ):
-        load_agent_config(config=str(TEST_CONF_DIR / "wrong_nodes_agent.yml"), reload=True)
+        load_agent_config(config=str(TEST_CONF_DIR / "wrong_nodes_agent.yml"), home=str(tmp_path), reload=True)
 
-    agent_config = load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), reload=True)
+    agent_config = load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), home=str(tmp_path), reload=True)
 
     with pytest.raises(DatusException, match="Unsupported value `abc` for field `benchmark`"):
         agent_config.override_by_args(database="snowflake", benchmark="abc")

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -242,15 +242,10 @@ def real_agent_config(tmp_path, reset_global_singletons):
     # Set current database (was: current_namespace = "test_ns")
     agent_config.current_database = "california_schools"
 
-    # Capture cwd before yielding, in case a test changes it
-    project_root = os.getcwd()
-
     yield agent_config
-
-    # Cleanup: storage backends with empty data_dir create datus_db* in cwd
-    for name in os.listdir(project_root):
-        if name.startswith("datus_db"):
-            shutil.rmtree(os.path.join(project_root, name), ignore_errors=True)
+    # tmp_path is pytest-managed; storage backends here use
+    # ``agent_config.path_manager.data_dir`` which is rooted at tmp_path, so no
+    # cwd cleanup is needed.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Four fixtures that called ``load_agent_config(config=tests/conf/agent.yml)`` relied on the yml's relative ``home: .datus_test_data`` / ``project_root: .datus_test_data/workspace``. Path.resolve() anchors those at ``os.getcwd()``, so any parallel or repeated run would dirty the repo root and collide on shared state. Anchor each fixture at pytest's ``tmp_path`` via ``monkeypatch.chdir(tmp_path)`` + explicit ``home=str(tmp_path)``.

Also drop the stale ``real_agent_config`` teardown loop that listed ``os.getcwd()`` and rmtree'd every ``datus_db*`` — the fixture already pins ``agent_config.path_manager.data_dir`` inside ``tmp_path``, so the cleanup never had anything to match and the loop itself would have been unsafe if the working directory ever changed.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation and reliability by anchoring configuration paths to temporary test directories.
  * Streamlined test cleanup processes for improved test execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->