### PR TITLE
[BugFix] Filter out LiteLLM empty-message sanitizer placeholder from UI display

### DIFF
--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -108,21 +108,27 @@ def _build_response_content(action: ActionHistory) -> List[IMessageContent]:
 
 def _build_thinking_content(action: ActionHistory) -> Optional[List[IMessageContent]]:
     """Extract text content from action for markdown display."""
+    from datus.utils.text_utils import strip_litellm_placeholder
+
     action_type = action.action_type
 
     if action_type == "llm_generation":
-        return [IMessageContent(type="thinking", payload={"content": action.messages})]
+        messages = strip_litellm_placeholder(action.messages)
+        return [IMessageContent(type="thinking", payload={"content": messages})] if messages else None
 
     output = action.output
     content = None
     if output and isinstance(output, dict):
         for key in ["response", "raw_output", "output", "thinking", "content"]:
             if key in output and output[key]:
-                content = str(output[key])
-                break
+                candidate = strip_litellm_placeholder(str(output[key]))
+                if candidate:
+                    content = candidate
+                    break
 
     if not content:
-        return [IMessageContent(type="thinking", payload={"content": action.messages})]
+        messages = strip_litellm_placeholder(action.messages)
+        return [IMessageContent(type="thinking", payload={"content": messages})] if messages else None
 
     result_json = llm_result2json(content)
 

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -47,11 +47,13 @@ def _truncate_middle(text: str, max_len: int = 120) -> str:
 
 def _get_assistant_content(action: ActionHistory) -> str:
     """Extract display content from an ASSISTANT action, preferring output.raw_output."""
+    from datus.utils.text_utils import strip_litellm_placeholder
+
     if action.output and isinstance(action.output, dict):
-        raw = action.output.get("raw_output", "")
+        raw = strip_litellm_placeholder(action.output.get("raw_output", ""))
         if raw:
             return raw
-    return action.messages or ""
+    return strip_litellm_placeholder(action.messages or "")
 
 
 # ── Icon/color mappings ─────────────────────────────────────────────────────

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -35,6 +35,7 @@ from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_str
 from datus.utils.loggings import get_logger
 from datus.utils.resource_utils import read_data_file_text
+from datus.utils.text_utils import strip_litellm_placeholder
 from datus.utils.traceable_utils import setup_tracing
 
 logger = get_logger(__name__)
@@ -394,7 +395,7 @@ class OpenAICompatibleModel(LLMBaseModel):
             # Use LiteLLM for unified provider support
             response = litellm.completion(messages=messages, **params)
             message = response.choices[0].message
-            content = message.content
+            content = strip_litellm_placeholder(message.content)
 
             # Handle reasoning content for reasoning models (DeepSeek R1, OpenAI O-series)
             reasoning_content = None
@@ -831,7 +832,7 @@ class OpenAICompatibleModel(LLMBaseModel):
 
                             # Stream text delta: yield thinking_delta for real-time display
                             if raw_type == "response.output_text.delta":
-                                delta_text = getattr(raw_data, "delta", None)
+                                delta_text = strip_litellm_placeholder(getattr(raw_data, "delta", None))
                                 if delta_text:
                                     if thinking_stream_id is None:
                                         thinking_stream_id = f"thinking_stream_{uuid.uuid4().hex[:8]}"
@@ -851,8 +852,8 @@ class OpenAICompatibleModel(LLMBaseModel):
 
                             # Content part done: emit completed thinking action
                             if raw_type == "response.content_part.done":
-                                if thinking_accumulated.strip():
-                                    full_text = thinking_accumulated.strip()
+                                full_text = strip_litellm_placeholder(thinking_accumulated.strip())
+                                if full_text:
                                     text_content_split = full_text if len(full_text) <= 200 else f"{full_text[:200]}..."
                                     is_thinking = len(temp_tool_calls) > 0
                                     thinking_action = ActionHistory(
@@ -883,7 +884,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                                             part_text = getattr(content_part, "text", None)
                                             if part_text:
                                                 text_parts.append(part_text)
-                                        full_text = "\n".join(text_parts).strip()
+                                        full_text = strip_litellm_placeholder("\n".join(text_parts).strip())
                                         if full_text:
                                             text_content_split = (
                                                 full_text if len(full_text) <= 200 else f"{full_text[:200]}..."
@@ -1058,9 +1059,8 @@ class OpenAICompatibleModel(LLMBaseModel):
                                 else:
                                     text_content = str(content)
 
+                                text_content = strip_litellm_placeholder(text_content)
                                 if text_content and len(text_content.strip()) > 0:
-                                    # Create thinking/final output action and yield it
-                                    # External AgenticNode will parse raw_output for SQL extraction
                                     text_content = text_content.strip()
                                     text_content_split = (
                                         text_content if len(text_content) <= 200 else f"{text_content[:200]}..."

--- a/datus/utils/text_utils.py
+++ b/datus/utils/text_utils.py
@@ -5,6 +5,17 @@
 import re
 import unicodedata
 
+LITELLM_EMPTY_PLACEHOLDER = "[System: Empty message content sanitised to satisfy protocol]"
+
+
+def strip_litellm_placeholder(text: str) -> str:
+    """Return empty string if text is only the LiteLLM sanitizer placeholder."""
+    if not text or not isinstance(text, str):
+        return text
+    if text.strip() == LITELLM_EMPTY_PLACEHOLDER:
+        return ""
+    return text
+
 
 def clean_text(text: str) -> str:
     if not text or not isinstance(text, str):

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -16,6 +16,7 @@ from datus.api.services.action_sse_converter import (
     action_to_sse_event,
 )
 from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
+from datus.utils.text_utils import LITELLM_EMPTY_PLACEHOLDER
 
 
 def _make_action(**overrides) -> ActionHistory:
@@ -296,6 +297,35 @@ class TestBuildThinkingContent:
         )
         contents = _build_thinking_content(action)
         assert contents[0].payload["content"] == "final fallback"
+
+    def test_placeholder_in_output_returns_none(self):
+        """LiteLLM sanitizer placeholder in output is filtered out."""
+        action = _make_action(
+            action_type="gen_sql",
+            output={"raw_output": LITELLM_EMPTY_PLACEHOLDER},
+            messages="",
+        )
+        contents = _build_thinking_content(action)
+        assert contents is None
+
+    def test_placeholder_in_messages_returns_none(self):
+        """LiteLLM sanitizer placeholder in messages fallback is filtered out."""
+        action = _make_action(
+            action_type="gen_sql",
+            output=None,
+            messages=LITELLM_EMPTY_PLACEHOLDER,
+        )
+        contents = _build_thinking_content(action)
+        assert contents is None
+
+    def test_placeholder_in_llm_generation_returns_none(self):
+        """LiteLLM sanitizer placeholder in llm_generation messages is filtered out."""
+        action = _make_action(
+            action_type="llm_generation",
+            messages=LITELLM_EMPTY_PLACEHOLDER,
+        )
+        contents = _build_thinking_content(action)
+        assert contents is None
 
 
 class TestBuildInteractionContent:

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -13,8 +13,9 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.text import Text
 
-from datus.cli.action_display.renderers import ActionContentGenerator, ActionRenderer
+from datus.cli.action_display.renderers import ActionContentGenerator, ActionRenderer, _get_assistant_content
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.utils.text_utils import LITELLM_EMPTY_PLACEHOLDER
 
 
 def _make_action(
@@ -822,3 +823,31 @@ class TestRenderBatchInteractionSuccess:
         result = _renderer().render_interaction_success(action, verbose=False)
         text = _plain(result)
         assert "Selected: y" in text
+
+
+class TestGetAssistantContentPlaceholderFiltering:
+    """Verify _get_assistant_content strips LiteLLM sanitizer placeholder."""
+
+    def test_placeholder_in_raw_output_returns_empty(self):
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            output_data={"raw_output": LITELLM_EMPTY_PLACEHOLDER},
+        )
+        assert _get_assistant_content(action) == ""
+
+    def test_placeholder_in_messages_returns_empty(self):
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            messages=LITELLM_EMPTY_PLACEHOLDER,
+        )
+        assert _get_assistant_content(action) == ""
+
+    def test_normal_raw_output_unchanged(self):
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            output_data={"raw_output": "SELECT * FROM users"},
+        )
+        assert _get_assistant_content(action) == "SELECT * FROM users"

--- a/tests/unit_tests/utils/test_text_utils.py
+++ b/tests/unit_tests/utils/test_text_utils.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from datus.utils.text_utils import clean_text
+from datus.utils.text_utils import LITELLM_EMPTY_PLACEHOLDER, clean_text, strip_litellm_placeholder
 
 
 class TestCleanText:
@@ -82,3 +82,27 @@ class TestCleanText:
     )
     def test_strip_various_whitespace(self, input_text, expected):
         assert clean_text(input_text) == expected
+
+
+class TestStripLitellmPlaceholder:
+    def test_exact_placeholder_returns_empty(self):
+        assert strip_litellm_placeholder(LITELLM_EMPTY_PLACEHOLDER) == ""
+
+    def test_placeholder_with_surrounding_whitespace_returns_empty(self):
+        assert strip_litellm_placeholder(f"  {LITELLM_EMPTY_PLACEHOLDER}  ") == ""
+
+    def test_normal_text_unchanged(self):
+        assert strip_litellm_placeholder("Hello, world!") == "Hello, world!"
+
+    def test_text_containing_placeholder_as_substring_unchanged(self):
+        text = f"Error: {LITELLM_EMPTY_PLACEHOLDER} was returned"
+        assert strip_litellm_placeholder(text) == text
+
+    def test_empty_string_returns_empty(self):
+        assert strip_litellm_placeholder("") == ""
+
+    def test_none_returns_none(self):
+        assert strip_litellm_placeholder(None) is None
+
+    def test_non_string_returns_unchanged(self):
+        assert strip_litellm_placeholder(42) == 42


### PR DESCRIPTION

LiteLLM injects "[System: Empty message content sanitised to satisfy protocol]" when model returns empty content. This placeholder was leaking into CLI and Web UI thinking cards. Strip it at model output, SSE converter, and CLI renderer layers.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty content in assistant messages to prevent placeholder text from appearing in output.
  * Enhanced content normalization across streaming and non-streaming responses for consistency.

* **Tests**
  * Added comprehensive test coverage for content sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->