### PR TITLE
[Refactor] Unify list_* FuncTool returns to FuncToolListResult envelope

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -5,7 +5,7 @@
 # -*- coding: utf-8 -*-
 import inspect
 import json
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from agents import FunctionTool, function_tool
 from pydantic import BaseModel, Field
@@ -36,6 +36,59 @@ class FuncToolResult(BaseModel):
         default=None, description="Error message: field is not empty when success=0", init=True
     )
     result: Optional[Any] = Field(default=None, description="Result of the execution", init=True)
+
+
+class FuncToolListResult(BaseModel):
+    """Canonical envelope for list-shaped FuncTool results.
+
+    Put ``FuncToolListResult(...).model_dump()`` inside ``FuncToolResult.result``
+    whenever a tool method conceptually returns "a list of records" (BI
+    ``list_dashboards``, scheduler ``list_scheduler_jobs``, semantic
+    ``list_metrics``, ...). Separating row data (``items``) from pagination
+    signals (``total`` / ``has_more``) and tool-specific metadata (``extra``)
+    lets CLI / LLM / agent consumers share one shape instead of each inventing
+    their own heuristic.
+
+    Field rules:
+      * ``items`` is the single source of truth for row data. Always
+        ``List[Dict]``; empty is ``[]``, never ``None``. Never carries an
+        alternative encoding (CSV blob, scalars).
+      * ``total`` is the upstream full count when known. ``None`` means the
+        source doesn't expose a total — consumers should fall back to
+        ``has_more`` or ``len(items) < limit`` for pagination decisions.
+        Do not set ``total = len(items)`` as a placeholder; it makes
+        consumers wrongly conclude there is no next page.
+      * ``has_more`` is the explicit "another page exists" hint. ``None``
+        when the source gives no signal.
+      * ``extra`` holds tool-specific side-channel data — most commonly
+        ``{"next_offset": <int>}`` so the LLM can copy the value instead
+        of computing the next offset itself. Never holds an alternative
+        encoding of ``items``; never holds error state (that belongs in
+        ``FuncToolResult.error``).
+    """
+
+    items: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="The rows. Always a list of dicts; never None; empty is [].",
+    )
+    total: Optional[int] = Field(
+        default=None,
+        description=(
+            "Upstream full row count. May exceed len(items) when paginated. "
+            "None when the source doesn't expose a total."
+        ),
+    )
+    has_more: Optional[bool] = Field(
+        default=None,
+        description="Explicit 'next page exists' hint. None when unknown.",
+    )
+    extra: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Tool-specific side channel. Typically contains 'next_offset' "
+            "when has_more is True. Consumers ignore unknown keys."
+        ),
+    )
 
 
 def trans_to_function_tool(bound_method: Callable) -> FunctionTool:

--- a/datus/tools/func_tool/bi_tools.py
+++ b/datus/tools/func_tool/bi_tools.py
@@ -11,7 +11,7 @@ from typing import Any, List
 
 from agents import Tool
 
-from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
 from datus.utils.loggings import get_logger
 
 _VALID_TABLE_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,62}$")
@@ -54,13 +54,25 @@ class BIFuncTool:
     # Read operations (available on all adapters)
     # ------------------------------------------------------------------ #
 
-    def list_dashboards(self, search: str = "") -> FuncToolResult:
-        """List dashboards in the BI platform. Optionally filter by search keyword."""
-        try:
-            if hasattr(self.adapter, "list_dashboards"):
-                results = self.adapter.list_dashboards(search=search)
-                return FuncToolResult(result=[r.model_dump() for r in results])
+    def list_dashboards(self, search: str = "", limit: int = 50, offset: int = 0) -> FuncToolResult:
+        """List dashboards in the BI platform. Optionally filter by search keyword.
+
+        Returns:
+            FuncToolResult with result as FuncToolListResult:
+              - items (List[Dict]): dashboard rows
+              - total (int | None): upstream full count (Superset exposes it;
+                Grafana /api/search doesn't → None)
+              - has_more (bool | None): next-page hint
+              - extra (dict | None): {"next_offset": int} when has_more is True
+
+            Pagination: call again with offset=extra.next_offset until
+            has_more is False.
+        """
+        if not hasattr(self.adapter, "list_dashboards"):
             return FuncToolResult(success=0, error="This adapter does not support list_dashboards")
+        try:
+            page = self.adapter.list_dashboards(search=search, limit=limit, offset=offset)
+            return self._build_list_envelope(page, offset=offset, limit=limit)
         except Exception as exc:
             logger.warning(f"list_dashboards failed: {exc}")
             return FuncToolResult(success=0, error=str(exc))
@@ -76,11 +88,14 @@ class BIFuncTool:
             logger.warning(f"get_dashboard failed: {exc}")
             return FuncToolResult(success=0, error=str(exc))
 
-    def list_charts(self, dashboard_id: str) -> FuncToolResult:
-        """List all charts/panels in a dashboard."""
+    def list_charts(self, dashboard_id: str, limit: int = 50, offset: int = 0) -> FuncToolResult:
+        """List all charts/panels in a dashboard.
+
+        Returns a FuncToolListResult envelope; see list_dashboards for details.
+        """
         try:
-            results = self.adapter.list_charts(dashboard_id)
-            return FuncToolResult(result=[r.model_dump() for r in results])
+            page = self.adapter.list_charts(dashboard_id, limit=limit, offset=offset)
+            return self._build_list_envelope(page, offset=offset, limit=limit)
         except Exception as exc:
             logger.warning(f"list_charts failed: {exc}")
             return FuncToolResult(success=0, error=str(exc))
@@ -132,14 +147,47 @@ class BIFuncTool:
             logger.warning(f"get_chart_data failed: {exc}")
             return FuncToolResult(success=0, error=str(exc))
 
-    def list_datasets(self, dashboard_id: str = "") -> FuncToolResult:
-        """List datasets available in the BI platform. For Superset, pass dashboard_id to scope results."""
+    def list_datasets(self, dashboard_id: str = "", limit: int = 50, offset: int = 0) -> FuncToolResult:
+        """List datasets available in the BI platform.
+
+        For Superset, pass dashboard_id to scope results. Returns a
+        FuncToolListResult envelope; see list_dashboards for details.
+        """
         try:
-            results = self.adapter.list_datasets(dashboard_id)
-            return FuncToolResult(result=[r.model_dump() for r in results])
+            page = self.adapter.list_datasets(dashboard_id, limit=limit, offset=offset)
+            return self._build_list_envelope(page, offset=offset, limit=limit)
         except Exception as exc:
             logger.warning(f"list_datasets failed: {exc}")
             return FuncToolResult(success=0, error=str(exc))
+
+    @staticmethod
+    def _build_list_envelope(page: Any, *, offset: int, limit: int) -> FuncToolResult:
+        """Translate an adapter ``PaginatedResult[T]`` into ``FuncToolListResult``.
+
+        * ``items`` = rows serialised via ``.model_dump()`` so the LLM / CLI
+          sees plain dicts.
+        * ``total`` comes from the adapter when the upstream reports it
+          (Superset ``count``). ``None`` on platforms that don't
+          (Grafana ``/api/search``).
+        * ``has_more`` is exact when ``total`` is known; otherwise falls
+          back to ``len(items) == limit`` as the "looks like another page"
+          heuristic.
+        * ``extra.next_offset`` is provided only when ``has_more`` is True,
+          so consumers can paste it back verbatim.
+        """
+        rows = [r.model_dump() for r in page.items]
+        total = page.total
+        if total is not None:
+            has_more: bool | None = offset + len(rows) < total
+        elif limit > 0:
+            has_more = len(rows) == limit
+        else:
+            has_more = None
+        extra = {"next_offset": offset + len(rows)} if has_more else None
+        return FuncToolResult(
+            success=1,
+            result=FuncToolListResult(items=rows, total=total, has_more=has_more, extra=extra).model_dump(),
+        )
 
     # ------------------------------------------------------------------ #
     # Dashboard write operations (DashboardWriteMixin)

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -11,7 +11,7 @@ from agents import Tool
 
 from datus.configuration.agent_config import AgentConfig
 from datus.tools import BaseTool
-from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -290,14 +290,25 @@ class SchedulerTools(BaseTool):
     def list_scheduler_jobs(
         self,
         limit: int = 20,
+        offset: int = 0,
     ) -> FuncToolResult:
         """List all scheduled jobs on the configured scheduler.
 
         Args:
             limit: Maximum number of jobs to return (default 20).
+            offset: Pagination offset (default 0).
 
         Returns:
-            FuncToolResult with result containing a list of job summaries.
+            FuncToolResult with result as FuncToolListResult:
+              - items (List[Dict]): job summary rows
+              - total (int | None): upstream total when the platform reports
+                it; None in multi-tenant modes where the server's count
+                would be misleading
+              - has_more (bool | None): next-page hint
+              - extra (dict | None): {"next_offset": int} when has_more=True
+
+            Pagination: call again with offset=extra.next_offset until
+            has_more is False.
         """
         try:
             adapter = self._get_adapter()
@@ -305,22 +316,17 @@ class SchedulerTools(BaseTool):
             return FuncToolResult(success=0, error=str(exc))
 
         try:
-            jobs = adapter.list_jobs(limit=limit)
-            return FuncToolResult(
-                success=1,
-                result={
-                    "total": len(jobs),
-                    "jobs": [
-                        {
-                            "job_id": j.job_id,
-                            "job_name": j.job_name,
-                            "status": j.status.value,
-                            "schedule": j.schedule,
-                        }
-                        for j in jobs
-                    ],
-                },
-            )
+            page = adapter.list_jobs(limit=limit, offset=offset)
+            rows = [
+                {
+                    "job_id": j.job_id,
+                    "job_name": j.job_name,
+                    "status": j.status.value,
+                    "schedule": j.schedule,
+                }
+                for j in page.items
+            ]
+            return self._build_scheduler_envelope(rows, total=page.total, offset=offset, limit=limit)
         except Exception as exc:
             logger.error("list_scheduler_jobs failed: %s", exc)
             return FuncToolResult(success=0, error=str(exc))
@@ -329,6 +335,32 @@ class SchedulerTools(BaseTool):
                 adapter.close()
             except Exception as close_exc:
                 logger.debug("adapter.close() failed: %s", close_exc)
+
+    @staticmethod
+    def _build_scheduler_envelope(
+        rows: list,
+        *,
+        total: "int | None",
+        offset: int,
+        limit: int,
+    ) -> FuncToolResult:
+        """Wrap adapter ListJobsResult / ListRunsResult rows into FuncToolListResult.
+
+        When ``total`` is known, ``has_more`` is exact. When it's ``None``
+        (multi-tenant Airflow or status-filtered runs), fall back to
+        ``len(rows) == limit`` as the "looks like another page" heuristic.
+        """
+        if total is not None:
+            has_more: "bool | None" = offset + len(rows) < total
+        elif limit > 0:
+            has_more = len(rows) == limit
+        else:
+            has_more = None
+        extra = {"next_offset": offset + len(rows)} if has_more else None
+        return FuncToolResult(
+            success=1,
+            result=FuncToolListResult(items=rows, total=total, has_more=has_more, extra=extra).model_dump(),
+        )
 
     def pause_job(
         self,
@@ -525,15 +557,18 @@ class SchedulerTools(BaseTool):
         self,
         job_id: str,
         limit: int = 10,
+        offset: int = 0,
     ) -> FuncToolResult:
         """List recent runs of a scheduled job, showing status and timing.
 
         Args:
             job_id: The job/DAG identifier to query.
-            limit:          Maximum number of runs to return (default 10).
+            limit: Maximum number of runs to return (default 10).
+            offset: Pagination offset (default 0).
 
         Returns:
-            FuncToolResult with result containing a list of run summaries.
+            FuncToolResult with result as FuncToolListResult. See
+            ``list_scheduler_jobs`` for field semantics.
         """
         try:
             adapter = self._get_adapter()
@@ -541,25 +576,17 @@ class SchedulerTools(BaseTool):
             return FuncToolResult(success=0, error=str(exc))
 
         try:
-            runs = adapter.list_job_runs(job_id, limit=limit)
-            return FuncToolResult(
-                success=1,
-                result={
-                    "job_id": job_id,
-                    "total": len(runs),
-                    "runs": [
-                        {
-                            "run_id": r.run_id,
-                            "status": r.status.value,
-                            "started_at": r.started_at.isoformat()
-                            if hasattr(r.started_at, "isoformat")
-                            else r.started_at,
-                            "ended_at": r.ended_at.isoformat() if hasattr(r.ended_at, "isoformat") else r.ended_at,
-                        }
-                        for r in runs
-                    ],
-                },
-            )
+            page = adapter.list_job_runs(job_id, limit=limit, offset=offset)
+            rows = [
+                {
+                    "run_id": r.run_id,
+                    "status": r.status.value,
+                    "started_at": r.started_at.isoformat() if hasattr(r.started_at, "isoformat") else r.started_at,
+                    "ended_at": r.ended_at.isoformat() if hasattr(r.ended_at, "isoformat") else r.ended_at,
+                }
+                for r in page.items
+            ]
+            return self._build_scheduler_envelope(rows, total=page.total, offset=offset, limit=limit)
         except Exception as exc:
             logger.error("list_job_runs failed: %s", exc)
             return FuncToolResult(success=0, error=str(exc))

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -18,7 +18,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.storage.metric.store import MetricRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.func_tool.attribution_utils import DimensionAttributionUtil
-from datus.tools.func_tool.base import FuncToolResult, normalize_null, trans_to_function_tool
+from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, normalize_null, trans_to_function_tool
 from datus.tools.semantic_tools.base import BaseSemanticAdapter
 from datus.tools.semantic_tools.models import AnomalyContext
 from datus.tools.semantic_tools.registry import semantic_adapter_registry
@@ -26,6 +26,30 @@ from datus.utils.compress_utils import DataCompressor
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+
+def _normalize_dimension_rows(raw) -> list:
+    """Normalize dimension payload into ``List[Dict[str, Any]]`` for the envelope.
+
+    Adapters (MetricFlow) return pydantic ``DimensionInfo`` objects with a
+    full schema; storage may hold bare strings (dimension name only) or
+    dicts. FuncToolListResult.items must be ``List[Dict]`` either way, so
+    wrap naked strings into ``{"name": str}`` and leave structured rows
+    untouched.
+    """
+    if not raw:
+        return []
+    normalized = []
+    for d in raw:
+        if hasattr(d, "model_dump"):
+            normalized.append(d.model_dump())
+        elif isinstance(d, dict):
+            normalized.append(d)
+        elif isinstance(d, str):
+            normalized.append({"name": d})
+        else:
+            normalized.append({"name": str(d)})
+    return normalized
 
 
 def _run_async(coro):
@@ -235,8 +259,17 @@ class SemanticTools:
             offset: Number of metrics to skip
 
         Returns:
-            FuncToolResult with list of metric dicts, each containing:
-                - name, description, type, dimensions, measures, unit, format, path
+            FuncToolResult with result as FuncToolListResult:
+              - items (List[Dict]): metric rows, each with name, description, type,
+                dimensions, measures, unit, format, path
+              - total (int | None): full metric count before pagination
+              - has_more (bool | None): True when offset + len(items) < total
+              - extra (dict | None): {"next_offset": int} when has_more is True
+
+            Pagination: call again with offset=extra.next_offset until
+            has_more is False. Default limit=100; override if you need bigger
+            pages. list_metrics never compresses — use the limit to control
+            response size.
         """
         # Normalize null values from LLM
         path = normalize_null(path)
@@ -253,7 +286,6 @@ class SemanticTools:
             paginated_metrics = all_metrics[offset : offset + limit]
 
             if paginated_metrics:
-                # Format storage results
                 formatted_metrics = [
                     {
                         "name": m.get("name"),
@@ -267,21 +299,16 @@ class SemanticTools:
                     }
                     for m in paginated_metrics
                 ]
-                return FuncToolResult(
-                    success=1,
-                    result=self.compressor.compress(formatted_metrics),
-                )
+                return self._build_metrics_envelope(formatted_metrics, total=len(all_metrics), offset=offset)
 
-            # Fallback to adapter if storage is empty
+            # Empty storage AND no adapter → empty envelope (total still reflects
+            # the filtered all_metrics, which may be >0 if offset overshot).
             if not self.adapter:
-                return FuncToolResult(
-                    success=1,
-                    result=self.compressor.compress([]),
-                )
+                return self._build_metrics_envelope([], total=len(all_metrics), offset=offset)
 
             logger.info("Storage empty, falling back to adapter")
             async_result = _run_async(self.adapter.list_metrics(path=path, limit=limit, offset=offset))
-            paginated_metrics = [
+            adapter_metrics = [
                 {
                     "name": m.name,
                     "description": m.description,
@@ -294,11 +321,9 @@ class SemanticTools:
                 }
                 for m in async_result
             ]
-
-            return FuncToolResult(
-                success=1,
-                result=self.compressor.compress(paginated_metrics),
-            )
+            # Adapter path has no upstream total — leave it None so consumers
+            # know to use has_more / len(items) < limit as the pagination hint.
+            return self._build_metrics_envelope(adapter_metrics, total=None, offset=offset, limit=limit)
 
         except Exception as e:
             logger.error(f"Error listing metrics: {e}")
@@ -306,6 +331,33 @@ class SemanticTools:
                 success=0,
                 error=f"Failed to list metrics: {str(e)}",
             )
+
+    @staticmethod
+    def _build_metrics_envelope(
+        items: List[dict],
+        *,
+        total: Optional[int],
+        offset: int,
+        limit: Optional[int] = None,
+    ) -> FuncToolResult:
+        """Wrap paginated metric rows into a FuncToolListResult.
+
+        When ``total`` is known (storage path) ``has_more`` is exact. When
+        ``total`` is None (adapter path) ``has_more`` falls back to
+        ``len(items) == limit`` — a heuristic, but good enough for the LLM
+        to decide whether to fetch another page.
+        """
+        if total is not None:
+            has_more: Optional[bool] = offset + len(items) < total
+        elif limit is not None:
+            has_more = len(items) == limit
+        else:
+            has_more = None
+        extra = {"next_offset": offset + len(items)} if has_more else None
+        return FuncToolResult(
+            success=1,
+            result=FuncToolListResult(items=items, total=total, has_more=has_more, extra=extra).model_dump(),
+        )
 
     def get_dimensions(
         self,
@@ -322,7 +374,13 @@ class SemanticTools:
             path: Optional subject tree path (e.g., ["Finance", "Revenue"])
 
         Returns:
-            FuncToolResult with list of dimensions (names or objects depending on source)
+            FuncToolResult with result as FuncToolListResult:
+              - items (List[Dict]): dimension rows. Adapter dimensions expose
+                their full schema (name, type, expr, ...); storage dimensions
+                fall back to a minimal {"name": ...} shape when only names are
+                stored.
+              - total, has_more, extra: dimensions isn't paginated, so total
+                equals len(items) and has_more is False.
         """
         # Normalize null values from LLM
         path = normalize_null(path)
@@ -331,9 +389,10 @@ class SemanticTools:
             # Get dimensions from adapter (MetricFlow) to ensure consistency with query execution
             if self.adapter:
                 dimensions = _run_async(self.adapter.get_dimensions(metric_name=metric_name, path=path))
+                items = _normalize_dimension_rows(dimensions)
                 return FuncToolResult(
                     success=1,
-                    result=dimensions,
+                    result=FuncToolListResult(items=items, total=len(items), has_more=False).model_dump(),
                 )
 
             # Fallback to storage if no adapter configured
@@ -351,16 +410,17 @@ class SemanticTools:
                     metric_details = matching[0]
 
             if metric_details:
-                dimensions = metric_details.get("dimensions", [])
+                raw = metric_details.get("dimensions", [])
+                items = _normalize_dimension_rows(raw)
                 return FuncToolResult(
                     success=1,
-                    result=dimensions,
+                    result=FuncToolListResult(items=items, total=len(items), has_more=False).model_dump(),
                 )
 
             return FuncToolResult(
                 success=0,
                 error=f"Metric '{metric_name}' not found and no adapter configured",
-                result=[],
+                result=FuncToolListResult(items=[], total=0, has_more=False).model_dump(),
             )
 
         except Exception as e:

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -7,7 +7,7 @@ import json
 
 import pytest
 
-from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
 
 
 class TestTransToFunctionTool:
@@ -100,3 +100,54 @@ class TestTransToFunctionTool:
 
         assert result["success"] == 1
         assert result["result"] == "test"
+
+
+class TestFuncToolListResult:
+    """Tests for the canonical list-shaped envelope."""
+
+    def test_defaults_empty_items_and_none_pagination(self):
+        env = FuncToolListResult()
+        assert env.items == []
+        assert env.total is None
+        assert env.has_more is None
+        assert env.extra is None
+
+    def test_serialization_round_trips_through_funcresult(self):
+        env = FuncToolListResult(
+            items=[{"id": "1", "name": "foo"}, {"id": "2", "name": "bar"}],
+            total=137,
+            has_more=True,
+            extra={"next_offset": 20},
+        )
+        outer = FuncToolResult(result=env.model_dump())
+        dumped = outer.model_dump(mode="json")
+
+        assert dumped["success"] == 1
+        assert dumped["error"] is None
+        assert dumped["result"] == {
+            "items": [{"id": "1", "name": "foo"}, {"id": "2", "name": "bar"}],
+            "total": 137,
+            "has_more": True,
+            "extra": {"next_offset": 20},
+        }
+
+    def test_items_stay_a_list_when_none_passed(self):
+        # Pydantic rejects items=None (default_factory returns []), so the
+        # "always a list" invariant is enforced at construction time.
+        with pytest.raises(ValueError):
+            FuncToolListResult(items=None)
+
+    def test_extra_accepts_arbitrary_tool_metadata(self):
+        env = FuncToolListResult(
+            items=[{"k": "v"}],
+            extra={"next_offset": 5, "cursor": "abc", "filters_applied": ["x"]},
+        )
+        assert env.extra["cursor"] == "abc"
+        assert env.extra["filters_applied"] == ["x"]
+
+    def test_empty_items_is_empty_list_not_missing(self):
+        env = FuncToolListResult(items=[], total=0, has_more=False)
+        dumped = env.model_dump()
+        assert dumped["items"] == []
+        assert dumped["total"] == 0
+        assert dumped["has_more"] is False

--- a/tests/unit_tests/tools/func_tool/test_bi_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_bi_tools.py
@@ -48,6 +48,19 @@ class _ChartDataResult:
         return self.__dict__
 
 
+class _PaginatedResult:
+    """Tiny stand-in for ``datus_bi_core.models.PaginatedResult[T]``.
+
+    Real adapters return ``PaginatedResult`` (items + optional total); the
+    stub mirrors that surface so BIFuncTool's envelope builder reads the
+    same attributes either way.
+    """
+
+    def __init__(self, items, total=None):
+        self.items = items
+        self.total = total
+
+
 class MockDashboardWriteMixin:
     def create_dashboard(self, spec):
         return _DashboardInfo(id=10, name=spec.title)
@@ -89,17 +102,17 @@ class FullMockAdapter(MockDashboardWriteMixin, MockChartWriteMixin, MockDatasetW
 
     supports_chart_data = True
 
-    def list_dashboards(self, search="", page_size=20):
-        return [_DashboardInfo(id=1, name="Test Dashboard")]
+    def list_dashboards(self, search="", limit=50, offset=0):
+        return _PaginatedResult(items=[_DashboardInfo(id=1, name="Test Dashboard")], total=1)
 
     def get_dashboard_info(self, dashboard_id):
         return _DashboardInfo(id=dashboard_id, name="Test", description="", chart_ids=[])
 
-    def list_charts(self, dashboard_id):
-        return [_ChartInfo(id=1, name="Chart 1", chart_type="bar")]
+    def list_charts(self, dashboard_id, limit=50, offset=0):
+        return _PaginatedResult(items=[_ChartInfo(id=1, name="Chart 1", chart_type="bar")], total=1)
 
-    def list_datasets(self, dashboard_id=""):
-        return [_DatasetInfo(id=1, name="orders", dialect="postgresql")]
+    def list_datasets(self, dashboard_id="", limit=50, offset=0):
+        return _PaginatedResult(items=[_DatasetInfo(id=1, name="orders", dialect="postgresql")], total=1)
 
     def get_chart(self, chart_id, dashboard_id=None):
         return _ChartInfo(id=chart_id, name="Test Chart", chart_type="bar")
@@ -126,33 +139,33 @@ class ReadOnlyMockAdapter:
 
     supports_chart_data = False
 
-    def list_dashboards(self, search="", page_size=20):
-        return []
+    def list_dashboards(self, search="", limit=50, offset=0):
+        return _PaginatedResult(items=[], total=0)
 
     def get_dashboard_info(self, dashboard_id):
         return _DashboardInfo(id=dashboard_id, name="Read Only Dashboard")
 
-    def list_charts(self, dashboard_id):
-        return []
+    def list_charts(self, dashboard_id, limit=50, offset=0):
+        return _PaginatedResult(items=[], total=0)
 
     def get_chart(self, chart_id, dashboard_id=None):
         return None
 
-    def list_datasets(self, dashboard_id=""):
-        return []
+    def list_datasets(self, dashboard_id="", limit=50, offset=0):
+        return _PaginatedResult(items=[], total=0)
 
 
 class MethodOnlyChartDataAdapter:
     """Mock adapter that implements get_chart_data without any support flag."""
 
-    def list_dashboards(self, search="", page_size=20):
-        return [_DashboardInfo(id=1, name="Test Dashboard")]
+    def list_dashboards(self, search="", limit=50, offset=0):
+        return _PaginatedResult(items=[_DashboardInfo(id=1, name="Test Dashboard")], total=1)
 
     def get_dashboard_info(self, dashboard_id):
         return _DashboardInfo(id=dashboard_id, name="Test")
 
-    def list_charts(self, dashboard_id):
-        return []
+    def list_charts(self, dashboard_id, limit=50, offset=0):
+        return _PaginatedResult(items=[], total=0)
 
     def get_chart(self, chart_id, dashboard_id=None):
         return _ChartInfo(id=chart_id, name="Test Chart", chart_type="bar")
@@ -167,8 +180,8 @@ class MethodOnlyChartDataAdapter:
             extra={},
         )
 
-    def list_datasets(self, dashboard_id=""):
-        return []
+    def list_datasets(self, dashboard_id="", limit=50, offset=0):
+        return _PaginatedResult(items=[], total=0)
 
 
 # ---- Build a mock datus_bi_core module ----
@@ -266,7 +279,11 @@ class TestBIFuncToolReadOps:
         tool = self._make_tool()
         result = tool.list_dashboards(search="Test")
         assert result.success == 1
-        assert len(result.result) == 1
+        envelope = result.result
+        assert envelope["items"] == [{"id": 1, "name": "Test Dashboard"}]
+        assert envelope["total"] == 1
+        assert envelope["has_more"] is False
+        assert envelope["extra"] is None
 
     def test_get_dashboard_success(self):
         tool = self._make_tool()
@@ -278,7 +295,10 @@ class TestBIFuncToolReadOps:
         tool = self._make_tool()
         result = tool.list_charts("1")
         assert result.success == 1
-        assert len(result.result) == 1
+        envelope = result.result
+        assert envelope["items"] == [{"id": 1, "name": "Chart 1", "chart_type": "bar"}]
+        assert envelope["total"] == 1
+        assert envelope["has_more"] is False
 
     def test_get_chart_success(self):
         tool = self._make_tool()
@@ -427,7 +447,10 @@ class TestBIFuncToolWriteOps:
         tool = self._make_tool()
         result = tool.list_datasets()
         assert result.success == 1
-        assert len(result.result) == 1
+        envelope = result.result
+        assert envelope["items"] == [{"id": 1, "name": "orders", "dialect": "postgresql"}]
+        assert envelope["total"] == 1
+        assert envelope["has_more"] is False
 
     def test_update_dashboard_success(self):
         tool = self._make_tool()
@@ -458,14 +481,21 @@ class TestBIFuncToolWriteOps:
         assert result.result["name"] == "my_ds"
 
     def test_list_dashboards_read_only_adapter(self):
-        """list_dashboards is now in BIAdapterBase and always available."""
+        """list_dashboards is now in BIAdapterBase and always available.
+
+        The read-only adapter returns an empty page — exercises the
+        envelope's empty-items / total=0 / has_more=False branch.
+        """
         with patch.dict(sys.modules, {"datus_bi_core": _bi_core_mock}):
             from datus.tools.func_tool.bi_tools import BIFuncTool
 
             tool = BIFuncTool(ReadOnlyMockAdapter())
         result = tool.list_dashboards()
         assert result.success == 1
-        assert isinstance(result.result, list)
+        envelope = result.result
+        assert envelope["items"] == []
+        assert envelope["total"] == 0
+        assert envelope["has_more"] is False
 
     def test_get_dashboard_not_found(self):
         tool = self._make_tool()

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -74,6 +74,17 @@ def _make_agent_config(scheduler_config=None):
     return cfg
 
 
+class _SchedulerPage:
+    """Minimal stand-in for ``PaginatedScheduledResult`` / ``ListJobsResult`` /
+    ``ListRunsResult``. The SchedulerTools envelope builder only looks at
+    ``.items`` and ``.total``, so mirroring those two attributes is enough.
+    """
+
+    def __init__(self, items, total=None):
+        self.items = list(items)
+        self.total = total
+
+
 def _make_scheduled_job(job_id="spark_pi_test"):
     job = MagicMock()
     job.job_id = job_id
@@ -242,11 +253,21 @@ class TestAdapterCloseError:
                 {},
                 lambda a: setattr(a, "get_job", MagicMock(return_value=_make_scheduled_job())),
             ),
-            ("list_scheduler_jobs", (), {}, lambda a: setattr(a, "list_jobs", MagicMock(return_value=[]))),
+            (
+                "list_scheduler_jobs",
+                (),
+                {},
+                lambda a: setattr(a, "list_jobs", MagicMock(return_value=_SchedulerPage(items=[], total=0))),
+            ),
             ("pause_job", ("dag_1",), {}, None),
             ("resume_job", ("dag_1",), {}, None),
             ("delete_job", ("dag_1",), {}, None),
-            ("list_job_runs", ("dag_1",), {}, lambda a: setattr(a, "list_job_runs", MagicMock(return_value=[]))),
+            (
+                "list_job_runs",
+                ("dag_1",),
+                {},
+                lambda a: setattr(a, "list_job_runs", MagicMock(return_value=_SchedulerPage(items=[], total=0))),
+            ),
             (
                 "get_run_log",
                 ("dag_1", "run_1"),
@@ -498,9 +519,12 @@ class TestGetSchedulerJob:
 
 class TestListSchedulerJobs:
     def test_list_jobs(self):
-        """list_scheduler_jobs returns a list of job summaries."""
+        """list_scheduler_jobs returns the canonical FuncToolListResult envelope."""
         mock_adapter = MagicMock()
-        mock_adapter.list_jobs.return_value = [_make_scheduled_job("dag_a"), _make_scheduled_job("dag_b")]
+        mock_adapter.list_jobs.return_value = _SchedulerPage(
+            items=[_make_scheduled_job("dag_a"), _make_scheduled_job("dag_b")],
+            total=2,
+        )
 
         tools = SchedulerTools(_make_agent_config())
 
@@ -508,8 +532,13 @@ class TestListSchedulerJobs:
             result = tools.list_scheduler_jobs(limit=10)
 
         assert result.success == 1
-        assert result.result["total"] == 2
-        assert result.result["jobs"][0]["job_id"] == "dag_a"
+        envelope = result.result
+        assert envelope["total"] == 2
+        assert len(envelope["items"]) == 2
+        assert envelope["items"][0]["job_id"] == "dag_a"
+        # 2 items with total=2 and offset=0 → last page, no next_offset.
+        assert envelope["has_more"] is False
+        assert envelope["extra"] is None
 
 
 # ── adapter.py: submit_job with job_type=spark ───────────────────────────
@@ -993,7 +1022,7 @@ class TestListJobRuns:
         mock_run.ended_at = datetime(2025, 1, 1, 8, 5, 0, tzinfo=timezone.utc)
 
         mock_adapter = MagicMock()
-        mock_adapter.list_job_runs.return_value = [mock_run]
+        mock_adapter.list_job_runs.return_value = _SchedulerPage(items=[mock_run], total=1)
 
         tools = SchedulerTools(_make_agent_config())
 
@@ -1001,11 +1030,14 @@ class TestListJobRuns:
             result = tools.list_job_runs("my_dag", limit=5)
 
         assert result.success == 1
-        assert result.result["total"] == 1
-        run = result.result["runs"][0]
+        envelope = result.result
+        assert envelope["total"] == 1
+        assert len(envelope["items"]) == 1
+        run = envelope["items"][0]
         assert run["run_id"] == "run_001"
         assert run["started_at"] == "2025-01-01T08:00:00+00:00"
         assert run["ended_at"] == "2025-01-01T08:05:00+00:00"
+        assert envelope["has_more"] is False
 
     def test_list_runs_string_timestamps(self):
         """Runs with string timestamps should pass through as-is."""
@@ -1016,7 +1048,7 @@ class TestListJobRuns:
         mock_run.ended_at = None
 
         mock_adapter = MagicMock()
-        mock_adapter.list_job_runs.return_value = [mock_run]
+        mock_adapter.list_job_runs.return_value = _SchedulerPage(items=[mock_run], total=None)
 
         tools = SchedulerTools(_make_agent_config())
 
@@ -1024,7 +1056,7 @@ class TestListJobRuns:
             result = tools.list_job_runs("my_dag")
 
         assert result.success == 1
-        run = result.result["runs"][0]
+        run = result.result["items"][0]
         assert run["started_at"] == "2025-01-01T08:00:00Z"
         assert run["ended_at"] is None
 

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -383,20 +383,37 @@ class TestListMetrics:
         result = semantic_tools_ext.list_metrics()
 
         assert result.success == 1
-        # Result is now a compressed dict
-        assert isinstance(result.result, dict)
-        assert result.result["original_rows"] == 1
-        assert "orders" in result.result["compressed_data"]
+        envelope = result.result
+        assert envelope["items"] == [
+            {
+                "name": "orders",
+                "description": "Order count",
+                "type": "count",
+                "dimensions": [],
+                "measures": [],
+                "unit": None,
+                "format": None,
+                "path": ["Sales"],
+            }
+        ]
+        assert envelope["total"] == 1
+        assert envelope["has_more"] is False
+        assert envelope["extra"] is None
+        # Contract: list_metrics MUST NOT carry compressor artefacts anymore.
+        assert "compressed_data" not in envelope
+        assert "original_rows" not in envelope
 
-    def test_empty_storage_no_adapter_returns_compressed_empty(self, semantic_tools_ext):
+    def test_empty_storage_no_adapter_returns_empty_envelope(self, semantic_tools_ext):
         semantic_tools_ext.metric_rag.search_all_metrics.return_value = []
 
         result = semantic_tools_ext.list_metrics()
 
         assert result.success == 1
-        assert isinstance(result.result, dict)
-        assert result.result["original_rows"] == 0
-        assert result.result["is_compressed"] is False
+        envelope = result.result
+        assert envelope["items"] == []
+        assert envelope["total"] == 0
+        assert envelope["has_more"] is False
+        assert envelope["extra"] is None
 
     def test_path_filter_applied(self, semantic_tools_ext):
         semantic_tools_ext.metric_rag.search_all_metrics.return_value = [
@@ -425,9 +442,11 @@ class TestListMetrics:
         result = semantic_tools_ext.list_metrics(path=["Finance"])
 
         assert result.success == 1
-        assert isinstance(result.result, dict)
-        assert result.result["original_rows"] == 1
-        assert "m1" in result.result["compressed_data"]
+        envelope = result.result
+        names = [row["name"] for row in envelope["items"]]
+        assert names == ["m1"]
+        assert envelope["total"] == 1
+        assert envelope["has_more"] is False
 
     def test_pagination(self, semantic_tools_ext):
         metrics = [
@@ -448,9 +467,36 @@ class TestListMetrics:
         result = semantic_tools_ext.list_metrics(limit=3, offset=2)
 
         assert result.success == 1
-        assert isinstance(result.result, dict)
-        assert result.result["original_rows"] == 3
-        assert "m2" in result.result["compressed_data"]
+        envelope = result.result
+        assert [row["name"] for row in envelope["items"]] == ["m2", "m3", "m4"]
+        assert envelope["total"] == 10
+        assert envelope["has_more"] is True
+        assert envelope["extra"] == {"next_offset": 5}
+
+    def test_pagination_last_page(self, semantic_tools_ext):
+        metrics = [
+            {
+                "name": f"m{i}",
+                "subject_path": [],
+                "description": "",
+                "metric_type": "",
+                "dimensions": [],
+                "base_measures": [],
+                "unit": None,
+                "format": None,
+            }
+            for i in range(5)
+        ]
+        semantic_tools_ext.metric_rag.search_all_metrics.return_value = metrics
+
+        result = semantic_tools_ext.list_metrics(limit=3, offset=3)
+
+        assert result.success == 1
+        envelope = result.result
+        assert [row["name"] for row in envelope["items"]] == ["m3", "m4"]
+        assert envelope["total"] == 5
+        assert envelope["has_more"] is False
+        assert envelope["extra"] is None
 
     def test_falls_back_to_adapter(self, semantic_tools_with_adapter):
         tool, mock_adapter = semantic_tools_with_adapter
@@ -463,9 +509,13 @@ class TestListMetrics:
             result = tool.list_metrics()
 
         assert result.success == 1
-        assert isinstance(result.result, dict)
-        assert result.result["original_rows"] == 1
-        assert "revenue" in result.result["compressed_data"]
+        envelope = result.result
+        assert len(envelope["items"]) == 1
+        assert envelope["items"][0]["name"] == "revenue"
+        # Adapter path has no upstream total — envelope signals unknown via None.
+        assert envelope["total"] is None
+        # has_more heuristic: len(items) == limit (1) < default limit (100) → False.
+        assert envelope["has_more"] is False
 
     def test_exception_returns_failure(self, semantic_tools_ext):
         semantic_tools_ext.metric_rag.search_all_metrics.side_effect = Exception("db error")
@@ -483,7 +533,10 @@ class TestGetDimensions:
             result = tool.get_dimensions("revenue")
 
         assert result.success == 1
-        assert result.result == ["date", "region"]
+        envelope = result.result
+        assert envelope["items"] == [{"name": "date"}, {"name": "region"}]
+        assert envelope["total"] == 2
+        assert envelope["has_more"] is False
 
     def test_no_adapter_from_storage(self, semantic_tools_ext):
         semantic_tools_ext.metric_rag.search_all_metrics.return_value = [
@@ -493,7 +546,9 @@ class TestGetDimensions:
         result = semantic_tools_ext.get_dimensions("revenue")
 
         assert result.success == 1
-        assert result.result == ["date", "channel"]
+        envelope = result.result
+        assert envelope["items"] == [{"name": "date"}, {"name": "channel"}]
+        assert envelope["total"] == 2
 
     def test_no_adapter_metric_not_found(self, semantic_tools_ext):
         semantic_tools_ext.metric_rag.search_all_metrics.return_value = []
@@ -502,6 +557,9 @@ class TestGetDimensions:
 
         assert result.success == 0
         assert "not found" in result.error
+        # Even the error path returns an envelope shape, keeping the
+        # consumer contract uniform.
+        assert result.result == {"items": [], "total": 0, "has_more": False, "extra": None}
 
     def test_with_path_filter(self, semantic_tools_ext):
         mock_storage = Mock()
@@ -511,7 +569,8 @@ class TestGetDimensions:
         result = semantic_tools_ext.get_dimensions("revenue", path=["Finance"])
 
         assert result.success == 1
-        assert result.result == ["date"]
+        envelope = result.result
+        assert envelope["items"] == [{"name": "date"}]
 
     def test_exception_returns_failure(self, semantic_tools_ext):
         semantic_tools_ext.metric_rag.search_all_metrics.side_effect = Exception("conn error")
@@ -725,8 +784,14 @@ class TestCompressorModelName:
             tool = SemanticTools(agent_config=config)
             assert tool.compressor.model_name == "deepseek/deepseek-chat"
 
-    def test_list_metrics_returns_compressed_dict(self, semantic_tools_ext):
-        """list_metrics result should be a compressed dict, not a raw list."""
+    def test_list_metrics_returns_envelope_without_compressor(self, semantic_tools_ext):
+        """list_metrics returns the canonical FuncToolListResult envelope.
+
+        Regression: list_metrics used to wrap rows in DataCompressor output
+        (``{original_rows, compressed_data, ...}``) regardless of size.
+        After the envelope migration it returns ``{items, total, has_more,
+        extra}`` with NO compressor artefacts — list_* never compresses.
+        """
         semantic_tools_ext.metric_rag.search_all_metrics.return_value = [
             {
                 "name": "orders",
@@ -741,5 +806,10 @@ class TestCompressorModelName:
         ]
         result = semantic_tools_ext.list_metrics()
         assert result.success == 1
-        assert "original_rows" in result.result
-        assert "compression_type" in result.result
+        envelope = result.result
+        assert set(envelope.keys()) == {"items", "total", "has_more", "extra"}
+        assert envelope["items"][0]["name"] == "orders"
+        # No compressor residue leaks through.
+        assert "original_rows" not in envelope
+        assert "compressed_data" not in envelope
+        assert "compression_type" not in envelope


### PR DESCRIPTION
## Why

Three ``list_*`` FuncTool methods return completely different shapes, which forces every consumer (CLI ``.services.*`` dispatcher, LLM prompts, agent nodes) to invent its own shape-guessing heuristic:

| Tool                                 | Today's result shape                                               |
|--------------------------------------|---------------------------------------------------------------------|
| ``BIFuncTool.list_dashboards / ...`` | bare ``List[dict]``, no pagination, no total                        |
| ``SchedulerTools.list_scheduler_jobs`` | ``{total: len(jobs), jobs: [...]}``                               |
| ``SchedulerTools.list_job_runs``     | ``{job_id, total: len(runs), runs: [...]}``                         |
| ``SemanticTools.list_metrics``       | ``DataCompressor.compress()`` envelope with a CSV string inside     |

Specifics:
- BI drops upstream ``total_entries`` / ``count``, so the LLM can't tell "is this the full result or just the first 20?".
- Each tool invents its own rows key (``jobs`` / ``runs`` / ``compressed_data``), bloating both CLI rendering and prompt docstrings.
- ``list_metrics`` leaks ``DataCompressor`` (a token-budget concern) into the base list shape — CLI has to reverse-engineer the CSV back into rows.
- No ``offset`` in BI / Scheduler tool signatures, so LLMs can't page past the first window.

## Solution

Introduce ``datus.tools.func_tool.base.FuncToolListResult`` — the canonical envelope every list-shaped FuncTool now nests inside ``FuncToolResult.result``:

```python
class FuncToolListResult(BaseModel):
    items: List[Dict[str, Any]]    # always a list; empty is []
    total: Optional[int] = None    # upstream full count when known
    has_more: Optional[bool] = None
    extra: Optional[Dict[str, Any]] = None  # e.g. {"next_offset": int}
```

Migrate all three tools:

- **BIFuncTool**: ``list_dashboards / list_charts / list_datasets`` gain ``(limit, offset)`` and return the envelope. Depends on the paired ``datus-bi-adapters#3`` which adds ``PaginatedResult[T]`` + ``limit/offset`` at the adapter layer.
- **SchedulerTools**: ``list_scheduler_jobs / list_job_runs`` gain ``offset`` and return the envelope. Depends on ``datus-scheduler-adapters#4`` which adds ``ListJobsResult`` / ``ListRunsResult`` and wires Airflow ``total_entries`` through.
- **SemanticTools**: ``list_metrics`` drops ``DataCompressor`` entirely (list_* never compresses — token control belongs to ``limit``). ``get_dimensions`` also moves onto the envelope. ``query_metrics`` keeps its compressor path untouched — it's query-shaped, not list-shaped.

Both agent-side migrations share a tiny ``_build_*_envelope`` helper that applies one rule: ``has_more`` is exact when ``total`` is known; otherwise falls back to ``len(items) == limit`` as a heuristic; ``extra.next_offset`` only appears when ``has_more is True`` so the LLM can paste it back verbatim.

Follow-ups:
- ``adapter-command`` rebases onto ``main`` after merge and rewrites CLI ``service_commands`` to read ``payload["items"]`` + ``payload["extra"]["next_offset"]``, deleting the compressor / jobs / runs heuristics there.

## Test Cases

All unit tests migrated to the new envelope assertions:

- ``tests/unit_tests/tools/func_tool/test_base.py``: new ``TestFuncToolListResult`` class covering defaults, serialization round-trip through ``FuncToolResult``, arbitrary ``extra`` keys, and the ``items`` always-a-list invariant.
- ``tests/unit_tests/tools/func_tool/test_bi_tools.py``: 54/54 pass. New assertions on ``items`` / ``total`` / ``has_more`` / ``extra`` across success, empty, and read-only adapter paths.
- ``tests/unit_tests/tools/func_tool/test_scheduler_tools.py``: 64/64 pass. Adds a ``_SchedulerPage`` test helper mirroring the adapter envelope shape.
- ``tests/unit_tests/tools/func_tool/test_semantic_tools.py``: 55/55 pass. Regression-asserts that ``list_metrics`` no longer emits ``compressed_data`` / ``original_rows`` / ``compression_type``.

Overall unit coverage: 82.82%. Diff coverage on changed files: 88%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support (limit and offset parameters) to list dashboards, charts, datasets, scheduler jobs, and job runs operations.
  * Introduced standardized list result format with pagination metadata including total count, has-more indicator, and next-offset information.

* **Bug Fixes**
  * Standardized list operation return formats for consistent data structure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->