### PR TITLE
[Feature] Add /language CLI command to set model response language

### DIFF
--- a/datus/cli/language_app.py
+++ b/datus/cli/language_app.py
@@ -1,0 +1,224 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Self-contained ``/language`` picker rendered as a single prompt_toolkit
+:class:`Application`.
+
+Two-step flow:
+1. Pick a language (or *auto* to clear the override).
+2. Pick a persistence scope (*project* or *global*).
+
+Runs inside one Application so the outer TUI only needs to release
+``stdin`` once via :meth:`DatusApp.suspend_input`.  Visual style mirrors
+:class:`datus.cli.model_app.ModelApp`: ``reverse`` highlight, ``→`` cursor,
+separator lines, and a footer hint row.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.layout.containers import HSplit, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from rich.console import Console
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+LANGUAGE_CHOICES: Dict[str, str] = {
+    "auto": "Model decides (clear override)",
+    "en": "English",
+    "zh": "Chinese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "it": "Italian",
+}
+
+SCOPE_CHOICES: Dict[str, str] = {
+    "project": ".datus/config.yml (this project only)",
+    "global": "agent.yml (all projects)",
+}
+
+
+class _Phase(Enum):
+    LANGUAGE = "language"
+    SCOPE = "scope"
+
+
+@dataclass
+class LanguageSelection:
+    """Outcome of a :class:`LanguageApp` run.
+
+    ``code`` is the selected language code (e.g. ``"zh"``).
+    ``scope`` is ``"project"`` or ``"global"``.
+    If ``code`` is ``"auto"``, the caller should clear the override.
+    """
+
+    code: str
+    scope: str = "project"
+
+
+class LanguageApp:
+    """Two-step language picker: language code -> persistence scope.
+
+    The caller wraps ``app.run()`` in ``tui_app.suspend_input()`` when the
+    REPL is in TUI mode. Returns ``None`` on cancel (Escape / Ctrl-C).
+    """
+
+    def __init__(
+        self,
+        console: Console,
+        current_language: str = "",
+        current_source: str = "not set",
+    ):
+        self._console = console
+        self._current = current_language
+        self._current_source = current_source
+
+        self._phase = _Phase.LANGUAGE
+        self._lang_keys: List[str] = list(LANGUAGE_CHOICES.keys())
+        self._scope_keys: List[str] = list(SCOPE_CHOICES.keys())
+        self._lang_idx: int = self._default_lang_index()
+        self._scope_idx: int = 0
+        self._selected_code: str = ""
+
+        self._app = self._build_app()
+
+    def run(self) -> Optional[LanguageSelection]:
+        try:
+            return self._app.run()
+        except KeyboardInterrupt:
+            return None
+        except Exception as exc:
+            logger.error("LanguageApp crashed: %s", exc)
+            self._console.print(f"[bold red]/language error:[/] {exc}")
+            return None
+
+    def _default_lang_index(self) -> int:
+        if self._current in self._lang_keys:
+            return self._lang_keys.index(self._current)
+        return 0
+
+    def _build_app(self) -> Application:
+        kb = KeyBindings()
+
+        @kb.add("up")
+        def _up(event):
+            if self._phase == _Phase.LANGUAGE:
+                self._lang_idx = max(0, self._lang_idx - 1)
+            else:
+                self._scope_idx = max(0, self._scope_idx - 1)
+
+        @kb.add("down")
+        def _down(event):
+            if self._phase == _Phase.LANGUAGE:
+                self._lang_idx = min(len(self._lang_keys) - 1, self._lang_idx + 1)
+            else:
+                self._scope_idx = min(len(self._scope_keys) - 1, self._scope_idx + 1)
+
+        @kb.add("enter")
+        def _enter(event):
+            if self._phase == _Phase.LANGUAGE:
+                self._selected_code = self._lang_keys[self._lang_idx]
+                if self._selected_code == "auto":
+                    event.app.exit(LanguageSelection(code="auto"))
+                    return
+                self._phase = _Phase.SCOPE
+            else:
+                scope = self._scope_keys[self._scope_idx]
+                event.app.exit(LanguageSelection(code=self._selected_code, scope=scope))
+
+        @kb.add("escape")
+        def _escape(event):
+            event.app.exit(None)
+
+        @kb.add("c-c")
+        def _ctrl_c(event):
+            event.app.exit(None)
+
+        header_window = Window(
+            content=FormattedTextControl(self._render_header, focusable=False),
+            height=Dimension(min=1, max=2),
+        )
+
+        list_window = Window(
+            content=FormattedTextControl(self._render_list, focusable=True),
+            always_hide_cursor=True,
+            height=Dimension(min=3),
+        )
+
+        hint_window = Window(
+            content=FormattedTextControl(self._render_footer_hint, focusable=False),
+            height=1,
+        )
+
+        root = HSplit(
+            [
+                header_window,
+                Window(height=1, char="\u2500"),
+                list_window,
+                Window(height=1, char="\u2500"),
+                hint_window,
+            ]
+        )
+
+        return Application(
+            layout=Layout(root, focused_element=list_window),
+            key_bindings=kb,
+            full_screen=False,
+            mouse_support=False,
+            erase_when_done=True,
+        )
+
+    def _render_header(self) -> List[Tuple[str, str]]:
+        lines: List[Tuple[str, str]] = []
+        if self._phase == _Phase.LANGUAGE:
+            lines.append(("bold", "  Select response language"))
+            if self._current:
+                display = LANGUAGE_CHOICES.get(self._current, self._current)
+                lines.append(("", f"  [current: {self._current} ({display}), source: {self._current_source}]"))
+            else:
+                lines.append(("", "  [current: not set (model decides)]"))
+        else:
+            lines.append(("bold", f"  Save '{self._selected_code}' to"))
+        return lines
+
+    def _render_list(self) -> List[Tuple[str, str]]:
+        lines: List[Tuple[str, str]] = []
+        if self._phase == _Phase.LANGUAGE:
+            for i, key in enumerate(self._lang_keys):
+                label = f"{key:<6} {LANGUAGE_CHOICES[key]}"
+                if key == self._current:
+                    label += "  \u2190 current"
+                if i == self._lang_idx:
+                    lines.append(("reverse", f"  \u2192 {label}\n"))
+                else:
+                    lines.append(("", f"    {label}\n"))
+        else:
+            for i, key in enumerate(self._scope_keys):
+                label = f"{key:<10} {SCOPE_CHOICES[key]}"
+                if i == self._scope_idx:
+                    lines.append(("reverse", f"  \u2192 {label}\n"))
+                else:
+                    lines.append(("", f"    {label}\n"))
+        return lines
+
+    def _render_footer_hint(self) -> List[Tuple[str, str]]:
+        return [("", "  \u2191\u2193 navigate   Enter select   Esc cancel")]
+
+    def _get_formatted_text(self):
+        return self._render_header() + [("", "\n")] + self._render_list()

--- a/datus/cli/language_app.py
+++ b/datus/cli/language_app.py
@@ -84,17 +84,23 @@ class LanguageApp:
         console: Console,
         current_language: str = "",
         current_source: str = "not set",
+        scope_only: Optional[str] = None,
     ):
         self._console = console
         self._current = current_language
         self._current_source = current_source
 
-        self._phase = _Phase.LANGUAGE
         self._lang_keys: List[str] = list(LANGUAGE_CHOICES.keys())
         self._scope_keys: List[str] = list(SCOPE_CHOICES.keys())
         self._lang_idx: int = self._default_lang_index()
         self._scope_idx: int = 0
-        self._selected_code: str = ""
+
+        if scope_only is not None:
+            self._phase = _Phase.SCOPE
+            self._selected_code = scope_only
+        else:
+            self._phase = _Phase.LANGUAGE
+            self._selected_code = ""
 
         self._app = self._build_app()
 
@@ -134,9 +140,6 @@ class LanguageApp:
         def _enter(event):
             if self._phase == _Phase.LANGUAGE:
                 self._selected_code = self._lang_keys[self._lang_idx]
-                if self._selected_code == "auto":
-                    event.app.exit(LanguageSelection(code="auto"))
-                    return
                 self._phase = _Phase.SCOPE
             else:
                 scope = self._scope_keys[self._scope_idx]
@@ -219,6 +222,3 @@ class LanguageApp:
 
     def _render_footer_hint(self) -> List[Tuple[str, str]]:
         return [("", "  \u2191\u2193 navigate   Enter select   Esc cancel")]
-
-    def _get_formatted_text(self):
-        return self._render_header() + [("", "\n")] + self._render_list()

--- a/datus/cli/language_commands.py
+++ b/datus/cli/language_commands.py
@@ -56,7 +56,7 @@ class LanguageCommands:
         project_lang = project_override.language if project_override else None
 
         if flag_clear:
-            self._clear_project(project_override, global_lang)
+            self._clear_language(project_override, global_lang, scope="project")
             return
 
         if not code and not flag_global and not flag_project:
@@ -64,7 +64,14 @@ class LanguageCommands:
             return
 
         if code == "auto":
-            self._clear_project(project_override, global_lang)
+            if flag_global:
+                self._clear_language(project_override, global_lang, scope="global")
+            elif flag_project:
+                self._clear_language(project_override, global_lang, scope="project")
+            else:
+                selection = self._run_scope_picker("auto")
+                if selection is not None:
+                    self._clear_language(project_override, global_lang, scope=selection.scope)
             return
 
         if code not in LANGUAGE_CHOICES:
@@ -100,7 +107,7 @@ class LanguageCommands:
         if selection is None:
             return
         if selection.code == "auto":
-            self._clear_project(project_override, global_lang)
+            self._clear_language(project_override, global_lang, scope=selection.scope)
             return
         if selection.code == current:
             self.console.print(f"[dim]Language unchanged: {current}[/]")
@@ -116,9 +123,8 @@ class LanguageCommands:
             console=self.console,
             current_language=code,
             current_source="",
+            scope_only=code,
         )
-        app._phase = app._phase.__class__("scope")
-        app._selected_code = code
         return self._run_app(app)
 
     def _run_app(self, app: LanguageApp) -> Optional[LanguageSelection]:
@@ -140,16 +146,21 @@ class LanguageCommands:
         path = save_project_override(override)
         self.console.print(f"[bold green]Language set to: {code} (saved to {path})[/]")
 
-    def _clear_project(self, project_override: Optional[ProjectOverride], global_lang: str) -> None:
-        if project_override and project_override.language is not None:
-            project_override.language = None
-            save_project_override(project_override)
-        self.agent_config.language = global_lang or None
-        if global_lang:
-            self.console.print(
-                f"[bold green]Project language override cleared. Falling back to global: {global_lang}[/]"
-            )
+    def _clear_language(self, project_override: Optional[ProjectOverride], global_lang: str, scope: str) -> None:
+        if scope == "global":
+            self.cli.configuration_manager.update_item("language", None)
+            self.agent_config.language = None
+            self.console.print("[bold green]Global language cleared. Language is now unset (model decides).[/]")
         else:
-            self.console.print(
-                "[bold green]Project language override cleared. Language is now unset (model decides).[/]"
-            )
+            if project_override and project_override.language is not None:
+                project_override.language = None
+                save_project_override(project_override)
+            self.agent_config.language = global_lang or None
+            if global_lang:
+                self.console.print(
+                    f"[bold green]Project language override cleared. Falling back to global: {global_lang}[/]"
+                )
+            else:
+                self.console.print(
+                    "[bold green]Project language override cleared. Language is now unset (model decides).[/]"
+                )

--- a/datus/cli/language_commands.py
+++ b/datus/cli/language_commands.py
@@ -1,0 +1,155 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""``/language`` slash command — set or show the response language.
+
+Entry point
+-----------
+
+  - ``/language``                      — open the interactive picker.
+  - ``/language zh``                   — set language, confirm scope interactively.
+  - ``/language zh --project``         — persist to .datus/config.yml.
+  - ``/language zh --global``          — persist to agent.yml.
+  - ``/language --clear``              — remove project-level override.
+
+The interactive path delegates to :class:`datus.cli.language_app.LanguageApp`,
+a single prompt_toolkit Application that hosts language selection and scope
+confirmation. In TUI mode we wrap the run in
+:meth:`datus.cli.tui.app.DatusApp.suspend_input` so the outer persistent
+Application releases ``stdin`` for the duration.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from datus.cli.language_app import LANGUAGE_CHOICES, LanguageApp, LanguageSelection
+from datus.configuration.project_config import ProjectOverride, load_project_override, save_project_override
+from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from datus.cli.repl import DatusCLI
+
+logger = get_logger(__name__)
+
+
+class LanguageCommands:
+    """Handlers for the ``/language`` slash command."""
+
+    def __init__(self, cli: "DatusCLI"):
+        self.cli = cli
+        self.console = cli.console
+        self.agent_config = cli.agent_config
+
+    def cmd_language(self, args: str) -> None:
+        """Dispatch ``/language`` based on its argument shape."""
+        tokens = args.strip().split()
+        flag_global = "--global" in tokens
+        flag_project = "--project" in tokens
+        flag_clear = "--clear" in tokens
+        code_tokens = [t for t in tokens if not t.startswith("--")]
+        code = code_tokens[0] if code_tokens else ""
+
+        global_lang = self.cli.configuration_manager.get("language") or ""
+        project_override = load_project_override()
+        project_lang = project_override.language if project_override else None
+
+        if flag_clear:
+            self._clear_project(project_override, global_lang)
+            return
+
+        if not code and not flag_global and not flag_project:
+            self._run_interactive(global_lang, project_lang, project_override)
+            return
+
+        if code == "auto":
+            self._clear_project(project_override, global_lang)
+            return
+
+        if code not in LANGUAGE_CHOICES:
+            self.console.print(f"[yellow]Warning:[/] '{code}' is not a well-known language code. Proceeding anyway.")
+
+        if flag_global:
+            self._save_global(code)
+        elif flag_project:
+            self._save_project(code, project_override)
+        else:
+            selection = self._run_scope_picker(code)
+            if selection is None:
+                return
+            if selection.scope == "global":
+                self._save_global(selection.code)
+            else:
+                self._save_project(selection.code, project_override)
+
+    def _run_interactive(
+        self,
+        global_lang: str,
+        project_lang: Optional[str],
+        project_override: Optional[ProjectOverride],
+    ) -> None:
+        current = getattr(self.agent_config, "language", None) or ""
+        source = "project" if project_lang else ("global" if global_lang else "not set")
+        app = LanguageApp(
+            console=self.console,
+            current_language=current,
+            current_source=source,
+        )
+        selection = self._run_app(app)
+        if selection is None:
+            return
+        if selection.code == "auto":
+            self._clear_project(project_override, global_lang)
+            return
+        if selection.code == current:
+            self.console.print(f"[dim]Language unchanged: {current}[/]")
+            return
+        if selection.scope == "global":
+            self._save_global(selection.code)
+        else:
+            self._save_project(selection.code, project_override)
+
+    def _run_scope_picker(self, code: str) -> Optional[LanguageSelection]:
+        """Run a scope-only picker for direct ``/language <code>`` invocations."""
+        app = LanguageApp(
+            console=self.console,
+            current_language=code,
+            current_source="",
+        )
+        app._phase = app._phase.__class__("scope")
+        app._selected_code = code
+        return self._run_app(app)
+
+    def _run_app(self, app: LanguageApp) -> Optional[LanguageSelection]:
+        tui_app = getattr(self.cli, "tui_app", None)
+        if tui_app is not None:
+            with tui_app.suspend_input():
+                return app.run()
+        return app.run()
+
+    def _save_global(self, code: str) -> None:
+        self.agent_config.language = code
+        self.cli.configuration_manager.update_item("language", code)
+        self.console.print(f"[bold green]Language set to: {code} (saved to agent.yml)[/]")
+
+    def _save_project(self, code: str, project_override: Optional[ProjectOverride]) -> None:
+        self.agent_config.language = code
+        override = project_override or ProjectOverride()
+        override.language = code
+        path = save_project_override(override)
+        self.console.print(f"[bold green]Language set to: {code} (saved to {path})[/]")
+
+    def _clear_project(self, project_override: Optional[ProjectOverride], global_lang: str) -> None:
+        if project_override and project_override.language is not None:
+            project_override.language = None
+            save_project_override(project_override)
+        self.agent_config.language = global_lang or None
+        if global_lang:
+            self.console.print(
+                f"[bold green]Project language override cleared. Falling back to global: {global_lang}[/]"
+            )
+        else:
+            self.console.print(
+                "[bold green]Project language override cleared. Language is now unset (model decides).[/]"
+            )

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -48,6 +48,7 @@ from datus.cli.autocomplete import (
 from datus.cli.bi_dashboard import BiDashboardCommands
 from datus.cli.chat_commands import ChatCommands
 from datus.cli.context_commands import ContextCommands
+from datus.cli.language_commands import LanguageCommands
 from datus.cli.metadata_commands import MetadataCommands
 from datus.cli.model_commands import ModelCommands
 from datus.cli.service_commands import ServiceCommands
@@ -112,6 +113,7 @@ _LEGACY_PREFIX_HINTS: dict[str, str] = {
     ".mcp": "/mcp",
     ".skill": "/skill",
     ".bootstrap-bi": "/bootstrap-bi",
+    ".language": "/language",
     "@catalog": "/catalog",
     "@subject": "/subject",
 }
@@ -228,6 +230,7 @@ class DatusCLI:
         self.sub_agent_commands = SubAgentCommands(self)
         self.bi_dashboard_commands = BiDashboardCommands(self)
         self.model_commands = ModelCommands(self)
+        self.language_commands = LanguageCommands(self)
         self.service_commands = ServiceCommands(self)
         self._status_bar_provider = StatusBarProvider(self)
 
@@ -295,6 +298,7 @@ class DatusCLI:
             "agent": self._cmd_agent,
             "subagent": self.sub_agent_commands.cmd,
             "namespace": self._cmd_switch_namespace,
+            "language": self.language_commands.cmd_language,
             # system
             "mcp": self._cmd_mcp,
             "skill": self._cmd_skill,

--- a/datus/cli/slash_registry.py
+++ b/datus/cli/slash_registry.py
@@ -75,6 +75,7 @@ SLASH_COMMANDS: tuple[SlashSpec, ...] = (
     SlashSpec("agent", "Select or inspect the default agent", "agent"),
     SlashSpec("subagent", "Manage sub-agents (list/add/remove/update)", "agent"),
     SlashSpec("namespace", "Switch the current namespace", "agent"),
+    SlashSpec("language", "Set or show the response language for model outputs", "agent"),
     # system
     SlashSpec("mcp", "Manage MCP servers (list/add/remove/check/call/filter)", "system"),
     SlashSpec("skill", "Manage skills and marketplace (list/install/publish/...)", "system"),

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -229,6 +229,8 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
                 db_cfg["default"] = db_name == override.default_datasource
     if override.project_name is not None:
         agent_raw["project_name"] = override.project_name
+    if override.language is not None:
+        agent_raw["language"] = override.language
 
 
 def load_agent_config(reload: bool = False, **kwargs) -> AgentConfig:

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -35,7 +35,7 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 PROJECT_CONFIG_REL = ".datus/config.yml"
-ALLOWED_KEYS = frozenset({"target", "default_datasource", "project_name"})
+ALLOWED_KEYS = frozenset({"target", "default_datasource", "project_name", "language"})
 
 
 @dataclass
@@ -65,9 +65,15 @@ class ProjectOverride:
     target: Optional[Union[str, ProjectTarget]] = None
     default_datasource: Optional[str] = None
     project_name: Optional[str] = None
+    language: Optional[str] = None
 
     def is_empty(self) -> bool:
-        return self.target is None and self.default_datasource is None and self.project_name is None
+        return (
+            self.target is None
+            and self.default_datasource is None
+            and self.project_name is None
+            and self.language is None
+        )
 
 
 def project_config_path(cwd: Optional[str] = None) -> Path:
@@ -137,6 +143,7 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         target=_parse_target(raw.get("target")),
         default_datasource=raw.get("default_datasource"),
         project_name=raw.get("project_name"),
+        language=raw.get("language"),
     )
 
 
@@ -167,6 +174,7 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
             "target": _target_to_yaml(override.target),
             "default_datasource": override.default_datasource,
             "project_name": override.project_name,
+            "language": override.language,
         }.items()
         if v is not None
     }

--- a/tests/unit_tests/cli/test_language_app.py
+++ b/tests/unit_tests/cli/test_language_app.py
@@ -84,9 +84,7 @@ class TestRenderHeader:
         assert "not set" in text
 
     def test_scope_phase_shows_selected_code(self):
-        app = LanguageApp(console=None)
-        app._phase = _Phase.SCOPE
-        app._selected_code = "zh"
+        app = LanguageApp(console=None, scope_only="zh")
         lines = app._render_header()
         text = "".join(content for _style, content in lines)
         assert "zh" in text
@@ -115,9 +113,7 @@ class TestRenderList:
         assert "\u2190 current" in text
 
     def test_scope_phase_shows_project_and_global(self):
-        app = LanguageApp(console=None, current_language="zh")
-        app._phase = _Phase.SCOPE
-        app._selected_code = "zh"
+        app = LanguageApp(console=None, current_language="zh", scope_only="zh")
         lines = app._render_list()
         text = "".join(content for _style, content in lines)
         assert "project" in text
@@ -134,11 +130,13 @@ class TestRenderFooterHint:
         assert "cancel" in text
 
 
-class TestGetFormattedText:
-    def test_combines_header_and_list(self):
-        app = LanguageApp(console=None, current_language="en", current_source="global")
-        lines = app._get_formatted_text()
-        text = "".join(content for _style, content in lines)
-        for code in LANGUAGE_CHOICES:
-            assert code in text
-        assert "Select" in text
+class TestScopeOnlyInit:
+    def test_scope_only_starts_in_scope_phase(self):
+        app = LanguageApp(console=None, scope_only="zh")
+        assert app._phase == _Phase.SCOPE
+        assert app._selected_code == "zh"
+
+    def test_scope_only_none_starts_in_language_phase(self):
+        app = LanguageApp(console=None)
+        assert app._phase == _Phase.LANGUAGE
+        assert app._selected_code == ""

--- a/tests/unit_tests/cli/test_language_app.py
+++ b/tests/unit_tests/cli/test_language_app.py
@@ -1,0 +1,144 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.cli.language_app.LanguageApp``.
+
+CI-level: no TTY, no external deps. The prompt_toolkit Application is not
+run — we test the data model, index logic, and formatted-text rendering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from datus.cli.language_app import (
+    LANGUAGE_CHOICES,
+    SCOPE_CHOICES,
+    LanguageApp,
+    LanguageSelection,
+    _Phase,
+)
+
+pytestmark = pytest.mark.ci
+
+
+class TestLanguageSelection:
+    def test_defaults(self):
+        sel = LanguageSelection(code="zh")
+        assert sel.code == "zh"
+        assert sel.scope == "project"
+
+    def test_explicit_scope(self):
+        sel = LanguageSelection(code="en", scope="global")
+        assert sel.scope == "global"
+
+
+class TestLanguageChoices:
+    def test_auto_is_first(self):
+        keys = list(LANGUAGE_CHOICES.keys())
+        assert keys[0] == "auto"
+
+    def test_common_codes_present(self):
+        for code in ("en", "zh", "ja", "ko", "es", "fr", "de", "pt", "ru", "it"):
+            assert code in LANGUAGE_CHOICES
+
+
+class TestScopeChoices:
+    def test_project_and_global(self):
+        assert "project" in SCOPE_CHOICES
+        assert "global" in SCOPE_CHOICES
+
+
+class TestLanguageAppInit:
+    def test_default_index_matches_current(self):
+        app = LanguageApp(console=None, current_language="zh")
+        assert app._lang_keys[app._lang_idx] == "zh"
+
+    def test_default_index_falls_back_to_zero(self):
+        app = LanguageApp(console=None, current_language="unknown-code")
+        assert app._lang_idx == 0
+
+    def test_initial_phase_is_language(self):
+        app = LanguageApp(console=None)
+        assert app._phase == _Phase.LANGUAGE
+
+    def test_scope_index_starts_at_zero(self):
+        app = LanguageApp(console=None)
+        assert app._scope_idx == 0
+
+
+class TestRenderHeader:
+    def test_language_phase_shows_current(self):
+        app = LanguageApp(console=None, current_language="en", current_source="global")
+        lines = app._render_header()
+        text = "".join(content for _style, content in lines)
+        assert "en" in text
+        assert "English" in text
+        assert "global" in text
+
+    def test_language_phase_shows_not_set(self):
+        app = LanguageApp(console=None, current_language="", current_source="not set")
+        lines = app._render_header()
+        text = "".join(content for _style, content in lines)
+        assert "not set" in text
+
+    def test_scope_phase_shows_selected_code(self):
+        app = LanguageApp(console=None)
+        app._phase = _Phase.SCOPE
+        app._selected_code = "zh"
+        lines = app._render_header()
+        text = "".join(content for _style, content in lines)
+        assert "zh" in text
+        assert "Save" in text
+
+
+class TestRenderList:
+    def test_language_phase_lists_all_choices(self):
+        app = LanguageApp(console=None, current_language="en", current_source="global")
+        lines = app._render_list()
+        text = "".join(content for _style, content in lines)
+        for code in LANGUAGE_CHOICES:
+            assert code in text
+
+    def test_selected_item_uses_reverse_style(self):
+        app = LanguageApp(console=None)
+        app._lang_idx = 1
+        lines = app._render_list()
+        styles = [style for style, _content in lines]
+        assert "reverse" in styles[1]
+
+    def test_current_language_shows_arrow_marker(self):
+        app = LanguageApp(console=None, current_language="zh")
+        lines = app._render_list()
+        text = "".join(content for _style, content in lines)
+        assert "\u2190 current" in text
+
+    def test_scope_phase_shows_project_and_global(self):
+        app = LanguageApp(console=None, current_language="zh")
+        app._phase = _Phase.SCOPE
+        app._selected_code = "zh"
+        lines = app._render_list()
+        text = "".join(content for _style, content in lines)
+        assert "project" in text
+        assert "global" in text
+
+
+class TestRenderFooterHint:
+    def test_contains_navigate_and_select(self):
+        app = LanguageApp(console=None)
+        lines = app._render_footer_hint()
+        text = "".join(content for _style, content in lines)
+        assert "navigate" in text
+        assert "select" in text
+        assert "cancel" in text
+
+
+class TestGetFormattedText:
+    def test_combines_header_and_list(self):
+        app = LanguageApp(console=None, current_language="en", current_source="global")
+        lines = app._get_formatted_text()
+        text = "".join(content for _style, content in lines)
+        for code in LANGUAGE_CHOICES:
+            assert code in text
+        assert "Select" in text

--- a/tests/unit_tests/cli/test_language_commands.py
+++ b/tests/unit_tests/cli/test_language_commands.py
@@ -120,13 +120,43 @@ class TestClearFlag:
 
 
 class TestAutoCode:
-    def test_auto_clears_project(self, commands):
+    def test_auto_with_project_flag_clears_project(self, commands):
         cmds, cli = commands
         existing = ProjectOverride(language="zh")
         with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_language("auto --project")
+        saved = mock_save.call_args[0][0]
+        assert saved.language is None
+
+    def test_auto_with_global_flag_clears_global(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_language("auto --global")
+        cli.configuration_manager.update_item.assert_called_once_with("language", None)
+        assert cli.agent_config.language is None
+
+    def test_auto_without_flag_opens_scope_picker(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(language="zh")
+        with (
+            patch(_PATCH_LOAD, return_value=existing),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_scope_picker", return_value=LanguageSelection(code="auto", scope="project")),
+        ):
             cmds.cmd_language("auto")
         saved = mock_save.call_args[0][0]
         assert saved.language is None
+
+    def test_auto_scope_picker_cancel(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_scope_picker", return_value=None),
+        ):
+            cmds.cmd_language("auto")
+        mock_save.assert_not_called()
+        cli.configuration_manager.update_item.assert_not_called()
 
 
 class TestUnknownCode:
@@ -173,9 +203,9 @@ class TestInteractiveFlow:
         mock_save.assert_not_called()
         cli.configuration_manager.update_item.assert_not_called()
 
-    def test_interactive_auto_clears(self, commands):
+    def test_interactive_auto_clears_project(self, commands):
         cmds, cli = commands
-        selection = LanguageSelection(code="auto")
+        selection = LanguageSelection(code="auto", scope="project")
         existing = ProjectOverride(language="zh")
         with (
             patch(_PATCH_LOAD, return_value=existing),
@@ -185,6 +215,17 @@ class TestInteractiveFlow:
             cmds.cmd_language("")
         saved = mock_save.call_args[0][0]
         assert saved.language is None
+
+    def test_interactive_auto_clears_global(self, commands):
+        cmds, cli = commands
+        selection = LanguageSelection(code="auto", scope="global")
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch.object(cmds, "_run_app", return_value=selection),
+        ):
+            cmds.cmd_language("")
+        cli.configuration_manager.update_item.assert_called_once_with("language", None)
+        assert cli.agent_config.language is None
 
     def test_interactive_unchanged_skips(self):
         cli = _stub_cli(language="zh")

--- a/tests/unit_tests/cli/test_language_commands.py
+++ b/tests/unit_tests/cli/test_language_commands.py
@@ -1,0 +1,234 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.cli.language_commands.LanguageCommands``.
+
+CI-level: patches ``LanguageApp.run`` to return scripted
+:class:`LanguageSelection` values so the dispatcher logic can be exercised
+without a TTY.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from datus.cli.language_app import LanguageSelection
+from datus.cli.language_commands import LanguageCommands
+from datus.configuration.project_config import ProjectOverride
+
+pytestmark = pytest.mark.ci
+
+_PATCH_LOAD = "datus.cli.language_commands.load_project_override"
+_PATCH_SAVE = "datus.cli.language_commands.save_project_override"
+
+
+def _stub_cli(language=None, global_language=None):
+    cli = MagicMock()
+    cli.console = Console(file=io.StringIO(), no_color=True)
+    cli.agent_config = MagicMock()
+    cli.agent_config.language = language
+    cli.configuration_manager = MagicMock()
+    cli.configuration_manager.get = MagicMock(return_value=global_language)
+    cli.tui_app = None
+    return cli
+
+
+@pytest.fixture
+def commands():
+    cli = _stub_cli()
+    return LanguageCommands(cli), cli
+
+
+class TestDirectCodeWithGlobalFlag:
+    def test_saves_to_global(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_language("zh --global")
+        cli.configuration_manager.update_item.assert_called_once_with("language", "zh")
+        assert cli.agent_config.language == "zh"
+
+    def test_output_mentions_agent_yml(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_language("en --global")
+        output = cli.console.file.getvalue()
+        assert "agent.yml" in output
+
+
+class TestDirectCodeWithProjectFlag:
+    def test_saves_to_project(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+        ):
+            cmds.cmd_language("zh --project")
+        assert cli.agent_config.language == "zh"
+        saved_override = mock_save.call_args[0][0]
+        assert saved_override.language == "zh"
+
+    def test_preserves_existing_override_fields(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(target="deepseek", default_datasource="db1")
+        with (
+            patch(_PATCH_LOAD, return_value=existing),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+        ):
+            cmds.cmd_language("fr --project")
+        saved = mock_save.call_args[0][0]
+        assert saved.target == "deepseek"
+        assert saved.default_datasource == "db1"
+        assert saved.language == "fr"
+
+
+class TestClearFlag:
+    def test_clears_project_override(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(target="deepseek", language="zh")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_language("--clear")
+        saved = mock_save.call_args[0][0]
+        assert saved.language is None
+        assert saved.target == "deepseek"
+
+    def test_falls_back_to_global(self):
+        cli = _stub_cli(language="zh", global_language="en")
+        cmds = LanguageCommands(cli)
+        existing = ProjectOverride(language="zh")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE):
+            cmds.cmd_language("--clear")
+        assert cli.agent_config.language == "en"
+
+    def test_falls_back_to_none_when_no_global(self):
+        cli = _stub_cli(language="zh", global_language=None)
+        cmds = LanguageCommands(cli)
+        existing = ProjectOverride(language="zh")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE):
+            cmds.cmd_language("--clear")
+        assert cli.agent_config.language is None
+
+    def test_no_save_when_no_project_override(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_language("--clear")
+        mock_save.assert_not_called()
+
+
+class TestAutoCode:
+    def test_auto_clears_project(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(language="zh")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_language("auto")
+        saved = mock_save.call_args[0][0]
+        assert saved.language is None
+
+
+class TestUnknownCode:
+    def test_warns_but_proceeds(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None), patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml"):
+            cmds.cmd_language("ar --project")
+        output = cli.console.file.getvalue()
+        assert "Warning" in output
+        assert cli.agent_config.language == "ar"
+
+
+class TestInteractiveFlow:
+    def test_interactive_saves_to_project(self, commands):
+        cmds, cli = commands
+        selection = LanguageSelection(code="ja", scope="project")
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+            patch.object(cmds, "_run_app", return_value=selection),
+        ):
+            cmds.cmd_language("")
+        assert cli.agent_config.language == "ja"
+        mock_save.assert_called_once()
+
+    def test_interactive_saves_to_global(self, commands):
+        cmds, cli = commands
+        selection = LanguageSelection(code="ko", scope="global")
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch.object(cmds, "_run_app", return_value=selection),
+        ):
+            cmds.cmd_language("")
+        cli.configuration_manager.update_item.assert_called_once_with("language", "ko")
+
+    def test_interactive_cancel_does_nothing(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_app", return_value=None),
+        ):
+            cmds.cmd_language("")
+        mock_save.assert_not_called()
+        cli.configuration_manager.update_item.assert_not_called()
+
+    def test_interactive_auto_clears(self, commands):
+        cmds, cli = commands
+        selection = LanguageSelection(code="auto")
+        existing = ProjectOverride(language="zh")
+        with (
+            patch(_PATCH_LOAD, return_value=existing),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_app", return_value=selection),
+        ):
+            cmds.cmd_language("")
+        saved = mock_save.call_args[0][0]
+        assert saved.language is None
+
+    def test_interactive_unchanged_skips(self):
+        cli = _stub_cli(language="zh")
+        cmds = LanguageCommands(cli)
+        selection = LanguageSelection(code="zh", scope="project")
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_app", return_value=selection),
+        ):
+            cmds.cmd_language("")
+        mock_save.assert_not_called()
+        output = cli.console.file.getvalue()
+        assert "unchanged" in output
+
+
+class TestDirectCodeWithScopePicker:
+    def test_scope_picker_project(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+            patch.object(cmds, "_run_scope_picker", return_value=LanguageSelection(code="de", scope="project")),
+        ):
+            cmds.cmd_language("de")
+        assert cli.agent_config.language == "de"
+        mock_save.assert_called_once()
+
+    def test_scope_picker_global(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch.object(cmds, "_run_scope_picker", return_value=LanguageSelection(code="de", scope="global")),
+        ):
+            cmds.cmd_language("de")
+        cli.configuration_manager.update_item.assert_called_once_with("language", "de")
+
+    def test_scope_picker_cancel(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_scope_picker", return_value=None),
+        ):
+            cmds.cmd_language("de")
+        mock_save.assert_not_called()
+        cli.configuration_manager.update_item.assert_not_called()

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -327,6 +327,25 @@ class TestApplyProjectOverride:
         assert agent_raw["target"] == "deepseek"
         assert agent_raw["project_name"] == "p"
 
+    def test_language_merged(self):
+        agent_raw = self._base_raw()
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(language="zh"),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["language"] == "zh"
+
+    def test_language_none_leaves_agent_raw_unchanged(self):
+        agent_raw = self._base_raw()
+        agent_raw["language"] = "en"
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(language=None),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["language"] == "en"
+
     def test_missing_models_section_target_stored_with_warning(self):
         agent_raw = {"services": {"datasources": {"db1": {}}}}
         with patch(

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -69,6 +69,15 @@ class TestLoadProjectOverride:
         assert result.target == "deepseek"
         assert result.default_datasource is None
         assert result.project_name is None
+        assert result.language is None
+
+    def test_parse_language_field(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"language": "zh"}))
+        result = load_project_override(str(tmp_path))
+        assert result.language == "zh"
+        assert result.target is None
 
     def test_unknown_keys_warn_and_drop(self, tmp_path, caplog):
         path = tmp_path / PROJECT_CONFIG_REL
@@ -130,6 +139,19 @@ class TestSaveProjectOverride:
         loaded = load_project_override(str(tmp_path))
         assert loaded == original
 
+    def test_round_trip_with_language(self, tmp_path):
+        original = ProjectOverride(target="a", language="zh")
+        save_project_override(original, cwd=str(tmp_path))
+        loaded = load_project_override(str(tmp_path))
+        assert loaded.language == "zh"
+        assert loaded.target == "a"
+
+    def test_language_none_omitted_from_yaml(self, tmp_path):
+        override = ProjectOverride(target="x", language=None)
+        written = save_project_override(override, cwd=str(tmp_path))
+        loaded = yaml.safe_load(written.read_text())
+        assert "language" not in loaded
+
     def test_overwrites_existing(self, tmp_path):
         save_project_override(ProjectOverride(target="old"), cwd=str(tmp_path))
         save_project_override(ProjectOverride(target="new"), cwd=str(tmp_path))
@@ -138,8 +160,8 @@ class TestSaveProjectOverride:
 
 
 class TestAllowedKeys:
-    def test_whitelist_contains_exactly_three_keys(self):
-        assert ALLOWED_KEYS == frozenset({"target", "default_datasource", "project_name"})
+    def test_whitelist_contains_expected_keys(self):
+        assert ALLOWED_KEYS == frozenset({"target", "default_datasource", "project_name", "language"})
 
 
 class TestProjectOverrideDataclass:
@@ -152,6 +174,7 @@ class TestProjectOverrideDataclass:
             ("target", "x"),
             ("default_datasource", "y"),
             ("project_name", "z"),
+            ("language", "zh"),
         ],
     )
     def test_is_not_empty_when_any_set(self, field, value):


### PR DESCRIPTION
Add a /language slash command with an interactive prompt_toolkit Application (matching /model's visual style) that lets users set the LLM response language at project level (.datus/config.yml) or global level (agent.yml). Extends ProjectOverride with a language field so project config overrides the global setting.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /language command with interactive picker to choose language and persistence scope (project or global), plus an "auto" option and clear behavior.
* **Configuration**
  * Project-level overrides now support a language field and agent configuration honors project language overrides.
* **Tests**
  * Added unit tests covering the interactive picker, command behaviors, and project/global config handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->