### PR TITLE
[Feature] Add per-request model override to chat API and custom model

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -213,15 +213,11 @@ class AgenticNode(Node):
             return self._pinned_model
         if self._agent_config_ref is None:
             return None
-        try:
-            return LLMBaseModel.create_model(
-                agent_config=self._agent_config_ref,
-                model_name=self._node_model_name,
-                scope=self.scope,
-            )
-        except Exception as exc:
-            logger.debug(f"Lazy model resolution failed for node {self.get_node_name()}: {exc}")
-            return None
+        return LLMBaseModel.create_model(
+            agent_config=self._agent_config_ref,
+            model_name=self._node_model_name,
+            scope=self.scope,
+        )
 
     @model.setter
     def model(self, value: Optional[LLMBaseModel]) -> None:
@@ -599,7 +595,12 @@ class AgenticNode(Node):
             logger.debug("Skipped compaction for ephemeral session")
             return {"success": False, "summary": "", "summary_token": 0}
 
-        if not self.model:
+        try:
+            model = self.model
+        except Exception as exc:
+            logger.warning("Cannot compact: model resolution failed: %s", exc)
+            return {"success": False, "summary": "", "summary_token": 0}
+        if not model:
             logger.warning("Cannot compact: no model available")
             return {"success": False, "summary": "", "summary_token": 0}
 
@@ -683,7 +684,11 @@ class AgenticNode(Node):
         Returns:
             True if compacting was triggered and successful, False otherwise
         """
-        if not self.model or not self.context_length:
+        try:
+            model = self.model
+        except Exception:
+            return False
+        if not model or not self.context_length:
             return False
 
         try:

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -119,6 +119,7 @@ class ChatInput(BaseModel):
             "example": {
                 "message": "Show me total sales for last month",
                 "session_id": "session_123",
+                "model": "openai/gpt-4.1",
                 "catalog": "main",
                 "database": "sales_db",
                 "db_schema": "public",
@@ -133,6 +134,14 @@ class ChatInput(BaseModel):
     # Core message fields
     message: str = Field(..., description="Chat message")
     session_id: Optional[str] = Field(None, description="Session ID")
+    model: Optional[str] = Field(
+        default=None,
+        description=(
+            "Per-request model override in 'provider/model_id' format "
+            "(e.g. 'openai/gpt-4.1', 'custom/my-model'). "
+            "Takes highest priority over all other model config."
+        ),
+    )
     plan_mode: bool = Field(False, description="Whether in plan mode")
     source: Optional[str] = Field(None, description="chat source, web/vscode")
     interactive: Optional[bool] = Field(

--- a/datus/api/models/config_models.py
+++ b/datus/api/models/config_models.py
@@ -220,8 +220,11 @@ class ModelInfo(BaseModel):
 
     model_config = ConfigDict(exclude_none=True)
 
-    provider: str = Field(..., description="Provider key from providers.yml")
+    provider: str = Field(..., description="Provider key from providers.yml, or 'custom' for agent.models entries")
     id: str = Field(..., description="Model slug as consumed by the SDK")
+    model: Optional[str] = Field(
+        None, description="Actual model name (same as id for provider models, ModelConfig.model for custom)"
+    )
     name: Optional[str] = Field(None, description="Human-readable model name")
     context_length: Optional[int] = Field(None, description="Maximum context window in tokens")
     max_tokens: Optional[int] = Field(None, description="Maximum completion tokens")

--- a/datus/api/routes/models_routes.py
+++ b/datus/api/routes/models_routes.py
@@ -78,6 +78,7 @@ def _build_model_info(
     return ModelInfo(
         provider=provider,
         id=slug,
+        model=slug,
         name=name,
         context_length=context_length,
         max_tokens=max_tokens,
@@ -136,6 +137,30 @@ async def list_models(svc: ServiceDep) -> Result[ModelsData]:
             if not isinstance(slug, str) or not slug:
                 continue
             models.append(_build_model_info(provider_key, entry, catalog))
+
+    custom_models = getattr(agent_config, "models", None)
+    if isinstance(custom_models, dict) and custom_models:
+        for model_key, model_cfg in custom_models.items():
+            if not isinstance(model_key, str) or not model_key:
+                continue
+            actual_model = getattr(model_cfg, "model", None)
+            if not isinstance(actual_model, str) or not actual_model:
+                actual_model = model_key
+            spec = _model_spec(catalog, actual_model)
+            spec_ctx = spec.get("context_length")
+            spec_max = spec.get("max_tokens")
+            models.append(
+                ModelInfo(
+                    provider="custom",
+                    id=model_key,
+                    model=actual_model,
+                    name=model_key,
+                    context_length=spec_ctx if isinstance(spec_ctx, int) else None,
+                    max_tokens=spec_max if isinstance(spec_max, int) else None,
+                )
+            )
+        if any(m.provider == "custom" for m in models):
+            seen_providers.append("custom")
 
     return Result(
         success=True,

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -68,7 +68,7 @@ class ChatService:
                 user_id=user_id,
             )
         except (ValueError, DatusException) as e:
-            error_code = e.error_code.name if isinstance(e, DatusException) else ErrorCode.COMMON_VALIDATION_FAILED.name
+            error_code = e.code.name if isinstance(e, DatusException) else ErrorCode.COMMON_VALIDATION_FAILED.name
             yield SSEEvent(
                 id=1,
                 event="error",
@@ -100,7 +100,7 @@ class ChatService:
             )
         except DatusException as e:
             logger.warning("No active model: %s", e.message)
-            return Result[ChatModelData](success=False, errorCode=e.error_code.name, errorMessage=e.message)
+            return Result[ChatModelData](success=False, errorCode=e.code.name, errorMessage=e.message)
         except Exception as e:
             logger.error(f"Failed to get active model: {e}")
             return Result[ChatModelData](success=False, errorCode="MODEL_LOOKUP_ERROR", errorMessage=str(e))

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -216,6 +216,14 @@ class ChatTaskManager:
         # yaml-level ``agent.language`` default intact.
         if request.language:
             agent_config.language = request.language
+        if request.model:
+            provider, _, model_id = request.model.partition("/")
+            if not model_id:
+                raise ValueError(f"Invalid model format '{request.model}': expected 'provider/model_id'")
+            if provider == "custom":
+                agent_config.set_active_custom(model_id, persist=False)
+            else:
+                agent_config.set_active_provider_model(provider, model_id, persist=False)
         _fill_database_context(
             agent_config,
             catalog=request.catalog,

--- a/tests/unit_tests/api/routes/test_models_routes.py
+++ b/tests/unit_tests/api/routes/test_models_routes.py
@@ -12,12 +12,14 @@ import pytest
 
 from datus.api.routes import models_routes
 from datus.api.routes.models_routes import list_models
+from datus.configuration.agent_config import ModelConfig
 
 
 def _make_svc(
     *,
     catalog: Dict[str, Any],
     available: Optional[Iterable[str]] = None,
+    custom_models: Optional[Dict[str, Any]] = None,
 ) -> MagicMock:
     """Build a MagicMock svc with provider_catalog + provider_available wired up.
 
@@ -29,6 +31,7 @@ def _make_svc(
     svc = MagicMock()
     svc.agent_config.provider_catalog = catalog
     svc.agent_config.provider_available.side_effect = lambda p: p in allowed
+    svc.agent_config.models = custom_models if custom_models is not None else {}
     return svc
 
 
@@ -142,6 +145,7 @@ class TestCacheMetadata:
         model = result.data.models[0]
         assert model.provider == "openai"
         assert model.id == "gpt-4o"
+        assert model.model == "gpt-4o"
         assert model.name == "GPT-4o"
         assert model.context_length == 128000
         assert model.max_tokens == 16384  # from model_specs fallback
@@ -160,6 +164,7 @@ class TestCacheMetadata:
         assert len(result.data.models) == 1
         model = result.data.models[0]
         assert model.id == "claude-sonnet-4-5"
+        assert model.model == "claude-sonnet-4-5"
         # context_length from model_specs, pricing unavailable without cache.
         assert model.context_length == 1048576
         assert model.pricing is None
@@ -325,3 +330,79 @@ class TestDefensiveParsing:
         result = await list_models(svc)
 
         assert [m.id for m in result.data.models] == ["gpt-4o"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Custom models from agent.models
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _custom_model(model: str, type_: str = "openai") -> ModelConfig:
+    return ModelConfig(type=type_, api_key="sk-test", model=model)
+
+
+class TestCustomModels:
+    @pytest.mark.asyncio
+    async def test_custom_models_are_appended(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        custom = {
+            "my-deepseek": _custom_model("deepseek-chat", "deepseek"),
+            "my-gpt": _custom_model("gpt-4", "openai"),
+        }
+        svc = _make_svc(catalog=_basic_catalog(), available=set(), custom_models=custom)
+        result = await list_models(svc)
+
+        assert "custom" in result.data.providers
+        assert len(result.data.models) == 2
+        by_id = {m.id: m for m in result.data.models}
+        assert by_id["my-deepseek"].provider == "custom"
+        assert by_id["my-deepseek"].model == "deepseek-chat"
+        assert by_id["my-gpt"].provider == "custom"
+        assert by_id["my-gpt"].model == "gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_custom_models_pick_up_model_specs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        custom = {"my-ds": _custom_model("deepseek-chat", "deepseek")}
+        svc = _make_svc(catalog=_basic_catalog(), available=set(), custom_models=custom)
+        result = await list_models(svc)
+
+        m = result.data.models[0]
+        assert m.id == "my-ds"
+        assert m.model == "deepseek-chat"
+        assert m.context_length == 65535
+        assert m.max_tokens == 8192
+
+    @pytest.mark.asyncio
+    async def test_empty_custom_models_no_custom_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        svc = _make_svc(catalog=_basic_catalog(), available=set(), custom_models={})
+        result = await list_models(svc)
+
+        assert "custom" not in result.data.providers
+        assert result.data.models == []
+
+    @pytest.mark.asyncio
+    async def test_custom_and_provider_models_coexist(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        custom = {"my-ds": _custom_model("deepseek-chat", "deepseek")}
+        svc = _make_svc(catalog=_basic_catalog(), available={"openai"}, custom_models=custom)
+        result = await list_models(svc)
+
+        providers = set(result.data.providers)
+        assert providers == {"openai", "custom"}
+        provider_models = [m for m in result.data.models if m.provider == "openai"]
+        custom_models = [m for m in result.data.models if m.provider == "custom"]
+        assert len(provider_models) == 2
+        assert all(m.model == m.id for m in provider_models)
+        assert len(custom_models) == 1
+        assert custom_models[0].id == "my-ds"
+        assert custom_models[0].model == "deepseek-chat"

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -924,3 +924,121 @@ class TestStartChatLanguageOverride:
         task = await manager.start_chat(real_agent_config, request)
         await task.asyncio_task
         assert captured["agent_config"].language == "zh"
+
+
+class TestStartChatModelOverride:
+    """``ChatInput.model`` (format ``provider/model_id``) must override the
+    cloned config's active model with the highest priority.
+    """
+
+    @pytest.mark.asyncio
+    async def test_provider_model_override(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", model="openai/gpt-4.1")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+        assert captured["agent_config"]._target_provider == "openai"
+        assert captured["agent_config"]._target_model == "gpt-4.1"
+
+    @pytest.mark.asyncio
+    async def test_custom_model_override(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", model="custom/mock")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+        assert captured["agent_config"].target == "mock"
+        assert captured["agent_config"]._target_provider is None
+        assert captured["agent_config"]._target_model is None
+
+    @pytest.mark.asyncio
+    async def test_model_with_slash_in_id(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", model="openai/org/gpt-4.1")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+        assert captured["agent_config"]._target_provider == "openai"
+        assert captured["agent_config"]._target_model == "org/gpt-4.1"
+
+    @pytest.mark.asyncio
+    async def test_model_without_slash_raises(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            pass
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", model="gpt-4.1")
+        with pytest.raises(ValueError, match="expected 'provider/model_id'"):
+            await manager.start_chat(real_agent_config, request)
+
+    @pytest.mark.asyncio
+    async def test_model_none_preserves_config(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+        assert captured["agent_config"].target == real_agent_config.target
+
+    @pytest.mark.asyncio
+    async def test_model_override_does_not_mutate_source(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+
+        original_target = real_agent_config.target
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            pass
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", model="openai/gpt-4.1")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+        assert real_agent_config.target == original_target
+        assert real_agent_config._target_provider is None or real_agent_config._target_provider != "openai"
+
+    @pytest.mark.asyncio
+    async def test_custom_model_unknown_raises(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.utils.exceptions import DatusException
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            pass
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", model="custom/nonexistent")
+        with pytest.raises(DatusException):
+            await manager.start_chat(real_agent_config, request)


### PR DESCRIPTION

Add `model` field to ChatInput with format `provider/model_id` that takes highest priority over all other model config. Extend /api/v1/models endpoint to include custom models from agent.models. Also fix AgenticNode.model property to propagate errors instead of silently returning None, and fix DatusException attribute typo (error_code→code) in chat_service.py.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-request model override capability for chat inputs
  * Introduced support for custom agent-defined models alongside provider models

* **Improvements**
  * Enhanced model resolution error handling to properly propagate failures
  * Extended model metadata to track actual model names and specifications
  * Added validation for model selection format (provider/model_id)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->