### PR TITLE
[BugFix] Resolve default database at bootstrap for API and claw

### DIFF
--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -130,9 +130,7 @@ class ChatAgenticNode(AgenticNode):
         # Setup tools
         self.setup_tools()
         logger.debug(f"ChatAgenticNode tools: {len(self.tools)} tools - {[tool.name for tool in self.tools]}")
-        logger.debug(
-            f"ChatAgenticNode initialized: {self.agent_config.current_database} {self.agent_config.current_database}"
-        )
+        logger.debug(f"ChatAgenticNode initialized: {self.agent_config.current_database}")
 
     def get_node_name(self) -> str:
         """Get the configured node name."""

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -157,6 +157,8 @@ def _fill_database_context(
     current_namespace and current_database. Otherwise, falls back to treating database
     as a namespace name if it exists in agent_config.namespaces.
     """
+    # agent_config.current_database is resolved at bootstrap by load_agent_config;
+    # leave it in place when the request does not override the database.
     if not database:
         return
     for ns_name, ns_dbs in agent_config.namespaces.items():

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -262,6 +262,32 @@ def load_agent_config(reload: bool = False, **kwargs) -> AgentConfig:
 
         if override_kwargs:
             agent_config.override_by_args(**override_kwargs)
+    # Resolve current_database regardless of CLI ``action`` so API / claw /
+    # SDK entry points that bypass ``override_by_args``'s action whitelist
+    # still get a usable default. Priority already applied upstream:
+    #   1. ``./.datus/config.yml::default_database`` (via _apply_project_override)
+    #   2. ``service.databases[*].default: true`` flag in base agent.yml
+    #   3. single-DB auto-select (ServiceConfig.default_database)
+    if not agent_config.current_database and agent_config.service.databases:
+        default_db = agent_config.service.default_database
+        if default_db:
+            agent_config.current_namespace = default_db
+        else:
+            raise DatusException(
+                code=ErrorCode.COMMON_CONFIG_ERROR,
+                message_args={
+                    "config_error": (
+                        "No default database could be resolved. Project-level "
+                        "./.datus/config.yml is missing and agent.yml has multiple "
+                        "databases without any marked as `default: true`. Run "
+                        "`datus` in this project directory first to launch the "
+                        "init wizard (which writes ./.datus/config.yml with your "
+                        "preferred default_database and target), or set "
+                        "`default: true` on one database under "
+                        "`service.databases` in agent.yml."
+                    )
+                },
+            )
     # Auto-select default database for file-based DBs if not already set
     if agent_config.db_type in {DBType.SQLITE, DBType.DUCKDB} and not agent_config.current_database:
         databases = agent_config.service.databases

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -184,6 +184,7 @@ agent:
       name: california_schools
       type: sqlite
       uri: ~/benchmark/bird/dev_20240627/dev_databases/california_schools/california_schools.sqlite # just support glob pattern
+      default: true
     duckdb:
       type: duckdb
       name: duck

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -18,6 +18,7 @@ from datus.configuration.agent_config_loader import (
     ConfigurationManager,
     _apply_project_override,
     configuration_manager,
+    load_agent_config,
     load_node_config,
     parse_config_path,
 )
@@ -342,3 +343,141 @@ class TestLoadNodeConfig:
         with patch("datus.configuration.agent_config_loader.NodeType.type_input", return_value={}):
             node_cfg = load_node_config("gen_sql", None)
         assert node_cfg.model == ""
+
+
+# ---------------------------------------------------------------------------
+# load_agent_config — default database resolution tail
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAgentConfigResolution:
+    """Cover the post-override resolution that guarantees ``current_database``
+    is populated for every entry point (REPL, datus-api, datus-claw, SDK),
+    regardless of whether ``override_by_args`` ran for the CLI ``action``.
+    """
+
+    def _write_base_yaml(self, tmp_path, databases: dict) -> Path:
+        """Write a minimal agent.yml with the given databases map."""
+        cfg = tmp_path / "agent.yml"
+        cfg.write_text(
+            yaml.safe_dump(
+                {
+                    "agent": {
+                        "home": str(tmp_path),
+                        "target": "mock",
+                        "models": {
+                            "mock": {
+                                "type": "openai",
+                                "api_key": "mock-api-key",
+                                "model": "mock-model",
+                                "base_url": "http://localhost:0",
+                            }
+                        },
+                        "service": {"databases": databases},
+                        "project_root": str(tmp_path / "workspace"),
+                    }
+                }
+            )
+        )
+        (tmp_path / "workspace").mkdir(exist_ok=True)
+        return cfg
+
+    def test_resolves_from_default_flag(self, tmp_path, reset_global_singletons):
+        """base has two DBs, one marked ``default: true`` → selected at bootstrap."""
+        cfg = self._write_base_yaml(
+            tmp_path,
+            {
+                "db_a": {"type": "sqlite", "uri": str(tmp_path / "a.sqlite"), "default": False},
+                "db_b": {"type": "sqlite", "uri": str(tmp_path / "b.sqlite"), "default": True},
+            },
+        )
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=None,
+        ):
+            agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
+        assert agent_config.current_database == "db_b"
+
+    def test_resolves_single_db_auto(self, tmp_path, reset_global_singletons):
+        """base has a single DB and no explicit default → auto-selected."""
+        cfg = self._write_base_yaml(
+            tmp_path,
+            {"only_db": {"type": "sqlite", "uri": str(tmp_path / "only.sqlite")}},
+        )
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=None,
+        ):
+            agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
+        assert agent_config.current_database == "only_db"
+
+    def test_project_overlay_wins_over_base_default(self, tmp_path, reset_global_singletons):
+        """``.datus/config.yml::default_database`` overrides the base default flag."""
+        cfg = self._write_base_yaml(
+            tmp_path,
+            {
+                "db_a": {"type": "sqlite", "uri": str(tmp_path / "a.sqlite"), "default": True},
+                "db_b": {"type": "sqlite", "uri": str(tmp_path / "b.sqlite")},
+            },
+        )
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(default_database="db_b", target="mock"),
+        ):
+            agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
+        assert agent_config.current_database == "db_b"
+        assert agent_config.target == "mock"
+
+    def test_raises_when_ambiguous_default(self, tmp_path, reset_global_singletons):
+        """Multi-DB + no ``default`` flag + no overlay → startup-time error that
+        tells the user how to fix it (run ``datus`` init wizard)."""
+        cfg = self._write_base_yaml(
+            tmp_path,
+            {
+                "db_a": {"type": "sqlite", "uri": str(tmp_path / "a.sqlite")},
+                "db_b": {"type": "sqlite", "uri": str(tmp_path / "b.sqlite")},
+            },
+        )
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=None,
+        ):
+            with pytest.raises(DatusException) as exc:
+                load_agent_config(config=str(cfg), home=str(tmp_path), reload=True, action="start")
+        msg = str(exc.value)
+        assert "./.datus/config.yml" in msg
+        # The guidance must name the CLI command so users know how to recover.
+        assert "datus" in msg
+
+    def test_service_action_still_resolves(self, tmp_path, reset_global_singletons):
+        """``action='service'`` previously skipped the namespace fallback in
+        ``override_by_args``; the loader tail must still populate the default."""
+        cfg = self._write_base_yaml(
+            tmp_path,
+            {
+                "db_a": {"type": "sqlite", "uri": str(tmp_path / "a.sqlite"), "default": True},
+                "db_b": {"type": "sqlite", "uri": str(tmp_path / "b.sqlite")},
+            },
+        )
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=None,
+        ):
+            agent_config = load_agent_config(
+                config=str(cfg),
+                home=str(tmp_path),
+                reload=True,
+                action="service",
+            )
+        assert agent_config.current_database == "db_a"
+
+    def test_no_databases_is_tolerated(self, tmp_path, reset_global_singletons):
+        """Deployments without any configured DB (pure KB / tool-only) must not
+        crash at bootstrap; ``current_database`` simply stays empty."""
+        cfg = self._write_base_yaml(tmp_path, {})
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=None,
+        ):
+            agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
+        assert agent_config.current_database == ""


### PR DESCRIPTION
load_agent_config() now guarantees current_database is populated for every entry point (datus-api, datus-claw, SDK), not just CLI verbs that pass
override_by_args's action whitelist. Priority: .datus/config.yml overlay >
service.databases[*].default flag > single-DB auto-select. When multi-DB config has no resolvable default, fail fast at startup with guidance to run the `datus` init wizard, instead of crashing later with "Namespace not found in config" on the first chat request.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now supports marking databases as default
  * Enhanced database resolution with error guidance during initialization

* **Bug Fixes**
  * Removed duplicate database reference in debug output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->