### PR TITLE
[Refactor] Unify runtime services configuration

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -591,9 +591,11 @@ class AgenticNode(Node):
             "scoped_context",
             "scoped_kb_path",
             "adapter_type",
+            "semantic_adapter",
             "sql_file_threshold",
             "sql_preview_lines",
             "bi_platform",
+            "scheduler_service",
             "subagents",
         ]
         for attr in direct_attributes:

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -157,12 +157,12 @@ class GenMetricsAgenticNode(AgenticNode):
         try:
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
-            # Default to "metricflow", override from config if specified
-            adapter_type = "metricflow"
+            adapter_type = None
             if hasattr(self.agent_config, "agentic_nodes") and self.NODE_NAME in self.agent_config.agentic_nodes:
                 node_config = self.agent_config.agentic_nodes[self.NODE_NAME]
                 if isinstance(node_config, dict) and node_config.get("semantic_adapter"):
                     adapter_type = node_config.get("semantic_adapter")
+            adapter_type = self.agent_config.resolve_semantic_adapter(adapter_type)
 
             # Initialize semantic func tool
             self.semantic_tools = SemanticTools(

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -166,12 +166,12 @@ class GenSemanticModelAgenticNode(AgenticNode):
         try:
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
-            # Default to "metricflow", override from config if specified
-            adapter_type = "metricflow"
+            adapter_type = None
             if hasattr(self.agent_config, "agentic_nodes") and self.NODE_NAME in self.agent_config.agentic_nodes:
                 node_config = self.agent_config.agentic_nodes[self.NODE_NAME]
                 if isinstance(node_config, dict) and node_config.get("semantic_adapter"):
                     adapter_type = node_config.get("semantic_adapter")
+            adapter_type = self.agent_config.resolve_semantic_adapter(adapter_type)
 
             # Initialize semantic func tool
             self.semantic_func_tool = SemanticTools(

--- a/datus/agent/node/scheduler_agentic_node.py
+++ b/datus/agent/node/scheduler_agentic_node.py
@@ -71,6 +71,7 @@ class SchedulerAgenticNode(AgenticNode):
 
         self.scheduler_tools = None
         self.ask_user_tool = None
+        self.scheduler_service = self.node_config.get("scheduler_service")
         self.setup_tools()
 
     def get_node_name(self) -> str:
@@ -105,7 +106,7 @@ class SchedulerAgenticNode(AgenticNode):
         if not self.scheduler_tools:
             return
 
-        scheduler_config = getattr(self.agent_config, "scheduler_config", {}) or {}
+        scheduler_config = self.agent_config.get_scheduler_config(self.scheduler_service)
         platform = scheduler_config.get("type", "airflow")
 
         skills_to_inject = [f"{platform}-workflow", "scheduler-validation"]
@@ -134,13 +135,17 @@ class SchedulerAgenticNode(AgenticNode):
         return ", ".join(merged_patterns)
 
     def _setup_scheduler_tools(self):
-        """Setup scheduler tools if scheduler_config is present."""
-        if not getattr(self.agent_config, "scheduler_config", None):
+        """Setup scheduler tools if `agent.service.schedulers` is configured."""
+        if not getattr(self.agent_config, "scheduler_services", None):
             return
         try:
             from datus.tools.func_tool.scheduler_tools import SchedulerTools
 
-            self.scheduler_tools = SchedulerTools(self.agent_config)
+            self.agent_config.get_scheduler_config(self.scheduler_service)
+            self.scheduler_tools = SchedulerTools(
+                self.agent_config,
+                scheduler_service=self.scheduler_service,
+            )
             self.tools.extend(self.scheduler_tools.available_tools())
             logger.info("Scheduler tools initialized")
         except ImportError as e:

--- a/datus/agent/node/scheduler_agentic_node.py
+++ b/datus/agent/node/scheduler_agentic_node.py
@@ -135,7 +135,7 @@ class SchedulerAgenticNode(AgenticNode):
         return ", ".join(merged_patterns)
 
     def _setup_scheduler_tools(self):
-        """Setup scheduler tools if `agent.service.schedulers` is configured."""
+        """Setup scheduler tools if `agent.services.schedulers` is configured."""
         if not getattr(self.agent_config, "scheduler_services", None):
             return
         try:

--- a/datus/cli/bi_dashboard.py
+++ b/datus/cli/bi_dashboard.py
@@ -981,12 +981,12 @@ class BiDashboardCommands:
             True if validation passed, False otherwise
         """
         try:
-            # Get adapter_type from agentic_nodes config, default to metricflow
-            adapter_type = "metricflow"
+            adapter_type = None
             agentic_nodes = getattr(self.agent_config, "agentic_nodes", None) or {}
             node_config = agentic_nodes.get("gen_semantic_model", {})
             if isinstance(node_config, dict) and node_config.get("semantic_adapter"):
                 adapter_type = node_config.get("semantic_adapter")
+            adapter_type = self.agent_config.resolve_semantic_adapter(adapter_type)
 
             semantic_tools = SemanticTools(
                 agent_config=self.agent_config,

--- a/datus/cli/init_workspace.py
+++ b/datus/cli/init_workspace.py
@@ -146,7 +146,7 @@ class InitWorkspace:
             project_type = _detect_project_type(self.project_dir)
 
             # Build services section from config
-            services_section = _build_services_section(agent_config.service.databases)
+            services_section = _build_services_section(agent_config.services.databases)
 
             # Probe database schema if --database specified
             db_schema_info = ""
@@ -182,7 +182,7 @@ class InitWorkspace:
             from datus.tools.db_tools.db_manager import DBManager
 
             self.console.print(f"[dim]Probing database '{db_name}'...[/dim]")
-            db_config = agent_config.service.databases.get(db_name)
+            db_config = agent_config.services.databases.get(db_name)
             if not db_config:
                 self.console.print(f"[yellow]Database '{db_name}' not found in config, skipping probe.[/yellow]")
                 return ""

--- a/datus/cli/interactive_configure.py
+++ b/datus/cli/interactive_configure.py
@@ -115,10 +115,13 @@ class InteractiveConfigure:
         self.target = agent.get("target", "")
         self.models = agent.get("models", {})
 
-        # Support both new services format and legacy namespace format
-        services = agent.get("services", {})
-        if services:
+        # Support new services format and legacy singular service / namespace formats
+        services = agent.get("services") or {}
+        legacy_service = agent.get("service") or {}
+        if isinstance(services, dict) and services.get("databases") is not None:
             self.databases = services.get("databases", {})
+        elif isinstance(legacy_service, dict) and legacy_service.get("databases") is not None:
+            self.databases = legacy_service.get("databases", {})
         elif "namespace" in agent:
             # Auto-migrate legacy namespace format
             from datus.configuration.agent_config import ServicesConfig
@@ -592,8 +595,13 @@ class InteractiveConfigure:
         agent["target"] = self.target
         agent["models"] = self.models
 
-        # Ensure services structure
-        services = agent.get("services", {})
+        # Ensure services structure, migrating any leftover legacy singular `service`
+        raw_services = agent.get("services")
+        services = dict(raw_services) if isinstance(raw_services, dict) else {}
+        legacy_service = agent.get("service")
+        if isinstance(legacy_service, dict):
+            for key, value in legacy_service.items():
+                services.setdefault(key, value)
         services["databases"] = self.databases
         if "semantic_layer" not in services:
             services["semantic_layer"] = {}
@@ -603,8 +611,9 @@ class InteractiveConfigure:
             services["schedulers"] = {}
         agent["services"] = services
 
-        # Remove legacy namespace
+        # Remove legacy namespace and singular service keys
         agent.pop("namespace", None)
+        agent.pop("service", None)
 
         # Set default nodes if not present
         if "nodes" not in agent:

--- a/datus/cli/interactive_configure.py
+++ b/datus/cli/interactive_configure.py
@@ -115,15 +115,15 @@ class InteractiveConfigure:
         self.target = agent.get("target", "")
         self.models = agent.get("models", {})
 
-        # Support both new service format and legacy namespace format
-        service = agent.get("service", {})
-        if service:
-            self.databases = service.get("databases", {})
+        # Support both new services format and legacy namespace format
+        services = agent.get("services", {})
+        if services:
+            self.databases = services.get("databases", {})
         elif "namespace" in agent:
             # Auto-migrate legacy namespace format
-            from datus.configuration.agent_config import ServiceConfig
+            from datus.configuration.agent_config import ServicesConfig
 
-            migrated = ServiceConfig.migrate_from_namespace(agent["namespace"])
+            migrated = ServicesConfig.migrate_from_namespace(agent["namespace"])
             self.databases = migrated.get("databases", {})
 
     def _load_provider_catalog(self) -> dict:
@@ -592,16 +592,16 @@ class InteractiveConfigure:
         agent["target"] = self.target
         agent["models"] = self.models
 
-        # Ensure service structure
-        service = agent.get("service", {})
-        service["databases"] = self.databases
-        if "semantic_layer" not in service:
-            service["semantic_layer"] = {}
-        if "bi_tools" not in service:
-            service["bi_tools"] = {}
-        if "schedulers" not in service:
-            service["schedulers"] = {}
-        agent["service"] = service
+        # Ensure services structure
+        services = agent.get("services", {})
+        services["databases"] = self.databases
+        if "semantic_layer" not in services:
+            services["semantic_layer"] = {}
+        if "bi_tools" not in services:
+            services["bi_tools"] = {}
+        if "schedulers" not in services:
+            services["schedulers"] = {}
+        agent["services"] = services
 
         # Remove legacy namespace
         agent.pop("namespace", None)

--- a/datus/cli/interactive_configure.py
+++ b/datus/cli/interactive_configure.py
@@ -595,6 +595,8 @@ class InteractiveConfigure:
         # Ensure service structure
         service = agent.get("service", {})
         service["databases"] = self.databases
+        if "semantic_layer" not in service:
+            service["semantic_layer"] = {}
         if "bi_tools" not in service:
             service["bi_tools"] = {}
         if "schedulers" not in service:

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -226,7 +226,7 @@ class Application:
             self.arg_parser.parser.print_help()
             return ""
 
-        databases = config.service.databases
+        databases = config.services.databases
         if not databases:
             console.print("[yellow]No databases configured. Run 'datus configure' first.[/yellow]")
             return ""
@@ -234,7 +234,7 @@ class Application:
         # default_database reflects the project-level overlay when present — it
         # is applied inside load_agent_config via _apply_project_override which
         # flips databases[*].default before AgentConfig is built.
-        default_db = config.service.default_database
+        default_db = config.services.default_database
         if default_db:
             console.print(f"[dim]Using default database: {default_db}[/dim]")
             return default_db
@@ -315,7 +315,7 @@ class Application:
             raise
 
         model_names = list((raw.get("models") or {}).keys())
-        db_names = list(((raw.get("service") or {}).get("databases") or {}).keys())
+        db_names = list(((raw.get("services") or {}).get("databases") or {}).keys())
 
         target_invalid = override.target is not None and override.target not in model_names
         db_invalid = override.default_database is not None and override.default_database not in db_names
@@ -369,16 +369,16 @@ class Application:
                     code=ErrorCode.COMMON_CONFIG_ERROR,
                     message_args={
                         "config_error": (
-                            "Base agent.yml has no 'agent.service.databases' defined; cannot repair "
+                            "Base agent.yml has no 'agent.services.databases' defined; cannot repair "
                             f"default_database={override.default_database!r} in .datus/config.yml."
                         )
                     },
                 )
             console.print(
                 f"  [red]default_database[/] = {override.default_database!r} not found in agent.yml "
-                f"service.databases ({sorted(db_names)}). Please pick a replacement:"
+                f"services.databases ({sorted(db_names)}). Please pick a replacement:"
             )
-            db_types = (raw.get("service") or {}).get("databases") or {}
+            db_types = (raw.get("services") or {}).get("databases") or {}
             choices = {name: f"{name}  ({(db_types.get(name) or {}).get('type', 'unknown')})" for name in db_names}
             picked = select_choice(console, choices, default=db_names[0])
             override.default_database = picked or db_names[0]

--- a/datus/cli/namespace_manager.py
+++ b/datus/cli/namespace_manager.py
@@ -293,10 +293,11 @@ class NamespaceManager:
 
             for db_name, db_config in self.agent_config.services.databases.items():
                 if db_config.type in (DBType.SQLITE, DBType.DUCKDB):
-                    entry = {
-                        "type": db_config.type,
-                        "uri": db_config.uri,
-                    }
+                    entry: dict = {"type": db_config.type}
+                    if db_config.path_pattern:
+                        entry["path_pattern"] = db_config.path_pattern
+                    elif db_config.uri:
+                        entry["uri"] = db_config.uri
                     if db_config.logic_name and db_config.logic_name != db_name:
                         entry["name"] = db_config.logic_name
                 else:

--- a/datus/cli/namespace_manager.py
+++ b/datus/cli/namespace_manager.py
@@ -11,6 +11,7 @@ without requiring users to manually write conf/agent.yml files.
 """
 
 from getpass import getpass
+from urllib.parse import urlsplit, urlunsplit
 
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
@@ -25,6 +26,21 @@ from datus.utils.path_manager import get_path_manager
 
 logger = get_logger(__name__)
 console = Console()
+
+
+def _redact_uri(uri: str) -> str:
+    """Redact any password in a database URI, keeping scheme/host/path visible."""
+    try:
+        parts = urlsplit(uri)
+    except ValueError:
+        return uri
+    if parts.password is None:
+        return uri
+    username = parts.username or ""
+    host = parts.hostname or ""
+    port = f":{parts.port}" if parts.port else ""
+    netloc = f"{username}:***@{host}{port}" if username else f"***@{host}{port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 def _validate_namespace_name(name: str) -> tuple[bool, str]:
@@ -99,7 +115,7 @@ class NamespaceManager:
             if db_config.host:
                 console.print(f"    Host: {db_config.host}:{db_config.port}")
             if db_config.uri:
-                console.print(f"    URI: {db_config.uri}")
+                console.print(f"    URI: {_redact_uri(db_config.uri)}")
             if db_config.database:
                 console.print(f"    Database: {db_config.database}")
             if db_config.schema:
@@ -301,9 +317,17 @@ class NamespaceManager:
                     if db_config.logic_name and db_config.logic_name != db_name:
                         entry["name"] = db_config.logic_name
                 else:
-                    entry = {k: v for k, v in db_config.to_dict().items() if v}
-                    for key in ("logic_name", "path_pattern", "extra", "default"):
-                        entry.pop(key, None)
+                    entry = {
+                        k: v
+                        for k, v in db_config.to_dict().items()
+                        if v and k not in ("logic_name", "path_pattern", "extra", "default")
+                    }
+                    # Preserve adapter-specific fields stored in DbConfig.extra
+                    if isinstance(db_config.extra, dict):
+                        for extra_key, extra_value in db_config.extra.items():
+                            if extra_value in (None, ""):
+                                continue
+                            entry.setdefault(extra_key, extra_value)
 
                 if db_config.default:
                     entry["default"] = True

--- a/datus/cli/namespace_manager.py
+++ b/datus/cli/namespace_manager.py
@@ -54,7 +54,10 @@ class NamespaceManager:
     def __init__(self, config_path: str):
         self.config_path = config_path
         try:
-            self.agent_config = load_agent_config(config=config_path, action="namespace", reload=True)
+            # NamespaceManager is now a compat shell over services.databases.
+            # Load without action-specific default-db enforcement because
+            # namespace CRUD should work even when no default DB is selected.
+            self.agent_config = load_agent_config(config=config_path, reload=True)
         except DatusException as e:
             if e.code == ErrorCode.COMMON_FILE_NOT_FOUND:
                 console.print("❌ Configuration file not found.")
@@ -83,33 +86,33 @@ class NamespaceManager:
             return 1
 
     def list(self) -> int:
-        if not self.agent_config.namespaces:
+        databases = self.agent_config.services.databases
+        if not databases:
             console.print("No namespace configured.")
             return 0
 
         console.print("[bold yellow]Configured namespaces:[/bold yellow]")
-        for namespace_name, db_configs in self.agent_config.namespaces.items():
+        for namespace_name, db_config in databases.items():
             console.print(f"\nNamespace: {namespace_name}")
-            for db_name, db_config in db_configs.items():
-                console.print(f"  Database: {db_name}")
-                console.print(f"    Type: {db_config.type}")
-                if db_config.host:
-                    console.print(f"    Host: {db_config.host}:{db_config.port}")
-                if db_config.uri:
-                    console.print(f"    URI: {db_config.uri}")
-                if db_config.database:
-                    console.print(f"    Database: {db_config.database}")
-                if db_config.schema:
-                    console.print(f"    Schema: {db_config.schema}")
-                if db_config.account:
-                    console.print(f"    Account: {db_config.account}")
-                if db_config.warehouse:
-                    console.print(f"    Warehouse: {db_config.warehouse}")
-                if db_config.catalog:
-                    console.print(f"    Catalog: {db_config.catalog}")
-                if db_config.username:
-                    console.print(f"    Username: {db_config.username}")
-                console.print()
+            console.print(f"  Database: {namespace_name}")
+            console.print(f"    Type: {db_config.type}")
+            if db_config.host:
+                console.print(f"    Host: {db_config.host}:{db_config.port}")
+            if db_config.uri:
+                console.print(f"    URI: {db_config.uri}")
+            if db_config.database:
+                console.print(f"    Database: {db_config.database}")
+            if db_config.schema:
+                console.print(f"    Schema: {db_config.schema}")
+            if db_config.account:
+                console.print(f"    Account: {db_config.account}")
+            if db_config.warehouse:
+                console.print(f"    Warehouse: {db_config.warehouse}")
+            if db_config.catalog:
+                console.print(f"    Catalog: {db_config.catalog}")
+            if db_config.username:
+                console.print(f"    Username: {db_config.username}")
+            console.print()
         return 0
 
     def add(self) -> int:
@@ -124,7 +127,7 @@ class NamespaceManager:
             return 1
 
         # Check if namespace already exists
-        if namespace_name in self.agent_config.namespaces:
+        if namespace_name in self.agent_config.services.databases:
             console.print(f"❌ Namespace '{namespace_name}' already exists")
             return 1
 
@@ -241,13 +244,14 @@ class NamespaceManager:
         console.print("[bold yellow]Delete Namespace[/bold yellow]")
 
         # Check if there are any namespaces to delete
-        if not self.agent_config.namespaces:
+        databases = self.agent_config.services.databases
+        if not databases:
             console.print("❌ No namespaces configured to delete")
             return 1
 
         # List available namespaces
         console.print("Available namespaces:")
-        for namespace_name in self.agent_config.namespaces.keys():
+        for namespace_name in databases.keys():
             console.print(f"  - {namespace_name}")
 
         # Get namespace name to delete
@@ -257,7 +261,7 @@ class NamespaceManager:
             return 1
 
         # Check if namespace exists
-        if namespace_name not in self.agent_config.namespaces:
+        if namespace_name not in databases:
             console.print(f"❌ Namespace '{namespace_name}' does not exist")
             return 1
 
@@ -271,7 +275,7 @@ class NamespaceManager:
             return 1
 
         # Delete namespace from configuration
-        del self.agent_config.namespaces[namespace_name]
+        del self.agent_config.services.databases[namespace_name]
 
         # Save configuration
         if self._save_configuration():
@@ -285,33 +289,37 @@ class NamespaceManager:
         """Save configuration to agent.yml file."""
         try:
             configure_manager = configuration_manager(config_path=self.config_path, reload=True)
-            namespace_section = {}
+            databases_section = {}
 
-            for ns_name, db_configs in self.agent_config.namespaces.items():
-                namespace_dict = {}
-                db_configs_list = list(db_configs.values())
-
-                if len(db_configs_list) == 1:
-                    db_config = db_configs_list[0]
-                    if db_config.type in (DBType.SQLITE, DBType.DUCKDB):
-                        namespace_dict["uri"] = db_config.uri
-                        namespace_dict["type"] = db_config.type
-                        namespace_dict["name"] = db_config.logic_name
-                    else:
-                        # Filter out empty fields from to_dict()
-                        namespace_dict = {k: v for k, v in db_config.to_dict().items() if v}
+            for db_name, db_config in self.agent_config.services.databases.items():
+                if db_config.type in (DBType.SQLITE, DBType.DUCKDB):
+                    entry = {
+                        "type": db_config.type,
+                        "uri": db_config.uri,
+                    }
+                    if db_config.logic_name and db_config.logic_name != db_name:
+                        entry["name"] = db_config.logic_name
                 else:
-                    namespace_dict["type"] = db_configs_list[0].type
-                    namespace_dict["dbs"] = []
-                    for db_config in db_configs_list:
-                        _db_config = {}
-                        _db_config["name"] = db_config.logic_name
-                        _db_config["uri"] = db_config.uri
-                        namespace_dict["dbs"].append(_db_config)
+                    entry = {k: v for k, v in db_config.to_dict().items() if v}
+                    for key in ("logic_name", "path_pattern", "extra", "default"):
+                        entry.pop(key, None)
 
-                namespace_section[ns_name] = namespace_dict
+                if db_config.default:
+                    entry["default"] = True
 
-            configure_manager.update(updates={"namespace": namespace_section}, delete_old_key=True)
+                databases_section[db_name] = entry
+
+            services_section = {
+                "databases": databases_section,
+                "semantic_layer": dict(self.agent_config.services.semantic_layer),
+                "bi_tools": dict(self.agent_config.services.bi_tools),
+                "schedulers": dict(self.agent_config.services.schedulers),
+            }
+
+            configure_manager.update(updates={"services": services_section}, delete_old_key=True)
+            if "namespace" in configure_manager.data:
+                del configure_manager.data["namespace"]
+                configure_manager.save()
             console.print(f"Configuration saved to {configure_manager.config_path}")
             return True
         except Exception as e:

--- a/datus/cli/namespace_manager.py
+++ b/datus/cli/namespace_manager.py
@@ -52,8 +52,9 @@ def _validate_port(port_str: str) -> tuple[bool, str]:
 
 class NamespaceManager:
     def __init__(self, config_path: str):
+        self.config_path = config_path
         try:
-            self.agent_config = load_agent_config(config=config_path, action="namespace")
+            self.agent_config = load_agent_config(config=config_path, action="namespace", reload=True)
         except DatusException as e:
             if e.code == ErrorCode.COMMON_FILE_NOT_FOUND:
                 console.print("❌ Configuration file not found.")
@@ -220,9 +221,9 @@ class NamespaceManager:
             console.print("✔ Database connection test successful\n")
 
             # Add to agent configuration (namespace is guaranteed to not exist from earlier check)
-            # Use service.databases directly — the namespaces property is a read-only compat view
+            # Use services.databases directly — the namespaces property is a read-only compat view
             db_config = DbConfig.filter_kwargs(DbConfig, config_data)
-            self.agent_config.service.databases[namespace_name] = db_config
+            self.agent_config.services.databases[namespace_name] = db_config
 
             # Save configuration
             if self._save_configuration():
@@ -283,7 +284,7 @@ class NamespaceManager:
     def _save_configuration(self) -> bool:
         """Save configuration to agent.yml file."""
         try:
-            configure_manager = configuration_manager()
+            configure_manager = configuration_manager(config_path=self.config_path, reload=True)
             namespace_section = {}
 
             for ns_name, db_configs in self.agent_config.namespaces.items():

--- a/datus/cli/project_init.py
+++ b/datus/cli/project_init.py
@@ -7,7 +7,7 @@
 Runs only in REPL mode when the project-level overlay does not yet
 exist.  The wizard is intentionally minimal: it asks the user to pick
 one of the LLM models already defined in the shared ``agent.yml`` and
-one of the databases under ``agent.service.databases``, plus an
+one of the databases under ``agent.services.databases``, plus an
 optional ``project_name``.  Everything else (provider configuration,
 API keys, database URIs, etc.) still lives in the base file — this
 overlay is just "which one do I want for this project".
@@ -55,12 +55,12 @@ def run_project_init(base_config: AgentConfig, cwd: Optional[str] = None) -> Pro
                 )
             },
         )
-    if not base_config.service.databases:
+    if not base_config.services.databases:
         raise DatusException(
             code=ErrorCode.COMMON_CONFIG_ERROR,
             message_args={
                 "config_error": (
-                    "Base agent.yml has no 'agent.service.databases' defined. "
+                    "Base agent.yml has no 'agent.services.databases' defined. "
                     "Run 'datus configure' to add at least one database first."
                 )
             },
@@ -84,8 +84,8 @@ def run_project_init(base_config: AgentConfig, cwd: Optional[str] = None) -> Pro
 
     console.print()
     console.print("[bold]- Select default database (from agent.yml):[/]")
-    db_choices = {name: f"{name}  ({cfg.type})" for name, cfg in base_config.service.databases.items()}
-    db_default = base_config.service.default_database or next(iter(db_choices))
+    db_choices = {name: f"{name}  ({cfg.type})" for name, cfg in base_config.services.databases.items()}
+    db_default = base_config.services.default_database or next(iter(db_choices))
     default_database = select_choice(console, db_choices, default=db_default)
     if not default_database:
         default_database = db_default

--- a/datus/cli/service_manager.py
+++ b/datus/cli/service_manager.py
@@ -6,7 +6,7 @@
 """
 Manage command for Services (databases, semantic layer, BI tools, schedulers).
 
-Replaces the legacy NamespaceManager. Works with the new service.databases
+Replaces the legacy NamespaceManager. Works with the new services.databases
 config structure where each database is an independent entry.
 """
 
@@ -54,8 +54,9 @@ class ServiceManager:
     """Manage services (databases, semantic layer, BI tools, schedulers) in agent.yml."""
 
     def __init__(self, config_path: str):
+        self.config_path = config_path
         try:
-            self.agent_config = load_agent_config(config=config_path, action="service")
+            self.agent_config = load_agent_config(config=config_path, action="service", reload=True)
         except DatusException as e:
             if e.code == ErrorCode.COMMON_FILE_NOT_FOUND:
                 console.print("Configuration file not found.")
@@ -83,7 +84,7 @@ class ServiceManager:
             return 1
 
     def list(self) -> int:
-        databases = self.agent_config.service.databases
+        databases = self.agent_config.services.databases
         if not databases:
             console.print("No databases configured.")
             return 0
@@ -94,7 +95,7 @@ class ServiceManager:
         table.add_column("Connection")
         table.add_column("Default")
 
-        default_db = self.agent_config.service.default_database
+        default_db = self.agent_config.services.default_database
         for db_name, db_config in databases.items():
             connection = ""
             if db_config.uri:
@@ -109,19 +110,19 @@ class ServiceManager:
 
         console.print(table)
 
-        semantic_layer = self.agent_config.service.semantic_layer
+        semantic_layer = self.agent_config.services.semantic_layer
         if semantic_layer:
             console.print("\n[bold yellow]Semantic Layer:[/bold yellow]")
             for name, cfg in semantic_layer.items():
                 console.print(f"  {name}: {cfg}")
 
-        bi_tools = self.agent_config.service.bi_tools
+        bi_tools = self.agent_config.services.bi_tools
         if bi_tools:
             console.print("\n[bold yellow]BI Tools:[/bold yellow]")
             for name, cfg in bi_tools.items():
                 console.print(f"  {name}: {cfg}")
 
-        schedulers = self.agent_config.service.schedulers
+        schedulers = self.agent_config.services.schedulers
         if schedulers:
             console.print("\n[bold yellow]Schedulers:[/bold yellow]")
             for name, cfg in schedulers.items():
@@ -139,7 +140,7 @@ class ServiceManager:
             console.print(f"{error_msg}")
             return 1
 
-        if db_name in self.agent_config.service.databases:
+        if db_name in self.agent_config.services.databases:
             console.print(f"Database '{db_name}' already exists")
             return 1
 
@@ -207,7 +208,7 @@ class ServiceManager:
                 config_data[field_name] = value
 
         # Ask if this should be the default
-        if not self.agent_config.service.databases:
+        if not self.agent_config.services.databases:
             config_data["default"] = True
         elif Confirm.ask("- Set as default database?", default=False):
             config_data["default"] = True
@@ -222,7 +223,7 @@ class ServiceManager:
             db_config = DbConfig.filter_kwargs(DbConfig, config_data)
             db_config.logic_name = db_name
             db_config.default = config_data.get("default", False)
-            self.agent_config.service.databases[db_name] = db_config
+            self.agent_config.services.databases[db_name] = db_config
 
             if self._save_configuration():
                 console.print(f"Database '{db_name}' added successfully")
@@ -238,7 +239,7 @@ class ServiceManager:
         """Interactive method to delete a database configuration."""
         console.print("[bold yellow]Delete Database[/bold yellow]")
 
-        databases = self.agent_config.service.databases
+        databases = self.agent_config.services.databases
         if not databases:
             console.print("No databases configured to delete")
             return 1
@@ -264,7 +265,7 @@ class ServiceManager:
             console.print("Deletion cancelled")
             return 1
 
-        del self.agent_config.service.databases[db_name]
+        del self.agent_config.services.databases[db_name]
 
         if self._save_configuration():
             console.print(f"Database '{db_name}' deleted successfully")
@@ -274,12 +275,12 @@ class ServiceManager:
             return 1
 
     def _save_configuration(self) -> bool:
-        """Save service configuration to agent.yml file."""
+        """Save services configuration to the agent.yml file."""
         try:
-            configure_manager = configuration_manager()
+            configure_manager = configuration_manager(config_path=self.config_path, reload=True)
             databases_section = {}
 
-            for db_name, db_config in self.agent_config.service.databases.items():
+            for db_name, db_config in self.agent_config.services.databases.items():
                 if db_config.type in (DBType.SQLITE, DBType.DUCKDB):
                     entry = {
                         "type": db_config.type,
@@ -298,14 +299,14 @@ class ServiceManager:
 
                 databases_section[db_name] = entry
 
-            service_section = {
+            services_section = {
                 "databases": databases_section,
-                "semantic_layer": dict(self.agent_config.service.semantic_layer),
-                "bi_tools": dict(self.agent_config.service.bi_tools),
-                "schedulers": dict(self.agent_config.service.schedulers),
+                "semantic_layer": dict(self.agent_config.services.semantic_layer),
+                "bi_tools": dict(self.agent_config.services.bi_tools),
+                "schedulers": dict(self.agent_config.services.schedulers),
             }
 
-            configure_manager.update(updates={"service": service_section}, delete_old_key=True)
+            configure_manager.update(updates={"services": services_section}, delete_old_key=True)
             # Remove legacy namespace key if it exists
             if "namespace" in configure_manager.data:
                 del configure_manager.data["namespace"]

--- a/datus/cli/service_manager.py
+++ b/datus/cli/service_manager.py
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 """
-Manage command for Services (databases, BI tools, schedulers).
+Manage command for Services (databases, semantic layer, BI tools, schedulers).
 
 Replaces the legacy NamespaceManager. Works with the new service.databases
 config structure where each database is an independent entry.
@@ -51,7 +51,7 @@ def _validate_port(port_str: str) -> tuple[bool, str]:
 
 
 class ServiceManager:
-    """Manage services (databases, BI tools, schedulers) in agent.yml."""
+    """Manage services (databases, semantic layer, BI tools, schedulers) in agent.yml."""
 
     def __init__(self, config_path: str):
         try:
@@ -109,7 +109,12 @@ class ServiceManager:
 
         console.print(table)
 
-        # Show BI tools and schedulers if configured
+        semantic_layer = self.agent_config.service.semantic_layer
+        if semantic_layer:
+            console.print("\n[bold yellow]Semantic Layer:[/bold yellow]")
+            for name, cfg in semantic_layer.items():
+                console.print(f"  {name}: {cfg}")
+
         bi_tools = self.agent_config.service.bi_tools
         if bi_tools:
             console.print("\n[bold yellow]BI Tools:[/bold yellow]")
@@ -295,6 +300,7 @@ class ServiceManager:
 
             service_section = {
                 "databases": databases_section,
+                "semantic_layer": dict(self.agent_config.service.semantic_layer),
                 "bi_tools": dict(self.agent_config.service.bi_tools),
                 "schedulers": dict(self.agent_config.service.schedulers),
             }

--- a/datus/cli/tutorial.py
+++ b/datus/cli/tutorial.py
@@ -47,26 +47,26 @@ class BenchmarkTutorial:
         self.benchmark_path = agent_config.path_manager.benchmark_dir
         if (
             self.namespace_name not in agent_config.benchmark_configs
-            or self.namespace_name not in agent_config.service.databases
+            or self.namespace_name not in agent_config.services.databases
         ):
-            # Add california_schools database to service.databases
+            # Add california_schools database to services.databases
             config_manager = configuration_manager(config_path=self.config_path, reload=True)
-            service_config = config_manager.data.get(
-                "service",
+            services_config = config_manager.data.get(
+                "services",
                 {"databases": {}, "semantic_layer": {}, "bi_tools": {}, "schedulers": {}},
             )
-            service_config.setdefault("databases", {})
-            service_config.setdefault("semantic_layer", {})
-            service_config.setdefault("bi_tools", {})
-            service_config.setdefault("schedulers", {})
-            service_config["databases"]["california_schools"] = {
+            services_config.setdefault("databases", {})
+            services_config.setdefault("semantic_layer", {})
+            services_config.setdefault("bi_tools", {})
+            services_config.setdefault("schedulers", {})
+            services_config["databases"]["california_schools"] = {
                 "type": "sqlite",
                 "name": "california_schools",
                 "uri": "~/.datus/benchmark/california_schools/california_schools.sqlite",
             }
             config_manager.update_item(
-                "service",
-                service_config,
+                "services",
+                services_config,
                 delete_old_key=False,
                 save=False,
             )
@@ -74,7 +74,7 @@ class BenchmarkTutorial:
 
             from rich.syntax import Syntax
 
-            self.console.print(Syntax(dict_to_yaml_str(service_config["databases"]), lexer="yaml"))
+            self.console.print(Syntax(dict_to_yaml_str(services_config["databases"]), lexer="yaml"))
 
             benchmark_config = {
                 self.namespace_name: {

--- a/datus/cli/tutorial.py
+++ b/datus/cli/tutorial.py
@@ -51,8 +51,14 @@ class BenchmarkTutorial:
         ):
             # Add california_schools database to service.databases
             config_manager = configuration_manager(config_path=self.config_path, reload=True)
-            service_config = config_manager.data.get("service", {"databases": {}, "bi_tools": {}, "schedulers": {}})
+            service_config = config_manager.data.get(
+                "service",
+                {"databases": {}, "semantic_layer": {}, "bi_tools": {}, "schedulers": {}},
+            )
             service_config.setdefault("databases", {})
+            service_config.setdefault("semantic_layer", {})
+            service_config.setdefault("bi_tools", {})
+            service_config.setdefault("schedulers", {})
             service_config["databases"]["california_schools"] = {
                 "type": "sqlite",
                 "name": "california_schools",

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -150,8 +150,8 @@ class DbConfig:
 
 
 @dataclass
-class ServiceConfig:
-    """Structured service configuration: databases, semantic layer, BI tools, schedulers.
+class ServicesConfig:
+    """Structured services configuration: databases, semantic layer, BI tools, schedulers.
 
     Replaces the old flat 'namespace' config. Each database is an independent entry.
     """
@@ -172,10 +172,10 @@ class ServiceConfig:
         return None
 
     @classmethod
-    def from_dict(cls, raw: Dict[str, Any]) -> "ServiceConfig":
-        """Parse service config from agent.yml 'service' section."""
+    def from_dict(cls, raw: Dict[str, Any]) -> "ServicesConfig":
+        """Parse services config from agent.yml 'services' section."""
         return cls(
-            databases={},  # populated by AgentConfig._init_service_config()
+            databases={},  # populated by AgentConfig._init_services_config()
             semantic_layer=raw.get("semantic_layer", {}),
             bi_tools=raw.get("bi_tools", {}),
             schedulers=raw.get("schedulers", {}),
@@ -183,7 +183,7 @@ class ServiceConfig:
 
     @classmethod
     def migrate_from_namespace(cls, namespace_config: Dict[str, Any]) -> Dict[str, Any]:
-        """Convert old namespace config format to new service.databases format.
+        """Convert old namespace config format to new services.databases format.
 
         Old format:
             namespace:
@@ -196,7 +196,7 @@ class ServiceConfig:
                     uri: ...
 
         New format:
-            service:
+            services:
               databases:
                 db1:
                   type: sqlite
@@ -411,7 +411,7 @@ class AgentConfig:
     _current_database: str
     _project_name: str
     _trajectory_dir: str
-    service: ServiceConfig
+    services: ServicesConfig
     scheduler_services: Dict[str, Dict[str, Any]]
     semantic_layer_configs: Dict[str, Dict[str, Any]]
 
@@ -489,18 +489,18 @@ class AgentConfig:
             if k != "plan":
                 # Store workflow configuration, supporting both list format and {steps: [], config: {}} format
                 self.custom_workflows[k] = v
-        # Initialize service config (databases, semantic layer, BI tools, schedulers)
-        # Supports both new 'service' format and legacy 'namespace' format with auto-migration
-        service_raw = kwargs.get("service", {})
+        # Initialize services config (databases, semantic layer, BI tools, schedulers)
+        # Supports the new 'services' format and legacy 'namespace' format with auto-migration
+        services_raw = kwargs.get("services", {})
         namespace_raw = kwargs.get("namespace", {})
-        if not service_raw and namespace_raw:
-            logger.info("Migrating legacy 'namespace' config to 'service.databases' format")
-            service_raw = ServiceConfig.migrate_from_namespace(namespace_raw)
-        self.service = ServiceConfig.from_dict(service_raw)
-        self._init_service_config(service_raw.get("databases", {}))
-        self.init_semantic_layer(self.service.semantic_layer)
-        self.init_dashboard(self.service.bi_tools)
-        self.init_scheduler_services(self.service.schedulers)
+        if not services_raw and namespace_raw:
+            logger.info("Migrating legacy 'namespace' config to 'services.databases' format")
+            services_raw = ServicesConfig.migrate_from_namespace(namespace_raw)
+        self.services = ServicesConfig.from_dict(services_raw)
+        self._init_services_config(services_raw.get("databases", {}))
+        self.init_semantic_layer(self.services.semantic_layer)
+        self.init_dashboard(self.services.bi_tools)
+        self.init_scheduler_services(self.services.schedulers)
 
         # SaaS mode: skip _init_dirs() because callers want only derived paths here,
         # not full local directory / backend initialization.
@@ -593,16 +593,16 @@ class AgentConfig:
 
     @current_database.setter
     def current_database(self, value):
-        """Set the current database name (must exist in service.databases)."""
+        """Set the current database name (must exist in services.databases)."""
         if not value:
             return
-        if value not in self.service.databases:
+        if value not in self.services.databases:
             raise DatusException(
                 ErrorCode.COMMON_CONFIG_ERROR,
-                message=f"No database configuration named `{value}` found. Available: {list(self.service.databases.keys())}",
+                message=f"No database configuration named `{value}` found. Available: {list(self.services.databases.keys())}",
             )
         self._current_database = value
-        self.db_type = self.service.databases[value].type
+        self.db_type = self.services.databases[value].type
 
     @property
     def project_name(self) -> str:
@@ -643,7 +643,7 @@ class AgentConfig:
     def current_namespace(self, value: str):
         """Backward-compat: setting current_namespace now sets current_database.
 
-        Accepts a database name from service.databases. Also accepts legacy namespace names
+        Accepts a database name from services.databases. Also accepts legacy namespace names
         which are auto-migrated to database names.
         """
         if not value:
@@ -651,7 +651,7 @@ class AgentConfig:
                 code=ErrorCode.COMMON_FIELD_REQUIRED,
                 message_args={"field_name": "database"},
             )
-        if value not in self.service.databases:
+        if value not in self.services.databases:
             raise DatusException(
                 code=ErrorCode.COMMON_UNSUPPORTED,
                 message_args={"field_name": "database", "your_value": value},
@@ -659,20 +659,20 @@ class AgentConfig:
         if value == self._current_database:
             return
         self._current_database = value
-        db_config = self.service.databases[value]
+        db_config = self.services.databases[value]
         self.db_type = db_config.type
 
     @property
     def namespaces(self) -> Dict[str, Dict[str, DbConfig]]:
-        """Backward-compat: wraps service.databases in old namespace structure.
+        """Backward-compat: wraps services.databases in old namespace structure.
 
         Each database entry becomes its own "namespace" with a single db inside,
         so DBManager only initializes one connection per namespace key.
         """
-        return {db_name: {db_name: db_config} for db_name, db_config in self.service.databases.items()}
+        return {db_name: {db_name: db_config} for db_name, db_config in self.services.databases.items()}
 
-    def _init_service_config(self, databases_config: Dict[str, Any]):
-        """Parse service.databases section into ServiceConfig.databases."""
+    def _init_services_config(self, databases_config: Dict[str, Any]):
+        """Parse services.databases section into ServicesConfig.databases."""
         for db_name, db_config_dict in databases_config.items():
             if not isinstance(db_config_dict, dict):
                 continue
@@ -692,12 +692,12 @@ class AgentConfig:
                     db_config = _parse_single_file_db(db_config_dict, db_type)
                     db_config.logic_name = db_name
                     db_config.default = is_default
-                    self.service.databases[db_name] = db_config
+                    self.services.databases[db_name] = db_config
             else:
                 db_config = DbConfig.filter_kwargs(DbConfig, db_config_dict)
                 db_config.logic_name = db_name
                 db_config.default = is_default
-                self.service.databases[db_name] = db_config
+                self.services.databases[db_name] = db_config
 
     def _parse_glob_pattern_flat(self, base_name: str, path_pattern: str, db_type: str):
         """Parse glob pattern and register each matched file as an independent database entry."""
@@ -722,7 +722,7 @@ class AgentConfig:
                 schema="",
                 logic_name=entry_name,
             )
-            self.service.databases[entry_name] = child_config
+            self.services.databases[entry_name] = child_config
 
         if not any_db_path:
             logger.warning(
@@ -772,7 +772,7 @@ class AgentConfig:
 
     def current_db_config(self, db_name: str = "") -> DbConfig:
         """Get a database config by name, or the current/default one."""
-        databases = self.service.databases
+        databases = self.services.databases
         if db_name and db_name in databases:
             return databases[db_name]
         if self._current_database and self._current_database in databases:
@@ -780,7 +780,7 @@ class AgentConfig:
         if len(databases) == 1:
             return list(databases.values())[0]
         if not db_name:
-            default = self.service.default_database
+            default = self.services.default_database
             if default:
                 return databases[default]
         raise DatusException(
@@ -790,7 +790,7 @@ class AgentConfig:
 
     def current_db_configs(self) -> Dict[str, DbConfig]:
         """Backward-compat: returns all databases (was namespace-scoped, now returns all)."""
-        return self.service.databases
+        return self.services.databases
 
     def default_scheduler_service(self) -> Optional[str]:
         defaults = [name for name, cfg in self.scheduler_services.items() if cfg.get("default")]
@@ -799,7 +799,7 @@ class AgentConfig:
                 ErrorCode.COMMON_CONFIG_ERROR,
                 message=(
                     "Multiple scheduler services are marked with `default: true` in "
-                    "`agent.service.schedulers`. Keep at most one default scheduler."
+                    "`agent.services.schedulers`. Keep at most one default scheduler."
                 ),
             )
         if defaults:
@@ -827,13 +827,13 @@ class AgentConfig:
         if not self.scheduler_services:
             raise DatusException(
                 ErrorCode.COMMON_CONFIG_ERROR,
-                message="No scheduler configured in `agent.service.schedulers`.",
+                message="No scheduler configured in `agent.services.schedulers`.",
             )
 
         raise DatusException(
             ErrorCode.COMMON_CONFIG_ERROR,
             message=(
-                "Multiple scheduler services are configured in `agent.service.schedulers`, "
+                "Multiple scheduler services are configured in `agent.services.schedulers`, "
                 "set `scheduler_service` on the scheduler node."
             ),
         )
@@ -848,7 +848,7 @@ class AgentConfig:
             raise DatusException(
                 ErrorCode.COMMON_CONFIG_ERROR,
                 message=(
-                    f"No semantic layer named `{normalized}` found in `agent.service.semantic_layer`. "
+                    f"No semantic layer named `{normalized}` found in `agent.services.semantic_layer`. "
                     f"Available: {list(self.semantic_layer_configs.keys())}"
                 ),
             )
@@ -860,7 +860,7 @@ class AgentConfig:
         raise DatusException(
             ErrorCode.COMMON_CONFIG_ERROR,
             message=(
-                "Multiple semantic layers are configured in `agent.service.semantic_layer`, "
+                "Multiple semantic layers are configured in `agent.services.semantic_layer`, "
                 "set `semantic_adapter` on the semantic node."
             ),
         )
@@ -883,7 +883,7 @@ class AgentConfig:
         config = self.get_semantic_layer_config(resolved_adapter)
         config.setdefault("type", resolved_adapter)
 
-        db_name = database_name or self.current_database or self.service.default_database
+        db_name = database_name or self.current_database or self.services.default_database
         if db_name:
             config.setdefault("namespace", db_name)
             db_config = _db_config_to_semantic_adapter_config(self.current_db_config(db_name))
@@ -1021,8 +1021,8 @@ class AgentConfig:
             db_arg = kwargs.get("database", "") or kwargs.get("namespace", "")
             if db_arg:
                 self.current_namespace = db_arg  # uses the compat setter
-            elif self.service.default_database:
-                self.current_namespace = self.service.default_database
+            elif self.services.default_database:
+                self.current_namespace = self.services.default_database
         if kwargs.get("benchmark", ""):
             benchmark_platform = kwargs["benchmark"]
             # Validate benchmark is supported (will raise exception if not)
@@ -1089,15 +1089,15 @@ class AgentConfig:
 
     def _current_db_config(self) -> Dict[str, DbConfig]:
         """Backward-compat: returns all database configs."""
-        if not self._current_database and not self.service.databases:
+        if not self._current_database and not self.services.databases:
             raise DatusException(
                 code=ErrorCode.COMMON_FIELD_REQUIRED,
                 message="Database is required, please run with --database <database>",
             )
-        return self.service.databases
+        return self.services.databases
 
     def current_db_name_type(self, db_name: str) -> tuple[str, str]:
-        databases = self.service.databases
+        databases = self.services.databases
         if db_name and db_name in databases:
             return db_name, databases[db_name].type
         if self._current_database and self._current_database in databases:
@@ -1195,7 +1195,7 @@ class AgentConfig:
                 raise DatusException(
                     ErrorCode.COMMON_CONFIG_ERROR,
                     message=(
-                        f"BI tool `{service_name}` must use the same key and type in `agent.service.bi_tools`. "
+                        f"BI tool `{service_name}` must use the same key and type in `agent.services.bi_tools`. "
                         f"Got key `{service_name}` with type `{declared_type}`."
                     ),
                 )
@@ -1234,7 +1234,7 @@ class AgentConfig:
                     ErrorCode.COMMON_CONFIG_ERROR,
                     message=(
                         f"Scheduler service `{service_name}` must declare a scheduler `type` in "
-                        f"`agent.service.schedulers.{service_name}`."
+                        f"`agent.services.schedulers.{service_name}`."
                     ),
                 )
             resolved["type"] = scheduler_type
@@ -1259,7 +1259,7 @@ class AgentConfig:
                     ErrorCode.COMMON_CONFIG_ERROR,
                     message=(
                         f"Semantic layer `{service_name}` must use the adapter type as the key in "
-                        f"`agent.service.semantic_layer`. Got key `{service_name}` with type `{declared_type}`."
+                        f"`agent.services.semantic_layer`. Got key `{service_name}` with type `{declared_type}`."
                     ),
                 )
             resolved["type"] = normalized_name

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -491,8 +491,12 @@ class AgentConfig:
                 self.custom_workflows[k] = v
         # Initialize services config (databases, semantic layer, BI tools, schedulers)
         # Supports the new 'services' format and legacy 'namespace' format with auto-migration
-        services_raw = kwargs.get("services", {})
-        namespace_raw = kwargs.get("namespace", {})
+        services_raw = kwargs.get("services") or {}
+        namespace_raw = kwargs.get("namespace") or {}
+        if not isinstance(services_raw, dict):
+            services_raw = {}
+        if not isinstance(namespace_raw, dict):
+            namespace_raw = {}
         if not services_raw and namespace_raw:
             logger.info("Migrating legacy 'namespace' config to 'services.databases' format")
             services_raw = ServicesConfig.migrate_from_namespace(namespace_raw)
@@ -883,7 +887,7 @@ class AgentConfig:
         config = self.get_semantic_layer_config(resolved_adapter)
         config.setdefault("type", resolved_adapter)
 
-        db_name = database_name or self.current_database or self.services.default_database
+        db_name = database_name or config.get("namespace") or self.current_database or self.services.default_database
         if db_name:
             config.setdefault("namespace", db_name)
             db_config = _db_config_to_semantic_adapter_config(self.current_db_config(db_name))
@@ -1286,13 +1290,21 @@ def _db_config_to_semantic_adapter_config(db_config: Optional[DbConfig]) -> Opti
         return None
 
     raw = db_config.to_dict()
-    return {
+    extra = raw.get("extra")
+    semantic_db_config = {
         key: str(value)
         for key, value in raw.items()
         if value is not None
         and value != ""
         and key not in ("extra", "logic_name", "path_pattern", "catalog", "default")
     }
+    # Merge connector-specific `extra` fields without overwriting explicit top-level keys
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            if value is None or value == "":
+                continue
+            semantic_db_config.setdefault(key, str(value))
+    return semantic_db_config
 
 
 def _resolve_nested_value(value: Any) -> Any:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -151,12 +151,13 @@ class DbConfig:
 
 @dataclass
 class ServiceConfig:
-    """Structured service configuration: databases, BI tools, schedulers.
+    """Structured service configuration: databases, semantic layer, BI tools, schedulers.
 
     Replaces the old flat 'namespace' config. Each database is an independent entry.
     """
 
     databases: Dict[str, DbConfig] = field(default_factory=dict)
+    semantic_layer: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     bi_tools: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     schedulers: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
@@ -175,6 +176,7 @@ class ServiceConfig:
         """Parse service config from agent.yml 'service' section."""
         return cls(
             databases={},  # populated by AgentConfig._init_service_config()
+            semantic_layer=raw.get("semantic_layer", {}),
             bi_tools=raw.get("bi_tools", {}),
             schedulers=raw.get("schedulers", {}),
         )
@@ -218,7 +220,7 @@ class ServiceConfig:
                 databases[ns_name] = ns_cfg
             else:
                 databases[ns_name] = ns_cfg
-        return {"databases": databases, "bi_tools": {}, "schedulers": {}}
+        return {"databases": databases, "semantic_layer": {}, "bi_tools": {}, "schedulers": {}}
 
 
 @dataclass
@@ -410,6 +412,8 @@ class AgentConfig:
     _project_name: str
     _trajectory_dir: str
     service: ServiceConfig
+    scheduler_services: Dict[str, Dict[str, Any]]
+    semantic_layer_configs: Dict[str, Dict[str, Any]]
 
     def __init__(self, nodes: Dict[str, NodeConfig], **kwargs):
         """
@@ -451,8 +455,9 @@ class AgentConfig:
         self.api_config: Dict[str, Any] = kwargs.get("api", {}) or {}
         self.agentic_nodes = kwargs.get("agentic_nodes", {})
         self.dashboard_config: Dict[str, DashboardConfig] = {}
-        self.init_dashboard(kwargs.get("dashboard", {}))
-        self.scheduler_config: Dict[str, Any] = kwargs.get("scheduler", {})
+        self.scheduler_services = {}
+        self.scheduler_config: Dict[str, Any] = {}
+        self.semantic_layer_configs = {}
 
         for name, raw_config in self.agentic_nodes.items():
             if not _SAFE_NAME_RE.match(name):
@@ -484,7 +489,7 @@ class AgentConfig:
             if k != "plan":
                 # Store workflow configuration, supporting both list format and {steps: [], config: {}} format
                 self.custom_workflows[k] = v
-        # Initialize service config (databases, bi_tools, schedulers)
+        # Initialize service config (databases, semantic layer, BI tools, schedulers)
         # Supports both new 'service' format and legacy 'namespace' format with auto-migration
         service_raw = kwargs.get("service", {})
         namespace_raw = kwargs.get("namespace", {})
@@ -493,6 +498,9 @@ class AgentConfig:
             service_raw = ServiceConfig.migrate_from_namespace(namespace_raw)
         self.service = ServiceConfig.from_dict(service_raw)
         self._init_service_config(service_raw.get("databases", {}))
+        self.init_semantic_layer(self.service.semantic_layer)
+        self.init_dashboard(self.service.bi_tools)
+        self.init_scheduler_services(self.service.schedulers)
 
         # SaaS mode: skip _init_dirs() because callers want only derived paths here,
         # not full local directory / backend initialization.
@@ -783,6 +791,108 @@ class AgentConfig:
     def current_db_configs(self) -> Dict[str, DbConfig]:
         """Backward-compat: returns all databases (was namespace-scoped, now returns all)."""
         return self.service.databases
+
+    def default_scheduler_service(self) -> Optional[str]:
+        defaults = [name for name, cfg in self.scheduler_services.items() if cfg.get("default")]
+        if len(defaults) > 1:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    "Multiple scheduler services are marked with `default: true` in "
+                    "`agent.service.schedulers`. Keep at most one default scheduler."
+                ),
+            )
+        if defaults:
+            return defaults[0]
+        if len(self.scheduler_services) == 1:
+            return next(iter(self.scheduler_services))
+        return None
+
+    def get_scheduler_config(self, service_name: Optional[str] = None) -> Dict[str, Any]:
+        if service_name:
+            if service_name not in self.scheduler_services:
+                raise DatusException(
+                    ErrorCode.COMMON_CONFIG_ERROR,
+                    message=(
+                        f"No scheduler service named `{service_name}` found. "
+                        f"Available: {list(self.scheduler_services.keys())}"
+                    ),
+                )
+            return self.scheduler_services[service_name]
+
+        default_service = self.default_scheduler_service()
+        if default_service:
+            return self.scheduler_services[default_service]
+
+        if not self.scheduler_services:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message="No scheduler configured in `agent.service.schedulers`.",
+            )
+
+        raise DatusException(
+            ErrorCode.COMMON_CONFIG_ERROR,
+            message=(
+                "Multiple scheduler services are configured in `agent.service.schedulers`, "
+                "set `scheduler_service` on the scheduler node."
+            ),
+        )
+
+    def resolve_semantic_adapter(self, adapter_type: Optional[str] = None) -> Optional[str]:
+        normalized = str(adapter_type or "").lower().strip()
+        if normalized:
+            if not self.semantic_layer_configs:
+                return normalized
+            if normalized in self.semantic_layer_configs:
+                return normalized
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    f"No semantic layer named `{normalized}` found in `agent.service.semantic_layer`. "
+                    f"Available: {list(self.semantic_layer_configs.keys())}"
+                ),
+            )
+
+        if not self.semantic_layer_configs:
+            return None
+        if len(self.semantic_layer_configs) == 1:
+            return next(iter(self.semantic_layer_configs))
+        raise DatusException(
+            ErrorCode.COMMON_CONFIG_ERROR,
+            message=(
+                "Multiple semantic layers are configured in `agent.service.semantic_layer`, "
+                "set `semantic_adapter` on the semantic node."
+            ),
+        )
+
+    def get_semantic_layer_config(self, adapter_type: Optional[str] = None) -> Dict[str, Any]:
+        resolved_adapter = self.resolve_semantic_adapter(adapter_type)
+        if not resolved_adapter or resolved_adapter not in self.semantic_layer_configs:
+            return {}
+        return dict(self.semantic_layer_configs[resolved_adapter])
+
+    def build_semantic_adapter_config(
+        self,
+        adapter_type: Optional[str] = None,
+        database_name: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        resolved_adapter = self.resolve_semantic_adapter(adapter_type)
+        if not resolved_adapter:
+            return None
+
+        config = self.get_semantic_layer_config(resolved_adapter)
+        config.setdefault("type", resolved_adapter)
+
+        db_name = database_name or self.current_database or self.service.default_database
+        if db_name:
+            config.setdefault("namespace", db_name)
+            db_config = _db_config_to_semantic_adapter_config(self.current_db_config(db_name))
+            if db_config:
+                config.setdefault("db_config", db_config)
+
+        config.setdefault("semantic_models_path", str(self.path_manager.semantic_model_path()))
+        config.setdefault("agent_home", self.home)
+        return config
 
     @property
     def output_dir(self) -> str:
@@ -1075,9 +1185,20 @@ class AgentConfig:
     def init_dashboard(self, param: Dict[str, Any]):
         if not isinstance(param, dict):
             return
-        for platform, auth_params in param.items():
+        self.dashboard_config = {}
+        for service_name, auth_params in param.items():
             if not isinstance(auth_params, dict):
                 continue
+            platform = str(service_name)
+            declared_type = auth_params.get("type")
+            if declared_type and str(declared_type) != platform:
+                raise DatusException(
+                    ErrorCode.COMMON_CONFIG_ERROR,
+                    message=(
+                        f"BI tool `{service_name}` must use the same key and type in `agent.service.bi_tools`. "
+                        f"Got key `{service_name}` with type `{declared_type}`."
+                    ),
+                )
             api_url_raw = auth_params.get("api_url", "")
             username_raw = auth_params.get("username", "")
             password_raw = auth_params.get("password", "")
@@ -1086,19 +1207,63 @@ class AgentConfig:
             username = resolve_env(str(username_raw)) if username_raw else ""
             password = resolve_env(str(password_raw)) if password_raw else ""
             api_key = resolve_env(str(api_key_raw)) if api_key_raw else ""
-            dataset_db_raw = auth_params.get("dataset_db")
-            dataset_db = None
-            if isinstance(dataset_db_raw, dict):
-                dataset_db = {k: resolve_env(str(v)) if isinstance(v, str) else v for k, v in dataset_db_raw.items()}
+            dataset_db = _resolve_nested_value(auth_params.get("dataset_db"))
             self.dashboard_config[platform] = DashboardConfig(
                 platform=platform,
                 api_url=api_url,
                 username=username,
                 password=password,
                 api_key=api_key,
-                extra=auth_params.get("extra", {}),
+                extra=_resolve_nested_value(auth_params.get("extra", {})),
                 dataset_db=dataset_db,
             )
+
+    def init_scheduler_services(self, param: Dict[str, Any]):
+        if not isinstance(param, dict):
+            return
+
+        self.scheduler_services = {}
+        for service_name, raw_config in param.items():
+            if not isinstance(raw_config, dict):
+                continue
+            resolved = _resolve_nested_value(raw_config)
+            resolved.setdefault("name", service_name)
+            scheduler_type = str(resolved.get("type") or "").lower().strip()
+            if not scheduler_type:
+                raise DatusException(
+                    ErrorCode.COMMON_CONFIG_ERROR,
+                    message=(
+                        f"Scheduler service `{service_name}` must declare a scheduler `type` in "
+                        f"`agent.service.schedulers.{service_name}`."
+                    ),
+                )
+            resolved["type"] = scheduler_type
+            self.scheduler_services[service_name] = resolved
+
+        default_service = self.default_scheduler_service()
+        self.scheduler_config = self.scheduler_services.get(default_service, {}) if default_service else {}
+
+    def init_semantic_layer(self, param: Dict[str, Any]):
+        if not isinstance(param, dict):
+            return
+
+        self.semantic_layer_configs = {}
+        for service_name, raw_config in param.items():
+            if not isinstance(raw_config, dict):
+                continue
+            normalized_name = str(service_name).lower().strip()
+            resolved = _resolve_nested_value(raw_config)
+            declared_type = str(resolved.get("type") or normalized_name).lower().strip()
+            if declared_type != normalized_name:
+                raise DatusException(
+                    ErrorCode.COMMON_CONFIG_ERROR,
+                    message=(
+                        f"Semantic layer `{service_name}` must use the adapter type as the key in "
+                        f"`agent.service.semantic_layer`. Got key `{service_name}` with type `{declared_type}`."
+                    ),
+                )
+            resolved["type"] = normalized_name
+            self.semantic_layer_configs[normalized_name] = resolved
 
 
 def resolve_env(value: str) -> str:
@@ -1114,6 +1279,30 @@ def resolve_env(value: str) -> str:
         return os.getenv(env_var, f"<MISSING:{env_var}>")
 
     return re.sub(pattern, replace_env, value)
+
+
+def _db_config_to_semantic_adapter_config(db_config: Optional[DbConfig]) -> Optional[Dict[str, str]]:
+    if not db_config:
+        return None
+
+    raw = db_config.to_dict()
+    return {
+        key: str(value)
+        for key, value in raw.items()
+        if value is not None
+        and value != ""
+        and key not in ("extra", "logic_name", "path_pattern", "catalog", "default")
+    }
+
+
+def _resolve_nested_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return resolve_env(value)
+    if isinstance(value, dict):
+        return {k: _resolve_nested_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_nested_value(item) for item in value]
+    return value
 
 
 def load_model_config(data: dict) -> ModelConfig:

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -262,17 +262,16 @@ def load_agent_config(reload: bool = False, **kwargs) -> AgentConfig:
 
         if override_kwargs:
             agent_config.override_by_args(**override_kwargs)
-    # Resolve current_database regardless of CLI ``action`` so API / claw /
-    # SDK entry points that bypass ``override_by_args``'s action whitelist
-    # still get a usable default. Priority already applied upstream:
+    # Resolve current_database when an unambiguous default exists. Priority
+    # already applied upstream:
     #   1. ``./.datus/config.yml::default_database`` (via _apply_project_override)
     #   2. ``service.databases[*].default: true`` flag in base agent.yml
     #   3. single-DB auto-select (ServiceConfig.default_database)
-    if not agent_config.current_database and agent_config.service.databases:
-        default_db = agent_config.service.default_database
+    if not agent_config.current_database and agent_config.services.databases:
+        default_db = agent_config.services.default_database
         if default_db:
             agent_config.current_namespace = default_db
-        else:
+        elif kwargs.get("action"):
             raise DatusException(
                 code=ErrorCode.COMMON_CONFIG_ERROR,
                 message_args={

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -172,7 +172,7 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
     ``default_database``. All three are written back into ``agent_raw``
     so ``AgentConfig.__init__`` picks them up naturally. For
     ``default_database`` this means flipping ``databases[*].default``
-    flags, since ``AgentConfig.service.default_database`` is derived
+    flags, since ``AgentConfig.services.default_database`` is derived
     from those flags — this keeps the overlay effective for every
     entry point that calls ``load_agent_config`` (REPL, print mode,
     web, ``datus-api``, SDK), not just the CLI layer.
@@ -193,7 +193,7 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
             )
         agent_raw["target"] = override.target
     if override.default_database is not None:
-        databases = (agent_raw.get("service", {}) or {}).get("databases", {}) or {}
+        databases = (agent_raw.get("services", {}) or {}).get("databases", {}) or {}
         if override.default_database not in databases:
             raise DatusException(
                 code=ErrorCode.COMMON_FIELD_INVALID,
@@ -290,7 +290,7 @@ def load_agent_config(reload: bool = False, **kwargs) -> AgentConfig:
             )
     # Auto-select default database for file-based DBs if not already set
     if agent_config.db_type in {DBType.SQLITE, DBType.DUCKDB} and not agent_config.current_database:
-        databases = agent_config.service.databases
+        databases = agent_config.services.databases
         if databases:
             first_key = next(iter(databases))
             agent_config.current_database = first_key

--- a/datus/configuration/config_migrator.py
+++ b/datus/configuration/config_migrator.py
@@ -3,7 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 """
-Config migration tool: converts legacy namespace-based agent.yml to new service-based format.
+Config migration tool: converts legacy namespace-based agent.yml to new services-based format.
 
 Usage:
     python -m datus.configuration.config_migrator [--config path/to/agent.yml] [--dry-run]
@@ -21,8 +21,8 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 
-def migrate_namespace_to_service(config: dict) -> dict:
-    """Convert legacy namespace config to new service.databases format.
+def migrate_namespace_to_services(config: dict) -> dict:
+    """Convert legacy namespace config to new services.databases format.
 
     Old format:
         agent:
@@ -39,7 +39,7 @@ def migrate_namespace_to_service(config: dict) -> dict:
 
     New format:
         agent:
-          service:
+          services:
             databases:
               db1:
                 type: sqlite
@@ -54,8 +54,8 @@ def migrate_namespace_to_service(config: dict) -> dict:
     config = copy.deepcopy(config)
     agent = config.get("agent", {})
 
-    if "service" in agent:
-        logger.info("Config already uses 'service' format, no migration needed.")
+    if "services" in agent:
+        logger.info("Config already uses 'services' format, no migration needed.")
         return config
 
     namespace_config = agent.pop("namespace", {})
@@ -96,7 +96,7 @@ def migrate_namespace_to_service(config: dict) -> dict:
         only_key = next(iter(databases))
         databases[only_key]["default"] = True
 
-    agent["service"] = {
+    agent["services"] = {
         "databases": databases,
         "semantic_layer": {},
         "bi_tools": {},
@@ -125,7 +125,7 @@ def migrate_file(config_path: str, dry_run: bool = False) -> bool:
         logger.error(f"Invalid config file (no 'agent' section): {config_path}")
         return False
 
-    if "service" in config.get("agent", {}):
+    if "services" in config.get("agent", {}):
         logger.info(f"Already migrated: {config_path}")
         return False
 
@@ -133,7 +133,7 @@ def migrate_file(config_path: str, dry_run: bool = False) -> bool:
         logger.info(f"No namespace section to migrate: {config_path}")
         return False
 
-    migrated = migrate_namespace_to_service(config)
+    migrated = migrate_namespace_to_services(config)
 
     if dry_run:
         print("--- Migrated config (dry run) ---")
@@ -153,7 +153,7 @@ def migrate_file(config_path: str, dry_run: bool = False) -> bool:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Migrate agent.yml from namespace to service format")
+    parser = argparse.ArgumentParser(description="Migrate agent.yml from namespace to services format")
     parser.add_argument("--config", type=str, default="conf/agent.yml", help="Path to agent.yml")
     parser.add_argument("--dry-run", action="store_true", help="Print migrated config without writing")
     args = parser.parse_args()

--- a/datus/configuration/config_migrator.py
+++ b/datus/configuration/config_migrator.py
@@ -47,6 +47,7 @@ def migrate_namespace_to_service(config: dict) -> dict:
               another_ns:
                 type: snowflake
                 ...
+            semantic_layer: {}
             bi_tools: {}
             schedulers: {}
     """
@@ -97,6 +98,7 @@ def migrate_namespace_to_service(config: dict) -> dict:
 
     agent["service"] = {
         "databases": databases,
+        "semantic_layer": {},
         "bi_tools": {},
         "schedulers": {},
     }

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -9,7 +9,7 @@ pin three values without copying the full config:
 
 - ``target``: which LLM to use (must match a key under ``agent.models``)
 - ``default_database``: which database to connect to on startup (must
-  match a key under ``agent.service.databases``)
+  match a key under ``agent.services.databases``)
 - ``project_name``: shard name for ``~/.datus/sessions/{project_name}/``
   and ``~/.datus/data/{project_name}/`` (optional)
 

--- a/datus/main.py
+++ b/datus/main.py
@@ -75,7 +75,7 @@ def create_parser() -> argparse.ArgumentParser:
     # service command (was: namespace)
     service_parser = subparsers.add_parser(
         "service",
-        help="Manage services (databases, BI tools, schedulers)",
+        help="Manage services (databases, semantic layer, BI tools, schedulers)",
         parents=[global_parser],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/datus/mcp_server.py
+++ b/datus/mcp_server.py
@@ -214,7 +214,16 @@ class ToolContextManager:
         services = self._config_manager.get("services", {}) or {}
         databases = services.get("databases", {}) or {}
         legacy_namespaces = self._config_manager.get("namespace", {}) or {}
-        self._available_namespaces: Set[str] = set(databases.keys()) or set(legacy_namespaces.keys())
+        if databases:
+            available_namespaces = set(databases.keys())
+        elif legacy_namespaces:
+            from datus.configuration.agent_config import ServicesConfig
+
+            migrated = ServicesConfig.migrate_from_namespace(legacy_namespaces)
+            available_namespaces = set(migrated.get("databases", {}).keys())
+        else:
+            available_namespaces = set()
+        self._available_namespaces: Set[str] = available_namespaces
         self._available_subagents: Set[str] = set(self._config_manager.get("agentic_nodes", {}).keys())
 
         logger.info(

--- a/datus/mcp_server.py
+++ b/datus/mcp_server.py
@@ -207,9 +207,14 @@ class ToolContextManager:
         self._contexts: OrderedDict[str, ToolContext] = OrderedDict()
         self._lock = asyncio.Lock()
 
-        # Load base configuration
+        # Load base configuration. Prefer the new services.databases layout,
+        # but keep legacy namespace support for older configs that may still
+        # be passed to the MCP server.
         self._config_manager = configuration_manager(config_path=config_path or "")
-        self._available_namespaces: Set[str] = set(self._config_manager.get("namespace", {}).keys())
+        services = self._config_manager.get("services", {}) or {}
+        databases = services.get("databases", {}) or {}
+        legacy_namespaces = self._config_manager.get("namespace", {}) or {}
+        self._available_namespaces: Set[str] = set(databases.keys()) or set(legacy_namespaces.keys())
         self._available_subagents: Set[str] = set(self._config_manager.get("agentic_nodes", {}).keys())
 
         logger.info(

--- a/datus/storage/metric/adapter_init.py
+++ b/datus/storage/metric/adapter_init.py
@@ -43,20 +43,25 @@ async def init_from_adapter(
     try:
         # Normalize adapter_type to lowercase for registry lookup
         adapter_type = adapter_type.lower().strip()
+        resolver = getattr(agent_config, "resolve_semantic_adapter", None)
+        if callable(resolver):
+            adapter_type = resolver(adapter_type) or adapter_type
 
-        # Get namespace from agent_config
         namespace = getattr(agent_config, "namespace", None) or agent_config.current_database
 
         # Get the registered config class for this adapter type
         metadata = semantic_adapter_registry.get_metadata(adapter_type)
+        builder = getattr(agent_config, "build_semantic_adapter_config", None)
+        base_config = builder(adapter_type) if callable(builder) else None
 
         # Build adapter config
         if adapter_config is None:
-            # Try to get config from agent_config if available
-            adapter_config = getattr(agent_config, f"{adapter_type}_config", None)
+            adapter_config = base_config
+        elif isinstance(adapter_config, dict):
+            # Convert dict to adapter-specific config class
+            adapter_config = {**(base_config or {}), **adapter_config}
 
         if adapter_config is None:
-            # Extract db_config from namespaces to pass to adapter (avoids re-reading agent.yml)
             ns_configs = agent_config.namespaces.get(namespace)
             db_config = None
             if ns_configs:
@@ -79,12 +84,8 @@ async def init_from_adapter(
                 from datus.tools.semantic_tools.config import SemanticAdapterConfig
 
                 adapter_config = SemanticAdapterConfig(namespace=namespace)
-        elif isinstance(adapter_config, dict):
-            # Convert dict to adapter-specific config class
-            # Ensure namespace is set
-            if "namespace" not in adapter_config:
-                adapter_config["namespace"] = namespace
 
+        if isinstance(adapter_config, dict):
             if metadata and metadata.config_class:
                 adapter_config = metadata.config_class(**adapter_config)
             else:

--- a/datus/storage/semantic_model/adapter_init.py
+++ b/datus/storage/semantic_model/adapter_init.py
@@ -41,20 +41,25 @@ async def init_from_adapter(
     try:
         # Normalize adapter_type to lowercase for registry lookup
         adapter_type = adapter_type.lower().strip()
+        resolver = getattr(agent_config, "resolve_semantic_adapter", None)
+        if callable(resolver):
+            adapter_type = resolver(adapter_type) or adapter_type
 
-        # Get namespace from agent_config
         namespace = getattr(agent_config, "namespace", None) or agent_config.current_database
 
         # Get the registered config class for this adapter type
         metadata = semantic_adapter_registry.get_metadata(adapter_type)
+        builder = getattr(agent_config, "build_semantic_adapter_config", None)
+        base_config = builder(adapter_type) if callable(builder) else None
 
         # Build adapter config
         if adapter_config is None:
-            # Try to get config from agent_config if available
-            adapter_config = getattr(agent_config, f"{adapter_type}_config", None)
+            adapter_config = base_config
+        elif isinstance(adapter_config, dict):
+            # Convert dict to adapter-specific config class
+            adapter_config = {**(base_config or {}), **adapter_config}
 
         if adapter_config is None:
-            # Extract db_config from namespaces to pass to adapter (avoids re-reading agent.yml)
             ns_configs = agent_config.namespaces.get(namespace)
             db_config = None
             if ns_configs:
@@ -77,12 +82,8 @@ async def init_from_adapter(
                 from datus.tools.semantic_tools.config import SemanticAdapterConfig
 
                 adapter_config = SemanticAdapterConfig(namespace=namespace)
-        elif isinstance(adapter_config, dict):
-            # Convert dict to adapter-specific config class
-            # Ensure namespace is set
-            if "namespace" not in adapter_config:
-                adapter_config["namespace"] = namespace
 
+        if isinstance(adapter_config, dict):
             if metadata and metadata.config_class:
                 adapter_config = metadata.config_class(**adapter_config)
             else:

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -217,7 +217,7 @@ class DBFuncTool:
             return self._connector_cache[db_name]
 
         # Fetch from db_manager.
-        # Each database in service.databases is its own namespace (see AgentConfig.namespaces).
+        # Each database in services.databases is its own namespace (see AgentConfig.namespaces).
         # For cross-database scenarios, use db_name as both namespace and logic_name.
         try:
             connector = self._db_manager.get_conn(db_name, db_name)

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -19,17 +19,18 @@ logger = get_logger(__name__)
 
 
 class SchedulerTools(BaseTool):
-    """Function tools for interacting with the configured scheduler platform (e.g. Airflow).
-
-    Requires a ``scheduler:`` section in ``agent.yml`` with the adapter config.
-    """
+    """Function tools for interacting with the configured scheduler platform (e.g. Airflow)."""
 
     tool_name = "scheduler_tools"
     tool_description = "Tools for submitting and managing scheduled jobs via Airflow"
 
-    def __init__(self, agent_config: AgentConfig, **kwargs):
+    def __init__(self, agent_config: AgentConfig, scheduler_service: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self.agent_config = agent_config
+        self.scheduler_service = scheduler_service
+
+    def _selected_scheduler_config(self) -> dict:
+        return dict(self.agent_config.get_scheduler_config(self.scheduler_service))
 
     # ── Adapter factory ────────────────────────────────────────────────────
 
@@ -45,14 +46,7 @@ class SchedulerTools(BaseTool):
                 "Install it with: pip install datus-scheduler-core",
             ) from exc
 
-        scheduler_config = getattr(self.agent_config, "scheduler_config", {}) or {}
-        if not scheduler_config:
-            raise DatusException(
-                ErrorCode.COMMON_CONFIG_ERROR,
-                message_args={"config_error": "No scheduler configured in agent.yml. Add a 'scheduler:' section."},
-            )
-
-        config = dict(scheduler_config)
+        config = self._selected_scheduler_config()
         platform = config.get("type", "airflow")
         return SchedulerAdapterRegistry.create_adapter(platform=platform, config=config)
 
@@ -614,7 +608,10 @@ class SchedulerTools(BaseTool):
         Returns:
             FuncToolResult with result containing a list of {conn_id, description}.
         """
-        scheduler_config = getattr(self.agent_config, "scheduler_config", {}) or {}
+        try:
+            scheduler_config = self._selected_scheduler_config()
+        except DatusException as exc:
+            return FuncToolResult(success=0, error=str(exc))
         connections = scheduler_config.get("connections", {})
         if not connections:
             return FuncToolResult(
@@ -639,7 +636,10 @@ class SchedulerTools(BaseTool):
 
     def _connections_description(self) -> str:
         """Build a suffix describing available conn_ids from scheduler config."""
-        scheduler_config = getattr(self.agent_config, "scheduler_config", {}) or {}
+        try:
+            scheduler_config = self._selected_scheduler_config()
+        except DatusException:
+            return ""
         connections = scheduler_config.get("connections", {})
         if not connections:
             return ""

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -116,7 +116,7 @@ class SemanticTools:
     @property
     def adapter(self) -> Optional[BaseSemanticAdapter]:
         """Lazy load semantic adapter if configured."""
-        if self._adapter is None and self.adapter_type:
+        if self._adapter is None:
             try:
                 resolved_adapter = self.adapter_type
                 resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -96,6 +96,8 @@ class SemanticTools:
             db_config_obj = self.agent_config.current_db_config(namespace)
         except Exception:
             return None
+        if db_config_obj is None:
+            return None
         raw = db_config_obj.to_dict()
         extra = raw.get("extra")
         db_config = {

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -91,16 +91,16 @@ class SemanticTools:
         self._attribution_tool: Optional[DimensionAttributionUtil] = None
 
     def _extract_db_config(self, namespace: str) -> Optional[dict]:
-        """Extract db_config dict from AgentConfig.namespaces for the given namespace."""
-        ns_configs = self.agent_config.namespaces.get(namespace)
-        if not ns_configs:
+        """Extract db_config dict from the selected database config."""
+        try:
+            db_config_obj = self.agent_config.current_db_config(namespace)
+        except Exception:
             return None
-        db_config_obj = list(ns_configs.values())[0]
         raw = db_config_obj.to_dict()
         return {
             k: str(v)
             for k, v in raw.items()
-            if v is not None and v != "" and k not in ("extra", "logic_name", "path_pattern", "catalog")
+            if v is not None and v != "" and k not in ("extra", "logic_name", "path_pattern", "catalog", "default")
         }
 
     @property
@@ -108,18 +108,21 @@ class SemanticTools:
         """Lazy load semantic adapter if configured."""
         if self._adapter is None and self.adapter_type:
             try:
-                # Try to get adapter-specific config from agent_config
-                adapter_config = getattr(self.agent_config, f"{self.adapter_type}_config", None)
-                if adapter_config is None:
-                    # Get namespace from agent_config
-                    namespace = getattr(self.agent_config, "namespace", None) or self.agent_config.current_database
+                resolved_adapter = self.adapter_type
+                resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
+                if callable(resolver):
+                    resolved_adapter = resolver(self.adapter_type)
+                if not resolved_adapter:
+                    return None
 
-                    # Extract db_config to pass to adapter (avoids re-reading agent.yml)
+                metadata = semantic_adapter_registry.get_metadata(resolved_adapter)
+                builder = getattr(self.agent_config, "build_semantic_adapter_config", None)
+                adapter_config = builder(resolved_adapter) if callable(builder) else None
+                if adapter_config is None:
+                    namespace = getattr(self.agent_config, "namespace", None) or self.agent_config.current_database
                     db_config = self._extract_db_config(namespace)
                     agent_home = getattr(self.agent_config, "home", None)
 
-                    # Get the registered config class for this adapter type
-                    metadata = semantic_adapter_registry.get_metadata(self.adapter_type)
                     if metadata and metadata.config_class:
                         adapter_config = metadata.config_class(
                             namespace=namespace,
@@ -127,13 +130,20 @@ class SemanticTools:
                             agent_home=agent_home,
                         )
                     else:
-                        # Fallback to base config
                         from datus.tools.semantic_tools.config import SemanticAdapterConfig
 
                         adapter_config = SemanticAdapterConfig(namespace=namespace)
+                elif isinstance(adapter_config, dict):
+                    if metadata and metadata.config_class:
+                        adapter_config = metadata.config_class(**adapter_config)
+                    else:
+                        from datus.tools.semantic_tools.config import SemanticAdapterConfig
 
-                self._adapter = semantic_adapter_registry.create_adapter(self.adapter_type, adapter_config)
-                logger.info(f"Loaded semantic adapter: {self.adapter_type}")
+                        adapter_config = SemanticAdapterConfig(**adapter_config)
+
+                self.adapter_type = resolved_adapter
+                self._adapter = semantic_adapter_registry.create_adapter(resolved_adapter, adapter_config)
+                logger.info(f"Loaded semantic adapter: {resolved_adapter}")
             except Exception as e:
                 logger.warning(f"Failed to load semantic adapter '{self.adapter_type}': {e}")
                 self._adapter = None

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -97,11 +97,19 @@ class SemanticTools:
         except Exception:
             return None
         raw = db_config_obj.to_dict()
-        return {
+        extra = raw.get("extra")
+        db_config = {
             k: str(v)
             for k, v in raw.items()
             if v is not None and v != "" and k not in ("extra", "logic_name", "path_pattern", "catalog", "default")
         }
+        # Preserve connector-specific `extra` fields without overwriting explicit top-level keys
+        if isinstance(extra, dict):
+            for k, v in extra.items():
+                if v is None or v == "":
+                    continue
+                db_config.setdefault(k, str(v))
+        return db_config
 
     @property
     def adapter(self) -> Optional[BaseSemanticAdapter]:

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -176,65 +176,66 @@ agent:
   # Supported benchmarks: bird_dev, spider2, semantic_layer
 
   # local databases configuration
-  namespace:
-    bird_sqlite:
-      type: sqlite
-      path_pattern: ~/benchmark/bird/dev_20240627/dev_databases/**/*.sqlite # just support glob pattern
-    bird_school:
-      name: california_schools
-      type: sqlite
-      uri: ~/benchmark/bird/dev_20240627/dev_databases/california_schools/california_schools.sqlite # just support glob pattern
-      default: true
-    duckdb:
-      type: duckdb
-      name: duck
-      uri: tests/data/datus_metricflow_db/duck.db # absolute path: sqlite:////full/path/to/example.db
-    local_duckdb:
-      type: duckdb
-      name: ssb
-      uri: sample_data/duckdb-demo.duckdb
-    ssb_sqlite:
-      type: sqlite
-      name: SSB
-      uri: tests/data/SSB.db
-    snowflake:
-      type: snowflake
-      account: ${SNOWFLAKE_ACCOUNT}
-      username: ${SNOWFLAKE_USERNAME}
-      password: ${SNOWFLAKE_PASSWORD}
-
-    starrocks:
-      type: starrocks
-      host: ${STARROCKS_HOST}
-      port: ${STARROCKS_PORT}
-      username: ${STARROCKS_USER}
-      password: ${STARROCKS_PASSWORD}
-      database: ${STARROCKS_DATABASE}
-    superset:
-      type: postgresql
-      host: 127.0.0.1
-      port: 15432
-      username: superset
-      password: superset
-      database: examples
+  services:
+    databases:
+      bird_sqlite:
+        type: sqlite
+        path_pattern: ~/benchmark/bird/dev_20240627/dev_databases/**/*.sqlite # just support glob pattern
+      bird_school:
+        name: california_schools
+        type: sqlite
+        uri: ~/benchmark/bird/dev_20240627/dev_databases/california_schools/california_schools.sqlite # just support glob pattern
+      duckdb:
+        type: duckdb
+        name: duck
+        uri: tests/data/datus_metricflow_db/duck.db # absolute path: sqlite:////full/path/to/example.db
+      local_duckdb:
+        type: duckdb
+        name: ssb
+        uri: sample_data/duckdb-demo.duckdb
+      ssb_sqlite:
+        type: sqlite
+        name: SSB
+        uri: tests/data/SSB.db
+      snowflake:
+        type: snowflake
+        account: ${SNOWFLAKE_ACCOUNT}
+        username: ${SNOWFLAKE_USERNAME}
+        password: ${SNOWFLAKE_PASSWORD}
+      starrocks:
+        type: starrocks
+        host: ${STARROCKS_HOST}
+        port: ${STARROCKS_PORT}
+        username: ${STARROCKS_USER}
+        password: ${STARROCKS_PASSWORD}
+        database: ${STARROCKS_DATABASE}
+      superset:
+        type: postgresql
+        host: 127.0.0.1
+        port: 15432
+        username: superset
+        password: superset
+        database: examples
+    semantic_layer:
+      metricflow: {}
+    bi_tools:
+      superset:
+        type: superset
+        api_url: http://localhost:8088
+        username: admin
+        password: admin
+        extra:
+          provider: db
+    schedulers:
+      airflow_local:
+        name: airflow_local
+        type: airflow
+        api_base_url: http://localhost:8080/api/v1
+        username: admin
+        password: admin123
+        dags_folder: /tmp/dags
+        dag_discovery_timeout: 60
+        dag_discovery_poll_interval: 5
   storage:
     base_path: data
     embedding_device_type: cpu
-
-  dashboard:
-    superset:
-      api_url: http://localhost:8088
-      username: admin
-      password: admin
-      extra:
-        provider: db
-
-  scheduler:
-    name: airflow_local
-    type: airflow
-    api_base_url: http://localhost:8080/api/v1
-    username: admin
-    password: admin123
-    dags_folder: /tmp/dags
-    dag_discovery_timeout: 60
-    dag_discovery_poll_interval: 5

--- a/tests/integration/agent/test_scheduler_agentic.py
+++ b/tests/integration/agent/test_scheduler_agentic.py
@@ -43,11 +43,8 @@ def scheduler_agent_config():
         pytest.skip("DEEPSEEK_API_KEY not set")
     if not _is_airflow_running():
         pytest.skip(f"Airflow not reachable at {AIRFLOW_URL}. Run docker compose up -d")
-    try:
-        import datus_scheduler_airflow  # noqa: F401
-        import datus_scheduler_core  # noqa: F401
-    except ImportError:
-        pytest.skip("datus-scheduler-core or datus-scheduler-airflow package not installed")
+    pytest.importorskip("datus_scheduler_core")
+    pytest.importorskip("datus_scheduler_airflow")
 
     from tests.conftest import load_acceptance_config
 

--- a/tests/integration/agent/test_scheduler_agentic.py
+++ b/tests/integration/agent/test_scheduler_agentic.py
@@ -63,7 +63,7 @@ def scheduler_agent_config():
     }
 
     # Ensure scheduler service config points to the running Airflow
-    config.service.schedulers = {
+    config.services.schedulers = {
         "airflow_local": {
             "name": "airflow_local",
             "type": "airflow",
@@ -75,7 +75,7 @@ def scheduler_agent_config():
             "dag_discovery_poll_interval": 5,
         }
     }
-    config.init_scheduler_services(config.service.schedulers)
+    config.init_scheduler_services(config.services.schedulers)
 
     return config
 

--- a/tests/integration/agent/test_scheduler_agentic.py
+++ b/tests/integration/agent/test_scheduler_agentic.py
@@ -59,19 +59,23 @@ def scheduler_agent_config():
     config.agentic_nodes["scheduler"] = {
         "system_prompt": "scheduler",
         "max_turns": 30,
+        "scheduler_service": "airflow_local",
     }
 
-    # Ensure scheduler config points to the running Airflow
-    config.scheduler_config = {
-        "name": "airflow_local",
-        "type": "airflow",
-        "api_base_url": AIRFLOW_URL,
-        "username": AIRFLOW_USER,
-        "password": AIRFLOW_PASS,
-        "dags_folder": "/tmp/dags",
-        "dag_discovery_timeout": 60,
-        "dag_discovery_poll_interval": 5,
+    # Ensure scheduler service config points to the running Airflow
+    config.service.schedulers = {
+        "airflow_local": {
+            "name": "airflow_local",
+            "type": "airflow",
+            "api_base_url": AIRFLOW_URL,
+            "username": AIRFLOW_USER,
+            "password": AIRFLOW_PASS,
+            "dags_folder": "/tmp/dags",
+            "dag_discovery_timeout": 60,
+            "dag_discovery_poll_interval": 5,
+        }
     }
+    config.init_scheduler_services(config.service.schedulers)
 
     return config
 

--- a/tests/integration/tools/test_migration_subagent.py
+++ b/tests/integration/tools/test_migration_subagent.py
@@ -69,7 +69,7 @@ agent:
       api_key: sk-fake
       model: claude-sonnet-4-6
       temperature: 0.0
-  service:
+  services:
     databases:
       source_duckdb:
         type: duckdb

--- a/tests/unit_tests/agent/node/test_node.py
+++ b/tests/unit_tests/agent/node/test_node.py
@@ -123,7 +123,7 @@ def agent_config() -> AgentConfig:
     # needed. Seed a valid default here so fixtures that touch the DB (e.g. `function_tools`)
     # can initialize.
     agent_config = load_acceptance_config(namespace="bird_sqlite")
-    if not agent_config.current_database and agent_config.service.databases:
+    if not agent_config.current_database and agent_config.services.databases:
         agent_config.current_database = "california_schools"
     Path(agent_config.rag_storage_path()).mkdir(parents=True, exist_ok=True)
     return agent_config
@@ -573,7 +573,7 @@ class TestNode:
                 exec_input = execute_sql_input[test_case_num]["input"]
                 input_data = ExecuteSQLInput(**exec_input)
                 # Use the database_name from the input to set the current database
-                if exec_input.get("database_name") and exec_input["database_name"] in agent_config.service.databases:
+                if exec_input.get("database_name") and exec_input["database_name"] in agent_config.services.databases:
                     agent_config.current_database = exec_input["database_name"]
                 else:
                     agent_config.current_database = "california_schools"

--- a/tests/unit_tests/agent/node/test_node.py
+++ b/tests/unit_tests/agent/node/test_node.py
@@ -146,7 +146,6 @@ def init_metricflow_db() -> None:
     if not db_dir.exists():
         db_dir.mkdir(parents=True, exist_ok=True)
     csv_path: Path = Path(__file__).parent / "data/metricflow_csv" / "*.csv"
-    print(f"Creating db_path: {db_path}")
     conn = duckdb.connect(db_path)
     conn.execute("CREATE SCHEMA IF NOT EXISTS mf_demo;")
     csv_files = glob.glob(str(csv_path))
@@ -155,7 +154,6 @@ def init_metricflow_db() -> None:
         file_name = full_file_name.split(".")[0]
         table_name = f"mf_demo.{file_name}"
         conn.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM read_csv_auto('{csv_file}', header=TRUE)")
-        print(f"finish the import of {csv_file}")
     conn.close()
 
 
@@ -251,7 +249,6 @@ class TestNode:
             assert node.input.input_text == test_case["input_text"]
             result = node.run()
             assert isinstance(result, SchemaLinkingResult)
-            print(f"result is {type(result)}, {result.success}, {result.schema_count}")
             assert isinstance(result, SchemaLinkingResult)
             assert result.success
             assert result.schema_count > 0
@@ -756,13 +753,6 @@ class TestNode:
                 "Suggestions should mention JOIN or table differences"
             )
 
-            # Print results for manual inspection
-            print("\n=== Compare Node Test Results ===")
-            print(f"Explanation: {result.explanation}")
-            print(f"Suggestions: {result.suggest}")
-            print(f"Success: {result.success}")
-            print("=====================================\n")
-
         except Exception as e:
             logger.error(f"Compare node test failed: {str(e)}")
             raise
@@ -868,18 +858,11 @@ class TestNode:
             )
 
             # Suggestions should be actionable and database-informed
-            if result.suggest:
-                suggest_lower = result.suggest.lower()
-                assert "join" in suggest_lower or "table" in suggest_lower or "modify" in suggest_lower, (
-                    "Should provide actionable database-informed suggestions"
-                )
-
-            # Print results for manual inspection
-            print("\n=== Compare MCP Node Test Results ===")
-            print(f"Explanation: {result.explanation}")
-            print(f"Suggestions: {result.suggest}")
-            print(f"Success: {result.success}")
-            print("==========================================\n")
+            assert result.suggest
+            suggest_lower = result.suggest.lower()
+            assert "join" in suggest_lower or "table" in suggest_lower or "modify" in suggest_lower, (
+                "Should provide actionable database-informed suggestions"
+            )
 
         except Exception as e:
             logger.error(f"Compare MCP node test failed: {str(e)}")

--- a/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
@@ -73,8 +73,8 @@ def _scheduler_service_config():
 
 def _add_scheduler_config(agent_config, max_turns=25, node_name="scheduler", scheduler_service="airflow_local"):
     """Add scheduler service config and scheduler agentic node config to an AgentConfig."""
-    agent_config.service.schedulers = {scheduler_service: _scheduler_service_config()}
-    agent_config.init_scheduler_services(agent_config.service.schedulers)
+    agent_config.services.schedulers = {scheduler_service: _scheduler_service_config()}
+    agent_config.init_scheduler_services(agent_config.services.schedulers)
     agent_config.agentic_nodes[node_name] = {
         "system_prompt": "scheduler",
         "max_turns": max_turns,
@@ -135,8 +135,8 @@ class TestSchedulerAgenticNodeInit:
     def test_max_turns_default(self, real_agent_config, mock_llm_create):
         """Default max_turns is 30 when scheduler not in agentic_nodes."""
         # Add scheduler service config but no scheduler agentic node config
-        real_agent_config.service.schedulers = {"airflow_local": _scheduler_service_config()}
-        real_agent_config.init_scheduler_services(real_agent_config.service.schedulers)
+        real_agent_config.services.schedulers = {"airflow_local": _scheduler_service_config()}
+        real_agent_config.init_scheduler_services(real_agent_config.services.schedulers)
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
@@ -207,7 +207,7 @@ class TestSchedulerToolSetup:
 
     def test_no_scheduler_config_no_tools(self, real_agent_config, mock_llm_create):
         """Without scheduler service config, node should have 0 scheduler tools (graceful no-op)."""
-        real_agent_config.service.schedulers = {}
+        real_agent_config.services.schedulers = {}
         real_agent_config.init_scheduler_services({})
         from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
@@ -494,7 +494,7 @@ class TestSchedulerTemplateContext:
 
     def test_context_without_tools(self, real_agent_config, mock_llm_create):
         """Without scheduler config, native_tools should be 'None'."""
-        real_agent_config.service.schedulers = {}
+        real_agent_config.services.schedulers = {}
         real_agent_config.init_scheduler_services({})
         from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 

--- a/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
@@ -6,7 +6,7 @@
 Unit tests for SchedulerAgenticNode.
 
 Tests cover:
-- Node creation with/without scheduler_config
+- Node creation with/without scheduler service config
 - Tools setup (scheduler tools only, no DB/BI/filesystem tools exposed)
 - Max turns configuration
 - Node name
@@ -60,9 +60,8 @@ def _make_mock_scheduler_tools():
     return mock_tools
 
 
-def _add_scheduler_config(agent_config, max_turns=25):
-    """Add scheduler config and scheduler agentic node config to an AgentConfig."""
-    agent_config.scheduler_config = {
+def _scheduler_service_config():
+    return {
         "name": "airflow_local",
         "type": "airflow",
         "api_base_url": "http://localhost:8080/api/v1",
@@ -70,9 +69,16 @@ def _add_scheduler_config(agent_config, max_turns=25):
         "password": "admin123",
         "dags_folder": "/tmp/dags",
     }
-    agent_config.agentic_nodes["scheduler"] = {
+
+
+def _add_scheduler_config(agent_config, max_turns=25, node_name="scheduler", scheduler_service="airflow_local"):
+    """Add scheduler service config and scheduler agentic node config to an AgentConfig."""
+    agent_config.service.schedulers = {scheduler_service: _scheduler_service_config()}
+    agent_config.init_scheduler_services(agent_config.service.schedulers)
+    agent_config.agentic_nodes[node_name] = {
         "system_prompt": "scheduler",
         "max_turns": max_turns,
+        "scheduler_service": scheduler_service,
     }
 
 
@@ -128,12 +134,9 @@ class TestSchedulerAgenticNodeInit:
 
     def test_max_turns_default(self, real_agent_config, mock_llm_create):
         """Default max_turns is 30 when scheduler not in agentic_nodes."""
-        # Add scheduler_config but no scheduler agentic node config
-        real_agent_config.scheduler_config = {
-            "name": "airflow_local",
-            "type": "airflow",
-            "api_base_url": "http://localhost:8080/api/v1",
-        }
+        # Add scheduler service config but no scheduler agentic node config
+        real_agent_config.service.schedulers = {"airflow_local": _scheduler_service_config()}
+        real_agent_config.init_scheduler_services(real_agent_config.service.schedulers)
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
@@ -150,7 +153,7 @@ class TestSchedulerToolSetup:
     """Tests for tool setup — scheduler tools only, no DB/BI/filesystem tools exposed."""
 
     def test_has_scheduler_tools_with_config(self, real_agent_config, mock_llm_create):
-        """With scheduler_config, node should have scheduler tools."""
+        """With scheduler service config, node should have scheduler tools."""
         _add_scheduler_config(real_agent_config)
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
@@ -203,9 +206,9 @@ class TestSchedulerToolSetup:
             assert "write_file" not in tool_names
 
     def test_no_scheduler_config_no_tools(self, real_agent_config, mock_llm_create):
-        """Without scheduler_config, node should have 0 scheduler tools (graceful no-op)."""
-        # Ensure no scheduler_config
-        real_agent_config.scheduler_config = None
+        """Without scheduler service config, node should have 0 scheduler tools (graceful no-op)."""
+        real_agent_config.service.schedulers = {}
+        real_agent_config.init_scheduler_services({})
         from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
         node = SchedulerAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
@@ -491,7 +494,8 @@ class TestSchedulerTemplateContext:
 
     def test_context_without_tools(self, real_agent_config, mock_llm_create):
         """Without scheduler config, native_tools should be 'None'."""
-        real_agent_config.scheduler_config = None
+        real_agent_config.service.schedulers = {}
+        real_agent_config.init_scheduler_services({})
         from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
         node = SchedulerAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
@@ -534,6 +538,7 @@ class TestSchedulerCustomNodeName:
         real_agent_config.agentic_nodes["my_scheduler"] = {
             "system_prompt": "scheduler",
             "max_turns": 15,
+            "scheduler_service": "airflow_local",
         }
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
@@ -550,6 +555,7 @@ class TestSchedulerCustomNodeName:
         real_agent_config.agentic_nodes["etl_scheduler"] = {
             "system_prompt": "scheduler",
             "max_turns": 50,
+            "scheduler_service": "airflow_local",
         }
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
@@ -565,6 +571,7 @@ class TestSchedulerCustomNodeName:
         real_agent_config.agentic_nodes["my_jobs"] = {
             "system_prompt": "scheduler",
             "max_turns": 10,
+            "scheduler_service": "airflow_local",
         }
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.node import Node
@@ -586,6 +593,7 @@ class TestSchedulerCustomNodeName:
         real_agent_config.agentic_nodes["etl_scheduler"] = {
             "system_prompt": "etl_scheduler",
             "max_turns": 15,
+            "scheduler_service": "airflow_local",
         }
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -174,12 +174,18 @@ class TestChatTaskManagerBehavior:
         """shutdown completes cleanly with no tasks."""
         manager = ChatTaskManager()
         await manager.shutdown()
+        assert manager._tasks == {}
+        assert manager._completed_tasks == {}
+        assert manager.has_active_tasks() is False
 
     @pytest.mark.asyncio
     async def test_wait_all_tasks_completes_without_tasks(self):
         """wait_all_tasks completes cleanly with no tasks."""
         manager = ChatTaskManager()
         await manager.wait_all_tasks()
+        assert manager._tasks == {}
+        assert manager._completed_tasks == {}
+        assert manager.has_active_tasks() is False
 
     @pytest.mark.asyncio
     async def test_push_event_appends_to_buffer(self):
@@ -297,10 +303,14 @@ class TestStartChat:
 
         manager = ChatTaskManager()
         request = StreamChatInput(message="wait test", session_id="wait-test")
-        await manager.start_chat(real_agent_config, request)
+        task = await manager.start_chat(real_agent_config, request)
 
         # wait_all_tasks should return (tasks may finish quickly with mock LLM)
         await manager.wait_all_tasks()
+        assert task.asyncio_task.done() is True
+        assert manager._tasks == {}
+        assert manager.get_task("wait-test") is task
+        assert manager.has_active_tasks() is False
         await manager.shutdown()
 
     async def test_consume_events_yields_ping_when_idle(self, monkeypatch):

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -40,8 +40,8 @@ class TestFillDatabaseContext:
 
     def test_known_database_updates_namespace_and_db(self, real_agent_config):
         """Known database in namespaces updates current_namespace and current_database."""
-        # real_agent_config has "california_schools" in service.databases
-        # After the namespace→service.databases refactor, each DB is its own namespace key
+        # real_agent_config has "california_schools" in services.databases
+        # After the namespace→services.databases refactor, each DB is its own namespace key
         _fill_database_context(real_agent_config, database="california_schools")
         assert real_agent_config.current_namespace == "california_schools"
         assert real_agent_config.current_database == "california_schools"

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -115,7 +115,7 @@ class TestListDatabases:
     def test_list_databases_with_datasource_filter(self, real_agent_config):
         """list_databases with datasource_id filter."""
         svc = DatabaseService(agent_config=real_agent_config)
-        # After namespace→service.databases refactor, datasource_id is a database name
+        # After namespace→services.databases refactor, datasource_id is a database name
         request = ListDatabasesInput(datasource_id="california_schools")
         result = svc.list_databases(request)
         assert result.success is True

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -108,9 +108,9 @@ class TestListDatabases:
         svc = DatabaseService(agent_config=real_agent_config)
         request = ListDatabasesInput()
         result = svc.list_databases(request)
-        for db in result.data.databases:
-            if db.connection_status == "connected":
-                assert db.tables_count > 0
+        connected_databases = [db for db in result.data.databases if db.connection_status == "connected"]
+        assert connected_databases
+        assert all(db.tables_count > 0 for db in connected_databases)
 
     def test_list_databases_with_datasource_filter(self, real_agent_config):
         """list_databases with datasource_id filter."""
@@ -132,9 +132,9 @@ class TestListDatabases:
         svc = DatabaseService(agent_config=real_agent_config)
         request = ListDatabasesInput()
         result = svc.list_databases(request)
-        for db in result.data.databases:
-            if db.tables is not None:
-                assert isinstance(db.tables, list)
+        databases_with_tables = [db for db in result.data.databases if db.tables is not None]
+        assert databases_with_tables
+        assert all(isinstance(db.tables, list) for db in databases_with_tables)
 
     def test_list_databases_has_type_field(self, real_agent_config):
         """list_databases includes database type."""

--- a/tests/unit_tests/cli/test_init_workspace.py
+++ b/tests/unit_tests/cli/test_init_workspace.py
@@ -191,7 +191,7 @@ class TestInitWorkspaceRun:
         args.database = ""
 
         mock_config = MagicMock()
-        mock_config.service.databases = {}
+        mock_config.services.databases = {}
 
         with (
             patch("datus.configuration.agent_config_loader.load_agent_config", return_value=mock_config),
@@ -251,7 +251,7 @@ class TestInitWorkspaceProbeDatabase:
         mock_db_cfg.type = "sqlite"
 
         mock_agent_config = MagicMock()
-        mock_agent_config.service.databases = {"test_db": mock_db_cfg}
+        mock_agent_config.services.databases = {"test_db": mock_db_cfg}
 
         mock_connector = MagicMock()
         mock_connector.get_tables.return_value = [
@@ -277,7 +277,7 @@ class TestInitWorkspaceProbeDatabase:
         iw = InitWorkspace(args)
 
         mock_agent_config = MagicMock()
-        mock_agent_config.service.databases = {}
+        mock_agent_config.services.databases = {}
 
         result = iw._probe_database(mock_agent_config, "nonexistent_db")
         assert result == ""
@@ -291,7 +291,7 @@ class TestInitWorkspaceProbeDatabase:
 
         mock_db_cfg = MagicMock()
         mock_agent_config = MagicMock()
-        mock_agent_config.service.databases = {"db": mock_db_cfg}
+        mock_agent_config.services.databases = {"db": mock_db_cfg}
 
         with patch("datus.tools.db_tools.db_manager.DBManager", side_effect=RuntimeError("connect failed")):
             result = iw._probe_database(mock_agent_config, "db")
@@ -309,7 +309,7 @@ class TestInitWorkspaceProbeDatabase:
         mock_db_cfg.type = "sqlite"
 
         mock_agent_config = MagicMock()
-        mock_agent_config.service.databases = {"mydb": mock_db_cfg}
+        mock_agent_config.services.databases = {"mydb": mock_db_cfg}
 
         mock_connector = MagicMock()
         mock_connector.get_tables.return_value = []
@@ -334,7 +334,7 @@ class TestInitWorkspaceProbeDatabase:
         mock_db_cfg.type = "postgresql"
 
         mock_agent_config = MagicMock()
-        mock_agent_config.service.databases = {"bigdb": mock_db_cfg}
+        mock_agent_config.services.databases = {"bigdb": mock_db_cfg}
 
         # 35 tables — triggers the > 30 truncation branch
         tables = [{"table_name": f"table_{i}"} for i in range(35)]
@@ -361,7 +361,7 @@ class TestInitWorkspaceProbeDatabase:
         mock_db_cfg.type = "duckdb"
 
         mock_agent_config = MagicMock()
-        mock_agent_config.service.databases = {"duck": mock_db_cfg}
+        mock_agent_config.services.databases = {"duck": mock_db_cfg}
 
         mock_connector = MagicMock()
         mock_connector.get_tables.return_value = [{"name": "sales"}, {"name": "users"}]
@@ -631,7 +631,7 @@ class TestInitWorkspaceRunFullFlow:
         iw = self._setup_iw(tmp_path)
 
         mock_config = MagicMock()
-        mock_config.service.databases = {}
+        mock_config.services.databases = {}
 
         llm_content = "# myproject\n\n## Architecture\n\nSome content here." * 10
 
@@ -651,7 +651,7 @@ class TestInitWorkspaceRunFullFlow:
         iw = self._setup_iw(tmp_path)
 
         mock_config = MagicMock()
-        mock_config.service.databases = {}
+        mock_config.services.databases = {}
 
         with (
             patch("datus.configuration.agent_config_loader.load_agent_config", return_value=mock_config),
@@ -668,7 +668,7 @@ class TestInitWorkspaceRunFullFlow:
         iw = self._setup_iw(tmp_path, database="mydb")
 
         mock_config = MagicMock()
-        mock_config.service.databases = {}
+        mock_config.services.databases = {}
 
         with (
             patch("datus.configuration.agent_config_loader.load_agent_config", return_value=mock_config),
@@ -688,7 +688,7 @@ class TestInitWorkspaceRunFullFlow:
         iw = self._setup_iw(tmp_path)
 
         mock_config = MagicMock()
-        mock_config.service.databases = {}
+        mock_config.services.databases = {}
 
         new_content = "# myproject\n\n## Architecture\nNew content." * 10
 
@@ -719,7 +719,7 @@ class TestInitWorkspaceRunFullFlow:
         iw = self._setup_iw(tmp_path)
 
         mock_config = MagicMock()
-        mock_config.service.databases = {}
+        mock_config.services.databases = {}
 
         with (
             patch("datus.configuration.agent_config_loader.load_agent_config", return_value=mock_config),

--- a/tests/unit_tests/cli/test_interactive_configure.py
+++ b/tests/unit_tests/cli/test_interactive_configure.py
@@ -8,6 +8,7 @@ import subprocess
 from unittest.mock import MagicMock, patch
 
 import yaml
+from rich.console import Console
 
 
 def _make_configure(tmp_path):
@@ -217,9 +218,12 @@ class TestInitDirsAndCopyFiles:
         """_copy_files() swallows exceptions from copy_data_file without raising."""
         cfg = _make_configure(tmp_path)
 
-        with patch("datus.cli.interactive_configure.copy_data_file", side_effect=Exception("copy failed")):
-            # Should not raise
+        with (
+            patch("datus.cli.interactive_configure.copy_data_file", side_effect=Exception("copy failed")),
+            patch("datus.cli.interactive_configure.logger.debug") as mock_debug,
+        ):
             cfg._copy_files()
+        assert mock_debug.call_count == 3
 
     def test_copy_files_copies_prompts_and_samples(self, tmp_path):
         """_copy_files() attempts to copy prompts, sample_data, and skills."""
@@ -421,9 +425,14 @@ class TestShowCurrentState:
             "my_db": {"type": "sqlite", "uri": "path/to/db.sqlite"},
         }
         cfg.target = "openai"
+        cfg.console = Console(record=True, width=120)
 
-        # Should not raise
         cfg._show_current_state()
+        output = cfg.console.export_text()
+        assert "Current Models" in output
+        assert "Current Databases" in output
+        assert "openai" in output
+        assert "my_db" in output
 
     def test_with_empty_models_and_databases_no_exception(self, tmp_path):
         """_show_current_state() handles empty state without errors."""
@@ -431,8 +440,12 @@ class TestShowCurrentState:
         cfg.models = {}
         cfg.databases = {}
         cfg.target = ""
+        cfg.console = Console(record=True, width=120)
 
         cfg._show_current_state()
+        output = cfg.console.export_text()
+        assert "No models configured." in output
+        assert "No databases configured." in output
 
     def test_marks_default_model_with_asterisk(self, tmp_path):
         """_show_current_state() shows '*' next to the target/default model."""
@@ -443,9 +456,13 @@ class TestShowCurrentState:
         }
         cfg.databases = {}
         cfg.target = "openai"
+        cfg.console = Console(record=True, width=120)
 
-        # No exception + table is rendered (verified by no exception)
         cfg._show_current_state()
+        output = cfg.console.export_text()
+        assert "openai" in output
+        assert "deepseek" in output
+        assert "*" in output
 
     def test_database_with_host_field_shows_host(self, tmp_path):
         """_show_current_state() uses 'host' as connection when 'uri' is absent."""
@@ -455,8 +472,12 @@ class TestShowCurrentState:
             "pg_db": {"type": "postgresql", "host": "localhost"},
         }
         cfg.target = ""
+        cfg.console = Console(record=True, width=120)
 
         cfg._show_current_state()
+        output = cfg.console.export_text()
+        assert "pg_db" in output
+        assert "localhost" in output
 
     def test_database_default_marked_with_asterisk(self, tmp_path):
         """_show_current_state() shows '*' next to the database with default=True."""
@@ -467,8 +488,13 @@ class TestShowCurrentState:
             "other_db": {"type": "sqlite", "uri": "other.sqlite"},
         }
         cfg.target = ""
+        cfg.console = Console(record=True, width=120)
 
         cfg._show_current_state()
+        output = cfg.console.export_text()
+        assert "main_db" in output
+        assert "other_db" in output
+        assert "*" in output
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit_tests/cli/test_interactive_configure.py
+++ b/tests/unit_tests/cli/test_interactive_configure.py
@@ -242,12 +242,12 @@ class TestLoadExistingConfig:
     """Tests for InteractiveConfigure._load_existing_config()."""
 
     def test_service_databases_format_populates_self_databases(self, tmp_path):
-        """New service.databases format is loaded into self.databases correctly."""
+        """New services.databases format is loaded into self.databases correctly."""
         raw = {
             "agent": {
                 "target": "openai",
                 "models": {"openai": {"type": "openai", "model": "gpt-4o", "api_key": "sk-test"}},
-                "service": {
+                "services": {
                     "databases": {
                         "my_db": {"type": "sqlite", "uri": "data/test.sqlite"},
                     },
@@ -269,7 +269,7 @@ class TestLoadExistingConfig:
         assert "openai" in cfg.models
 
     def test_legacy_namespace_format_auto_migrates(self, tmp_path):
-        """Legacy namespace format is auto-migrated via ServiceConfig.migrate_from_namespace."""
+        """Legacy namespace format is auto-migrated via ServicesConfig.migrate_from_namespace."""
         raw = {
             "agent": {
                 "target": "",
@@ -288,7 +288,7 @@ class TestLoadExistingConfig:
         migrate_result = {"databases": {"legacy_db": {"type": "duckdb", "uri": "legacy.duckdb"}}}
 
         with patch(
-            "datus.configuration.agent_config.ServiceConfig.migrate_from_namespace",
+            "datus.configuration.agent_config.ServicesConfig.migrate_from_namespace",
             return_value=migrate_result,
         ):
             cfg = _make_configure(tmp_path)
@@ -1862,7 +1862,7 @@ class TestSave:
     """Tests for InteractiveConfigure._save()."""
 
     def test_save_writes_yaml_with_service_structure(self, tmp_path):
-        """_save() writes a YAML file containing the service.databases section."""
+        """_save() writes a YAML file containing the services.databases section."""
         cfg = _make_configure(tmp_path)
         cfg.models = {"openai": {"type": "openai", "model": "gpt-4o", "api_key": "sk-test"}}
         cfg.databases = {"my_db": {"type": "sqlite", "uri": "path/to/db.sqlite", "default": True}}
@@ -1876,10 +1876,10 @@ class TestSave:
 
         agent = saved["agent"]
         assert agent["target"] == "openai"
-        assert "my_db" in agent["service"]["databases"]
-        assert "semantic_layer" in agent["service"]
-        assert "bi_tools" in agent["service"]
-        assert "schedulers" in agent["service"]
+        assert "my_db" in agent["services"]["databases"]
+        assert "semantic_layer" in agent["services"]
+        assert "bi_tools" in agent["services"]
+        assert "schedulers" in agent["services"]
 
     def test_save_merges_with_existing_config_preserves_other_sections(self, tmp_path):
         """_save() preserves sections not managed by InteractiveConfigure."""

--- a/tests/unit_tests/cli/test_interactive_configure.py
+++ b/tests/unit_tests/cli/test_interactive_configure.py
@@ -251,6 +251,7 @@ class TestLoadExistingConfig:
                     "databases": {
                         "my_db": {"type": "sqlite", "uri": "data/test.sqlite"},
                     },
+                    "semantic_layer": {},
                     "bi_tools": {},
                     "schedulers": {},
                 },
@@ -1876,6 +1877,7 @@ class TestSave:
         agent = saved["agent"]
         assert agent["target"] == "openai"
         assert "my_db" in agent["service"]["databases"]
+        assert "semantic_layer" in agent["service"]
         assert "bi_tools" in agent["service"]
         assert "schedulers" in agent["service"]
 

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -252,7 +252,7 @@ class TestRepairProjectOverrides:
 
     def _raw_agent(self, models, databases):
         service_dbs = {name: {"type": db_type} for name, db_type in databases.items()}
-        return {"models": {name: {} for name in models}, "service": {"databases": service_dbs}}
+        return {"models": {name: {} for name in models}, "services": {"databases": service_dbs}}
 
     def _mock_mgr(self, raw):
         mgr = MagicMock()
@@ -436,13 +436,13 @@ class TestRepairProjectOverrides:
 class TestResolveDefaultDatabase:
     def _make_config(self, databases: dict, default: str = ""):
         cfg = MagicMock()
-        cfg.service.databases = databases
-        cfg.service.default_database = default
+        cfg.services.databases = databases
+        cfg.services.default_database = default
         return cfg
 
     def test_returns_service_default_database(self):
         """_resolve_default_database is now a thin wrapper over
-        config.service.default_database — the overlay is applied upstream by
+        config.services.default_database — the overlay is applied upstream by
         _apply_project_override, so this function just reads the resolved
         value. We verify the resolved value wins regardless of the base
         agent.yml: the mock returns "b" directly."""

--- a/tests/unit_tests/cli/test_namespace_manager.py
+++ b/tests/unit_tests/cli/test_namespace_manager.py
@@ -118,12 +118,12 @@ class TestNamespaceManagerAdd:
         result = nm.add()
 
         assert result == 0  # 0 means success
-        # After add, the new entry should be in service.databases (keyed by logical name)
+        # After add, the new entry should be in services.databases (keyed by logical name)
         # The namespace_manager adds with logical_name = namespace_name input ("test_duckdb")
         # or may use the path stem as the database name (e.g. "test")
-        db_names = set(nm.agent_config.service.databases.keys())
+        db_names = set(nm.agent_config.services.databases.keys())
         assert "test_duckdb" in db_names or "test" in db_names, (
-            f"Expected 'test_duckdb' or 'test' in service.databases, got: {db_names}"
+            f"Expected 'test_duckdb' or 'test' in services.databases, got: {db_names}"
         )
         mock_console.print.assert_any_call("✔ Database connection test successful\n")
         mock_console.print.assert_any_call("✔ Namespace 'test_duckdb' added successfully")
@@ -136,7 +136,7 @@ class TestNamespaceManagerList:
         """Test listing namespaces when none are configured."""
         nm = NamespaceManager(config_path)
         # Clear all databases (namespaces is a compat property, so clear the source)
-        nm.agent_config.service.databases.clear()
+        nm.agent_config.services.databases.clear()
 
         result = nm.list()
 

--- a/tests/unit_tests/cli/test_namespace_manager.py
+++ b/tests/unit_tests/cli/test_namespace_manager.py
@@ -118,13 +118,9 @@ class TestNamespaceManagerAdd:
         result = nm.add()
 
         assert result == 0  # 0 means success
-        # After add, the new entry should be in services.databases (keyed by logical name)
-        # The namespace_manager adds with logical_name = namespace_name input ("test_duckdb")
-        # or may use the path stem as the database name (e.g. "test")
+        # After add, the new entry should be in services.databases keyed by the requested logical name.
         db_names = set(nm.agent_config.services.databases.keys())
-        assert "test_duckdb" in db_names or "test" in db_names, (
-            f"Expected 'test_duckdb' or 'test' in services.databases, got: {db_names}"
-        )
+        assert "test_duckdb" in db_names, f"Expected 'test_duckdb' in services.databases, got: {db_names}"
         mock_console.print.assert_any_call("✔ Database connection test successful\n")
         mock_console.print.assert_any_call("✔ Namespace 'test_duckdb' added successfully")
 

--- a/tests/unit_tests/cli/test_project_init.py
+++ b/tests/unit_tests/cli/test_project_init.py
@@ -22,7 +22,7 @@ def _make_base_config(models, databases, target="", default_database=""):
     cfg = MagicMock()
     cfg.models = models
     cfg.target = target
-    cfg.service = SimpleNamespace(
+    cfg.services = SimpleNamespace(
         databases={name: SimpleNamespace(type=t) for name, t in databases.items()},
         default_database=default_database,
     )

--- a/tests/unit_tests/cli/test_service_manager.py
+++ b/tests/unit_tests/cli/test_service_manager.py
@@ -10,16 +10,16 @@ from datus.utils.exceptions import DatusException, ErrorCode
 
 
 def _make_agent_config(databases=None):
-    """Build a minimal mock AgentConfig with service.databases."""
+    """Build a minimal mock AgentConfig with services.databases."""
     db_map = databases if databases is not None else {}
-    service = MagicMock()
-    service.databases = db_map
-    service.default_database = next(iter(db_map), None)
-    service.semantic_layer = {}
-    service.bi_tools = {}
-    service.schedulers = {}
+    services = MagicMock()
+    services.databases = db_map
+    services.default_database = next(iter(db_map), None)
+    services.semantic_layer = {}
+    services.bi_tools = {}
+    services.schedulers = {}
     agent_config = MagicMock()
-    agent_config.service = service
+    agent_config.services = services
     return agent_config
 
 
@@ -183,7 +183,7 @@ class TestServiceManagerList:
         """list() prints BI tools section when bi_tools are configured."""
         db_cfg = _make_db_config()
         mock_config = _make_agent_config({"my_db": db_cfg})
-        mock_config.service.bi_tools = {"tableau": {"url": "http://tableau"}}
+        mock_config.services.bi_tools = {"tableau": {"url": "http://tableau"}}
 
         with (
             patch("datus.cli.service_manager.load_agent_config", return_value=mock_config),
@@ -230,7 +230,7 @@ class TestServiceManagerList:
         """list() prints schedulers section when schedulers are configured."""
         db_cfg = _make_db_config()
         mock_config = _make_agent_config({"my_db": db_cfg})
-        mock_config.service.schedulers = {"airflow": {"url": "http://airflow"}}
+        mock_config.services.schedulers = {"airflow": {"url": "http://airflow"}}
 
         with (
             patch("datus.cli.service_manager.load_agent_config", return_value=mock_config),
@@ -249,7 +249,7 @@ class TestServiceManagerList:
         db_cfg_default = _make_db_config(default=True)
         db_cfg_other = _make_db_config(default=False)
         mock_config = _make_agent_config({"default_db": db_cfg_default, "other_db": db_cfg_other})
-        mock_config.service.default_database = "default_db"
+        mock_config.services.default_database = "default_db"
 
         with (
             patch("datus.cli.service_manager.load_agent_config", return_value=mock_config),
@@ -930,7 +930,7 @@ class TestServiceManagerSaveConfiguration:
     """Tests for ServiceManager._save_configuration()."""
 
     def test_save_configuration_builds_correct_structure(self):
-        """_save_configuration() calls configure_manager.update with correct service section."""
+        """_save_configuration() calls configure_manager.update with the correct services section."""
         db_cfg = _make_db_config(db_type="sqlite", uri="data/db.sqlite", default=True)
         mock_config = _make_agent_config({"main_db": db_cfg})
 
@@ -950,8 +950,8 @@ class TestServiceManagerSaveConfiguration:
             mock_cm.update.assert_called_once()
             call_kwargs = mock_cm.update.call_args
             updates = call_kwargs[1]["updates"] if call_kwargs[1] else call_kwargs[0][0]
-            assert "service" in updates
-            assert "databases" in updates["service"]
+            assert "services" in updates
+            assert "databases" in updates["services"]
 
     def test_save_configuration_returns_false_on_exception(self):
         """_save_configuration() returns False when configuration_manager raises."""
@@ -1010,7 +1010,7 @@ class TestServiceManagerSaveConfiguration:
         db_cfg.to_dict.assert_called_once()
         call_kwargs = mock_cm.update.call_args
         updates = call_kwargs[1]["updates"] if call_kwargs[1] else call_kwargs[0][0]
-        pg_entry = updates["service"]["databases"]["pg_db"]
+        pg_entry = updates["services"]["databases"]["pg_db"]
         # Internal fields should be removed
         assert "logic_name" not in pg_entry
         assert "path_pattern" not in pg_entry
@@ -1021,7 +1021,7 @@ class TestServiceManagerSaveConfiguration:
         mock_config = _make_agent_config({"main_db": db_cfg})
 
         mock_cm = MagicMock()
-        mock_cm.data = {"namespace": {"old_db": {}}, "service": {}}
+        mock_cm.data = {"namespace": {"old_db": {}}, "services": {}}
 
         with (
             patch("datus.cli.service_manager.load_agent_config", return_value=mock_config),
@@ -1058,7 +1058,7 @@ class TestServiceManagerSaveConfiguration:
         assert result is True
         call_kwargs = mock_cm.update.call_args
         updates = call_kwargs[1]["updates"] if call_kwargs[1] else call_kwargs[0][0]
-        main_entry = updates["service"]["databases"]["main_db"]
+        main_entry = updates["services"]["databases"]["main_db"]
         assert main_entry.get("default") is True
 
     def test_save_configuration_non_default_sqlite_no_logic_name_diff(self):
@@ -1112,7 +1112,7 @@ class TestServiceManagerSaveConfiguration:
         assert result is True
         call_kwargs = mock_cm.update.call_args
         updates = call_kwargs[1]["updates"] if call_kwargs[1] else call_kwargs[0][0]
-        main_entry = updates["service"]["databases"]["main_db"]
+        main_entry = updates["services"]["databases"]["main_db"]
         assert main_entry.get("name") == "alias_name"
 
 

--- a/tests/unit_tests/cli/test_service_manager.py
+++ b/tests/unit_tests/cli/test_service_manager.py
@@ -15,6 +15,7 @@ def _make_agent_config(databases=None):
     service = MagicMock()
     service.databases = db_map
     service.default_database = next(iter(db_map), None)
+    service.semantic_layer = {}
     service.bi_tools = {}
     service.schedulers = {}
     agent_config = MagicMock()

--- a/tests/unit_tests/cli/test_tutorial.py
+++ b/tests/unit_tests/cli/test_tutorial.py
@@ -162,8 +162,8 @@ class TestBenchmarkTutorialEnsureConfig:
         mock_agent_config = MagicMock()
         mock_agent_config.home = str(tmp_path)
         mock_agent_config.benchmark_configs = {"california_schools": {}}
-        mock_agent_config.service = MagicMock()
-        mock_agent_config.service.databases = {"california_schools": {}}
+        mock_agent_config.services = MagicMock()
+        mock_agent_config.services.databases = {"california_schools": {}}
         mock_agent_config.path_manager = MagicMock()
         mock_agent_config.path_manager.benchmark_dir = tmp_path / "benchmark"
 
@@ -183,8 +183,8 @@ class TestBenchmarkTutorialEnsureConfig:
         mock_agent_config = MagicMock()
         mock_agent_config.home = str(tmp_path)
         mock_agent_config.benchmark_configs = {}
-        mock_agent_config.service = MagicMock()
-        mock_agent_config.service.databases = {}
+        mock_agent_config.services = MagicMock()
+        mock_agent_config.services.databases = {}
         mock_agent_config.path_manager = MagicMock()
         mock_agent_config.path_manager.benchmark_dir = tmp_path / "benchmark"
 
@@ -206,9 +206,9 @@ class TestBenchmarkTutorialEnsureConfig:
 
         assert result is True
         assert mock_config_manager.update_item.call_count == 2
-        # First call for service config (databases)
+        # First call for services config (databases)
         first_call = mock_config_manager.update_item.call_args_list[0]
-        assert first_call[0][0] == "service"
+        assert first_call[0][0] == "services"
         # Second call for benchmark config
         second_call = mock_config_manager.update_item.call_args_list[1]
         assert second_call[0][0] == "benchmark"
@@ -222,8 +222,8 @@ class TestBenchmarkTutorialEnsureConfig:
         mock_agent_config = MagicMock()
         mock_agent_config.home = str(tmp_path)
         mock_agent_config.benchmark_configs = {}
-        mock_agent_config.service = MagicMock()
-        mock_agent_config.service.databases = {}
+        mock_agent_config.services = MagicMock()
+        mock_agent_config.services.databases = {}
         mock_agent_config.path_manager = MagicMock()
         mock_agent_config.path_manager.benchmark_dir = tmp_path / "benchmark"
 
@@ -242,11 +242,11 @@ class TestBenchmarkTutorialEnsureConfig:
         seed_agent = (yaml.safe_load(seed_config.read_text(encoding="utf-8")) or {}).get("agent", {})
         target_agent = (yaml.safe_load(target_config.read_text(encoding="utf-8")) or {}).get("agent", {})
 
-        assert "service" not in seed_agent
+        assert "services" not in seed_agent
         assert "benchmark" not in seed_agent
-        assert "service" in target_agent
+        assert "services" in target_agent
         assert "benchmark" in target_agent
-        assert "california_schools" in target_agent["service"]["databases"]
+        assert "california_schools" in target_agent["services"]["databases"]
         assert "california_schools" in target_agent["benchmark"]
 
 
@@ -404,8 +404,8 @@ class TestBenchmarkTutorialRun:
         mock_agent_config = MagicMock()
         mock_agent_config.home = str(tmp_path)
         mock_agent_config.benchmark_configs = {"california_schools": {}}
-        mock_agent_config.service = MagicMock()
-        mock_agent_config.service.databases = {"california_schools": {}}
+        mock_agent_config.services = MagicMock()
+        mock_agent_config.services.databases = {"california_schools": {}}
         benchmark_path = tmp_path / "benchmark"
         benchmark_path.mkdir()
         mock_agent_config.path_manager = MagicMock()

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -161,7 +161,10 @@ class TestBenchmarkConfigValidate:
             question_file="dev.json",
             question_id_key="id",
         )
-        cfg.validate()  # should not raise
+        assert cfg.validate() is None
+        assert cfg.question_key == "question"
+        assert cfg.question_file == "dev.json"
+        assert cfg.question_id_key == "id"
 
     def test_missing_question_key_raises(self):
         cfg = BenchmarkConfig(question_file="dev.json", question_id_key="id")

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -356,7 +356,7 @@ class TestLoadModelConfig:
 
 
 class TestAgentConfigServiceSelectors:
-    def _make(self, tmp_path, *, service=None, agentic_nodes=None):
+    def _make(self, tmp_path, *, services=None, agentic_nodes=None):
         return AgentConfig(
             nodes={"test": NodeConfig(model="test-model", input=None)},
             home=str(tmp_path / "h"),
@@ -369,7 +369,7 @@ class TestAgentConfigServiceSelectors:
                     "base_url": "http://localhost:0",
                 }
             },
-            service=service or {"databases": {}},
+            services=services or {"databases": {}},
             agentic_nodes=agentic_nodes or {},
             skip_init_dirs=True,
         )
@@ -377,7 +377,7 @@ class TestAgentConfigServiceSelectors:
     def test_resolve_semantic_adapter_returns_explicit_configured_adapter(self, tmp_path):
         cfg = self._make(
             tmp_path,
-            service={
+            services={
                 "databases": {},
                 "semantic_layer": {
                     "metricflow": {"timeout": 300},
@@ -389,7 +389,7 @@ class TestAgentConfigServiceSelectors:
     def test_resolve_semantic_adapter_auto_selects_single_configured_entry(self, tmp_path):
         cfg = self._make(
             tmp_path,
-            service={
+            services={
                 "databases": {},
                 "semantic_layer": {
                     "metricflow": {"timeout": 300},
@@ -401,7 +401,7 @@ class TestAgentConfigServiceSelectors:
     def test_resolve_semantic_adapter_requires_explicit_choice_for_multiple_entries(self, tmp_path):
         cfg = self._make(
             tmp_path,
-            service={
+            services={
                 "databases": {},
                 "semantic_layer": {
                     "metricflow": {"timeout": 300},
@@ -415,7 +415,7 @@ class TestAgentConfigServiceSelectors:
     def test_default_scheduler_service_prefers_single_default(self, tmp_path):
         cfg = self._make(
             tmp_path,
-            service={
+            services={
                 "databases": {},
                 "schedulers": {
                     "airflow_prod": {"type": "airflow", "default": True},
@@ -429,7 +429,7 @@ class TestAgentConfigServiceSelectors:
         with pytest.raises(DatusException, match="Multiple scheduler services are marked"):
             self._make(
                 tmp_path,
-                service={
+                services={
                     "databases": {},
                     "schedulers": {
                         "airflow_prod": {"type": "airflow", "default": True},
@@ -441,7 +441,7 @@ class TestAgentConfigServiceSelectors:
     def test_get_scheduler_config_requires_explicit_choice_when_multiple_instances_exist(self, tmp_path):
         cfg = self._make(
             tmp_path,
-            service={
+            services={
                 "databases": {},
                 "schedulers": {
                     "airflow_prod": {"type": "airflow"},
@@ -455,7 +455,7 @@ class TestAgentConfigServiceSelectors:
     def test_get_scheduler_config_returns_requested_instance(self, tmp_path):
         cfg = self._make(
             tmp_path,
-            service={
+            services={
                 "databases": {},
                 "schedulers": {
                     "airflow_prod": {"type": "airflow", "api_base_url": "http://prod"},
@@ -469,7 +469,7 @@ class TestAgentConfigServiceSelectors:
         with pytest.raises(DatusException, match="must declare a scheduler `type`"):
             self._make(
                 tmp_path,
-                service={
+                services={
                     "databases": {},
                     "schedulers": {
                         "airflow_prod": {"api_base_url": "http://prod"},

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -17,10 +17,12 @@ import argparse
 import pytest
 
 from datus.configuration.agent_config import (
+    AgentConfig,
     BenchmarkConfig,
     DbConfig,
     DocumentConfig,
     ModelConfig,
+    NodeConfig,
     file_stem_from_uri,
     load_model_config,
     resolve_env,
@@ -351,6 +353,129 @@ class TestLoadModelConfig:
         d = cfg.to_dict()
         assert d["type"] == "openai"
         assert d["model"] == "gpt-4"
+
+
+class TestAgentConfigServiceSelectors:
+    def _make(self, tmp_path, *, service=None, agentic_nodes=None):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            service=service or {"databases": {}},
+            agentic_nodes=agentic_nodes or {},
+            skip_init_dirs=True,
+        )
+
+    def test_resolve_semantic_adapter_returns_explicit_configured_adapter(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            service={
+                "databases": {},
+                "semantic_layer": {
+                    "metricflow": {"timeout": 300},
+                },
+            },
+        )
+        assert cfg.resolve_semantic_adapter("metricflow") == "metricflow"
+
+    def test_resolve_semantic_adapter_auto_selects_single_configured_entry(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            service={
+                "databases": {},
+                "semantic_layer": {
+                    "metricflow": {"timeout": 300},
+                },
+            },
+        )
+        assert cfg.resolve_semantic_adapter() == "metricflow"
+
+    def test_resolve_semantic_adapter_requires_explicit_choice_for_multiple_entries(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            service={
+                "databases": {},
+                "semantic_layer": {
+                    "metricflow": {"timeout": 300},
+                    "cube": {"timeout": 60},
+                },
+            },
+        )
+        with pytest.raises(DatusException, match="Multiple semantic layers are configured"):
+            cfg.resolve_semantic_adapter()
+
+    def test_default_scheduler_service_prefers_single_default(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            service={
+                "databases": {},
+                "schedulers": {
+                    "airflow_prod": {"type": "airflow", "default": True},
+                    "airflow_dev": {"type": "airflow"},
+                },
+            },
+        )
+        assert cfg.default_scheduler_service() == "airflow_prod"
+
+    def test_default_scheduler_service_rejects_multiple_defaults(self, tmp_path):
+        with pytest.raises(DatusException, match="Multiple scheduler services are marked"):
+            self._make(
+                tmp_path,
+                service={
+                    "databases": {},
+                    "schedulers": {
+                        "airflow_prod": {"type": "airflow", "default": True},
+                        "airflow_dev": {"type": "airflow", "default": True},
+                    },
+                },
+            )
+
+    def test_get_scheduler_config_requires_explicit_choice_when_multiple_instances_exist(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            service={
+                "databases": {},
+                "schedulers": {
+                    "airflow_prod": {"type": "airflow"},
+                    "airflow_dev": {"type": "airflow"},
+                },
+            },
+        )
+        with pytest.raises(DatusException, match="set `scheduler_service` on the scheduler node"):
+            cfg.get_scheduler_config()
+
+    def test_get_scheduler_config_returns_requested_instance(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            service={
+                "databases": {},
+                "schedulers": {
+                    "airflow_prod": {"type": "airflow", "api_base_url": "http://prod"},
+                    "airflow_dev": {"type": "airflow", "api_base_url": "http://dev"},
+                },
+            },
+        )
+        assert cfg.get_scheduler_config("airflow_dev")["api_base_url"] == "http://dev"
+
+    def test_init_scheduler_services_requires_declared_type(self, tmp_path):
+        with pytest.raises(DatusException, match="must declare a scheduler `type`"):
+            self._make(
+                tmp_path,
+                service={
+                    "databases": {},
+                    "schedulers": {
+                        "airflow_prod": {"api_base_url": "http://prod"},
+                    },
+                },
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -373,7 +373,7 @@ class TestLoadAgentConfigResolution:
                                 "base_url": "http://localhost:0",
                             }
                         },
-                        "service": {"databases": databases},
+                        "services": {"databases": databases},
                         "project_root": str(tmp_path / "workspace"),
                     }
                 }

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -206,7 +206,7 @@ class TestApplyProjectOverride:
         return {
             "target": "openai",
             "models": {"openai": {"type": "openai"}, "deepseek": {"type": "deepseek"}},
-            "service": {"databases": {"db1": {"type": "sqlite"}, "db2": {"type": "duckdb"}}},
+            "services": {"databases": {"db1": {"type": "sqlite"}, "db2": {"type": "duckdb"}}},
         }
 
     def test_no_override_is_noop(self):
@@ -258,7 +258,7 @@ class TestApplyProjectOverride:
 
     def test_valid_default_database_flips_default_flags(self):
         """default_database overlay is applied by flipping databases[*].default
-        so AgentConfig.service.default_database resolves to the override target
+        so AgentConfig.services.default_database resolves to the override target
         uniformly across every entry point (REPL, datus-api, SDK)."""
         agent_raw = self._base_raw()
         with patch(
@@ -266,22 +266,22 @@ class TestApplyProjectOverride:
             return_value=ProjectOverride(default_database="db2"),
         ):
             _apply_project_override(agent_raw)
-        assert agent_raw["service"]["databases"]["db2"]["default"] is True
-        assert agent_raw["service"]["databases"]["db1"]["default"] is False
+        assert agent_raw["services"]["databases"]["db2"]["default"] is True
+        assert agent_raw["services"]["databases"]["db1"]["default"] is False
 
     def test_default_database_overlay_clears_prior_default(self):
         """A base config marking db1 as default must have that flag cleared
         when the overlay points elsewhere, otherwise default_database would
         return the first match (db1) and ignore the overlay."""
         agent_raw = self._base_raw()
-        agent_raw["service"]["databases"]["db1"]["default"] = True
+        agent_raw["services"]["databases"]["db1"]["default"] = True
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
             return_value=ProjectOverride(default_database="db2"),
         ):
             _apply_project_override(agent_raw)
-        assert agent_raw["service"]["databases"]["db1"]["default"] is False
-        assert agent_raw["service"]["databases"]["db2"]["default"] is True
+        assert agent_raw["services"]["databases"]["db1"]["default"] is False
+        assert agent_raw["services"]["databases"]["db2"]["default"] is True
 
     def test_invalid_default_database_raises(self):
         agent_raw = self._base_raw()
@@ -305,7 +305,7 @@ class TestApplyProjectOverride:
         assert agent_raw["project_name"] == "p"
 
     def test_missing_models_section_invalid_target_raises(self):
-        agent_raw = {"service": {"databases": {"db1": {}}}}
+        agent_raw = {"services": {"databases": {"db1": {}}}}
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
             return_value=ProjectOverride(target="deepseek"),

--- a/tests/unit_tests/configuration/test_config_migrator.py
+++ b/tests/unit_tests/configuration/test_config_migrator.py
@@ -6,14 +6,14 @@
 
 import yaml
 
-from datus.configuration.config_migrator import migrate_file, migrate_namespace_to_service
+from datus.configuration.config_migrator import migrate_file, migrate_namespace_to_services
 
 
-class TestMigrateNamespaceToService:
-    """Tests for migrate_namespace_to_service()."""
+class TestMigrateNamespaceToServices:
+    """Tests for migrate_namespace_to_services()."""
 
-    def test_single_db_namespace_produces_service_databases(self):
-        """Old namespace with single DB entry becomes service.databases entry."""
+    def test_single_db_namespace_produces_services_databases(self):
+        """Old namespace with single DB entry becomes services.databases entry."""
         config = {
             "agent": {
                 "namespace": {
@@ -24,18 +24,18 @@ class TestMigrateNamespaceToService:
                 }
             }
         }
-        result = migrate_namespace_to_service(config)
-        service = result["agent"]["service"]
-        assert "databases" in service
-        assert "my_db" in service["databases"]
-        db = service["databases"]["my_db"]
+        result = migrate_namespace_to_services(config)
+        services = result["agent"]["services"]
+        assert "databases" in services
+        assert "my_db" in services["databases"]
+        db = services["databases"]["my_db"]
         assert db["type"] == "sqlite"
         assert db["uri"] == "path/to/my.sqlite"
         # Single-entry default mark
         assert db.get("default") is True
-        assert service["semantic_layer"] == {}
-        assert service["bi_tools"] == {}
-        assert service["schedulers"] == {}
+        assert services["semantic_layer"] == {}
+        assert services["bi_tools"] == {}
+        assert services["schedulers"] == {}
 
     def test_dbs_list_is_flattened_to_individual_entries(self):
         """Namespace with 'dbs' list produces one entry per db, type inherited from namespace."""
@@ -52,8 +52,8 @@ class TestMigrateNamespaceToService:
                 }
             }
         }
-        result = migrate_namespace_to_service(config)
-        databases = result["agent"]["service"]["databases"]
+        result = migrate_namespace_to_services(config)
+        databases = result["agent"]["services"]["databases"]
         assert "db1" in databases
         assert "db2" in databases
         assert databases["db1"]["type"] == "sqlite"
@@ -76,17 +76,17 @@ class TestMigrateNamespaceToService:
                 }
             }
         }
-        result = migrate_namespace_to_service(config)
-        databases = result["agent"]["service"]["databases"]
+        result = migrate_namespace_to_services(config)
+        databases = result["agent"]["services"]["databases"]
         assert "glob_ns" in databases
         assert databases["glob_ns"]["path_pattern"] == "data/*.sqlite"
         assert databases["glob_ns"]["type"] == "sqlite"
 
     def test_already_migrated_config_is_no_op(self):
-        """Config with existing 'service' key is returned unchanged."""
+        """Config with existing 'services' key is returned unchanged."""
         config = {
             "agent": {
-                "service": {
+                "services": {
                     "databases": {"existing_db": {"type": "duckdb"}},
                     "semantic_layer": {},
                     "bi_tools": {},
@@ -94,26 +94,26 @@ class TestMigrateNamespaceToService:
                 }
             }
         }
-        result = migrate_namespace_to_service(config)
-        # Namespace section should not have been touched; service intact
+        result = migrate_namespace_to_services(config)
+        # Namespace section should not have been touched; services intact
         assert "namespace" not in result["agent"]
-        assert result["agent"]["service"]["databases"]["existing_db"]["type"] == "duckdb"
+        assert result["agent"]["services"]["databases"]["existing_db"]["type"] == "duckdb"
 
     def test_no_namespace_section_is_no_op(self):
-        """Config with no 'namespace' section is returned unchanged (no 'service' added)."""
+        """Config with no 'namespace' section is returned unchanged (no 'services' added)."""
         config = {
             "agent": {
                 "target": "openai",
                 "models": {"openai": {"type": "openai", "model": "gpt-4o"}},
             }
         }
-        result = migrate_namespace_to_service(config)
-        # No service key added when there was no namespace to migrate
-        assert "service" not in result["agent"]
+        result = migrate_namespace_to_services(config)
+        # No services key added when there was no namespace to migrate
+        assert "services" not in result["agent"]
         assert result["agent"]["target"] == "openai"
 
     def test_original_config_not_mutated(self):
-        """migrate_namespace_to_service returns a deep copy; original dict unchanged."""
+        """migrate_namespace_to_services returns a deep copy; original dict unchanged."""
         config = {
             "agent": {
                 "namespace": {
@@ -128,7 +128,7 @@ class TestMigrateNamespaceToService:
                 }
             }
         }
-        migrate_namespace_to_service(config)
+        migrate_namespace_to_services(config)
         assert config == original_copy
 
     def test_multiple_namespaces_produce_multiple_databases(self):
@@ -141,8 +141,8 @@ class TestMigrateNamespaceToService:
                 }
             }
         }
-        result = migrate_namespace_to_service(config)
-        databases = result["agent"]["service"]["databases"]
+        result = migrate_namespace_to_services(config)
+        databases = result["agent"]["services"]["databases"]
         assert "snowflake_ns" in databases
         assert "duckdb_ns" in databases
         # Multiple entries: no automatic default marking
@@ -173,7 +173,7 @@ class TestMigrateFile:
         assert not backup.exists()
 
     def test_migrate_file_writes_new_format(self, tmp_path):
-        """migrate_file writes new service format and creates backup."""
+        """migrate_file writes the new services format and creates a backup."""
         config_data = {
             "agent": {
                 "namespace": {
@@ -190,11 +190,11 @@ class TestMigrateFile:
         # Backup created
         backup = tmp_path / "agent.yml.bak"
         assert backup.exists()
-        # New file has service format
+        # New file has services format
         with open(config_file, encoding="utf-8") as f:
             new_config = yaml.safe_load(f)
-        assert "service" in new_config["agent"]
-        assert "db1" in new_config["agent"]["service"]["databases"]
+        assert "services" in new_config["agent"]
+        assert "db1" in new_config["agent"]["services"]["databases"]
 
     def test_migrate_file_nonexistent_path_returns_false(self, tmp_path):
         """migrate_file returns False when config file does not exist."""
@@ -202,10 +202,10 @@ class TestMigrateFile:
         assert result is False
 
     def test_migrate_file_already_migrated_returns_false(self, tmp_path):
-        """migrate_file returns False when config already uses service format."""
+        """migrate_file returns False when config already uses services format."""
         config_data = {
             "agent": {
-                "service": {
+                "services": {
                     "databases": {},
                     "semantic_layer": {},
                     "bi_tools": {},

--- a/tests/unit_tests/configuration/test_config_migrator.py
+++ b/tests/unit_tests/configuration/test_config_migrator.py
@@ -33,6 +33,7 @@ class TestMigrateNamespaceToService:
         assert db["uri"] == "path/to/my.sqlite"
         # Single-entry default mark
         assert db.get("default") is True
+        assert service["semantic_layer"] == {}
         assert service["bi_tools"] == {}
         assert service["schedulers"] == {}
 
@@ -87,6 +88,7 @@ class TestMigrateNamespaceToService:
             "agent": {
                 "service": {
                     "databases": {"existing_db": {"type": "duckdb"}},
+                    "semantic_layer": {},
                     "bi_tools": {},
                     "schedulers": {},
                 }
@@ -205,6 +207,7 @@ class TestMigrateFile:
             "agent": {
                 "service": {
                     "databases": {},
+                    "semantic_layer": {},
                     "bi_tools": {},
                     "schedulers": {},
                 }

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -39,14 +39,14 @@ def test_config_exception(tmp_path):
 
 def test_service_config_structure(agent_config: AgentConfig):
     """Verify service config sections load into AgentConfig."""
-    assert agent_config.service is not None
-    assert len(agent_config.service.databases) > 0
-    assert "bird_school" in agent_config.service.databases
-    assert "snowflake" in agent_config.service.databases
-    assert "local_duckdb" in agent_config.service.databases
-    assert "metricflow" in agent_config.service.semantic_layer
-    assert "superset" in agent_config.service.bi_tools
-    assert "airflow_local" in agent_config.service.schedulers
+    assert agent_config.services is not None
+    assert len(agent_config.services.databases) > 0
+    assert "bird_school" in agent_config.services.databases
+    assert "snowflake" in agent_config.services.databases
+    assert "local_duckdb" in agent_config.services.databases
+    assert "metricflow" in agent_config.services.semantic_layer
+    assert "superset" in agent_config.services.bi_tools
+    assert "airflow_local" in agent_config.services.schedulers
 
 
 @pytest.mark.parametrize("database", ["bird_school", "snowflake", "local_duckdb"])
@@ -87,7 +87,7 @@ def test_configuration_load(database: str, agent_config: AgentConfig):
 
 def test_benchmark_db_check(agent_config: AgentConfig):
     db_name = "snowflake"
-    agent_config.service.databases[db_name].type = DBType.SQLITE
+    agent_config.services.databases[db_name].type = DBType.SQLITE
 
     with pytest.raises(DatusException, match="spider2 only support snowflake"):
         agent_config.override_by_args(

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -38,13 +38,15 @@ def test_config_exception(tmp_path):
 
 
 def test_service_config_structure(agent_config: AgentConfig):
-    """Verify legacy namespace config is migrated to service.databases."""
+    """Verify service config sections load into AgentConfig."""
     assert agent_config.service is not None
     assert len(agent_config.service.databases) > 0
-    # bird_school should be migrated as a database entry
     assert "bird_school" in agent_config.service.databases
     assert "snowflake" in agent_config.service.databases
     assert "local_duckdb" in agent_config.service.databases
+    assert "metricflow" in agent_config.service.semantic_layer
+    assert "superset" in agent_config.service.bi_tools
+    assert "airflow_local" in agent_config.service.schedulers
 
 
 @pytest.mark.parametrize("database", ["bird_school", "snowflake", "local_duckdb"])

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -180,6 +180,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
                     "default": True,
                 },
             },
+            "semantic_layer": {},
             "bi_tools": {},
             "schedulers": {},
         },

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -171,7 +171,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
                 "base_url": "http://localhost:0",
             },
         },
-        "service": {
+        "services": {
             "databases": {
                 "california_schools": {
                     "type": "sqlite",

--- a/tests/unit_tests/storage/metric/test_adapter_init.py
+++ b/tests/unit_tests/storage/metric/test_adapter_init.py
@@ -21,6 +21,10 @@ def _make_agent_config(namespace="test_ns", adapter_type_config=None):
     config = MagicMock()
     config.namespace = namespace
     config.current_database = namespace
+    config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: (
+        adapter_type.lower().strip() if adapter_type else None
+    )
+    config.build_semantic_adapter_config.side_effect = lambda adapter_type=None: {"namespace": namespace}
     # By default, no adapter-specific config on agent_config
     if adapter_type_config is not None:
         for key, val in adapter_type_config.items():

--- a/tests/unit_tests/storage/semantic_model/test_adapter_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_adapter_init.py
@@ -21,6 +21,10 @@ def _make_agent_config(namespace="test_ns"):
     config = MagicMock()
     config.namespace = namespace
     config.current_database = namespace
+    config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: (
+        adapter_type.lower().strip() if adapter_type else None
+    )
+    config.build_semantic_adapter_config.side_effect = lambda adapter_type=None: {"namespace": namespace}
     return config
 
 
@@ -249,8 +253,8 @@ class TestInitFromAdapter:
     @pytest.mark.asyncio
     @patch("datus.storage.semantic_model.adapter_init.SemanticStorageManager")
     @patch("datus.storage.semantic_model.adapter_init.semantic_adapter_registry")
-    async def test_none_config_falls_back_to_agent_config_attr(self, mock_registry, MockStorageManager):
-        """When adapter_config is None, should try agent_config.{adapter_type}_config."""
+    async def test_none_config_uses_build_semantic_adapter_config(self, mock_registry, MockStorageManager):
+        """When adapter_config is None, should use agent_config.build_semantic_adapter_config()."""
         from datus.storage.semantic_model.adapter_init import init_from_adapter
 
         mock_metadata = MagicMock()
@@ -262,14 +266,13 @@ class TestInitFromAdapter:
         mock_manager.sync_from_adapter = AsyncMock(return_value={"semantic_models_synced": 1})
         MockStorageManager.return_value = mock_manager
 
-        # agent_config has dbt_config attribute set to a config object
         existing_config = MagicMock()
         config = _make_agent_config()
-        config.dbt_config = existing_config
+        config.build_semantic_adapter_config.side_effect = None
+        config.build_semantic_adapter_config.return_value = existing_config
 
         await init_from_adapter(config, "dbt")
 
-        # The existing config object should be passed directly to create_adapter
         mock_registry.create_adapter.assert_called_once_with("dbt", existing_config)
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -35,6 +35,7 @@ if "datus_scheduler_core" not in sys.modules:
     sys.modules["datus_scheduler_core.config"] = _mock_core.config  # audit-noqa: module_level_sys_modules
 
 from datus.tools.func_tool.scheduler_tools import SchedulerTools
+from datus.utils.exceptions import DatusException, ErrorCode
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -52,6 +53,24 @@ def _make_agent_config(scheduler_config=None):
         }
     else:
         cfg.scheduler_config = scheduler_config
+    cfg.scheduler_services = {"airflow_local": cfg.scheduler_config} if cfg.scheduler_config else {}
+
+    def _get_scheduler_config(service_name=None):
+        if service_name:
+            if service_name not in cfg.scheduler_services:
+                raise DatusException(
+                    ErrorCode.COMMON_CONFIG_ERROR,
+                    message=f"No scheduler service named `{service_name}` found.",
+                )
+            return cfg.scheduler_services[service_name]
+        if cfg.scheduler_services:
+            return next(iter(cfg.scheduler_services.values()))
+        raise DatusException(
+            ErrorCode.COMMON_CONFIG_ERROR,
+            message="No scheduler configured in `agent.service.schedulers`.",
+        )
+
+    cfg.get_scheduler_config.side_effect = _get_scheduler_config
     return cfg
 
 
@@ -848,8 +867,8 @@ class TestListSchedulerConnections:
         tools = SchedulerTools(cfg)
         result = tools.list_scheduler_connections()
 
-        assert result.success == 1
-        assert result.result["total"] == 0
+        assert result.success == 0
+        assert "scheduler" in (result.error or "").lower()
 
 
 # ── available_tools: conn_id injection into description ──────────────────

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -67,7 +67,7 @@ def _make_agent_config(scheduler_config=None):
             return next(iter(cfg.scheduler_services.values()))
         raise DatusException(
             ErrorCode.COMMON_CONFIG_ERROR,
-            message="No scheduler configured in `agent.service.schedulers`.",
+            message="No scheduler configured in `agent.services.schedulers`.",
         )
 
     cfg.get_scheduler_config.side_effect = _get_scheduler_config

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -45,6 +45,8 @@ def semantic_tools():
 
         mock_config = Mock()
         mock_config.active_model.return_value.model = "gpt-4o"
+        mock_config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: adapter_type
+        mock_config.build_semantic_adapter_config.side_effect = lambda adapter_type=None: {"namespace": "ns1"}
         tool = SemanticTools(agent_config=mock_config, adapter_type="mock_adapter")
         return tool
 
@@ -287,6 +289,8 @@ def semantic_tools_ext():
 
         config = Mock()
         config.active_model.return_value.model = "gpt-4o"
+        config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: adapter_type
+        config.build_semantic_adapter_config.side_effect = lambda adapter_type=None: {"namespace": "ns1"}
         tool = SemanticTools(agent_config=config)
         return tool
 
@@ -301,6 +305,8 @@ def semantic_tools_with_adapter():
 
         config = Mock()
         config.active_model.return_value.model = "gpt-4o"
+        config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: adapter_type
+        config.build_semantic_adapter_config.side_effect = lambda adapter_type=None: {"namespace": "ns1"}
         tool = SemanticTools(agent_config=config, adapter_type="metricflow")
         mock_adapter = Mock()
         tool._adapter = mock_adapter
@@ -646,8 +652,8 @@ class TestExtractDbConfig:
     """Tests for _extract_db_config helper method."""
 
     def test_returns_none_when_namespace_not_in_namespaces(self, semantic_tools):
-        """Should return None when namespace is not found in agent_config.namespaces."""
-        semantic_tools.agent_config.namespaces = {}
+        """Should return None when the database config cannot be resolved."""
+        semantic_tools.agent_config.current_db_config.side_effect = Exception("missing")
         result = semantic_tools._extract_db_config("missing_ns")
         assert result is None
 
@@ -664,7 +670,7 @@ class TestExtractDbConfig:
             "path_pattern": "skip",
             "catalog": "skip",
         }
-        semantic_tools.agent_config.namespaces = {"ns1": {"default": mock_db_config}}
+        semantic_tools.agent_config.current_db_config.return_value = mock_db_config
 
         result = semantic_tools._extract_db_config("ns1")
 

--- a/tests/unit_tests/utils/test_compress_utils.py
+++ b/tests/unit_tests/utils/test_compress_utils.py
@@ -124,7 +124,7 @@ def agent_config():
 def db_manager(agent_config: AgentConfig) -> DBManager:
     # Only pass sqlite/duckdb databases to avoid connector-not-installed errors
     sqlite_dbs = {
-        name: {name: cfg} for name, cfg in agent_config.service.databases.items() if cfg.type in ("sqlite", "duckdb")
+        name: {name: cfg} for name, cfg in agent_config.services.databases.items() if cfg.type in ("sqlite", "duckdb")
     }
     return db_manager_instance(sqlite_dbs)
 

--- a/tests/unit_tests/utils/test_compress_utils.py
+++ b/tests/unit_tests/utils/test_compress_utils.py
@@ -25,13 +25,11 @@ from tests.conftest import load_acceptance_config
 def test_compress_mock():
     import numpy as np
 
-    # Initialize compressor with CSV output format
-    compressor_csv = DataCompressor(model_name="gpt-3.5-turbo", token_threshold=1024, output_format="csv")
+    np.random.seed(0)
 
-    # Initialize compressor with table output format
+    compressor_csv = DataCompressor(model_name="gpt-3.5-turbo", token_threshold=1024, output_format="csv")
     compressor_table = DataCompressor(model_name="gpt-3.5-turbo", token_threshold=1024, output_format="table")
 
-    # Generate sample data with many rows
     sample_data = []
     for i in range(100):
         sample_data.append(
@@ -47,72 +45,49 @@ def test_compress_mock():
             }
         )
 
-    # Test CSV format compression
-    print("=" * 50)
-    print("CSV Format Compression:")
-    print("=" * 50)
     result_csv = compressor_csv.compress(sample_data)
-    print(f"Original rows: {result_csv['original_rows']}")
-    print(f"Original columns: {result_csv['original_columns']}")  # Now shows list of column names
-    assert len(result_csv["original_columns"]) > 0
-    print(f"Is compressed: {result_csv['is_compressed']}")
-    print(f"Compression type: {result_csv['compression_type']}")
-    print(f"Removed columns: {result_csv['removed_columns']}")
-    print(f"\nCompressed data (CSV format):\n{result_csv['compressed_data']}")
+    assert result_csv["original_rows"] == 100
+    assert len(result_csv["original_columns"]) == len(sample_data[0])
+    assert result_csv["is_compressed"] is True
+    assert result_csv["compression_type"] in {"rows", "rows_and_columns"}
+    assert result_csv["compressed_data"]
+    assert "user_id" in result_csv["compressed_data"]
 
-    print("\n" + "=" * 50)
-    print("Table Format Compression:")
-    print("=" * 50)
-    result_table = compressor_table.compress(sample_data[:30])  # Use fewer rows for table format demo
-    print(f"Original rows: {result_table['original_rows']}")
-    print(f"Original columns: {result_table['original_columns']}")  # Now shows list of column names
-    print(f"Is compressed: {result_table['is_compressed']}")
-    print(f"Compression type: {result_table['compression_type']}")
-    print(f"Removed columns: {result_table['removed_columns']}")
-    print(f"\nCompressed data (Table format):\n{result_table['compressed_data']}")
+    result_table = compressor_table.compress(sample_data[:30])
+    assert result_table["original_rows"] == 30
+    assert len(result_table["original_columns"]) == len(sample_data[0])
+    assert result_table["is_compressed"] is True
+    assert result_table["compression_type"] in {"rows", "rows_and_columns"}
+    assert result_table["compressed_data"]
+    assert "..." in result_table["compressed_data"]
 
-    # Test with pandas DataFrame
-    print("\n" + "=" * 50)
-    print("Testing with pandas DataFrame:")
-    print("=" * 50)
     df = pd.DataFrame(sample_data[:50])
     result_df = compressor_csv.compress(df)
-    print(f"Original columns: {result_df['original_columns']}")  # Shows actual column names
-    print(f"Compression type: {result_df['compression_type']}")
-    print(f"\nCompressed DataFrame:\n{result_df['compressed_data']}")
+    assert result_df["original_rows"] == 50
+    assert len(result_df["original_columns"]) == len(sample_data[0])
+    assert result_df["is_compressed"] is True
+    assert result_df["compression_type"] in {"rows", "rows_and_columns"}
+    assert result_df["compressed_data"]
 
-    # Test with small data that doesn't need compression
-    print("\n" + "=" * 50)
-    print("Testing with small data (no compression needed):")
-    print("=" * 50)
     small_data = sample_data[:5]
     result_small = compressor_csv.compress(small_data)
-    print(f"Is compressed: {result_small['is_compressed']}")
-    print(f"Original columns: {result_small['original_columns']}")
-    print(f"\nData:\n{result_small['compressed_data']}")
+    assert result_small["original_rows"] == 5
+    assert result_small["is_compressed"] is False
+    assert result_small["compression_type"] == "none"
+    assert result_small["compressed_data"]
 
-    # Test quick compress class method
-    print("\n" + "=" * 50)
-    print("Testing quick_compress class method:")
-    print("=" * 50)
     quick_result = DataCompressor.quick_compress(sample_data[:40], output_format="csv")
-    print(f"Quick compressed data:\n{quick_result}")
+    assert isinstance(quick_result, str)
+    assert quick_result
+    assert "user_id" in quick_result
 
-    # Test with very large list to show performance improvement
-    print("\n" + "=" * 50)
-    print("Testing with large dataset (10000 rows):")
-    print("=" * 50)
-    large_data = sample_data * 100  # 10000 rows
-    import time
-
-    start_time = time.time()
+    large_data = sample_data * 100
     result_large = compressor_csv.compress(large_data)
-    end_time = time.time()
-
-    print(f"Original rows: {result_large['original_rows']}")
-    print(f"Compression type: {result_large['compression_type']}")
-    print(f"Time taken: {end_time - start_time:.3f} seconds")
-    print("After compressed", result_large["compressed_data"])
+    assert result_large["original_rows"] == 10000
+    assert result_large["is_compressed"] is True
+    assert result_large["compression_type"] in {"rows", "rows_and_columns"}
+    assert result_large["compressed_data"]
+    assert "user_id" in result_large["compressed_data"]
 
 
 @pytest.fixture
@@ -158,8 +133,7 @@ ORDER BY
     query_result = result.result
     assert query_result["is_compressed"]
     assert query_result["original_rows"] > 10
-    print(query_result["compressed_data"])
-
+    assert query_result["compressed_data"]
     assert len(query_result["original_columns"]) > 0
 
 


### PR DESCRIPTION
## Summary

- unify runtime config under `agent.services.*` and remove runtime fallback to top-level `dashboard:` / `scheduler:` settings
- rename the root config key from `agent.service` to `agent.services`, add `services.semantic_layer`, and route BI/scheduler/semantic runtime reads through the new structure
- add scheduler service selection and update CLI/config helpers, MCP namespace discovery, and regression tests so the new config model works end to end

## Why

Runtime configuration was split across legacy keys and partially migrated code paths. That left scheduler/BI/semantic initialization inconsistent, and the broad config rename exposed pre-existing test-audit P0 issues and a namespace-manager regression during CI.

## Impact

- `agent.service` is now `agent.services`
- runtime no longer reads top-level `dashboard:` / `scheduler:` blocks
- scheduler nodes select instances via `scheduler_service`; semantic adapters read from `services.semantic_layer`; namespace management now persists `services.databases`

## Validation

- `python3 ci/audit_tests.py --repo-root . --diff-only upstream/main --json /tmp/service-services-audit-after-namespace-fix.json --github-output` (`P0=0`, `P1=52`)
- `PATH="/Users/kangxue/work/datus/agent-1/.venv/bin:$PATH" ./.venv/bin/python ci/run-tests-and-coverage.py main` (`10179 passed`, `0 failed`, overall coverage `83.00%`, diff coverage `84.00%`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-node scheduler service selection and support for multiple scheduler services.
  * Named semantic layer adapters with centralized adapter resolution and per-project selection.

* **Refactor**
  * Configuration schema migrated from agent.service → agent.services with automatic legacy migration; CLI, init, and tooling updated to the new layout.

* **Quality**
  * Database URIs displayed with passwords redacted; tests updated to match new config shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->