### PR TITLE
[Enhancement] Unify CLI startup output into a single banner

### DIFF
--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -613,7 +613,21 @@ class InlineStreamingContext:
         """Start or update the Live display showing all active subagent groups."""
         renderable = self._build_subagent_groups_renderable()
         if self._subagent_live is None:
-            self._subagent_live = Live(renderable, console=self.display.console, refresh_per_second=4, transient=True)
+            # ``redirect_stdout`` / ``redirect_stderr`` are set to ``False`` so
+            # Rich does not install its own stdout wrapper. When the REPL runs
+            # under the TUI, stdout is already patched by prompt_toolkit's
+            # ``patch_stdout(raw=True)`` — double-patching would fight the
+            # pinned status-bar + input. Outside the TUI the behavior is
+            # unchanged: Rich writes ANSI directly to the real stdout.
+            self._subagent_live = Live(
+                renderable,
+                console=self.display.console,
+                refresh_per_second=4,
+                transient=True,
+                redirect_stdout=False,
+                redirect_stderr=False,
+                screen=False,
+            )
             self._subagent_live.start()
         else:
             self._subagent_live.update(renderable)
@@ -680,7 +694,18 @@ class InlineStreamingContext:
 
         with self._print_lock:
             if self._live is None:
-                self._live = Live(renderable, console=self.display.console, refresh_per_second=4, transient=True)
+                # See the comment in ``_update_subagent_groups_live``: Live
+                # must not install its own stdout wrapper when the TUI is
+                # active, and the flags are safe for non-TUI callers too.
+                self._live = Live(
+                    renderable,
+                    console=self.display.console,
+                    refresh_per_second=4,
+                    transient=True,
+                    redirect_stdout=False,
+                    redirect_stderr=False,
+                    screen=False,
+                )
                 self._live.start()
             else:
                 self._live.update(renderable)

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -73,6 +73,7 @@ class InlineStreamingContext:
         self._broker = interaction_broker
         self._input_collector: Optional[Callable[[ActionHistory, Console], Optional[str]]] = None
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._clear_header_callback: Optional[Callable[[], None]] = None
 
     @property
     def live(self) -> Optional[Live]:
@@ -106,6 +107,14 @@ class InlineStreamingContext:
         The collector returns the user's choice string, or None if the interaction was aborted.
         """
         self._input_collector = collector
+
+    def set_clear_header_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        """Register a callback invoked at the top of the screen after Ctrl+O clears it.
+
+        Used to reprint the CLI banner so it remains the first thing on screen
+        after a verbose-mode toggle redraw.
+        """
+        self._clear_header_callback = callback
 
     # -- sync mode entry point ---------------------------------------------
 
@@ -264,6 +273,8 @@ class InlineStreamingContext:
                         self.display.console.clear()
                         sys.stdout.write("\033[3J")
                         sys.stdout.flush()
+                        if self._clear_header_callback is not None:
+                            self._clear_header_callback()
                         self.display.console.print(
                             "[bold bright_black]  \u23af switched to verbose mode (frozen) \u23af[/]"
                         )
@@ -278,6 +289,8 @@ class InlineStreamingContext:
                         self.display.console.clear()
                         sys.stdout.write("\033[3J")
                         sys.stdout.flush()
+                        if self._clear_header_callback is not None:
+                            self._clear_header_callback()
                         self.display.console.print("[bold bright_black]  \u23af switched to compact mode \u23af[/]")
                     self._reprint_history(verbose=self._verbose)
                     # Restart Live for any remaining active subagent groups

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -274,7 +274,14 @@ class InlineStreamingContext:
                         sys.stdout.write("\033[3J")
                         sys.stdout.flush()
                         if self._clear_header_callback is not None:
-                            self._clear_header_callback()
+                            try:
+                                self._clear_header_callback()
+                            except Exception as exc:
+                                logger.debug(
+                                    "clear_header_callback raised in verbose toggle: %s",
+                                    exc,
+                                    exc_info=True,
+                                )
                         self.display.console.print(
                             "[bold bright_black]  \u23af switched to verbose mode (frozen) \u23af[/]"
                         )
@@ -290,7 +297,14 @@ class InlineStreamingContext:
                         sys.stdout.write("\033[3J")
                         sys.stdout.flush()
                         if self._clear_header_callback is not None:
-                            self._clear_header_callback()
+                            try:
+                                self._clear_header_callback()
+                            except Exception as exc:
+                                logger.debug(
+                                    "clear_header_callback raised in compact toggle: %s",
+                                    exc,
+                                    exc_info=True,
+                                )
                         self.display.console.print("[bold bright_black]  \u23af switched to compact mode \u23af[/]")
                     self._reprint_history(verbose=self._verbose)
                     # Restart Live for any remaining active subagent groups

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -373,6 +373,10 @@ class ChatCommands:
                     current_user_message=message,
                     interaction_broker=current_node.interaction_broker,
                 )
+                # Reprint the CLI banner at the top after Ctrl+O clears the screen.
+                banner_callback = getattr(self.cli, "_print_welcome", None)
+                if banner_callback is not None:
+                    streaming_ctx.set_clear_header_callback(banner_callback)
 
                 # In TUI mode the persistent prompt_toolkit Application owns
                 # stdin, so the termios-based ``interrupt_on_escape`` listener
@@ -1050,6 +1054,9 @@ class ChatCommands:
         self.console.clear()
         sys.stdout.write("\033[3J")
         sys.stdout.flush()
+        banner_callback = getattr(self.cli, "_print_welcome", None)
+        if banner_callback is not None:
+            banner_callback()
         self.console.print(f"[bold bright_black]  ⎯ switched to {mode_label} mode ⎯[/]")
         action_display = ActionHistoryDisplay(self.console)
 

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -14,6 +14,7 @@ import platform
 import re
 import subprocess
 import sys
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from rich.markdown import Markdown
@@ -28,7 +29,20 @@ from datus.cli.execution_state import ExecutionInterrupted, auto_submit_interact
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
 from datus.utils.loggings import get_logger
-from datus.utils.terminal_utils import interrupt_on_escape
+from datus.utils.terminal_utils import EscapeGuard, interrupt_on_escape
+
+
+@contextmanager
+def _noop_escape_guard():
+    """Context manager that yields an inert :class:`EscapeGuard`.
+
+    Used in TUI mode where prompt_toolkit owns stdin and installing the
+    termios-based ESC listener would conflict. The inert guard's
+    ``paused()`` is a no-op so callers written against the termios path
+    (e.g. ``_make_input_collector``) continue to work unchanged.
+    """
+    yield EscapeGuard()
+
 
 if TYPE_CHECKING:
     from datus.cli.repl import DatusCLI
@@ -82,6 +96,10 @@ class ChatCommands:
         self.last_actions = []
         self.all_turn_actions: List[Tuple[str, List[ActionHistory]]] = []
         self._trace_verbose = False  # toggle state for post-run Ctrl+O
+        # Live handle to the active streaming context, consumed by the TUI
+        # to route ESC (interrupt) and Ctrl+O (verbose toggle) key bindings
+        # to the currently running agent loop. ``None`` when idle.
+        self.current_streaming_ctx = None
 
     def update_chat_node_tools(self):
         """Update current node tools when namespace changes."""
@@ -355,21 +373,36 @@ class ChatCommands:
                     current_user_message=message,
                     interaction_broker=current_node.interaction_broker,
                 )
-                with (
-                    interrupt_on_escape(
+
+                # In TUI mode the persistent prompt_toolkit Application owns
+                # stdin, so the termios-based ``interrupt_on_escape`` listener
+                # would fight the main input loop. Skip it and rely on
+                # dedicated ESC / Ctrl+O key bindings registered on the TUI
+                # (see ``DatusCLI._init_tui_app``), which consult this
+                # streaming_ctx and the node's interrupt_controller directly.
+                if getattr(self.cli, "_use_tui", False):
+                    esc_cm = _noop_escape_guard()
+                else:
+                    esc_cm = interrupt_on_escape(
                         current_node.interrupt_controller,
                         key_callbacks={b"\x0f": streaming_ctx.toggle_verbose},
-                    ) as esc_guard,
-                    streaming_ctx,
-                ):
-                    streaming_ctx.set_input_collector(self._make_input_collector(esc_guard))
-                    try:
-                        asyncio.run(run_chat_stream())
-                    except KeyboardInterrupt:
-                        current_node.interrupt_controller.interrupt()
-                        logger.info("KeyboardInterrupt caught, execution interrupted gracefully")
-                    except ExecutionInterrupted:
-                        logger.info("ExecutionInterrupted caught, execution stopped gracefully")
+                    )
+
+                # Publish the streaming context so the TUI Ctrl+O / ESC
+                # bindings can locate it while the agent runs.
+                self.current_streaming_ctx = streaming_ctx
+                try:
+                    with esc_cm as esc_guard, streaming_ctx:
+                        streaming_ctx.set_input_collector(self._make_input_collector(esc_guard))
+                        try:
+                            asyncio.run(run_chat_stream())
+                        except KeyboardInterrupt:
+                            current_node.interrupt_controller.interrupt()
+                            logger.info("KeyboardInterrupt caught, execution interrupted gracefully")
+                        except ExecutionInterrupted:
+                            logger.info("ExecutionInterrupted caught, execution stopped gracefully")
+                finally:
+                    self.current_streaming_ctx = None
             else:
 
                 async def run_stream():

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -236,7 +236,6 @@ class Application:
         # flips databases[*].default before AgentConfig is built.
         default_db = config.service.default_database
         if default_db:
-            console.print(f"[dim]Using default database: {default_db}[/dim]")
             return default_db
 
         # Multiple databases, no default — show list and ask user to specify

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -617,6 +617,14 @@ class DatusCLI:
                 self._execute_chat_command(args, subagent_name=cmd)
             elif cmd_type == CommandType.INTERNAL:
                 self._execute_internal_command(cmd, args)
+                # ``.rewind`` sets ``_prefill_input`` from inside the internal
+                # command. In TUI mode the buffer was already drained before
+                # dispatch, so push the rewound message back into the live
+                # input area here. ``set_input_text`` schedules the mutation
+                # onto the prompt_toolkit loop, so it is safe from the worker.
+                if self._use_tui and self.tui_app is not None and self._prefill_input:
+                    self.tui_app.set_input_text(self._prefill_input)
+                    self._prefill_input = None
         except KeyboardInterrupt:
             # Interrupt during a single command dispatch is non-fatal: the
             # outer loop (or TUI event loop) stays alive.

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -43,6 +43,8 @@ from datus.cli.context_commands import ContextCommands
 from datus.cli.metadata_commands import MetadataCommands
 from datus.cli.status_bar import StatusBarProvider
 from datus.cli.sub_agent_commands import SubAgentCommands
+from datus.cli.tui import DatusApp, tui_enabled
+from datus.cli.tui.app import EXIT_SENTINEL
 from datus.configuration.agent_config_loader import configuration_manager, load_agent_config
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
@@ -134,9 +136,20 @@ class DatusCLI:
         if hasattr(self.agent_config, "agentic_nodes") and self.agent_config.agentic_nodes:
             self.available_subagents.update(name for name in self.agent_config.agentic_nodes.keys() if name != "chat")
 
+        # TUI mode: use persistent prompt_toolkit Application with pinned
+        # status bar + input. Requires a TTY on both stdin/stdout and can be
+        # disabled via ``DATUS_TUI=0`` as an escape hatch.
+        self._use_tui = self.interactive and tui_enabled()
+        self.tui_app: Optional[DatusApp] = None
+
         self.at_completer: AtReferenceCompleter
         if self.interactive:
-            self._init_prompt_session()
+            # Both paths build completers, lexers and styles via the same
+            # helpers so feature parity is preserved.
+            if self._use_tui:
+                self._init_tui_app()
+            else:
+                self._init_prompt_session()
         else:
             self.at_completer = AtReferenceCompleter(self.agent_config, available_subagents=self.available_subagents)
 
@@ -332,6 +345,184 @@ class DatusCLI:
         tokens.append(("class:prompt", prompt_text))
         return tokens
 
+    def _build_app_style(self) -> Style:
+        """Return the prompt_toolkit Style used by both PromptSession and TUI.
+
+        Declaring it once keeps status-bar/input coloring in sync between the
+        two input paths and avoids drift when new status-bar segments are
+        added.
+        """
+        return merge_styles(
+            [
+                style_from_pygments_cls(CustomPygmentsStyle),
+                Style.from_dict(
+                    {
+                        "prompt": "ansigreen bold",
+                        "input-prompt": "ansigreen bold",
+                        "input-prompt.busy": "ansibrightblack",
+                        "input-area": "",
+                        "status-bar": "#9a9aaa",
+                        "status-bar.brand": "#ffd866 bold",
+                        "status-bar.plan": "#9a9aaa",
+                        "status-bar.sep": "#9a9aaa",
+                        "status-bar.agent": "#9a9aaa",
+                        "status-bar.connector": "#9a9aaa",
+                        "status-bar.model": "#9a9aaa",
+                        "status-bar.tokens": "#9a9aaa",
+                        "status-bar.ctx": "#9a9aaa",
+                        "status-bar.running": "#ffb86c bold",
+                        "separator": "#444444",
+                    }
+                ),
+            ]
+        )
+
+    def _status_tokens_for_tui(self) -> List[Tuple[str, str]]:
+        """Build status-bar tokens for the persistent TUI layout.
+
+        Shares :class:`StatusBarProvider` with the PromptSession path so both
+        modes present the same brand/plan/agent/connector/model/tokens/ctx
+        segments.
+        """
+        try:
+            state = self._status_bar_provider.current_state()
+            return state.to_formatted_tokens()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"status bar render failed: {e}")
+            return []
+
+    def _init_tui_app(self) -> None:
+        """Create the persistent ``DatusApp`` and register REPL bindings."""
+        # The Tab handler matches the legacy PromptSession behavior
+        # (trigger completion only, no navigation). Additional bindings —
+        # Shift+Tab plan-mode toggle, Ctrl+O trace details, ESC interrupt —
+        # are wired in later phases.
+        from prompt_toolkit.lexers import PygmentsLexer
+
+        # The TUI path still relies on the same AtReferenceCompleter handle
+        # that downstream code queries for subagent state, so attach it
+        # before constructing the app.
+        completer = self.create_combined_completer()
+
+        self.tui_app = DatusApp(
+            status_tokens_fn=self._status_tokens_for_tui,
+            dispatch_fn=self._dispatch_command_text,
+            completer=completer,
+            history=self.history,
+            lexer=PygmentsLexer(CustomSqlLexer),
+            style=self._build_app_style(),
+            input_prompt_fn=self._get_prompt_text,
+        )
+
+        @self.tui_app.key_bindings.add("tab")
+        def _tab(event):  # noqa: ANN001 - prompt_toolkit signature
+            buffer = event.app.current_buffer
+            if buffer.complete_state:
+                buffer.complete_next()
+            else:
+                buffer.start_completion(select_first=False)
+
+        @self.tui_app.key_bindings.add("s-tab")
+        def _s_tab(event):  # noqa: ANN001
+            """Shift+Tab: Toggle Plan Mode on/off.
+
+            Unlike the PromptSession handler, the TUI must not call
+            ``event.app.exit()`` — that would tear down the persistent
+            Application. Instead the REPL just flips the flag and asks the
+            layout to repaint; the status-bar's ``PLAN`` segment is driven
+            by :meth:`StatusBarState.to_formatted_tokens` so a single
+            ``invalidate`` is enough to reflect the change.
+            """
+            from datus.cli.tui.console_bridge import run_in_terminal_sync
+
+            self.plan_mode_active = not self.plan_mode_active
+            active = self.plan_mode_active
+
+            def _announce() -> None:
+                if active:
+                    self.console.print("[bold green]Plan Mode Activated![/]")
+                    self.console.print("[dim]Enter your planning task and press Enter to generate plan[/]")
+                else:
+                    self.console.print("[yellow]Plan Mode Deactivated[/]")
+
+            # Printing via ``run_in_terminal`` keeps the pinned status-bar +
+            # input intact: prompt_toolkit temporarily moves them out of the
+            # way, emits the message, then restores them at the bottom.
+            run_in_terminal_sync(_announce)
+            event.app.invalidate()
+
+        @self.tui_app.key_bindings.add("c-o")
+        def _c_o(event):  # noqa: ANN001
+            """Ctrl+O: toggle verbose during a live stream, or expand the
+            last chat's inline trace details when idle."""
+            from datus.cli.tui.console_bridge import run_in_terminal_sync
+
+            chat_commands = getattr(self, "chat_commands", None)
+            if chat_commands is None:
+                return
+
+            # Live stream active: toggle verbose on the streaming context
+            # (mirrors the key_callbacks entry the termios listener used to
+            # wire for Ctrl+O outside the TUI).
+            streaming_ctx = getattr(chat_commands, "current_streaming_ctx", None)
+            if streaming_ctx is not None:
+                try:
+                    streaming_ctx.toggle_verbose()
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug(f"toggle_verbose failed: {exc}")
+                return
+
+            last_actions = getattr(chat_commands, "last_actions", None)
+            if not last_actions:
+                return
+
+            def _show() -> None:
+                chat_commands.display_inline_trace_details(last_actions)
+
+            run_in_terminal_sync(_show)
+
+        @self.tui_app.key_bindings.add("escape")
+        def _esc(event):  # noqa: ANN001
+            """Escape: interrupt the running agent loop.
+
+            prompt_toolkit debounces ESC so this handler only fires for a
+            standalone key press, not for the leading byte of arrow-key
+            escape sequences (``\\x1b[A`` etc.). While idle the binding is
+            a no-op so default Buffer behavior (no-op for ESC in insert
+            mode) is preserved.
+            """
+            if not self.tui_app._agent_running.is_set():
+                return
+
+            chat_commands = getattr(self, "chat_commands", None)
+            current_node = getattr(chat_commands, "current_node", None) if chat_commands else None
+            controller = getattr(current_node, "interrupt_controller", None) if current_node else None
+            if controller is not None:
+                try:
+                    controller.interrupt()
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug(f"interrupt_controller.interrupt failed: {exc}")
+
+        @self.tui_app.key_bindings.add("c-c")
+        def _c_c(event):  # noqa: ANN001
+            """Ctrl+C: interrupt agent while running, clear buffer when idle.
+
+            Overrides the default DatusApp binding because the TUI needs a
+            handle to the chat node's interrupt_controller, which only
+            DatusCLI can resolve.
+            """
+            if self.tui_app._agent_running.is_set():
+                chat_commands = getattr(self, "chat_commands", None)
+                current_node = getattr(chat_commands, "current_node", None) if chat_commands else None
+                controller = getattr(current_node, "interrupt_controller", None) if current_node else None
+                if controller is not None:
+                    try:
+                        controller.interrupt()
+                    except Exception as exc:  # pragma: no cover - defensive
+                        logger.debug(f"interrupt_controller.interrupt failed: {exc}")
+                return
+            event.app.current_buffer.reset()
+
     def _init_prompt_session(self):
         # Setup prompt session with custom key bindings
         self.session = PromptSession(
@@ -344,24 +535,7 @@ class DatusCLI:
             enable_history_search=True,
             search_ignore_case=True,
             erase_when_done=True,
-            style=merge_styles(
-                [
-                    style_from_pygments_cls(CustomPygmentsStyle),
-                    Style.from_dict(
-                        {
-                            "prompt": "ansigreen bold",
-                            "status-bar": "#9a9aaa",
-                            "status-bar.brand": "#ffd866 bold",
-                            "status-bar.plan": "#9a9aaa",
-                            "status-bar.sep": "#9a9aaa",
-                            "status-bar.agent": "#9a9aaa",
-                            "status-bar.model": "#9a9aaa",
-                            "status-bar.tokens": "#9a9aaa",
-                            "status-bar.ctx": "#9a9aaa",
-                        }
-                    ),
-                ]
-            ),
+            style=self._build_app_style(),
             complete_while_typing=True,
         )
 
@@ -387,8 +561,70 @@ class DatusCLI:
             ]
         )
 
+    def _dispatch_command_text(self, user_input_raw: str) -> Optional[str]:
+        """Parse and execute a single user command.
+
+        Shared by both the PromptSession loop and the TUI worker thread. When
+        invoked from the TUI, this function runs on a :class:`ThreadPoolExecutor`
+        worker so ``asyncio.run(...)`` inside chat commands does not collide
+        with the prompt_toolkit Application's event loop on the main thread.
+
+        Returns :data:`EXIT_SENTINEL` when the user requested an exit so the
+        caller can tear down the TUI; returns ``None`` otherwise.
+        """
+        if user_input_raw is None:
+            return None
+        user_input = user_input_raw.strip()
+        if not user_input:
+            return None
+
+        # Re-echo user input with syntax highlighting. In TUI mode the input
+        # TextArea clears on Enter, so echoing via the patched stdout keeps a
+        # transcript of what was submitted. In PromptSession mode
+        # ``erase_when_done=True`` removes the prompt line, so the echo is
+        # still useful.
+        prompt_text = self._get_prompt_text()
+        try:
+            self._echo_user_input(prompt_text, user_input)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"echo_user_input failed: {e}")
+
+        try:
+            cmd_type, cmd, args = self._parse_command(user_input)
+            if cmd_type == CommandType.EXIT:
+                return EXIT_SENTINEL
+            if cmd_type == CommandType.SQL:
+                self._execute_sql(user_input)
+            elif cmd_type == CommandType.TOOL:
+                self._execute_tool_command(cmd, args)
+            elif cmd_type == CommandType.CONTEXT:
+                self._execute_context_command(cmd, args)
+            elif cmd_type == CommandType.CHAT:
+                self._execute_chat_command(args, subagent_name=cmd)
+            elif cmd_type == CommandType.INTERNAL:
+                self._execute_internal_command(cmd, args)
+        except KeyboardInterrupt:
+            # Interrupt during a single command dispatch is non-fatal: the
+            # outer loop (or TUI event loop) stays alive.
+            pass
+        except Exception as e:
+            if "exit" in str(e).lower() and "app" in str(e).lower():
+                # Shift+Tab plan-mode toggle historically surfaced as an app
+                # exit event; treat it as benign.
+                pass
+            else:
+                logger.error(f"Error: {str(e)}")
+                self.console.print(f"[bold red]Error:[/] {str(e)}")
+        return None
+
     def run(self):
         """Run the REPL loop."""
+        if self._use_tui and self.tui_app is not None:
+            return self._run_tui()
+        return self._run_prompt_session()
+
+    def _run_prompt_session(self):
+        """Classic ``PromptSession`` main loop (used for non-TTY fallback)."""
         self._print_welcome()
 
         while True:
@@ -409,42 +645,44 @@ class DatusCLI:
                         self.chat_commands.display_inline_trace_details(self.chat_commands.last_actions)
                     continue
                 self._prefill_input = None
-                user_input = user_input_raw.strip()
 
-                if not user_input:
-                    continue
-
-                # Re-echo user input with syntax highlighting (prompt_toolkit erased on submit)
-                self._echo_user_input(prompt_text, user_input)
-
-                # Parse and execute the command
-                cmd_type, cmd, args = self._parse_command(user_input)
-                if cmd_type == CommandType.EXIT:
+                result = self._dispatch_command_text(user_input_raw)
+                if result == EXIT_SENTINEL:
                     return True
-
-                # Execute the command based on type
-                if cmd_type == CommandType.SQL:
-                    self._execute_sql(user_input)
-                elif cmd_type == CommandType.TOOL:
-                    self._execute_tool_command(cmd, args)
-                elif cmd_type == CommandType.CONTEXT:
-                    self._execute_context_command(cmd, args)
-                elif cmd_type == CommandType.CHAT:
-                    self._execute_chat_command(args, subagent_name=cmd)
-                elif cmd_type == CommandType.INTERNAL:
-                    self._execute_internal_command(cmd, args)
 
             except KeyboardInterrupt:
                 continue
             except EOFError:
                 return 0
             except Exception as e:
-                # Check if this is an exit event (for plan mode toggle)
                 if "exit" in str(e).lower() and "app" in str(e).lower():
-                    # This is expected from shift+tab toggle, continue loop
                     continue
                 logger.error(f"Error: {str(e)}")
                 self.console.print(f"[bold red]Error:[/] {str(e)}")
+
+    def _run_tui(self):
+        """Persistent TUI main loop.
+
+        The prompt_toolkit Application owns the main thread; user input is
+        dispatched to :meth:`_dispatch_command_text` on a worker thread so
+        long-running agent loops do not block UI redraws, and so that
+        ``asyncio.run(...)`` inside those handlers does not collide with the
+        Application's event loop.
+        """
+        self._print_welcome()
+
+        # Prefill support mirrors the PromptSession path: ``.rewind`` stores
+        # the replayed user message in ``_prefill_input`` and expects the
+        # next prompt to display it as pre-filled editable text.
+        if self._prefill_input:
+            self.tui_app.set_input_text(self._prefill_input)
+            self._prefill_input = None
+
+        try:
+            self.tui_app.run()
+        except KeyboardInterrupt:
+            return 0
+        return True
 
     def _async_init_agent(self):
         """Initialize the agent asynchronously as a background coroutine.

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -27,13 +27,16 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.styles import Style, merge_styles, style_from_pygments_cls
 from rich.console import Console
+from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 if TYPE_CHECKING:
     from datus.agent.workflow_runner import WorkflowRunner
 
 from datus_db_core import BaseSqlConnector
 
+from datus import __version__
 from datus.cli._cli_utils import prompt_input, select_choice
 from datus.cli.agent_commands import AgentCommands
 from datus.cli.autocomplete import AtReferenceCompleter, CustomPygmentsStyle, CustomSqlLexer, SubagentCompleter
@@ -55,6 +58,17 @@ from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_sql_type
 
 logger = get_logger(__name__)
+
+
+DATUS_BANNER_TEXT = (
+    "██████╗   █████╗  ████████╗ ██╗   ██╗ ███████╗\n"
+    "██╔══██╗ ██╔══██╗ ╚══██╔══╝ ██║   ██║ ██╔════╝\n"
+    "██║  ██║ ███████║    ██║    ██║   ██║ ███████╗\n"
+    "██║  ██║ ██╔══██║    ██║    ██║   ██║ ╚════██║\n"
+    "██████╔╝ ██║  ██║    ██║    ╚██████╔╝ ███████║\n"
+    "╚═════╝  ╚═╝  ╚═╝    ╚═╝     ╚═════╝  ╚══════╝"
+)
+_BANNER_MIN_WIDTH = 60
 
 
 class CommandType(Enum):
@@ -697,7 +711,6 @@ class DatusCLI:
             return
 
         self.agent_initializing = True
-        self.console.print("[dim]Initializing AI capabilities in background...[/]")
 
         # Capture the current ContextVar state so the background task sees
         # ``set_current_path_manager`` bindings made in the main thread.
@@ -1377,39 +1390,65 @@ class DatusCLI:
         self.selected_catalog_path = selected_path
         self.selected_catalog_data = selected_data
 
-    def _print_welcome(self):
-        """Print the welcome message."""
-        welcome_text = """
-[bold green]Datus[/] - [bold]AI-powered SQL command-line interface[/]
-Type '.help' for a list of commands or '.exit' to quit.
-"""
-        self.console.print(welcome_text)
-
+    def _build_banner_panel(self) -> Panel:
+        """Build the unified startup banner as a Rich Panel."""
         database = (
             getattr(self.args, "database", "")
             or getattr(self.args, "namespace", "")
             or getattr(self.agent_config, "current_database", "")
         )
-        if database:
-            self.console.print(f"Database [bold green]{database}[/] selected")
+        db_type = getattr(self.agent_config, "db_type", "") or ""
+
+        if self.db_connector and database:
+            db_line = f"[bold green]{database}[/]"
+            if db_type:
+                db_line += f"  [dim]({db_type})[/]"
+            if self.cli_context.current_db_name and self.cli_context.current_db_name != database:
+                db_line += f"  [dim]using {self.cli_context.current_db_name}[/]"
+        elif database:
+            db_line = f"[bold green]{database}[/]  [yellow]not connected[/]"
         else:
-            self.console.print("[yellow]Warning: No database selected, please use .database to select a database[/]")
-        # Display connection info
-        if self.db_connector:
-            db_info = f"Connected to [bold green]{self.agent_config.db_type}[/]"
-            if self.cli_context.current_db_name:
-                db_info += f" using database [bold]{self.cli_context.current_db_name}[/]"
+            db_line = "[yellow]not selected  (use .database to choose)[/]"
 
-            self.console.print(db_info)
+        context_summary = self.cli_context.get_context_summary() if self.db_connector else "No context available"
+        show_context = context_summary and context_summary != "No context available"
 
-            # Show CLI context summary
-            context_summary = self.cli_context.get_context_summary()
-            if context_summary != "No context available":
-                self.console.print(f"[dim]Context: {context_summary}[/]")
+        use_art = self.console.width >= _BANNER_MIN_WIDTH
+        body = Table.grid(padding=(0, 0))
+        body.add_column()
 
-            self.console.print("Type SQL statements or use ! @ . commands to interact.")
+        if use_art:
+            body.add_row(Text(DATUS_BANNER_TEXT, style="bold"))
         else:
-            self.console.print("[yellow]Warning: No database connection initialized.[/]")
+            body.add_row(Text(f"DATUS v{__version__}", style="bold"))
+        body.add_row(Text(""))
+        body.add_row(Text("AI-powered SQL command-line interface", style="bold"))
+        body.add_row(Text(""))
+
+        info = Table.grid(padding=(0, 2))
+        info.add_column(style="dim", justify="left", no_wrap=True)
+        info.add_column()
+        info.add_row("Database", Text.from_markup(db_line))
+        if show_context:
+            info.add_row("Context", Text.from_markup(f"[dim]{context_summary}[/]"))
+        body.add_row(info)
+        body.add_row(Text(""))
+        body.add_row(Text.from_markup("[dim]Type .help for commands, .exit to quit[/]"))
+
+        return Panel(
+            body,
+            title=f"v{__version__}",
+            title_align="left",
+            padding=(1, 2),
+        )
+
+    def _print_welcome(self):
+        """Print the unified startup banner.
+
+        Also used as the Ctrl+O clear-screen header callback so the banner
+        reappears at the top after verbose-mode toggles redraw the terminal.
+        """
+        self.console.print(self._build_banner_panel())
 
     def prompt_input(self, message: str, default: str = "", choices: list = None, multiline: bool = False):
         """

--- a/datus/cli/screen/base_app.py
+++ b/datus/cli/screen/base_app.py
@@ -33,6 +33,34 @@ class BaseApp(App):
         self._app_ready = False
         self._error_console = Console(stderr=True, force_terminal=True)
 
+    def run(self, *args, **kwargs):  # type: ignore[override]
+        """Run the Textual App, suspending any active prompt_toolkit TUI first.
+
+        The Datus REPL's persistent TUI owns the normal screen + stdin; a
+        Textual app needs to take over the same terminal for its own
+        fullscreen rendering. Scheduling the Textual ``run`` via
+        ``run_in_terminal`` tells prompt_toolkit to relinquish control,
+        execute the callable, and reinstall its pinned layout when the
+        callable returns. When no TUI is active this is a no-op and the
+        call path is unchanged.
+        """
+        from prompt_toolkit.application import get_app_or_none
+
+        pt_app = get_app_or_none()
+        if pt_app is None:
+            return super().run(*args, **kwargs)
+
+        from prompt_toolkit.application.run_in_terminal import run_in_terminal
+
+        result_box: dict = {}
+
+        def _invoke() -> None:
+            result_box["value"] = super(BaseApp, self).run(*args, **kwargs)
+
+        future = run_in_terminal(_invoke)
+        future.result()
+        return result_box.get("value")
+
     def on_mount(self) -> None:
         """App mount handler"""
         self._app_ready = True

--- a/datus/cli/status_bar.py
+++ b/datus/cli/status_bar.py
@@ -58,6 +58,7 @@ class StatusBarState:
     context_used: int = 0
     context_total: int = 0
     plan_mode: bool = False
+    agent_running: bool = False
 
     def context_display(self) -> str:
         if self.context_total > 0:
@@ -107,9 +108,15 @@ class StatusBarState:
                 ("class:status-bar.tokens", self.tokens_display()),
                 sep,
                 ("class:status-bar.ctx", self.context_display()),
-                pad,
             ]
         )
+        if self.agent_running:
+            # Trailing indicator signals that the REPL is busy. It is only
+            # surfaced by the TUI path, which sets ``agent_running`` via
+            # ``StatusBarProvider.current_state``; the legacy PromptSession
+            # never exposes a truthy value so its rendering is unchanged.
+            tokens.extend([sep, ("class:status-bar.running", "● running")])
+        tokens.append(pad)
         return tokens
 
 
@@ -121,6 +128,13 @@ class StatusBarProvider:
 
     def current_state(self) -> StatusBarState:
         cumulative, cached = self._resolve_session_totals()
+        tui_app = getattr(self._cli, "tui_app", None)
+        agent_running = False
+        if tui_app is not None:
+            try:
+                agent_running = tui_app.agent_running.is_set()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug(f"status_bar: failed to read agent_running: {e}")
         return StatusBarState(
             agent=self._resolve_agent(),
             model=self._resolve_model(),
@@ -130,6 +144,7 @@ class StatusBarProvider:
             context_used=self._resolve_context_used(),
             context_total=self._resolve_context_total(),
             plan_mode=bool(getattr(self._cli, "plan_mode_active", False)),
+            agent_running=agent_running,
         )
 
     def _current_node(self):

--- a/datus/cli/tui/__init__.py
+++ b/datus/cli/tui/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Persistent prompt_toolkit TUI shell for the Datus REPL.
+
+The TUI keeps the status bar and input TextArea pinned to the bottom of the
+terminal across the entire REPL lifetime, including while agent loops run in
+a worker thread. This module is only loaded when ``sys.stdin``/``sys.stdout``
+are TTYs and ``DATUS_TUI`` is not explicitly disabled; non-TTY paths (CI,
+pipes, ``--print`` mode) continue to use the classic ``PromptSession``.
+"""
+
+from datus.cli.tui.app import DatusApp, tui_enabled
+
+__all__ = ["DatusApp", "tui_enabled"]

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -183,9 +183,24 @@ class DatusApp:
         return self._agent_running
 
     def set_input_text(self, text: str) -> None:
-        """Prefill the input buffer (e.g. for ``.rewind``)."""
-        self._input_area.buffer.document = self._input_area.buffer.document.__class__(text)
-        self.invalidate()
+        """Prefill the input buffer (e.g. for ``.rewind``). Thread-safe."""
+        buffer = self._input_area.buffer
+        document_cls = buffer.document.__class__
+
+        def _apply() -> None:
+            buffer.document = document_cls(text)
+            self._app.invalidate()
+
+        if self._loop is None:
+            # Application has not started yet — direct mutation is safe because
+            # no event loop owns the buffer.
+            _apply()
+            return
+        try:
+            self._loop.call_soon_threadsafe(_apply)
+        except RuntimeError:
+            # Loop already closed; the buffer won't be observed anyway.
+            pass
 
     def invalidate(self) -> None:
         """Trigger a redraw from any thread."""
@@ -321,6 +336,11 @@ class DatusApp:
 
         @kb.add("c-d")
         def _ctrl_d(event) -> None:  # noqa: ANN001
+            if self._agent_running.is_set():
+                # A worker task still owns the executor; tearing down the
+                # Application here would drop the pinned TUI while the agent
+                # keeps running. Ignore Ctrl+D until the worker finishes.
+                return
             if event.app.current_buffer.text:
                 # Standard readline semantics: Ctrl+D with content does nothing.
                 return

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -1,0 +1,337 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Persistent prompt_toolkit Application that pins the status bar + input.
+
+The Datus REPL historically used ``PromptSession.prompt()`` and re-rendered
+the status bar as a prefix each round. During agent loops, the session was
+not active and the status bar + input disappeared. :class:`DatusApp` replaces
+that pull model with a long-lived ``Application(full_screen=False)`` whose
+layout keeps the status bar (1 row) and input :class:`TextArea` at the bottom
+of the terminal for the entire REPL lifetime. Agent work runs on a dedicated
+worker thread; its output is captured by ``patch_stdout(raw=True)`` and
+scrolls in the area above the pinned bottom.
+
+Concurrency contract:
+
+* The prompt_toolkit Application owns the main thread and its asyncio loop.
+* User input is accepted via an ``enter`` key binding; when the agent is idle,
+  the input text is passed to ``dispatch_fn`` on a ``ThreadPoolExecutor``
+  (``max_workers=1``). While that future is pending, ``agent_running`` is set,
+  Enter is swallowed, and the status bar/input reflect the busy state.
+* ``dispatch_fn`` runs in the worker thread and may use ``asyncio.run(...)``
+  internally without clashing with the main loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import os
+import sys
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Callable, List, Optional, Tuple
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.completion import Completer
+from prompt_toolkit.formatted_text import FormattedText
+from prompt_toolkit.history import History
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.layout.containers import HSplit, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.lexers import Lexer
+from prompt_toolkit.patch_stdout import patch_stdout
+from prompt_toolkit.styles import Style
+from prompt_toolkit.widgets import TextArea
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+# Sentinel returned by ``dispatch_fn`` to request clean shutdown of the TUI.
+EXIT_SENTINEL = "__datus_tui_exit__"
+
+
+def tui_enabled() -> bool:
+    """Decide whether the TUI path should be used for this invocation.
+
+    Returns ``True`` only when both stdin and stdout are TTYs and the
+    ``DATUS_TUI`` environment variable is not set to a falsy value
+    (``0``/``false``/``no``/``off``, case-insensitive).
+    """
+    env = os.environ.get("DATUS_TUI", "").strip().lower()
+    if env in {"0", "false", "no", "off"}:
+        return False
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+class DatusApp:
+    """Wrapper around a persistent prompt_toolkit Application.
+
+    The Application is built eagerly in ``__init__`` so callers can attach
+    additional key bindings (via :meth:`key_bindings`) or introspect the
+    input buffer before :meth:`run` is invoked.
+    """
+
+    def __init__(
+        self,
+        *,
+        status_tokens_fn: Callable[[], List[Tuple[str, str]]],
+        dispatch_fn: Callable[[str], Optional[str]],
+        completer: Optional[Completer] = None,
+        history: Optional[History] = None,
+        lexer: Optional[Lexer] = None,
+        style: Optional[Style] = None,
+        placeholder_fn: Optional[Callable[[], str]] = None,
+        input_prompt_fn: Optional[Callable[[], str]] = None,
+    ) -> None:
+        self._status_tokens_fn = status_tokens_fn
+        self._dispatch_fn = dispatch_fn
+        self._placeholder_fn = placeholder_fn or (lambda: "")
+        self._input_prompt_fn = input_prompt_fn or (lambda: "> ")
+
+        self._agent_running = threading.Event()
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="datus-tui-worker")
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._exit_code: int = 0
+
+        # Input: multi-line TextArea. We intentionally do not set an
+        # ``accept_handler`` — Enter is handled by our own key binding so we
+        # can swallow it while the agent is running.
+        self._input_area = TextArea(
+            height=Dimension(min=1),
+            multiline=True,
+            wrap_lines=True,
+            completer=completer,
+            history=history,
+            lexer=lexer,
+            focus_on_click=True,
+            complete_while_typing=True,
+            auto_suggest=None,
+            style="class:input-area",
+            prompt=self._get_input_prompt,
+        )
+
+        self._status_window = Window(
+            content=FormattedTextControl(
+                text=self._safe_status_tokens,
+                focusable=False,
+                show_cursor=False,
+            ),
+            height=1,
+            style="class:status-bar",
+            wrap_lines=False,
+        )
+
+        # In ``full_screen=False`` mode the Application renders only the rows
+        # it needs (status bar + input) at the bottom of the terminal. All
+        # program output above that region is emitted via ``patch_stdout``,
+        # which inserts new lines above the Application's rendered area, so
+        # no explicit output window is required here.
+        root = HSplit(
+            [
+                self._make_separator(),
+                self._status_window,
+                self._make_separator(),
+                self._input_area,
+                self._make_separator(),
+            ]
+        )
+
+        self._kb = self._build_default_key_bindings()
+
+        self._app: Application = Application(
+            layout=Layout(root, focused_element=self._input_area),
+            key_bindings=self._kb,
+            style=style or Style([]),
+            full_screen=False,
+            mouse_support=False,
+            erase_when_done=False,
+        )
+
+    @staticmethod
+    def _make_separator() -> Window:
+        """Full-width horizontal rule rendered with box-drawing character."""
+        return Window(height=1, char="\u2500", style="class:separator")
+
+    # -- public API --------------------------------------------------------
+
+    @property
+    def application(self) -> Application:
+        return self._app
+
+    @property
+    def input_buffer(self) -> Buffer:
+        return self._input_area.buffer
+
+    @property
+    def key_bindings(self) -> KeyBindings:
+        """Shared KeyBindings. Callers may attach additional handlers."""
+        return self._kb
+
+    @property
+    def agent_running(self) -> threading.Event:
+        return self._agent_running
+
+    def set_input_text(self, text: str) -> None:
+        """Prefill the input buffer (e.g. for ``.rewind``)."""
+        self._input_area.buffer.document = self._input_area.buffer.document.__class__(text)
+        self.invalidate()
+
+    def invalidate(self) -> None:
+        """Trigger a redraw from any thread."""
+        if self._loop is None:
+            return
+        try:
+            self._loop.call_soon_threadsafe(self._app.invalidate)
+        except RuntimeError:
+            # Loop already closed; redraw is not meaningful anymore.
+            pass
+
+    def submit_user_input(self, text: str) -> Optional[Future]:
+        """Dispatch user input to the worker thread.
+
+        Returns the :class:`Future` tracking the worker task (or ``None`` if
+        the input was rejected because the agent is already running or the
+        text is blank).
+        """
+        if self._agent_running.is_set():
+            return None
+        if not text.strip():
+            return None
+        if self._loop is None:
+            # Application has not started yet — run synchronously.
+            self._safe_dispatch(text)
+            return None
+
+        self._agent_running.set()
+        self._app.invalidate()
+        # Snapshot ContextVars on the prompt_toolkit loop thread so the worker
+        # sees bindings (e.g. ``set_current_path_manager``) set during startup.
+        # ``run_in_executor`` does not propagate ContextVars on its own.
+        ctx = contextvars.copy_context()
+        future = self._loop.run_in_executor(self._executor, ctx.run, self._safe_dispatch, text)
+        future.add_done_callback(self._on_dispatch_done)
+        return future
+
+    def exit(self, code: int = 0) -> None:
+        """Request Application exit (thread-safe)."""
+        self._exit_code = code
+        if self._loop is None:
+            return
+        try:
+            self._loop.call_soon_threadsafe(self._app.exit)
+        except RuntimeError:
+            pass
+
+    def run(self) -> int:
+        """Run the Application under ``patch_stdout``. Blocks until exit."""
+
+        async def _main() -> None:
+            self._loop = asyncio.get_running_loop()
+            try:
+                await self._app.run_async()
+            finally:
+                self._loop = None
+
+        try:
+            with patch_stdout(raw=True):
+                asyncio.run(_main())
+        finally:
+            self._executor.shutdown(wait=False)
+        return self._exit_code
+
+    # -- internals ---------------------------------------------------------
+
+    def _safe_status_tokens(self) -> FormattedText:
+        try:
+            tokens = self._status_tokens_fn()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("status_tokens_fn raised: %s", exc)
+            tokens = []
+        return FormattedText(tokens)
+
+    def _get_input_prompt(self) -> FormattedText:
+        try:
+            text = self._input_prompt_fn() or "> "
+        except Exception:  # pragma: no cover - defensive
+            text = "> "
+        style_class = "class:input-prompt.busy" if self._agent_running.is_set() else "class:input-prompt"
+        return FormattedText([(style_class, text)])
+
+    def _safe_dispatch(self, text: str) -> Optional[str]:
+        try:
+            return self._dispatch_fn(text)
+        except SystemExit:
+            raise
+        except BaseException:  # pragma: no cover - defensive
+            logger.exception("dispatch_fn raised for input: %r", text)
+            return None
+
+    def _on_dispatch_done(self, future: Future) -> None:
+        self._agent_running.clear()
+        self.invalidate()
+        try:
+            result = future.result()
+        except BaseException:  # pragma: no cover - already logged
+            return
+        if result == EXIT_SENTINEL:
+            self.exit(0)
+
+    def _build_default_key_bindings(self) -> KeyBindings:
+        """Default bindings: Enter submit/swallow, Ctrl+D exit, Ctrl+C cancel.
+
+        REPL-specific bindings (Tab completion, Shift+Tab Plan Mode, Ctrl+O
+        trace details, ESC interrupt) are attached by the caller via
+        :attr:`key_bindings` so DatusCLI can keep its existing handlers close
+        to the state they mutate.
+        """
+        kb = KeyBindings()
+
+        @kb.add("enter")
+        def _enter(event) -> None:  # noqa: ANN001 - prompt_toolkit signature
+            buffer = event.app.current_buffer
+
+            # Completion menu interaction mirrors the legacy PromptSession.
+            if buffer.complete_state:
+                cs = buffer.complete_state
+                comp = cs.current_completion
+                if comp is not None:
+                    buffer.apply_completion(comp)
+                else:
+                    buffer.cancel_completion()
+                return
+
+            if self._agent_running.is_set():
+                # Editable but not submittable. Silently ignore Enter.
+                return
+
+            text = buffer.text
+            buffer.reset()
+            self.submit_user_input(text)
+
+        @kb.add("c-d")
+        def _ctrl_d(event) -> None:  # noqa: ANN001
+            if event.app.current_buffer.text:
+                # Standard readline semantics: Ctrl+D with content does nothing.
+                return
+            self.exit(0)
+
+        @kb.add("c-c")
+        def _ctrl_c(event) -> None:  # noqa: ANN001
+            # When the agent is idle, clear any typed text (like bash).
+            # Agent-running handling is injected by the REPL (it has the
+            # interrupt_controller handle) via the shared KeyBindings.
+            if not self._agent_running.is_set():
+                event.app.current_buffer.reset()
+
+        return kb

--- a/datus/cli/tui/console_bridge.py
+++ b/datus/cli/tui/console_bridge.py
@@ -1,0 +1,51 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Helpers bridging Rich output to a running prompt_toolkit Application.
+
+``patch_stdout(raw=True)`` inside :class:`DatusApp` replaces ``sys.stdout``
+with a proxy that renders new lines above the pinned status bar + input.
+Rich ``Console`` instances that write to ``sys.stdout`` therefore scroll
+correctly without fighting the bottom area.
+
+Two concerns remain:
+
+1. Rich ``Live`` must not also patch stdout (otherwise both layers fight).
+   Callers construct ``Live(redirect_stdout=False, redirect_stderr=False)``;
+   this module does not own that choice but documents it here for reference.
+2. Some outputs — e.g. Pygments-highlighted user echo — prefer to appear
+   exactly where the cursor currently is. ``run_in_terminal_sync`` wraps
+   ``prompt_toolkit.application.run_in_terminal`` so callers can schedule a
+   print and block until it is rendered, useful from worker threads.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from prompt_toolkit.application import get_app_or_none
+from prompt_toolkit.application.run_in_terminal import run_in_terminal
+
+
+def run_in_terminal_sync(func: Callable[[], None]) -> None:
+    """Schedule ``func`` to print above the TUI and return after it runs.
+
+    Safe to call from any thread. When no Application is active (non-TTY
+    fallback path), simply invokes ``func`` directly.
+    """
+    app = get_app_or_none()
+    if app is None:
+        func()
+        return
+
+    future = run_in_terminal(func)
+    # ``run_in_terminal`` returns an asyncio.Future; ``result()`` blocks until
+    # the callback completes on the Application event loop.
+    try:
+        future.result()
+    except Exception:  # pragma: no cover - defensive
+        # Propagating would leak into background threads; callers that care
+        # should wrap ``func`` themselves. Here we swallow to keep the TUI
+        # responsive.
+        pass

--- a/datus/cli/tui/console_bridge.py
+++ b/datus/cli/tui/console_bridge.py
@@ -22,6 +22,7 @@ Two concerns remain:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Callable
 
 from prompt_toolkit.application import get_app_or_none
@@ -40,6 +41,21 @@ def run_in_terminal_sync(func: Callable[[], None]) -> None:
         return
 
     future = run_in_terminal(func)
+
+    # Callers invoked from a prompt_toolkit key handler run on the same
+    # asyncio loop that schedules the ``run_in_terminal`` callback. Blocking
+    # that thread on ``future.result()`` deadlocks the loop. Detect the
+    # in-loop case and let the scheduled callback finish asynchronously.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        on_event_loop = False
+    else:
+        on_event_loop = True
+
+    if on_event_loop:
+        return
+
     # ``run_in_terminal`` returns an asyncio.Future; ``result()`` blocks until
     # the callback completes on the Application event loop.
     try:

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -456,6 +456,19 @@ class TestStreamingInteractionProcessing:
         finally:
             loop.close()
 
+    def test_set_clear_header_callback(self):
+        """set_clear_header_callback stores and clears the banner reprint hook."""
+        display = ActionHistoryDisplay()
+        ctx = InlineStreamingContext([], display)
+        assert ctx._clear_header_callback is None
+
+        callback = MagicMock()
+        ctx.set_clear_header_callback(callback)
+        assert ctx._clear_header_callback is callback
+
+        ctx.set_clear_header_callback(None)
+        assert ctx._clear_header_callback is None
+
     def test_history_reprint_skips_interaction(self):
         """Ctrl+O reprint skips INTERACTION actions (only shown during live interaction)."""
         buf = StringIO()

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3499,7 +3499,10 @@ class TestUpdateChatNodeToolsExtended:
     def test_no_current_node_no_crash(self, chat_cmd):
         chat_cmd.current_node = None
         chat_cmd.chat_node = None
-        chat_cmd.update_chat_node_tools()  # should not raise
+        chat_cmd.update_chat_node_tools()
+        # Both node handles remain None — no setup work was attempted.
+        assert chat_cmd.current_node is None
+        assert chat_cmd.chat_node is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -72,6 +72,9 @@ class MinimalCLI:
         """Return empty string for prompt input."""
         return ""
 
+    def _print_welcome(self):
+        """No-op stand-in for the real banner printer."""
+
 
 # ===========================================================================
 # Shared helper to capture console output

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -746,10 +746,11 @@ class TestInitConnection:
 
 
 class TestPrintWelcome:
-    """Test _print_welcome database fallback chain."""
+    """Test _print_welcome banner output and database fallback chain."""
 
-    def _get_output(self, cli):
+    def _get_output(self, cli, width: int = 100):
         """Call _print_welcome and return the console output."""
+        cli.console = Console(file=io.StringIO(), no_color=True, width=width)
         cli._print_welcome()
         return cli.console.file.getvalue()
 
@@ -759,7 +760,9 @@ class TestPrintWelcome:
         cli.args = MagicMock(database="my_db", namespace="my_ns")
         real_agent_config._current_database = "config_db"
         output = self._get_output(cli)
-        assert "Database my_db selected" in output
+        assert "my_db" in output
+        assert "my_ns" not in output
+        assert "config_db" not in output
 
     def test_database_fallback_to_args_namespace(self, real_agent_config):
         """Falls back to args.namespace when args.database is empty."""
@@ -767,7 +770,7 @@ class TestPrintWelcome:
         cli.args = MagicMock(database="", namespace="my_ns")
         real_agent_config._current_database = ""
         output = self._get_output(cli)
-        assert "Database my_ns selected" in output
+        assert "my_ns" in output
 
     def test_database_fallback_to_agent_config(self, real_agent_config):
         """Falls back to agent_config.current_database when args are empty."""
@@ -775,15 +778,107 @@ class TestPrintWelcome:
         cli.args = MagicMock(database="", namespace="")
         real_agent_config._current_database = "config_db"
         output = self._get_output(cli)
-        assert "Database config_db selected" in output
+        assert "config_db" in output
 
     def test_no_database_warning(self, real_agent_config):
-        """Shows warning when no database is available."""
+        """Shows 'not selected' hint when no database is available."""
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="", namespace="")
         real_agent_config._current_database = ""
         output = self._get_output(cli)
-        assert "No database selected" in output
+        assert "not selected" in output
+
+
+class TestBuildBannerPanel:
+    """Test the unified banner structure (version, art, AI status)."""
+
+    def _render(self, cli, width: int = 100) -> str:
+        cli.console = Console(file=io.StringIO(), no_color=True, width=width)
+        cli._print_welcome()
+        return cli.console.file.getvalue()
+
+    def test_contains_version(self, real_agent_config):
+        from datus import __version__
+
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        output = self._render(cli)
+        assert f"v{__version__}" in output
+
+    def test_contains_subtitle(self, real_agent_config):
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        output = self._render(cli)
+        assert "AI-powered SQL command-line interface" in output
+
+    def test_contains_ascii_art_on_wide_terminal(self, real_agent_config):
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        output = self._render(cli, width=100)
+        assert "██████╗" in output
+
+    def test_narrow_terminal_falls_back_to_text(self, real_agent_config):
+        from datus import __version__
+
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        output = self._render(cli, width=40)
+        assert f"DATUS v{__version__}" in output
+        assert "██████╗" not in output
+
+    def test_no_ai_status_row(self, real_agent_config):
+        """Banner must not include an AI status row."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        cli.agent_ready = True
+        cli.agent_initializing = False
+        output = self._render(cli)
+        assert "initializing" not in output
+        # "AI" label should not appear as a standalone banner row
+        for line in output.splitlines():
+            stripped = line.strip("│ ").strip()
+            assert not stripped.startswith("AI ")
+
+    def test_not_connected_label(self, real_agent_config):
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        cli.db_connector = None
+        output = self._render(cli)
+        assert "not connected" in output
+
+    def test_no_command_prefix_cheatsheet(self, real_agent_config):
+        """Banner must not include the '/ . @ !' command prefix cheatsheet row."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        output = self._render(cli)
+        assert "! @ ." not in output
+        assert "Commands:" not in output
+
+    def test_using_suffix_when_active_db_differs(self, real_agent_config):
+        """Database line appends 'using <name>' when current_db_name != configured db."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        cli.cli_context.current_db_name = "other_db"
+        output = self._render(cli)
+        assert "using other_db" in output
+
+    def test_context_row_rendered_when_available(self, real_agent_config):
+        """Context row appears when cli_context has a non-empty summary."""
+        cli = _make_cli(real_agent_config)
+        cli.args = MagicMock(database="benchmark", namespace="")
+        real_agent_config._current_database = ""
+        cli.cli_context.current_db_name = "benchmark"
+        output = self._render(cli)
+        assert "Context" in output
+        assert "database: benchmark" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_status_bar.py
+++ b/tests/unit_tests/cli/test_status_bar.py
@@ -135,6 +135,36 @@ class TestStatusBarState:
         styles = [style for style, _ in state.to_formatted_tokens()]
         assert "class:status-bar.connector" not in styles
 
+    def test_to_formatted_tokens_appends_running_segment_when_agent_running(self):
+        # The TUI path sets ``agent_running`` true while the worker thread is
+        # dispatching; the status bar must surface a ``● running`` indicator
+        # as the trailing segment so users can tell the REPL is busy at a
+        # glance even though input remains editable.
+        state = StatusBarState(agent="chat", agent_running=True)
+        tokens = state.to_formatted_tokens()
+        styles = [style for style, _ in tokens]
+        texts = [text for _, text in tokens]
+        assert "class:status-bar.running" in styles
+        running_text = texts[styles.index("class:status-bar.running")]
+        assert "running" in running_text
+        # The running token must be the last meaningful segment (followed
+        # only by the trailing pad so the bar has a breathing space at the
+        # terminal edge).
+        last_non_pad = None
+        for style, text in reversed(tokens):
+            if style == "class:status-bar":
+                continue
+            last_non_pad = style
+            break
+        assert last_non_pad == "class:status-bar.running"
+
+    def test_to_formatted_tokens_omits_running_segment_when_idle(self):
+        # The legacy PromptSession path never sets ``agent_running`` true,
+        # so the running indicator must never appear outside the TUI.
+        state = StatusBarState(agent="chat")
+        styles = [style for style, _ in state.to_formatted_tokens()]
+        assert "class:status-bar.running" not in styles
+
 
 class TestStatusBarProviderAgent:
     def test_subagent_name_wins_over_default(self):

--- a/tests/unit_tests/cli/tui/test_app.py
+++ b/tests/unit_tests/cli/tui/test_app.py
@@ -1,0 +1,425 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for :mod:`datus.cli.tui.app`.
+
+These tests avoid actually running the prompt_toolkit Application (which
+requires a TTY) and instead verify the pure Python state machine around
+``agent_running``, the Enter dispatch swallow behavior, ``EXIT_SENTINEL``
+handling, and ``tui_enabled`` environment detection.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from concurrent.futures import Future
+from unittest import mock
+
+import pytest
+
+from datus.cli.tui.app import EXIT_SENTINEL, DatusApp, tui_enabled
+
+
+@pytest.fixture
+def tui_app() -> DatusApp:
+    """Construct a minimal :class:`DatusApp` wired to recording callbacks."""
+    status_calls: list = []
+
+    def _status() -> list:
+        status_calls.append(True)
+        return [("class:status-bar", "Datus")]
+
+    dispatch_log: list = []
+
+    def _dispatch(text: str):
+        dispatch_log.append(text)
+        return None
+
+    app = DatusApp(
+        status_tokens_fn=_status,
+        dispatch_fn=_dispatch,
+    )
+    # Expose the logs so test functions can assert against them.
+    app._test_dispatch_log = dispatch_log  # type: ignore[attr-defined]
+    app._test_status_calls = status_calls  # type: ignore[attr-defined]
+    return app
+
+
+class TestTuiEnabled:
+    def test_disabled_when_env_set_to_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DATUS_TUI", "0")
+        assert tui_enabled() is False
+
+    def test_disabled_when_env_set_to_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DATUS_TUI", "FALSE")
+        assert tui_enabled() is False
+
+    def test_disabled_when_stdin_not_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DATUS_TUI", raising=False)
+        # In the test runner stdout/stdin are pipes, so the check should fail.
+        # Assert the outcome matches reality to avoid making the test
+        # environment-sensitive (CI would always fail this otherwise).
+        import sys
+
+        expected = bool(sys.stdin.isatty() and sys.stdout.isatty())
+        assert tui_enabled() is expected
+
+    def test_honors_environment_over_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Even if TTY detection would return True, the env var takes priority.
+        monkeypatch.setenv("DATUS_TUI", "off")
+        with (
+            mock.patch("sys.stdin.isatty", return_value=True),
+            mock.patch("sys.stdout.isatty", return_value=True),
+        ):
+            assert tui_enabled() is False
+
+
+class TestDatusAppState:
+    def test_agent_running_is_fresh_threading_event(self, tui_app: DatusApp) -> None:
+        assert isinstance(tui_app.agent_running, threading.Event)
+        assert tui_app.agent_running.is_set() is False
+
+    def test_submit_blank_input_is_rejected(self, tui_app: DatusApp) -> None:
+        future = tui_app.submit_user_input("   \n  ")
+        assert future is None
+        # Blank input must not flip the running flag or reach dispatch_fn.
+        assert tui_app.agent_running.is_set() is False
+        assert tui_app._test_dispatch_log == []
+
+    def test_submit_while_running_is_swallowed(self, tui_app: DatusApp) -> None:
+        tui_app.agent_running.set()
+        future = tui_app.submit_user_input("SELECT 1")
+        assert future is None
+        # Dispatch must not run when the agent is already busy.
+        assert tui_app._test_dispatch_log == []
+
+    def test_submit_without_loop_runs_synchronously(self, tui_app: DatusApp) -> None:
+        # With no event loop bound, the app should execute the dispatcher
+        # inline so tests (and startup-time invocations) can exercise the
+        # same wiring without spinning up an Application.
+        tui_app.submit_user_input("SELECT 1")
+        assert tui_app._test_dispatch_log == ["SELECT 1"]
+        # The inline path must not leave the flag stuck on.
+        assert tui_app.agent_running.is_set() is False
+
+
+class TestOnDispatchDone:
+    def test_clears_running_flag_on_success(self, tui_app: DatusApp) -> None:
+        tui_app.agent_running.set()
+        future: Future = Future()
+        future.set_result(None)
+        tui_app._on_dispatch_done(future)
+        assert tui_app.agent_running.is_set() is False
+
+    def test_clears_running_flag_on_exception(self, tui_app: DatusApp) -> None:
+        tui_app.agent_running.set()
+        future: Future = Future()
+        future.set_exception(RuntimeError("boom"))
+        tui_app._on_dispatch_done(future)
+        assert tui_app.agent_running.is_set() is False
+
+    def test_exit_sentinel_triggers_exit(self, tui_app: DatusApp) -> None:
+        tui_app.agent_running.set()
+        future: Future = Future()
+        future.set_result(EXIT_SENTINEL)
+
+        with mock.patch.object(tui_app, "exit") as mocked_exit:
+            tui_app._on_dispatch_done(future)
+            mocked_exit.assert_called_once_with(0)
+
+    def test_non_exit_result_does_not_call_exit(self, tui_app: DatusApp) -> None:
+        future: Future = Future()
+        future.set_result("anything else")
+
+        with mock.patch.object(tui_app, "exit") as mocked_exit:
+            tui_app._on_dispatch_done(future)
+            mocked_exit.assert_not_called()
+
+
+class TestStatusTokens:
+    def test_status_tokens_are_wrapped_in_formatted_text(self, tui_app: DatusApp) -> None:
+        # ``_safe_status_tokens`` is called on every redraw and must survive
+        # callable exceptions without tearing the TUI down.
+        ft = tui_app._safe_status_tokens()
+        # FormattedText subclasses list, so the iteration check also validates
+        # that the returned value is usable by the Window/FormattedTextControl
+        # plumbing.
+        assert list(ft) == [("class:status-bar", "Datus")]
+
+    def test_status_tokens_tolerates_callable_errors(self) -> None:
+        def _boom() -> list:
+            raise RuntimeError("explode")
+
+        app = DatusApp(
+            status_tokens_fn=_boom,
+            dispatch_fn=lambda text: None,
+        )
+        # Must not propagate; returning an empty token list keeps the
+        # status bar visible with no segments rather than crashing redraw.
+        assert list(app._safe_status_tokens()) == []
+
+
+class TestInputPrompt:
+    def test_prompt_uses_busy_style_when_running(self, tui_app: DatusApp) -> None:
+        tui_app.agent_running.set()
+        rendered = tui_app._get_input_prompt()
+        assert rendered == [("class:input-prompt.busy", "> ")]
+
+    def test_prompt_uses_idle_style_when_not_running(self, tui_app: DatusApp) -> None:
+        assert tui_app.agent_running.is_set() is False
+        rendered = tui_app._get_input_prompt()
+        assert rendered == [("class:input-prompt", "> ")]
+
+    def test_prompt_fn_errors_fallback_to_default(self) -> None:
+        def _boom() -> str:
+            raise RuntimeError("explode")
+
+        app = DatusApp(
+            status_tokens_fn=lambda: [],
+            dispatch_fn=lambda text: None,
+            input_prompt_fn=_boom,
+        )
+        rendered = app._get_input_prompt()
+        # Defensive fallback is exercised and still produces a usable prompt.
+        assert rendered == [("class:input-prompt", "> ")]
+
+
+class TestKeyBindingsContract:
+    """Verify Enter's dispatch-vs-swallow contract.
+
+    prompt_toolkit stores ``"enter"`` as :class:`Keys.ControlM`, so finding
+    the handler by key requires looking up the enum rather than the literal
+    string we passed to ``@kb.add``.
+    """
+
+    @staticmethod
+    def _enter_handler(app: DatusApp):
+        from prompt_toolkit.keys import Keys
+
+        for binding in app.key_bindings.bindings:
+            if Keys.ControlM in getattr(binding, "keys", ()):
+                return binding.handler
+        raise AssertionError("DatusApp must register an Enter binding")
+
+    def test_enter_swallowed_while_running(self, tui_app: DatusApp) -> None:
+        handler = self._enter_handler(tui_app)
+
+        tui_app.agent_running.set()
+
+        event = mock.MagicMock()
+        buffer = mock.MagicMock()
+        buffer.complete_state = None
+        buffer.text = "SELECT 1"
+        event.app.current_buffer = buffer
+
+        handler(event)
+
+        # Swallowed: dispatch should not be called, buffer should not be reset.
+        assert tui_app._test_dispatch_log == []
+        buffer.reset.assert_not_called()
+
+    def test_enter_dispatches_when_idle(self, tui_app: DatusApp) -> None:
+        handler = self._enter_handler(tui_app)
+
+        event = mock.MagicMock()
+        buffer = mock.MagicMock()
+        buffer.complete_state = None
+        buffer.text = "SELECT 1"
+        event.app.current_buffer = buffer
+
+        handler(event)
+
+        buffer.reset.assert_called_once()
+        assert tui_app._test_dispatch_log == ["SELECT 1"]
+
+    def test_enter_applies_active_completion(self, tui_app: DatusApp) -> None:
+        """When the completion menu has a highlighted item, Enter applies it
+        instead of submitting — matching the legacy PromptSession UX."""
+        handler = self._enter_handler(tui_app)
+
+        completion = mock.MagicMock()
+        complete_state = mock.MagicMock()
+        complete_state.current_completion = completion
+
+        buffer = mock.MagicMock()
+        buffer.complete_state = complete_state
+
+        event = mock.MagicMock()
+        event.app.current_buffer = buffer
+
+        handler(event)
+
+        buffer.apply_completion.assert_called_once_with(completion)
+        buffer.cancel_completion.assert_not_called()
+        # Submitting must NOT happen while a completion is being applied.
+        assert tui_app._test_dispatch_log == []
+
+    def test_enter_closes_menu_without_highlight(self, tui_app: DatusApp) -> None:
+        """Open completion menu with no highlighted item: Enter closes it."""
+        handler = self._enter_handler(tui_app)
+
+        complete_state = mock.MagicMock()
+        complete_state.current_completion = None
+
+        buffer = mock.MagicMock()
+        buffer.complete_state = complete_state
+
+        event = mock.MagicMock()
+        event.app.current_buffer = buffer
+
+        handler(event)
+
+        buffer.cancel_completion.assert_called_once()
+        buffer.apply_completion.assert_not_called()
+        assert tui_app._test_dispatch_log == []
+
+
+def test_exit_when_loop_absent_is_noop(tui_app: DatusApp) -> None:
+    # Calling ``exit`` before the Application starts must not raise; the
+    # exit code is still recorded for any later consumer.
+    tui_app.exit(7)
+    assert tui_app._exit_code == 7
+
+
+def test_invalidate_without_loop_is_noop(tui_app: DatusApp) -> None:
+    # A safety check: invalidate() is called from many callbacks, and
+    # several of them fire during startup/shutdown when the loop pointer
+    # is ``None``. The method must tolerate that without crashing.
+    tui_app.invalidate()
+
+
+def test_env_var_whitespace_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Whitespace around the env value must not bypass the disable check —
+    # operators commonly paste ``DATUS_TUI= 0`` with a stray space.
+    monkeypatch.setenv("DATUS_TUI", "  0  ")
+    assert tui_enabled() is False
+
+
+def test_os_environ_unset_uses_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Defensive coverage: if a subprocess inherits an empty string value
+    # (common with ``os.execve`` reset patterns), tui_enabled should not
+    # misinterpret it as "disabled".
+    monkeypatch.setenv("DATUS_TUI", "")
+    with (
+        mock.patch("sys.stdin.isatty", return_value=True),
+        mock.patch("sys.stdout.isatty", return_value=True),
+    ):
+        assert tui_enabled() is True
+
+
+def test_environ_truthy_values_allow_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arbitrary non-falsy values should not disable the TUI; only the
+    # documented disabled tokens (``0``/``false``/``no``/``off``) flip it.
+    monkeypatch.setenv("DATUS_TUI", "yes")
+    with (
+        mock.patch("sys.stdin.isatty", return_value=True),
+        mock.patch("sys.stdout.isatty", return_value=True),
+    ):
+        assert tui_enabled() is True
+
+
+def test_os_environ_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Sanity: nothing in the environment means we defer to TTY detection.
+    monkeypatch.delenv("DATUS_TUI", raising=False)
+    assert "DATUS_TUI" not in os.environ
+
+
+def _binding_for_key(app: DatusApp, key):
+    for binding in app.key_bindings.bindings:
+        if key in getattr(binding, "keys", ()):
+            return binding.handler
+    raise AssertionError(f"{key!r} binding missing")
+
+
+class TestCtrlDBinding:
+    """Ctrl+D must only exit when the input buffer is empty."""
+
+    def test_exits_when_buffer_empty(self, tui_app: DatusApp) -> None:
+        from prompt_toolkit.keys import Keys
+
+        handler = _binding_for_key(tui_app, Keys.ControlD)
+        event = mock.MagicMock()
+        event.app.current_buffer.text = ""
+
+        with mock.patch.object(tui_app, "exit") as mocked_exit:
+            handler(event)
+            mocked_exit.assert_called_once_with(0)
+
+    def test_noop_when_buffer_has_text(self, tui_app: DatusApp) -> None:
+        from prompt_toolkit.keys import Keys
+
+        handler = _binding_for_key(tui_app, Keys.ControlD)
+        event = mock.MagicMock()
+        event.app.current_buffer.text = "partial"
+
+        with mock.patch.object(tui_app, "exit") as mocked_exit:
+            handler(event)
+            mocked_exit.assert_not_called()
+
+
+class TestCtrlCBinding:
+    """Default Ctrl+C just clears the buffer when idle; agent-running
+    behavior is wired by DatusCLI (tested separately)."""
+
+    def test_clears_buffer_when_idle(self, tui_app: DatusApp) -> None:
+        from prompt_toolkit.keys import Keys
+
+        handler = _binding_for_key(tui_app, Keys.ControlC)
+        event = mock.MagicMock()
+        event.app.current_buffer = mock.MagicMock()
+
+        handler(event)
+        event.app.current_buffer.reset.assert_called_once()
+
+    def test_noop_when_agent_running(self, tui_app: DatusApp) -> None:
+        from prompt_toolkit.keys import Keys
+
+        tui_app.agent_running.set()
+        handler = _binding_for_key(tui_app, Keys.ControlC)
+
+        event = mock.MagicMock()
+        event.app.current_buffer = mock.MagicMock()
+
+        handler(event)
+        # When the agent is running, the default handler is inert: DatusCLI
+        # installs a more specific c-c binding that routes to the node's
+        # interrupt_controller.
+        event.app.current_buffer.reset.assert_not_called()
+
+
+def test_set_input_text_replaces_buffer(tui_app: DatusApp) -> None:
+    """``.rewind`` feeds a replayed user message through ``set_input_text``
+    so the prefill round-trip must keep the buffer's document type
+    consistent with what prompt_toolkit expects."""
+    tui_app.set_input_text("SELECT from orders")
+    assert tui_app.input_buffer.text == "SELECT from orders"
+
+    # Calling with empty string must clear any prior prefill cleanly.
+    tui_app.set_input_text("")
+    assert tui_app.input_buffer.text == ""
+
+
+def test_safe_dispatch_reraises_system_exit(tui_app: DatusApp) -> None:
+    """SystemExit is the one exception type we must not swallow — callers
+    rely on it to propagate out of the executor so graceful shutdown can
+    proceed. Catching it here would strand the worker thread."""
+
+    def _explode(text: str):
+        raise SystemExit(2)
+
+    tui_app._dispatch_fn = _explode
+
+    with pytest.raises(SystemExit):
+        tui_app._safe_dispatch("anything")
+
+
+def test_safe_dispatch_logs_and_returns_none_on_base_exception(tui_app: DatusApp) -> None:
+    def _explode(text: str):
+        raise RuntimeError("kaboom")
+
+    tui_app._dispatch_fn = _explode
+
+    # Defensive swallow: must return ``None`` (no crash) so the worker
+    # can be reused for the next command.
+    assert tui_app._safe_dispatch("anything") is None

--- a/tests/unit_tests/cli/tui/test_app.py
+++ b/tests/unit_tests/cli/tui/test_app.py
@@ -287,6 +287,8 @@ def test_invalidate_without_loop_is_noop(tui_app: DatusApp) -> None:
     # several of them fire during startup/shutdown when the loop pointer
     # is ``None``. The method must tolerate that without crashing.
     tui_app.invalidate()
+    # No loop was created as a side effect; the app stays in pre-start state.
+    assert tui_app._loop is None
 
 
 def test_env_var_whitespace_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/cli/tui/test_console_bridge.py
+++ b/tests/unit_tests/cli/tui/test_console_bridge.py
@@ -1,0 +1,84 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for :mod:`datus.cli.tui.console_bridge`.
+
+The bridge has a single helper, ``run_in_terminal_sync``, whose contract is:
+
+* If no prompt_toolkit Application is active, invoke ``func`` directly.
+* If one is active, schedule ``func`` via ``run_in_terminal`` and block on
+  the returned future.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from datus.cli.tui.console_bridge import run_in_terminal_sync
+
+
+def test_runs_inline_when_no_application() -> None:
+    # The real ``get_app_or_none`` returns ``None`` in unit tests (there is
+    # no Application), so patching is unnecessary here — exercise the real
+    # code path to catch accidental regressions in the fallback logic.
+    called: dict = {"count": 0}
+
+    def _fn() -> None:
+        called["count"] += 1
+
+    run_in_terminal_sync(_fn)
+
+    assert called["count"] == 1
+
+
+def test_schedules_via_run_in_terminal_when_app_active() -> None:
+    fake_future = mock.MagicMock()
+    fake_future.result.return_value = None
+    fake_app = mock.MagicMock()
+
+    with (
+        mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
+        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future) as mocked_rit,
+    ):
+        fn = mock.MagicMock()
+        run_in_terminal_sync(fn)
+
+        mocked_rit.assert_called_once_with(fn)
+        # ``result()`` must be awaited so the caller can rely on the print
+        # having completed before returning control.
+        fake_future.result.assert_called_once()
+
+
+def test_swallows_future_exceptions() -> None:
+    # Exceptions raised on the prompt_toolkit loop thread must not leak
+    # back to callers: a worker-thread callback failing silently is
+    # preferable to the REPL crashing mid-dispatch.
+    fake_future = mock.MagicMock()
+    fake_future.result.side_effect = RuntimeError("boom")
+    fake_app = mock.MagicMock()
+
+    with (
+        mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
+        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future),
+    ):
+        # Must not raise.
+        run_in_terminal_sync(lambda: None)
+
+
+def test_passes_exact_callable_without_wrapping() -> None:
+    # ``run_in_terminal`` accepts a no-arg callable; the bridge must not
+    # wrap it in a lambda (which would defeat introspection in hooks).
+    target = mock.MagicMock()
+    fake_future = mock.MagicMock()
+    fake_future.result.return_value = None
+    fake_app = mock.MagicMock()
+
+    with (
+        mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
+        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future) as mocked_rit,
+    ):
+        run_in_terminal_sync(target)
+        # Positional argument identity check — our helper should forward the
+        # object unchanged.
+        (passed,), _kwargs = mocked_rit.call_args
+        assert passed is target

--- a/tests/unit_tests/cli/tui/test_console_bridge.py
+++ b/tests/unit_tests/cli/tui/test_console_bridge.py
@@ -59,10 +59,14 @@ def test_swallows_future_exceptions() -> None:
 
     with (
         mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
-        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future),
+        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future) as mocked_rit,
     ):
-        # Must not raise.
         run_in_terminal_sync(lambda: None)
+
+    # The bridge both scheduled the callback and awaited its result even
+    # though the result raised — the exception was swallowed, not re-raised.
+    mocked_rit.assert_called_once()
+    fake_future.result.assert_called_once()
 
 
 def test_passes_exact_callable_without_wrapping() -> None:


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent TUI shell with status bar, running indicator, and new keybindings (Tab, Shift+Tab, Ctrl+O, Escape, Ctrl+C).

* **Improvements**
  * Responsive welcome/banner with version and context; centralized command dispatch and shared prompt styling.
  * Customizable clear-header behavior for mode toggles and improved console/stdout handling for on-screen overlays.

* **Removed**
  * Suppressed default-database auto-selection message and background AI init message.

* **Tests**
  * Added comprehensive tests for TUI, status bar, streaming, and console-bridge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->