### PR TITLE
[Feature] Add agent.language to pin AgenticNode response language

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -39,6 +39,33 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+_LANGUAGE_NAME_MAP: Dict[str, str] = {
+    "en": "English",
+    "zh": "Chinese",
+    "zh-cn": "Chinese",
+    "zh-tw": "Traditional Chinese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "it": "Italian",
+}
+
+
+def _resolve_language_name(code: str) -> str:
+    """Map a language code (e.g. ``"zh"``) to a human-readable name.
+
+    Unknown codes are returned as-is so operators can plug in custom values
+    without a code change.
+    """
+    if not code:
+        return "English"
+    return _LANGUAGE_NAME_MAP.get(code.strip().lower(), code)
+
+
 class AgenticNode(Node):
     """
     Base agentic node that provides session-based, streaming interactions
@@ -261,6 +288,36 @@ class AgenticNode(Node):
         # Inject memory context for eligible nodes.
         base_prompt = self._inject_memory_context(base_prompt, override_node_name=memory_node_name_override)
 
+        # Inject response language policy so every agentic node — including
+        # sub-agents invoked via ``task`` — honors the configured output language.
+        base_prompt = self._inject_response_language(base_prompt)
+
+        return base_prompt
+
+    def _inject_response_language(self, base_prompt: str) -> str:
+        """Append a language directive driven by ``agent_config.language``.
+
+        When ``language`` is unset (``None`` or empty), this is a no-op so the
+        model decides the response language on its own. Setting a code (e.g.
+        ``"en"``/``"zh"``) in yaml or via the Chat API pins every AgenticNode
+        to that output language through a single append hook.
+        """
+        language_raw = getattr(self.agent_config, "language", None)
+        if not language_raw or not str(language_raw).strip():
+            return base_prompt
+        language_code = str(language_raw).strip()
+        try:
+            language_section = get_prompt_manager(agent_config=self.agent_config).render_template(
+                template_name="response_language",
+                version=None,
+                language_code=language_code,
+                language_name=_resolve_language_name(language_code),
+            )
+        except Exception as e:
+            logger.warning(f"Failed to render response_language template: {e}")
+            return base_prompt
+        if language_section and language_section.strip():
+            base_prompt = base_prompt + "\n\n" + language_section
         return base_prompt
 
     def _inject_memory_context(self, base_prompt: str, override_node_name: Optional[str] = None) -> str:

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -270,6 +270,13 @@ class StreamChatInput(ChatInput):
     subagent_id: Optional[str] = Field(default=None, description="Subagent ID (builtin name or DB SubAgent id)")
     prompt_version: Optional[str] = Field(default=None, description="Prompt version")
     prompt_language: str = Field(default="en", description="Prompt language")
+    language: Optional[str] = Field(
+        default=None,
+        description=(
+            "Response language override for all agentic node outputs (e.g. 'en', 'zh'). "
+            "Falls back to agent.language from yaml when unset."
+        ),
+    )
     source_session_id: Optional[str] = Field(
         default=None,
         description="Source session to seed the agent with (currently used by feedback agent to copy history).",

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -229,6 +229,10 @@ class ChatTaskManager:
         # access, so force filesystem strict mode — every node constructed
         # below reads this flag via AgenticNode._resolve_filesystem_strict().
         agent_config.filesystem_strict = True
+        # Per-request response language override. Empty / None keeps the
+        # yaml-level ``agent.language`` default intact.
+        if request.language:
+            agent_config.language = request.language
         _fill_database_context(
             agent_config,
             catalog=request.catalog,

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -482,6 +482,11 @@ class AgentConfig:
         self.benchmark_configs: Dict[str, BenchmarkConfig] = {}
         self.schema_linking_rate = kwargs.get("schema_linking_rate", "fast")
         self.search_metrics_rate = kwargs.get("search_metrics_rate", "fast")
+        # Response language for model outputs (user-facing text). ``None`` (the
+        # default) means the model picks its own language per turn; set a code
+        # like "en"/"zh" in agent.yml or via ``StreamChatInput.language`` to pin
+        # every AgenticNode to a specific output language.
+        self.language = kwargs.get("language")
         self.db_type = ""
 
         # Benchmark paths are now fixed at {agent.home}/benchmark/{name}

--- a/datus/prompts/prompt_templates/response_language_1.0.j2
+++ b/datus/prompts/prompt_templates/response_language_1.0.j2
@@ -1,0 +1,4 @@
+# Response Language
+- Use: {{ language_name }} ({{ language_code }})
+- Apply to: replies, sub-agent prompts, file comments/prose, `ask_user` questions
+- Exclude: code, SQL, identifiers, file paths, URLs, JSON keys

--- a/docs/API/chat.md
+++ b/docs/API/chat.md
@@ -22,7 +22,8 @@ Send a chat message and stream the response as Server-Sent Events.
 | `catalog`/`database`/`db_schema` | string? | Database context |
 | `table_paths`/`metric_paths`/`sql_paths`/`knowledge_paths` | string[]? | `@`-reference paths |
 | `max_turns`      | int      | Default `30` |
-| `prompt_language`| string   | `en` (default) or `zh` |
+| `prompt_language`| string   | `en` (default) or `zh` — selects the prompt template variant |
+| `language`       | string?  | Optional response language override (e.g. `en`, `zh`, `ja`). Falls back to `agent.language` from yaml; when neither is set, no language directive is injected and the model chooses its own response language. Controls the natural language every agentic node uses for replies, file comments, sub-agent prompts, and `ask_user` questions. Code/SQL/identifiers stay in their original form. |
 | `stream_response`| bool?   | Stream thinking deltas token-by-token; `null` defers to server `--stream` flag (default `false`) |
 
 **Response**: `text/event-stream`. See [Streaming format](#streaming-format) below.

--- a/docs/API/chat.zh.md
+++ b/docs/API/chat.zh.md
@@ -22,7 +22,8 @@ Chat 相关接口驱动 Agent 的对话循环。流式接口以 Server-Sent Even
 | `catalog`/`database`/`db_schema` | string? | 数据库上下文 |
 | `table_paths`/`metric_paths`/`sql_paths`/`knowledge_paths` | string[]? | `@` 引用路径 |
 | `max_turns`      | int      | 默认 `30` |
-| `prompt_language`| string   | `en`(默认)或 `zh` |
+| `prompt_language`| string   | `en`(默认)或 `zh`——选择 prompt 模板变体 |
+| `language`       | string?  | 响应语言覆盖（如 `en`、`zh`、`ja`）。留空时回退到 yaml 中的 `agent.language`；若 yaml 也未设置，则不向 system prompt 注入语言指令，由模型自行选择回答语言。控制所有 agentic 节点的回答文本、写入文件的注释、调用子 agent 的 prompt 及 `ask_user` 问题所使用的自然语言；代码、SQL、标识符保持原样。 |
 | `stream_response`| bool?   | 是否逐 token 流式下发 thinking 内容;`null` 时使用服务端 `--stream` 启动参数(默认 `false`) |
 
 **响应**:`text/event-stream`,格式见下文 [流式格式](#streaming-format)。

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -13,6 +13,23 @@ agent:
   target: openai  # Default model configuration key from models section
 ```
 
+### Response Language
+
+`language` is an **optional** field that pins the natural language used by every agentic node for **user-facing** outputs — replies, summaries, clarifying questions, sub-agent prompts issued via `task`, and prose written into files. Code, SQL, identifiers, file paths, URLs, and JSON keys stay in their original form regardless of the setting.
+
+When omitted, no directive is injected into the system prompt and the model picks its own response language per turn.
+
+```yaml
+agent:
+  # Leave it out entirely to let the model decide.
+  # Set a code to pin every agentic node to that language.
+  language: zh   # Common codes: en, zh, ja, ko, es, fr, de, pt, ru, it
+```
+
+Built-in code → name mapping (injected into the system prompt): `en` → English, `zh` / `zh-cn` → Chinese, `zh-tw` → Traditional Chinese, `ja` → Japanese, `ko` → Korean, `es` → Spanish, `fr` → French, `de` → German, `pt` → Portuguese, `ru` → Russian, `it` → Italian. Unknown codes are used verbatim.
+
+Chat API requests can override this per task by sending a `language` field in the request body (see [Chat API](../API/chat.md)). CLI usage inherits the yaml default.
+
 ### Models Configuration
 
 Configure LLM providers that your agent can use. Each model configuration includes the provider type, API endpoints, credentials, and specific model names.

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -11,6 +11,22 @@ agent:
   target: openai
 ```
 
+### 响应语言（language）
+`language` 是**可选**字段，用于把所有 agentic 节点的**面向用户自然语言输出**统一到指定语言，覆盖：回答文本、总结、澄清提问、通过 `task` 工具调用子 agent 时写入的 prompt、以及写入文件的注释与说明。代码、SQL、表/列标识符、文件路径、URL、JSON key 等机器可读成分保持原样。
+
+若不填写该字段，系统不会向 system prompt 注入任何语言指令，模型将自行根据上下文选择回答语言。
+
+```yaml
+agent:
+  # 完全省略该字段即可让模型自行决定语言。
+  # 填写语言码即可固定所有 agentic 节点的输出语言：
+  language: zh   # 常用取值：en, zh, ja, ko, es, fr, de, pt, ru, it
+```
+
+内置语言码映射：`en` → English、`zh` / `zh-cn` → Chinese、`zh-tw` → Traditional Chinese、`ja` → Japanese、`ko` → Korean、`es` → Spanish、`fr` → French、`de` → German、`pt` → Portuguese、`ru` → Russian、`it` → Italian。未知代码将原样注入 system prompt，方便扩展。
+
+Chat API 请求可通过请求体中的 `language` 字段按任务覆盖该默认值（详见 [Chat API](../API/chat.zh.md)）。CLI 无覆盖参数，直接沿用 yaml 中的默认。
+
 ### 模型提供方（models） {#models-configuration}
 为智能体配置可用的 LLM 提供方：
 

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1518,3 +1518,103 @@ class TestGetLastTurnUsage:
         result = asyncio.run(node.get_last_turn_usage())
         assert result is not None
         assert result.context_length == 0
+
+
+# ---------------------------------------------------------------------------
+# TestResolveLanguageName + TestInjectResponseLanguage
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLanguageName:
+    def test_known_codes_return_human_names(self):
+        from datus.agent.node.agentic_node import _resolve_language_name
+
+        assert _resolve_language_name("en") == "English"
+        assert _resolve_language_name("zh") == "Chinese"
+        assert _resolve_language_name("ja") == "Japanese"
+
+    def test_case_insensitive(self):
+        from datus.agent.node.agentic_node import _resolve_language_name
+
+        assert _resolve_language_name("EN") == "English"
+        assert _resolve_language_name("ZH-CN") == "Chinese"
+
+    def test_unknown_code_returned_as_is(self):
+        from datus.agent.node.agentic_node import _resolve_language_name
+
+        assert _resolve_language_name("xx-yy") == "xx-yy"
+
+    def test_empty_falls_back_to_english(self):
+        from datus.agent.node.agentic_node import _resolve_language_name
+
+        assert _resolve_language_name("") == "English"
+        assert _resolve_language_name(None) == "English"
+
+
+class TestInjectResponseLanguage:
+    """``_inject_response_language`` appends a single language-policy block
+    driven by ``agent_config.language`` and is invoked from
+    ``_finalize_system_prompt`` for every AgenticNode subclass.
+    """
+
+    class _Cfg:
+        """Lightweight stand-in for AgentConfig. Using a MagicMock would let
+        ``getattr(cfg, "prompt_manager")`` return a MagicMock and short-circuit
+        ``get_prompt_manager``, defeating the real Jinja render under test.
+        """
+
+        def __init__(self, language):
+            self.language = language
+            self.prompt_manager = None
+            self.path_manager = None
+
+    def _agent_config(self, language="en"):
+        return self._Cfg(language)
+
+    def test_explicit_english_appends_english_block(self):
+        """Explicit ``language: en`` still pins output to English — the policy
+        is only skipped when the setting is unset entirely."""
+        node = _make_node(agent_config=self._agent_config("en"))
+        result = node._inject_response_language("BASE")
+        assert "Response Language" in result
+        assert "English (en)" in result
+        assert result.startswith("BASE")
+
+    def test_chinese_override_uses_chinese_name(self):
+        node = _make_node(agent_config=self._agent_config("zh"))
+        result = node._inject_response_language("BASE")
+        assert "Chinese (zh)" in result
+
+    def test_unknown_code_uses_raw_value(self):
+        node = _make_node(agent_config=self._agent_config("xx"))
+        result = node._inject_response_language("BASE")
+        assert "xx (xx)" in result
+
+    def test_none_language_skips_injection(self):
+        """``language=None`` means "let the model decide" — no directive."""
+        node = _make_node(agent_config=self._agent_config(None))
+        result = node._inject_response_language("BASE")
+        assert result == "BASE"
+
+    def test_empty_language_skips_injection(self):
+        """Whitespace-only/empty language is treated as unset."""
+        node = _make_node(agent_config=self._agent_config(""))
+        assert node._inject_response_language("BASE") == "BASE"
+        node2 = _make_node(agent_config=self._agent_config("   "))
+        assert node2._inject_response_language("BASE") == "BASE"
+
+    def test_missing_attribute_skips_injection(self):
+        """agent_config without ``language`` attribute is a no-op."""
+
+        class _Bare:
+            pass
+
+        node = _make_node(agent_config=_Bare())
+        assert node._inject_response_language("BASE") == "BASE"
+
+    def test_render_failure_returns_base_unchanged(self):
+        node = _make_node(agent_config=self._agent_config("zh"))
+        with patch("datus.agent.node.agentic_node.get_prompt_manager") as mgr:
+            mgr.return_value.render_template.side_effect = RuntimeError("boom")
+            result = node._inject_response_language("BASE")
+        assert result == "BASE"

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -314,13 +314,19 @@ class TestClearSession:
         assert node._session is None
 
     def test_clear_session_no_model(self):
+        """Non-ephemeral clear with ``model=None`` is a no-op: ``_session`` and
+        ``session_id`` must survive untouched so the caller can reuse the node
+        after reattaching a model later.
+        """
         node = _make_node()
         node.ephemeral = False
         node.model = None
         node.session_id = "some_id"
-        node._session = MagicMock()
-        # Should not raise
+        sentinel_session = MagicMock()
+        node._session = sentinel_session
         node.clear_session()
+        assert node._session is sentinel_session
+        assert node.session_id == "some_id"
 
 
 # ---------------------------------------------------------------------------
@@ -1007,11 +1013,15 @@ class TestSessionManagement:
         assert node._session is None
 
     def test_clear_session_no_model(self):
+        """No-op path: without a model, clear_session leaves session state
+        alone so the node is reusable once a model is later assigned."""
         node = _make_simple_node()
-        node._session = MagicMock()
+        sentinel_session = MagicMock()
+        node._session = sentinel_session
         node.session_id = "sess_3"
-        # no model - should not raise
         node.clear_session()
+        assert node._session is sentinel_session
+        assert node.session_id == "sess_3"
 
     def test_delete_session_ephemeral(self):
         node = _make_simple_node(ephemeral=True, session_id="sess_4")

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -155,6 +155,7 @@ class TestFinalizeSystemPrompt:
         )
         node.skill_func_tool = None
         monkeypatch.setattr(node, "_inject_memory_context", lambda p, override_node_name=None: p)
+        monkeypatch.setattr(node, "_inject_response_language", lambda p: p)
 
         base_prompt = "This is the base system prompt."
         result = node._finalize_system_prompt(base_prompt)
@@ -198,6 +199,7 @@ class TestFinalizeSystemPrompt:
         node.skill_manager = skill_manager
         node.skill_func_tool = SkillFuncTool(manager=skill_manager, node_name="test_node")
         monkeypatch.setattr(node, "_inject_memory_context", lambda p, override_node_name=None: p)
+        monkeypatch.setattr(node, "_inject_response_language", lambda p: p)
 
         base_prompt = "This is the base system prompt."
         result = node._finalize_system_prompt(base_prompt)

--- a/tests/unit_tests/api/models/test_cli_models.py
+++ b/tests/unit_tests/api/models/test_cli_models.py
@@ -7,7 +7,7 @@
 import pytest
 from pydantic import ValidationError
 
-from datus.api.models.cli_models import SSEEndData, UserInteractionInput
+from datus.api.models.cli_models import SSEEndData, StreamChatInput, UserInteractionInput
 
 
 class TestSSEEndDataTokenFields:
@@ -108,3 +108,25 @@ class TestUserInteractionInput:
         """Missing input raises validation error."""
         with pytest.raises(ValidationError):
             UserInteractionInput(session_id="s1", interaction_key="k1")
+
+
+class TestStreamChatInputLanguage:
+    """``language`` is an optional per-request override for the configured
+    ``agent.language``. Unset means "inherit yaml default".
+    """
+
+    def test_language_defaults_to_none(self):
+        obj = StreamChatInput(message="hi")
+        assert obj.language is None
+
+    def test_language_accepts_code(self):
+        obj = StreamChatInput(message="hi", language="zh")
+        assert obj.language == "zh"
+
+    def test_language_independent_from_prompt_language(self):
+        """``prompt_language`` selects prompt template variant (unchanged);
+        ``language`` controls user-facing response language (new). Both must
+        travel as separate fields."""
+        obj = StreamChatInput(message="hi", prompt_language="zh", language="en")
+        assert obj.prompt_language == "zh"
+        assert obj.language == "en"

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -890,3 +890,49 @@ class TestCreateNodeCustomSubAgent:
         node = ChatTaskManager()._create_node(agent_config, "unknown", "s1")
         assert isinstance(node, _StubGenSQLNode)
         assert node.node_name == "unknown"
+
+
+class TestStartChatLanguageOverride:
+    """``StreamChatInput.language`` must land on the cloned config's
+    ``language`` attribute so every downstream AgenticNode sees it.
+
+    We short-circuit the async loop to avoid spinning up real nodes: the
+    override happens synchronously inside ``start_chat`` before
+    ``_run_loop`` is awaited.
+    """
+
+    @pytest.mark.asyncio
+    async def test_request_language_overrides_cloned_config(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        real_agent_config.language = "en"
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", language="zh")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task  # drain the fake loop
+        assert captured["agent_config"].language == "zh"
+        # Source config remains untouched because start_chat deep-copies.
+        assert real_agent_config.language == "en"
+
+    @pytest.mark.asyncio
+    async def test_missing_language_preserves_yaml_default(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        real_agent_config.language = "zh"
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi")  # no language field
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+        assert captured["agent_config"].language == "zh"

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -757,6 +757,44 @@ class TestAgentConfigFilesystemStrict:
         assert cfg.filesystem_strict is True
 
 
+class TestAgentConfigLanguage:
+    """``agent.language`` is the default response language for all agentic
+    nodes. Chat API requests may override it per-task on the cloned config.
+    """
+
+    def _make(self, tmp_path, **extra_kwargs):
+        kwargs = dict(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            skip_init_dirs=True,
+        )
+        kwargs.update(extra_kwargs)
+        return AgentConfig(**kwargs)
+
+    def test_default_language_is_none(self, tmp_path):
+        """Unset language lets the model choose its own response language."""
+        cfg = self._make(tmp_path)
+        assert cfg.language is None
+
+    def test_custom_language_preserved(self, tmp_path):
+        cfg = self._make(tmp_path, language="zh")
+        assert cfg.language == "zh"
+
+    def test_runtime_override_sets_language(self, tmp_path):
+        cfg = self._make(tmp_path, language="en")
+        cfg.language = "ja"
+        assert cfg.language == "ja"
+
+
 class TestServicesConfigFromDict:
     def test_bi_platforms_key_is_parsed(self):
         cfg = ServicesConfig.from_dict({"bi_platforms": {"superset": {"type": "superset"}}})


### PR DESCRIPTION
Adds an optional ``agent.language`` yaml field and ``StreamChatInput.language`` chat-API override that inject a single response-language directive into every AgenticNode via ``_finalize_system_prompt``. Unset means the model picks its own language, matching prior behavior.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-request `language` override and an optional `agent.language` YAML setting to pin the response language for agent outputs.
  * Language control affects natural-language outputs (replies, summaries, clarifying questions, sub-agent prompts, file prose) while leaving code/SQL/identifiers unchanged.

* **Documentation**
  * API and configuration docs updated to describe the new request/body field, YAML option, fallback rules, and scope of effect.

* **Tests**
  * Unit tests added/updated to cover language override and injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->