### PR TITLE
[Feature] Default semantic adapter to metricflow

### DIFF
--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -859,6 +859,14 @@ class AgentConfig:
             ),
         )
 
+    def default_semantic_adapter(self) -> Optional[str]:
+        if len(self.semantic_layer_configs) == 1:
+            return next(iter(self.semantic_layer_configs))
+        if not self.semantic_layer_configs:
+            # MetricFlow is currently the built-in default semantic adapter.
+            return "metricflow"
+        return None
+
     def resolve_semantic_adapter(self, adapter_type: Optional[str] = None) -> Optional[str]:
         normalized = str(adapter_type or "").lower().strip()
         if normalized:
@@ -874,10 +882,9 @@ class AgentConfig:
                 ),
             )
 
-        if not self.semantic_layer_configs:
-            return None
-        if len(self.semantic_layer_configs) == 1:
-            return next(iter(self.semantic_layer_configs))
+        default_adapter = self.default_semantic_adapter()
+        if default_adapter:
+            return default_adapter
         raise DatusException(
             ErrorCode.COMMON_CONFIG_ERROR,
             message=(

--- a/docs/adapters/semantic_adapters.md
+++ b/docs/adapters/semantic_adapters.md
@@ -50,6 +50,8 @@ Once installed, Datus Agent will automatically detect and load the adapter.
 
 Configure semantic adapters under `agent.services.semantic_layer` in `agent.yml`:
 
+The entire `semantic_layer` block is optional when you use MetricFlow with default settings. In that case Datus defaults to `metricflow` automatically.
+
 ### MetricFlow
 
 ```yaml
@@ -78,6 +80,7 @@ By default, Datus points MetricFlow at the current project's semantic model dire
 
 - The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup. Comparison is case-insensitive and trims surrounding whitespace, so `MetricFlow` and ` metricflow ` also match.
 - Semantic nodes choose the adapter with `semantic_adapter`.
+- If both `services.semantic_layer` and `semantic_adapter` are omitted, Datus defaults to `metricflow`.
 - If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.
 - If multiple semantic layers are configured, set `semantic_adapter` explicitly.
 

--- a/docs/adapters/semantic_adapters.zh.md
+++ b/docs/adapters/semantic_adapters.zh.md
@@ -50,6 +50,8 @@ pip install -e ../datus-semantic-adapter/datus-semantic-metricflow
 
 在 `agent.yml` 的 `agent.services.semantic_layer` 中配置语义层适配器：
 
+如果你使用的是 MetricFlow 的默认配置，整个 `semantic_layer` 段也可以省略；此时 Datus 会自动默认使用 `metricflow`。
+
 ### MetricFlow
 
 ```yaml
@@ -78,6 +80,7 @@ agent:
 
 - `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。比较时会先对 key 与 `type` 做 lowercase + trim 处理，因此 `MetricFlow` 或 ` metricflow ` 也会被视为与 `metricflow` 匹配。
 - 语义相关节点通过 `semantic_adapter` 选择适配器。
+- 如果 `services.semantic_layer` 和 `semantic_adapter` 都省略，Datus 会默认使用 `metricflow`。
 - 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。
 - 如果配置了多个 semantic layer，则必须显式填写 `semantic_adapter`。
 

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -2,6 +2,8 @@
 
 Semantic adapters are configured under `agent.services.semantic_layer`.
 
+When you use MetricFlow with default settings, the entire `semantic_layer` block can be omitted. Datus defaults to `metricflow`.
+
 ## Structure
 
 ```yaml
@@ -25,6 +27,7 @@ agent:
 - The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup. Comparison is case-insensitive and trims surrounding whitespace, so `MetricFlow` and ` metricflow ` also match.
 - Semantic nodes choose the adapter with `semantic_adapter`.
 - There is no `default: true` for semantic adapters.
+- If both `services.semantic_layer` and `semantic_adapter` are omitted, Datus defaults to `metricflow`.
 - If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.
 - If multiple semantic layers are configured, set `semantic_adapter` explicitly.
 

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -2,6 +2,8 @@
 
 语义适配器统一配置在 `agent.services.semantic_layer` 下。
 
+如果你使用的是 MetricFlow 的默认配置，整个 `semantic_layer` 段可以省略；Datus 会默认使用 `metricflow`。
+
 ## 配置结构
 
 ```yaml
@@ -25,6 +27,7 @@ agent:
 - `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。比较时会先对 key 与 `type` 做 lowercase + trim 处理，因此 `MetricFlow` 或 ` metricflow ` 也会被视为与 `metricflow` 匹配。
 - 语义相关节点通过 `semantic_adapter` 选择适配器。
 - 语义适配器不支持 `default: true`。
+- 如果 `services.semantic_layer` 和 `semantic_adapter` 都省略，Datus 会默认使用 `metricflow`。
 - 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。
 - 如果配置了多个 semantic layer，则必须显式填写 `semantic_adapter`。
 

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -402,6 +402,29 @@ class TestAgentConfigServiceSelectors:
         )
         assert cfg.resolve_semantic_adapter() == "metricflow"
 
+    def test_resolve_semantic_adapter_defaults_to_metricflow_without_service_config(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "databases": {},
+            },
+        )
+        assert cfg.resolve_semantic_adapter() == "metricflow"
+
+    def test_build_semantic_adapter_config_defaults_to_metricflow_without_service_config(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "databases": {},
+            },
+        )
+
+        config = cfg.build_semantic_adapter_config()
+
+        assert config["type"] == "metricflow"
+        assert config["agent_home"] == str(tmp_path / "h")
+        assert config["semantic_models_path"].endswith("subject/semantic_models")
+
     def test_resolve_semantic_adapter_requires_explicit_choice_for_multiple_entries(self, tmp_path):
         cfg = self._make(
             tmp_path,


### PR DESCRIPTION
## What changed

Default the semantic adapter to `metricflow` when `agent.services.semantic_layer` is omitted.

This updates `AgentConfig` so semantic adapter resolution can fall back to a built-in default, and adds docs plus unit tests that cover the implicit MetricFlow path.

## Why

The previous behavior returned no semantic adapter when the semantic layer service config was absent, which forced callers to handle an unnecessary `None` path even though MetricFlow is the built-in adapter.

## Impact

Users can omit `services.semantic_layer` for the default MetricFlow flow and still get a usable adapter type resolved automatically.

## Validation

- `uv run pytest tests/unit_tests/configuration/test_agent_config.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Datus now automatically defaults to the MetricFlow semantic adapter when no semantic layer configuration or semantic adapter is specified.

* **Documentation**
  * Updated documentation to clarify that the semantic layer configuration block is optional and that MetricFlow is the default adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->