### PR TITLE
[Feature] Add datus-claw configure subcommand for channel CRUD

### DIFF
--- a/datus/claw/configure.py
+++ b/datus/claw/configure.py
@@ -1,0 +1,300 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Interactive configuration wizard for Datus Claw IM channels.
+
+Provides CRUD for the ``channels:`` section of ``agent.yml`` and an
+optional ``pip install`` helper for adapter-specific SDK dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from getpass import getpass
+from typing import Any, Dict, List, Optional, Tuple
+
+from rich.console import Console
+from rich.prompt import Confirm, Prompt
+
+from datus.claw.channel.registry import list_adapters, register_builtins
+from datus.claw.models import ChannelConfig, Verbose
+from datus.cli._cli_utils import select_choice
+from datus.configuration.agent_config_loader import configuration_manager
+from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+console = Console()
+
+
+ADAPTER_DEPS: Dict[str, List[str]] = {
+    "feishu": ["lark-oapi"],
+    "slack": ["slack-sdk[socket_mode]"],
+}
+
+# (field_name, prompt_text, is_secret, required)
+ADAPTER_FIELDS: Dict[str, List[Tuple[str, str, bool, bool]]] = {
+    "feishu": [
+        ("app_id", "Feishu App ID (cli_...)", False, True),
+        ("app_secret", "Feishu App Secret", True, True),
+    ],
+    "slack": [
+        ("app_token", "Slack App Token (xapp-...)", True, True),
+        ("bot_token", "Slack Bot Token (xoxb-...)", True, True),
+    ],
+}
+
+_ACTIONS = ("list", "add", "delete", "install-deps")
+_SECRET_KEY_PATTERN = re.compile(r"(secret|token|password)", re.IGNORECASE)
+_ENV_PLACEHOLDER_PATTERN = re.compile(r"^\$\{[^}]+\}$")
+_NAME_INVALID_CHARS = set(' \t\n/\\:*?"<>|')
+
+
+def _validate_channel_name(name: str, existing: Dict[str, Any]) -> Tuple[bool, str]:
+    name = (name or "").strip()
+    if not name:
+        return False, "Channel name cannot be empty."
+    if any(ch in _NAME_INVALID_CHARS for ch in name):
+        return False, 'Channel name cannot contain whitespace or any of / \\ : * ? " < > |'
+    if name in existing:
+        return False, f"Channel '{name}' already exists."
+    return True, ""
+
+
+def _redact(key: str, value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    if _ENV_PLACEHOLDER_PATTERN.match(value):
+        return value
+    if not _SECRET_KEY_PATTERN.search(key):
+        return value
+    tail = value[-4:] if len(value) > 4 else ""
+    return f"***{tail}" if tail else "***"
+
+
+class ChannelConfigurator:
+    """Interactive CRUD for the ``channels:`` section of ``agent.yml``."""
+
+    def __init__(self, config_path: str = ""):
+        self.config_path = config_path
+        register_builtins()
+        try:
+            self.cm = configuration_manager(config_path, reload=True)
+        except DatusException as e:
+            if e.code == ErrorCode.COMMON_FILE_NOT_FOUND:
+                console.print("[red]Configuration file not found.[/red]")
+                console.print("Run 'datus-agent init' first, or pass --config <path>.")
+            else:
+                console.print(f"[red]{e.message}[/red]")
+            self.cm = None
+        except Exception as e:
+            console.print(f"[red]Failed to load configuration: {e}[/red]")
+            self.cm = None
+
+    def run(self, action: Optional[str]) -> int:
+        if self.cm is None:
+            return 1
+
+        if not action:
+            action = self._prompt_action()
+            if not action:
+                return 0
+
+        if action == "list":
+            return self.list()
+        if action == "add":
+            return self.add()
+        if action == "delete":
+            return self.delete()
+        if action == "install-deps":
+            return self.install_deps_interactive()
+
+        console.print(f"[red]Unknown action: {action}[/red]")
+        return 1
+
+    def _prompt_action(self) -> Optional[str]:
+        choice = select_choice(
+            console,
+            {
+                "list": "List configured channels",
+                "add": "Add a new channel",
+                "delete": "Delete a channel",
+                "install-deps": "Install adapter pip dependencies",
+            },
+            default="list",
+        )
+        return choice if choice in _ACTIONS else None
+
+    def _channels(self) -> Dict[str, Any]:
+        channels = self.cm.get("channels", {}) or {}
+        if not isinstance(channels, dict):
+            return {}
+        return channels
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    def list(self) -> int:
+        channels = self._channels()
+        if not channels:
+            console.print("[yellow]No channels configured.[/yellow]")
+            console.print(f"Config file: {self.cm.config_path}")
+            return 0
+
+        console.print(f"[bold]Channels in {self.cm.config_path}:[/bold]")
+        for name, cfg in channels.items():
+            adapter = cfg.get("adapter", "?") if isinstance(cfg, dict) else "?"
+            enabled = cfg.get("enabled", True) if isinstance(cfg, dict) else True
+            verbose = cfg.get("verbose", Verbose.ON.value) if isinstance(cfg, dict) else "?"
+            status = "[green]enabled[/green]" if enabled else "[dim]disabled[/dim]"
+            console.print(f"\n  [cyan]{name}[/cyan]  ({adapter}, {status}, verbose={verbose})")
+            extra = cfg.get("extra", {}) if isinstance(cfg, dict) else {}
+            if isinstance(extra, dict) and extra:
+                for k, v in extra.items():
+                    console.print(f"    {k}: {_redact(k, v)}")
+        return 0
+
+    def add(self) -> int:
+        channels = self._channels()
+
+        adapters = list_adapters()
+        if not adapters:
+            console.print("[red]No channel adapters are registered.[/red]")
+            return 1
+
+        while True:
+            name = Prompt.ask("Channel name (unique key under 'channels:')").strip()
+            ok, err = _validate_channel_name(name, channels)
+            if ok:
+                break
+            console.print(f"[red]{err}[/red]")
+
+        adapter = select_choice(
+            console,
+            {a: a for a in adapters},
+            default=adapters[0],
+        )
+        if adapter not in adapters:
+            console.print("[red]No adapter selected.[/red]")
+            return 1
+
+        extra: Dict[str, Any] = {}
+        for field, label, is_secret, required in ADAPTER_FIELDS.get(adapter, []):
+            while True:
+                if is_secret:
+                    value = getpass(f"{label}: ").strip()
+                else:
+                    value = Prompt.ask(label).strip()
+                if value or not required:
+                    break
+                console.print(f"[red]{field} is required.[/red]")
+            if value:
+                extra[field] = value
+
+        enabled = Confirm.ask("Enable this channel now?", default=True)
+
+        verbose_value = Verbose.ON.value
+        if Confirm.ask("Override default verbose (brief)?", default=False):
+            verbose_value = select_choice(
+                console,
+                {v.value: f"{v.value} ({v.name.lower()})" for v in Verbose},
+                default=Verbose.ON.value,
+            )
+
+        try:
+            cfg_model = ChannelConfig(
+                adapter=adapter,
+                enabled=enabled,
+                verbose=Verbose(verbose_value),
+                extra=extra,
+            )
+        except Exception as e:
+            console.print(f"[red]Invalid channel configuration: {e}[/red]")
+            return 1
+
+        cfg_dict = cfg_model.model_dump(mode="json", exclude_none=True)
+
+        if not self.cm.update_item("channels", {name: cfg_dict}, delete_old_key=False):
+            console.print("[red]Failed to write channel to agent.yml.[/red]")
+            return 1
+
+        console.print(f"[green]Channel '{name}' saved to {self.cm.config_path}[/green]")
+
+        deps = ADAPTER_DEPS.get(adapter, [])
+        if deps:
+            if Confirm.ask(f"Install required pip packages {deps}?", default=True):
+                return self._pip_install(deps)
+            console.print("[dim]Run the command below when ready:[/dim]")
+            console.print(f"  {sys.executable} -m pip install {' '.join(deps)}")
+        return 0
+
+    def delete(self) -> int:
+        channels = self._channels()
+        if not channels:
+            console.print("[yellow]No channels configured — nothing to delete.[/yellow]")
+            return 0
+
+        display = {
+            name: f"{name} ({cfg.get('adapter', '?')})" if isinstance(cfg, dict) else name
+            for name, cfg in channels.items()
+        }
+        name = select_choice(console, display, default=next(iter(display)))
+        if name not in channels:
+            console.print("[yellow]No channel selected.[/yellow]")
+            return 0
+
+        if not Confirm.ask(f"Delete channel '{name}'?", default=False):
+            console.print("[dim]Cancelled.[/dim]")
+            return 0
+
+        try:
+            self.cm.remove_item_recursively("channels", name)
+        except DatusException as e:
+            console.print(f"[red]{e.message}[/red]")
+            return 1
+        console.print(f"[green]Channel '{name}' removed from {self.cm.config_path}[/green]")
+        return 0
+
+    def install_deps_interactive(self) -> int:
+        channels = self._channels()
+        adapters_in_use = sorted(
+            {
+                cfg.get("adapter")
+                for cfg in channels.values()
+                if isinstance(cfg, dict) and cfg.get("adapter") in ADAPTER_DEPS
+            }
+        )
+        if not adapters_in_use:
+            console.print("[yellow]No channels with known pip deps are configured.[/yellow]")
+            return 0
+
+        adapter = select_choice(
+            console,
+            {a: f"{a} -> {ADAPTER_DEPS[a]}" for a in adapters_in_use},
+            default=adapters_in_use[0],
+        )
+        deps = ADAPTER_DEPS.get(adapter, [])
+        if not deps:
+            console.print("[yellow]No pip deps registered for this adapter.[/yellow]")
+            return 0
+        return self._pip_install(deps)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _pip_install(self, packages: List[str]) -> int:
+        cmd = [sys.executable, "-m", "pip", "install", *packages]
+        console.print(f"[dim]$ {' '.join(cmd)}[/dim]")
+        try:
+            completed = subprocess.run(cmd, check=False)
+        except OSError as e:
+            console.print(f"[red]Failed to invoke pip: {e}[/red]")
+            return 1
+        if completed.returncode != 0:
+            console.print(f"[red]pip install exited with code {completed.returncode}[/red]")
+            return completed.returncode
+        console.print("[green]Dependencies installed.[/green]")
+        return 0

--- a/datus/claw/configure.py
+++ b/datus/claw/configure.py
@@ -2,15 +2,18 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Interactive configuration wizard for Datus Claw IM channels.
+"""Interactive configuration hub for Datus Claw IM channels.
 
-Provides CRUD for the ``channels:`` section of ``agent.yml`` and an
-optional ``pip install`` helper for adapter-specific SDK dependencies.
+Single-window TUI: an "Add" entry at the top, followed by a live list of
+configured channels. Selecting a channel opens a per-channel submenu
+(toggle enabled, change verbose, reinstall deps, delete). Any save
+operation is reflected in ``agent.yml`` immediately.
 """
 
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 import sys
 from getpass import getpass
@@ -47,10 +50,11 @@ ADAPTER_FIELDS: Dict[str, List[Tuple[str, str, bool, bool]]] = {
     ],
 }
 
-_ACTIONS = ("list", "add", "delete", "install-deps")
 _SECRET_KEY_PATTERN = re.compile(r"(secret|token|password)", re.IGNORECASE)
 _ENV_PLACEHOLDER_PATTERN = re.compile(r"^\$\{[^}]+\}$")
 _NAME_INVALID_CHARS = set(' \t\n/\\:*?"<>|')
+
+_MENU_SEPARATOR = "─" * 40
 
 
 def _validate_channel_name(name: str, existing: Dict[str, Any]) -> Tuple[bool, str]:
@@ -75,8 +79,157 @@ def _redact(key: str, value: Any) -> Any:
     return f"***{tail}" if tail else "***"
 
 
+def _select_menu(
+    rows: List[Tuple[str, str, bool]],
+    default_key: Optional[str] = None,
+    footer: str = "  [↑↓] navigate  [Enter] select  [q/Esc] back",
+) -> Optional[str]:
+    """Arrow-key menu supporting mixed selectable/static rows.
+
+    Args:
+        rows: Ordered list of ``(key, display, selectable)`` tuples. Rows with
+              ``selectable=False`` are shown but skipped during navigation.
+        default_key: Key of the row that should be pre-selected. Falls back to
+                     the first selectable row when missing.
+        footer: Hint line rendered below the list.
+
+    Returns:
+        The selected row's key, or ``None`` if the user cancels (Esc / ``q`` /
+        Ctrl+C) or if there are no selectable rows.
+    """
+    if not rows:
+        return None
+
+    total = len(rows)
+    selectable_indices = [i for i, r in enumerate(rows) if r[2]]
+    if not selectable_indices:
+        return None
+
+    try:
+        from prompt_toolkit import Application
+        from prompt_toolkit.key_binding import KeyBindings
+        from prompt_toolkit.layout import Layout
+        from prompt_toolkit.layout.containers import Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+
+        initial = selectable_indices[0]
+        if default_key is not None:
+            for i, (key, _, selectable) in enumerate(rows):
+                if selectable and key == default_key:
+                    initial = i
+                    break
+        selected = [initial]
+
+        term_height = shutil.get_terminal_size((120, 40)).lines
+        max_visible = max(3, term_height - 4)
+        offset = [0]
+        if selected[0] >= max_visible:
+            offset[0] = min(max(0, selected[0] - max_visible // 2), max(0, total - max_visible))
+
+        def _ensure_visible() -> None:
+            if selected[0] < offset[0]:
+                offset[0] = selected[0]
+            elif selected[0] >= offset[0] + max_visible:
+                offset[0] = selected[0] - max_visible + 1
+
+        def _next_selectable(current: int, direction: int) -> int:
+            i = current
+            for _ in range(total):
+                i = (i + direction) % total
+                if rows[i][2]:
+                    return i
+            return current
+
+        def _nearest_selectable(target: int) -> int:
+            if rows[target][2]:
+                return target
+            for delta in range(1, total):
+                fwd = target + delta
+                bwd = target - delta
+                if 0 <= fwd < total and rows[fwd][2]:
+                    return fwd
+                if 0 <= bwd < total and rows[bwd][2]:
+                    return bwd
+            return selected[0]
+
+        kb = KeyBindings()
+
+        @kb.add("up")
+        def _move_up(event):
+            selected[0] = _next_selectable(selected[0], -1)
+            _ensure_visible()
+
+        @kb.add("down")
+        def _move_down(event):
+            selected[0] = _next_selectable(selected[0], 1)
+            _ensure_visible()
+
+        @kb.add("pageup")
+        def _page_up(event):
+            target = max(0, selected[0] - max_visible)
+            selected[0] = _nearest_selectable(target)
+            _ensure_visible()
+
+        @kb.add("pagedown")
+        def _page_down(event):
+            target = min(total - 1, selected[0] + max_visible)
+            selected[0] = _nearest_selectable(target)
+            _ensure_visible()
+
+        @kb.add("enter")
+        def _confirm(event):
+            event.app.exit(result=rows[selected[0]][0])
+
+        @kb.add("c-c")
+        def _cancel_ctrlc(event):
+            event.app.exit(result=None)
+
+        @kb.add("escape")
+        def _cancel_escape(event):
+            event.app.exit(result=None)
+
+        @kb.add("q")
+        def _cancel_q(event):
+            event.app.exit(result=None)
+
+        def _get_formatted_text():
+            lines = []
+            visible_end = min(offset[0] + max_visible, total)
+            if total > max_visible:
+                lines.append(("ansiyellow", f"  ({offset[0] + 1}-{visible_end} of {total})\n"))
+            for i in range(offset[0], visible_end):
+                _, display, selectable = rows[i]
+                is_sel = i == selected[0]
+                if is_sel:
+                    lines.append(("ansicyan bold", f"  →  {display}\n"))
+                elif not selectable:
+                    lines.append(("ansibrightblack", f"     {display}\n"))
+                else:
+                    lines.append(("", f"     {display}\n"))
+            if footer:
+                lines.append(("ansibrightblack", f"\n{footer}\n"))
+            return lines
+
+        app = Application(
+            layout=Layout(
+                Window(FormattedTextControl(_get_formatted_text, show_cursor=False), always_hide_cursor=True)
+            ),
+            key_bindings=kb,
+            full_screen=False,
+        )
+        return app.run()
+
+    except (KeyboardInterrupt, EOFError):
+        console.print("\n[yellow]Input cancelled[/]")
+        return None
+    except Exception as e:
+        logger.error(f"Interactive menu error: {e}")
+        console.print(f"[bold red]Menu error:[/] {str(e)}")
+        return None
+
+
 class ChannelConfigurator:
-    """Interactive CRUD for the ``channels:`` section of ``agent.yml``."""
+    """Interactive hub for the ``channels:`` section of ``agent.yml``."""
 
     def __init__(self, config_path: str = ""):
         self.config_path = config_path
@@ -94,39 +247,18 @@ class ChannelConfigurator:
             console.print(f"[red]Failed to load configuration: {e}[/red]")
             self.cm = None
 
-    def run(self, action: Optional[str]) -> int:
+    def run(self) -> int:
         if self.cm is None:
             return 1
 
-        if not action:
-            action = self._prompt_action()
-            if not action:
+        while True:
+            action, payload = self._render_hub()
+            if action == "quit":
                 return 0
-
-        if action == "list":
-            return self.list()
-        if action == "add":
-            return self.add()
-        if action == "delete":
-            return self.delete()
-        if action == "install-deps":
-            return self.install_deps_interactive()
-
-        console.print(f"[red]Unknown action: {action}[/red]")
-        return 1
-
-    def _prompt_action(self) -> Optional[str]:
-        choice = select_choice(
-            console,
-            {
-                "list": "List configured channels",
-                "add": "Add a new channel",
-                "delete": "Delete a channel",
-                "install-deps": "Install adapter pip dependencies",
-            },
-            default="list",
-        )
-        return choice if choice in _ACTIONS else None
+            if action == "add":
+                self.add()
+            elif action == "channel" and payload is not None:
+                self._channel_submenu(payload)
 
     def _channels(self) -> Dict[str, Any]:
         channels = self.cm.get("channels", {}) or {}
@@ -135,28 +267,86 @@ class ChannelConfigurator:
         return channels
 
     # ------------------------------------------------------------------
-    # Actions
+    # Hub & submenus
     # ------------------------------------------------------------------
-    def list(self) -> int:
+    def _render_hub(self) -> Tuple[str, Optional[str]]:
         channels = self._channels()
+        rows: List[Tuple[str, str, bool]] = [
+            ("__header__", f"Datus Claw channels — {self.cm.config_path}", False),
+            ("__add__", "+ Add a new channel", True),
+            ("__sep__", _MENU_SEPARATOR, False),
+        ]
         if not channels:
-            console.print("[yellow]No channels configured.[/yellow]")
-            console.print(f"Config file: {self.cm.config_path}")
-            return 0
+            rows.append(("__empty__", "(no channels configured)", False))
+        else:
+            name_width = max(len(n) for n in channels)
+            for name, cfg in channels.items():
+                if isinstance(cfg, dict):
+                    adapter = cfg.get("adapter", "?")
+                    enabled = cfg.get("enabled", True)
+                else:
+                    adapter = "?"
+                    enabled = True
+                status = "enabled" if enabled else "disabled"
+                display = f"{name:<{name_width}}  ({adapter}, {status})"
+                rows.append((f"channel:{name}", display, True))
 
-        console.print(f"[bold]Channels in {self.cm.config_path}:[/bold]")
-        for name, cfg in channels.items():
-            adapter = cfg.get("adapter", "?") if isinstance(cfg, dict) else "?"
-            enabled = cfg.get("enabled", True) if isinstance(cfg, dict) else True
-            verbose = cfg.get("verbose", Verbose.ON.value) if isinstance(cfg, dict) else "?"
-            status = "[green]enabled[/green]" if enabled else "[dim]disabled[/dim]"
-            console.print(f"\n  [cyan]{name}[/cyan]  ({adapter}, {status}, verbose={verbose})")
-            extra = cfg.get("extra", {}) if isinstance(cfg, dict) else {}
-            if isinstance(extra, dict) and extra:
-                for k, v in extra.items():
-                    console.print(f"    {k}: {_redact(k, v)}")
-        return 0
+        key = _select_menu(rows, default_key="__add__")
+        if key is None:
+            return ("quit", None)
+        if key == "__add__":
+            return ("add", None)
+        if key.startswith("channel:"):
+            return ("channel", key[len("channel:") :])
+        return ("quit", None)
 
+    def _channel_submenu(self, name: str) -> None:
+        channels = self._channels()
+        cfg = channels.get(name)
+        if not isinstance(cfg, dict):
+            console.print(f"[yellow]Channel '{name}' not found.[/yellow]")
+            return
+
+        adapter = cfg.get("adapter", "?")
+        enabled = cfg.get("enabled", True)
+        verbose = cfg.get("verbose", Verbose.ON.value)
+        extra = cfg.get("extra", {})
+
+        rows: List[Tuple[str, str, bool]] = [
+            ("__header__", f"Channel: {name}", False),
+            ("__info_adapter__", f"  adapter: {adapter}", False),
+            ("__info_enabled__", f"  enabled: {enabled}", False),
+            ("__info_verbose__", f"  verbose: {verbose}", False),
+        ]
+        if isinstance(extra, dict):
+            for k, v in extra.items():
+                rows.append((f"__info_extra_{k}__", f"  {k}: {_redact(k, v)}", False))
+        rows.append(("__sep__", _MENU_SEPARATOR, False))
+
+        toggle_label = "Disable channel" if enabled else "Enable channel"
+        rows.append(("toggle_enabled", toggle_label, True))
+        rows.append(("change_verbose", f"Change verbose (current: {verbose})", True))
+        if adapter in ADAPTER_DEPS:
+            deps = ADAPTER_DEPS[adapter]
+            rows.append(("reinstall_deps", f"Reinstall pip deps ({' '.join(deps)})", True))
+        rows.append(("delete", "Delete this channel", True))
+        rows.append(("back", "Back", True))
+
+        key = _select_menu(rows, default_key="back")
+        if key is None or key == "back":
+            return
+        if key == "toggle_enabled":
+            self._toggle_enabled(name)
+        elif key == "change_verbose":
+            self._change_verbose(name)
+        elif key == "reinstall_deps":
+            self._reinstall_deps(adapter)
+        elif key == "delete":
+            self.delete(name)
+
+    # ------------------------------------------------------------------
+    # Mutators
+    # ------------------------------------------------------------------
     def add(self) -> int:
         channels = self._channels()
 
@@ -231,19 +421,22 @@ class ChannelConfigurator:
             console.print(f"  {sys.executable} -m pip install {' '.join(deps)}")
         return 0
 
-    def delete(self) -> int:
+    def delete(self, name: Optional[str] = None) -> int:
         channels = self._channels()
         if not channels:
             console.print("[yellow]No channels configured — nothing to delete.[/yellow]")
             return 0
 
-        display = {
-            name: f"{name} ({cfg.get('adapter', '?')})" if isinstance(cfg, dict) else name
-            for name, cfg in channels.items()
-        }
-        name = select_choice(console, display, default=next(iter(display)))
-        if name not in channels:
-            console.print("[yellow]No channel selected.[/yellow]")
+        if name is None:
+            display = {
+                n: f"{n} ({cfg.get('adapter', '?')})" if isinstance(cfg, dict) else n for n, cfg in channels.items()
+            }
+            name = select_choice(console, display, default=next(iter(display)))
+            if name not in channels:
+                console.print("[yellow]No channel selected.[/yellow]")
+                return 0
+        elif name not in channels:
+            console.print(f"[yellow]Channel '{name}' not found.[/yellow]")
             return 0
 
         if not Confirm.ask(f"Delete channel '{name}'?", default=False):
@@ -258,27 +451,54 @@ class ChannelConfigurator:
         console.print(f"[green]Channel '{name}' removed from {self.cm.config_path}[/green]")
         return 0
 
-    def install_deps_interactive(self) -> int:
+    def _toggle_enabled(self, name: str) -> int:
         channels = self._channels()
-        adapters_in_use = sorted(
-            {
-                cfg.get("adapter")
-                for cfg in channels.values()
-                if isinstance(cfg, dict) and cfg.get("adapter") in ADAPTER_DEPS
-            }
-        )
-        if not adapters_in_use:
-            console.print("[yellow]No channels with known pip deps are configured.[/yellow]")
-            return 0
+        cfg = channels.get(name)
+        if not isinstance(cfg, dict):
+            console.print(f"[yellow]Channel '{name}' not found.[/yellow]")
+            return 1
+        new_cfg = dict(cfg)
+        new_cfg["enabled"] = not cfg.get("enabled", True)
+        if not self.cm.update_item("channels", {name: new_cfg}, delete_old_key=False):
+            console.print("[red]Failed to update channel.[/red]")
+            return 1
+        state = "enabled" if new_cfg["enabled"] else "disabled"
+        console.print(f"[green]Channel '{name}' {state}.[/green]")
+        return 0
 
-        adapter = select_choice(
+    def _change_verbose(self, name: str) -> int:
+        channels = self._channels()
+        cfg = channels.get(name)
+        if not isinstance(cfg, dict):
+            console.print(f"[yellow]Channel '{name}' not found.[/yellow]")
+            return 1
+        current = cfg.get("verbose", Verbose.ON.value)
+        choice = select_choice(
             console,
-            {a: f"{a} -> {ADAPTER_DEPS[a]}" for a in adapters_in_use},
-            default=adapters_in_use[0],
+            {v.value: f"{v.value} ({v.name.lower()})" for v in Verbose},
+            default=current if current in {v.value for v in Verbose} else Verbose.ON.value,
         )
+        if choice not in {v.value for v in Verbose}:
+            console.print("[yellow]No change.[/yellow]")
+            return 0
+        if choice == current:
+            console.print("[dim]Verbose unchanged.[/dim]")
+            return 0
+        new_cfg = dict(cfg)
+        new_cfg["verbose"] = choice
+        if not self.cm.update_item("channels", {name: new_cfg}, delete_old_key=False):
+            console.print("[red]Failed to update channel.[/red]")
+            return 1
+        console.print(f"[green]Channel '{name}' verbose -> {choice}.[/green]")
+        return 0
+
+    def _reinstall_deps(self, adapter: str) -> int:
         deps = ADAPTER_DEPS.get(adapter, [])
         if not deps:
-            console.print("[yellow]No pip deps registered for this adapter.[/yellow]")
+            console.print(f"[yellow]No pip deps registered for adapter '{adapter}'.[/yellow]")
+            return 0
+        if not Confirm.ask(f"Install required pip packages {deps}?", default=True):
+            console.print("[dim]Cancelled.[/dim]")
             return 0
         return self._pip_install(deps)
 

--- a/datus/claw/main.py
+++ b/datus/claw/main.py
@@ -235,6 +235,28 @@ def _build_parser() -> argparse.ArgumentParser:
         type=str,
         help=f"Daemon log file path (default: ~/.datus/logs/{_SERVICE_NAME}.log)",
     )
+
+    # Optional subcommands (backwards-compatible: no subcommand = daemon flow).
+    subparsers = parser.add_subparsers(dest="subcommand")
+    configure_parser = subparsers.add_parser(
+        "configure",
+        help="Manage Claw IM channels (list / add / delete / install-deps)",
+    )
+    configure_parser.add_argument(
+        "configure_action",
+        nargs="?",
+        choices=["list", "add", "delete", "install-deps"],
+        default=None,
+        help="Configuration action (omit to enter an interactive menu)",
+    )
+    configure_parser.add_argument(
+        "--config",
+        dest="configure_config",
+        type=str,
+        default=None,
+        help="Override agent configuration file for this command",
+    )
+
     return parser
 
 
@@ -251,6 +273,15 @@ def main() -> None:
 
     if args.debug:
         args.log_level = "DEBUG"
+
+    # Subcommand dispatch (does not touch daemon/pid paths).
+    if getattr(args, "subcommand", None) == "configure":
+        from datus.claw.configure import ChannelConfigurator
+
+        configure_logging(args.debug)
+        config_path = getattr(args, "configure_config", None) or args.config or ""
+        configurator = ChannelConfigurator(config_path)
+        raise SystemExit(configurator.run(getattr(args, "configure_action", None)))
 
     # Resolve defaults for pid/log
     default_pid, default_log = _default_paths(args.config or "")

--- a/datus/claw/main.py
+++ b/datus/claw/main.py
@@ -240,14 +240,7 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="subcommand")
     configure_parser = subparsers.add_parser(
         "configure",
-        help="Manage Claw IM channels (list / add / delete / install-deps)",
-    )
-    configure_parser.add_argument(
-        "configure_action",
-        nargs="?",
-        choices=["list", "add", "delete", "install-deps"],
-        default=None,
-        help="Configuration action (omit to enter an interactive menu)",
+        help="Manage Claw IM channels interactively",
     )
     configure_parser.add_argument(
         "--config",
@@ -280,8 +273,7 @@ def main() -> None:
 
         configure_logging(args.debug)
         config_path = getattr(args, "configure_config", None) or args.config or ""
-        configurator = ChannelConfigurator(config_path)
-        raise SystemExit(configurator.run(getattr(args, "configure_action", None)))
+        raise SystemExit(ChannelConfigurator(config_path).run())
 
     # Resolve defaults for pid/log
     default_pid, default_log = _default_paths(args.config or "")

--- a/tests/unit_tests/claw/test_configure.py
+++ b/tests/unit_tests/claw/test_configure.py
@@ -58,11 +58,8 @@ def test_redact_masks_secret_keys():
 
     assert _redact("app_secret", "SECRETVALUE1234") == "***1234"
     assert _redact("bot_token", "xoxb-1234-abcd") == "***abcd"
-    # env placeholders pass through
     assert _redact("app_secret", "${FEISHU_APP_SECRET}") == "${FEISHU_APP_SECRET}"
-    # non-secret keys pass through
     assert _redact("app_id", "cli_12345") == "cli_12345"
-    # short secrets mask entirely
     assert _redact("password", "abc") == "***"
 
 
@@ -85,32 +82,6 @@ def test_validate_channel_name_rules():
 
 
 # ---------------------------------------------------------------------------
-# list
-# ---------------------------------------------------------------------------
-def test_list_prints_redacted_secret(configurator, capsys):
-    rc = configurator.list()
-    out = capsys.readouterr().out
-    assert rc == 0
-    assert "existing-feishu" in out
-    assert "SECRETVALUEABCD" not in out
-    assert "***ABCD" in out
-    assert "cli_existing" in out  # non-secret is visible
-
-
-def test_list_empty(tmp_path, monkeypatch, capsys):
-    import datus.configuration.agent_config_loader as loader
-
-    loader.CONFIGURATION_MANAGER = None
-    path = tmp_path / "agent.yml"
-    path.write_text(yaml.safe_dump({"agent": {"models": []}}, sort_keys=False))
-    from datus.claw.configure import ChannelConfigurator
-
-    c = ChannelConfigurator(str(path))
-    assert c.list() == 0
-    assert "No channels configured" in capsys.readouterr().out
-
-
-# ---------------------------------------------------------------------------
 # add
 # ---------------------------------------------------------------------------
 def test_add_slack_channel_preserves_existing(configurator, agent_yml):
@@ -129,10 +100,8 @@ def test_add_slack_channel_preserves_existing(configurator, agent_yml):
     assert rc == 0
     data = _reload(agent_yml)
     channels = data["channels"]
-    # Existing channel untouched
     assert "existing-feishu" in channels
     assert channels["existing-feishu"]["extra"]["app_secret"] == "SECRETVALUEABCD"
-    # New channel added
     slack = channels["slack-prod"]
     assert slack["adapter"] == "slack"
     assert slack["enabled"] is True
@@ -141,8 +110,6 @@ def test_add_slack_channel_preserves_existing(configurator, agent_yml):
 
 
 def test_add_rejects_duplicate_then_accepts(configurator, agent_yml):
-    # First Prompt.ask returns a duplicate name, second returns a valid name,
-    # third returns the app_id. Confirms: enabled, override verbose?, install deps?
     prompts = iter(["existing-feishu", "feishu-alt", "cli_new"])
     confirms = iter([True, False, False])
     passwords = iter(["sekret"])
@@ -187,19 +154,15 @@ def test_add_triggers_pip_install_when_confirmed(configurator):
 # ---------------------------------------------------------------------------
 # delete
 # ---------------------------------------------------------------------------
-def test_delete_removes_selected_channel(configurator, agent_yml):
-    # Seed a second channel so deletion leaves one behind.
+def test_delete_removes_named_channel(configurator, agent_yml):
     configurator.cm.update_item(
         "channels",
         {"slack-old": {"adapter": "slack", "enabled": False, "extra": {"bot_token": "xoxb-old"}}},
         delete_old_key=False,
     )
 
-    with (
-        patch("datus.claw.configure.select_choice", return_value="slack-old"),
-        patch("datus.claw.configure.Confirm.ask", return_value=True),
-    ):
-        rc = configurator.delete()
+    with patch("datus.claw.configure.Confirm.ask", return_value=True):
+        rc = configurator.delete("slack-old")
 
     assert rc == 0
     data = _reload(agent_yml)
@@ -208,14 +171,18 @@ def test_delete_removes_selected_channel(configurator, agent_yml):
 
 
 def test_delete_aborts_when_user_declines(configurator, agent_yml):
-    with (
-        patch("datus.claw.configure.select_choice", return_value="existing-feishu"),
-        patch("datus.claw.configure.Confirm.ask", return_value=False),
-    ):
-        rc = configurator.delete()
+    with patch("datus.claw.configure.Confirm.ask", return_value=False):
+        rc = configurator.delete("existing-feishu")
     assert rc == 0
     data = _reload(agent_yml)
     assert "existing-feishu" in data["channels"]
+
+
+def test_delete_with_unknown_name_is_noop(configurator, agent_yml, capsys):
+    rc = configurator.delete("does-not-exist")
+    assert rc == 0
+    assert "not found" in capsys.readouterr().out
+    assert "existing-feishu" in _reload(agent_yml)["channels"]
 
 
 def test_delete_empty_returns_zero(tmp_path, capsys):
@@ -232,31 +199,217 @@ def test_delete_empty_returns_zero(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
-# install_deps
+# toggle_enabled
 # ---------------------------------------------------------------------------
-def test_install_deps_interactive_invokes_pip(configurator):
+def test_toggle_enabled_flips_flag(configurator, agent_yml):
+    rc = configurator._toggle_enabled("existing-feishu")
+    assert rc == 0
+    channel = _reload(agent_yml)["channels"]["existing-feishu"]
+    assert channel["enabled"] is False
+    # Other fields are preserved.
+    assert channel["adapter"] == "feishu"
+    assert channel["verbose"] == "brief"
+    assert channel["extra"]["app_id"] == "cli_existing"
+    assert channel["extra"]["app_secret"] == "SECRETVALUEABCD"
+
+    # Toggling again flips back.
+    rc = configurator._toggle_enabled("existing-feishu")
+    assert rc == 0
+    assert _reload(agent_yml)["channels"]["existing-feishu"]["enabled"] is True
+
+
+def test_toggle_enabled_unknown_channel(configurator, capsys):
+    rc = configurator._toggle_enabled("nope")
+    assert rc == 1
+    assert "not found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# change_verbose
+# ---------------------------------------------------------------------------
+def test_change_verbose_updates_value(configurator, agent_yml):
+    with patch("datus.claw.configure.select_choice", return_value="detail"):
+        rc = configurator._change_verbose("existing-feishu")
+    assert rc == 0
+    assert _reload(agent_yml)["channels"]["existing-feishu"]["verbose"] == "detail"
+
+
+def test_change_verbose_noop_when_unchanged(configurator, agent_yml, capsys):
+    with patch("datus.claw.configure.select_choice", return_value="brief"):
+        rc = configurator._change_verbose("existing-feishu")
+    assert rc == 0
+    assert "unchanged" in capsys.readouterr().out
+    assert _reload(agent_yml)["channels"]["existing-feishu"]["verbose"] == "brief"
+
+
+def test_change_verbose_unknown_channel(configurator, capsys):
+    rc = configurator._change_verbose("nope")
+    assert rc == 1
+    assert "not found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# reinstall_deps
+# ---------------------------------------------------------------------------
+def test_reinstall_deps_invokes_pip(configurator):
     fake_completed = MagicMock(returncode=0)
     with (
-        patch("datus.claw.configure.select_choice", return_value="feishu"),
+        patch("datus.claw.configure.Confirm.ask", return_value=True),
         patch("datus.claw.configure.subprocess.run", return_value=fake_completed) as mock_run,
     ):
-        rc = configurator.install_deps_interactive()
+        rc = configurator._reinstall_deps("feishu")
     assert rc == 0
     cmd = mock_run.call_args.args[0]
     assert "lark-oapi" in cmd
 
 
-def test_install_deps_reports_failure(configurator):
+def test_reinstall_deps_reports_failure(configurator):
     fake_completed = MagicMock(returncode=2)
     with (
-        patch("datus.claw.configure.select_choice", return_value="feishu"),
+        patch("datus.claw.configure.Confirm.ask", return_value=True),
         patch("datus.claw.configure.subprocess.run", return_value=fake_completed),
     ):
-        rc = configurator.install_deps_interactive()
+        rc = configurator._reinstall_deps("feishu")
     assert rc == 2
 
 
-def test_install_deps_no_channels(tmp_path, capsys):
+def test_reinstall_deps_cancelled(configurator, capsys):
+    with patch("datus.claw.configure.Confirm.ask", return_value=False):
+        rc = configurator._reinstall_deps("feishu")
+    assert rc == 0
+    assert "Cancelled" in capsys.readouterr().out
+
+
+def test_reinstall_deps_unknown_adapter(configurator, capsys):
+    rc = configurator._reinstall_deps("unknown-adapter")
+    assert rc == 0
+    assert "No pip deps registered" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Hub loop (run)
+# ---------------------------------------------------------------------------
+def test_run_quits_immediately(configurator):
+    with patch.object(configurator, "_render_hub", return_value=("quit", None)):
+        assert configurator.run() == 0
+
+
+def test_run_dispatches_add_then_quits(configurator):
+    with (
+        patch.object(configurator, "_render_hub", side_effect=[("add", None), ("quit", None)]),
+        patch.object(configurator, "add", return_value=0) as mock_add,
+    ):
+        assert configurator.run() == 0
+    mock_add.assert_called_once_with()
+
+
+def test_run_dispatches_channel_submenu_then_quits(configurator):
+    with (
+        patch.object(
+            configurator,
+            "_render_hub",
+            side_effect=[("channel", "existing-feishu"), ("quit", None)],
+        ),
+        patch.object(configurator, "_channel_submenu") as mock_submenu,
+    ):
+        assert configurator.run() == 0
+    mock_submenu.assert_called_once_with("existing-feishu")
+
+
+def test_run_returns_one_when_config_missing(tmp_path):
+    import datus.configuration.agent_config_loader as loader
+
+    loader.CONFIGURATION_MANAGER = None
+    from datus.claw.configure import ChannelConfigurator
+
+    c = ChannelConfigurator(str(tmp_path / "does_not_exist.yml"))
+    assert c.cm is None
+    assert c.run() == 1
+
+
+# ---------------------------------------------------------------------------
+# Channel submenu dispatch
+# ---------------------------------------------------------------------------
+def test_channel_submenu_routes_toggle(configurator):
+    with (
+        patch("datus.claw.configure._select_menu", return_value="toggle_enabled"),
+        patch.object(configurator, "_toggle_enabled") as mock_toggle,
+    ):
+        configurator._channel_submenu("existing-feishu")
+    mock_toggle.assert_called_once_with("existing-feishu")
+
+
+def test_channel_submenu_routes_change_verbose(configurator):
+    with (
+        patch("datus.claw.configure._select_menu", return_value="change_verbose"),
+        patch.object(configurator, "_change_verbose") as mock_change,
+    ):
+        configurator._channel_submenu("existing-feishu")
+    mock_change.assert_called_once_with("existing-feishu")
+
+
+def test_channel_submenu_routes_reinstall(configurator):
+    with (
+        patch("datus.claw.configure._select_menu", return_value="reinstall_deps"),
+        patch.object(configurator, "_reinstall_deps") as mock_reinstall,
+    ):
+        configurator._channel_submenu("existing-feishu")
+    mock_reinstall.assert_called_once_with("feishu")
+
+
+def test_channel_submenu_routes_delete(configurator):
+    with (
+        patch("datus.claw.configure._select_menu", return_value="delete"),
+        patch.object(configurator, "delete") as mock_delete,
+    ):
+        configurator._channel_submenu("existing-feishu")
+    mock_delete.assert_called_once_with("existing-feishu")
+
+
+def test_channel_submenu_back_is_noop(configurator):
+    with (
+        patch("datus.claw.configure._select_menu", return_value="back"),
+        patch.object(configurator, "delete") as mock_delete,
+        patch.object(configurator, "_toggle_enabled") as mock_toggle,
+    ):
+        configurator._channel_submenu("existing-feishu")
+    mock_delete.assert_not_called()
+    mock_toggle.assert_not_called()
+
+
+def test_channel_submenu_cancel_is_noop(configurator):
+    with (
+        patch("datus.claw.configure._select_menu", return_value=None),
+        patch.object(configurator, "delete") as mock_delete,
+    ):
+        configurator._channel_submenu("existing-feishu")
+    mock_delete.assert_not_called()
+
+
+def test_channel_submenu_unknown_channel(configurator, capsys):
+    configurator._channel_submenu("does-not-exist")
+    assert "not found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _render_hub
+# ---------------------------------------------------------------------------
+def test_render_hub_returns_add(configurator):
+    with patch("datus.claw.configure._select_menu", return_value="__add__"):
+        assert configurator._render_hub() == ("add", None)
+
+
+def test_render_hub_returns_channel(configurator):
+    with patch("datus.claw.configure._select_menu", return_value="channel:existing-feishu"):
+        assert configurator._render_hub() == ("channel", "existing-feishu")
+
+
+def test_render_hub_quit_on_cancel(configurator):
+    with patch("datus.claw.configure._select_menu", return_value=None):
+        assert configurator._render_hub() == ("quit", None)
+
+
+def test_render_hub_empty_channels(tmp_path):
     import datus.configuration.agent_config_loader as loader
 
     loader.CONFIGURATION_MANAGER = None
@@ -265,43 +418,44 @@ def test_install_deps_no_channels(tmp_path, capsys):
     from datus.claw.configure import ChannelConfigurator
 
     c = ChannelConfigurator(str(path))
-    rc = c.install_deps_interactive()
-    assert rc == 0
-    assert "No channels" in capsys.readouterr().out
+    captured_rows: list = []
+
+    def _capture(rows, **kwargs):
+        captured_rows.extend(rows)
+        return None
+
+    with patch("datus.claw.configure._select_menu", side_effect=_capture):
+        assert c._render_hub() == ("quit", None)
+
+    keys = [r[0] for r in captured_rows]
+    assert "__add__" in keys
+    assert "__empty__" in keys
+    # No channel rows rendered.
+    assert not any(k.startswith("channel:") for k in keys)
 
 
-# ---------------------------------------------------------------------------
-# run() dispatcher
-# ---------------------------------------------------------------------------
-def test_run_dispatches_list(configurator):
-    with patch.object(configurator, "list", return_value=0) as mock_list:
-        assert configurator.run("list") == 0
-    mock_list.assert_called_once()
+def test_render_hub_builds_channel_rows(configurator):
+    configurator.cm.update_item(
+        "channels",
+        {"slack-prod": {"adapter": "slack", "enabled": False, "verbose": "brief", "extra": {}}},
+        delete_old_key=False,
+    )
+    captured_rows: list = []
 
+    def _capture(rows, **kwargs):
+        captured_rows.extend(rows)
+        return None
 
-def test_run_prompts_when_action_missing(configurator):
-    with (
-        patch.object(configurator, "_prompt_action", return_value="list"),
-        patch.object(configurator, "list", return_value=0),
-    ):
-        assert configurator.run(None) == 0
+    with patch("datus.claw.configure._select_menu", side_effect=_capture):
+        configurator._render_hub()
 
-
-def test_run_unknown_action(configurator, capsys):
-    rc = configurator.run("unknown")
-    assert rc == 1
-    assert "Unknown action" in capsys.readouterr().out
-
-
-def test_run_returns_one_when_config_missing(tmp_path, capsys):
-    import datus.configuration.agent_config_loader as loader
-
-    loader.CONFIGURATION_MANAGER = None
-    from datus.claw.configure import ChannelConfigurator
-
-    c = ChannelConfigurator(str(tmp_path / "does_not_exist.yml"))
-    assert c.cm is None
-    assert c.run("list") == 1
+    keys = [r[0] for r in captured_rows]
+    assert "channel:existing-feishu" in keys
+    assert "channel:slack-prod" in keys
+    # Enabled/disabled badges rendered in the display column.
+    displays = {r[0]: r[1] for r in captured_rows}
+    assert "enabled" in displays["channel:existing-feishu"]
+    assert "disabled" in displays["channel:slack-prod"]
 
 
 # ---------------------------------------------------------------------------
@@ -312,7 +466,7 @@ def test_main_cli_dispatches_configure(monkeypatch, agent_yml):
 
     fake_instance = MagicMock()
     fake_instance.run.return_value = 0
-    monkeypatch.setattr("sys.argv", ["datus-claw", "configure", "list", "--config", str(agent_yml)])
+    monkeypatch.setattr("sys.argv", ["datus-claw", "configure", "--config", str(agent_yml)])
 
     with (
         patch("datus.claw.configure.ChannelConfigurator", return_value=fake_instance) as mock_cls,
@@ -322,11 +476,11 @@ def test_main_cli_dispatches_configure(monkeypatch, agent_yml):
 
     assert excinfo.value.code == 0
     mock_cls.assert_called_once_with(str(agent_yml))
-    fake_instance.run.assert_called_once_with("list")
+    fake_instance.run.assert_called_once_with()
 
 
 def test_main_cli_parser_allows_bare_configure(monkeypatch):
-    """Backwards-compat: daemon invocations must still parse without a subcommand."""
+    """Daemon invocations still parse without a subcommand."""
     from datus.claw.main import _build_parser
 
     parser = _build_parser()
@@ -336,4 +490,14 @@ def test_main_cli_parser_allows_bare_configure(monkeypatch):
 
     ns = parser.parse_args(["configure"])
     assert ns.subcommand == "configure"
-    assert ns.configure_action is None
+    # Legacy action positional is gone.
+    assert not hasattr(ns, "configure_action")
+
+
+def test_main_cli_parser_rejects_legacy_action():
+    """Old `datus-claw configure list` syntax must now fail."""
+    from datus.claw.main import _build_parser
+
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["configure", "list"])

--- a/tests/unit_tests/claw/test_configure.py
+++ b/tests/unit_tests/claw/test_configure.py
@@ -1,0 +1,339 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for datus.claw.configure.ChannelConfigurator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def agent_yml(tmp_path: Path) -> Path:
+    cfg = {
+        "agent": {
+            "channels": {
+                "existing-feishu": {
+                    "adapter": "feishu",
+                    "enabled": True,
+                    "verbose": "brief",
+                    "stream_response": True,
+                    "extra": {
+                        "app_id": "cli_existing",
+                        "app_secret": "SECRETVALUEABCD",
+                    },
+                }
+            }
+        }
+    }
+    path = tmp_path / "agent.yml"
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def configurator(agent_yml: Path):
+    # Force a fresh ConfigurationManager bound to our tmp file.
+    import datus.configuration.agent_config_loader as loader
+
+    loader.CONFIGURATION_MANAGER = None
+    from datus.claw.configure import ChannelConfigurator
+
+    return ChannelConfigurator(str(agent_yml))
+
+
+def _reload(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["agent"]
+
+
+# ---------------------------------------------------------------------------
+# Redaction helper
+# ---------------------------------------------------------------------------
+def test_redact_masks_secret_keys():
+    from datus.claw.configure import _redact
+
+    assert _redact("app_secret", "SECRETVALUE1234") == "***1234"
+    assert _redact("bot_token", "xoxb-1234-abcd") == "***abcd"
+    # env placeholders pass through
+    assert _redact("app_secret", "${FEISHU_APP_SECRET}") == "${FEISHU_APP_SECRET}"
+    # non-secret keys pass through
+    assert _redact("app_id", "cli_12345") == "cli_12345"
+    # short secrets mask entirely
+    assert _redact("password", "abc") == "***"
+
+
+# ---------------------------------------------------------------------------
+# Channel name validation
+# ---------------------------------------------------------------------------
+def test_validate_channel_name_rules():
+    from datus.claw.configure import _validate_channel_name
+
+    existing = {"feishu-main": {}}
+    assert _validate_channel_name("slack-prod", existing) == (True, "")
+    ok, err = _validate_channel_name("", existing)
+    assert not ok and "empty" in err
+    ok, err = _validate_channel_name("has space", existing)
+    assert not ok and "whitespace" in err
+    ok, err = _validate_channel_name("has/slash", existing)
+    assert not ok
+    ok, err = _validate_channel_name("feishu-main", existing)
+    assert not ok and "exists" in err
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+def test_list_prints_redacted_secret(configurator, capsys):
+    rc = configurator.list()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "existing-feishu" in out
+    assert "SECRETVALUEABCD" not in out
+    assert "***ABCD" in out
+    assert "cli_existing" in out  # non-secret is visible
+
+
+def test_list_empty(tmp_path, monkeypatch, capsys):
+    import datus.configuration.agent_config_loader as loader
+
+    loader.CONFIGURATION_MANAGER = None
+    path = tmp_path / "agent.yml"
+    path.write_text(yaml.safe_dump({"agent": {"models": []}}, sort_keys=False))
+    from datus.claw.configure import ChannelConfigurator
+
+    c = ChannelConfigurator(str(path))
+    assert c.list() == 0
+    assert "No channels configured" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# add
+# ---------------------------------------------------------------------------
+def test_add_slack_channel_preserves_existing(configurator, agent_yml):
+    prompt_responses = iter(["slack-prod"])
+    confirm_responses = iter([True, False, False])  # enabled, override verbose?, install deps?
+    getpass_responses = iter(["xapp-TOKEN-1", "xoxb-TOKEN-2"])
+
+    with (
+        patch("datus.claw.configure.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_responses)),
+        patch("datus.claw.configure.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_responses)),
+        patch("datus.claw.configure.getpass", side_effect=lambda prompt="": next(getpass_responses)),
+        patch("datus.claw.configure.select_choice", return_value="slack"),
+    ):
+        rc = configurator.add()
+
+    assert rc == 0
+    data = _reload(agent_yml)
+    channels = data["channels"]
+    # Existing channel untouched
+    assert "existing-feishu" in channels
+    assert channels["existing-feishu"]["extra"]["app_secret"] == "SECRETVALUEABCD"
+    # New channel added
+    slack = channels["slack-prod"]
+    assert slack["adapter"] == "slack"
+    assert slack["enabled"] is True
+    assert slack["verbose"] == "brief"
+    assert slack["extra"] == {"app_token": "xapp-TOKEN-1", "bot_token": "xoxb-TOKEN-2"}
+
+
+def test_add_rejects_duplicate_then_accepts(configurator, agent_yml):
+    # First Prompt.ask returns a duplicate name, second returns a valid name,
+    # third returns the app_id. Confirms: enabled, override verbose?, install deps?
+    prompts = iter(["existing-feishu", "feishu-alt", "cli_new"])
+    confirms = iter([True, False, False])
+    passwords = iter(["sekret"])
+
+    with (
+        patch("datus.claw.configure.Prompt.ask", side_effect=lambda *a, **kw: next(prompts)),
+        patch("datus.claw.configure.Confirm.ask", side_effect=lambda *a, **kw: next(confirms)),
+        patch("datus.claw.configure.getpass", side_effect=lambda prompt="": next(passwords)),
+        patch("datus.claw.configure.select_choice", return_value="feishu"),
+    ):
+        rc = configurator.add()
+
+    assert rc == 0
+    data = _reload(agent_yml)
+    assert "feishu-alt" in data["channels"]
+    assert data["channels"]["feishu-alt"]["extra"]["app_id"] == "cli_new"
+    assert data["channels"]["feishu-alt"]["extra"]["app_secret"] == "sekret"
+
+
+def test_add_triggers_pip_install_when_confirmed(configurator):
+    prompts = iter(["feishu-alt", "cli_new"])
+    confirms = iter([True, False, True])  # enabled, override?, install deps
+    passwords = iter(["sekret"])
+
+    fake_completed = MagicMock(returncode=0)
+    with (
+        patch("datus.claw.configure.Prompt.ask", side_effect=lambda *a, **kw: next(prompts)),
+        patch("datus.claw.configure.Confirm.ask", side_effect=lambda *a, **kw: next(confirms)),
+        patch("datus.claw.configure.getpass", side_effect=lambda prompt="": next(passwords)),
+        patch("datus.claw.configure.select_choice", return_value="feishu"),
+        patch("datus.claw.configure.subprocess.run", return_value=fake_completed) as mock_run,
+    ):
+        rc = configurator.add()
+
+    assert rc == 0
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args.args[0]
+    assert cmd[1:4] == ["-m", "pip", "install"]
+    assert "lark-oapi" in cmd
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+def test_delete_removes_selected_channel(configurator, agent_yml):
+    # Seed a second channel so deletion leaves one behind.
+    configurator.cm.update_item(
+        "channels",
+        {"slack-old": {"adapter": "slack", "enabled": False, "extra": {"bot_token": "xoxb-old"}}},
+        delete_old_key=False,
+    )
+
+    with (
+        patch("datus.claw.configure.select_choice", return_value="slack-old"),
+        patch("datus.claw.configure.Confirm.ask", return_value=True),
+    ):
+        rc = configurator.delete()
+
+    assert rc == 0
+    data = _reload(agent_yml)
+    assert "slack-old" not in data["channels"]
+    assert "existing-feishu" in data["channels"]
+
+
+def test_delete_aborts_when_user_declines(configurator, agent_yml):
+    with (
+        patch("datus.claw.configure.select_choice", return_value="existing-feishu"),
+        patch("datus.claw.configure.Confirm.ask", return_value=False),
+    ):
+        rc = configurator.delete()
+    assert rc == 0
+    data = _reload(agent_yml)
+    assert "existing-feishu" in data["channels"]
+
+
+def test_delete_empty_returns_zero(tmp_path, capsys):
+    import datus.configuration.agent_config_loader as loader
+
+    loader.CONFIGURATION_MANAGER = None
+    path = tmp_path / "agent.yml"
+    path.write_text(yaml.safe_dump({"agent": {}}, sort_keys=False))
+    from datus.claw.configure import ChannelConfigurator
+
+    c = ChannelConfigurator(str(path))
+    assert c.delete() == 0
+    assert "nothing to delete" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# install_deps
+# ---------------------------------------------------------------------------
+def test_install_deps_interactive_invokes_pip(configurator):
+    fake_completed = MagicMock(returncode=0)
+    with (
+        patch("datus.claw.configure.select_choice", return_value="feishu"),
+        patch("datus.claw.configure.subprocess.run", return_value=fake_completed) as mock_run,
+    ):
+        rc = configurator.install_deps_interactive()
+    assert rc == 0
+    cmd = mock_run.call_args.args[0]
+    assert "lark-oapi" in cmd
+
+
+def test_install_deps_reports_failure(configurator):
+    fake_completed = MagicMock(returncode=2)
+    with (
+        patch("datus.claw.configure.select_choice", return_value="feishu"),
+        patch("datus.claw.configure.subprocess.run", return_value=fake_completed),
+    ):
+        rc = configurator.install_deps_interactive()
+    assert rc == 2
+
+
+def test_install_deps_no_channels(tmp_path, capsys):
+    import datus.configuration.agent_config_loader as loader
+
+    loader.CONFIGURATION_MANAGER = None
+    path = tmp_path / "agent.yml"
+    path.write_text(yaml.safe_dump({"agent": {}}, sort_keys=False))
+    from datus.claw.configure import ChannelConfigurator
+
+    c = ChannelConfigurator(str(path))
+    rc = c.install_deps_interactive()
+    assert rc == 0
+    assert "No channels" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# run() dispatcher
+# ---------------------------------------------------------------------------
+def test_run_dispatches_list(configurator):
+    with patch.object(configurator, "list", return_value=0) as mock_list:
+        assert configurator.run("list") == 0
+    mock_list.assert_called_once()
+
+
+def test_run_prompts_when_action_missing(configurator):
+    with (
+        patch.object(configurator, "_prompt_action", return_value="list"),
+        patch.object(configurator, "list", return_value=0),
+    ):
+        assert configurator.run(None) == 0
+
+
+def test_run_unknown_action(configurator, capsys):
+    rc = configurator.run("unknown")
+    assert rc == 1
+    assert "Unknown action" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_config_missing(tmp_path, capsys):
+    import datus.configuration.agent_config_loader as loader
+
+    loader.CONFIGURATION_MANAGER = None
+    from datus.claw.configure import ChannelConfigurator
+
+    c = ChannelConfigurator(str(tmp_path / "does_not_exist.yml"))
+    assert c.cm is None
+    assert c.run("list") == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch in datus.claw.main
+# ---------------------------------------------------------------------------
+def test_main_cli_dispatches_configure(monkeypatch, agent_yml):
+    from datus.claw import main as claw_main
+
+    fake_instance = MagicMock()
+    fake_instance.run.return_value = 0
+    monkeypatch.setattr("sys.argv", ["datus-claw", "configure", "list", "--config", str(agent_yml)])
+
+    with (
+        patch("datus.claw.configure.ChannelConfigurator", return_value=fake_instance) as mock_cls,
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        claw_main.main()
+
+    assert excinfo.value.code == 0
+    mock_cls.assert_called_once_with(str(agent_yml))
+    fake_instance.run.assert_called_once_with("list")
+
+
+def test_main_cli_parser_allows_bare_configure(monkeypatch):
+    """Backwards-compat: daemon invocations must still parse without a subcommand."""
+    from datus.claw.main import _build_parser
+
+    parser = _build_parser()
+    ns = parser.parse_args(["--action", "stop"])
+    assert ns.subcommand is None
+    assert ns.action == "stop"
+
+    ns = parser.parse_args(["configure"])
+    assert ns.subcommand == "configure"
+    assert ns.configure_action is None


### PR DESCRIPTION
Introduce `datus-claw configure {list,add,delete,install-deps}` to let users manage the agent.yml `channels:` section interactively instead of hand-editing YAML. The add wizard validates the channel name, prompts for adapter-specific fields (secrets via getpass), writes the entry through ConfigurationManager, and optionally runs pip install for the adapter SDK (lark-oapi / slack-sdk[socket_mode]). Existing daemon invocations (start/stop/restart/status) remain unchanged.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive configure subcommand to manage channels: view status, add channels with adapter selection and secure credential entry, toggle enabled/verbose, delete channels with confirmation, and install adapter dependencies; includes name validation and redaction of sensitive fields, with immediate saving and error reporting.

* **Tests**
  * Added comprehensive tests covering configuration flows, validation, redaction, dependency install behavior, CLI dispatch, and user-interaction paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->