### PR TITLE
[Doc] Fix services-docs inconsistencies (semantic_layer key, metrics path)

### DIFF
--- a/docs/adapters/semantic_adapters.md
+++ b/docs/adapters/semantic_adapters.md
@@ -76,7 +76,7 @@ By default, Datus points MetricFlow at the current project's semantic model dire
 
 ### Selection Rules
 
-- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup.
+- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup. Comparison is case-insensitive and trims surrounding whitespace, so `MetricFlow` and ` metricflow ` also match.
 - Semantic nodes choose the adapter with `semantic_adapter`.
 - If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.
 - If multiple semantic layers are configured, set `semantic_adapter` explicitly.

--- a/docs/adapters/semantic_adapters.md
+++ b/docs/adapters/semantic_adapters.md
@@ -76,7 +76,7 @@ By default, Datus points MetricFlow at the current project's semantic model dire
 
 ### Selection Rules
 
-- The key under `services.semantic_layer` is the adapter type, for example `metricflow`.
+- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup.
 - Semantic nodes choose the adapter with `semantic_adapter`.
 - If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.
 - If multiple semantic layers are configured, set `semantic_adapter` explicitly.

--- a/docs/adapters/semantic_adapters.zh.md
+++ b/docs/adapters/semantic_adapters.zh.md
@@ -76,7 +76,7 @@ agent:
 
 ### 选择规则
 
-- `services.semantic_layer` 下的 key 就是 adapter type，例如 `metricflow`。
+- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。
 - 语义相关节点通过 `semantic_adapter` 选择适配器。
 - 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。
 - 如果配置了多个 semantic layer，则必须显式填写 `semantic_adapter`。

--- a/docs/adapters/semantic_adapters.zh.md
+++ b/docs/adapters/semantic_adapters.zh.md
@@ -76,7 +76,7 @@ agent:
 
 ### 选择规则
 
-- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。
+- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。比较时会先对 key 与 `type` 做 lowercase + trim 处理，因此 `MetricFlow` 或 ` metricflow ` 也会被视为与 `metricflow` 匹配。
 - 语义相关节点通过 `semantic_adapter` 选择适配器。
 - 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。
 - 如果配置了多个 semantic layer，则必须显式填写 `semantic_adapter`。

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -22,7 +22,7 @@ agent:
 
 ## Selection Rules
 
-- The key under `services.semantic_layer` is the adapter type, for example `metricflow`.
+- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup.
 - Semantic nodes choose the adapter with `semantic_adapter`.
 - There is no `default: true` for semantic adapters.
 - If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -22,7 +22,7 @@ agent:
 
 ## Selection Rules
 
-- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup.
+- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup. Comparison is case-insensitive and trims surrounding whitespace, so `MetricFlow` and ` metricflow ` also match.
 - Semantic nodes choose the adapter with `semantic_adapter`.
 - There is no `default: true` for semantic adapters.
 - If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -1,0 +1,35 @@
+# 语义层配置（Semantic Layer）
+
+语义适配器统一配置在 `agent.services.semantic_layer` 下。
+
+## 配置结构
+
+```yaml
+agent:
+  services:
+    semantic_layer:
+      metricflow:
+        timeout: 300
+        config_path: ./conf/agent.yml   # 可选的高级覆盖项
+
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: metricflow
+
+    gen_metrics:
+      semantic_adapter: metricflow
+```
+
+## 选择规则
+
+- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。
+- 语义相关节点通过 `semantic_adapter` 选择适配器。
+- 语义适配器不支持 `default: true`。
+- 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。
+- 如果配置了多个 semantic layer，则必须显式填写 `semantic_adapter`。
+
+## MetricFlow 说明
+
+- `config_path` 是可选项。
+- Datus 默认会基于当前 `services.databases` 中选中的数据库和项目语义模型目录自动构建运行时配置。
+- 仅当你需要 MetricFlow 直接读取某个指定的 `agent.yml` 时才需要设置 `config_path`。

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -22,7 +22,7 @@ agent:
 
 ## 选择规则
 
-- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。
+- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。比较时会先对 key 与 `type` 做 lowercase + trim 处理，因此 `MetricFlow` 或 ` metricflow ` 也会被视为与 `metricflow` 匹配。
 - 语义相关节点通过 `semantic_adapter` 选择适配器。
 - 语义适配器不支持 `default: true`。
 - 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。

--- a/docs/subagent/builtin_subagents.md
+++ b/docs/subagent/builtin_subagents.md
@@ -533,10 +533,13 @@ metric:
 
 #### File Organization
 
-Metrics are appended to existing semantic model files using the YAML document separator `---`:
+Metrics are stored in dedicated files, separate from their semantic models:
 
+- **Semantic Model**: `{table_name}.yml` — `data_source` definition (measures, dimensions, identifiers)
+- **Metrics**: `metrics/{table_name}_metrics.yml` — one or more metric definitions, separated by the YAML document separator `---`
+
+**Semantic Model File** (`transactions.yml`):
 ```yaml
-# Existing semantic model
 data_source:
   name: transactions
   sql_table: transactions
@@ -547,9 +550,10 @@ data_source:
   dimensions:
     - name: transaction_date
       type: TIME
+```
 
----
-# First metric (appended)
+**Metrics File** (`metrics/transactions_metrics.yml`):
+```yaml
 metric:
   name: total_revenue
   type: measure_proxy
@@ -557,7 +561,6 @@ metric:
     measure: revenue
 
 ---
-# Second metric (appended)
 metric:
   name: avg_transaction_value
   type: ratio
@@ -566,10 +569,12 @@ metric:
     denominator: transaction_count
 ```
 
-**Why append instead of separate files?**
-- Keeps related metrics close to their semantic model
-- Easier maintenance and validation
-- MetricFlow can validate all definitions together
+**Why separate files?**
+- Clear separation between schema definitions and business metrics
+- Metrics can be maintained independently from the underlying semantic model
+- MetricFlow validates all YAML documents under the semantic model directory together
+
+See [gen_metrics](gen_metrics.md) for full details.
 
 #### Knowledge Base Storage
 

--- a/docs/subagent/builtin_subagents.md
+++ b/docs/subagent/builtin_subagents.md
@@ -375,7 +375,7 @@ graph LR
     C --> D[Reads measures]
     D --> E[Checks for duplicates]
     E --> F[Generates metric YAML]
-    F --> G[Appends to file]
+    F --> G[Writes metric to metrics file]
     G --> H[Validates]
     H --> I[User confirms]
     I --> J[Syncs to Knowledge Base]
@@ -596,7 +596,7 @@ The metrics generation feature provides:
 - ✅ **Validation**: MetricFlow validation ensures correctness
 - ✅ **Interactive Workflow**: Review and approve before syncing
 - ✅ **Knowledge Base Integration**: Semantic search for metric discovery
-- ✅ **File Management**: Appends to existing semantic model files safely
+- ✅ **File Management**: Maintains dedicated per-table metrics files under `metrics/`
 
 ---
 

--- a/docs/subagent/builtin_subagents.zh.md
+++ b/docs/subagent/builtin_subagents.zh.md
@@ -532,10 +532,13 @@ metric:
 
 #### 文件组织
 
-使用 YAML 文档分隔符 `---` 将指标追加到现有语义模型文件：
+指标存放在独立文件中，与语义模型文件分离：
 
+- **语义模型**：`{table_name}.yml` —— `data_source` 定义（measures、dimensions、identifiers）
+- **指标**：`metrics/{table_name}_metrics.yml` —— 一个或多个指标定义，使用 YAML 文档分隔符 `---` 分隔
+
+**语义模型文件** (`transactions.yml`)：
 ```yaml
-# 现有语义模型
 data_source:
   name: transactions
   sql_table: transactions
@@ -546,9 +549,10 @@ data_source:
   dimensions:
     - name: transaction_date
       type: TIME
+```
 
----
-# 第一个指标（追加）
+**指标文件** (`metrics/transactions_metrics.yml`)：
+```yaml
 metric:
   name: total_revenue
   type: measure_proxy
@@ -556,7 +560,6 @@ metric:
     measure: revenue
 
 ---
-# 第二个指标（追加）
 metric:
   name: avg_transaction_value
   type: ratio
@@ -565,10 +568,12 @@ metric:
     denominator: transaction_count
 ```
 
-**为什么追加而不是单独文件？**
-- 保持相关指标靠近其语义模型
-- 更易于维护和验证
-- MetricFlow 可以一起验证所有定义
+**为什么使用独立文件？**
+- 清晰分离 schema 定义与业务指标
+- 指标可以独立于底层语义模型维护
+- MetricFlow 会把 semantic_models 目录下所有 YAML 文档一起验证
+
+更多细节见 [gen_metrics](gen_metrics.md)。
 
 #### 知识库存储
 
@@ -590,7 +595,7 @@ metric:
 - ✅ **验证**：MetricFlow 验证确保正确性
 - ✅ **交互式工作流**：同步前审阅和批准
 - ✅ **知识库集成**：语义搜索以发现指标
-- ✅ **文件管理**：安全地追加到现有语义模型文件
+- ✅ **文件管理**：在 `metrics/` 目录下维护独立的指标文件
 
 ---
 

--- a/docs/subagent/builtin_subagents.zh.md
+++ b/docs/subagent/builtin_subagents.zh.md
@@ -374,7 +374,7 @@ graph LR
     C --> D[读取度量]
     D --> E[检查重复]
     E --> F[生成指标 YAML]
-    F --> G[追加到文件]
+    F --> G[写入指标文件]
     G --> H[验证]
     H --> I[用户确认]
     I --> J[同步到知识库]
@@ -573,7 +573,7 @@ metric:
 - 指标可以独立于底层语义模型维护
 - MetricFlow 会把 semantic_models 目录下所有 YAML 文档一起验证
 
-更多细节见 [gen_metrics](gen_metrics.md)。
+更多细节见 [gen_metrics](gen_metrics.zh.md)。
 
 #### 知识库存储
 

--- a/docs/subagent/gen_metrics.md
+++ b/docs/subagent/gen_metrics.md
@@ -80,11 +80,20 @@ Please enter your choice: [1/2]
 Most configurations are built-in. In `agent.yml`, minimal setup is needed:
 
 ```yaml
-agentic_nodes:
-  gen_metrics:
-    model: claude        # Optional: defaults to configured model
-    max_turns: 40        # Optional: defaults to 30
+agent:
+  services:
+    semantic_layer:
+      metricflow: {}     # Key MUST equal the adapter type (e.g. `metricflow`).
+                         # If `type:` is given, it must match the key; otherwise Datus raises a config error at startup.
+
+  agentic_nodes:
+    gen_metrics:
+      model: claude      # Optional: defaults to configured model
+      max_turns: 40      # Optional: defaults to 30
+      semantic_adapter: metricflow   # Optional when only one semantic layer is configured
 ```
+
+See [Semantic Layer Configuration](../configuration/semantic_layer.md) for the full set of options.
 
 **Built-in configurations** (automatically enabled):
 - **Tools**: Generation tools and filesystem tools

--- a/docs/subagent/gen_metrics.zh.md
+++ b/docs/subagent/gen_metrics.zh.md
@@ -78,11 +78,20 @@ Please enter your choice: [1/2]
 大部分配置是内置的。在 `agent.yml` 中，最小化设置即可：
 
 ```yaml
-agentic_nodes:
-  gen_metrics:
-    model: claude        # 可选：默认使用已配置的模型
-    max_turns: 30        # 可选：默认为 30
+agent:
+  services:
+    semantic_layer:
+      metricflow: {}     # key 必须等于 adapter type（例如 `metricflow`）。
+                         # 如果同时写了 `type:` 字段，必须与 key 一致，否则 Datus 会在启动时抛出配置错误。
+
+  agentic_nodes:
+    gen_metrics:
+      model: claude      # 可选：默认使用已配置的模型
+      max_turns: 30      # 可选：默认为 30
+      semantic_adapter: metricflow   # 当仅配置了一个 semantic layer 时可省略
 ```
+
+完整配置项见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
 **内置配置**（自动启用）：
 - **工具**：生成工具和文件系统工具

--- a/docs/subagent/gen_semantic_model.md
+++ b/docs/subagent/gen_semantic_model.md
@@ -68,11 +68,20 @@ Please enter your choice: [1/2]
 Most configurations are built-in. In `agent.yml`, minimal setup is needed:
 
 ```yaml
-agentic_nodes:
-  gen_semantic_model:
-    model: claude        # Optional: defaults to configured model
-    max_turns: 30        # Optional: defaults to 30
+agent:
+  services:
+    semantic_layer:
+      metricflow: {}     # Key MUST equal the adapter type (e.g. `metricflow`).
+                         # If `type:` is given, it must match the key; otherwise Datus raises a config error at startup.
+
+  agentic_nodes:
+    gen_semantic_model:
+      model: claude      # Optional: defaults to configured model
+      max_turns: 30      # Optional: defaults to 30
+      semantic_adapter: metricflow   # Optional when only one semantic layer is configured
 ```
+
+See [Semantic Layer Configuration](../configuration/semantic_layer.md) for the full set of options.
 
 **Built-in configurations** (automatically enabled):
 - **Tools**: Database tools, generation tools, and filesystem tools

--- a/docs/subagent/gen_semantic_model.zh.md
+++ b/docs/subagent/gen_semantic_model.zh.md
@@ -66,11 +66,20 @@ Please enter your choice: [1/2]
 大部分配置是内置的。在 `agent.yml` 中，最小化设置即可：
 
 ```yaml
-agentic_nodes:
-  gen_semantic_model:
-    model: claude        # 可选：默认使用已配置的模型
-    max_turns: 30        # 可选：默认为 30
+agent:
+  services:
+    semantic_layer:
+      metricflow: {}     # key 必须等于 adapter type（例如 `metricflow`）。
+                         # 如果同时写了 `type:` 字段，必须与 key 一致，否则 Datus 会在启动时抛出配置错误。
+
+  agentic_nodes:
+    gen_semantic_model:
+      model: claude      # 可选：默认使用已配置的模型
+      max_turns: 30      # 可选：默认为 30
+      semantic_adapter: metricflow   # 当仅配置了一个 semantic layer 时可省略
 ```
+
+完整配置项见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
 **内置配置**（自动启用）：
 - **工具**：数据库工具、生成工具和文件系统工具


### PR DESCRIPTION
## Why

Two inconsistencies between the services docs and the code were flagged during a docs-vs-code audit:

1. **`services.semantic_layer` key=type constraint is silent in docs.** `datus/configuration/agent_config.py:1270-1278` raises a `COMMON_CONFIG_ERROR` at startup if the YAML key under `agent.services.semantic_layer` does not equal the adapter type (or an explicit `type:` that disagrees with the key). None of `docs/configuration/semantic_layer.md`, `docs/adapters/semantic_adapters.md`, `docs/subagent/gen_semantic_model.md`, or `docs/subagent/gen_metrics.md` warned about this, making misconfiguration hard to debug. `docs/configuration/semantic_layer.zh.md` did not exist.

2. **`builtin_subagents.md` described the wrong metrics file layout.** The "How Metrics Are Stored" section said metrics are appended to the existing semantic model file with `---`. The authoritative prompt template (`datus/prompts/prompt_templates/gen_metrics_system_1.2.j2:118,165`) and `docs/subagent/gen_metrics.md` both place metrics in a dedicated `metrics/{table_name}_metrics.yml`. The zh version carried the same mistake.

## Solution

Commit `[Doc] Clarify semantic_layer key=type constraint and add zh doc`:
- Selection Rules in `configuration/semantic_layer.md` and `adapters/semantic_adapters.md` now state the key=type requirement and the startup-time error it raises.
- `gen_semantic_model.md` and `gen_metrics.md` Agent Configuration examples show a full `services.semantic_layer` block alongside `agentic_nodes`, with an inline comment about the constraint, and link to the central semantic_layer doc.
- New `docs/configuration/semantic_layer.zh.md` mirrors the English page.
- All four matching `.zh.md` files updated to mirror the English changes.

Commit `[BugFix] Fix metrics storage location in builtin_subagents doc`:
- Rewrite the "How Metrics Are Stored" section in `builtin_subagents.md` (and `.zh.md`) to describe the real `metrics/{table_name}_metrics.yml` layout, cross-link to `gen_metrics.md` as the authoritative spec, and update the trailing "file management" bullet accordingly.

## Test Cases

Doc-only change; no code touched and no integration/nightly tests are applicable. The corrections were derived by cross-referencing:
- `datus/configuration/agent_config.py:1270-1278` for the key=type constraint
- `datus/prompts/prompt_templates/gen_metrics_system_1.2.j2:118,165` for the metrics file path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified semantic layer configuration: keys must match adapter type; if a `type:` is present it must align (case/whitespace-insensitive) or startup will error.
  * Added new semantic layer guidance with setup rules, MetricFlow notes, and when `semantic_adapter` is optional vs required.
  * Switched metrics storage guidance to dedicated per-table files under metrics/.
  * Updated subagent examples to reflect the new nested configuration structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->