### PR TITLE
[Enhancement] Support client-provided execute_task_id on /sql/execute

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -18,6 +18,7 @@ class ExecuteSQLInput(BaseModel):
                 "sql_query": "SELECT * FROM users WHERE status = 'active'",
                 "result_format": "csv",
                 "system": False,
+                "execute_task_id": "client-generated-uuid",
             }
         }
     )
@@ -26,6 +27,15 @@ class ExecuteSQLInput(BaseModel):
     sql_query: str = Field(..., description="SQL query to execute")
     result_format: str = Field("arrow", description="Result format (arrow, csv, json)")
     system: bool = Field(False, description="Whether this is a system command")
+    execute_task_id: Optional[str] = Field(
+        None,
+        description=(
+            "Client-provided task ID for this SQL execution. "
+            "When supplied, it can be used with /sql/stop_execute to cancel the task "
+            "before the execute response returns. "
+            "If omitted, the server generates one and returns it in ExecuteSQLData."
+        ),
+    )
 
 
 class ExecuteSQLData(BaseModel):

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -236,10 +236,20 @@ class CLIService:
     async def execute_sql(self, request: ExecuteSQLInput) -> Result[ExecuteSQLData]:
         """Execute SQL query asynchronously with cancellation support.
 
-        Returns a Result containing an execute_task_id that can be used
-        to stop the execution via stop_execute_sql().
+        If the request carries an ``execute_task_id``, it is used as the task ID
+        and echoed back in the response. Otherwise the server generates one.
+        Either way, the returned ID can be passed to ``stop_execute_sql`` to
+        cancel the task.
         """
-        task_id = str(uuid.uuid4())
+        task_id = request.execute_task_id or str(uuid.uuid4())
+
+        with self._sql_tasks_lock:
+            if task_id in self._sql_tasks and not self._sql_tasks[task_id].done():
+                return Result(
+                    success=False,
+                    errorCode=ErrorCode.SQL_EXECUTION_ERROR,
+                    errorMessage=f"Another SQL execution is already running for task ID: {task_id}",
+                )
 
         async def _run() -> Result[ExecuteSQLData]:
             try:

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -164,6 +164,54 @@ class TestCLIServiceStopExecuteSQL:
         assert len(result.data.execute_task_id) > 0
 
     @pytest.mark.asyncio
+    async def test_execute_sql_honors_client_task_id(self, cli_svc):
+        """execute_sql echoes back a client-provided execute_task_id."""
+        client_task_id = "client-task-123"
+        request = ExecuteSQLInput(sql_query="SELECT 1 as val", execute_task_id=client_task_id)
+        result = await cli_svc.execute_sql(request)
+        assert result.success is True
+        assert result.data.execute_task_id == client_task_id
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_rejects_duplicate_running_task_id(self, cli_svc):
+        """execute_sql refuses to start when another task shares the same running ID."""
+        task_id = "duplicate-running-id"
+
+        async def _slow_task():
+            await asyncio.sleep(60)
+
+        running = asyncio.create_task(_slow_task())
+        cli_svc._sql_tasks[task_id] = running
+        try:
+            request = ExecuteSQLInput(sql_query="SELECT 1", execute_task_id=task_id)
+            result = await cli_svc.execute_sql(request)
+            assert result.success is False
+            assert "already running" in result.errorMessage
+        finally:
+            running.cancel()
+            await asyncio.sleep(0)
+            cli_svc._sql_tasks.pop(task_id, None)
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_reuses_client_id_for_stop(self, cli_svc):
+        """A client-provided execute_task_id can be used to stop the task while it is running."""
+        task_id = "stoppable-client-id"
+
+        async def _slow_task():
+            await asyncio.sleep(60)
+
+        running = asyncio.create_task(_slow_task())
+        cli_svc._sql_tasks[task_id] = running
+        try:
+            stop_result = await cli_svc.stop_execute_sql(task_id)
+            assert stop_result.success is True
+            assert stop_result.data.execute_task_id == task_id
+            assert stop_result.data.stopped is True
+        finally:
+            await asyncio.sleep(0)
+            cli_svc._sql_tasks.pop(task_id, None)
+
+    @pytest.mark.asyncio
     async def test_stop_running_task(self):
         """stop_execute_sql cancels a running task."""
         svc = CLIService(agent_config=None, chat_service=None)


### PR DESCRIPTION
## Why

The `/sql/execute` endpoint returns an `execute_task_id` in `ExecuteSQLData`, and `/sql/stop_execute` accepts that same ID to cancel the running task. But the ID is generated by the server, so clients only learn it after the execute response comes back. That makes it impossible to cancel an in-flight SQL query before the execute response returns — exactly the case where cancellation matters most.

## Solution

Let the client pre-register the task ID.

- `ExecuteSQLInput` gains an optional `execute_task_id` field. When supplied, the service uses it as the task ID and echoes it back in `ExecuteSQLData`. When omitted, the server generates a UUID (existing behavior).
- Duplicate IDs for tasks still running are rejected with `SQL_EXECUTION_ERROR` to avoid silently shadowing an existing task.
- `stop_execute_sql` is unchanged — it already accepts the same task ID regardless of who generated it.

This lets a client kick off execution and — since it already owns the ID — immediately call `/sql/stop_execute` on the same ID to cancel, without waiting for the execute response.

## Test Cases

Added three unit tests in `tests/unit_tests/api/services/test_cli_service.py`:

- `test_execute_sql_honors_client_task_id` — client-provided ID is echoed back in the response.
- `test_execute_sql_rejects_duplicate_running_task_id` — a second execute call with an ID that is already running fails cleanly.
- `test_execute_sql_reuses_client_id_for_stop` — a client-provided ID is usable by `stop_execute_sql` to cancel the task.

All 45 tests in `test_cli_service.py` pass, and the broader `tests/unit_tests/api/` suite (798 tests) passes unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL execution now supports optional, client-provided task identifiers for improved operation tracking and management
  * The system checks for in-flight tasks and prevents concurrent executions using the same task ID, returning an error if one is already in progress
  * Client-supplied task identifiers are returned in execution responses for enhanced tracking and request correlation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->