### PR TITLE
[Enhancement] Auto-inject project_name into Airflow scheduler config

### DIFF
--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -54,6 +54,15 @@ class SchedulerTools(BaseTool):
 
         config = dict(scheduler_config)
         platform = config.get("type", "airflow")
+
+        # Multi-tenant Airflow: auto-inject agent.project_name so users don't
+        # have to restate it in the scheduler section of agent.yml. Each Datus
+        # instance gets its own DAG subdirectory and dag_id prefix, preventing
+        # collisions when many instances share one Airflow cluster. Users can
+        # still override explicitly in agent.yml (setdefault preserves it).
+        if platform == "airflow":
+            config.setdefault("project_name", self.agent_config.project_name)
+
         return SchedulerAdapterRegistry.create_adapter(platform=platform, config=config)
 
     # ── Tool methods ───────────────────────────────────────────────────────

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -102,6 +102,91 @@ class TestGetAdapter:
                 adapter = tools._get_adapter()
         assert adapter is mock_adapter
 
+    def test_airflow_injects_project_name_from_agent_config(self):
+        """For Airflow, _get_adapter must auto-inject agent.project_name into the
+        scheduler config so each Datus instance lands in its own DAG subdirectory
+        and gets its own dag_id prefix — without users having to repeat the value
+        in agent.yml's scheduler section."""
+        agent_cfg = _make_agent_config(
+            scheduler_config={
+                "name": "airflow_local",
+                "type": "airflow",
+                "api_base_url": "http://localhost:8080/api/v1",
+                "username": "admin",
+                "password": "admin",
+                "dags_folder_root": "/opt/airflow/dags",
+                # Note: no project_name here — adapter expects the tool to inject it
+            }
+        )
+        agent_cfg.project_name = "reports-team"
+        tools = SchedulerTools(agent_cfg)
+
+        mock_registry = MagicMock()
+        mock_registry.create_adapter.return_value = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"datus_scheduler_core.registry": MagicMock(SchedulerAdapterRegistry=mock_registry)},
+        ):
+            tools._get_adapter()
+
+        # Verify the injected project_name reached create_adapter
+        call_kwargs = mock_registry.create_adapter.call_args.kwargs
+        assert call_kwargs["platform"] == "airflow"
+        assert call_kwargs["config"]["project_name"] == "reports-team"
+
+    def test_airflow_explicit_project_name_takes_precedence(self):
+        """setdefault semantics: if user writes project_name in agent.yml, Datus
+        must NOT overwrite it with agent.project_name."""
+        agent_cfg = _make_agent_config(
+            scheduler_config={
+                "name": "airflow_local",
+                "type": "airflow",
+                "api_base_url": "http://localhost:8080/api/v1",
+                "username": "admin",
+                "password": "admin",
+                "dags_folder_root": "/opt/airflow/dags",
+                "project_name": "explicit-override",
+            }
+        )
+        agent_cfg.project_name = "reports-team"
+        tools = SchedulerTools(agent_cfg)
+
+        mock_registry = MagicMock()
+        mock_registry.create_adapter.return_value = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"datus_scheduler_core.registry": MagicMock(SchedulerAdapterRegistry=mock_registry)},
+        ):
+            tools._get_adapter()
+
+        call_kwargs = mock_registry.create_adapter.call_args.kwargs
+        assert call_kwargs["config"]["project_name"] == "explicit-override"
+
+    def test_non_airflow_platform_not_injected(self):
+        """Only Airflow config schema has a project_name field; don't inject for
+        DS/Azkaban (their 'project' semantics are platform-side, not Datus)."""
+        agent_cfg = _make_agent_config(
+            scheduler_config={
+                "name": "ds_prod",
+                "type": "dolphinscheduler",
+                "api_base_url": "http://localhost:12345/dolphinscheduler",
+                "token": "fake-token",
+            }
+        )
+        agent_cfg.project_name = "reports-team"
+        tools = SchedulerTools(agent_cfg)
+
+        mock_registry = MagicMock()
+        mock_registry.create_adapter.return_value = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"datus_scheduler_core.registry": MagicMock(SchedulerAdapterRegistry=mock_registry)},
+        ):
+            tools._get_adapter()
+
+        call_kwargs = mock_registry.create_adapter.call_args.kwargs
+        assert "project_name" not in call_kwargs["config"]
+
 
 # ── SchedulerTools.available_tools ─────────────────────────────────────────
 


### PR DESCRIPTION
## Why

When multiple Datus instances share one Airflow cluster (the new multi-tenant deployment mode added in [Datus-ai/datus-scheduler-adapters#3](https://github.com/Datus-ai/datus-scheduler-adapters/pull/3)), each instance needs to:

- write its DAGs into a per-instance subdirectory under `AIRFLOW__CORE__DAGS_FOLDER`
- prefix every `dag_id` with its project identifier so different instances' jobs don't collide

The natural value for both is `agent.project_name` — Datus already uses it everywhere else (`~/.datus/sessions/{project_name}/`, `~/.datus/data/{project_name}/`, etc.). Forcing users to restate it in the `scheduler:` section of `agent.yml` is duplication and a source of subtle bugs when the two drift.

## Solution

In `SchedulerToolkit._get_adapter`, when the configured platform is `airflow`, populate the scheduler config's `project_name` from `self.agent_config.project_name` via `setdefault` — preserving any explicit override the user wrote in `agent.yml`.

Only applied for `type='airflow'`. DolphinScheduler and Azkaban have a different platform-side "project" concept (their own `default_project` field semantics), so we don't touch their configs.

```python
config = dict(scheduler_config)
platform = config.get("type", "airflow")

if platform == "airflow":
    config.setdefault("project_name", self.agent_config.project_name)

return SchedulerAdapterRegistry.create_adapter(platform=platform, config=config)
```

## Dependency

This PR depends on [Datus-ai/datus-scheduler-adapters#3](https://github.com/Datus-ai/datus-scheduler-adapters/pull/3) being merged and a new version of `datus-scheduler-airflow` being released — that PR adds the `project_name` field to `AirflowConfig`. Without it the field is unknown and Pydantic will reject the injection. Hold this PR until the scheduler-adapters release lands and `pyproject.toml` is bumped to that version.

## Test Cases

3 new unit tests added in `tests/unit_tests/tools/func_tool/test_scheduler_tools.py::TestGetAdapter`:

- `test_airflow_injects_project_name_from_agent_config` — Airflow without explicit `project_name` gets `agent.project_name` injected
- `test_airflow_explicit_project_name_takes_precedence` — `setdefault` semantics: explicit value in `agent.yml` is preserved
- `test_non_airflow_platform_not_injected` — DolphinScheduler / Azkaban configs are not touched

All 64 existing scheduler_tools tests still pass; ruff format/check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Airflow scheduler configuration now properly defaults to the agent's configured project name when not explicitly specified in scheduler settings. Explicit values in configuration remain preserved.

* **Tests**
  * Added test coverage for project name default behavior in Airflow scheduler configurations, including validation of explicit value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->