### PR TITLE
[Refactor] Rename CLI --database to --datasource and internal current_database/default_database to current_datasource/default_datasource

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -159,7 +159,7 @@ class Agent:
     def check_db(self):
         """Validate database connectivity."""
         logger.info("Checking database connectivity")
-        namespace = self.global_config.current_database
+        namespace = self.global_config.current_datasource
         if namespace in self.global_config.namespaces:
             connections = self.db_manager.get_connections(namespace)
             if not connections:
@@ -411,7 +411,7 @@ class Agent:
                     init_dev_schema(
                         self.metadata_store,
                         self.db_manager,
-                        self.global_config.current_database,
+                        self.global_config.current_datasource,
                         benchmark_path,
                         kb_update_strategy,
                         pool_size=pool_size,
@@ -687,7 +687,7 @@ class Agent:
         self, benchmark_platform: str, target_task_ids: Optional[Set[str]] = None, run_id: Optional[str] = None
     ):
         _, conn = db_manager_instance(self.global_config.namespaces).first_conn_with_name(
-            self.global_config.current_database
+            self.global_config.current_datasource
         )
         self.check_db()
 
@@ -823,11 +823,11 @@ class Agent:
 
     def _cleanup_benchmark_output_paths(self, benchmark_path: str):
         """Clean up previous benchmark execution results to avoid interference."""
-        current_database = self.global_config.current_database
+        current_datasource = self.global_config.current_datasource
 
         # Clean up namespace directory in output directory
         output_dir = self.global_config.output_dir
-        namespace_dir = os.path.join(output_dir, current_database)
+        namespace_dir = os.path.join(output_dir, current_datasource)
         if os.path.exists(namespace_dir):
             logger.info(f"Cleaning up namespace directory: {namespace_dir}")
             try:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -267,7 +267,7 @@ class AgenticNode(Node):
                 version=version,
                 # Add common template variables
                 agent_config=self.agent_config,
-                namespace=getattr(self.agent_config, "current_database", None) if self.agent_config else None,
+                namespace=getattr(self.agent_config, "current_datasource", None) if self.agent_config else None,
                 workspace_root=root_path,  # DEPRECATED: Use semantic_model_dir or sql_summary_dir instead
                 # Add conversation summary if available
                 conversation_summary=conversation_summary,

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -130,7 +130,7 @@ class ChatAgenticNode(AgenticNode):
         # Setup tools
         self.setup_tools()
         logger.debug(f"ChatAgenticNode tools: {len(self.tools)} tools - {[tool.name for tool in self.tools]}")
-        logger.debug(f"ChatAgenticNode initialized: {self.agent_config.current_database}")
+        logger.debug(f"ChatAgenticNode initialized: {self.agent_config.current_datasource}")
 
     def get_node_name(self) -> str:
         """Get the configured node name."""
@@ -141,7 +141,7 @@ class ChatAgenticNode(AgenticNode):
     def setup_tools(self):
         """Initialize all tools with default database connection."""
         db_manager = db_manager_instance(self.agent_config.namespaces)
-        conn = db_manager.get_conn(self.agent_config.current_database, self.agent_config.current_database)
+        conn = db_manager.get_conn(self.agent_config.current_datasource, self.agent_config.current_datasource)
         self.db_func_tool = DBFuncTool(conn, agent_config=self.agent_config)
         self.context_search_tools = ContextSearchTools(self.agent_config)
         self.reference_template_tools = ReferenceTemplateTools(self.agent_config, db_func_tool=self.db_func_tool)
@@ -293,7 +293,7 @@ class ChatAgenticNode(AgenticNode):
     def _update_database_connection(self, database_name: str):
         """Update database connection to a different database."""
         db_manager = db_manager_instance(self.agent_config.namespaces)
-        conn = db_manager.get_conn(self.agent_config.current_database, database_name)
+        conn = db_manager.get_conn(self.agent_config.current_datasource, database_name)
         self.db_func_tool = DBFuncTool(conn, agent_config=self.agent_config)
         self._rebuild_tools()
 
@@ -357,7 +357,7 @@ class ChatAgenticNode(AgenticNode):
                     if server:
                         mcp_servers["metricflow_mcp"] = server
                         logger.info(
-                            f"Setup metricflow_mcp MCP server for database: {self.agent_config.current_database}"
+                            f"Setup metricflow_mcp MCP server for database: {self.agent_config.current_datasource}"
                         )
                     continue
 
@@ -381,7 +381,7 @@ class ChatAgenticNode(AgenticNode):
             if not db_config:
                 return None
 
-            metricflow_server = MCPServer.get_metricflow_mcp_server(namespace=self.agent_config.current_database)
+            metricflow_server = MCPServer.get_metricflow_mcp_server(namespace=self.agent_config.current_datasource)
             if metricflow_server:
                 logger.info(f"Added metricflow_mcp MCP server for database: {db_config.database}")
                 return metricflow_server

--- a/datus/agent/node/compare_agentic_node.py
+++ b/datus/agent/node/compare_agentic_node.py
@@ -87,10 +87,10 @@ class CompareAgenticNode(AgenticNode):
             return
 
         try:
-            namespace = self.agent_config.current_database
+            namespace = self.agent_config.current_datasource
 
             db_manager = db_manager_instance(self.agent_config.namespaces)
-            database = getattr(self.agent_config, "current_database", "")
+            database = getattr(self.agent_config, "current_datasource", "")
             try:
                 connector = db_manager.get_conn(namespace, database)
             except Exception:

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -114,7 +114,7 @@ class ExploreAgenticNode(AgenticNode):
         """Setup database tools (all are read-only)."""
         try:
             db_manager = db_manager_instance(self.agent_config.namespaces)
-            namespace = self.agent_config.current_namespace or self.agent_config.current_datasource
+            namespace = self.agent_config.current_datasource
             conn = db_manager.get_conn(namespace, self.agent_config.current_datasource)
             dynamic_scoped_tables = None
             if isinstance(self.input, ExploreNodeInput) and self.input.scoped_tables:

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -114,8 +114,8 @@ class ExploreAgenticNode(AgenticNode):
         """Setup database tools (all are read-only)."""
         try:
             db_manager = db_manager_instance(self.agent_config.namespaces)
-            namespace = self.agent_config.current_namespace or self.agent_config.current_database
-            conn = db_manager.get_conn(namespace, self.agent_config.current_database)
+            namespace = self.agent_config.current_namespace or self.agent_config.current_datasource
+            conn = db_manager.get_conn(namespace, self.agent_config.current_datasource)
             dynamic_scoped_tables = None
             if isinstance(self.input, ExploreNodeInput) and self.input.scoped_tables:
                 dynamic_scoped_tables = self.input.scoped_tables
@@ -183,7 +183,7 @@ class ExploreAgenticNode(AgenticNode):
             "has_context_search_tools": bool(self.context_search_tools),
             "has_filesystem_tools": bool(self.filesystem_func_tool),
             "has_date_parsing_tools": bool(self.date_parsing_tools),
-            "namespace": getattr(self.agent_config, "current_database", None) if self.agent_config else None,
+            "namespace": getattr(self.agent_config, "current_datasource", None) if self.agent_config else None,
             "workspace_root": self._resolve_workspace_root(),
             "conversation_summary": conversation_summary,
             "current_date": get_default_current_date(None),

--- a/datus/agent/node/feedback_agentic_node.py
+++ b/datus/agent/node/feedback_agentic_node.py
@@ -165,7 +165,7 @@ class FeedbackAgenticNode(AgenticNode):
                 "has_task_tool": bool(self.sub_agent_task_tool),
                 "has_ask_user_tool": self.ask_user_tool is not None,
                 "knowledge_base_dir": str(self.agent_config.path_manager.subject_dir),
-                "current_database": self.agent_config.current_database,
+                "current_datasource": self.agent_config.current_datasource,
                 "workspace_root": self._resolve_workspace_root(),
             }
 

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -161,7 +161,7 @@ class GenExtKnowledgeAgenticNode(AgenticNode):
         # filesystem_tools: read_file, write_file, edit_file
         # Chat node uses all available tools by default
         db_manager = db_manager_instance(self.agent_config.namespaces)
-        self.conn = db_manager.get_conn(self.agent_config.current_database, self.agent_config.current_database)
+        self.conn = db_manager.get_conn(self.agent_config.current_datasource, self.agent_config.current_datasource)
         self.db_func_tool = DBFuncTool(self.conn, agent_config=self.agent_config)
         self.context_search_tools = ContextSearchTools(self.agent_config)
         if self.db_func_tool:
@@ -446,7 +446,7 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
             sql_task = SqlTask(
                 database_type=self.agent_config.database_type if hasattr(self.agent_config, "database_type") else "",
                 database_name=(
-                    self.agent_config.current_database if hasattr(self.agent_config, "current_database") else ""
+                    self.agent_config.current_datasource if hasattr(self.agent_config, "current_datasource") else ""
                 ),
                 task=getattr(self, "_current_question", "SQL verification task"),
                 external_knowledge=str(generated_knowledge) if generated_knowledge else "",
@@ -543,7 +543,7 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
         context["knowledge_base_dir"] = self.knowledge_base_dir
         # Filesystem tool is rooted at project_root; full path required.
         context["kind_subdir"] = "subject/ext_knowledge"
-        context["current_database"] = self.agent_config.current_database
+        context["current_datasource"] = self.agent_config.current_datasource
         context["has_filesystem_tools"] = bool(self.filesystem_func_tool)
         context["has_ask_user_tool"] = self.ask_user_tool is not None
         context["has_gold_sql"] = bool(gold_sql)

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -252,7 +252,7 @@ class GenMetricsAgenticNode(AgenticNode):
         context["knowledge_base_dir"] = self.knowledge_base_dir
         # Filesystem tool is rooted at project_root; full path required.
         context["kind_subdir"] = "subject/semantic_models"
-        context["current_database"] = self.agent_config.current_database
+        context["current_datasource"] = self.agent_config.current_datasource
         context["has_ask_user_tool"] = self.ask_user_tool is not None
 
         # Handle subject_tree context based on whether predefined or query from storage

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -206,7 +206,7 @@ class GenReportAgenticNode(AgenticNode):
         """Setup database tools."""
         try:
             db_manager = db_manager_instance(self.agent_config.namespaces)
-            conn = db_manager.get_conn(self.agent_config.current_database, self.agent_config.current_database)
+            conn = db_manager.get_conn(self.agent_config.current_datasource, self.agent_config.current_datasource)
             self.db_func_tool = DBFuncTool(
                 conn,
                 agent_config=self.agent_config,
@@ -267,7 +267,9 @@ class GenReportAgenticNode(AgenticNode):
             elif tool_type == "db_tools":
                 if not self.db_func_tool:
                     db_manager = db_manager_instance(self.agent_config.namespaces)
-                    conn = db_manager.get_conn(self.agent_config.current_database, self.agent_config.current_database)
+                    conn = db_manager.get_conn(
+                        self.agent_config.current_datasource, self.agent_config.current_datasource
+                    )
                     self.db_func_tool = DBFuncTool(
                         conn,
                         agent_config=self.agent_config,
@@ -331,8 +333,8 @@ class GenReportAgenticNode(AgenticNode):
 
         # Add namespace info
         if self.agent_config:
-            context["namespace"] = getattr(self.agent_config, "current_database", None)
-            context["db_name"] = getattr(self.agent_config, "current_database", None)
+            context["namespace"] = getattr(self.agent_config, "current_datasource", None)
+            context["db_name"] = getattr(self.agent_config, "current_datasource", None)
 
         from datus.utils.time_utils import get_default_current_date
 

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -137,7 +137,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
         """Setup database tools."""
         try:
             db_manager = db_manager_instance(self.agent_config.namespaces)
-            conn = db_manager.get_conn(self.agent_config.current_database, self.agent_config.current_database)
+            conn = db_manager.get_conn(self.agent_config.current_datasource, self.agent_config.current_datasource)
             self.db_func_tool = DBFuncTool(
                 conn,
                 agent_config=self.agent_config,
@@ -260,7 +260,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
         # Filesystem tool is now rooted at project_root (not subject/), so the
         # LLM must pass the full ``subject/<kind>/…`` relative path.
         context["kind_subdir"] = "subject/semantic_models"
-        context["current_database"] = self.agent_config.current_database
+        context["current_datasource"] = self.agent_config.current_datasource
         context["has_ask_user_tool"] = self.ask_user_tool is not None
 
         logger.debug(f"Prepared template context: {context}")

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -143,7 +143,7 @@ class SkillCreatorAgenticNode(AgenticNode):
         """Setup database tools (optional, for understanding schema when creating data-related skills)."""
         try:
             db_manager = db_manager_instance(self.agent_config.namespaces)
-            conn = db_manager.get_conn(self.agent_config.current_namespace, self.agent_config.current_database)
+            conn = db_manager.get_conn(self.agent_config.current_namespace, self.agent_config.current_datasource)
             self.db_func_tool = DBFuncTool(
                 conn,
                 agent_config=self.agent_config,

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -143,7 +143,7 @@ class SkillCreatorAgenticNode(AgenticNode):
         """Setup database tools (optional, for understanding schema when creating data-related skills)."""
         try:
             db_manager = db_manager_instance(self.agent_config.namespaces)
-            conn = db_manager.get_conn(self.agent_config.current_namespace, self.agent_config.current_datasource)
+            conn = db_manager.get_conn(self.agent_config.current_datasource, self.agent_config.current_datasource)
             self.db_func_tool = DBFuncTool(
                 conn,
                 agent_config=self.agent_config,

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -215,7 +215,7 @@ class GenSQLAgenticNode(AgenticNode):
             database_name: The name of the database to connect to
         """
         db_manager = db_manager_instance(self.agent_config.namespaces)
-        conn = db_manager.get_conn(self.agent_config.current_database, database_name)
+        conn = db_manager.get_conn(self.agent_config.current_datasource, database_name)
         self.db_func_tool = DBFuncTool(
             conn,
             agent_config=self.agent_config,
@@ -304,7 +304,7 @@ class GenSQLAgenticNode(AgenticNode):
                 )
             else:
                 db_manager = db_manager_instance(self.agent_config.namespaces)
-                conn = db_manager.get_conn(self.agent_config.current_database, self.agent_config.current_database)
+                conn = db_manager.get_conn(self.agent_config.current_datasource, self.agent_config.current_datasource)
                 self.db_func_tool = DBFuncTool(
                     conn,
                     agent_config=self.agent_config,
@@ -335,7 +335,7 @@ class GenSQLAgenticNode(AgenticNode):
             db_tool = self.db_func_tool
             if not db_tool:
                 db_manager = db_manager_instance(self.agent_config.namespaces)
-                conn = db_manager.get_conn(self.agent_config.current_namespace, self.agent_config.current_database)
+                conn = db_manager.get_conn(self.agent_config.current_namespace, self.agent_config.current_datasource)
                 db_tool = DBFuncTool(
                     conn,
                     agent_config=self.agent_config,
@@ -454,7 +454,7 @@ class GenSQLAgenticNode(AgenticNode):
                     else:
                         db_manager = db_manager_instance(self.agent_config.namespaces)
                         conn = db_manager.get_conn(
-                            self.agent_config.current_database, self.agent_config.current_database
+                            self.agent_config.current_datasource, self.agent_config.current_datasource
                         )
                         self.db_func_tool = DBFuncTool(
                             conn,
@@ -480,7 +480,7 @@ class GenSQLAgenticNode(AgenticNode):
                     if not db_tool:
                         _db_manager = db_manager_instance(self.agent_config.namespaces)
                         _conn = _db_manager.get_conn(
-                            self.agent_config.current_namespace, self.agent_config.current_database
+                            self.agent_config.current_namespace, self.agent_config.current_datasource
                         )
                         db_tool = DBFuncTool(
                             _conn,
@@ -521,7 +521,7 @@ class GenSQLAgenticNode(AgenticNode):
                 logger.warning("Database config not found")
                 return None
 
-            metricflow_server = MCPServer.get_metricflow_mcp_server(namespace=self.agent_config.current_database)
+            metricflow_server = MCPServer.get_metricflow_mcp_server(namespace=self.agent_config.current_datasource)
             if metricflow_server:
                 logger.info(f"Added metricflow_mcp MCP server for database: {db_config.database}")
                 return metricflow_server
@@ -577,7 +577,7 @@ class GenSQLAgenticNode(AgenticNode):
                     if server:
                         mcp_servers["metricflow_mcp"] = server
                         logger.info(
-                            f"Setup metricflow_mcp MCP server for database: {self.agent_config.current_database}"
+                            f"Setup metricflow_mcp MCP server for database: {self.agent_config.current_datasource}"
                         )
 
                 # Handle MCP servers from {agent.home}/conf/.mcp.json using mcp_manager
@@ -1254,8 +1254,8 @@ def prepare_template_context(
     # Add namespace and workspace info
     if agent_config:
         context["agent_config"] = agent_config
-        context["namespace"] = getattr(agent_config, "current_database", None)
-        context["db_name"] = getattr(agent_config, "current_database", None)
+        context["namespace"] = getattr(agent_config, "current_datasource", None)
+        context["db_name"] = getattr(agent_config, "current_datasource", None)
         context["workspace_root"] = workspace_root or getattr(agent_config, "project_root", None)
     logger.debug(f"Prepared template context: {context}")
     return context

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -335,7 +335,7 @@ class GenSQLAgenticNode(AgenticNode):
             db_tool = self.db_func_tool
             if not db_tool:
                 db_manager = db_manager_instance(self.agent_config.namespaces)
-                conn = db_manager.get_conn(self.agent_config.current_namespace, self.agent_config.current_datasource)
+                conn = db_manager.get_conn(self.agent_config.current_datasource, self.agent_config.current_datasource)
                 db_tool = DBFuncTool(
                     conn,
                     agent_config=self.agent_config,
@@ -480,7 +480,7 @@ class GenSQLAgenticNode(AgenticNode):
                     if not db_tool:
                         _db_manager = db_manager_instance(self.agent_config.namespaces)
                         _conn = _db_manager.get_conn(
-                            self.agent_config.current_namespace, self.agent_config.current_datasource
+                            self.agent_config.current_datasource, self.agent_config.current_datasource
                         )
                         db_tool = DBFuncTool(
                             _conn,

--- a/datus/agent/node/node.py
+++ b/datus/agent/node/node.py
@@ -446,7 +446,7 @@ class Node(ABC):
 
     def _sql_connector(self, database_name: str = "") -> BaseSqlConnector:
         return db_manager_instance(self.agent_config.namespaces).get_conn(
-            self.agent_config.current_database,
+            self.agent_config.current_datasource,
             database_name,
         )
 

--- a/datus/agent/node/schema_linking_node.py
+++ b/datus/agent/node/schema_linking_node.py
@@ -158,11 +158,11 @@ class SchemaLinkingNode(Node):
             db_manager = db_manager_instance(self.agent_config.namespaces)
 
             # Get current namespace and database connection
-            current_database = self.agent_config.current_database
+            current_datasource = self.agent_config.current_datasource
             database_name = self.input.database_name if hasattr(self.input, "database_name") else ""
 
             # Get database connector
-            connector = db_manager.get_conn(current_database, database_name)
+            connector = db_manager.get_conn(current_datasource, database_name)
 
             return tool.get_schems_by_db(connector=connector, input_param=self.input)
 

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -244,7 +244,7 @@ class SqlSummaryAgenticNode(AgenticNode):
         context["knowledge_base_dir"] = self.knowledge_base_dir
         # Filesystem tool is rooted at project_root; full path required.
         context["kind_subdir"] = "subject/sql_summaries"
-        context["current_database"] = self.agent_config.current_database
+        context["current_datasource"] = self.agent_config.current_datasource
         context["has_ask_user_tool"] = self.ask_user_tool is not None
 
         # Handle subject_tree context based on whether predefined or query from storage

--- a/datus/api/models/config_models.py
+++ b/datus/api/models/config_models.py
@@ -112,7 +112,7 @@ class DatabaseInfo(BaseModel):
 
     version: str = Field(..., description="Database version")
     databases: List[str] = Field(..., description="Available databases")
-    current_database: str = Field(..., description="Current database name")
+    current_datasource: str = Field(..., description="Current database name")
     catalogs: Optional[List[str]] = Field(None, description="Available catalogs (if supported)")
 
 

--- a/datus/api/routes/config_routes.py
+++ b/datus/api/routes/config_routes.py
@@ -143,7 +143,7 @@ async def get_agent_config_endpoint(
         data={
             "target": config.target,
             "models": config.models,
-            "current_datasource": config.current_namespace,
+            "current_datasource": config.current_datasource,
             "datasources": flat_datasources,
             "home": config.home,
         },

--- a/datus/api/routes/config_routes.py
+++ b/datus/api/routes/config_routes.py
@@ -143,7 +143,7 @@ async def get_agent_config_endpoint(
         data={
             "target": config.target,
             "models": config.models,
-            "current_database": config.current_namespace,
+            "current_datasource": config.current_namespace,
             "datasources": flat_datasources,
             "home": config.home,
         },

--- a/datus/api/routes/database_routes.py
+++ b/datus/api/routes/database_routes.py
@@ -17,7 +17,7 @@ from datus.api.models.database_models import (
 router = APIRouter(prefix="/api/v1", tags=["databases"])
 
 # Pre-configured parameters to avoid definition-time evaluation in defaults
-DATASOURCE_QUERY = Query("", description="Namespace to list databases from")
+DATASOURCE_QUERY = Query("", description="Datasource to list databases from")
 DATABASE_NAME_QUERY = Query("", description="Database name")
 SCHEMA_NAME_QUERY = Query("", description="Schema name")
 CATALOG_NAME_QUERY = Query("", description="Catalog name")

--- a/datus/api/routes/database_routes.py
+++ b/datus/api/routes/database_routes.py
@@ -40,7 +40,7 @@ async def list_catalogs(
 ) -> Result[DatabasesData]:
     """List available databases."""
     request = ListDatabasesInput(
-        datasource_id=datasource_id or svc.database.current_namespace,
+        datasource_id=datasource_id or svc.database.current_datasource,
         catalog_name=catalog_name,
         database_name=database_name,
         schema_name=schema_name,

--- a/datus/api/service.py
+++ b/datus/api/service.py
@@ -93,7 +93,7 @@ class DatusAPIService:
             if not self.agent_config:
                 raise HTTPException(status_code=500, detail="Agent configuration not available")
 
-            self.agent_config.current_database = namespace
+            self.agent_config.current_datasource = namespace
             # Create agent instance
             self.agents[namespace] = Agent(self.args, self.agent_config)
             logger.info(f"Created new agent for namespace: {namespace}")
@@ -295,7 +295,7 @@ class DatusAPIService:
 
                 # Check database connectivity
                 db_check = temp_agent.check_db()
-                database_status[self.agent_config.current_database] = db_check.get("status", "unknown")
+                database_status[self.agent_config.current_datasource] = db_check.get("status", "unknown")
 
                 # Check LLM connectivity
                 llm_check = temp_agent.probe_llm()

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -146,30 +146,13 @@ def _merge_delta_run(run: list[SSEEvent]) -> SSEEvent:
 
 
 def _fill_database_context(
-    agent_config: AgentConfig,
+    agent_config: AgentConfig,  # noqa: ARG001
     catalog: Optional[str] = None,  # noqa: ARG001 — reserved for future use
-    database: Optional[str] = None,
+    database: Optional[str] = None,  # noqa: ARG001 — reserved for future use
     schema: Optional[str] = None,  # noqa: ARG001 — reserved for future use
 ) -> None:
-    """Set agent_config's current_datasource and current_datasource based on request context.
-
-    If database is provided, searches for it in agent_config.namespaces and updates both
-    current_datasource and current_datasource. Otherwise, falls back to treating database
-    as a namespace name if it exists in agent_config.namespaces.
-    """
-    # agent_config.current_datasource is resolved at bootstrap by load_agent_config;
-    # leave it in place when the request does not override the database.
-    if not database:
-        return
-    for ns_name, ns_dbs in agent_config.namespaces.items():
-        if database in ns_dbs:
-            if agent_config.current_datasource != ns_name:
-                agent_config.current_datasource = ns_name
-            agent_config.current_datasource = database
-            return
-    # Fallback: database itself is a namespace name
-    if database in agent_config.namespaces:
-        agent_config.current_datasource = database
+    """No-op: current_datasource is resolved at bootstrap; per-request database
+    selection is a logical-DB concern handled downstream, not a datasource override."""
 
 
 class ChatTask:

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -151,13 +151,13 @@ def _fill_database_context(
     database: Optional[str] = None,
     schema: Optional[str] = None,  # noqa: ARG001 — reserved for future use
 ) -> None:
-    """Set agent_config's current_namespace and current_database based on request context.
+    """Set agent_config's current_namespace and current_datasource based on request context.
 
     If database is provided, searches for it in agent_config.namespaces and updates both
-    current_namespace and current_database. Otherwise, falls back to treating database
+    current_namespace and current_datasource. Otherwise, falls back to treating database
     as a namespace name if it exists in agent_config.namespaces.
     """
-    # agent_config.current_database is resolved at bootstrap by load_agent_config;
+    # agent_config.current_datasource is resolved at bootstrap by load_agent_config;
     # leave it in place when the request does not override the database.
     if not database:
         return
@@ -165,7 +165,7 @@ def _fill_database_context(
         if database in ns_dbs:
             if agent_config.current_namespace != ns_name:
                 agent_config.current_namespace = ns_name
-            agent_config.current_database = database
+            agent_config.current_datasource = database
             return
     # Fallback: database itself is a namespace name
     if database in agent_config.namespaces:

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -151,10 +151,10 @@ def _fill_database_context(
     database: Optional[str] = None,
     schema: Optional[str] = None,  # noqa: ARG001 — reserved for future use
 ) -> None:
-    """Set agent_config's current_namespace and current_datasource based on request context.
+    """Set agent_config's current_datasource and current_datasource based on request context.
 
     If database is provided, searches for it in agent_config.namespaces and updates both
-    current_namespace and current_datasource. Otherwise, falls back to treating database
+    current_datasource and current_datasource. Otherwise, falls back to treating database
     as a namespace name if it exists in agent_config.namespaces.
     """
     # agent_config.current_datasource is resolved at bootstrap by load_agent_config;
@@ -163,13 +163,13 @@ def _fill_database_context(
         return
     for ns_name, ns_dbs in agent_config.namespaces.items():
         if database in ns_dbs:
-            if agent_config.current_namespace != ns_name:
-                agent_config.current_namespace = ns_name
+            if agent_config.current_datasource != ns_name:
+                agent_config.current_datasource = ns_name
             agent_config.current_datasource = database
             return
     # Fallback: database itself is a namespace name
     if database in agent_config.namespaces:
-        agent_config.current_namespace = database
+        agent_config.current_datasource = database
 
 
 class ChatTask:

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -52,10 +52,10 @@ class CLIService:
         # Initialize database manager and namespace only if agent_config is provided
         if self.agent_config:
             self.db_manager = DBManager(self.agent_config.namespaces)
-            self.current_namespace = self.agent_config.current_namespace
+            self.current_datasource = self.agent_config.current_datasource
         else:
             self.db_manager = None
-            self.current_namespace = None
+            self.current_datasource = None
 
         # Initialize CLI context first (before _initialize_connection)
         from datus.cli.cli_context import CliContext
@@ -78,9 +78,9 @@ class CLIService:
 
     def _initialize_connection(self):
         """Initialize the current database connection."""
-        if self.db_manager and self.current_namespace:
+        if self.db_manager and self.current_datasource:
             try:
-                db_name, connector = self.db_manager.first_conn_with_name(self.current_namespace)
+                db_name, connector = self.db_manager.first_conn_with_name(self.current_datasource)
                 self.current_db_connector = connector
                 self.current_db_name = db_name
 
@@ -400,7 +400,7 @@ class CLIService:
                     db_info = {"connection_status": "disconnected"}
 
                 result_data.context_info = {
-                    "current_namespace": self.current_namespace,
+                    "current_datasource": self.current_datasource,
                     "current_database": self.current_db_name,
                     "current_catalog": getattr(self.cli_context, "current_catalog", None) if self.cli_context else None,
                     "current_schema": getattr(self.cli_context, "current_schema", None) if self.cli_context else None,
@@ -556,7 +556,7 @@ class CLIService:
 
             elif command in ["databases", "database"]:
                 if self.db_manager:
-                    connections = self.db_manager.get_connections(self.current_namespace)
+                    connections = self.db_manager.get_connections(self.current_datasource)
                     # Handle both single connector and dict of connectors
                     if isinstance(connections, dict):
                         db_list = list(connections.keys())

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -48,7 +48,7 @@ class DatabaseService:
         self.agent_config = agent_config
 
         self.db_manager = DBManager(agent_config.namespaces)
-        self.current_namespace = agent_config.current_namespace
+        self.current_datasource = agent_config.current_datasource
         self.semantic_rag = SemanticModelRAG(self.agent_config)
 
         self.current_db_connector = None
@@ -70,8 +70,8 @@ class DatabaseService:
         target_db = database_name or self.current_database
 
         try:
-            if self.agent_config and self.current_namespace in self.agent_config.namespaces:
-                namespace_config = self.agent_config.namespaces[self.current_namespace]
+            if self.agent_config and self.current_datasource in self.agent_config.namespaces:
+                namespace_config = self.agent_config.namespaces[self.current_datasource]
                 if target_db and target_db in namespace_config:
                     db_config = namespace_config[target_db]
                     db_type = db_config.type.value if hasattr(db_config.type, "value") else str(db_config.type)
@@ -86,9 +86,9 @@ class DatabaseService:
 
     def _initialize_connection(self):
         """Initialize the current database connection."""
-        if self.db_manager and self.current_namespace:
+        if self.db_manager and self.current_datasource:
             try:
-                db_name, connector = self.db_manager.first_conn_with_name(self.current_namespace)
+                db_name, connector = self.db_manager.first_conn_with_name(self.current_datasource)
                 self.current_db_connector = connector
                 self.current_database = connector.database_name or db_name
             except Exception as e:
@@ -272,7 +272,7 @@ class DatabaseService:
                 )
 
             # Get connections from the specified namespace
-            namespace = request.datasource_id or self.current_namespace
+            namespace = request.datasource_id or self.current_datasource
             connections = self.db_manager.get_connections(namespace)
 
             databases = []
@@ -569,7 +569,7 @@ class DatabaseService:
                 yaml_content=request.yaml,
                 file_path=semantic_file_path,
                 datus_home=self.agent_config.home,
-                namespace=self.agent_config.current_namespace,
+                namespace=self.agent_config.current_datasource,
             )
 
             if not is_valid:

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -40,7 +40,7 @@ class ExplorerService:
             agent_config: Agent configuration object
         """
         self.agent_config = agent_config
-        self.datasource_id = agent_config.current_namespace
+        self.datasource_id = agent_config.current_datasource
         logger.info("ExplorerService initialized")
 
         from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
@@ -745,7 +745,7 @@ class ExplorerService:
             yaml_content=yaml_content,
             file_path=file_path,
             datus_home=self.agent_config.home,
-            namespace=self.agent_config.current_namespace,
+            namespace=self.agent_config.current_datasource,
         )
 
     async def create_metric(self, request: EditMetricInput) -> Result[dict]:

--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -561,7 +561,7 @@ class TableCompleter(DynamicAtReferenceCompleter):
         storage = SchemaWithValueRAG(self.agent_config, sub_agent_name=self.sub_agent_name or None)
         try:
             schema_table = storage.search_all_schemas(
-                # database_name=self.agent_config.current_database,
+                # database_name=self.agent_config.current_datasource,
                 select_fields=[
                     "catalog_name",
                     "database_name",
@@ -927,7 +927,7 @@ class AtReferenceCompleter(Completer):
         raw_config = self.agent_config.sub_agent_config(first_token)
         if raw_config:
             sub_config = SubAgentConfig.model_validate(raw_config)
-            if sub_config.has_scoped_context() and not sub_config.is_in_namespace(self.agent_config.current_database):
+            if sub_config.has_scoped_context() and not sub_config.is_in_namespace(self.agent_config.current_datasource):
                 return ""
         return first_token
 

--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -561,7 +561,6 @@ class TableCompleter(DynamicAtReferenceCompleter):
         storage = SchemaWithValueRAG(self.agent_config, sub_agent_name=self.sub_agent_name or None)
         try:
             schema_table = storage.search_all_schemas(
-                # database_name=self.agent_config.current_datasource,
                 select_fields=[
                     "catalog_name",
                     "database_name",

--- a/datus/cli/bi_dashboard.py
+++ b/datus/cli/bi_dashboard.py
@@ -122,12 +122,12 @@ class BiDashboardCommands:
             return
 
         adapter = self._create_adapter(options)
-        default_catalog, default_datasource, default_schema = self._resolve_default_table_context()
+        default_catalog, default_database, default_schema = self._resolve_default_table_context()
         assembler = DashboardAssembler(
             adapter,
             default_dialect=options.dialect,
             default_catalog=default_catalog,
-            default_datasource=default_datasource,
+            default_database=default_database,
             default_schema=default_schema,
         )
 

--- a/datus/cli/bi_dashboard.py
+++ b/datus/cli/bi_dashboard.py
@@ -101,8 +101,8 @@ class BiDashboardCommands:
         self._force = force
         self.db_manager = db_manager_instance(self.agent_config.namespaces)
 
-    def current_database_context(self) -> Tuple[str, str, str]:
-        current_con = self.db_manager.get_conn(self.agent_config.current_database)
+    def current_datasource_context(self) -> Tuple[str, str, str]:
+        current_con = self.db_manager.get_conn(self.agent_config.current_datasource)
         return (
             getattr(current_con, "catalog_name", ""),
             getattr(current_con, "database_name", ""),
@@ -122,12 +122,12 @@ class BiDashboardCommands:
             return
 
         adapter = self._create_adapter(options)
-        default_catalog, default_database, default_schema = self._resolve_default_table_context()
+        default_catalog, default_datasource, default_schema = self._resolve_default_table_context()
         assembler = DashboardAssembler(
             adapter,
             default_dialect=options.dialect,
             default_catalog=default_catalog,
-            default_database=default_database,
+            default_datasource=default_datasource,
             default_schema=default_schema,
         )
 
@@ -350,7 +350,7 @@ class BiDashboardCommands:
 
         if not (catalog and database and schema):
             try:
-                db_config = self.agent_config.current_db_config(self.agent_config.current_database)
+                db_config = self.agent_config.current_db_config(self.agent_config.current_datasource)
             except Exception:
                 db_config = None
             if db_config:
@@ -483,7 +483,7 @@ class BiDashboardCommands:
         dashboard: DashboardInfo,
         result: DashboardAssemblyResult,
     ) -> None:
-        if not getattr(self.agent_config, "current_database", ""):
+        if not getattr(self.agent_config, "current_datasource", ""):
             self.console.print("[yellow]No namespace set. Skipping sub-agent save.[/]")
             return
 
@@ -535,7 +535,7 @@ class BiDashboardCommands:
 
         manager = SubAgentManager(
             configuration_manager=self._configuration_manager or configuration_manager(),
-            namespace=self.agent_config.current_database,
+            namespace=self.agent_config.current_datasource,
             agent_config=self.agent_config,
         )
         self._do_save_sub_agent(
@@ -653,7 +653,7 @@ class BiDashboardCommands:
         database, schema) from the live connection, then rebuilds via
         ``metadata_identifier`` so the bootstrap's right-alignment matches.
         """
-        catalog, database, schema = self.current_database_context()
+        catalog, database, schema = self.current_datasource_context()
         dialect = self.agent_config.db_type or ""
         qualified: List[str] = []
         for name in table_names:

--- a/datus/cli/init_workspace.py
+++ b/datus/cli/init_workspace.py
@@ -148,9 +148,9 @@ class InitWorkspace:
             # Build services section from config
             services_section = _build_services_section(agent_config.services.datasources)
 
-            # Probe database schema if --database specified
+            # Probe database schema if --datasource specified
             db_schema_info = ""
-            db_name = getattr(self.args, "database", "")
+            db_name = getattr(self.args, "datasource", "")
             if db_name:
                 db_schema_info = self._probe_database(agent_config, db_name)
 

--- a/datus/cli/interactive_init.py
+++ b/datus/cli/interactive_init.py
@@ -627,7 +627,7 @@ class InteractiveInit:
         from datus.configuration.agent_config_loader import load_agent_config
 
         agent_config = load_agent_config(reload=True)
-        agent_config.current_database = self.namespace_name
+        agent_config.current_datasource = self.namespace_name
 
         return Agent(args, agent_config)
 
@@ -673,7 +673,7 @@ def create_agent(namespace_name: str, components: list, config_path: str, **kwar
 
     agent_config = load_agent_config(reload=True, config=config_path, **vars(args))
 
-    agent_config.current_database = namespace_name
+    agent_config.current_datasource = namespace_name
 
     return Agent(args, agent_config)
 
@@ -784,7 +784,7 @@ def init_metadata_and_log_result(namespace_name: str, config_path: str, console:
     from datus.tools.db_tools.db_manager import db_manager_instance
 
     agent_config = load_agent_config(reload=True, config=config_path)
-    agent_config.current_database = namespace_name
+    agent_config.current_datasource = namespace_name
     kb_update_strategy = "overwrite"
     storage_path = agent_config.rag_storage_path()
 
@@ -843,7 +843,7 @@ def overwrite_sql_and_log_result(
 
     try:
         agent_config = load_agent_config(reload=True, config=config_path)
-        agent_config.current_database = namespace_name
+        agent_config.current_datasource = namespace_name
         do_init_sql_and_log_result(agent_config, sql_dir, subject_tree, console, force=force)
     except Exception as e:
         print_rich_exception(console, e, "Reference SQL initialization failed", logger)
@@ -898,7 +898,9 @@ def do_init_sql_and_log_result(
         else:
             agent_config.check_init_storage_config("reference_sql")
 
-        console.print(f"Reference SQL initialization for {agent_config.current_database} (dir: {escape(str(sql_dir))})")
+        console.print(
+            f"Reference SQL initialization for {agent_config.current_datasource} (dir: {escape(str(sql_dir))})"
+        )
 
         # Create StreamOutputManager
         output_mgr = StreamOutputManager(

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -60,10 +60,10 @@ class ArgumentParser:
         # storage_path parameter deprecated - data path is now fixed at {agent.home}/data
 
         self.parser.add_argument(
-            "--database",
+            "--datasource",
             "--namespace",
             type=str,
-            help="Database name to connect (use --database, --namespace is deprecated)",
+            help="Datasource name to connect (use --datasource, --namespace is deprecated)",
             default="",
         )
 
@@ -185,15 +185,15 @@ class Application:
         configure_logging(args.debug, console_output=False)
 
         # REPL-only: ensure ./.datus/config.yml exists before anything touches
-        # agent config. Must run before _resolve_default_database so the
-        # project-level default_database can win over the base agent.yml's.
+        # agent config. Must run before _resolve_default_datasource so the
+        # project-level default_datasource can win over the base agent.yml's.
         if args.print_mode is None and not args.web:
             self._ensure_project_config(args)
 
-        if not args.database:
-            # Try to auto-select: default database or single database
-            args.database = self._resolve_default_database(args)
-            if not args.database:
+        if not args.datasource:
+            # Try to auto-select: default datasource or single datasource
+            args.datasource = self._resolve_default_datasource(args)
+            if not args.datasource:
                 return
 
         if args.resume and args.print_mode is None:
@@ -212,8 +212,8 @@ class Application:
             cli = DatusCLI(args)
             cli.run()
 
-    def _resolve_default_database(self, args) -> str:
-        """Auto-select database when --database is not specified."""
+    def _resolve_default_datasource(self, args) -> str:
+        """Auto-select datasource when --datasource is not specified."""
         from rich.console import Console
         from rich.table import Table
 
@@ -231,15 +231,15 @@ class Application:
             console.print("[yellow]No datasources configured. Run 'datus configure' first.[/yellow]")
             return ""
 
-        # default_database reflects the project-level overlay when present — it
+        # default_datasource reflects the project-level overlay when present — it
         # is applied inside load_agent_config via _apply_project_override which
         # flips datasources[*].default before AgentConfig is built.
-        default_db = config.services.default_database
+        default_db = config.services.default_datasource
         if default_db:
             return default_db
 
         # Multiple datasources, no default — show list and ask user to specify
-        console.print("[yellow]Multiple datasources configured. Please specify --database <name>[/yellow]\n")
+        console.print("[yellow]Multiple datasources configured. Please specify --datasource <name>[/yellow]\n")
         table = Table(show_header=True, header_style="bold")
         table.add_column("Name", style="cyan")
         table.add_column("Type")
@@ -279,7 +279,7 @@ class Application:
 
     def _repair_project_overrides(self, args) -> None:
         """Re-prompt the user when ``./.datus/config.yml`` references a
-        ``target`` or ``default_database`` that no longer exists in the base
+        ``target`` or ``default_datasource`` that no longer exists in the base
         agent.yml, and persist the corrected values.
 
         Reads the raw agent.yml directly via ``configuration_manager`` to
@@ -317,7 +317,7 @@ class Application:
         db_names = list(((raw.get("services") or {}).get("datasources") or {}).keys())
 
         target_invalid = override.target is not None and override.target not in model_names
-        db_invalid = override.default_database is not None and override.default_database not in db_names
+        db_invalid = override.default_datasource is not None and override.default_datasource not in db_names
         if not (target_invalid or db_invalid):
             return
 
@@ -326,7 +326,7 @@ class Application:
             if target_invalid:
                 stale.append(f"target={override.target!r}")
             if db_invalid:
-                stale.append(f"default_database={override.default_database!r}")
+                stale.append(f"default_datasource={override.default_datasource!r}")
             raise DatusException(
                 code=ErrorCode.COMMON_CONFIG_ERROR,
                 message_args={
@@ -369,23 +369,23 @@ class Application:
                     message_args={
                         "config_error": (
                             "Base agent.yml has no 'agent.services.datasources' defined; cannot repair "
-                            f"default_database={override.default_database!r} in .datus/config.yml."
+                            f"default_datasource={override.default_datasource!r} in .datus/config.yml."
                         )
                     },
                 )
             console.print(
-                f"  [red]default_database[/] = {override.default_database!r} not found in agent.yml "
+                f"  [red]default_datasource[/] = {override.default_datasource!r} not found in agent.yml "
                 f"services.datasources ({sorted(db_names)}). Please pick a replacement:"
             )
             db_types = (raw.get("services") or {}).get("datasources") or {}
             choices = {name: f"{name}  ({(db_types.get(name) or {}).get('type', 'unknown')})" for name in db_names}
             picked = select_choice(console, choices, default=db_names[0])
-            override.default_database = picked or db_names[0]
+            override.default_datasource = picked or db_names[0]
 
         written = save_project_override(override)
         console.print(
             f"[green]Updated project config:[/] {written} "
-            f"(target={override.target}, default_database={override.default_database})"
+            f"(target={override.target}, default_datasource={override.default_datasource})"
         )
 
     def _run_web_interface(self, args):

--- a/datus/cli/metadata_commands.py
+++ b/datus/cli/metadata_commands.py
@@ -126,23 +126,21 @@ class MetadataCommands:
             )
             return
 
-        self.cli.agent_config.current_datasource = new_db
+        current_datasource = self.cli.agent_config.current_datasource
         self.cli.cli_context.current_logic_db_name = new_db
         if self.cli.agent_config.db_type in (DBType.SQLITE, DBType.DUCKDB):
             if new_db not in self.cli.agent_config.current_db_configs():
                 self.cli.console.print(f"[bold yellow]No corresponding database was found: {new_db}[/]")
                 return
             # Logic database name
-            self.cli.db_connector = self.cli.db_manager.get_conn(self.cli.agent_config.current_datasource, new_db)
+            self.cli.db_connector = self.cli.db_manager.get_conn(current_datasource, new_db)
             # use real database name
             self.cli.cli_context.update_database_context(
                 db_name=self.cli.db_connector.database_name, db_logic_name=new_db
             )
-            self.cli.agent_config.current_datasource = new_db
             self.cli.reset_session()
         else:
             self.cli.db_connector.switch_context(database_name=new_db)
-            self.cli.agent_config.current_datasource = new_db
             self.cli.cli_context.update_database_context(db_name=new_db)
 
         if self.cli.agent_config.db_type in (DBType.SQLITE, DBType.DUCKDB):

--- a/datus/cli/metadata_commands.py
+++ b/datus/cli/metadata_commands.py
@@ -35,7 +35,7 @@ class MetadataCommands:
         """List all databases in the current connection."""
         try:
             # For SQLite, this is simply the current database file
-            namespace = self.cli.agent_config.current_database
+            namespace = self.cli.agent_config.current_datasource
             database_config_dict = self.cli.agent_config.namespaces[namespace]
             result = []
             show_uri = False
@@ -126,23 +126,23 @@ class MetadataCommands:
             )
             return
 
-        self.cli.agent_config.current_database = new_db
+        self.cli.agent_config.current_datasource = new_db
         self.cli.cli_context.current_logic_db_name = new_db
         if self.cli.agent_config.db_type in (DBType.SQLITE, DBType.DUCKDB):
             if new_db not in self.cli.agent_config.current_db_configs():
                 self.cli.console.print(f"[bold yellow]No corresponding database was found: {new_db}[/]")
                 return
             # Logic database name
-            self.cli.db_connector = self.cli.db_manager.get_conn(self.cli.agent_config.current_database, new_db)
+            self.cli.db_connector = self.cli.db_manager.get_conn(self.cli.agent_config.current_datasource, new_db)
             # use real database name
             self.cli.cli_context.update_database_context(
                 db_name=self.cli.db_connector.database_name, db_logic_name=new_db
             )
-            self.cli.agent_config.current_database = new_db
+            self.cli.agent_config.current_datasource = new_db
             self.cli.reset_session()
         else:
             self.cli.db_connector.switch_context(database_name=new_db)
-            self.cli.agent_config.current_database = new_db
+            self.cli.agent_config.current_datasource = new_db
             self.cli.cli_context.update_database_context(db_name=new_db)
 
         if self.cli.agent_config.db_type in (DBType.SQLITE, DBType.DUCKDB):

--- a/datus/cli/print_mode.py
+++ b/datus/cli/print_mode.py
@@ -43,9 +43,9 @@ class PrintModeRunner:
         self.scope = getattr(args, "session_scope", None)
         self.stream_thinking = getattr(args, "stream_thinking", False)
 
-        # Database context from args
+        # Datasource context from args
         self.catalog = getattr(args, "catalog", None)
-        self.database = getattr(args, "database", None) or None
+        self.database = getattr(args, "datasource", None) or None
         self.db_schema = getattr(args, "schema", None)
 
     def run(self):

--- a/datus/cli/project_init.py
+++ b/datus/cli/project_init.py
@@ -70,7 +70,7 @@ def run_project_init(base_config: AgentConfig, cwd: Optional[str] = None) -> Pro
     console.print("[bold cyan]First-run project setup[/]")
     console.print(f"[dim]Writing project-level overrides to {project_config_path(cwd)}[/]")
     console.print(
-        "[dim]This file pins target / default_database / project_name for this project; "
+        "[dim]This file pins target / default_datasource / project_name for this project; "
         "everything else comes from the shared agent.yml.[/]"
     )
     console.print()
@@ -85,10 +85,10 @@ def run_project_init(base_config: AgentConfig, cwd: Optional[str] = None) -> Pro
     console.print()
     console.print("[bold]- Select default datasource (from agent.yml):[/]")
     db_choices = {name: f"{name}  ({cfg.type})" for name, cfg in base_config.services.datasources.items()}
-    db_default = base_config.services.default_database or next(iter(db_choices))
-    default_database = select_choice(console, db_choices, default=db_default)
-    if not default_database:
-        default_database = db_default
+    db_default = base_config.services.default_datasource or next(iter(db_choices))
+    default_datasource = select_choice(console, db_choices, default=db_default)
+    if not default_datasource:
+        default_datasource = db_default
 
     console.print()
     project_name_default = _normalize_project_name(cwd or os.getcwd())
@@ -108,12 +108,12 @@ def run_project_init(base_config: AgentConfig, cwd: Optional[str] = None) -> Pro
 
     override = ProjectOverride(
         target=target,
-        default_database=default_database,
+        default_datasource=default_datasource,
         project_name=project_name if project_name != project_name_default else None,
     )
     written = save_project_override(override, cwd=cwd)
     console.print()
     console.print(f"[green]Saved project config:[/] {written}")
-    console.print(f"[dim]  target={target}  default_database={default_database}  project_name={project_name}[/]")
+    console.print(f"[dim]  target={target}  default_datasource={default_datasource}  project_name={project_name}[/]")
     console.print()
     return override

--- a/datus/cli/project_init.py
+++ b/datus/cli/project_init.py
@@ -85,7 +85,11 @@ def run_project_init(base_config: AgentConfig, cwd: Optional[str] = None) -> Pro
     console.print()
     console.print("[bold]- Select default datasource (from agent.yml):[/]")
     db_choices = {name: f"{name}  ({cfg.type})" for name, cfg in base_config.services.datasources.items()}
-    db_default = base_config.services.default_datasource or next(iter(db_choices))
+    db_default = (
+        base_config.services.default_datasource
+        if base_config.services.default_datasource in db_choices
+        else next(iter(db_choices))
+    )
     default_datasource = select_choice(console, db_choices, default=db_default)
     if not default_datasource:
         default_datasource = db_default

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -1058,8 +1058,10 @@ class DatusCLI:
             self._cmd_list_namespaces()
             return
         else:
-            self.agent_config.current_datasource = args.strip()
-            name, self.db_connector = self.db_manager.first_conn_with_name(self.agent_config.current_datasource)
+            next_datasource = args.strip()
+            name, connector = self.db_manager.first_conn_with_name(next_datasource)
+            self.agent_config.current_datasource = next_datasource
+            self.db_connector = connector
             db_name = self.db_connector.database_name
             db_logic_name = name or self.agent_config.current_datasource
             self.cli_context.update_database_context(

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -890,7 +890,7 @@ class DatusCLI:
         table = Table(show_header=True, header_style="bold green")
         table.add_column("Namespace")
         for namespace in self.agent_config.namespaces.keys():
-            if self.agent_config.current_database == namespace:
+            if self.agent_config.current_datasource == namespace:
                 table.add_row(f"[bold green]{namespace}[/]")
             else:
                 table.add_row(namespace)
@@ -1007,7 +1007,7 @@ class DatusCLI:
 
         visible = {name for name in self.available_subagents if name not in HIDDEN_SYS_SUB_AGENTS}
         if hasattr(self.agent_config, "agentic_nodes") and self.agent_config.agentic_nodes:
-            current_db = getattr(self.agent_config, "current_database", None)
+            current_db = getattr(self.agent_config, "current_datasource", None)
             for name, sub_config in self.agent_config.agentic_nodes.items():
                 scoped_ns = (sub_config or {}).get("scoped_context", {}).get("namespace")
                 if scoped_ns and scoped_ns != current_db:
@@ -1048,20 +1048,20 @@ class DatusCLI:
     def _cmd_switch_namespace(self, args: str):
         if args.strip() == "":
             self._cmd_list_namespaces()
-        elif self.agent_config.current_database == args.strip():
+        elif self.agent_config.current_datasource == args.strip():
             self.console.print(
                 (
-                    f"[yellow]It's now under the namespace [bold]{self.agent_config.current_database}[/]"
+                    f"[yellow]It's now under the namespace [bold]{self.agent_config.current_datasource}[/]"
                     " and doesn't need to be switched[/]"
                 )
             )
             self._cmd_list_namespaces()
             return
         else:
-            self.agent_config.current_database = args.strip()
-            name, self.db_connector = self.db_manager.first_conn_with_name(self.agent_config.current_database)
+            self.agent_config.current_datasource = args.strip()
+            name, self.db_connector = self.db_manager.first_conn_with_name(self.agent_config.current_datasource)
             db_name = self.db_connector.database_name
-            db_logic_name = name or self.agent_config.current_database
+            db_logic_name = name or self.agent_config.current_datasource
             self.cli_context.update_database_context(
                 catalog=self.db_connector.catalog_name,
                 db_name=db_name,
@@ -1070,7 +1070,7 @@ class DatusCLI:
             )
             self.reset_session()
             self.chat_commands.update_chat_node_tools()
-            self.console.print(f"[bold green]Namespace changed to: {self.agent_config.current_database}[/]")
+            self.console.print(f"[bold green]Namespace changed to: {self.agent_config.current_datasource}[/]")
 
     def _parse_command(self, text: str) -> Tuple[CommandType, str, str]:
         """Classify raw user input into a ``CommandType`` + canonical cmd + args.
@@ -1496,9 +1496,9 @@ class DatusCLI:
     def _build_banner_panel(self) -> Panel:
         """Build the unified startup banner as a Rich Panel."""
         database = (
-            getattr(self.args, "database", "")
+            getattr(self.args, "datasource", "")
             or getattr(self.args, "namespace", "")
-            or getattr(self.agent_config, "current_database", "")
+            or getattr(self.agent_config, "current_datasource", "")
         )
         db_type = getattr(self.agent_config, "db_type", "") or ""
 
@@ -1577,15 +1577,15 @@ class DatusCLI:
         Args:
             timeout_seconds: Maximum time to wait for connection (default: 30 seconds)
         """
-        current_database = self.agent_config.current_database
+        current_datasource = self.agent_config.current_datasource
 
         def _do_init_connection():
             """Inner function to perform connection initialization."""
             if not self.cli_context.current_db_name:
-                db_name, connector = self.db_manager.first_conn_with_name(current_database)
+                db_name, connector = self.db_manager.first_conn_with_name(current_datasource)
                 return db_name, connector
             else:
-                connector = self.db_manager.get_conn(current_database, self.cli_context.current_db_name)
+                connector = self.db_manager.get_conn(current_datasource, self.cli_context.current_db_name)
                 return self.cli_context.current_db_name, connector
 
         try:
@@ -1597,10 +1597,10 @@ class DatusCLI:
                 except FuturesTimeoutError:
                     self.console.print(
                         f"[bold red]Error:[/] Database connection timed out after {timeout_seconds} seconds. "
-                        f"Please check if the database server for namespace '{current_database}' is running "
+                        f"Please check if the database server for namespace '{current_datasource}' is running "
                         "and accessible."
                     )
-                    logger.error(f"Database connection timeout for namespace: {current_database}")
+                    logger.error(f"Database connection timeout for namespace: {current_datasource}")
                     self.db_connector = None
                     return
 
@@ -1615,7 +1615,7 @@ class DatusCLI:
                 self.cli_context.update_database_context(
                     catalog=self.db_connector.catalog_name,
                     db_name=self.db_connector.database_name,
-                    db_logic_name=db_name or self.db_connector.database_name or current_database,
+                    db_logic_name=db_name or self.db_connector.database_name or current_datasource,
                 )
 
             # Test the connection with timeout
@@ -1627,14 +1627,14 @@ class DatusCLI:
                 except FuturesTimeoutError:
                     self.console.print(
                         f"[bold red]Error:[/] Connection test timed out after {timeout_seconds} seconds. "
-                        f"The database server for namespace '{current_database}' may be unresponsive."
+                        f"The database server for namespace '{current_datasource}' may be unresponsive."
                     )
-                    logger.error(f"Connection test timeout for namespace: {current_database}")
+                    logger.error(f"Connection test timeout for namespace: {current_datasource}")
                     self.db_connector = None
 
         except Exception as e:
             self.console.print(f"[bold red]Error:[/] Failed to connect to database: {str(e)}")
-            logger.error(f"Database connection failed for namespace {current_database}: {e}")
+            logger.error(f"Database connection failed for namespace {current_datasource}: {e}")
             self.db_connector = None
 
     def _create_workflow_runner(self) -> WorkflowRunner:

--- a/datus/cli/service_client.py
+++ b/datus/cli/service_client.py
@@ -351,10 +351,10 @@ class ServiceClientRegistry:
     def _namespace_fingerprint(self) -> Tuple[Any, ...]:
         """Capture the agent_config state that affects built tool instances.
 
-        ``SemanticTools`` bakes ``current_database`` into ``MetricRAG`` /
+        ``SemanticTools`` bakes ``current_datasource`` into ``MetricRAG`` /
         ``SemanticModelRAG`` at init time and resolves the adapter against
         the active namespace. ``BIFuncTool.read_connector`` is similarly
-        pulled via ``db_manager.get_conn(current_database, current_database)``
+        pulled via ``db_manager.get_conn(current_datasource, current_datasource)``
         on first use. If any of those change, cached instances must be
         rebuilt — a session-scoped cache would otherwise keep executing
         queries against the pre-switch namespace after ``.database ...`` /
@@ -362,7 +362,7 @@ class ServiceClientRegistry:
         """
         cfg = self._agent_config
         return (
-            getattr(cfg, "current_database", None),
+            getattr(cfg, "current_datasource", None),
             getattr(cfg, "namespace", None),
         )
 

--- a/datus/cli/service_manager.py
+++ b/datus/cli/service_manager.py
@@ -95,7 +95,7 @@ class ServiceManager:
         table.add_column("Connection")
         table.add_column("Default")
 
-        default_db = self.agent_config.services.default_database
+        default_db = self.agent_config.services.default_datasource
         for db_name, db_config in databases.items():
             connection = ""
             if db_config.uri:

--- a/datus/cli/sub_agent_commands.py
+++ b/datus/cli/sub_agent_commands.py
@@ -29,7 +29,7 @@ class SubAgentCommands:
         if self._sub_agent_manager is None:
             self._sub_agent_manager = SubAgentManager(
                 configuration_manager=self.cli_instance.configuration_manager,
-                namespace=self.cli_instance.agent_config.current_database,
+                namespace=self.cli_instance.agent_config.current_datasource,
                 agent_config=self.cli_instance.agent_config,
             )
         return self._sub_agent_manager
@@ -120,7 +120,7 @@ class SubAgentCommands:
             agent = SubAgentConfig.model_validate(agent)
             if (
                 not agent.has_scoped_context()
-                or agent.scoped_context.namespace == self.cli_instance.agent_config.current_database
+                or agent.scoped_context.namespace == self.cli_instance.agent_config.current_datasource
             ):
                 show_agents.append(agent)
 

--- a/datus/cli/tutorial.py
+++ b/datus/cli/tutorial.py
@@ -209,7 +209,7 @@ class BenchmarkTutorial:
         logger.info(f"Semantic model initialization with {self.benchmark_path}/{self.namespace_name}/success_story.csv")
         try:
             agent_config = load_agent_config(reload=True, config=self.config_path)
-            agent_config.current_database = self.namespace_name
+            agent_config.current_datasource = self.namespace_name
 
             successful, result = init_semantic_model(
                 success_path=success_path,
@@ -232,7 +232,7 @@ class BenchmarkTutorial:
         logger.info(f"Metrics initialization with {self.benchmark_path}/{self.namespace_name}/success_story.csv")
         try:
             agent_config = load_agent_config(reload=True, config=self.config_path)
-            agent_config.current_database = self.namespace_name
+            agent_config.current_datasource = self.namespace_name
             subject_tree = parse_subject_tree(
                 "california_schools/Continuation_School/Free_Rate,california_schools/Charter/Education_Location"
             )

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -45,7 +45,7 @@ def _build_agent_args(args: argparse.Namespace) -> argparse.Namespace:
     ``create_app`` / ``DatusAPIService``.
     """
     agent_args = argparse.Namespace(
-        namespace=args.database,
+        namespace=args.datasource,
         config=getattr(args, "config", None),
         debug=getattr(args, "debug", False),
         # Fields expected by DatusAPIService but not present in CLI args
@@ -179,7 +179,7 @@ def run_web_interface(args: argparse.Namespace) -> None:
         url += f"/?subagent={args.subagent}"
 
     logger.info("Starting Datus Web Interface...")
-    logger.info(f"Database: {args.database}")
+    logger.info(f"Datasource: {args.datasource}")
     logger.info(f"Server URL: {url}")
 
     app = create_web_app(args)

--- a/datus/cli/web/config_manager.py
+++ b/datus/cli/web/config_manager.py
@@ -47,7 +47,7 @@ def get_available_namespaces(config_path: str = "") -> List[str]:
         return []
 
 
-def create_cli_args(config_path: str = "", namespace: str = None, catalog: str = "", database: str = "") -> Namespace:
+def create_cli_args(config_path: str = "", namespace: str = None, catalog: str = "", datasource: str = "") -> Namespace:
     """Create CLI arguments for DatusCLI initialization"""
     args = Namespace()
     args.config = parse_config_path(config_path)
@@ -55,7 +55,7 @@ def create_cli_args(config_path: str = "", namespace: str = None, catalog: str =
     args.history_file = ".datus_history"
     args.db_type = "sqlite"
     args.db_path = None
-    args.database = database
+    args.datasource = datasource
     args.catalog = catalog
     args.schema = ""
     args.debug = False
@@ -108,7 +108,7 @@ class ConfigManager:
         self.cli = cli
 
     def setup_config(
-        self, config_path: str = "conf/agent.yml", namespace: str = None, catalog: str = "", database: str = ""
+        self, config_path: str = "conf/agent.yml", namespace: str = None, catalog: str = "", datasource: str = ""
     ) -> DatusCLI:
         """
         Setup agent configuration by initializing real DatusCLI.
@@ -117,7 +117,7 @@ class ConfigManager:
             config_path: Path to agent configuration file
             namespace: Namespace to use (optional)
             catalog: Catalog to use (optional)
-            database: Database to use (optional)
+            datasource: Datasource to use (optional)
 
         Returns:
             Initialized DatusCLI instance
@@ -126,7 +126,7 @@ class ConfigManager:
             Exception: If configuration loading fails
         """
         # Create CLI arguments
-        args = create_cli_args(config_path, namespace, catalog, database=database)
+        args = create_cli_args(config_path, namespace, catalog, datasource=datasource)
 
         # Initialize real DatusCLI
         cli = DatusCLI(args)

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -162,7 +162,7 @@ class ServicesConfig:
     schedulers: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
     @property
-    def default_database(self) -> Optional[str]:
+    def default_datasource(self) -> Optional[str]:
         """Return the datasource entry marked as default, or the only one if just one exists."""
         defaults = [name for name, cfg in self.datasources.items() if cfg.default]
         if defaults:
@@ -436,7 +436,7 @@ class AgentConfig:
     search_metrics_rate: str
     _reflection_nodes: Dict[str, List[str]]
     _save_dir: str
-    _current_database: str
+    _current_datasource: str
     _project_name: str
     _trajectory_dir: str
     services: ServicesConfig
@@ -477,7 +477,7 @@ class AgentConfig:
         # CLI, or direct assignment from API/gateway bootstraps.
         filesystem_raw = kwargs.get("filesystem") or {}
         self._filesystem_strict = bool(filesystem_raw.get("strict", False))
-        self._current_database = ""
+        self._current_datasource = ""
         self.nodes = nodes
         self.export_config: Dict[str, Any] = kwargs.get("export", {})
         self.api_config: Dict[str, Any] = kwargs.get("api", {}) or {}
@@ -627,11 +627,11 @@ class AgentConfig:
         self._filesystem_strict = bool(value)
 
     @property
-    def current_database(self):
-        return self._current_database
+    def current_datasource(self):
+        return self._current_datasource
 
-    @current_database.setter
-    def current_database(self, value):
+    @current_datasource.setter
+    def current_datasource(self, value):
         """Set the current datasource name (must exist in services.datasources)."""
         if not value:
             return
@@ -640,7 +640,7 @@ class AgentConfig:
                 ErrorCode.COMMON_CONFIG_ERROR,
                 message=f"No datasource configuration named `{value}` found. Available: {list(self.services.datasources.keys())}",
             )
-        self._current_database = value
+        self._current_datasource = value
         self.db_type = self.services.datasources[value].type
 
     @property
@@ -671,8 +671,8 @@ class AgentConfig:
 
     @property
     def current_namespace(self) -> str:
-        """Backward-compat: returns current_database as namespace key for DBManager compat."""
-        return self._current_database
+        """Backward-compat: returns current_datasource as namespace key for DBManager compat."""
+        return self._current_datasource
 
     @property
     def max_export_lines(self) -> int:
@@ -680,7 +680,7 @@ class AgentConfig:
 
     @current_namespace.setter
     def current_namespace(self, value: str):
-        """Backward-compat: setting current_namespace now sets current_database.
+        """Backward-compat: setting current_namespace now sets current_datasource.
 
         Accepts a datasource name from services.datasources. Also accepts legacy namespace names
         which are auto-migrated to datasource names.
@@ -688,16 +688,16 @@ class AgentConfig:
         if not value:
             raise DatusException(
                 code=ErrorCode.COMMON_FIELD_REQUIRED,
-                message_args={"field_name": "database"},
+                message_args={"field_name": "datasource"},
             )
         if value not in self.services.datasources:
             raise DatusException(
                 code=ErrorCode.COMMON_UNSUPPORTED,
-                message_args={"field_name": "database", "your_value": value},
+                message_args={"field_name": "datasource", "your_value": value},
             )
-        if value == self._current_database:
+        if value == self._current_datasource:
             return
-        self._current_database = value
+        self._current_datasource = value
         db_config = self.services.datasources[value]
         self.db_type = db_config.type
 
@@ -814,12 +814,12 @@ class AgentConfig:
         datasources = self.services.datasources
         if db_name and db_name in datasources:
             return datasources[db_name]
-        if self._current_database and self._current_database in datasources:
-            return datasources[self._current_database]
+        if self._current_datasource and self._current_datasource in datasources:
+            return datasources[self._current_datasource]
         if len(datasources) == 1:
             return list(datasources.values())[0]
         if not db_name:
-            default = self.services.default_database
+            default = self.services.default_datasource
             if default:
                 return datasources[default]
         raise DatusException(
@@ -929,7 +929,9 @@ class AgentConfig:
         config = self.get_semantic_layer_config(resolved_adapter)
         config.setdefault("type", resolved_adapter)
 
-        db_name = database_name or config.get("namespace") or self.current_database or self.services.default_database
+        db_name = (
+            database_name or config.get("namespace") or self.current_datasource or self.services.default_datasource
+        )
         if db_name:
             config.setdefault("namespace", db_name)
             db_config = _db_config_to_semantic_adapter_config(self.current_db_config(db_name))
@@ -942,10 +944,10 @@ class AgentConfig:
 
     @property
     def output_dir(self) -> str:
-        return f"{self._save_dir}/{self._current_database}"
+        return f"{self._save_dir}/{self._current_datasource}"
 
     def get_save_run_dir(self, run_id: Optional[str] = None) -> str:
-        return str(self.save_run_dir(self._current_database, run_id))
+        return str(self.save_run_dir(self._current_datasource, run_id))
 
     def save_run_dir(self, database: str, run_id: Optional[str] = None) -> Path:
         from datus.utils.path_manager import DatusPathManager
@@ -957,7 +959,7 @@ class AgentConfig:
         return self._trajectory_dir
 
     def get_trajectory_run_dir(self, run_id: Optional[str] = None) -> str:
-        return str(self.trajectory_run_dir(self._current_database, run_id))
+        return str(self.trajectory_run_dir(self._current_datasource, run_id))
 
     def trajectory_run_dir(self, database: str, run_id: Optional[str] = None) -> Path:
         from datus.utils.path_manager import DatusPathManager
@@ -1063,12 +1065,12 @@ class AgentConfig:
         if kwargs.get("plan", ""):
             self.workflow_plan = kwargs["plan"]
         if kwargs.get("action", "") not in ["probe-llm", "generate-dataset", "service", "platform-doc"]:
-            # Support both --database (new) and --namespace (legacy) CLI args
-            db_arg = kwargs.get("database", "") or kwargs.get("namespace", "")
+            # Support both --datasource (new) and --namespace (legacy) CLI args
+            db_arg = kwargs.get("datasource", "") or kwargs.get("namespace", "")
             if db_arg:
                 self.current_namespace = db_arg  # uses the compat setter
-            elif self.services.default_database:
-                self.current_namespace = self.services.default_database
+            elif self.services.default_datasource:
+                self.current_namespace = self.services.default_datasource
         if kwargs.get("benchmark", ""):
             benchmark_platform = kwargs["benchmark"]
             # Validate benchmark is supported (will raise exception if not)
@@ -1135,7 +1137,7 @@ class AgentConfig:
 
     def _current_db_config(self) -> Dict[str, DbConfig]:
         """Backward-compat: returns all datasource configs."""
-        if not self._current_database and not self.services.datasources:
+        if not self._current_datasource and not self.services.datasources:
             raise DatusException(
                 code=ErrorCode.COMMON_FIELD_REQUIRED,
                 message="Database is required, please run with --database <database>",
@@ -1146,8 +1148,8 @@ class AgentConfig:
         datasources = self.services.datasources
         if db_name and db_name in datasources:
             return db_name, datasources[db_name].type
-        if self._current_database and self._current_database in datasources:
-            return self._current_database, datasources[self._current_database].type
+        if self._current_datasource and self._current_datasource in datasources:
+            return self._current_datasource, datasources[self._current_datasource].type
         if len(datasources) == 1:
             cfg = list(datasources.values())[0]
             return cfg.logic_name or db_name, cfg.type

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1117,7 +1117,7 @@ class AgentConfig:
         if not self._current_datasource and not self.services.datasources:
             raise DatusException(
                 code=ErrorCode.COMMON_FIELD_REQUIRED,
-                message="Database is required, please run with --database <database>",
+                message="Datasource is required, please run with --datasource <datasource>",
             )
         return self.services.datasources
 

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -634,12 +634,17 @@ class AgentConfig:
     def current_datasource(self, value):
         """Set the current datasource name (must exist in services.datasources)."""
         if not value:
-            return
+            raise DatusException(
+                code=ErrorCode.COMMON_FIELD_REQUIRED,
+                message_args={"field_name": "datasource"},
+            )
         if value not in self.services.datasources:
             raise DatusException(
-                ErrorCode.COMMON_CONFIG_ERROR,
-                message=f"No datasource configuration named `{value}` found. Available: {list(self.services.datasources.keys())}",
+                code=ErrorCode.COMMON_UNSUPPORTED,
+                message_args={"field_name": "datasource", "your_value": value},
             )
+        if value == self._current_datasource:
+            return
         self._current_datasource = value
         self.db_type = self.services.datasources[value].type
 
@@ -670,36 +675,8 @@ class AgentConfig:
         return str(self._project_root)
 
     @property
-    def current_namespace(self) -> str:
-        """Backward-compat: returns current_datasource as namespace key for DBManager compat."""
-        return self._current_datasource
-
-    @property
     def max_export_lines(self) -> int:
         return self.export_config.get("max_lines", 1000)
-
-    @current_namespace.setter
-    def current_namespace(self, value: str):
-        """Backward-compat: setting current_namespace now sets current_datasource.
-
-        Accepts a datasource name from services.datasources. Also accepts legacy namespace names
-        which are auto-migrated to datasource names.
-        """
-        if not value:
-            raise DatusException(
-                code=ErrorCode.COMMON_FIELD_REQUIRED,
-                message_args={"field_name": "datasource"},
-            )
-        if value not in self.services.datasources:
-            raise DatusException(
-                code=ErrorCode.COMMON_UNSUPPORTED,
-                message_args={"field_name": "datasource", "your_value": value},
-            )
-        if value == self._current_datasource:
-            return
-        self._current_datasource = value
-        db_config = self.services.datasources[value]
-        self.db_type = db_config.type
 
     @property
     def namespaces(self) -> Dict[str, Dict[str, DbConfig]]:
@@ -1068,9 +1045,9 @@ class AgentConfig:
             # Support both --datasource (new) and --namespace (legacy) CLI args
             db_arg = kwargs.get("datasource", "") or kwargs.get("namespace", "")
             if db_arg:
-                self.current_namespace = db_arg  # uses the compat setter
+                self.current_datasource = db_arg
             elif self.services.default_datasource:
-                self.current_namespace = self.services.default_datasource
+                self.current_datasource = self.services.default_datasource
         if kwargs.get("benchmark", ""):
             benchmark_platform = kwargs["benchmark"]
             # Validate benchmark is supported (will raise exception if not)

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -169,10 +169,10 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
     """Merge ``./.datus/config.yml`` overlay into the raw agent config dict.
 
     Only three keys are honored: ``target``, ``project_name``, and
-    ``default_database``. All three are written back into ``agent_raw``
+    ``default_datasource``. All three are written back into ``agent_raw``
     so ``AgentConfig.__init__`` picks them up naturally. For
-    ``default_database`` this means flipping ``datasources[*].default``
-    flags, since ``AgentConfig.services.default_database`` is derived
+    ``default_datasource`` this means flipping ``datasources[*].default``
+    flags, since ``AgentConfig.services.default_datasource`` is derived
     from those flags — this keeps the overlay effective for every
     entry point that calls ``load_agent_config`` (REPL, print mode,
     web, ``datus-api``, SDK), not just the CLI layer.
@@ -192,20 +192,20 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
                 },
             )
         agent_raw["target"] = override.target
-    if override.default_database is not None:
+    if override.default_datasource is not None:
         datasources = (agent_raw.get("services", {}) or {}).get("datasources", {}) or {}
-        if override.default_database not in datasources:
+        if override.default_datasource not in datasources:
             raise DatusException(
                 code=ErrorCode.COMMON_FIELD_INVALID,
                 message_args={
-                    "field_name": "default_database (from .datus/config.yml)",
+                    "field_name": "default_datasource (from .datus/config.yml)",
                     "except_values": sorted(datasources.keys()),
-                    "your_value": override.default_database,
+                    "your_value": override.default_datasource,
                 },
             )
         for db_name, db_cfg in datasources.items():
             if isinstance(db_cfg, dict):
-                db_cfg["default"] = db_name == override.default_database
+                db_cfg["default"] = db_name == override.default_datasource
     if override.project_name is not None:
         agent_raw["project_name"] = override.project_name
 
@@ -262,13 +262,13 @@ def load_agent_config(reload: bool = False, **kwargs) -> AgentConfig:
 
         if override_kwargs:
             agent_config.override_by_args(**override_kwargs)
-    # Resolve current_database when an unambiguous default exists. Priority
+    # Resolve current_datasource when an unambiguous default exists. Priority
     # already applied upstream:
-    #   1. ``./.datus/config.yml::default_database`` (via _apply_project_override)
+    #   1. ``./.datus/config.yml::default_datasource`` (via _apply_project_override)
     #   2. ``services.datasources[*].default: true`` flag in base agent.yml
-    #   3. single-entry auto-select (ServiceConfig.default_database)
-    if not agent_config.current_database and agent_config.services.datasources:
-        default_db = agent_config.services.default_database
+    #   3. single-entry auto-select (ServiceConfig.default_datasource)
+    if not agent_config.current_datasource and agent_config.services.datasources:
+        default_db = agent_config.services.default_datasource
         if default_db:
             agent_config.current_namespace = default_db
         elif kwargs.get("action"):
@@ -281,18 +281,18 @@ def load_agent_config(reload: bool = False, **kwargs) -> AgentConfig:
                         "datasources without any marked as `default: true`. Run "
                         "`datus` in this project directory first to launch the "
                         "init wizard (which writes ./.datus/config.yml with your "
-                        "preferred default_database and target), or set "
+                        "preferred default_datasource and target), or set "
                         "`default: true` on one entry under "
                         "`services.datasources` in agent.yml."
                     )
                 },
             )
     # Auto-select default datasource for file-based DBs if not already set
-    if agent_config.db_type in {DBType.SQLITE, DBType.DUCKDB} and not agent_config.current_database:
+    if agent_config.db_type in {DBType.SQLITE, DBType.DUCKDB} and not agent_config.current_datasource:
         datasources = agent_config.services.datasources
         if datasources:
             first_key = next(iter(datasources))
-            agent_config.current_database = first_key
+            agent_config.current_datasource = first_key
 
     return agent_config
 

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -270,7 +270,7 @@ def load_agent_config(reload: bool = False, **kwargs) -> AgentConfig:
     if not agent_config.current_datasource and agent_config.services.datasources:
         default_db = agent_config.services.default_datasource
         if default_db:
-            agent_config.current_namespace = default_db
+            agent_config.current_datasource = default_db
         elif kwargs.get("action"):
             raise DatusException(
                 code=ErrorCode.COMMON_CONFIG_ERROR,

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -8,7 +8,7 @@ A small, strict overlay on the base ``agent.yml`` that lets every project
 pin three values without copying the full config:
 
 - ``target``: which LLM to use (must match a key under ``agent.models``)
-- ``default_database``: which datasource to connect to on startup (must
+- ``default_datasource``: which datasource to connect to on startup (must
   match a key under ``agent.services.datasources``)
 - ``project_name``: shard name for ``~/.datus/sessions/{project_name}/``
   and ``~/.datus/data/{project_name}/`` (optional)
@@ -29,7 +29,7 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 PROJECT_CONFIG_REL = ".datus/config.yml"
-ALLOWED_KEYS = frozenset({"target", "default_database", "project_name"})
+ALLOWED_KEYS = frozenset({"target", "default_datasource", "project_name"})
 
 
 @dataclass
@@ -40,11 +40,11 @@ class ProjectOverride:
     """
 
     target: Optional[str] = None
-    default_database: Optional[str] = None
+    default_datasource: Optional[str] = None
     project_name: Optional[str] = None
 
     def is_empty(self) -> bool:
-        return self.target is None and self.default_database is None and self.project_name is None
+        return self.target is None and self.default_datasource is None and self.project_name is None
 
 
 def project_config_path(cwd: Optional[str] = None) -> Path:
@@ -80,7 +80,7 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         logger.warning(f"Ignoring unknown keys in {path}: {sorted(unknown)}. Only {sorted(ALLOWED_KEYS)} are accepted.")
     return ProjectOverride(
         target=raw.get("target"),
-        default_database=raw.get("default_database"),
+        default_datasource=raw.get("default_datasource"),
         project_name=raw.get("project_name"),
     )
 
@@ -98,7 +98,7 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
         k: v
         for k, v in {
             "target": override.target,
-            "default_database": override.default_database,
+            "default_datasource": override.default_datasource,
             "project_name": override.project_name,
         }.items()
         if v is not None

--- a/datus/main.py
+++ b/datus/main.py
@@ -69,7 +69,7 @@ def create_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     init_parser.add_argument(
-        "--database", "--namespace", type=str, default="", help="Database to probe for schema info in AGENTS.md"
+        "--datasource", "--namespace", type=str, default="", help="Datasource to probe for schema info in AGENTS.md"
     )
 
     # service command (was: namespace)
@@ -106,7 +106,9 @@ def create_parser() -> argparse.ArgumentParser:
         parents=[global_parser],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    check_db_parser.add_argument("--database", "--namespace", type=str, required=True, help="Database name to check")
+    check_db_parser.add_argument(
+        "--datasource", "--namespace", type=str, required=True, help="Datasource name to check"
+    )
 
     # bootstrap-kb command
     bootstrap_parser = subparsers.add_parser(
@@ -142,7 +144,7 @@ def create_parser() -> argparse.ArgumentParser:
     bootstrap_parser.add_argument(
         "--benchmark", type=str, choices=["spider2", "bird_dev", "bird_critic"], help="Benchmark dataset to use"
     )
-    bootstrap_parser.add_argument("--database", "--namespace", type=str, required=True, help="Database name")
+    bootstrap_parser.add_argument("--datasource", "--namespace", type=str, required=True, help="Datasource name")
     bootstrap_parser.add_argument(
         "--schema_linking_type",
         type=str,
@@ -318,7 +320,7 @@ def create_parser() -> argparse.ArgumentParser:
     benchmark_parser.add_argument(
         "--benchmark_task_ids", type=str, nargs="+", help="Specific benchmark task IDs to run"
     )
-    benchmark_parser.add_argument("--database", "--namespace", type=str, required=True, help="Database name")
+    benchmark_parser.add_argument("--datasource", "--namespace", type=str, required=True, help="Datasource name")
     benchmark_parser.add_argument("--task_db_name", type=str, help="Database name for the task")
     benchmark_parser.add_argument("--task_schema", type=str, help="Schema name for the task")
     benchmark_parser.add_argument("--subject_path", type=str, help="Subject path for the task")
@@ -384,7 +386,7 @@ def create_parser() -> argparse.ArgumentParser:
         parents=[global_parser],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    run_parser.add_argument("--database", "--namespace", type=str, required=True, help="Database name")
+    run_parser.add_argument("--datasource", "--namespace", type=str, required=True, help="Datasource name")
     run_parser.add_argument("--task", type=str, required=True, help="Natural language task description")
     run_parser.add_argument(
         "--task_id",
@@ -423,7 +425,7 @@ def create_parser() -> argparse.ArgumentParser:
         parents=[global_parser],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    evaluation_parser.add_argument("--database", "--namespace", type=str, required=True, help="Database name")
+    evaluation_parser.add_argument("--datasource", "--namespace", type=str, required=True, help="Datasource name")
     evaluation_parser.add_argument(
         "--benchmark",
         type=str,
@@ -449,7 +451,7 @@ def create_parser() -> argparse.ArgumentParser:
         parents=[global_parser],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    bi_subparser.add_argument("--database", "--namespace", type=str, required=True, help="Database name")
+    bi_subparser.add_argument("--datasource", "--namespace", type=str, required=True, help="Datasource name")
 
     multi_benchmark_parser = subparsers.add_parser(
         "multi-round-benchmark", parents=[global_parser], help="Multi-round benchmarking"

--- a/datus/mcp_server.py
+++ b/datus/mcp_server.py
@@ -1235,10 +1235,10 @@ HTTP Client Usage:
     )
 
     parser.add_argument(
-        "--database",
+        "--datasource",
         "-d",
         default=None,
-        help="Run in static mode with specified database name",
+        help="Run in static mode with specified datasource name",
     )
 
     parser.add_argument(
@@ -1310,7 +1310,7 @@ HTTP Client Usage:
         server = create_server(
             namespace=args.namespace,
             sub_agent=args.sub_agent,
-            database_name=args.database,
+            database_name=args.datasource,
             config_path=args.config,
         )
         server.run(transport=args.transport, host=args.host, port=args.port)

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -196,7 +196,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                 node_name = getattr(self.current_node, "node_type", "") or ""
             agent_config = getattr(self.current_node, "agent_config", None)
             if agent_config:
-                namespace = getattr(agent_config, "current_namespace", "") or ""
+                namespace = getattr(agent_config, "current_datasource", "") or ""
                 database = getattr(agent_config, "current_datasource", "") or ""
 
         raw_key = "|".join(

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -188,7 +188,7 @@ class OpenAICompatibleModel(LLMBaseModel):
 
         node_name = ""
         namespace = ""
-        database = ""
+        datasource = ""
         if getattr(self, "current_node", None):
             try:
                 node_name = self.current_node.get_node_name()
@@ -197,7 +197,7 @@ class OpenAICompatibleModel(LLMBaseModel):
             agent_config = getattr(self.current_node, "agent_config", None)
             if agent_config:
                 namespace = getattr(agent_config, "current_datasource", "") or ""
-                database = getattr(agent_config, "current_datasource", "") or ""
+                datasource = getattr(agent_config, "current_datasource", "") or ""
 
         raw_key = "|".join(
             [
@@ -206,7 +206,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                 agent_name,
                 node_name,
                 namespace,
-                database,
+                datasource,
             ]
         )
         return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()[:32]

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -197,7 +197,7 @@ class OpenAICompatibleModel(LLMBaseModel):
             agent_config = getattr(self.current_node, "agent_config", None)
             if agent_config:
                 namespace = getattr(agent_config, "current_namespace", "") or ""
-                database = getattr(agent_config, "current_database", "") or ""
+                database = getattr(agent_config, "current_datasource", "") or ""
 
         raw_key = "|".join(
             [

--- a/datus/prompts/prompt_templates/feedback_system_1.0.j2
+++ b/datus/prompts/prompt_templates/feedback_system_1.0.j2
@@ -57,4 +57,4 @@ After completing the analysis and archival, provide a summary:
 - What was skipped and why
 - Any recommendations for the user
 
-Database context: {{ current_database }}
+Database context: {{ current_datasource }}

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -25,7 +25,7 @@ class CatalogUpdater:
 
     def __init__(self, agent_config: AgentConfig, datasource_id: Optional[str] = None):
         self._agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.semantic_model_storage = get_storage(
             SemanticModelStorage, "semantic_model", project=agent_config.project_name
         )

--- a/datus/storage/ext_knowledge/store.py
+++ b/datus/storage/ext_knowledge/store.py
@@ -310,7 +310,7 @@ class ExtKnowledgeRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.store = get_storage(ExtKnowledgeStore, "ext_knowledge", project=agent_config.project_name)
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.store, "ext_knowledge")
 

--- a/datus/storage/metric/adapter_init.py
+++ b/datus/storage/metric/adapter_init.py
@@ -47,7 +47,7 @@ async def init_from_adapter(
         if callable(resolver):
             adapter_type = resolver(adapter_type) or adapter_type
 
-        namespace = getattr(agent_config, "namespace", None) or agent_config.current_database
+        namespace = getattr(agent_config, "namespace", None) or agent_config.current_datasource
 
         # Get the registered config class for this adapter type
         metadata = semantic_adapter_registry.get_metadata(adapter_type)

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -498,7 +498,7 @@ class MetricRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.storage: MetricStorage = get_storage(MetricStorage, "metric", project=agent_config.project_name)
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.storage, "metrics")
 

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -438,7 +438,7 @@ class ReferenceSqlRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.reference_sql_storage = get_storage(
             ReferenceSqlStorage, "reference_sql", project=agent_config.project_name
         )

--- a/datus/storage/reference_template/reference_template_init.py
+++ b/datus/storage/reference_template/reference_template_init.py
@@ -72,7 +72,7 @@ def _enrich_dimension_sample_values(params: list, agent_config: AgentConfig) -> 
 
     try:
         db_manager = db_manager_instance(agent_config.namespaces)
-        conn = db_manager.get_conn(agent_config.current_namespace, agent_config.current_database)
+        conn = db_manager.get_conn(agent_config.current_namespace, agent_config.current_datasource)
         db_tool = DBFuncTool(conn, agent_config=agent_config)
     except Exception as e:
         logger.debug(f"Cannot create DB connection for parameter value enrichment: {e}")

--- a/datus/storage/reference_template/reference_template_init.py
+++ b/datus/storage/reference_template/reference_template_init.py
@@ -72,7 +72,7 @@ def _enrich_dimension_sample_values(params: list, agent_config: AgentConfig) -> 
 
     try:
         db_manager = db_manager_instance(agent_config.namespaces)
-        conn = db_manager.get_conn(agent_config.current_namespace, agent_config.current_datasource)
+        conn = db_manager.get_conn(agent_config.current_datasource, agent_config.current_datasource)
         db_tool = DBFuncTool(conn, agent_config=agent_config)
     except Exception as e:
         logger.debug(f"Cannot create DB connection for parameter value enrichment: {e}")

--- a/datus/storage/reference_template/store.py
+++ b/datus/storage/reference_template/store.py
@@ -195,7 +195,7 @@ class ReferenceTemplateRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.reference_template_storage = get_storage(
             ReferenceTemplateStorage, "reference_template", project=agent_config.project_name
         )

--- a/datus/storage/schema_metadata/local_init.py
+++ b/datus/storage/schema_metadata/local_init.py
@@ -91,10 +91,10 @@ def init_local_schema(
     """
     event_helper = BatchEventHelper(BIZ_NAME, emit)
 
-    logger.info(f"Initializing local schema for namespace: {agent_config.current_database}")
-    event_helper.task_started(namespace=agent_config.current_database, build_mode=build_mode, table_type=table_type)
+    logger.info(f"Initializing local schema for namespace: {agent_config.current_datasource}")
+    event_helper.task_started(namespace=agent_config.current_datasource, build_mode=build_mode, table_type=table_type)
 
-    db_configs = agent_config.namespaces[agent_config.current_database]
+    db_configs = agent_config.namespaces[agent_config.current_datasource]
     if len(db_configs) == 1:
         db_configs = list(db_configs.values())[0]
 
@@ -188,7 +188,7 @@ def init_sqlite_schema(
     event_helper: Optional[BatchEventHelper] = None,
 ):
     database_name = getattr(db_config, "database", "")
-    sql_connector = db_manager.get_conn(agent_config.current_database, database_name)
+    sql_connector = db_manager.get_conn(agent_config.current_datasource, database_name)
     all_schema_tables, all_value_tables = exists_table_value(
         table_lineage_store,
         database_name=database_name,
@@ -253,7 +253,7 @@ def init_duckdb_schema(
     logger.info(
         f"Exists data from vector store {database_name}, tables={len(all_schema_tables)},values={len(all_value_tables)}"
     )
-    sql_connector = db_manager.get_conn(agent_config.current_database, database_name)
+    sql_connector = db_manager.get_conn(agent_config.current_datasource, database_name)
     if table_type == "table" or table_type == "full":
         # Get all tables with DDL
         tables = sql_connector.get_tables_with_ddl(schema_name=schema_name)
@@ -303,7 +303,7 @@ def init_other_three_level_schema(
     schema_name = getattr(db_config, "schema", "")
     catalog_name = catalog_name or getattr(db_config, "catalog", "")
 
-    sql_connector = db_manager.get_conn(agent_config.current_database)
+    sql_connector = db_manager.get_conn(agent_config.current_datasource)
 
     if not database_name and hasattr(sql_connector, "database_name"):
         database_name = getattr(sql_connector, "database_name", "")

--- a/datus/storage/schema_metadata/store.py
+++ b/datus/storage/schema_metadata/store.py
@@ -244,7 +244,7 @@ class SchemaWithValueRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.schema_store = get_storage(SchemaStorage, "database", project=agent_config.project_name)
         self.value_store = get_storage(SchemaValueStorage, "database", project=agent_config.project_name)
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.schema_store, "tables")

--- a/datus/storage/semantic_model/adapter_init.py
+++ b/datus/storage/semantic_model/adapter_init.py
@@ -45,7 +45,7 @@ async def init_from_adapter(
         if callable(resolver):
             adapter_type = resolver(adapter_type) or adapter_type
 
-        namespace = getattr(agent_config, "namespace", None) or agent_config.current_database
+        namespace = getattr(agent_config, "namespace", None) or agent_config.current_datasource
 
         # Get the registered config class for this adapter type
         metadata = semantic_adapter_registry.get_metadata(adapter_type)

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -271,7 +271,7 @@ class SemanticModelRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.storage: SemanticModelStorage = get_storage(
             SemanticModelStorage, "semantic_model", project=agent_config.project_name
         )

--- a/datus/storage/subject_manager.py
+++ b/datus/storage/subject_manager.py
@@ -26,7 +26,7 @@ class SubjectUpdater:
 
     def __init__(self, agent_config: AgentConfig, datasource_id: Optional[str] = None):
         self._agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_database or ""
+        self.datasource_id = datasource_id or agent_config.current_datasource or ""
         self.metrics_storage: MetricStorage = get_storage(MetricStorage, "metric", project=agent_config.project_name)
         self.reference_sql_storage: ReferenceSqlStorage = get_storage(
             ReferenceSqlStorage, "reference_sql", project=agent_config.project_name

--- a/datus/tools/func_tool/bi_tools.py
+++ b/datus/tools/func_tool/bi_tools.py
@@ -216,7 +216,7 @@ class BIFuncTool:
                 from datus.tools.db_tools.db_manager import db_manager_instance
 
                 db_manager = db_manager_instance(self.agent_config.namespaces)
-                current_db = getattr(self.agent_config, "current_database", "") or ""
+                current_db = getattr(self.agent_config, "current_datasource", "") or ""
                 # Pick whichever connector the namespace carries rather than
                 # assuming ``namespace == logic_db``. In the post-services
                 # migration they happen to match, but ``first_conn_with_name``

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -148,8 +148,8 @@ class DBFuncTool:
             if not agent_config:
                 raise ValueError("AgentConfiguration is required when using DBManager mode")
             self._db_manager = connector_or_manager
-            self._namespace = agent_config.current_database
-            self._default_database = default_database or (agent_config.current_database if agent_config else "")
+            self._namespace = agent_config.current_datasource
+            self._default_database = default_database or (agent_config.current_datasource if agent_config else "")
             if len(agent_config.current_db_configs()) == 1:
                 self._init_single_db_connector(self._db_manager.first_conn(self._namespace))
             else:
@@ -1567,7 +1567,7 @@ def db_function_tool_instance(
     """
     db_manager = db_manager_instance(agent_config.namespaces)
     return DBFuncTool(
-        db_manager.get_conn(agent_config.current_database, database_name or agent_config.current_database),
+        db_manager.get_conn(agent_config.current_datasource, database_name or agent_config.current_datasource),
         agent_config=agent_config,
         sub_agent_name=sub_agent_name,
     )
@@ -1597,7 +1597,7 @@ def db_function_tool_instance_multi(
     return DBFuncTool(
         db_manager,
         agent_config=agent_config,
-        default_database=agent_config.current_database,
+        default_database=agent_config.current_datasource,
         sub_agent_name=sub_agent_name,
         connector_cache_size=connector_cache_size,
     )

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -190,7 +190,7 @@ class GenerationTools:
             metric_file: Path to the generated metric YAML file (required).
                 Relative paths (e.g. ``"metrics/orders_metrics.yml"``) are preferred
                 and resolved against the sub-agent's semantic-model workspace using
-                the live ``agent_config.current_namespace``. Absolute paths are also
+                the live ``agent_config.current_datasource``. Absolute paths are also
                 accepted and used as-is.
             semantic_model_file: Path to the primary semantic model file that defines
                 the measure(s) used by this metric. Optional — provide this if the

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -153,7 +153,7 @@ class SemanticTools:
                 builder = getattr(self.agent_config, "build_semantic_adapter_config", None)
                 adapter_config = builder(resolved_adapter) if callable(builder) else None
                 if adapter_config is None:
-                    namespace = getattr(self.agent_config, "namespace", None) or self.agent_config.current_database
+                    namespace = getattr(self.agent_config, "namespace", None) or self.agent_config.current_datasource
                     db_config = self._extract_db_config(namespace)
                     semantic_models_path = str(self.agent_config.path_manager.semantic_models_dir)
 

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -678,13 +678,13 @@ class SubAgentTaskTool:
         if isinstance(node, ExploreAgenticNode):
             return ExploreNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         if isinstance(node, GenSQLAgenticNode):
             return GenSQLNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         # Built-in system subagent input types
@@ -701,7 +701,7 @@ class SubAgentTaskTool:
 
             return SemanticNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         if isinstance(node, (GenSemanticModelAgenticNode, GenMetricsAgenticNode)):
@@ -709,7 +709,7 @@ class SubAgentTaskTool:
 
             return SemanticNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         if isinstance(node, SqlSummaryAgenticNode):
@@ -717,7 +717,7 @@ class SubAgentTaskTool:
 
             return SqlSummaryNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         if isinstance(node, GenExtKnowledgeAgenticNode):
@@ -732,7 +732,7 @@ class SubAgentTaskTool:
 
             return GenDashboardNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
@@ -742,7 +742,7 @@ class SubAgentTaskTool:
 
             return SchedulerNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
@@ -752,7 +752,7 @@ class SubAgentTaskTool:
 
             return GenReportNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_database,
+                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
@@ -1005,7 +1005,7 @@ class SubAgentTaskTool:
         types.extend(sorted(name for name in SYS_SUB_AGENTS if name != "feedback"))
 
         if self.agent_config and hasattr(self.agent_config, "agentic_nodes"):
-            current_database = self.agent_config.current_database
+            current_datasource = self.agent_config.current_datasource
 
             for name, config in self.agent_config.agentic_nodes.items():
                 if name in ("chat", "explore", "feedback") or name in SYS_SUB_AGENTS:
@@ -1014,7 +1014,7 @@ class SubAgentTaskTool:
                 # If scoped_context is configured, namespace must match current namespace
                 try:
                     sub_config = SubAgentConfig.model_validate(config)
-                    if sub_config.has_scoped_context() and not sub_config.is_in_namespace(current_database):
+                    if sub_config.has_scoped_context() and not sub_config.is_in_namespace(current_datasource):
                         continue
                 except Exception as e:
                     logger.debug(f"Skipping invalid subagent config '{name}': {e}")

--- a/datus/utils/benchmark_utils.py
+++ b/datus/utils/benchmark_utils.py
@@ -2077,7 +2077,7 @@ def _build_gold_result_provider(
         )
 
     db_manager = db_manager_instance(agent_config.namespaces)
-    connections = db_manager.get_connections(agent_config.current_database)
+    connections = db_manager.get_connections(agent_config.current_datasource)
 
     return SingleFileGoldProvider(
         result_file=str(result_file),
@@ -2096,7 +2096,7 @@ def evaluate_benchmark(
     target_task_ids: Optional[Iterable[str]] = None,
     run_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    namespace = agent_config.current_database
+    namespace = agent_config.current_datasource
     trajectory_directory = Path(agent_config.trajectory_dir)
 
     try:

--- a/datus/utils/node_utils.py
+++ b/datus/utils/node_utils.py
@@ -23,7 +23,7 @@ def resolve_database_name_for_prompt(connector: Any, connection_name: str = "") 
 
     Args:
         connector: Database connector instance (BaseSqlConnector or similar).
-        connection_name: Connection name from user_input.database or agent_config.current_database.
+        connection_name: Connection name from user_input.database or agent_config.current_datasource.
 
     Returns:
         The most appropriate database name for the LLM prompt.

--- a/tests/integration/agent/test_kb_path_e2e.py
+++ b/tests/integration/agent/test_kb_path_e2e.py
@@ -84,7 +84,7 @@ class TestKnowledgeBaseHomeE2E:
                 "Use get_table_ddl to get the schema, then write the YAML file and "
                 "call end_semantic_model_generation."
             ),
-            database=nightly_agent_config.current_namespace,
+            database=nightly_agent_config.current_datasource,
         )
 
         action_manager = ActionHistoryManager()

--- a/tests/integration/tools/test_func_tools_db.py
+++ b/tests/integration/tools/test_func_tools_db.py
@@ -327,7 +327,7 @@ class TestScopedTables:
         return DBFuncTool(
             db_manager,
             agent_config=ssb_config,
-            default_database=ssb_config.current_database,
+            default_database=ssb_config.current_datasource,
             scoped_tables=["customer", "lineorder"],
         )
 
@@ -350,7 +350,7 @@ class TestScopedTables:
         scoped_tool = DBFuncTool(
             db_manager,
             agent_config=ssb_config,
-            default_database=ssb_config.current_database,
+            default_database=ssb_config.current_datasource,
             scoped_tables=["customer"],
         )
 

--- a/tests/integration/tools/test_tools_output.py
+++ b/tests/integration/tools/test_tools_output.py
@@ -50,7 +50,7 @@ class TestBirdDevOutput:
         assert test_data, "test fixture produced no benchmarks"
         for benchmark, data in test_data.items():
             logger.info("switch benchmark to %s", benchmark)
-            global_config.current_database = data["namespace"]
+            global_config.current_datasource = data["namespace"]
             self._do_execute(benchmark, data, global_config, llm_model)
 
     def _do_execute(

--- a/tests/unit_tests/agent/node/test_agentic_node_ephemeral.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_ephemeral.py
@@ -45,8 +45,8 @@ def mock_agent_config():
     """Minimal AgentConfig mock for testing."""
     config = Mock(spec=AgentConfig)
     config.db_type = "sqlite"
-    config.current_database = "test_db"
-    config.current_database = "default"
+    config.current_datasource = "test_db"
+    config.current_datasource = "default"
     config.agentic_nodes = {
         "chat": {"model": "default"},
         "gen_sql": {"model": "default", "system_prompt": "gen_sql", "node_class": "gen_sql"},

--- a/tests/unit_tests/agent/node/test_agentic_node_ephemeral.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_ephemeral.py
@@ -46,7 +46,7 @@ def mock_agent_config():
     config = Mock(spec=AgentConfig)
     config.db_type = "sqlite"
     config.current_datasource = "test_db"
-    config.current_datasource = "default"
+    config.default_datasource = "default"
     config.agentic_nodes = {
         "chat": {"model": "default"},
         "gen_sql": {"model": "default", "system_prompt": "gen_sql", "node_class": "gen_sql"},

--- a/tests/unit_tests/agent/node/test_date_parser_node.py
+++ b/tests/unit_tests/agent/node/test_date_parser_node.py
@@ -17,7 +17,7 @@ from datus.schemas.node_models import SqlTask
 def make_agent_config(date_parser_language=None):
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     if date_parser_language:
         node_cfg = MagicMock()
         node_cfg.input.language = date_parser_language

--- a/tests/unit_tests/agent/node/test_execute_sql_node.py
+++ b/tests/unit_tests/agent/node/test_execute_sql_node.py
@@ -16,7 +16,7 @@ from datus.schemas.node_models import ExecuteSQLInput, ExecuteSQLResult, SQLCont
 def make_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     return cfg
 

--- a/tests/unit_tests/agent/node/test_fix_node.py
+++ b/tests/unit_tests/agent/node/test_fix_node.py
@@ -17,7 +17,7 @@ from datus.schemas.node_models import SQLContext, SqlTask, TableSchema
 def make_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     return cfg
 

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -628,7 +628,7 @@ class TestGenDashboardRegistration:
             result = tool._build_node_input(node, "List all dashboards")
             assert isinstance(result, GenDashboardNodeInput)
             assert result.user_message == "List all dashboards"
-            assert result.database == real_agent_config.current_database
+            assert result.database == real_agent_config.current_datasource
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_generate_sql_node.py
+++ b/tests/unit_tests/agent/node/test_generate_sql_node.py
@@ -17,7 +17,7 @@ from datus.schemas.node_models import GenerateSQLInput, GenerateSQLResult, SqlTa
 def make_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     return cfg
 

--- a/tests/unit_tests/agent/node/test_node.py
+++ b/tests/unit_tests/agent/node/test_node.py
@@ -119,12 +119,12 @@ def search_metrics_input() -> List[Dict[str, Any]]:
 def agent_config() -> AgentConfig:
     # Post-refactor (PR #542) legacy `namespace:` configs with `path_pattern` expand into
     # one database per matched file (keyed by logic name). The old "bird_sqlite" key is no
-    # longer valid, so the loader drops it; individual tests override `current_database` as
+    # longer valid, so the loader drops it; individual tests override `current_datasource` as
     # needed. Seed a valid default here so fixtures that touch the DB (e.g. `function_tools`)
     # can initialize.
     agent_config = load_acceptance_config(namespace="bird_sqlite")
-    if not agent_config.current_database and agent_config.services.datasources:
-        agent_config.current_database = "california_schools"
+    if not agent_config.current_datasource and agent_config.services.datasources:
+        agent_config.current_datasource = "california_schools"
     Path(agent_config.rag_storage_path()).mkdir(parents=True, exist_ok=True)
     return agent_config
 
@@ -235,7 +235,7 @@ class TestNode:
         for inputs in schema_linking_input:
             test_case = inputs["input"]
             if "namespace" in test_case:
-                agent_config.current_database = test_case["namespace"]
+                agent_config.current_datasource = test_case["namespace"]
                 del test_case["namespace"]
             node = Node.new_instance(
                 node_id="schema_link",
@@ -279,7 +279,7 @@ class TestNode:
             ]
         )
 
-        agent_config.current_database = "california_schools"
+        agent_config.current_datasource = "california_schools"
         agent_config.rag_base_path = "/tmp/test_data"
         node = Node.new_instance(
             node_id="schema_link",
@@ -451,7 +451,7 @@ class TestNode:
                 ]
             )
 
-            agent_config.current_database = "ssb_sqlite"
+            agent_config.current_datasource = "ssb_sqlite"
 
             # Create simple ReasoningInput with revenue calculation task
             input_data = ReasoningInput(
@@ -571,9 +571,9 @@ class TestNode:
                 input_data = ExecuteSQLInput(**exec_input)
                 # Use the database_name from the input to set the current database
                 if exec_input.get("database_name") and exec_input["database_name"] in agent_config.services.datasources:
-                    agent_config.current_database = exec_input["database_name"]
+                    agent_config.current_datasource = exec_input["database_name"]
                 else:
-                    agent_config.current_database = "california_schools"
+                    agent_config.current_datasource = "california_schools"
 
                 # Create node instance for testing
                 node = Node.new_instance(
@@ -634,7 +634,7 @@ class TestNode:
     def test_search_metrics_node(self, search_metrics_input, agent_config: AgentConfig):
         """Test schema linking node"""
         # Take first test case from the list
-        _current_database = agent_config.current_database
+        _current_datasource = agent_config.current_datasource
         try:
             for case in search_metrics_input:
                 input_data = SearchMetricsInput(**case["input"])

--- a/tests/unit_tests/agent/node/test_node_base.py
+++ b/tests/unit_tests/agent/node/test_node_base.py
@@ -18,7 +18,7 @@ from datus.schemas.schema_linking_node_models import SchemaLinkingResult
 def make_mock_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     cfg.custom_workflows = {}
     return cfg

--- a/tests/unit_tests/agent/node/test_parallel_node.py
+++ b/tests/unit_tests/agent/node/test_parallel_node.py
@@ -17,7 +17,7 @@ from datus.schemas.parallel_node_models import ParallelInput, ParallelResult
 def make_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     cfg.custom_workflows = {}
     return cfg

--- a/tests/unit_tests/agent/node/test_reason_sql_node.py
+++ b/tests/unit_tests/agent/node/test_reason_sql_node.py
@@ -15,7 +15,7 @@ from datus.schemas.reason_sql_node_models import ReasoningInput, ReasoningResult
 def make_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     return cfg
 

--- a/tests/unit_tests/agent/node/test_reflect_node.py
+++ b/tests/unit_tests/agent/node/test_reflect_node.py
@@ -16,7 +16,7 @@ from datus.schemas.node_models import ReflectionInput, ReflectionResult, SQLCont
 def make_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     return cfg
 

--- a/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
@@ -306,7 +306,7 @@ class TestSchedulerRegistration:
             result = tool._build_node_input(node, "List all jobs")
             assert isinstance(result, SchedulerNodeInput)
             assert result.user_message == "List all jobs"
-            assert result.database == real_agent_config.current_database
+            assert result.database == real_agent_config.current_datasource
 
     def test_node_factory_with_input_data(self, real_agent_config, mock_llm_create):
         """Node.new_instance with input_data should set node.input."""

--- a/tests/unit_tests/agent/node/test_schema_linking_node.py
+++ b/tests/unit_tests/agent/node/test_schema_linking_node.py
@@ -26,7 +26,7 @@ from datus.schemas.schema_linking_node_models import SchemaLinkingInput, SchemaL
 def _make_agent_config(rag_path="/tmp/nonexistent_rag"):
     cfg = MagicMock()
     cfg.schema_linking_rate = "fast"
-    cfg.current_database = "test_ns"
+    cfg.current_datasource = "test_ns"
     cfg.namespaces = {"test_ns": {}}
     cfg.rag_storage_path.return_value = rag_path
     cfg.agentic_nodes = {}

--- a/tests/unit_tests/agent/node/test_selection_node.py
+++ b/tests/unit_tests/agent/node/test_selection_node.py
@@ -17,7 +17,7 @@ from datus.schemas.parallel_node_models import SelectionInput, SelectionResult
 def make_agent_config():
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     cfg.custom_workflows = {}
     return cfg

--- a/tests/unit_tests/agent/node/test_subworkflow_node.py
+++ b/tests/unit_tests/agent/node/test_subworkflow_node.py
@@ -318,14 +318,16 @@ class TestSubworkflowNodeApplyNodeParams:
         fake_child.input = FakeInput()
         workflow.nodes.values.return_value = [fake_child]
 
-        # Should not raise, just warn
+        # Should not raise, just warn — and the attribute should not be set
         node._apply_node_params(workflow)
+        assert not hasattr(fake_child.input, "nonexistent_param")
 
     def test_apply_node_params_empty(self):
         node = make_node(SubworkflowInput(workflow_name="wf", node_params=None))
         workflow = MagicMock()
-        # Should be a no-op
+        # Should be a no-op — workflow.nodes should not be accessed
         node._apply_node_params(workflow)
+        workflow.nodes.values.assert_not_called()
 
 
 class TestSubworkflowNodeApplyConfigParams:
@@ -351,14 +353,16 @@ class TestSubworkflowNodeApplyConfigParams:
     def test_apply_config_none(self):
         node = make_node()
         workflow = MagicMock()
-        # Should be a no-op
+        # Should be a no-op — workflow.nodes should not be accessed
         node._apply_config_params(workflow, None)
+        workflow.nodes.values.assert_not_called()
 
     def test_apply_config_string_file_not_found(self):
         node = make_node()
         workflow = MagicMock()
         # File doesn't exist, should log warning but not raise
         node._apply_config_params(workflow, "/nonexistent/path/config.yaml")
+        workflow.nodes.values.assert_not_called()
 
 
 class TestSubworkflowNodeSetupInput:

--- a/tests/unit_tests/agent/node/test_subworkflow_node.py
+++ b/tests/unit_tests/agent/node/test_subworkflow_node.py
@@ -16,7 +16,7 @@ from datus.schemas.subworkflow_node_models import SubworkflowInput, SubworkflowR
 def make_agent_config(has_workflow=True, workflow_name="my_wf"):
     cfg = MagicMock()
     cfg.namespaces = {}
-    cfg.current_database = "test"
+    cfg.current_datasource = "test"
     cfg.nodes = {}
     if has_workflow:
         cfg.custom_workflows = {workflow_name: {}}

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -757,8 +757,8 @@ class TestEmitReferenceSqlEvent:
         agent = _make_agent_ext()
         evt = self._event(BatchStage.ITEM_FAILED, error=None)
         agent._emit_reference_sql_event(evt)
-        # Should not raise, empty output is fine
-        capsys.readouterr()
+        out = capsys.readouterr().out
+        assert "error" not in out.lower() or out == ""
 
 
 # ---------------------------------------------------------------------------
@@ -822,7 +822,8 @@ class TestEmitReferenceTemplateEvent:
         agent = _make_agent_ext()
         evt = self._event(BatchStage.ITEM_FAILED, error=None)
         agent._emit_reference_template_event(evt)
-        capsys.readouterr()
+        out = capsys.readouterr().out
+        assert "error" not in out.lower() or out == ""
 
     def test_reset_stream_state(self):
         agent = _make_agent_ext()
@@ -856,11 +857,14 @@ class TestEmitMetricsEvent:
     def test_task_started_logs(self, capsys):
         agent = _make_agent_ext()
         agent._emit_metrics_event(self._event(BatchStage.TASK_STARTED))
-        # No output expected, just no exception
+        captured = capsys.readouterr()
+        assert captured.err == ""
 
     def test_task_completed_logs(self, capsys):
         agent = _make_agent_ext()
         agent._emit_metrics_event(self._event(BatchStage.TASK_COMPLETED))
+        captured = capsys.readouterr()
+        assert captured.err == ""
 
     def test_item_processing_prints_action_name_once(self, capsys):
         agent = _make_agent_ext()
@@ -899,6 +903,8 @@ class TestEmitMetricsEvent:
     def test_item_completed_logs(self, capsys):
         agent = _make_agent_ext()
         agent._emit_metrics_event(self._event(BatchStage.ITEM_COMPLETED))
+        captured = capsys.readouterr()
+        assert captured.err == ""
 
 
 # ---------------------------------------------------------------------------
@@ -1243,8 +1249,8 @@ class TestBenchmarkHelpers:
         f = tmp_path / "tasks.csv"
         f.write_text("question,sql\n")
         agent = _make_agent_ext()
-        # Should not raise
-        agent._check_benchmark_file(str(f))
+        result = agent._check_benchmark_file(str(f))
+        assert result is None
 
     def test_cleanup_benchmark_output_paths_removes_namespace_dir(self, tmp_path):
         agent = _make_agent_ext()
@@ -1253,21 +1259,19 @@ class TestBenchmarkHelpers:
         agent.global_config.output_dir = str(tmp_path)
         agent.global_config.current_datasource = "test_ns"
 
-        with patch("datus.agent.agent.safe_rmtree", return_value=True):
+        with patch("shutil.rmtree") as mock_rmtree:
             agent._cleanup_benchmark_output_paths(str(tmp_path / "bm"))
 
-        # Namespace dir should have been removed
-
-        # The actual rmtree is shutil.rmtree, not safe_rmtree in this branch
-        # Just verify it doesn't raise
+        mock_rmtree.assert_called_once_with(str(namespace_dir))
 
     def test_cleanup_benchmark_output_paths_gold_not_present(self, tmp_path):
         agent = _make_agent_ext()
         agent.global_config.output_dir = str(tmp_path)
         agent.global_config.current_datasource = "test_ns"
 
-        # No gold dir, no error
+        # No gold dir — should not raise
         agent._cleanup_benchmark_output_paths(str(tmp_path / "bm"))
+        assert not (tmp_path / "bm").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -262,7 +262,7 @@ def _make_args(**kwargs):
 
 def _make_agent_config(namespace="test_ns"):
     cfg = MagicMock()
-    cfg.current_database = namespace
+    cfg.current_datasource = namespace
     cfg.namespaces = {namespace: {"type": "sqlite", "dbs": []}}
     cfg.workflow_plan = "reflection"
     cfg.get_trajectory_run_dir.return_value = "/tmp/traj"
@@ -552,7 +552,7 @@ def _make_args_ext(**kwargs):
 
 def _make_agent_config_ext(namespace="test_ns"):
     cfg = MagicMock()
-    cfg.current_database = namespace
+    cfg.current_datasource = namespace
     cfg.namespaces = {namespace: {"type": "sqlite", "dbs": []}}
     cfg.workflow_plan = "reflection"
     cfg.get_trajectory_run_dir.return_value = "/tmp/traj"
@@ -1251,7 +1251,7 @@ class TestBenchmarkHelpers:
         namespace_dir = tmp_path / "test_ns"
         namespace_dir.mkdir()
         agent.global_config.output_dir = str(tmp_path)
-        agent.global_config.current_database = "test_ns"
+        agent.global_config.current_datasource = "test_ns"
 
         with patch("datus.agent.agent.safe_rmtree", return_value=True):
             agent._cleanup_benchmark_output_paths(str(tmp_path / "bm"))
@@ -1264,7 +1264,7 @@ class TestBenchmarkHelpers:
     def test_cleanup_benchmark_output_paths_gold_not_present(self, tmp_path):
         agent = _make_agent_ext()
         agent.global_config.output_dir = str(tmp_path)
-        agent.global_config.current_database = "test_ns"
+        agent.global_config.current_datasource = "test_ns"
 
         # No gold dir, no error
         agent._cleanup_benchmark_output_paths(str(tmp_path / "bm"))

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -23,11 +23,11 @@ from datus.api.routes.config_routes import (
 from datus.utils.exceptions import DatusException
 
 
-def _mock_svc(databases, *, target="deepseek", current_database="starrocks", models=None, home="~/.datus"):
+def _mock_svc(databases, *, target="deepseek", current_datasource="starrocks", models=None, home="~/.datus"):
     svc = MagicMock()
     svc.agent_config.target = target
     svc.agent_config.models = models if models is not None else {}
-    svc.agent_config.current_namespace = current_database
+    svc.agent_config.current_namespace = current_datasource
     svc.agent_config.namespaces = databases
     svc.agent_config.home = home
     return svc
@@ -53,7 +53,7 @@ async def test_get_agent_config_flattens_matching_inner_key():
         "starrocks22": starrocks22_cfg,
     }
     assert result.data["target"] == "deepseek"
-    assert result.data["current_database"] == "starrocks"
+    assert result.data["current_datasource"] == "starrocks"
     assert result.data["home"] == "~/.datus"
 
 

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -27,7 +27,7 @@ def _mock_svc(databases, *, target="deepseek", current_datasource="starrocks", m
     svc = MagicMock()
     svc.agent_config.target = target
     svc.agent_config.models = models if models is not None else {}
-    svc.agent_config.current_namespace = current_datasource
+    svc.agent_config.current_datasource = current_datasource
     svc.agent_config.namespaces = databases
     svc.agent_config.home = home
     return svc

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -39,12 +39,12 @@ class TestFillDatabaseContext:
         assert real_agent_config.current_namespace == original_ns
 
     def test_known_database_updates_namespace_and_db(self, real_agent_config):
-        """Known database in namespaces updates current_namespace and current_database."""
+        """Known database in namespaces updates current_namespace and current_datasource."""
         # real_agent_config has "california_schools" in services.datasources
         # After the namespace→services.datasources refactor, each DB is its own namespace key
         _fill_database_context(real_agent_config, database="california_schools")
         assert real_agent_config.current_namespace == "california_schools"
-        assert real_agent_config.current_database == "california_schools"
+        assert real_agent_config.current_datasource == "california_schools"
 
     def test_database_as_namespace_name(self, real_agent_config):
         """Database matching a namespace name falls back to namespace lookup."""
@@ -274,7 +274,7 @@ class TestStartChat:
         request = StreamChatInput(message="hello", database="california_schools")
         task = await manager.start_chat(real_agent_config, request)
         assert task is not None
-        assert real_agent_config.current_database == "california_schools"
+        assert real_agent_config.current_datasource == "california_schools"
         await manager.shutdown()
 
     async def test_stop_running_task_with_node(self, real_agent_config, mock_llm_create):

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -28,35 +28,35 @@ class TestFillDatabaseContext:
 
     def test_no_database_is_noop(self, real_agent_config):
         """No database parameter leaves config unchanged."""
-        original_ns = real_agent_config.current_namespace
+        original_ns = real_agent_config.current_datasource
         _fill_database_context(real_agent_config, database=None)
-        assert real_agent_config.current_namespace == original_ns
+        assert real_agent_config.current_datasource == original_ns
 
     def test_empty_database_is_noop(self, real_agent_config):
         """Empty string database leaves config unchanged."""
-        original_ns = real_agent_config.current_namespace
+        original_ns = real_agent_config.current_datasource
         _fill_database_context(real_agent_config, database="")
-        assert real_agent_config.current_namespace == original_ns
+        assert real_agent_config.current_datasource == original_ns
 
     def test_known_database_updates_namespace_and_db(self, real_agent_config):
-        """Known database in namespaces updates current_namespace and current_datasource."""
+        """Known database in namespaces updates current_datasource and current_datasource."""
         # real_agent_config has "california_schools" in services.datasources
         # After the namespace→services.datasources refactor, each DB is its own namespace key
         _fill_database_context(real_agent_config, database="california_schools")
-        assert real_agent_config.current_namespace == "california_schools"
+        assert real_agent_config.current_datasource == "california_schools"
         assert real_agent_config.current_datasource == "california_schools"
 
     def test_database_as_namespace_name(self, real_agent_config):
         """Database matching a namespace name falls back to namespace lookup."""
         # After refactor, namespace keys equal database names
         _fill_database_context(real_agent_config, database="california_schools")
-        assert real_agent_config.current_namespace == "california_schools"
+        assert real_agent_config.current_datasource == "california_schools"
 
     def test_unknown_database_leaves_unchanged(self, real_agent_config):
         """Unknown database leaves config unchanged."""
-        original_ns = real_agent_config.current_namespace
+        original_ns = real_agent_config.current_datasource
         _fill_database_context(real_agent_config, database="nonexistent_db")
-        assert real_agent_config.current_namespace == original_ns
+        assert real_agent_config.current_datasource == original_ns
 
 
 class TestChatTaskInit:

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -24,39 +24,27 @@ from datus.api.services.chat_task_manager import (
 
 
 class TestFillDatabaseContext:
-    """Tests for _fill_database_context — namespace/database resolution."""
+    """Tests for _fill_database_context — now a no-op (datasource resolved at bootstrap)."""
 
     def test_no_database_is_noop(self, real_agent_config):
-        """No database parameter leaves config unchanged."""
-        original_ns = real_agent_config.current_datasource
+        original = real_agent_config.current_datasource
         _fill_database_context(real_agent_config, database=None)
-        assert real_agent_config.current_datasource == original_ns
+        assert real_agent_config.current_datasource == original
 
     def test_empty_database_is_noop(self, real_agent_config):
-        """Empty string database leaves config unchanged."""
-        original_ns = real_agent_config.current_datasource
+        original = real_agent_config.current_datasource
         _fill_database_context(real_agent_config, database="")
-        assert real_agent_config.current_datasource == original_ns
+        assert real_agent_config.current_datasource == original
 
-    def test_known_database_updates_namespace_and_db(self, real_agent_config):
-        """Known database in namespaces updates current_datasource and current_datasource."""
-        # real_agent_config has "california_schools" in services.datasources
-        # After the namespace→services.datasources refactor, each DB is its own namespace key
+    def test_known_database_does_not_override_datasource(self, real_agent_config):
+        original = real_agent_config.current_datasource
         _fill_database_context(real_agent_config, database="california_schools")
-        assert real_agent_config.current_datasource == "california_schools"
-        assert real_agent_config.current_datasource == "california_schools"
-
-    def test_database_as_namespace_name(self, real_agent_config):
-        """Database matching a namespace name falls back to namespace lookup."""
-        # After refactor, namespace keys equal database names
-        _fill_database_context(real_agent_config, database="california_schools")
-        assert real_agent_config.current_datasource == "california_schools"
+        assert real_agent_config.current_datasource == original
 
     def test_unknown_database_leaves_unchanged(self, real_agent_config):
-        """Unknown database leaves config unchanged."""
-        original_ns = real_agent_config.current_datasource
+        original = real_agent_config.current_datasource
         _fill_database_context(real_agent_config, database="nonexistent_db")
-        assert real_agent_config.current_datasource == original_ns
+        assert real_agent_config.current_datasource == original
 
 
 class TestChatTaskInit:

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -27,7 +27,7 @@ class TestCLIServiceInit:
 
         assert cli_svc.agent_config is real_agent_config
         assert isinstance(cli_svc.db_manager, DBManager)
-        assert cli_svc.current_namespace == real_agent_config.current_namespace
+        assert cli_svc.current_datasource == real_agent_config.current_datasource
         # Connector must expose execute() — the only contract CLIService relies on
         assert callable(getattr(cli_svc.current_db_connector, "execute", None))
 
@@ -35,7 +35,7 @@ class TestCLIServiceInit:
         """CLIService initializes without agent config."""
         svc = CLIService(agent_config=None, chat_service=None)
         assert svc.db_manager is None
-        assert svc.current_namespace is None
+        assert svc.current_datasource is None
         assert svc.current_db_connector is None
 
     def test_init_sets_cli_context(self, cli_svc):
@@ -298,7 +298,7 @@ class TestCLIServiceExecuteContext:
         result = cli_svc.execute_context("context", request)
         assert result.success is True
         info = result.data.result.context_info
-        assert "current_namespace" in info
+        assert "current_datasource" in info
         assert "database" in info
 
     def test_context_catalog(self, cli_svc):

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -21,9 +21,9 @@ class TestDatabaseServiceInit:
         assert svc.current_database is not None
 
     def test_init_sets_namespace(self, real_agent_config):
-        """Init stores current_namespace from config."""
+        """Init stores current_datasource from config."""
         svc = DatabaseService(agent_config=real_agent_config)
-        assert svc.current_namespace == real_agent_config.current_namespace
+        assert svc.current_datasource == real_agent_config.current_datasource
 
     def test_db_manager_created(self, real_agent_config):
         """Init creates DBManager."""

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -631,9 +631,9 @@ class TestExplorerServiceCreateMetric:
         # May fail on deep validation (no data_source in model) — that's expected.
         # The important thing is it exercises the full path: parse → check existence → validate
         assert result is not None
-        if not result.success:
-            # Should be a validation error, not a crash
-            assert "validation" in result.errorMessage.lower() or "not defined" in result.errorMessage.lower()
+        assert result.success or (
+            "validation" in result.errorMessage.lower() or "not defined" in result.errorMessage.lower()
+        )
 
     async def test_create_metric_duplicate_file_fails(self, real_agent_config):
         """create_metric rejects when file already exists on disk."""

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -22,7 +22,7 @@ class TestExplorerServiceInit:
         svc = ExplorerService(agent_config=real_agent_config)
         assert svc is not None
         assert svc.agent_config is real_agent_config
-        assert svc.datasource_id == real_agent_config.current_namespace
+        assert svc.datasource_id == real_agent_config.current_datasource
 
     def test_init_creates_rag_stores(self, real_agent_config):
         """ExplorerService creates metric, ref_sql, and knowledge RAG stores."""

--- a/tests/unit_tests/api/test_api_endpoints.py
+++ b/tests/unit_tests/api/test_api_endpoints.py
@@ -34,7 +34,7 @@ from datus.api.legacy_models import (
 @pytest.fixture
 def mock_agent_config():
     config = MagicMock()
-    config.current_database = "test_ns"
+    config.current_datasource = "test_ns"
     config.rag_base_path = "/tmp/test_rag"
     config.api_config = {}
     return config

--- a/tests/unit_tests/api/test_service.py
+++ b/tests/unit_tests/api/test_service.py
@@ -469,7 +469,7 @@ class TestHealthCheck:
     async def test_healthy_when_agent_config_available(self):
         service = _make_service()
         service.agent_config = MagicMock()
-        service.agent_config.current_database = "ns"
+        service.agent_config.current_datasource = "ns"
 
         mock_agent = MagicMock()
         mock_agent.check_db.return_value = {"status": "success"}

--- a/tests/unit_tests/api/test_service.py
+++ b/tests/unit_tests/api/test_service.py
@@ -91,7 +91,10 @@ class TestDatusAPIServiceInitialize:
 
         with patch("datus.api.service.load_agent_config", return_value=mock_cfg):
             with patch("datus.api.service.TaskStore", return_value=mock_task_store):
-                await service.initialize()  # should not raise
+                await service.initialize()
+
+        mock_task_store.cleanup_old_tasks.assert_called_once()
+        assert service.agent_config is mock_cfg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -54,7 +54,7 @@ def agent_config(tmp_path):
     cfg = MagicMock()
     cfg.home = str(tmp_path)
     cfg.current_datasource = "test_ns"
-    cfg.current_namespace = "test_ns"
+    cfg.current_datasource = "test_ns"
     cfg.db_type = "sqlite"
     cfg.path_manager = MagicMock()
     cfg.path_manager.semantic_model_path.return_value = subject_dir / "semantic_models"
@@ -1388,7 +1388,7 @@ class TestGetBaseDirEdgeCases:
     def test_returns_none_when_resolver_attr_is_none(self, broker):
         """path_manager exists but the named resolver attribute is None."""
         cfg = MagicMock()
-        cfg.current_namespace = "ns"
+        cfg.current_datasource = "ns"
         cfg.path_manager = MagicMock(spec=[])  # no attrs → getattr returns None
         h = GenerationHooks(broker=broker, agent_config=cfg)
         assert h._get_base_dir("semantic") is None
@@ -1396,7 +1396,7 @@ class TestGetBaseDirEdgeCases:
     def test_returns_none_when_resolver_raises(self, broker):
         """Exceptions raised by the resolver are caught and return None."""
         cfg = MagicMock()
-        cfg.current_namespace = "ns"
+        cfg.current_datasource = "ns"
         cfg.path_manager = MagicMock()
         cfg.path_manager.semantic_model_path = MagicMock(side_effect=RuntimeError("boom"))
         h = GenerationHooks(broker=broker, agent_config=cfg)

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -53,7 +53,7 @@ def agent_config(tmp_path):
     (subject_dir / "ext_knowledge").mkdir(parents=True, exist_ok=True)
     cfg = MagicMock()
     cfg.home = str(tmp_path)
-    cfg.current_database = "test_ns"
+    cfg.current_datasource = "test_ns"
     cfg.current_namespace = "test_ns"
     cfg.db_type = "sqlite"
     cfg.path_manager = MagicMock()

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -148,16 +148,20 @@ class TestOnToolEnd:
 @pytest.mark.asyncio
 class TestStubHooks:
     async def test_on_start(self, hooks):
-        await hooks.on_start(MagicMock(), MagicMock())  # no exception
+        result = await hooks.on_start(MagicMock(), MagicMock())
+        assert result is None
 
     async def test_on_tool_start(self, hooks):
-        await hooks.on_tool_start(MagicMock(), MagicMock(), MagicMock())
+        result = await hooks.on_tool_start(MagicMock(), MagicMock(), MagicMock())
+        assert result is None
 
     async def test_on_handoff(self, hooks):
-        await hooks.on_handoff(MagicMock(), MagicMock(), MagicMock())
+        result = await hooks.on_handoff(MagicMock(), MagicMock(), MagicMock())
+        assert result is None
 
     async def test_on_end(self, hooks):
-        await hooks.on_end(MagicMock(), MagicMock(), MagicMock())
+        result = await hooks.on_end(MagicMock(), MagicMock(), MagicMock())
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -400,7 +404,9 @@ class TestHandleEndSemanticModelGeneration:
     async def test_cancelled_exception_absorbed(self, hooks):
         hooks._process_single_file = AsyncMock(side_effect=GenerationCancelledException)
         result = {"result": {"semantic_model_files": ["/a.yaml"]}}
-        await hooks._handle_end_semantic_model_generation(result)  # should not raise
+        await hooks._handle_end_semantic_model_generation(result)
+        # Path rejected by sandbox validation — _process_single_file never reached
+        assert hooks._process_single_file.await_count == 0
 
 
 @pytest.fixture
@@ -1460,11 +1466,13 @@ class TestHandleEndMetricGeneration:
         hooks._extract_metric_generation_result = MagicMock(return_value=("m.yml", None, {}))
         hooks._resolve_path = MagicMock(side_effect=lambda p, k: p)
         hooks._process_single_file = AsyncMock(side_effect=GenerationCancelledException("user-cancel"))
-        await hooks._handle_end_metric_generation({"result": {}})  # must not raise
+        await hooks._handle_end_metric_generation({"result": {}})
+        hooks._process_single_file.assert_awaited_once()
 
     async def test_unexpected_exception_absorbed(self, hooks):
         hooks._extract_metric_generation_result = MagicMock(side_effect=RuntimeError("boom"))
-        await hooks._handle_end_metric_generation({"result": {}})  # must not raise
+        await hooks._handle_end_metric_generation({"result": {}})
+        hooks._extract_metric_generation_result.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_init_workspace.py
+++ b/tests/unit_tests/cli/test_init_workspace.py
@@ -168,7 +168,7 @@ class TestInitWorkspaceRun:
 
         args = MagicMock()
         args.config = str(tmp_path / "missing.yml")
-        args.database = ""
+        args.datasource = ""
 
         with patch("datus.configuration.agent_config_loader.load_agent_config", side_effect=Exception("not found")):
             iw = InitWorkspace(args)
@@ -188,7 +188,7 @@ class TestInitWorkspaceRun:
 
         args = MagicMock()
         args.config = ""
-        args.database = ""
+        args.datasource = ""
 
         mock_config = MagicMock()
         mock_config.services.datasources = {}
@@ -618,7 +618,7 @@ class TestInitWorkspaceRunFullFlow:
 
         args = MagicMock()
         args.config = ""
-        args.database = database
+        args.datasource = database
 
         iw = InitWorkspace(args)
         iw.project_dir = str(tmp_path)
@@ -664,7 +664,7 @@ class TestInitWorkspaceRunFullFlow:
         assert "## Architecture" in content
 
     def test_run_probes_database_when_database_arg_set(self, tmp_path):
-        """run() calls _probe_database when args.database is non-empty."""
+        """run() calls _probe_database when args.datasource is non-empty."""
         iw = self._setup_iw(tmp_path, database="mydb")
 
         mock_config = MagicMock()

--- a/tests/unit_tests/cli/test_interactive_configure.py
+++ b/tests/unit_tests/cli/test_interactive_configure.py
@@ -2022,7 +2022,7 @@ class TestDisplayCompletion:
     """Tests for InteractiveConfigure._display_completion()."""
 
     def test_shows_default_datasource_in_message(self, tmp_path):
-        """_display_completion() includes the default database name in the output."""
+        """_display_completion() includes the default datasource name in the output."""
         cfg = _make_configure(tmp_path)
         cfg.datasources = {
             "main_db": {"type": "duckdb", "default": True},

--- a/tests/unit_tests/cli/test_interactive_configure.py
+++ b/tests/unit_tests/cli/test_interactive_configure.py
@@ -2021,7 +2021,7 @@ class TestSave:
 class TestDisplayCompletion:
     """Tests for InteractiveConfigure._display_completion()."""
 
-    def test_shows_default_database_in_message(self, tmp_path):
+    def test_shows_default_datasource_in_message(self, tmp_path):
         """_display_completion() includes the default database name in the output."""
         cfg = _make_configure(tmp_path)
         cfg.datasources = {

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -34,39 +34,39 @@ class TestArgumentParser:
         assert args.db_type == "sqlite"
         assert args.debug is False
         assert args.no_color is False
-        assert args.database == ""
+        assert args.datasource == ""
         assert args.print_mode is None
         assert args.web is False
         assert args.resume is None
 
     def test_parse_args_debug_flag(self):
         ap = ArgumentParser()
-        with patch.object(sys, "argv", ["datus", "--debug", "--database", "ns1"]):
+        with patch.object(sys, "argv", ["datus", "--debug", "--datasource", "ns1"]):
             args = ap.parse_args()
         assert args.debug is True
-        assert args.database == "ns1"
+        assert args.datasource == "ns1"
 
     def test_parse_args_print(self):
         ap = ArgumentParser()
-        with patch.object(sys, "argv", ["datus", "--database", "ns1", "--print", "hello"]):
+        with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--print", "hello"]):
             args = ap.parse_args()
         assert args.print_mode == "hello"
 
     def test_parse_args_print_short(self):
         ap = ArgumentParser()
-        with patch.object(sys, "argv", ["datus", "--database", "ns1", "-p", "hello"]):
+        with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "-p", "hello"]):
             args = ap.parse_args()
         assert args.print_mode == "hello"
 
     def test_parse_args_resume(self):
         ap = ArgumentParser()
-        with patch.object(sys, "argv", ["datus", "--database", "ns1", "--print", "hello", "--resume", "sess_123"]):
+        with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--print", "hello", "--resume", "sess_123"]):
             args = ap.parse_args()
         assert args.resume == "sess_123"
 
     def test_parse_args_web(self):
         ap = ArgumentParser()
-        with patch.object(sys, "argv", ["datus", "--database", "ns1", "--web"]):
+        with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--web"]):
             args = ap.parse_args()
         assert args.web is True
 
@@ -84,29 +84,29 @@ class TestArgumentParser:
 
 class TestApplicationRun:
     def test_run_no_namespace_prints_help(self):
-        """When no database is set and _resolve_default_database fails, help is printed."""
+        """When no database is set and _resolve_default_datasource fails, help is printed."""
         app = Application()
         mock_args = SimpleNamespace(
-            debug=False, database="", print_mode=None, web=False, resume=None, proxy_tools=None, config=None
+            debug=False, datasource="", print_mode=None, web=False, resume=None, proxy_tools=None, config=None
         )
         with (
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
             patch("datus.cli.main.configure_logging"),
             patch.object(app, "_ensure_project_config"),
-            patch.object(app, "_resolve_default_database", return_value=""),
+            patch.object(app, "_resolve_default_datasource", return_value=""),
             patch.object(app.arg_parser.parser, "print_help") as mock_help,
         ):
             app.run()
-        # _resolve_default_database returning "" should cause early return without
+        # _resolve_default_datasource returning "" should cause early return without
         # reaching the REPL; no test asserts print_help here because the real
-        # print_help is triggered inside _resolve_default_database (which we mocked).
+        # print_help is triggered inside _resolve_default_datasource (which we mocked).
         # Just verify the run returned cleanly.
         mock_help.assert_not_called()
 
     def test_resume_without_print_mode_errors(self):
         app = Application()
         mock_args = SimpleNamespace(
-            debug=False, database="ns1", print_mode=None, web=False, resume="sess_123", proxy_tools=None, config=None
+            debug=False, datasource="ns1", print_mode=None, web=False, resume="sess_123", proxy_tools=None, config=None
         )
         with (
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
@@ -120,7 +120,7 @@ class TestApplicationRun:
         """Verify that --proxy_tools without --print raises SystemExit."""
         app = Application()
         mock_args = SimpleNamespace(
-            debug=False, database="ns1", print_mode=None, web=False, resume=None, proxy_tools="*", config=None
+            debug=False, datasource="ns1", print_mode=None, web=False, resume=None, proxy_tools="*", config=None
         )
         with (
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
@@ -134,7 +134,7 @@ class TestApplicationRun:
         app = Application()
         mock_args = SimpleNamespace(
             debug=False,
-            database="ns1",
+            datasource="ns1",
             print_mode="hello world",
             web=False,
             resume=None,
@@ -157,7 +157,7 @@ class TestApplicationRun:
     def test_run_interactive_mode(self):
         app = Application()
         mock_args = SimpleNamespace(
-            debug=False, database="ns1", print_mode=None, web=False, resume=None, proxy_tools=None, config=None
+            debug=False, datasource="ns1", print_mode=None, web=False, resume=None, proxy_tools=None, config=None
         )
         mock_cli = MagicMock()
         with (
@@ -174,7 +174,7 @@ class TestApplicationRun:
     def test_run_web_mode(self):
         app = Application()
         mock_args = SimpleNamespace(
-            debug=False, database="ns1", print_mode=None, web=True, resume=None, proxy_tools=None, config=None
+            debug=False, datasource="ns1", print_mode=None, web=True, resume=None, proxy_tools=None, config=None
         )
         with (
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
@@ -278,7 +278,7 @@ class TestRepairProjectOverrides:
 
         app = Application()
         args = SimpleNamespace(config=None)
-        override = ProjectOverride(target="claude", default_database="bench")
+        override = ProjectOverride(target="claude", default_datasource="bench")
         raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
         with (
             patch("datus.configuration.project_config.load_project_override", return_value=override),
@@ -299,7 +299,7 @@ class TestRepairProjectOverrides:
 
         app = Application()
         args = SimpleNamespace(config=None)
-        override = ProjectOverride(target="claude-sonnet", default_database="bench")
+        override = ProjectOverride(target="claude-sonnet", default_datasource="bench")
         raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
         with (
             patch("datus.configuration.project_config.load_project_override", return_value=override),
@@ -318,15 +318,15 @@ class TestRepairProjectOverrides:
         mock_save.assert_called_once()
         (saved_override,) = mock_save.call_args.args
         assert saved_override.target == "deepseek"
-        assert saved_override.default_database == "bench"
+        assert saved_override.default_datasource == "bench"
 
-    def test_repairs_stale_default_database(self):
-        """Stale default_database → prompt only for db; keep valid target."""
+    def test_repairs_stale_default_datasource(self):
+        """Stale default_datasource → prompt only for db; keep valid target."""
         from datus.configuration.project_config import ProjectOverride
 
         app = Application()
         args = SimpleNamespace(config=None)
-        override = ProjectOverride(target="claude", default_database="benchmark1")
+        override = ProjectOverride(target="claude", default_datasource="benchmark1")
         raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
         with (
             patch("datus.configuration.project_config.load_project_override", return_value=override),
@@ -344,7 +344,7 @@ class TestRepairProjectOverrides:
         mock_save.assert_called_once()
         (saved_override,) = mock_save.call_args.args
         assert saved_override.target == "claude"
-        assert saved_override.default_database == "bench"
+        assert saved_override.default_datasource == "bench"
 
     def test_repairs_both_fields(self):
         """Both values stale → two prompts, saved override uses both picks."""
@@ -352,7 +352,7 @@ class TestRepairProjectOverrides:
 
         app = Application()
         args = SimpleNamespace(config=None)
-        override = ProjectOverride(target="claude1", default_database="benchmark1")
+        override = ProjectOverride(target="claude1", default_datasource="benchmark1")
         raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
         with (
             patch("datus.configuration.project_config.load_project_override", return_value=override),
@@ -373,7 +373,7 @@ class TestRepairProjectOverrides:
         mock_save.assert_called_once()
         (saved_override,) = mock_save.call_args.args
         assert saved_override.target == "claude"
-        assert saved_override.default_database == "bench"
+        assert saved_override.default_datasource == "bench"
 
     def test_raises_when_base_has_no_models(self):
         """Base config empty on the same key we need to repair → nothing to
@@ -384,7 +384,7 @@ class TestRepairProjectOverrides:
 
         app = Application()
         args = SimpleNamespace(config=None)
-        override = ProjectOverride(target="claude-sonnet", default_database=None)
+        override = ProjectOverride(target="claude-sonnet", default_datasource=None)
         raw = self._raw_agent([], {"bench": "sqlite"})
         with (
             patch("datus.configuration.project_config.load_project_override", return_value=override),
@@ -412,7 +412,7 @@ class TestRepairProjectOverrides:
 
         app = Application()
         args = SimpleNamespace(config=None)
-        override = ProjectOverride(target="claude-sonnet", default_database=None)
+        override = ProjectOverride(target="claude-sonnet", default_datasource=None)
         raw = self._raw_agent(["claude", "deepseek"], {"bench": "sqlite"})
         with (
             patch("datus.configuration.project_config.load_project_override", return_value=override),
@@ -437,12 +437,12 @@ class TestResolveDefaultDatabase:
     def _make_config(self, datasources: dict, default: str = ""):
         cfg = MagicMock()
         cfg.services.datasources = datasources
-        cfg.services.default_database = default
+        cfg.services.default_datasource = default
         return cfg
 
-    def test_returns_service_default_database(self):
-        """_resolve_default_database is now a thin wrapper over
-        config.services.default_database — the overlay is applied upstream by
+    def test_returns_service_default_datasource(self):
+        """_resolve_default_datasource is now a thin wrapper over
+        config.services.default_datasource — the overlay is applied upstream by
         _apply_project_override, so this function just reads the resolved
         value. We verify the resolved value wins regardless of the base
         agent.yml: the mock returns "b" directly."""
@@ -450,7 +450,7 @@ class TestResolveDefaultDatabase:
         args = SimpleNamespace(config=None)
         config = self._make_config({"a": MagicMock(type="sqlite"), "b": MagicMock(type="duckdb")}, default="b")
         with patch("datus.configuration.agent_config_loader.load_agent_config", return_value=config):
-            result = app._resolve_default_database(args)
+            result = app._resolve_default_datasource(args)
         assert result == "b"
 
     def test_falls_through_to_base_default(self):
@@ -458,7 +458,7 @@ class TestResolveDefaultDatabase:
         args = SimpleNamespace(config=None)
         config = self._make_config({"a": MagicMock(type="sqlite")}, default="a")
         with patch("datus.configuration.agent_config_loader.load_agent_config", return_value=config):
-            result = app._resolve_default_database(args)
+            result = app._resolve_default_datasource(args)
         assert result == "a"
 
     def test_no_databases_returns_empty(self):
@@ -468,7 +468,7 @@ class TestResolveDefaultDatabase:
         with (
             patch("datus.configuration.agent_config_loader.load_agent_config", return_value=config),
         ):
-            result = app._resolve_default_database(args)
+            result = app._resolve_default_datasource(args)
         assert result == ""
 
 
@@ -480,7 +480,7 @@ class TestResolveDefaultDatabase:
 class TestRunWebInterface:
     def test_delegates_to_run_web_interface(self):
         app = Application()
-        mock_args = SimpleNamespace(database="ns1")
+        mock_args = SimpleNamespace(datasource="ns1")
         with patch("datus.cli.web.run_web_interface") as mock_web:
             with patch.dict("sys.modules", {"datus.cli.web": MagicMock(run_web_interface=mock_web)}):
                 app._run_web_interface(mock_args)

--- a/tests/unit_tests/cli/test_metadata_commands.py
+++ b/tests/unit_tests/cli/test_metadata_commands.py
@@ -41,7 +41,7 @@ def _make_cli(db_type=DBType.SQLITE):
 
     # agent_config
     db_cfg = _make_db_config(db_type=db_type)
-    cli.agent_config.current_database = "test_ns"
+    cli.agent_config.current_datasource = "test_ns"
     cli.agent_config.namespaces = {"test_ns": {"mydb": db_cfg}}
     cli.agent_config.db_type = db_type
 
@@ -91,7 +91,7 @@ class TestCmdListDatabases:
         assert any("Empty set" in c for c in calls)
 
     def test_exception_prints_error(self, meta):
-        meta.cli.agent_config.current_database = None
+        meta.cli.agent_config.current_datasource = None
         meta.cli.agent_config.namespaces = {}
         meta.cmd_list_databases()
         meta.cli.console.print.assert_called()

--- a/tests/unit_tests/cli/test_project_init.py
+++ b/tests/unit_tests/cli/test_project_init.py
@@ -17,14 +17,14 @@ from datus.configuration.project_config import load_project_override
 from datus.utils.exceptions import DatusException
 
 
-def _make_base_config(models, datasources, target="", default_database=""):
+def _make_base_config(models, datasources, target="", default_datasource=""):
     """Build a minimal AgentConfig stand-in with the attributes the wizard reads."""
     cfg = MagicMock()
     cfg.models = models
     cfg.target = target
     cfg.services = SimpleNamespace(
         datasources={name: SimpleNamespace(type=t) for name, t in datasources.items()},
-        default_database=default_database,
+        default_datasource=default_datasource,
     )
     return cfg
 
@@ -35,7 +35,7 @@ class TestRunProjectInit:
             models={"openai": {}, "deepseek": {}},
             datasources={"db1": "sqlite", "db2": "duckdb"},
             target="openai",
-            default_database="db1",
+            default_datasource="db1",
         )
         with (
             patch("datus.cli.project_init.select_choice", side_effect=["deepseek", "db2"]),
@@ -43,12 +43,12 @@ class TestRunProjectInit:
         ):
             override = run_project_init(base, cwd=str(tmp_path))
         assert override.target == "deepseek"
-        assert override.default_database == "db2"
+        assert override.default_datasource == "db2"
         assert override.project_name == "my_proj"
         # File persisted with those values
         reloaded = load_project_override(str(tmp_path))
         assert reloaded.target == "deepseek"
-        assert reloaded.default_database == "db2"
+        assert reloaded.default_datasource == "db2"
         assert reloaded.project_name == "my_proj"
 
     def test_uses_base_target_as_default(self, tmp_path):
@@ -56,7 +56,7 @@ class TestRunProjectInit:
             models={"openai": {}, "deepseek": {}},
             datasources={"db1": "sqlite"},
             target="deepseek",
-            default_database="db1",
+            default_datasource="db1",
         )
         # select_choice returning empty string simulates Ctrl+C → fall back to default
         with (
@@ -65,7 +65,7 @@ class TestRunProjectInit:
         ):
             override = run_project_init(base, cwd=str(tmp_path))
         assert override.target == "deepseek"
-        assert override.default_database == "db1"
+        assert override.default_datasource == "db1"
 
     def test_no_models_raises(self, tmp_path):
         base = _make_base_config(
@@ -90,7 +90,7 @@ class TestRunProjectInit:
             models={"openai": {}},
             datasources={"db1": "sqlite"},
             target="openai",
-            default_database="db1",
+            default_datasource="db1",
         )
         with (
             patch("datus.cli.project_init.select_choice", side_effect=["openai", "db1"]),
@@ -107,7 +107,7 @@ class TestRunProjectInit:
             models={"openai": {}},
             datasources={"db1": "sqlite"},
             target="openai",
-            default_database="db1",
+            default_datasource="db1",
         )
         from datus.configuration.agent_config import _normalize_project_name
 

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -309,8 +309,8 @@ class TestCmdListNamespaces:
         # Should have printed something (the table)
         assert len(output) > 0
 
-    def test_current_database_highlighted(self, cli):
-        cli.agent_config.current_database = "california_schools"
+    def test_current_datasource_highlighted(self, cli):
+        cli.agent_config.current_datasource = "california_schools"
         cli._cmd_list_namespaces()
         output = cli.console.file.getvalue()
         # Each database is listed as its own namespace entry
@@ -329,7 +329,7 @@ class TestCmdSwitchNamespace:
         mock_list.assert_called_once()
 
     def test_same_namespace_prints_message(self, cli):
-        current_ns = cli.agent_config.current_database
+        current_ns = cli.agent_config.current_datasource
         with patch.object(cli, "_cmd_list_namespaces"):
             cli._cmd_switch_namespace(current_ns)
         output = cli.console.file.getvalue()
@@ -715,11 +715,11 @@ class TestCmdSwitchNamespaceExtended:
         mock_conn.schema_name = ""
         cli.db_manager.first_conn_with_name.return_value = ("test_ns", mock_conn)
 
-        # Patch current_database property to return a different value so the
+        # Patch current_datasource property to return a different value so the
         # "already on this namespace" branch is NOT taken; setter is a no-op.
         with patch.object(
             type(cli.agent_config),
-            "current_database",
+            "current_datasource",
             new_callable=lambda: property(
                 lambda self: "other_ns",
                 lambda self, v: None,
@@ -733,7 +733,7 @@ class TestCmdSwitchNamespaceExtended:
         assert "Namespace changed" in output
 
     def test_same_namespace_both_listed_and_message(self, cli):
-        current = cli.agent_config.current_database
+        current = cli.agent_config.current_datasource
 
         with patch.object(cli, "_cmd_list_namespaces") as mock_list:
             cli._cmd_switch_namespace(current)
@@ -802,37 +802,37 @@ class TestPrintWelcome:
         cli._print_welcome()
         return cli.console.file.getvalue()
 
-    def test_database_from_args_database(self, real_agent_config):
-        """args.database takes highest priority."""
+    def test_database_from_args_datasource(self, real_agent_config):
+        """args.datasource takes highest priority."""
         cli = _make_cli(real_agent_config)
-        cli.args = MagicMock(database="my_db", namespace="my_ns")
-        real_agent_config._current_database = "config_db"
+        cli.args = MagicMock(datasource="my_db", namespace="my_ns")
+        real_agent_config._current_datasource = "config_db"
         output = self._get_output(cli)
         assert "my_db" in output
         assert "my_ns" not in output
         assert "config_db" not in output
 
     def test_database_fallback_to_args_namespace(self, real_agent_config):
-        """Falls back to args.namespace when args.database is empty."""
+        """Falls back to args.namespace when args.datasource is empty."""
         cli = _make_cli(real_agent_config)
-        cli.args = MagicMock(database="", namespace="my_ns")
-        real_agent_config._current_database = ""
+        cli.args = MagicMock(datasource="", namespace="my_ns")
+        real_agent_config._current_datasource = ""
         output = self._get_output(cli)
         assert "my_ns" in output
 
     def test_database_fallback_to_agent_config(self, real_agent_config):
-        """Falls back to agent_config.current_database when args are empty."""
+        """Falls back to agent_config.current_datasource when args are empty."""
         cli = _make_cli(real_agent_config)
-        cli.args = MagicMock(database="", namespace="")
-        real_agent_config._current_database = "config_db"
+        cli.args = MagicMock(datasource="", namespace="")
+        real_agent_config._current_datasource = "config_db"
         output = self._get_output(cli)
         assert "config_db" in output
 
     def test_no_database_warning(self, real_agent_config):
         """Shows 'not selected' hint when no database is available."""
         cli = _make_cli(real_agent_config)
-        cli.args = MagicMock(database="", namespace="")
-        real_agent_config._current_database = ""
+        cli.args = MagicMock(datasource="", namespace="")
+        real_agent_config._current_datasource = ""
         output = self._get_output(cli)
         assert "not selected" in output
 
@@ -850,21 +850,21 @@ class TestBuildBannerPanel:
 
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         output = self._render(cli)
         assert f"v{__version__}" in output
 
     def test_contains_subtitle(self, real_agent_config):
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         output = self._render(cli)
         assert "AI-powered SQL command-line interface" in output
 
     def test_contains_ascii_art_on_wide_terminal(self, real_agent_config):
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         output = self._render(cli, width=100)
         assert "██████╗" in output
 
@@ -873,7 +873,7 @@ class TestBuildBannerPanel:
 
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         output = self._render(cli, width=40)
         assert f"DATUS v{__version__}" in output
         assert "██████╗" not in output
@@ -882,7 +882,7 @@ class TestBuildBannerPanel:
         """Banner must not include an AI status row."""
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         cli.agent_ready = True
         cli.agent_initializing = False
         output = self._render(cli)
@@ -895,7 +895,7 @@ class TestBuildBannerPanel:
     def test_not_connected_label(self, real_agent_config):
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         cli.db_connector = None
         output = self._render(cli)
         assert "not connected" in output
@@ -904,7 +904,7 @@ class TestBuildBannerPanel:
         """Banner must not include the '/ . @ !' command prefix cheatsheet row."""
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         output = self._render(cli)
         assert "! @ ." not in output
         assert "Commands:" not in output
@@ -913,7 +913,7 @@ class TestBuildBannerPanel:
         """Database line appends 'using <name>' when current_db_name != configured db."""
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         cli.cli_context.current_db_name = "other_db"
         output = self._render(cli)
         assert "using other_db" in output
@@ -922,7 +922,7 @@ class TestBuildBannerPanel:
         """Context row appears when cli_context has a non-empty summary."""
         cli = _make_cli(real_agent_config)
         cli.args = MagicMock(database="benchmark", namespace="")
-        real_agent_config._current_database = ""
+        real_agent_config._current_datasource = ""
         cli.cli_context.current_db_name = "benchmark"
         output = self._render(cli)
         assert "Context" in output

--- a/tests/unit_tests/cli/test_service_client.py
+++ b/tests/unit_tests/cli/test_service_client.py
@@ -295,7 +295,7 @@ class TestServiceClientRegistry:
         """
         cfg = SimpleNamespace(
             services=SimpleNamespace(bi_platforms={"superset": {}}, schedulers={}, semantic_layer={}),
-            current_database="namespace_a",
+            current_datasource="namespace_a",
         )
         factory = MagicMock(side_effect=lambda *_: _FakeBITool())
         with (
@@ -311,8 +311,8 @@ class TestServiceClientRegistry:
             assert registry.get("superset") is c1
             factory.assert_called_once()
 
-            # User runs ``.database namespace_b`` — current_database mutates.
-            cfg.current_database = "namespace_b"
+            # User runs ``.database namespace_b`` — current_datasource mutates.
+            cfg.current_datasource = "namespace_b"
             c2 = registry.get("superset")
             assert c2 is not c1
             assert factory.call_count == 2
@@ -321,11 +321,11 @@ class TestServiceClientRegistry:
             assert statuses["superset"] == "active"
 
     def test_namespace_field_also_triggers_invalidation(self):
-        """Not every install uses ``current_database`` — the ``namespace``
+        """Not every install uses ``current_datasource`` — the ``namespace``
         attribute is also part of the fingerprint."""
         cfg = SimpleNamespace(
             services=SimpleNamespace(bi_platforms={"superset": {}}, schedulers={}, semantic_layer={}),
-            current_database="shared",
+            current_datasource="shared",
             namespace="tenant_a",
         )
         factory = MagicMock(side_effect=lambda *_: _FakeBITool())
@@ -342,7 +342,7 @@ class TestServiceClientRegistry:
     def test_list_services_drops_to_configured_after_invalidation(self):
         cfg = SimpleNamespace(
             services=SimpleNamespace(bi_platforms={"superset": {}}, schedulers={}, semantic_layer={}),
-            current_database="a",
+            current_datasource="a",
         )
         with (
             patch.dict(
@@ -357,7 +357,7 @@ class TestServiceClientRegistry:
 
             # Namespace switch without a follow-up get() — status drops back to
             # "configured" (adapter still available, client cache cleared).
-            cfg.current_database = "b"
+            cfg.current_datasource = "b"
             # list_services itself triggers invalidation.
             assert registry.list_services()[0][2] == "configured"
 
@@ -393,7 +393,7 @@ class TestServiceClientRegistry:
     def test_adapter_available_is_cached_until_fingerprint_change(self):
         cfg = SimpleNamespace(
             services=SimpleNamespace(bi_platforms={"superset": {}}, schedulers={}, semantic_layer={}),
-            current_database="a",
+            current_datasource="a",
         )
         probe = MagicMock(return_value=True)
         with patch.dict("datus.cli.service_client._PROBES", {"bi_platforms": probe}):
@@ -404,7 +404,7 @@ class TestServiceClientRegistry:
             assert probe.call_count == 1
 
             # Namespace switch → cache dropped → probe runs again.
-            cfg.current_database = "b"
+            cfg.current_datasource = "b"
             assert registry.adapter_available("superset") is True
             assert probe.call_count == 2
 

--- a/tests/unit_tests/cli/test_service_manager.py
+++ b/tests/unit_tests/cli/test_service_manager.py
@@ -14,7 +14,7 @@ def _make_agent_config(datasources=None):
     db_map = datasources if datasources is not None else {}
     services = MagicMock()
     services.datasources = db_map
-    services.default_database = next(iter(db_map), None)
+    services.default_datasource = next(iter(db_map), None)
     services.semantic_layer = {}
     services.bi_platforms = {}
     services.schedulers = {}
@@ -244,12 +244,12 @@ class TestServiceManagerList:
             calls = [str(c) for c in mock_console.print.call_args_list]
             assert any("Schedulers" in c or "airflow" in c for c in calls)
 
-    def test_list_marks_default_database(self):
+    def test_list_marks_default_datasource(self):
         """list() marks the default database with '*' in the Default column."""
         db_cfg_default = _make_db_config(default=True)
         db_cfg_other = _make_db_config(default=False)
         mock_config = _make_agent_config({"default_db": db_cfg_default, "other_db": db_cfg_other})
-        mock_config.services.default_database = "default_db"
+        mock_config.services.default_datasource = "default_db"
 
         with (
             patch("datus.cli.service_manager.load_agent_config", return_value=mock_config),

--- a/tests/unit_tests/cli/test_sub_agent_commands.py
+++ b/tests/unit_tests/cli/test_sub_agent_commands.py
@@ -24,7 +24,7 @@ def _make_cli():
     cli = MagicMock()
     cli.console = MagicMock()
     cli.agent_config = MagicMock()
-    cli.agent_config.current_database = "test_ns"
+    cli.agent_config.current_datasource = "test_ns"
     cli.agent_config.agentic_nodes = {}
     cli.available_subagents = set()
     return cli

--- a/tests/unit_tests/cli/test_sub_agent_commands.py
+++ b/tests/unit_tests/cli/test_sub_agent_commands.py
@@ -250,9 +250,9 @@ class TestRefreshAgentConfig:
         cmds._sub_agent_manager.list_agents.return_value = {"my_sub": {"system_prompt": "my_sub"}}
         cmds.cli_instance.agent_config.agentic_nodes = {}
         cmds._refresh_agent_config()
-        # Should not raise
+        cmds._sub_agent_manager.list_agents.assert_called_once()
 
     def test_refresh_handles_exception_gracefully(self, cmds):
         cmds._sub_agent_manager.list_agents.side_effect = RuntimeError("oops")
-        # Should not raise (defensive)
         cmds._refresh_agent_config()
+        cmds._sub_agent_manager.list_agents.assert_called_once()

--- a/tests/unit_tests/cli/test_tutorial.py
+++ b/tests/unit_tests/cli/test_tutorial.py
@@ -29,7 +29,7 @@ class DummyAgentConfig:
 
     def __init__(self):
         self.db_type = "sqlite"
-        self.current_database = "test_namespace"
+        self.current_datasource = "test_namespace"
         self._db_config = SimpleNamespace(catalog="catalog", database="database", schema="schema")
 
     def current_db_config(self):
@@ -449,7 +449,7 @@ class TestBenchmarkTutorialInitMetrics:
         config_file.write_text("agent: {}")
 
         mock_agent_config = MagicMock()
-        mock_agent_config.current_database = "california_schools"
+        mock_agent_config.current_datasource = "california_schools"
         mock_agent_config.rag_storage_path.return_value = str(tmp_path / "storage")
 
         monkeypatch.setattr(tutorial_module, "load_agent_config", lambda reload, config: mock_agent_config)
@@ -485,7 +485,7 @@ class TestBenchmarkTutorialInitMetrics:
         config_file.write_text("agent: {}")
 
         mock_agent_config = MagicMock()
-        mock_agent_config.current_database = "california_schools"
+        mock_agent_config.current_datasource = "california_schools"
         mock_agent_config.rag_storage_path.return_value = str(tmp_path / "storage")
 
         monkeypatch.setattr(tutorial_module, "load_agent_config", lambda reload, config: mock_agent_config)
@@ -542,7 +542,7 @@ class TestBenchmarkTutorialInitMetrics:
         config_file.write_text("agent: {}")
 
         mock_agent_config = MagicMock()
-        mock_agent_config.current_database = "california_schools"
+        mock_agent_config.current_datasource = "california_schools"
 
         monkeypatch.setattr(tutorial_module, "load_agent_config", lambda reload, config: mock_agent_config)
 

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -23,7 +23,7 @@ class TestBuildAgentArgs:
         from datus.cli.web.chatbot import _build_agent_args
 
         args = argparse.Namespace(
-            database="myns",
+            datasource="myns",
             config="conf/agent.yml",
             debug=False,
         )
@@ -39,7 +39,7 @@ class TestBuildAgentArgs:
     def test_debug_mode(self):
         from datus.cli.web.chatbot import _build_agent_args
 
-        args = argparse.Namespace(database="ns", config=None, debug=True)
+        args = argparse.Namespace(datasource="ns", config=None, debug=True)
         result = _build_agent_args(args)
 
         assert result.log_level == "DEBUG"
@@ -48,7 +48,7 @@ class TestBuildAgentArgs:
         """Fields not present on CLI args should have safe defaults."""
         from datus.cli.web.chatbot import _build_agent_args
 
-        args = argparse.Namespace(database="ns")
+        args = argparse.Namespace(datasource="ns")
         result = _build_agent_args(args)
 
         assert result.config is None
@@ -98,7 +98,7 @@ class TestCreateWebApp:
         from datus.cli.web.chatbot import create_web_app
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,
@@ -129,7 +129,7 @@ class TestCreateWebApp:
         (dist_dir / "datus-chatbot.css").write_text("/* css */")
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,
@@ -157,7 +157,7 @@ class TestCreateWebApp:
         from datus.cli.web.chatbot import _CDN_CHATBOT_JS, _CDN_REACT_JS, create_web_app
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,
@@ -187,7 +187,7 @@ class TestCreateWebApp:
         from datus.cli.web.chatbot import create_web_app
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,
@@ -219,7 +219,7 @@ class TestCreateWebApp:
         (dist_dir / "datus-chatbot.css").write_text("/* css */")
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,
@@ -248,7 +248,7 @@ class TestCreateWebApp:
         from datus.cli.web.chatbot import create_web_app
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="myhost",
             port=9999,
@@ -282,7 +282,7 @@ class TestRunWebInterface:
         from datus.cli.web.chatbot import run_web_interface
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config="conf/agent.yml",
             host="localhost",
             port=8501,
@@ -317,7 +317,7 @@ class TestRunWebInterface:
         from datus.cli.web.chatbot import run_web_interface
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,
@@ -343,7 +343,7 @@ class TestRunWebInterface:
         from datus.cli.web.chatbot import run_web_interface
 
         args = argparse.Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -361,8 +361,8 @@ class TestRunWebInterface:
             patch("datus.utils.path_manager.set_current_path_manager"),
         ):
             mock_uvicorn.run.side_effect = KeyboardInterrupt
-            # Should not raise
             run_web_interface(args)
+            mock_uvicorn.run.assert_called_once()
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit_tests/cli/web/test_chatbot_subagent.py
+++ b/tests/unit_tests/cli/web/test_chatbot_subagent.py
@@ -36,7 +36,7 @@ class TestSubagentCLIParam:
 
         args = Namespace(
             config="conf/agent.yml",
-            database="starrocks",
+            datasource="starrocks",
             host="localhost",
             port=8501,
             subagent="baisheng",
@@ -95,7 +95,7 @@ class TestCreateWebApp:
         from datus.cli.web.chatbot import create_web_app
 
         args = Namespace(
-            database="test",
+            datasource="test",
             config=None,
             host="localhost",
             port=8501,
@@ -120,7 +120,7 @@ class TestCreateWebApp:
         from datus.cli.web.chatbot import _build_agent_args
 
         args = Namespace(
-            database="myns",
+            datasource="myns",
             config="conf/agent.yml",
             debug=True,
         )

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -406,7 +406,7 @@ class TestAgentConfigServiceSelectors:
         cfg = self._make(
             tmp_path,
             services={
-                "databases": {},
+                "datasources": {},
             },
         )
         assert cfg.resolve_semantic_adapter() == "metricflow"
@@ -415,7 +415,7 @@ class TestAgentConfigServiceSelectors:
         cfg = self._make(
             tmp_path,
             services={
-                "databases": {},
+                "datasources": {},
             },
         )
 

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -256,46 +256,46 @@ class TestApplyProjectOverride:
             _apply_project_override(agent_raw)
         assert agent_raw["project_name"] == "my_proj"
 
-    def test_valid_default_database_flips_default_flags(self):
-        """default_database overlay is applied by flipping databases[*].default
-        so AgentConfig.services.default_database resolves to the override target
+    def test_valid_default_datasource_flips_default_flags(self):
+        """default_datasource overlay is applied by flipping databases[*].default
+        so AgentConfig.services.default_datasource resolves to the override target
         uniformly across every entry point (REPL, datus-api, SDK)."""
         agent_raw = self._base_raw()
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
-            return_value=ProjectOverride(default_database="db2"),
+            return_value=ProjectOverride(default_datasource="db2"),
         ):
             _apply_project_override(agent_raw)
         assert agent_raw["services"]["datasources"]["db2"]["default"] is True
         assert agent_raw["services"]["datasources"]["db1"]["default"] is False
 
-    def test_default_database_overlay_clears_prior_default(self):
+    def test_default_datasource_overlay_clears_prior_default(self):
         """A base config marking db1 as default must have that flag cleared
-        when the overlay points elsewhere, otherwise default_database would
+        when the overlay points elsewhere, otherwise default_datasource would
         return the first match (db1) and ignore the overlay."""
         agent_raw = self._base_raw()
         agent_raw["services"]["datasources"]["db1"]["default"] = True
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
-            return_value=ProjectOverride(default_database="db2"),
+            return_value=ProjectOverride(default_datasource="db2"),
         ):
             _apply_project_override(agent_raw)
         assert agent_raw["services"]["datasources"]["db1"]["default"] is False
         assert agent_raw["services"]["datasources"]["db2"]["default"] is True
 
-    def test_invalid_default_database_raises(self):
+    def test_invalid_default_datasource_raises(self):
         agent_raw = self._base_raw()
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
-            return_value=ProjectOverride(default_database="ghost_db"),
+            return_value=ProjectOverride(default_datasource="ghost_db"),
         ):
             with pytest.raises(DatusException) as exc:
                 _apply_project_override(agent_raw)
-        assert "default_database" in str(exc.value)
+        assert "default_datasource" in str(exc.value)
 
     def test_all_three_fields_merged(self):
         agent_raw = self._base_raw()
-        override = ProjectOverride(target="deepseek", default_database="db1", project_name="p")
+        override = ProjectOverride(target="deepseek", default_datasource="db1", project_name="p")
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
             return_value=override,
@@ -317,7 +317,7 @@ class TestApplyProjectOverride:
         agent_raw = {"models": {"openai": {}}}
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
-            return_value=ProjectOverride(default_database="db1"),
+            return_value=ProjectOverride(default_datasource="db1"),
         ):
             with pytest.raises(DatusException):
                 _apply_project_override(agent_raw)
@@ -351,7 +351,7 @@ class TestLoadNodeConfig:
 
 
 class TestLoadAgentConfigResolution:
-    """Cover the post-override resolution that guarantees ``current_database``
+    """Cover the post-override resolution that guarantees ``current_datasource``
     is populated for every entry point (REPL, datus-api, datus-gateway, SDK),
     regardless of whether ``override_by_args`` ran for the CLI ``action``.
     """
@@ -396,7 +396,7 @@ class TestLoadAgentConfigResolution:
             return_value=None,
         ):
             agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
-        assert agent_config.current_database == "db_b"
+        assert agent_config.current_datasource == "db_b"
 
     def test_resolves_single_db_auto(self, tmp_path, reset_global_singletons):
         """base has a single DB and no explicit default → auto-selected."""
@@ -409,10 +409,10 @@ class TestLoadAgentConfigResolution:
             return_value=None,
         ):
             agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
-        assert agent_config.current_database == "only_db"
+        assert agent_config.current_datasource == "only_db"
 
     def test_project_overlay_wins_over_base_default(self, tmp_path, reset_global_singletons):
-        """``.datus/config.yml::default_database`` overrides the base default flag."""
+        """``.datus/config.yml::default_datasource`` overrides the base default flag."""
         cfg = self._write_base_yaml(
             tmp_path,
             {
@@ -422,10 +422,10 @@ class TestLoadAgentConfigResolution:
         )
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
-            return_value=ProjectOverride(default_database="db_b", target="mock"),
+            return_value=ProjectOverride(default_datasource="db_b", target="mock"),
         ):
             agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
-        assert agent_config.current_database == "db_b"
+        assert agent_config.current_datasource == "db_b"
         assert agent_config.target == "mock"
 
     def test_raises_when_ambiguous_default(self, tmp_path, reset_global_singletons):
@@ -469,15 +469,15 @@ class TestLoadAgentConfigResolution:
                 reload=True,
                 action="service",
             )
-        assert agent_config.current_database == "db_a"
+        assert agent_config.current_datasource == "db_a"
 
     def test_no_databases_is_tolerated(self, tmp_path, reset_global_singletons):
         """Deployments without any configured DB (pure KB / tool-only) must not
-        crash at bootstrap; ``current_database`` simply stays empty."""
+        crash at bootstrap; ``current_datasource`` simply stays empty."""
         cfg = self._write_base_yaml(tmp_path, {})
         with patch(
             "datus.configuration.agent_config_loader.load_project_override",
             return_value=None,
         ):
             agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
-        assert agent_config.current_database == ""
+        assert agent_config.current_datasource == ""

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -31,10 +31,10 @@ def test_config_exception(tmp_path):
     agent_config = load_agent_config(config=str(TEST_CONF_DIR / "agent.yml"), home=str(tmp_path), reload=True)
 
     with pytest.raises(DatusException, match="Unsupported value `abc` for field `benchmark`"):
-        agent_config.override_by_args(database="snowflake", benchmark="abc")
+        agent_config.override_by_args(datasource="snowflake", benchmark="abc")
 
-    with pytest.raises(DatusException, match="Unsupported value `abc` for field `database`"):
-        agent_config.override_by_args(database="abc")
+    with pytest.raises(DatusException, match="Unsupported value `abc` for field `datasource`"):
+        agent_config.override_by_args(datasource="abc")
 
 
 def test_service_config_structure(agent_config: AgentConfig):
@@ -61,7 +61,7 @@ def test_configuration_load(database: str, agent_config: AgentConfig):
     agent_config.override_by_args(
         **{
             "schema_linking_rate": "slow",
-            "database": database,
+            "datasource": database,
         }
     )
 
@@ -73,11 +73,11 @@ def test_configuration_load(database: str, agent_config: AgentConfig):
     assert storage_path.endswith("datus_db")
     assert f"/data/{agent_config.project_name}/datus_db" in storage_path.replace(os.sep, "/")
 
-    with pytest.raises(DatusException, match="Missing required field: database"):
+    with pytest.raises(DatusException, match="Missing required field: datasource"):
         agent_config.current_namespace = ""
 
     error_db = "abc"
-    with pytest.raises(DatusException, match=f"Unsupported value `{error_db}` for field `database`"):
+    with pytest.raises(DatusException, match=f"Unsupported value `{error_db}` for field `datasource`"):
         agent_config.current_namespace = error_db
 
     error_benchmark = "abc"
@@ -93,7 +93,7 @@ def test_benchmark_db_check(agent_config: AgentConfig):
         agent_config.override_by_args(
             **{
                 "benchmark": "spider2",
-                "database": db_name,
+                "datasource": db_name,
             }
         )
 
@@ -105,7 +105,7 @@ def test_benchmark_db_check(agent_config: AgentConfig):
 def test_benchmark_config(database: str, benchmark: str, agent_config: AgentConfig):
     agent_config.override_by_args(
         **{
-            "database": database,
+            "datasource": database,
             "benchmark": benchmark,
         }
     )

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -74,11 +74,11 @@ def test_configuration_load(database: str, agent_config: AgentConfig):
     assert f"/data/{agent_config.project_name}/datus_db" in storage_path.replace(os.sep, "/")
 
     with pytest.raises(DatusException, match="Missing required field: datasource"):
-        agent_config.current_namespace = ""
+        agent_config.current_datasource = ""
 
     error_db = "abc"
     with pytest.raises(DatusException, match=f"Unsupported value `{error_db}` for field `datasource`"):
-        agent_config.current_namespace = error_db
+        agent_config.current_datasource = error_db
 
     error_benchmark = "abc"
     with pytest.raises(DatusException, match=f"Unsupported value `{error_benchmark}` for field `benchmark`"):

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -50,14 +50,14 @@ class TestLoadProjectOverride:
             yaml.safe_dump(
                 {
                     "target": "deepseek",
-                    "default_database": "my_db",
+                    "default_datasource": "my_db",
                     "project_name": "proj_a",
                 }
             )
         )
         result = load_project_override(str(tmp_path))
         assert result.target == "deepseek"
-        assert result.default_database == "my_db"
+        assert result.default_datasource == "my_db"
         assert result.project_name == "proj_a"
         assert not result.is_empty()
 
@@ -67,7 +67,7 @@ class TestLoadProjectOverride:
         path.write_text(yaml.safe_dump({"target": "deepseek"}))
         result = load_project_override(str(tmp_path))
         assert result.target == "deepseek"
-        assert result.default_database is None
+        assert result.default_datasource is None
         assert result.project_name is None
 
     def test_unknown_keys_warn_and_drop(self, tmp_path, caplog):
@@ -112,20 +112,20 @@ class TestLoadProjectOverride:
 
 class TestSaveProjectOverride:
     def test_writes_and_creates_parent_dir(self, tmp_path):
-        override = ProjectOverride(target="x", default_database="y", project_name="z")
+        override = ProjectOverride(target="x", default_datasource="y", project_name="z")
         written = save_project_override(override, cwd=str(tmp_path))
         assert written == tmp_path / PROJECT_CONFIG_REL
         assert written.exists()
         assert written.parent.name == ".datus"
 
     def test_none_fields_are_omitted(self, tmp_path):
-        override = ProjectOverride(target="x")  # default_database & project_name left as None
+        override = ProjectOverride(target="x")  # default_datasource & project_name left as None
         written = save_project_override(override, cwd=str(tmp_path))
         loaded = yaml.safe_load(written.read_text())
         assert loaded == {"target": "x"}
 
     def test_round_trip(self, tmp_path):
-        original = ProjectOverride(target="a", default_database="b", project_name="c")
+        original = ProjectOverride(target="a", default_datasource="b", project_name="c")
         save_project_override(original, cwd=str(tmp_path))
         loaded = load_project_override(str(tmp_path))
         assert loaded == original
@@ -139,7 +139,7 @@ class TestSaveProjectOverride:
 
 class TestAllowedKeys:
     def test_whitelist_contains_exactly_three_keys(self):
-        assert ALLOWED_KEYS == frozenset({"target", "default_database", "project_name"})
+        assert ALLOWED_KEYS == frozenset({"target", "default_datasource", "project_name"})
 
 
 class TestProjectOverrideDataclass:
@@ -150,7 +150,7 @@ class TestProjectOverrideDataclass:
         "field,value",
         [
             ("target", "x"),
-            ("default_database", "y"),
+            ("default_datasource", "y"),
             ("project_name", "z"),
         ],
     )

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -241,7 +241,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
     agent_config = AgentConfig(nodes=nodes, **config_kwargs)
 
     # Set current database (was: current_namespace = "test_ns")
-    agent_config.current_database = "california_schools"
+    agent_config.current_datasource = "california_schools"
 
     yield agent_config
     # tmp_path is pytest-managed; storage backends here use

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -240,7 +240,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
     nodes: dict[str, NodeConfig] = {}
     agent_config = AgentConfig(nodes=nodes, **config_kwargs)
 
-    # Set current database (was: current_datasource = "test_ns")
+    # Set current datasource (was: current_namespace = "test_ns")
     agent_config.current_datasource = "california_schools"
 
     yield agent_config

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -240,7 +240,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
     nodes: dict[str, NodeConfig] = {}
     agent_config = AgentConfig(nodes=nodes, **config_kwargs)
 
-    # Set current database (was: current_namespace = "test_ns")
+    # Set current database (was: current_datasource = "test_ns")
     agent_config.current_datasource = "california_schools"
 
     yield agent_config

--- a/tests/unit_tests/storage/metric/test_adapter_init.py
+++ b/tests/unit_tests/storage/metric/test_adapter_init.py
@@ -20,7 +20,7 @@ def _make_agent_config(namespace="test_ns", adapter_type_config=None):
     """Create a mock AgentConfig."""
     config = MagicMock()
     config.namespace = namespace
-    config.current_database = namespace
+    config.current_datasource = namespace
     config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: (
         adapter_type.lower().strip() if adapter_type else None
     )
@@ -198,9 +198,9 @@ class TestInitFromAdapter:
 
         # agent_config must NOT have metricflow_config so code falls through
         # to the metadata.config_class branch. Use spec to restrict attributes.
-        config = MagicMock(spec=["namespace", "current_database", "namespaces", "path_manager"])
+        config = MagicMock(spec=["namespace", "current_datasource", "namespaces", "path_manager"])
         config.namespace = "ns1"
-        config.current_database = "ns1"
+        config.current_datasource = "ns1"
         config.namespaces = {}
         config.path_manager.semantic_models_dir = "/tmp/project/subject/semantic_models"
 
@@ -237,8 +237,8 @@ class TestInitFromAdapter:
     @pytest.mark.asyncio
     @patch("datus.storage.metric.adapter_init.SemanticStorageManager")
     @patch("datus.storage.metric.adapter_init.semantic_adapter_registry")
-    async def test_namespace_from_current_database_fallback(self, mock_registry, MockStorageManager):
-        """Should use current_database when namespace attr is None."""
+    async def test_namespace_from_current_datasource_fallback(self, mock_registry, MockStorageManager):
+        """Should use current_datasource when namespace attr is None."""
         from datus.storage.metric.adapter_init import init_from_adapter
 
         mock_metadata = MagicMock()
@@ -251,9 +251,9 @@ class TestInitFromAdapter:
         MockStorageManager.return_value = mock_manager
 
         # Use spec to prevent auto-generated attributes like dbt_config
-        config = MagicMock(spec=["namespace", "current_database", "namespaces", "path_manager"])
+        config = MagicMock(spec=["namespace", "current_datasource", "namespaces", "path_manager"])
         config.namespace = None
-        config.current_database = "fallback_ns"
+        config.current_datasource = "fallback_ns"
         config.namespaces = {}
         config.path_manager.semantic_models_dir = "/tmp/project/subject/semantic_models"
 
@@ -296,9 +296,9 @@ class TestInitFromAdapter:
             "logic_name": "ignore_me_too",
         }
 
-        config = MagicMock(spec=["namespace", "current_database", "namespaces", "path_manager"])
+        config = MagicMock(spec=["namespace", "current_datasource", "namespaces", "path_manager"])
         config.namespace = "ns1"
-        config.current_database = "ns1"
+        config.current_datasource = "ns1"
         config.namespaces = {"ns1": {"default": mock_db_config}}
         config.path_manager.semantic_models_dir = "/tmp/project/subject/semantic_models"
 

--- a/tests/unit_tests/storage/reference_template/test_reference_template_init.py
+++ b/tests/unit_tests/storage/reference_template/test_reference_template_init.py
@@ -364,7 +364,7 @@ class TestProcessTemplateItem:
 
         mock_config = MagicMock()
         mock_config.path_manager.sql_summary_path.return_value = summary_dir
-        mock_config.current_namespace = "test_ns"
+        mock_config.current_datasource = "test_ns"
 
         item = {
             "template": "SELECT * FROM t WHERE x = '{{val}}'",
@@ -446,7 +446,7 @@ class TestProcessTemplateItem:
 
         mock_config = MagicMock()
         mock_config.path_manager.sql_summary_path.return_value = summary_dir
-        mock_config.current_namespace = "test_ns"
+        mock_config.current_datasource = "test_ns"
 
         item = {"template": "SELECT 1", "filepath": "/tmp/test.j2", "comment": ""}
 
@@ -480,7 +480,7 @@ class TestProcessTemplateItem:
 
         mock_config = MagicMock()
         mock_config.path_manager.sql_summary_path.return_value = Path("/nonexistent/dir")
-        mock_config.current_namespace = "test_ns"
+        mock_config.current_datasource = "test_ns"
 
         item = {"template": "SELECT 1", "filepath": "/tmp/test.j2", "comment": ""}
 
@@ -554,7 +554,7 @@ class TestProcessTemplateItem:
 
         mock_config = MagicMock()
         mock_config.path_manager.sql_summary_path.return_value = summary_dir
-        mock_config.current_namespace = "test_ns"
+        mock_config.current_datasource = "test_ns"
 
         item = {"template": "SELECT 1", "filepath": "/tmp/test.j2", "comment": ""}
 
@@ -597,7 +597,7 @@ class TestProcessTemplateItem:
 
         mock_config = MagicMock()
         mock_config.path_manager.sql_summary_path.return_value = summary_dir
-        mock_config.current_namespace = "test_ns"
+        mock_config.current_datasource = "test_ns"
 
         mock_event_helper = MagicMock()
 

--- a/tests/unit_tests/storage/reference_template/test_store.py
+++ b/tests/unit_tests/storage/reference_template/test_store.py
@@ -160,7 +160,7 @@ class TestReferenceTemplateRAG:
             mock_filter.return_value = filter_value
 
         config = MagicMock()
-        config.current_database = "test_ns"
+        config.current_datasource = "test_ns"
         return ReferenceTemplateRAG(config), mock_storage
 
     @patch("datus.storage.rag_scope._build_sub_agent_filter", return_value=None)

--- a/tests/unit_tests/storage/schema_metadata/test_local_init.py
+++ b/tests/unit_tests/storage/schema_metadata/test_local_init.py
@@ -394,7 +394,7 @@ pytestmark = pytest.mark.ci
 
 def _make_agent_config(namespace="test_ns", db_type=DBType.SQLITE, db_name="mydb"):
     config = MagicMock()
-    config.current_database = namespace
+    config.current_datasource = namespace
     db_config = MagicMock()
     db_config.type = db_type
     db_config.database = db_name
@@ -773,7 +773,7 @@ class TestInitLocalSchema:
 
         db_config = DbConfig(type=db_type, database=db_name)
         agent_config = MagicMock()
-        agent_config.current_database = "test_ns"
+        agent_config.current_datasource = "test_ns"
         agent_config.namespaces = {"test_ns": {db_name: db_config}}
         return agent_config, db_config
 
@@ -821,7 +821,7 @@ class TestInitLocalSchema:
 
         mock_store = MagicMock()
         agent_config = MagicMock()
-        agent_config.current_database = "test_ns"
+        agent_config.current_datasource = "test_ns"
 
         db_config_a = MagicMock()
         db_config_a.type = DBType.SQLITE
@@ -848,7 +848,7 @@ class TestInitLocalSchema:
 
         mock_store = MagicMock()
         agent_config = MagicMock()
-        agent_config.current_database = "test_ns"
+        agent_config.current_datasource = "test_ns"
 
         db_config_a = MagicMock()
         db_config_a.type = DBType.SQLITE
@@ -874,7 +874,7 @@ class TestInitLocalSchema:
 
         mock_store = MagicMock()
         agent_config = MagicMock()
-        agent_config.current_database = "test_ns"
+        agent_config.current_datasource = "test_ns"
         agent_config.namespaces = {"test_ns": {}}  # empty
         db_manager = MagicMock()
 
@@ -888,7 +888,7 @@ class TestInitLocalSchema:
 
         mock_store = MagicMock()
         agent_config = MagicMock()
-        agent_config.current_database = "test_ns"
+        agent_config.current_datasource = "test_ns"
 
         db_config = MagicMock()
         db_config.type = "oracle"  # not SQLITE or DUCKDB in multi-db mode

--- a/tests/unit_tests/storage/semantic_model/test_adapter_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_adapter_init.py
@@ -20,7 +20,7 @@ def _make_agent_config(namespace="test_ns"):
     """Create a mock AgentConfig."""
     config = MagicMock()
     config.namespace = namespace
-    config.current_database = namespace
+    config.current_datasource = namespace
     config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: (
         adapter_type.lower().strip() if adapter_type else None
     )
@@ -211,9 +211,9 @@ class TestInitFromAdapter:
 
         # agent_config must NOT have cube_config so code falls through
         # to the metadata.config_class branch. Use spec to restrict attributes.
-        config = MagicMock(spec=["namespace", "current_database", "namespaces", "path_manager"])
+        config = MagicMock(spec=["namespace", "current_datasource", "namespaces", "path_manager"])
         config.namespace = "ns1"
-        config.current_database = "ns1"
+        config.current_datasource = "ns1"
         config.namespaces = {}
         config.path_manager.semantic_models_dir = "/tmp/project/subject/semantic_models"
 
@@ -226,8 +226,8 @@ class TestInitFromAdapter:
     @pytest.mark.asyncio
     @patch("datus.storage.semantic_model.adapter_init.SemanticStorageManager")
     @patch("datus.storage.semantic_model.adapter_init.semantic_adapter_registry")
-    async def test_namespace_falls_back_to_current_database(self, mock_registry, MockStorageManager):
-        """Should use current_database when namespace attr is None."""
+    async def test_namespace_falls_back_to_current_datasource(self, mock_registry, MockStorageManager):
+        """Should use current_datasource when namespace attr is None."""
         from datus.storage.semantic_model.adapter_init import init_from_adapter
 
         mock_metadata = MagicMock()
@@ -240,9 +240,9 @@ class TestInitFromAdapter:
         MockStorageManager.return_value = mock_manager
 
         # Use spec to prevent auto-generated attributes like dbt_config
-        config = MagicMock(spec=["namespace", "current_database", "namespaces", "path_manager"])
+        config = MagicMock(spec=["namespace", "current_datasource", "namespaces", "path_manager"])
         config.namespace = None
-        config.current_database = "fallback_ns"
+        config.current_datasource = "fallback_ns"
         config.namespaces = {}
         config.path_manager.semantic_models_dir = "/tmp/project/subject/semantic_models"
 
@@ -338,9 +338,9 @@ class TestInitFromAdapter:
             "logic_name": "ignore_me_too",
         }
 
-        config = MagicMock(spec=["namespace", "current_database", "namespaces", "path_manager"])
+        config = MagicMock(spec=["namespace", "current_datasource", "namespaces", "path_manager"])
         config.namespace = "ns1"
-        config.current_database = "ns1"
+        config.current_datasource = "ns1"
         config.namespaces = {"ns1": {"default": mock_db_config}}
         config.path_manager.semantic_models_dir = "/tmp/project/subject/semantic_models"
 

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -42,7 +42,7 @@ class TestCreateParser:
             ]
         )
         assert args.action == "run"
-        assert args.database == "myns"
+        assert args.datasource == "myns"
         assert args.task == "count rows"
         assert args.task_db_name == "mydb"
 
@@ -81,7 +81,7 @@ class TestCreateParser:
             ]
         )
         assert args.action == "check-db"
-        assert args.database == "testns"
+        assert args.datasource == "testns"
 
     def test_probe_llm_action_parsed(self):
         parser = create_parser()

--- a/tests/unit_tests/tools/db_tools/test_db_func_tools.py
+++ b/tests/unit_tests/tools/db_tools/test_db_func_tools.py
@@ -1293,7 +1293,7 @@ class TestDBFuncToolMultiConnector:
     def mock_agent_config(self):
         """Create a mock AgentConfig for multi-connector tests."""
         config = Mock()
-        config.current_database = "db1"
+        config.current_datasource = "db1"
         # Return multiple databases to trigger multi-connector mode
         config.current_db_configs.return_value = {"db1": {}, "db2": {}}
         return config
@@ -1302,7 +1302,7 @@ class TestDBFuncToolMultiConnector:
     def mock_single_db_agent_config(self):
         """Create a mock AgentConfig with single database."""
         config = Mock()
-        config.current_database = "db1"
+        config.current_datasource = "db1"
         # Return single database to trigger single connector mode
         config.current_db_configs.return_value = {"db1": {}}
         return config

--- a/tests/unit_tests/tools/func_tool/test_bi_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_bi_tools.py
@@ -253,7 +253,7 @@ def _build_tool(
     mock_cfg = MagicMock()
     mock_cfg.dashboard_config = {bi_service: dash_cfg}
     mock_cfg.namespaces = {}
-    mock_cfg.current_database = ""
+    mock_cfg.current_datasource = ""
 
     return BIFuncTool(mock_cfg, bi_service=bi_service, adapter=adapter)
 

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -612,7 +612,7 @@ class TestGetConnectorRouting:
 
         mock_config = Mock()
         mock_config.active_model.return_value.model = "gpt-5.4"
-        mock_config.current_database = "duckdb"
+        mock_config.current_datasource = "duckdb"
         # Must have >1 database so DBFuncTool enters true multi-connector mode
         mock_config.current_db_configs.return_value = {"duckdb": Mock(), "greenplum": Mock()}
 
@@ -653,7 +653,7 @@ class TestGetConnectorRouting:
 
         mock_config = Mock()
         mock_config.active_model.return_value.model = "gpt-5.4"
-        mock_config.current_database = "duckdb"
+        mock_config.current_datasource = "duckdb"
         mock_config.current_db_configs.return_value = {"duckdb": Mock(), "greenplum": Mock()}
 
         with (
@@ -687,7 +687,7 @@ class TestGetConnectorRouting:
 
         mock_config = Mock()
         mock_config.active_model.return_value.model = "gpt-5.4"
-        mock_config.current_database = "default_db"
+        mock_config.current_datasource = "default_db"
         mock_config.current_db_configs.return_value = {"default_db": Mock(), "other_db": Mock()}
 
         with (
@@ -716,7 +716,7 @@ class TestGetConnectorRouting:
 
         mock_config = Mock()
         mock_config.active_model.return_value.model = "gpt-5.4"
-        mock_config.current_database = "default_db"
+        mock_config.current_datasource = "default_db"
         mock_config.current_db_configs.return_value = {"default_db": Mock(), "other_db": Mock()}
 
         with (
@@ -752,7 +752,7 @@ class TestGetConnectorRouting:
 
         mock_config = Mock()
         mock_config.active_model.return_value.model = "gpt-5.4"
-        mock_config.current_database = "source_db"
+        mock_config.current_datasource = "source_db"
         databases = {"source_db": Mock(), "broken_db": Mock()}
         mock_config.current_db_configs.return_value = databases
 

--- a/tests/unit_tests/tools/func_tool/test_reference_template_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_reference_template_tools.py
@@ -14,7 +14,7 @@ from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTool
 @pytest.fixture
 def mock_agent_config():
     config = MagicMock()
-    config.current_namespace = "test_namespace"
+    config.current_datasource = "test_namespace"
     return config
 
 

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -23,7 +23,7 @@ from datus.utils.constants import SYS_SUB_AGENTS
 def mock_agent_config():
     config = Mock(spec=AgentConfig)
     config.db_type = "sqlite"
-    config.current_database = "test_db"
+    config.current_datasource = "test_db"
     config.agentic_nodes = {
         "chat": {"model": "default"},
         "gen_sql": {"model": "default", "system_prompt": "gen_sql", "node_class": "gen_sql"},
@@ -96,7 +96,7 @@ class TestGetAvailableTypes:
     def test_includes_agent_without_node_class(self):
         """Subagent without node_class should still be discovered (defaults to gen_sql)."""
         config = Mock(spec=AgentConfig)
-        config.current_database = "default"
+        config.current_datasource = "default"
         config.agentic_nodes = {
             "chat": {"model": "default"},
             "custom": {"model": "default"},  # no node_class
@@ -109,7 +109,7 @@ class TestGetAvailableTypes:
     def test_excludes_scoped_agent_wrong_namespace(self):
         """Subagent with scoped_context bound to a different namespace should be excluded."""
         config = Mock(spec=AgentConfig)
-        config.current_database = "default"
+        config.current_datasource = "default"
         config.agentic_nodes = {
             "chat": {"model": "default"},
             "scoped_agent": {
@@ -125,7 +125,7 @@ class TestGetAvailableTypes:
     def test_includes_scoped_agent_matching_namespace(self):
         """Subagent with scoped_context matching current namespace should be included."""
         config = Mock(spec=AgentConfig)
-        config.current_database = "sales"
+        config.current_datasource = "sales"
         config.agentic_nodes = {
             "chat": {"model": "default"},
             "scoped_agent": {
@@ -141,7 +141,7 @@ class TestGetAvailableTypes:
     def test_includes_agent_without_scoped_context(self):
         """Subagent without scoped_context should not be filtered by namespace."""
         config = Mock(spec=AgentConfig)
-        config.current_database = "default"
+        config.current_datasource = "default"
         config.agentic_nodes = {
             "chat": {"model": "default"},
             "global_agent": {
@@ -157,7 +157,7 @@ class TestGetAvailableTypes:
     def test_explicit_list_filters_out_unknown_types(self, caplog):
         """Unknown types in explicit allowed_subagents are skipped with a warning."""
         config = Mock(spec=AgentConfig)
-        config.current_database = "default"
+        config.current_datasource = "default"
         config.agentic_nodes = {"chat": {"model": "default"}}
         tool = SubAgentTaskTool(
             agent_config=config,
@@ -178,7 +178,7 @@ class TestGetAvailableTypes:
     def test_explicit_list_excludes_self(self):
         """The parent node name is excluded even if listed in allowed_subagents."""
         config = Mock(spec=AgentConfig)
-        config.current_database = "default"
+        config.current_datasource = "default"
         config.agentic_nodes = {"chat": {"model": "default"}}
         tool = SubAgentTaskTool(
             agent_config=config,

--- a/tests/unit_tests/utils/test_benchmark_evaluation.py
+++ b/tests/unit_tests/utils/test_benchmark_evaluation.py
@@ -343,6 +343,7 @@ def test_evaluate_benchmark_and_report_with_csv_manifest(agent_config: AgentConf
         agent_config=agent_config,
         benchmark_platform=benchmark_name,
     )
+    assert report["status"] == "success"
     _assert_report_structure(report)
 
 
@@ -419,4 +420,5 @@ def test_evaluate_benchmark_and_report_with_jsonl_manifest(agent_config: AgentCo
         agent_config=agent_config,
         benchmark_platform=benchmark_name,
     )
+    assert report["status"] == "success"
     _assert_report_structure(report)

--- a/tests/unit_tests/utils/test_benchmark_evaluation.py
+++ b/tests/unit_tests/utils/test_benchmark_evaluation.py
@@ -332,7 +332,7 @@ def test_evaluate_benchmark_and_report_with_csv_manifest(agent_config: AgentConf
     _write_sql(result_dir / "task-456.sql", "SELECT name, total FROM other_table;")
 
     # Arrange trajectories (must be under {trajectory_dir}/{namespace}/)
-    trajectory_dir = Path(agent_config.trajectory_dir) / agent_config.current_database
+    trajectory_dir = Path(agent_config.trajectory_dir) / agent_config.current_datasource
     _write_trajectory(trajectory_dir / "task-123_1.yaml", "task-123", _match_tool_actions())
     _write_trajectory(trajectory_dir / "task-456_1.yaml", "task-456", _mismatch_tool_actions())
 
@@ -410,7 +410,7 @@ def test_evaluate_benchmark_and_report_with_jsonl_manifest(agent_config: AgentCo
     )
     _write_sql(result_dir / "task-456.sql", "SELECT name, total FROM other_table;")
 
-    trajectory_dir = Path(agent_config.trajectory_dir) / agent_config.current_database
+    trajectory_dir = Path(agent_config.trajectory_dir) / agent_config.current_datasource
     _write_trajectory(trajectory_dir / "task-123_1.yaml", "task-123", _match_tool_actions())
     _write_trajectory(trajectory_dir / "task-456_1.yaml", "task-456", _mismatch_tool_actions())
 


### PR DESCRIPTION

Aligns CLI arguments and internal property names with the services.datasources config key renamed in #633. Renames:
- CLI arg --database → --datasource (--namespace kept as alias)
- AgentConfig.current_database → current_datasource
- ServicesConfig.default_database → default_datasource
- ProjectOverride.default_database → default_datasource
- Template variable {{ current_database }} → {{ current_datasource }}
- API response field DatabaseInfo.current_database → current_datasource

Preserves DatabaseService.current_database, DBFuncTool._default_database, DashboardAssembler.default_database, and ListDatabasesData.current_database which carry real DB connection name semantics.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Renamed current_database → current_datasource across configs, API responses, and project overrides
  * CLI flags and help updated from --database to --datasource

* **Updates**
  * UI, agents, tools, and storage now surface "datasource" consistently (banners, prompts, diagnostics)
  * Tests, onboarding, and init flows updated to reflect the new naming and default-selection behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->