### PR TITLE
[Refactor] Rename database→datasource in config_routes API layer

### DIFF
--- a/datus/api/routes/config_routes.py
+++ b/datus/api/routes/config_routes.py
@@ -55,8 +55,8 @@ class ProbeModelRequest(BaseModel):
     base_url: Optional[str] = None
 
 
-class ProbeDatabaseRequest(BaseModel):
-    """Single database config dict — flat shape matching IDatabaseConfig."""
+class ProbeDatasourceRequest(BaseModel):
+    """Single datasource config dict — flat shape matching IDatasourceConfig."""
 
     model_config = {"extra": "allow"}
 
@@ -78,7 +78,7 @@ def _probe_llm_sync(payload: Dict[str, Any]) -> None:
     client.generate("Hello")
 
 
-def _probe_database_sync(payload: Dict[str, Any]) -> None:
+def _probe_datasource_sync(payload: Dict[str, Any]) -> None:
     """Build a one-shot connector from a raw dict and run a SELECT 1 probe."""
     from datus.tools.db_tools.db_manager import DBManager
 
@@ -143,7 +143,7 @@ async def get_agent_config_endpoint(
         data={
             "target": config.target,
             "models": config.models,
-            "current_database": config.current_namespace,
+            "current_datasource": config.current_namespace,
             "datasources": flat_datasources,
             "home": config.home,
         },
@@ -237,20 +237,20 @@ async def probe_model_connectivity_endpoint(
 
 
 @router.post(
-    "/config/databases/test",
+    "/config/datasources/test",
     response_model=Result[dict],
-    summary="Test Database Connectivity",
-    description="Run SELECT 1 against a database config to verify reachability and credentials.",
+    summary="Test Datasource Connectivity",
+    description="Run SELECT 1 against a datasource config to verify reachability and credentials.",
 )
-async def probe_database_connectivity_endpoint(
-    body: ProbeDatabaseRequest,
+async def probe_datasource_connectivity_endpoint(
+    body: ProbeDatasourceRequest,
     svc: ServiceDep,  # noqa: ARG001
 ) -> Result[dict]:
     """Return `{ok: True}` if the probe succeeds, else `{ok: False, message: ...}`."""
     payload = body.model_dump()
     try:
-        await asyncio.to_thread(_probe_database_sync, payload)
+        await asyncio.to_thread(_probe_datasource_sync, payload)
         return Result(success=True, data={"ok": True})
     except Exception as e:
-        logger.info(f"Database connectivity probe failed: {e}")
+        logger.info(f"Datasource connectivity probe failed: {e}")
         return Result(success=True, data={"ok": False, "message": str(e)})

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -10,12 +10,12 @@ import pytest
 
 from datus.api.routes import config_routes
 from datus.api.routes.config_routes import (
-    ProbeDatabaseRequest,
+    ProbeDatasourceRequest,
     ProbeModelRequest,
     UpdateDatasourcesRequest,
     UpdateModelsRequest,
     get_agent_config_endpoint,
-    probe_database_connectivity_endpoint,
+    probe_datasource_connectivity_endpoint,
     probe_model_connectivity_endpoint,
     update_datasources_endpoint,
     update_models_endpoint,
@@ -23,23 +23,23 @@ from datus.api.routes.config_routes import (
 from datus.utils.exceptions import DatusException
 
 
-def _mock_svc(databases, *, target="deepseek", current_database="starrocks", models=None, home="~/.datus"):
+def _mock_svc(datasources, *, target="deepseek", current_datasource="starrocks", models=None, home="~/.datus"):
     svc = MagicMock()
     svc.agent_config.target = target
     svc.agent_config.models = models if models is not None else {}
-    svc.agent_config.current_namespace = current_database
-    svc.agent_config.namespaces = databases
+    svc.agent_config.current_namespace = current_datasource
+    svc.agent_config.namespaces = datasources
     svc.agent_config.home = home
     return svc
 
 
 @pytest.mark.asyncio
 async def test_get_agent_config_flattens_matching_inner_key():
-    """When inner key matches the database name, that entry is returned flat."""
+    """When inner key matches the datasource name, that entry is returned flat."""
     starrocks_cfg = {"logic_name": "starrocks", "type": "starrocks", "host": "h1"}
     starrocks22_cfg = {"logic_name": "starrocks22", "type": "starrocks", "host": "h2"}
     svc = _mock_svc(
-        databases={
+        datasources={
             "starrocks": {"starrocks": starrocks_cfg},
             "starrocks22": {"starrocks22": starrocks22_cfg},
         },
@@ -53,15 +53,15 @@ async def test_get_agent_config_flattens_matching_inner_key():
         "starrocks22": starrocks22_cfg,
     }
     assert result.data["target"] == "deepseek"
-    assert result.data["current_database"] == "starrocks"
+    assert result.data["current_datasource"] == "starrocks"
     assert result.data["home"] == "~/.datus"
 
 
 @pytest.mark.asyncio
 async def test_get_agent_config_falls_back_to_first_inner_value():
-    """When inner key does not match database name, first inner value is used."""
+    """When inner key does not match datasource name, first inner value is used."""
     inner_cfg = {"logic_name": "db_a", "type": "duckdb"}
-    svc = _mock_svc(databases={"my_db": {"db_a": inner_cfg}})
+    svc = _mock_svc(datasources={"my_db": {"db_a": inner_cfg}})
 
     result = await get_agent_config_endpoint(svc)
 
@@ -70,9 +70,9 @@ async def test_get_agent_config_falls_back_to_first_inner_value():
 
 @pytest.mark.asyncio
 async def test_get_agent_config_skips_empty_inner_dict():
-    """Databases with empty inner dicts are dropped from the response."""
+    """Datasources with empty inner dicts are dropped from the response."""
     real_cfg = {"logic_name": "real", "type": "duckdb"}
-    svc = _mock_svc(databases={"empty": {}, "real": {"real": real_cfg}})
+    svc = _mock_svc(datasources={"empty": {}, "real": {"real": real_cfg}})
 
     result = await get_agent_config_endpoint(svc)
 
@@ -80,8 +80,8 @@ async def test_get_agent_config_skips_empty_inner_dict():
 
 
 @pytest.mark.asyncio
-async def test_get_agent_config_handles_empty_databases():
-    svc = _mock_svc(databases={})
+async def test_get_agent_config_handles_empty_datasources():
+    svc = _mock_svc(datasources={})
 
     result = await get_agent_config_endpoint(svc)
 
@@ -334,17 +334,17 @@ async def test_test_model_connectivity_passes_extra_fields(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_test_database_connectivity_ok(monkeypatch):
-    """Successful DB probe returns ok=True and forwards the payload unchanged."""
+async def test_test_datasource_connectivity_ok(monkeypatch):
+    """Successful datasource probe returns ok=True and forwards the payload unchanged."""
     captured = {}
 
     def fake_probe(payload):
         captured["payload"] = payload
 
-    monkeypatch.setattr(config_routes, "_probe_database_sync", fake_probe)
+    monkeypatch.setattr(config_routes, "_probe_datasource_sync", fake_probe)
 
-    body = ProbeDatabaseRequest.model_validate({"type": "duckdb", "uri": "/tmp/test.duckdb"})
-    result = await probe_database_connectivity_endpoint(body, svc=MagicMock())
+    body = ProbeDatasourceRequest.model_validate({"type": "duckdb", "uri": "/tmp/test.duckdb"})
+    result = await probe_datasource_connectivity_endpoint(body, svc=MagicMock())
 
     assert result.data == {"ok": True}
     assert captured["payload"]["type"] == "duckdb"
@@ -352,16 +352,16 @@ async def test_test_database_connectivity_ok(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_test_database_connectivity_reports_error_message(monkeypatch):
+async def test_test_datasource_connectivity_reports_error_message(monkeypatch):
     """Probe exception is surfaced as ok=False with message; HTTP stays 200."""
 
     def fake_probe(payload):
         raise RuntimeError("connection refused")
 
-    monkeypatch.setattr(config_routes, "_probe_database_sync", fake_probe)
+    monkeypatch.setattr(config_routes, "_probe_datasource_sync", fake_probe)
 
-    body = ProbeDatabaseRequest.model_validate({"type": "starrocks", "host": "unreachable", "port": "9999"})
-    result = await probe_database_connectivity_endpoint(body, svc=MagicMock())
+    body = ProbeDatasourceRequest.model_validate({"type": "starrocks", "host": "unreachable", "port": "9999"})
+    result = await probe_datasource_connectivity_endpoint(body, svc=MagicMock())
 
     assert result.data["ok"] is False
     assert "connection refused" in result.data["message"]

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -23,12 +23,12 @@ from datus.api.routes.config_routes import (
 from datus.utils.exceptions import DatusException
 
 
-def _mock_svc(databases, *, target="deepseek", current_datasource="starrocks", models=None, home="~/.datus"):
+def _mock_svc(datasources, *, target="deepseek", current_datasource="starrocks", models=None, home="~/.datus"):
     svc = MagicMock()
     svc.agent_config.target = target
     svc.agent_config.models = models if models is not None else {}
     svc.agent_config.current_datasource = current_datasource
-    svc.agent_config.namespaces = databases
+    svc.agent_config.namespaces = datasources
     svc.agent_config.home = home
     return svc
 


### PR DESCRIPTION
## Why

PR #633 renamed `services.databases` → `services.datasources` in agent.yml but the HTTP API layer still exposed the old wording. This follows up to align the public API surface (paths, request/response field names, schema classes) with the new naming, so frontend callers can talk to `/config/datasources` consistently.

## Solution

Surgical rename in `datus/api/routes/config_routes.py` and its unit tests:

- Path: `POST /api/v1/config/databases/test` → `POST /api/v1/config/datasources/test`
- Response field: `current_database` → `current_datasource` (from `get_agent_config_endpoint`)
- Class: `ProbeDatabaseRequest` → `ProbeDatasourceRequest`
- Endpoint: `probe_database_connectivity_endpoint` → `probe_datasource_connectivity_endpoint`
- Internal helper: `_probe_database_sync` → `_probe_datasource_sync`
- Matching changes in OpenAPI `summary` / `description` and log messages
- Tests updated to import and exercise the renamed symbols

The request schema's underlying shape (`DbConfig` fields, connector logic) is unchanged — this PR only renames the user-facing surface to match the configuration model.

## Test Cases

All 22 unit tests in `tests/unit_tests/api/routes/test_config_routes.py` still pass after the rename, including:

- `test_get_agent_config_flattens_matching_inner_key` — asserts the new `current_datasource` field
- `test_test_datasource_connectivity_ok` — verifies the renamed probe endpoint succeeds and forwards payload
- `test_test_datasource_connectivity_reports_error_message` — verifies error path surfaces `ok: False` with message
- Existing datasource update/validation tests (`test_update_datasources_*`) — unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Connectivity probe endpoint and public-facing text changed from "database" to "datasource", including the API route path; response shape and success/error semantics remain unchanged.
* **Tests**
  * Unit tests updated to use the "datasource" terminology and verify identical probe behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->