### PR TITLE
[BugFix] fs-tool strict returns success=0

### DIFF
--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -14,6 +14,7 @@ from datus import __version__
 from datus.cli.repl import DatusCLI
 from datus.utils.async_utils import setup_windows_policy
 from datus.utils.constants import DBType
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import configure_logging, get_logger
 
 logger = get_logger(__name__)
@@ -249,26 +250,119 @@ class Application:
         return ""
 
     def _ensure_project_config(self, args) -> None:
-        """Trigger the first-run wizard if ``./.datus/config.yml`` is absent.
+        """Trigger the first-run wizard if ``./.datus/config.yml`` is absent,
+        or repair it when existing overrides no longer match the base
+        ``agent.yml`` (e.g. a ``target`` that was renamed or removed).
 
-        Idempotent: does nothing when the overlay file already exists.
-        Loads the base ``agent.yml`` first so the wizard can constrain
-        choices to models/databases that actually exist; when the base
-        config itself cannot be loaded, surface that error directly
-        (the wizard has nothing to offer in that case).
+        Idempotent: does nothing when the overlay file is valid. Loads the
+        base ``agent.yml`` first so the wizard can constrain choices to
+        models/databases that actually exist; when the base config itself
+        cannot be loaded, surface that error directly (the wizard has
+        nothing to offer in that case).
+
+        Repair is REPL-only: API / print / web paths keep raising on
+        invalid overrides, because they have no broker to prompt the user.
         """
         from datus.cli.project_init import run_project_init
         from datus.configuration.agent_config_loader import load_agent_config
         from datus.configuration.project_config import project_config_path
 
-        if project_config_path().exists():
+        if not project_config_path().exists():
+            try:
+                base_config = load_agent_config(config=args.config or "", reload=True)
+            except Exception as e:
+                logger.error(f"Cannot run project setup wizard: base agent.yml failed to load: {e}")
+                raise
+            run_project_init(base_config)
             return
+
+        self._repair_project_overrides(args)
+
+    def _repair_project_overrides(self, args) -> None:
+        """Re-prompt the user when ``./.datus/config.yml`` references a
+        ``target`` or ``default_database`` that no longer exists in the base
+        agent.yml, and persist the corrected values.
+
+        Reads the raw agent.yml directly via ``configuration_manager`` to
+        avoid tripping ``_apply_project_override`` (which is exactly what
+        would raise on the stale value we're trying to fix).
+        """
+        from rich.console import Console
+
+        from datus.cli._cli_utils import select_choice
+        from datus.configuration.agent_config_loader import configuration_manager
+        from datus.configuration.project_config import (
+            load_project_override,
+            project_config_path,
+            save_project_override,
+        )
+
+        override = load_project_override()
+        if override is None or override.is_empty():
+            return
+
         try:
-            base_config = load_agent_config(config=args.config or "", reload=True)
+            raw = dict(configuration_manager(config_path=args.config or "", reload=True).data)
         except Exception as e:
-            logger.error(f"Cannot run project setup wizard: base agent.yml failed to load: {e}")
+            logger.error(f"Cannot validate project overrides: base agent.yml failed to load: {e}")
             raise
-        run_project_init(base_config)
+
+        model_names = list((raw.get("models") or {}).keys())
+        db_names = list(((raw.get("service") or {}).get("databases") or {}).keys())
+
+        target_invalid = override.target is not None and override.target not in model_names
+        db_invalid = override.default_database is not None and override.default_database not in db_names
+        if not (target_invalid or db_invalid):
+            return
+
+        console = Console()
+        console.print()
+        console.print(f"[yellow]Project config {project_config_path()} has stale values:[/]")
+
+        if target_invalid:
+            if not model_names:
+                raise DatusException(
+                    code=ErrorCode.COMMON_CONFIG_ERROR,
+                    message_args={
+                        "config_error": (
+                            "Base agent.yml has no 'agent.models' defined; cannot repair "
+                            f"target={override.target!r} in .datus/config.yml."
+                        )
+                    },
+                )
+            console.print(
+                f"  [red]target[/] = {override.target!r} not found in agent.yml models "
+                f"({sorted(model_names)}). Please pick a replacement:"
+            )
+            choices = {name: name for name in model_names}
+            picked = select_choice(console, choices, default=model_names[0])
+            override.target = picked or model_names[0]
+
+        if db_invalid:
+            if not db_names:
+                raise DatusException(
+                    code=ErrorCode.COMMON_CONFIG_ERROR,
+                    message_args={
+                        "config_error": (
+                            "Base agent.yml has no 'agent.service.databases' defined; cannot repair "
+                            f"default_database={override.default_database!r} in .datus/config.yml."
+                        )
+                    },
+                )
+            console.print(
+                f"  [red]default_database[/] = {override.default_database!r} not found in agent.yml "
+                f"service.databases ({sorted(db_names)}). Please pick a replacement:"
+            )
+            db_types = (raw.get("service") or {}).get("databases") or {}
+            choices = {name: f"{name}  ({(db_types.get(name) or {}).get('type', 'unknown')})" for name in db_names}
+            picked = select_choice(console, choices, default=db_names[0])
+            override.default_database = picked or db_names[0]
+
+        written = save_project_override(override)
+        console.print(
+            f"[green]Updated project config:[/] {written} "
+            f"(target={override.target}, default_database={override.default_database})"
+        )
 
     def _run_web_interface(self, args):
         """Launch web chatbot interface"""

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -286,7 +286,14 @@ class Application:
         Reads the raw agent.yml directly via ``configuration_manager`` to
         avoid tripping ``_apply_project_override`` (which is exactly what
         would raise on the stale value we're trying to fix).
+
+        Requires an interactive TTY: ``select_choice`` silently falls back
+        to its default when prompt_toolkit cannot run, which would
+        otherwise persist an unintended choice. When stdin is not a TTY,
+        raise instead of silently auto-writing.
         """
+        import sys
+
         from rich.console import Console
 
         from datus.cli._cli_utils import select_choice
@@ -314,6 +321,24 @@ class Application:
         db_invalid = override.default_database is not None and override.default_database not in db_names
         if not (target_invalid or db_invalid):
             return
+
+        if not sys.stdin.isatty():
+            stale = []
+            if target_invalid:
+                stale.append(f"target={override.target!r}")
+            if db_invalid:
+                stale.append(f"default_database={override.default_database!r}")
+            raise DatusException(
+                code=ErrorCode.COMMON_CONFIG_ERROR,
+                message_args={
+                    "config_error": (
+                        f"Project config {project_config_path()} has stale values "
+                        f"({', '.join(stale)}) and stdin is not a TTY; cannot prompt "
+                        f"for replacements. Edit .datus/config.yml manually or rerun "
+                        f"the CLI in an interactive terminal."
+                    )
+                },
+            )
 
         console = Console()
         console.print()

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -75,11 +75,14 @@ class FilesystemPolicy:
 
     ``strict`` mirrors :attr:`FilesystemFuncTool.strict` so the hook and the
     tool agree on what to do with ``EXTERNAL`` paths. When ``True``, the
-    hook denies them up front (no broker prompt) because the API / claw
-    surfaces have no interactive broker attached — prompting would hang the
-    request. The tool-level ``strict`` is still the source of truth, but
-    having the same flag in the policy lets the hook fail fast before the
-    tool even gets invoked.
+    hook skips the broker prompt and delegates the denial to the
+    filesystem tool, which returns ``FuncToolResult(success=0)`` with a
+    "strict mode" error message. This matters for API / claw surfaces with
+    no interactive broker attached — prompting would hang the request,
+    while raising would surface as an uncaught exception. The tool-level
+    ``strict`` is still the source of truth; having the same flag in the
+    policy lets the hook avoid prompting while preserving the normal
+    tool-failure payload the caller already knows how to handle.
     """
 
     root_path: Path

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -316,20 +316,18 @@ class PermissionHooks(AgentHooks):
             logger.debug("Filesystem zone HIDDEN: letting tool return not-found for %s", resolved.display)
             return True
 
-        # EXTERNAL in strict mode → deny up front, no broker prompt. Mirrors
-        # FilesystemFuncTool.strict so callers without an interactive broker
-        # (API / claw) fail fast instead of hanging waiting for user input.
+        # EXTERNAL in strict mode → delegate to the tool, which returns
+        # FuncToolResult(success=0). We return True here (no broker prompt,
+        # no exception) so callers without an interactive broker (API / claw)
+        # still fail fast but surface the denial as a normal tool-failure
+        # payload the agent can read, rather than an uncaught exception.
         if policy.strict:
             logger.info(
-                "Filesystem strict mode: rejecting EXTERNAL access to %s (tool=%s)",
+                "Filesystem strict mode: delegating EXTERNAL access to tool for %s (tool=%s)",
                 resolved.resolved,
                 tool_name,
             )
-            raise PermissionDeniedException(
-                f"Filesystem strict mode: path outside workspace is not allowed: {resolved.resolved}",
-                tool_category="filesystem_tools",
-                tool_name=pattern_name,
-            )
+            return True
 
         # EXTERNAL: force ASK, keyed by absolute path to prevent broad auto-approval.
         cache_key = f"filesystem_tools.external::{resolved.resolved}"

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -204,6 +204,11 @@ class TestEnsureProjectConfig:
         mock_wizard.assert_called_once_with(mock_base)
 
     def test_idempotent_when_file_exists(self):
+        """File exists + override empty → neither wizard nor repair runs.
+
+        ``load_project_override`` is mocked to ``None`` so the repair path
+        short-circuits before touching the real YAML loader.
+        """
         app = Application()
         args = SimpleNamespace(config=None)
         mock_path = MagicMock()
@@ -212,6 +217,7 @@ class TestEnsureProjectConfig:
             patch("datus.configuration.project_config.project_config_path", return_value=mock_path),
             patch("datus.configuration.agent_config_loader.load_agent_config") as mock_load,
             patch("datus.cli.project_init.run_project_init") as mock_wizard,
+            patch("datus.configuration.project_config.load_project_override", return_value=None),
         ):
             app._ensure_project_config(args)
         mock_load.assert_not_called()
@@ -233,6 +239,159 @@ class TestEnsureProjectConfig:
             with pytest.raises(RuntimeError, match="boom"):
                 app._ensure_project_config(args)
         mock_wizard.assert_not_called()
+
+
+class TestRepairProjectOverrides:
+    """``_repair_project_overrides`` re-prompts the user when stale values
+    in ``./.datus/config.yml`` reference models/databases that no longer
+    exist in the base ``agent.yml``, and persists the corrected values.
+    It must be a no-op when every override is already valid — the
+    regression that surfaced this fix was a stale ``target`` leaving the
+    CLI stuck in ``print_help``."""
+
+    def _raw_agent(self, models, databases):
+        service_dbs = {name: {"type": db_type} for name, db_type in databases.items()}
+        return {"models": {name: {} for name in models}, "service": {"databases": service_dbs}}
+
+    def _mock_mgr(self, raw):
+        mgr = MagicMock()
+        mgr.data = raw
+        return mgr
+
+    def test_returns_when_override_is_none(self):
+        """No overlay file → nothing to validate; must not touch loader."""
+        app = Application()
+        args = SimpleNamespace(config=None)
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=None),
+            patch("datus.configuration.agent_config_loader.configuration_manager") as mock_cfg_mgr,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+        ):
+            app._repair_project_overrides(args)
+        mock_cfg_mgr.assert_not_called()
+        mock_save.assert_not_called()
+
+    def test_skips_when_all_valid(self):
+        """All override values match the base config → no prompt, no save."""
+        from datus.configuration.project_config import ProjectOverride
+
+        app = Application()
+        args = SimpleNamespace(config=None)
+        override = ProjectOverride(target="claude", default_database="bench")
+        raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=override),
+            patch(
+                "datus.configuration.agent_config_loader.configuration_manager",
+                return_value=self._mock_mgr(raw),
+            ),
+            patch("datus.cli._cli_utils.select_choice") as mock_pick,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+        ):
+            app._repair_project_overrides(args)
+        mock_pick.assert_not_called()
+        mock_save.assert_not_called()
+
+    def test_repairs_stale_target(self):
+        """Stale target → prompt, write back corrected overlay, keep db."""
+        from datus.configuration.project_config import ProjectOverride
+
+        app = Application()
+        args = SimpleNamespace(config=None)
+        override = ProjectOverride(target="claude-sonnet", default_database="bench")
+        raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=override),
+            patch(
+                "datus.configuration.agent_config_loader.configuration_manager",
+                return_value=self._mock_mgr(raw),
+            ),
+            patch("datus.cli._cli_utils.select_choice", return_value="deepseek") as mock_pick,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+        ):
+            app._repair_project_overrides(args)
+        # select_choice called exactly once (for target), not for the valid db.
+        assert mock_pick.call_count == 1
+        mock_save.assert_called_once()
+        (saved_override,) = mock_save.call_args.args
+        assert saved_override.target == "deepseek"
+        assert saved_override.default_database == "bench"
+
+    def test_repairs_stale_default_database(self):
+        """Stale default_database → prompt only for db; keep valid target."""
+        from datus.configuration.project_config import ProjectOverride
+
+        app = Application()
+        args = SimpleNamespace(config=None)
+        override = ProjectOverride(target="claude", default_database="benchmark1")
+        raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=override),
+            patch(
+                "datus.configuration.agent_config_loader.configuration_manager",
+                return_value=self._mock_mgr(raw),
+            ),
+            patch("datus.cli._cli_utils.select_choice", return_value="bench") as mock_pick,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+        ):
+            app._repair_project_overrides(args)
+        assert mock_pick.call_count == 1
+        mock_save.assert_called_once()
+        (saved_override,) = mock_save.call_args.args
+        assert saved_override.target == "claude"
+        assert saved_override.default_database == "bench"
+
+    def test_repairs_both_fields(self):
+        """Both values stale → two prompts, saved override uses both picks."""
+        from datus.configuration.project_config import ProjectOverride
+
+        app = Application()
+        args = SimpleNamespace(config=None)
+        override = ProjectOverride(target="claude1", default_database="benchmark1")
+        raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=override),
+            patch(
+                "datus.configuration.agent_config_loader.configuration_manager",
+                return_value=self._mock_mgr(raw),
+            ),
+            patch(
+                "datus.cli._cli_utils.select_choice",
+                side_effect=["claude", "bench"],
+            ) as mock_pick,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+        ):
+            app._repair_project_overrides(args)
+        assert mock_pick.call_count == 2
+        mock_save.assert_called_once()
+        (saved_override,) = mock_save.call_args.args
+        assert saved_override.target == "claude"
+        assert saved_override.default_database == "bench"
+
+    def test_raises_when_base_has_no_models(self):
+        """Base config empty on the same key we need to repair → nothing to
+        offer, so surface a config error instead of silently writing a bad
+        value."""
+        from datus.configuration.project_config import ProjectOverride
+        from datus.utils.exceptions import DatusException
+
+        app = Application()
+        args = SimpleNamespace(config=None)
+        override = ProjectOverride(target="claude-sonnet", default_database=None)
+        raw = self._raw_agent([], {"bench": "sqlite"})
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=override),
+            patch(
+                "datus.configuration.agent_config_loader.configuration_manager",
+                return_value=self._mock_mgr(raw),
+            ),
+            patch("datus.cli._cli_utils.select_choice") as mock_pick,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+        ):
+            with pytest.raises(DatusException):
+                app._repair_project_overrides(args)
+        mock_pick.assert_not_called()
+        mock_save.assert_not_called()
 
 
 class TestResolveDefaultDatabase:

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -8,6 +8,7 @@ Unit tests for datus/cli/main.py — ArgumentParser, Application, main().
 All external dependencies (DatusCLI, run_web_interface, configure_logging) are mocked.
 """
 
+import argparse
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -24,7 +25,7 @@ from datus.cli.main import Application, ArgumentParser
 class TestArgumentParser:
     def test_init_creates_parser(self):
         ap = ArgumentParser()
-        assert ap.parser is not None
+        assert isinstance(ap.parser, argparse.ArgumentParser)
 
     def test_parse_args_defaults(self):
         ap = ArgumentParser()
@@ -308,7 +309,9 @@ class TestRepairProjectOverrides:
             ),
             patch("datus.cli._cli_utils.select_choice", return_value="deepseek") as mock_pick,
             patch("datus.configuration.project_config.save_project_override") as mock_save,
+            patch("sys.stdin") as mock_stdin,
         ):
+            mock_stdin.isatty.return_value = True
             app._repair_project_overrides(args)
         # select_choice called exactly once (for target), not for the valid db.
         assert mock_pick.call_count == 1
@@ -333,7 +336,9 @@ class TestRepairProjectOverrides:
             ),
             patch("datus.cli._cli_utils.select_choice", return_value="bench") as mock_pick,
             patch("datus.configuration.project_config.save_project_override") as mock_save,
+            patch("sys.stdin") as mock_stdin,
         ):
+            mock_stdin.isatty.return_value = True
             app._repair_project_overrides(args)
         assert mock_pick.call_count == 1
         mock_save.assert_called_once()
@@ -360,7 +365,9 @@ class TestRepairProjectOverrides:
                 side_effect=["claude", "bench"],
             ) as mock_pick,
             patch("datus.configuration.project_config.save_project_override") as mock_save,
+            patch("sys.stdin") as mock_stdin,
         ):
+            mock_stdin.isatty.return_value = True
             app._repair_project_overrides(args)
         assert mock_pick.call_count == 2
         mock_save.assert_called_once()
@@ -387,9 +394,41 @@ class TestRepairProjectOverrides:
             ),
             patch("datus.cli._cli_utils.select_choice") as mock_pick,
             patch("datus.configuration.project_config.save_project_override") as mock_save,
+            patch("sys.stdin") as mock_stdin,
         ):
+            mock_stdin.isatty.return_value = True
             with pytest.raises(DatusException):
                 app._repair_project_overrides(args)
+        mock_pick.assert_not_called()
+        mock_save.assert_not_called()
+
+    def test_raises_when_stdin_is_not_a_tty(self):
+        """Stale value + non-interactive stdin → raise instead of silently
+        persisting select_choice's default fallback. Guards against the
+        REPL-only repair flow accidentally writing a bad config when run
+        from a pipe / CI / API surface."""
+        from datus.configuration.project_config import ProjectOverride
+        from datus.utils.exceptions import DatusException
+
+        app = Application()
+        args = SimpleNamespace(config=None)
+        override = ProjectOverride(target="claude-sonnet", default_database=None)
+        raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=override),
+            patch(
+                "datus.configuration.agent_config_loader.configuration_manager",
+                return_value=self._mock_mgr(raw),
+            ),
+            patch("datus.cli._cli_utils.select_choice") as mock_pick,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = False
+            with pytest.raises(DatusException) as exc_info:
+                app._repair_project_overrides(args)
+        assert "stdin is not a TTY" in str(exc_info.value)
+        assert "target='claude-sonnet'" in str(exc_info.value)
         mock_pick.assert_not_called()
         mock_save.assert_not_called()
 
@@ -445,7 +484,7 @@ class TestRunWebInterface:
         with patch("datus.cli.web.run_web_interface") as mock_web:
             with patch.dict("sys.modules", {"datus.cli.web": MagicMock(run_web_interface=mock_web)}):
                 app._run_web_interface(mock_args)
-        # Just verify no exceptions are raised — the method delegates to lazy import
+        mock_web.assert_called_once_with(mock_args)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -612,14 +612,13 @@ class TestFilesystemZoneBranch:
         # 2. Tool layer produces the success=0 payload with the strict-mode message.
         read_result = tool.read_file(str(external))
         assert read_result.success == 0
-        assert read_result.error is not None
-        assert "strict mode" in read_result.error.lower()
+        assert read_result.error.startswith("Path outside workspace is not allowed in strict mode:")
         assert str(external) in read_result.error
 
         write_result = tool.write_file(str(external), "new content")
         assert write_result.success == 0
-        assert write_result.error is not None
-        assert "strict mode" in write_result.error.lower()
+        assert write_result.error.startswith("Path outside workspace is not allowed in strict mode:")
+        assert str(external) in write_result.error
 
         # Guardrail: the external file was not actually touched.
         assert external.read_text() == "secret"

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -543,10 +543,12 @@ class TestFilesystemZoneBranch:
             await hooks.on_tool_start(ctx, MagicMock(), tool)
 
     @pytest.mark.asyncio
-    async def test_strict_external_denies_without_broker(self, mock_broker, tmp_path):
-        """Strict policy → EXTERNAL is rejected with PermissionDenied and the
-        broker is never touched. Regression guard for API/claw flows that
-        have no interactive prompt — they must fail fast, not hang."""
+    async def test_strict_external_delegates_to_tool_without_broker(self, mock_broker, tmp_path):
+        """Strict policy → EXTERNAL is delegated to the tool layer (which
+        returns FuncToolResult(success=0)) instead of raising. The broker is
+        still never touched. Regression guard for API/claw flows: they must
+        fail fast with a readable tool-failure payload, not hang and not
+        raise."""
         hooks, _, _ = self._build(mock_broker, tmp_path, strict=True)
         target = tmp_path / "elsewhere.md"
         target.write_text("x")
@@ -554,9 +556,7 @@ class TestFilesystemZoneBranch:
         ctx.tool_arguments = f'{{"path": "{target}"}}'
         tool = MagicMock()
         tool.name = "read_file"
-        with pytest.raises(PermissionDeniedException) as exc_info:
-            await hooks.on_tool_start(ctx, MagicMock(), tool)
-        assert "strict mode" in str(exc_info.value).lower()
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
         mock_broker.request.assert_not_called()
 
     @pytest.mark.asyncio
@@ -571,6 +571,58 @@ class TestFilesystemZoneBranch:
         tool.name = "read_file"
         await hooks.on_tool_start(ctx, MagicMock(), tool)
         mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_strict_external_end_to_end_returns_success_0(self, mock_broker, tmp_path):
+        """End-to-end contract: hook + real tool in strict mode must surface
+        EXTERNAL denials as ``FuncToolResult(success=0)`` with a "strict mode"
+        error message, never as an exception. Cross-component guard for the
+        fix that moved the rejection from the hook (raise) to the tool
+        (success=0)."""
+        from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        external = tmp_path / "outside.md"
+        external.write_text("secret")
+
+        registry = ToolRegistry()
+        fs_tool = MagicMock()
+        fs_tool.name = "read_file"
+        registry.register_tools("filesystem_tools", [fs_tool])
+
+        manager = PermissionManager(global_config=PermissionConfig(default_permission=PermissionLevel.ALLOW, rules=[]))
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            fs_policy=FilesystemPolicy(root_path=project, current_node="chat", strict=True),
+        )
+        tool = FilesystemFuncTool(root_path=str(project), current_node="chat", strict=True)
+
+        # 1. Hook must not raise and must not prompt.
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{external}"}}'
+        hook_tool = MagicMock()
+        hook_tool.name = "read_file"
+        await hooks.on_tool_start(ctx, MagicMock(), hook_tool)
+        mock_broker.request.assert_not_called()
+
+        # 2. Tool layer produces the success=0 payload with the strict-mode message.
+        read_result = tool.read_file(str(external))
+        assert read_result.success == 0
+        assert read_result.error is not None
+        assert "strict mode" in read_result.error.lower()
+        assert str(external) in read_result.error
+
+        write_result = tool.write_file(str(external), "new content")
+        assert write_result.success == 0
+        assert write_result.error is not None
+        assert "strict mode" in write_result.error.lower()
+
+        # Guardrail: the external file was not actually touched.
+        assert external.read_text() == "secret"
 
     @pytest.mark.asyncio
     async def test_external_broker_cancel_denies(self, mock_broker, tmp_path):


### PR DESCRIPTION

- Permission hook no longer raises PermissionDeniedException on strict+EXTERNAL; delegates to FilesystemFuncTool which already returns FuncToolResult(success=0). API/claw callers now see a readable tool-failure payload instead of an uncaught exception.
- CLI REPL startup re-prompts the user when target/default_database in .datus/config.yml no longer exist in agent.yml, writes the corrected values back, and resumes startup instead of silently printing --help.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project config overlays now detect stale model/database selections and offer interactive prompts to repair and persist corrected values.

* **Bug Fixes**
  * Strict-mode filesystem access for external paths now delegates to the tool layer and returns tool-style failure results instead of raising immediate hook exceptions.
  * Repair attempts on non-interactive stdin now fail with a clear error instead of prompting.

* **Tests**
  * Added and updated unit tests covering repair prompts, persistence, non-interactive failures, and strict-mode filesystem behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->