### PR TITLE
[Enhancement] Rename namespaces to databases; add PUT /config/databases and /config/models

### DIFF
--- a/datus/api/routes/config_routes.py
+++ b/datus/api/routes/config_routes.py
@@ -5,9 +5,13 @@ This module provides endpoints for initialization status checks
 and supported provider/database type listings.
 """
 
-from fastapi import APIRouter
+from typing import Any, Dict, Optional
 
-from datus.api.deps import ServiceDep
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from datus.api import deps
+from datus.api.deps import AppContextDep, ServiceDep
 from datus.api.models.base_models import Result
 from datus.api.models.config_models import (
     DatabaseTypeInfo,
@@ -15,8 +19,56 @@ from datus.api.models.config_models import (
     LLMProviderInfo,
     LLMProvidersData,
 )
+from datus.configuration.agent_config import _SAFE_NAME_RE
+from datus.configuration.agent_config_loader import configuration_manager
+from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["configuration"])
+
+
+class UpdateDatabasesRequest(BaseModel):
+    """Full desired state for `services.databases`.
+
+    Any existing database key absent from `databases` will be deleted.
+    """
+
+    databases: Dict[str, Dict[str, Any]]
+
+
+class UpdateModelsRequest(BaseModel):
+    """Optional full-replace for `models` and/or update to `target`.
+
+    At least one of `models` or `target` must be provided.
+    """
+
+    models: Optional[Dict[str, Dict[str, Any]]] = None
+    target: Optional[str] = None
+
+
+def _validate_keys(entries: Dict[str, Any], kind: str) -> None:
+    """Ensure every key matches the naming policy used by AgentConfig."""
+    for name in entries.keys():
+        if not _SAFE_NAME_RE.match(name):
+            raise DatusException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                message=(
+                    f"Invalid {kind} name '{name}'. Only alphanumeric characters, underscores, and hyphens are allowed."
+                ),
+            )
+
+
+async def _evict_current_project(project_id: str) -> None:
+    """Drop the cached DatusService so the next request reloads from YAML."""
+    cache = deps._service_cache
+    if cache is None:
+        return
+    try:
+        await cache.evict(project_id)
+    except Exception:
+        logger.exception(f"Failed to evict service cache for project {project_id}")
 
 
 @router.get(
@@ -30,23 +82,23 @@ async def get_agent_config_endpoint(
 ) -> Result[dict]:
     """Return the project's loaded AgentConfig summary."""
     config = svc.agent_config
-    flat_namespaces: dict = {}
+    flat_databases: dict = {}
 
-    for ns_name, inner in config.namespaces.items():
+    for db_name, inner in config.namespaces.items():
         if not inner:
             continue
-        db_config = inner.get(ns_name)
+        db_config = inner.get(db_name)
         if db_config is None:
             db_config = next(iter(inner.values()))
-        flat_namespaces[ns_name] = db_config
+        flat_databases[db_name] = db_config
 
     return Result(
         success=True,
         data={
             "target": config.target,
             "models": config.models,
-            "current_namespace": config.current_namespace,
-            "namespaces": flat_namespaces,
+            "current_database": config.current_namespace,
+            "databases": flat_databases,
             "home": config.home,
         },
     )
@@ -148,3 +200,69 @@ async def get_database_types() -> Result[DatabaseTypesData]:
         success=True,
         data=DatabaseTypesData(database_types=database_types, default="postgresql"),
     )
+
+
+@router.put(
+    "/config/databases",
+    response_model=Result[dict],
+    summary="Update Databases",
+    description="Replace the databases (services.databases) block in agent.yml.",
+)
+async def update_databases_endpoint(
+    body: UpdateDatabasesRequest,
+    svc: ServiceDep,  # noqa: ARG001  # populates request.state.app_context; must resolve before AppContextDep
+    ctx: AppContextDep,
+) -> Result[dict]:
+    """Full-replace `services.databases` with the provided databases."""
+    _validate_keys(body.databases, kind="database")
+
+    cm = configuration_manager()
+    services = cm.data.setdefault("services", {})
+    services["databases"] = dict(body.databases)
+    cm.save()
+
+    await _evict_current_project(ctx.project_id or "default")
+
+    return Result(success=True, data={"updated": True})
+
+
+@router.put(
+    "/config/models",
+    response_model=Result[dict],
+    summary="Update Models and Target",
+    description="Replace the models block and/or update the default target in agent.yml.",
+)
+async def update_models_endpoint(
+    body: UpdateModelsRequest,
+    svc: ServiceDep,  # noqa: ARG001
+    ctx: AppContextDep,
+) -> Result[dict]:
+    """Optional full-replace `models`, optional update `target`. One must be set."""
+    if body.models is None and body.target is None:
+        raise DatusException(
+            ErrorCode.COMMON_FIELD_INVALID,
+            message="At least one of 'models' or 'target' must be provided.",
+        )
+
+    if body.models is not None:
+        _validate_keys(body.models, kind="model")
+
+    cm = configuration_manager()
+
+    if body.target is not None:
+        effective_models = body.models if body.models is not None else cm.data.get("models") or {}
+        if body.target not in effective_models:
+            raise DatusException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                message=f"target '{body.target}' does not exist in models.",
+            )
+
+    if body.models is not None:
+        cm.data["models"] = dict(body.models)
+    if body.target is not None:
+        cm.data["target"] = body.target
+    cm.save()
+
+    await _evict_current_project(ctx.project_id or "default")
+
+    return Result(success=True, data={"updated": True})

--- a/datus/api/routes/config_routes.py
+++ b/datus/api/routes/config_routes.py
@@ -5,6 +5,7 @@ This module provides endpoints for initialization status checks
 and supported provider/database type listings.
 """
 
+import asyncio
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter
@@ -19,8 +20,9 @@ from datus.api.models.config_models import (
     LLMProviderInfo,
     LLMProvidersData,
 )
-from datus.configuration.agent_config import _SAFE_NAME_RE
+from datus.configuration.agent_config import _SAFE_NAME_RE, DbConfig, load_model_config
 from datus.configuration.agent_config_loader import configuration_manager
+from datus.models.base import LLMBaseModel
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -46,6 +48,56 @@ class UpdateModelsRequest(BaseModel):
 
     models: Optional[Dict[str, Dict[str, Any]]] = None
     target: Optional[str] = None
+
+
+class ProbeModelRequest(BaseModel):
+    """Single LLM model config dict — flat shape matching IModelInfo."""
+
+    model_config = {"extra": "allow"}
+
+    type: str
+    model: str
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+
+
+class ProbeDatabaseRequest(BaseModel):
+    """Single database config dict — flat shape matching IDatabaseConfig."""
+
+    model_config = {"extra": "allow"}
+
+    type: str
+
+
+def _probe_llm_sync(payload: Dict[str, Any]) -> None:
+    """Build a one-shot LLM client from a raw dict and send a tiny probe."""
+    model_cfg = load_model_config(payload)
+    model_class_name = LLMBaseModel.MODEL_TYPE_MAP.get(model_cfg.type)
+    if model_class_name is None:
+        raise DatusException(
+            ErrorCode.COMMON_FIELD_INVALID,
+            message=f"Unsupported model type: {model_cfg.type}",
+        )
+    module = __import__(f"datus.models.{model_cfg.type}_model", fromlist=[model_class_name])
+    model_class = getattr(module, model_class_name)
+    client = model_class(model_config=model_cfg)
+    client.generate("Hello")
+
+
+def _probe_database_sync(payload: Dict[str, Any]) -> None:
+    """Build a one-shot connector from a raw dict and run a SELECT 1 probe."""
+    from datus.tools.db_tools.db_manager import DBManager
+
+    kwargs = dict(payload)
+    kwargs.setdefault("name", "_probe_")
+    db_config = DbConfig.filter_kwargs(DbConfig, kwargs)
+
+    manager = DBManager({"_probe_": {"_probe_": db_config}})
+    try:
+        conn = manager.get_conn("_probe_")
+        conn.test_connection()
+    finally:
+        manager.close()
 
 
 def _validate_keys(entries: Dict[str, Any], kind: str) -> None:
@@ -266,3 +318,43 @@ async def update_models_endpoint(
     await _evict_current_project(ctx.project_id or "default")
 
     return Result(success=True, data={"updated": True})
+
+
+@router.post(
+    "/config/models/test",
+    response_model=Result[dict],
+    summary="Test Model Connectivity",
+    description="Send a tiny probe to verify an LLM model config is reachable.",
+)
+async def probe_model_connectivity_endpoint(
+    body: ProbeModelRequest,
+    svc: ServiceDep,  # noqa: ARG001
+) -> Result[dict]:
+    """Return `{ok: True}` if the probe succeeds, else `{ok: False, message: ...}`."""
+    payload = body.model_dump()
+    try:
+        await asyncio.to_thread(_probe_llm_sync, payload)
+        return Result(success=True, data={"ok": True})
+    except Exception as e:
+        logger.info(f"Model connectivity probe failed: {e}")
+        return Result(success=True, data={"ok": False, "message": str(e)})
+
+
+@router.post(
+    "/config/databases/test",
+    response_model=Result[dict],
+    summary="Test Database Connectivity",
+    description="Run SELECT 1 against a database config to verify reachability and credentials.",
+)
+async def probe_database_connectivity_endpoint(
+    body: ProbeDatabaseRequest,
+    svc: ServiceDep,  # noqa: ARG001
+) -> Result[dict]:
+    """Return `{ok: True}` if the probe succeeds, else `{ok: False, message: ...}`."""
+    payload = body.model_dump()
+    try:
+        await asyncio.to_thread(_probe_database_sync, payload)
+        return Result(success=True, data={"ok": True})
+    except Exception as e:
+        logger.info(f"Database connectivity probe failed: {e}")
+        return Result(success=True, data={"ok": False, "message": str(e)})

--- a/datus/api/routes/config_routes.py
+++ b/datus/api/routes/config_routes.py
@@ -30,14 +30,23 @@ async def get_agent_config_endpoint(
 ) -> Result[dict]:
     """Return the project's loaded AgentConfig summary."""
     config = svc.agent_config
+    flat_namespaces: dict = {}
+
+    for ns_name, inner in config.namespaces.items():
+        if not inner:
+            continue
+        db_config = inner.get(ns_name)
+        if db_config is None:
+            db_config = next(iter(inner.values()))
+        flat_namespaces[ns_name] = db_config
+
     return Result(
         success=True,
         data={
             "target": config.target,
-            "models": list(config.models.keys()),
+            "models": config.models,
             "current_namespace": config.current_namespace,
-            "namespaces": list(config.namespaces.keys()),
-            "agentic_nodes": list(config.agentic_nodes.keys()) if config.agentic_nodes else [],
+            "namespaces": flat_namespaces,
             "home": config.home,
         },
     )

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -3,34 +3,41 @@
 
 """Unit tests for datus/api/routes/config_routes.py."""
 
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from datus.api.routes import config_routes
 from datus.api.routes.config_routes import (
+    UpdateDatabasesRequest,
+    UpdateModelsRequest,
     get_agent_config_endpoint,
     get_database_types,
     get_llm_providers,
+    update_databases_endpoint,
+    update_models_endpoint,
 )
+from datus.utils.exceptions import DatusException
 
 
-def _mock_svc(namespaces, *, target="deepseek", current_namespace="starrocks", models=None, home="~/.datus"):
+def _mock_svc(databases, *, target="deepseek", current_database="starrocks", models=None, home="~/.datus"):
     svc = MagicMock()
     svc.agent_config.target = target
     svc.agent_config.models = models if models is not None else {}
-    svc.agent_config.current_namespace = current_namespace
-    svc.agent_config.namespaces = namespaces
+    svc.agent_config.current_namespace = current_database
+    svc.agent_config.namespaces = databases
     svc.agent_config.home = home
     return svc
 
 
 @pytest.mark.asyncio
 async def test_get_agent_config_flattens_matching_inner_key():
-    """When inner key matches the namespace name, that entry is returned flat."""
+    """When inner key matches the database name, that entry is returned flat."""
     starrocks_cfg = {"logic_name": "starrocks", "type": "starrocks", "host": "h1"}
     starrocks22_cfg = {"logic_name": "starrocks22", "type": "starrocks", "host": "h2"}
     svc = _mock_svc(
-        namespaces={
+        databases={
             "starrocks": {"starrocks": starrocks_cfg},
             "starrocks22": {"starrocks22": starrocks22_cfg},
         },
@@ -39,44 +46,44 @@ async def test_get_agent_config_flattens_matching_inner_key():
     result = await get_agent_config_endpoint(svc)
 
     assert result.success is True
-    assert result.data["namespaces"] == {
+    assert result.data["databases"] == {
         "starrocks": starrocks_cfg,
         "starrocks22": starrocks22_cfg,
     }
     assert result.data["target"] == "deepseek"
-    assert result.data["current_namespace"] == "starrocks"
+    assert result.data["current_database"] == "starrocks"
     assert result.data["home"] == "~/.datus"
 
 
 @pytest.mark.asyncio
 async def test_get_agent_config_falls_back_to_first_inner_value():
-    """When inner key does not match namespace name, first inner value is used."""
+    """When inner key does not match database name, first inner value is used."""
     inner_cfg = {"logic_name": "db_a", "type": "duckdb"}
-    svc = _mock_svc(namespaces={"my_ns": {"db_a": inner_cfg}})
+    svc = _mock_svc(databases={"my_db": {"db_a": inner_cfg}})
 
     result = await get_agent_config_endpoint(svc)
 
-    assert result.data["namespaces"] == {"my_ns": inner_cfg}
+    assert result.data["databases"] == {"my_db": inner_cfg}
 
 
 @pytest.mark.asyncio
 async def test_get_agent_config_skips_empty_inner_dict():
-    """Namespaces with empty inner dicts are dropped from the response."""
+    """Databases with empty inner dicts are dropped from the response."""
     real_cfg = {"logic_name": "real", "type": "duckdb"}
-    svc = _mock_svc(namespaces={"empty": {}, "real": {"real": real_cfg}})
+    svc = _mock_svc(databases={"empty": {}, "real": {"real": real_cfg}})
 
     result = await get_agent_config_endpoint(svc)
 
-    assert result.data["namespaces"] == {"real": real_cfg}
+    assert result.data["databases"] == {"real": real_cfg}
 
 
 @pytest.mark.asyncio
-async def test_get_agent_config_handles_empty_namespaces():
-    svc = _mock_svc(namespaces={})
+async def test_get_agent_config_handles_empty_databases():
+    svc = _mock_svc(databases={})
 
     result = await get_agent_config_endpoint(svc)
 
-    assert result.data["namespaces"] == {}
+    assert result.data["databases"] == {}
 
 
 @pytest.mark.asyncio
@@ -93,3 +100,196 @@ async def test_get_database_types_returns_known_templates():
     assert result.success is True
     types = {item.type for item in result.data.database_types}
     assert {"postgresql", "mysql", "starrocks", "duckdb", "snowflake"} <= types
+
+
+class _FakeConfigManager:
+    """Minimal stand-in for ConfigurationManager — captures save() calls."""
+
+    def __init__(self, initial=None):
+        self.data = dict(initial) if initial else {}
+        self.save_count = 0
+
+    def save(self):
+        self.save_count += 1
+
+
+@pytest.fixture
+def patched_cm(monkeypatch):
+    """Replace the module-level configuration_manager() with a fake instance."""
+    cm = _FakeConfigManager()
+    monkeypatch.setattr(config_routes, "configuration_manager", lambda: cm)
+    return cm
+
+
+@pytest.fixture
+def patched_cache(monkeypatch):
+    """Replace deps._service_cache with an AsyncMock so evict() is awaitable."""
+    cache = MagicMock()
+    cache.evict = AsyncMock()
+    monkeypatch.setattr(config_routes.deps, "_service_cache", cache)
+    return cache
+
+
+def _ctx(project_id="proj_a"):
+    return SimpleNamespace(project_id=project_id)
+
+
+@pytest.mark.asyncio
+async def test_update_databases_replaces_services_databases(patched_cm, patched_cache):
+    patched_cm.data = {"services": {"databases": {"old": {"type": "duckdb"}}, "other": "keep"}}
+    body = UpdateDatabasesRequest(
+        databases={
+            "db_a": {"type": "starrocks", "host": "h1"},
+            "db_b": {"type": "duckdb", "uri": "/tmp/a.db"},
+        }
+    )
+
+    result = await update_databases_endpoint(body, svc=MagicMock(), ctx=_ctx("proj_a"))
+
+    assert result.success is True
+    assert result.data == {"updated": True}
+    assert patched_cm.data["services"]["databases"] == {
+        "db_a": {"type": "starrocks", "host": "h1"},
+        "db_b": {"type": "duckdb", "uri": "/tmp/a.db"},
+    }
+    assert patched_cm.data["services"]["other"] == "keep"
+    assert patched_cm.save_count == 1
+    patched_cache.evict.assert_awaited_once_with("proj_a")
+
+
+@pytest.mark.asyncio
+async def test_update_databases_empty_dict_clears_block(patched_cm, patched_cache):
+    patched_cm.data = {"services": {"databases": {"old": {"type": "duckdb"}}}}
+
+    result = await update_databases_endpoint(UpdateDatabasesRequest(databases={}), svc=MagicMock(), ctx=_ctx())
+
+    assert result.data["updated"] is True
+    assert patched_cm.data["services"]["databases"] == {}
+
+
+@pytest.mark.asyncio
+async def test_update_databases_rejects_invalid_name(patched_cm, patched_cache):
+    body = UpdateDatabasesRequest(databases={"bad name!": {"type": "duckdb"}})
+    with pytest.raises(DatusException):
+        await update_databases_endpoint(body, svc=MagicMock(), ctx=_ctx())
+    assert patched_cm.save_count == 0
+    patched_cache.evict.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_databases_initializes_services_when_missing(patched_cm, patched_cache):
+    patched_cm.data = {}
+
+    await update_databases_endpoint(
+        UpdateDatabasesRequest(databases={"db_a": {"type": "duckdb"}}),
+        svc=MagicMock(),
+        ctx=_ctx(),
+    )
+
+    assert patched_cm.data["services"]["databases"] == {"db_a": {"type": "duckdb"}}
+
+
+@pytest.mark.asyncio
+async def test_update_models_replaces_models_and_target(patched_cm, patched_cache):
+    patched_cm.data = {"models": {"old": {"type": "openai"}}, "target": "old"}
+    body = UpdateModelsRequest(
+        models={"new": {"type": "deepseek", "model": "deepseek-chat"}},
+        target="new",
+    )
+
+    result = await update_models_endpoint(body, svc=MagicMock(), ctx=_ctx("proj_b"))
+
+    assert result.data["updated"] is True
+    assert patched_cm.data["models"] == {"new": {"type": "deepseek", "model": "deepseek-chat"}}
+    assert patched_cm.data["target"] == "new"
+    assert patched_cm.save_count == 1
+    patched_cache.evict.assert_awaited_once_with("proj_b")
+
+
+@pytest.mark.asyncio
+async def test_update_models_target_only(patched_cm, patched_cache):
+    patched_cm.data = {"models": {"m1": {"type": "openai"}, "m2": {"type": "claude"}}, "target": "m1"}
+
+    await update_models_endpoint(UpdateModelsRequest(target="m2"), svc=MagicMock(), ctx=_ctx())
+
+    assert patched_cm.data["target"] == "m2"
+    assert patched_cm.data["models"] == {"m1": {"type": "openai"}, "m2": {"type": "claude"}}
+
+
+@pytest.mark.asyncio
+async def test_update_models_models_only(patched_cm, patched_cache):
+    patched_cm.data = {"models": {"old": {}}, "target": "old"}
+
+    await update_models_endpoint(
+        UpdateModelsRequest(models={"old": {"type": "openai"}}),
+        svc=MagicMock(),
+        ctx=_ctx(),
+    )
+
+    assert patched_cm.data["models"] == {"old": {"type": "openai"}}
+    assert patched_cm.data["target"] == "old"
+
+
+@pytest.mark.asyncio
+async def test_update_models_requires_at_least_one_field(patched_cm, patched_cache):
+    with pytest.raises(DatusException):
+        await update_models_endpoint(UpdateModelsRequest(), svc=MagicMock(), ctx=_ctx())
+    assert patched_cm.save_count == 0
+
+
+@pytest.mark.asyncio
+async def test_update_models_rejects_target_not_in_models(patched_cm, patched_cache):
+    patched_cm.data = {"models": {"m1": {}}, "target": "m1"}
+
+    with pytest.raises(DatusException):
+        await update_models_endpoint(UpdateModelsRequest(target="ghost"), svc=MagicMock(), ctx=_ctx())
+    assert patched_cm.save_count == 0
+
+
+@pytest.mark.asyncio
+async def test_update_models_target_validated_against_new_models(patched_cm, patched_cache):
+    """When both models and target are provided, target must exist in the NEW models."""
+    patched_cm.data = {"models": {"keep_me": {}}, "target": "keep_me"}
+
+    with pytest.raises(DatusException):
+        await update_models_endpoint(
+            UpdateModelsRequest(models={"only_new": {"type": "openai"}}, target="keep_me"),
+            svc=MagicMock(),
+            ctx=_ctx(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_models_rejects_invalid_model_name(patched_cm, patched_cache):
+    with pytest.raises(DatusException):
+        await update_models_endpoint(
+            UpdateModelsRequest(models={"bad name!": {"type": "openai"}}),
+            svc=MagicMock(),
+            ctx=_ctx(),
+        )
+    assert patched_cm.save_count == 0
+
+
+@pytest.mark.asyncio
+async def test_update_databases_survives_missing_service_cache(monkeypatch, patched_cm):
+    """No crash when the service cache hasn't been initialized yet."""
+    monkeypatch.setattr(config_routes.deps, "_service_cache", None)
+
+    result = await update_databases_endpoint(
+        UpdateDatabasesRequest(databases={"db_a": {"type": "duckdb"}}),
+        svc=MagicMock(),
+        ctx=_ctx(),
+    )
+
+    assert result.data["updated"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_databases_uses_default_project_when_missing(patched_cm, patched_cache):
+    await update_databases_endpoint(
+        UpdateDatabasesRequest(databases={"db_a": {"type": "duckdb"}}),
+        svc=MagicMock(),
+        ctx=_ctx(project_id=None),
+    )
+
+    patched_cache.evict.assert_awaited_once_with("default")

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -1,0 +1,95 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for datus/api/routes/config_routes.py."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.api.routes.config_routes import (
+    get_agent_config_endpoint,
+    get_database_types,
+    get_llm_providers,
+)
+
+
+def _mock_svc(namespaces, *, target="deepseek", current_namespace="starrocks", models=None, home="~/.datus"):
+    svc = MagicMock()
+    svc.agent_config.target = target
+    svc.agent_config.models = models if models is not None else {}
+    svc.agent_config.current_namespace = current_namespace
+    svc.agent_config.namespaces = namespaces
+    svc.agent_config.home = home
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_get_agent_config_flattens_matching_inner_key():
+    """When inner key matches the namespace name, that entry is returned flat."""
+    starrocks_cfg = {"logic_name": "starrocks", "type": "starrocks", "host": "h1"}
+    starrocks22_cfg = {"logic_name": "starrocks22", "type": "starrocks", "host": "h2"}
+    svc = _mock_svc(
+        namespaces={
+            "starrocks": {"starrocks": starrocks_cfg},
+            "starrocks22": {"starrocks22": starrocks22_cfg},
+        },
+    )
+
+    result = await get_agent_config_endpoint(svc)
+
+    assert result.success is True
+    assert result.data["namespaces"] == {
+        "starrocks": starrocks_cfg,
+        "starrocks22": starrocks22_cfg,
+    }
+    assert result.data["target"] == "deepseek"
+    assert result.data["current_namespace"] == "starrocks"
+    assert result.data["home"] == "~/.datus"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_config_falls_back_to_first_inner_value():
+    """When inner key does not match namespace name, first inner value is used."""
+    inner_cfg = {"logic_name": "db_a", "type": "duckdb"}
+    svc = _mock_svc(namespaces={"my_ns": {"db_a": inner_cfg}})
+
+    result = await get_agent_config_endpoint(svc)
+
+    assert result.data["namespaces"] == {"my_ns": inner_cfg}
+
+
+@pytest.mark.asyncio
+async def test_get_agent_config_skips_empty_inner_dict():
+    """Namespaces with empty inner dicts are dropped from the response."""
+    real_cfg = {"logic_name": "real", "type": "duckdb"}
+    svc = _mock_svc(namespaces={"empty": {}, "real": {"real": real_cfg}})
+
+    result = await get_agent_config_endpoint(svc)
+
+    assert result.data["namespaces"] == {"real": real_cfg}
+
+
+@pytest.mark.asyncio
+async def test_get_agent_config_handles_empty_namespaces():
+    svc = _mock_svc(namespaces={})
+
+    result = await get_agent_config_endpoint(svc)
+
+    assert result.data["namespaces"] == {}
+
+
+@pytest.mark.asyncio
+async def test_get_llm_providers_returns_known_templates():
+    result = await get_llm_providers()
+    assert result.success is True
+    assert "openai" in result.data.providers
+    assert result.data.default == "openai"
+
+
+@pytest.mark.asyncio
+async def test_get_database_types_returns_known_templates():
+    result = await get_database_types()
+    assert result.success is True
+    types = {item.type for item in result.data.database_types}
+    assert {"postgresql", "mysql", "starrocks", "duckdb", "snowflake"} <= types

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -10,11 +10,15 @@ import pytest
 
 from datus.api.routes import config_routes
 from datus.api.routes.config_routes import (
+    ProbeDatabaseRequest,
+    ProbeModelRequest,
     UpdateDatabasesRequest,
     UpdateModelsRequest,
     get_agent_config_endpoint,
     get_database_types,
     get_llm_providers,
+    probe_database_connectivity_endpoint,
+    probe_model_connectivity_endpoint,
     update_databases_endpoint,
     update_models_endpoint,
 )
@@ -293,3 +297,89 @@ async def test_update_databases_uses_default_project_when_missing(patched_cm, pa
     )
 
     patched_cache.evict.assert_awaited_once_with("default")
+
+
+@pytest.mark.asyncio
+async def test_test_model_connectivity_ok(monkeypatch):
+    """Successful LLM probe returns ok=True and forwards the payload unchanged."""
+    captured = {}
+
+    def fake_probe(payload):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(config_routes, "_probe_llm_sync", fake_probe)
+
+    body = ProbeModelRequest(type="openai", model="gpt-4o", api_key="sk-xxx", base_url="https://api.openai.com/v1")
+    result = await probe_model_connectivity_endpoint(body, svc=MagicMock())
+
+    assert result.success is True
+    assert result.data == {"ok": True}
+    assert captured["payload"]["type"] == "openai"
+    assert captured["payload"]["api_key"] == "sk-xxx"
+
+
+@pytest.mark.asyncio
+async def test_test_model_connectivity_reports_error_message(monkeypatch):
+    """Probe exception is surfaced as ok=False with message; HTTP stays 200."""
+
+    def fake_probe(payload):
+        raise RuntimeError("401 unauthorized")
+
+    monkeypatch.setattr(config_routes, "_probe_llm_sync", fake_probe)
+
+    body = ProbeModelRequest(type="openai", model="gpt-4o", api_key="bad")
+    result = await probe_model_connectivity_endpoint(body, svc=MagicMock())
+
+    assert result.success is True
+    assert result.data["ok"] is False
+    assert "401" in result.data["message"]
+
+
+@pytest.mark.asyncio
+async def test_test_model_connectivity_passes_extra_fields(monkeypatch):
+    """Unknown fields on the request body are forwarded to the probe (extra=allow)."""
+    captured = {}
+
+    def fake_probe(payload):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(config_routes, "_probe_llm_sync", fake_probe)
+
+    body = ProbeModelRequest.model_validate({"type": "openai", "model": "gpt-4o", "api_key": "k", "vendor": "openai"})
+    await probe_model_connectivity_endpoint(body, svc=MagicMock())
+
+    assert captured["payload"].get("vendor") == "openai"
+
+
+@pytest.mark.asyncio
+async def test_test_database_connectivity_ok(monkeypatch):
+    """Successful DB probe returns ok=True and forwards the payload unchanged."""
+    captured = {}
+
+    def fake_probe(payload):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(config_routes, "_probe_database_sync", fake_probe)
+
+    body = ProbeDatabaseRequest.model_validate({"type": "duckdb", "uri": "/tmp/test.duckdb"})
+    result = await probe_database_connectivity_endpoint(body, svc=MagicMock())
+
+    assert result.data == {"ok": True}
+    assert captured["payload"]["type"] == "duckdb"
+    assert captured["payload"]["uri"] == "/tmp/test.duckdb"
+
+
+@pytest.mark.asyncio
+async def test_test_database_connectivity_reports_error_message(monkeypatch):
+    """Probe exception is surfaced as ok=False with message; HTTP stays 200."""
+
+    def fake_probe(payload):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(config_routes, "_probe_database_sync", fake_probe)
+
+    body = ProbeDatabaseRequest.model_validate({"type": "starrocks", "host": "unreachable", "port": "9999"})
+    result = await probe_database_connectivity_endpoint(body, svc=MagicMock())
+
+    assert result.data["ok"] is False
+    assert "connection refused" in result.data["message"]


### PR DESCRIPTION
## Why

The `/api/v1/config/agent` endpoint previously returned `namespaces` as a two-level nested map (`{namespace_name: {logic_name: db_config}}`), producing awkward duplicated keys for callers (e.g. `\"starrocks\": {\"starrocks\": {...}}`). The frontend also had no dedicated API to persist config edits, and the legacy \"namespace\" vocabulary had drifted away from the product surface, which now consistently talks about \"databases\".

## Solution

**Flatten the GET response** to `{database_name: db_config}` in `datus/api/routes/config_routes.py`:
- Pick the inner entry whose key matches the outer name; fall back to the first inner value when there is no match.
- Drop entries whose inner dict is empty.
- Restore the full `models` dict (it was previously projected to its keys).

**Add two write endpoints** (directly in `config_routes.py`, not wrapped in a service, because they are unstable and may be removed):
- `PUT /api/v1/config/databases` — full-replace `services.databases` with the provided dict.
- `PUT /api/v1/config/models` — optional full-replace `models`; optional update to `target`; at least one field required.

Both endpoints validate names with `_SAFE_NAME_RE`, persist via `ConfigurationManager.save()`, and evict the cached `DatusService` for the current project so the next request reloads fresh config from disk.

**Rename \"namespaces\" → \"databases\"** throughout the API surface:
- GET response: `namespaces` → `databases`, `current_namespace` → `current_database`.
- Request models: `UpdateNamespacesRequest` → `UpdateDatabasesRequest`; field `namespaces` → `databases`.
- Response field `configuration_updated` → `updated`.

## Test Cases

`tests/unit_tests/api/routes/test_config_routes.py` — 19 tests covering:

**GET /config/agent** (flatten behavior):
- Matching inner-key flattening, inner-key fallback, empty inner dicts dropped, empty namespaces.

**PUT /config/databases**:
- Full-replace preserves sibling keys under `services`, empty dict clears the block, invalid name rejected, `services` auto-initialized when missing, missing service cache handled gracefully, `project_id=None` falls back to `\"default\"`.

**PUT /config/models**:
- Full-replace models + update target, target-only update, models-only update, requires at least one field, target must exist in resulting models (checked against NEW models when both provided), invalid model name rejected.

**Baseline coverage** for `/config/llm/providers` and `/config/database/types` is also included.

Diff coverage: 100%. Overall unit-test coverage: 82.95% (gate: 80%).

Companion frontend migration: Datus-saas PR (separate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints to update databases and models and to probe model/database connectivity via the config API.

* **Improvements**
  * Config responses now return full model objects, replace namespace fields with a flattened databases mapping, and include a current_database field.

* **Tests**
  * Added tests covering config shaping, validations, update error paths, connectivity probes, and cache-eviction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->