### PR TITLE
[Refactor] Rename bi_platforms.api_url to api_base_url

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -162,7 +162,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: admin
         password: admin
         extra: # Special configurations for different platforms

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -392,7 +392,7 @@ class DashboardConfig:
     # dict lookup. May be an arbitrary user-chosen name (``superset_prod``,
     # ``grafana_staging``, ...).
     platform: str
-    api_url: str = ""
+    api_base_url: str = ""
     # use login or api_key
     username: str = ""
     password: str = ""
@@ -1479,7 +1479,7 @@ class AgentConfig:
             platform = str(service_name)
             # ``type`` is the adapter kind (``superset`` / ``grafana`` / ...).
             # When omitted, default to the key — preserves the single-instance
-            # convention ``services.bi_platforms.superset: { api_url: ... }``.
+            # convention ``services.bi_platforms.superset: { api_base_url: ... }``.
             # When provided and different from the key, the user is opting
             # into a multi-instance deployment (alias ``superset_prod`` or
             # similar); we keep both fields on ``DashboardConfig`` so the
@@ -1487,18 +1487,18 @@ class AgentConfig:
             # CLI / dashboard_config still key by the user-chosen alias.
             declared_type = auth_params.get("type")
             adapter_type = str(declared_type).strip() if declared_type else platform
-            api_url_raw = auth_params.get("api_url", "")
+            api_base_url_raw = auth_params.get("api_base_url", "")
             username_raw = auth_params.get("username", "")
             password_raw = auth_params.get("password", "")
             api_key_raw = auth_params.get("api_key", "")
-            api_url = resolve_env(str(api_url_raw)) if api_url_raw else ""
+            api_base_url = resolve_env(str(api_base_url_raw)) if api_base_url_raw else ""
             username = resolve_env(str(username_raw)) if username_raw else ""
             password = resolve_env(str(password_raw)) if password_raw else ""
             api_key = resolve_env(str(api_key_raw)) if api_key_raw else ""
             dataset_db = _resolve_nested_value(auth_params.get("dataset_db"))
             self.dashboard_config[platform] = DashboardConfig(
                 platform=platform,
-                api_url=api_url,
+                api_base_url=api_base_url,
                 username=username,
                 password=password,
                 api_key=api_key,

--- a/datus/tools/func_tool/bi_tools.py
+++ b/datus/tools/func_tool/bi_tools.py
@@ -164,7 +164,7 @@ class BIFuncTool:
                         pass
 
         return adapter_cls(
-            api_base_url=dash_cfg.api_url,
+            api_base_url=dash_cfg.api_base_url,
             auth_params=AuthParam(
                 username=dash_cfg.username,
                 password=dash_cfg.password,

--- a/docs/adapters/bi_adapters.md
+++ b/docs/adapters/bi_adapters.md
@@ -44,7 +44,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: ${SUPERSET_USER}
         password: ${SUPERSET_PASSWORD}
         dataset_db:
@@ -53,7 +53,7 @@ agent:
 
       grafana:
         type: grafana
-        api_url: http://localhost:3000
+        api_base_url: http://localhost:3000
         api_key: ${GRAFANA_API_KEY}
         dataset_db:
           uri: ${GRAFANA_DB_URI}

--- a/docs/adapters/bi_adapters.zh.md
+++ b/docs/adapters/bi_adapters.zh.md
@@ -44,7 +44,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: ${SUPERSET_USER}
         password: ${SUPERSET_PASSWORD}
         dataset_db:
@@ -53,7 +53,7 @@ agent:
 
       grafana:
         type: grafana
-        api_url: http://localhost:3000
+        api_base_url: http://localhost:3000
         api_key: ${GRAFANA_API_KEY}
         dataset_db:
           uri: ${GRAFANA_DB_URI}

--- a/docs/configuration/bi_platforms.md
+++ b/docs/configuration/bi_platforms.md
@@ -10,7 +10,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: ${SUPERSET_USER}
         password: ${SUPERSET_PASSWORD}
         dataset_db:
@@ -19,7 +19,7 @@ agent:
 
       grafana:
         type: grafana
-        api_url: http://localhost:3000
+        api_base_url: http://localhost:3000
         api_key: ${GRAFANA_API_KEY}
         dataset_db:
           uri: ${GRAFANA_DB_URI}

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -41,7 +41,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: ${SUPERSET_USER}
         password: ${SUPERSET_PASSWORD}
 

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -41,7 +41,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: ${SUPERSET_USER}
         password: ${SUPERSET_PASSWORD}
 

--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -67,7 +67,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: "http://localhost:8088"
+        api_base_url: "http://localhost:8088"
         username: "${SUPERSET_USER}"
         password: "${SUPERSET_PASSWORD}"
 

--- a/docs/configuration/introduction.zh.md
+++ b/docs/configuration/introduction.zh.md
@@ -49,7 +49,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: "http://localhost:8088"
+        api_base_url: "http://localhost:8088"
         username: "${SUPERSET_USER}"
         password: "${SUPERSET_PASSWORD}"
 

--- a/docs/getting_started/dashboard_copilot.md
+++ b/docs/getting_started/dashboard_copilot.md
@@ -145,7 +145,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: admin
         password: admin
         extra:

--- a/docs/getting_started/dashboard_copilot.zh.md
+++ b/docs/getting_started/dashboard_copilot.zh.md
@@ -144,7 +144,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: admin
         password: admin
         extra:

--- a/docs/getting_started/data_engineering_quickstart.md
+++ b/docs/getting_started/data_engineering_quickstart.md
@@ -115,7 +115,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://127.0.0.1:8088
+        api_base_url: http://127.0.0.1:8088
         username: admin
         password: admin
         dataset_db:

--- a/docs/getting_started/data_engineering_quickstart.zh.md
+++ b/docs/getting_started/data_engineering_quickstart.zh.md
@@ -115,7 +115,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://127.0.0.1:8088
+        api_base_url: http://127.0.0.1:8088
         username: admin
         password: admin
         dataset_db:

--- a/docs/subagent/builtin_subagents.md
+++ b/docs/subagent/builtin_subagents.md
@@ -1009,7 +1009,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: "http://localhost:8088"
+        api_base_url: "http://localhost:8088"
         username: "${SUPERSET_USER}"
         password: "${SUPERSET_PASSWORD}"
         dataset_db:

--- a/docs/subagent/builtin_subagents.zh.md
+++ b/docs/subagent/builtin_subagents.zh.md
@@ -1007,7 +1007,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: "http://localhost:8088"
+        api_base_url: "http://localhost:8088"
         username: "${SUPERSET_USER}"
         password: "${SUPERSET_PASSWORD}"
         dataset_db:

--- a/docs/subagent/gen_dashboard.md
+++ b/docs/subagent/gen_dashboard.md
@@ -95,7 +95,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: "http://localhost:8088"
+        api_base_url: "http://localhost:8088"
         username: "${SUPERSET_USER}"
         password: "${SUPERSET_PASSWORD}"
         dataset_db:
@@ -103,7 +103,7 @@ agent:
           schema: "public"
       grafana:
         type: grafana
-        api_url: "http://localhost:3000"
+        api_base_url: "http://localhost:3000"
         api_key: "${GRAFANA_API_KEY}"
         dataset_db:
           uri: "${GRAFANA_DB_URI}"
@@ -124,7 +124,7 @@ agent:
 | `max_turns` | No | Maximum conversation turns | 30 |
 | `bi_platform` | No | Explicit platform key from `services.bi_platforms` (`superset`, `grafana`) | Auto-detected when only one BI platform is configured |
 | `services.bi_platforms.<platform>.type` | No | BI platform type. If set, it must match the config key | Uses the config key |
-| `services.bi_platforms.<platform>.api_url` | Yes | BI platform API endpoint | — |
+| `services.bi_platforms.<platform>.api_base_url` | Yes | BI platform API endpoint | — |
 | `services.bi_platforms.<platform>.username` | Superset | Login username | — |
 | `services.bi_platforms.<platform>.password` | Superset | Login password | — |
 | `services.bi_platforms.<platform>.api_key` | Grafana | Grafana API key | — |

--- a/docs/subagent/gen_dashboard.zh.md
+++ b/docs/subagent/gen_dashboard.zh.md
@@ -95,7 +95,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: "http://localhost:8088"
+        api_base_url: "http://localhost:8088"
         username: "${SUPERSET_USER}"
         password: "${SUPERSET_PASSWORD}"
         dataset_db:
@@ -103,7 +103,7 @@ agent:
           schema: "public"
       grafana:
         type: grafana
-        api_url: "http://localhost:3000"
+        api_base_url: "http://localhost:3000"
         api_key: "${GRAFANA_API_KEY}"
         dataset_db:
           uri: "${GRAFANA_DB_URI}"
@@ -124,7 +124,7 @@ agent:
 | `max_turns` | 否 | 最大对话轮数 | 30 |
 | `bi_platform` | 否 | `services.bi_platforms` 中的平台键（如 `superset`、`grafana`） | 仅配置一个 BI 平台时自动检测 |
 | `services.bi_platforms.<platform>.type` | 否 | BI 平台类型；如果填写，必须与配置键一致 | 使用配置键 |
-| `services.bi_platforms.<platform>.api_url` | 是 | BI 平台 API 地址 | — |
+| `services.bi_platforms.<platform>.api_base_url` | 是 | BI 平台 API 地址 | — |
 | `services.bi_platforms.<platform>.username` | Superset | 登录用户名 | — |
 | `services.bi_platforms.<platform>.password` | Superset | 登录密码 | — |
 | `services.bi_platforms.<platform>.api_key` | Grafana | Grafana API Key | — |

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -221,7 +221,7 @@ agent:
     bi_platforms:
       superset:
         type: superset
-        api_url: http://localhost:8088
+        api_base_url: http://localhost:8088
         username: admin
         password: admin
         extra:

--- a/tests/integration/agent/test_gen_dashboard_agentic.py
+++ b/tests/integration/agent/test_gen_dashboard_agentic.py
@@ -43,10 +43,7 @@ def dashboard_agent_config():
         pytest.skip("DEEPSEEK_API_KEY not set")
     if not _is_superset_running():
         pytest.skip(f"Superset not reachable at {SUPERSET_URL}. Run docker compose up -d")
-    try:
-        import datus_bi_superset  # noqa: F401
-    except ImportError:
-        pytest.skip("datus-bi-superset package not installed")
+    pytest.importorskip("datus_bi_superset", reason="datus-bi-superset package not installed")
 
     from tests.conftest import load_acceptance_config
 

--- a/tests/integration/agent/test_gen_dashboard_agentic.py
+++ b/tests/integration/agent/test_gen_dashboard_agentic.py
@@ -66,7 +66,7 @@ def dashboard_agent_config():
 
     config.dashboard_config["superset"] = DashboardConfig(
         platform="superset",
-        api_url=SUPERSET_URL,
+        api_base_url=SUPERSET_URL,
         username=SUPERSET_USER,
         password=SUPERSET_PASS,
         extra={"provider": "db"},

--- a/tests/integration/cli/test_service_commands.py
+++ b/tests/integration/cli/test_service_commands.py
@@ -284,7 +284,7 @@ def cli_with_superset(tmp_path, bi_core_stub):
         tmp_path,
         bi_tools={
             "superset": {
-                "api_url": "http://superset.test/api",
+                "api_base_url": "http://superset.test/api",
                 "username": "admin",
                 "password": "admin",
                 "type": "superset",
@@ -300,13 +300,13 @@ def cli_with_two_bi_services(tmp_path, bi_core_stub):
         tmp_path,
         bi_tools={
             "superset": {
-                "api_url": "http://superset.test/api",
+                "api_base_url": "http://superset.test/api",
                 "username": "admin",
                 "password": "admin",
                 "type": "superset",
             },
             "grafana_ro": {
-                "api_url": "http://grafana.test/api",
+                "api_base_url": "http://grafana.test/api",
                 "api_key": "token",
                 "type": "grafana_ro",
             },
@@ -471,13 +471,13 @@ class TestMultiInstanceSamePlatform:
             tmp_path,
             bi_tools={
                 "superset_prod": {
-                    "api_url": "http://prod.test/api",
+                    "api_base_url": "http://prod.test/api",
                     "username": "admin",
                     "password": "admin",
                     "type": "superset",
                 },
                 "superset_staging": {
-                    "api_url": "http://staging.test/api",
+                    "api_base_url": "http://staging.test/api",
                     "username": "admin",
                     "password": "admin",
                     "type": "superset",
@@ -527,7 +527,7 @@ class TestMissingAdapterEndToEnd:
         # fails the way it would on a real machine missing ``datus-bi-<x>``.
         agent_config = _build_agent_config(
             tmp_path,
-            bi_tools={"tableau": {"api_url": "http://tableau.test", "type": "tableau"}},
+            bi_tools={"tableau": {"api_base_url": "http://tableau.test", "type": "tableau"}},
         )
         return _FakeCLI(agent_config)
 

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -211,7 +211,7 @@ def _add_dashboard_config(agent_config, platform="superset"):
     """Add dashboard config and gen_dashboard agentic node config to an AgentConfig."""
     agent_config.dashboard_config[platform] = DashboardConfig(
         platform=platform,
-        api_url="http://localhost:8088",
+        api_base_url="http://localhost:8088",
         username="admin",
         password="admin",
         extra={"provider": "db"},
@@ -280,7 +280,7 @@ class TestGenDashboardAgenticNodeInit:
         # Add dashboard config but no gen_dashboard agentic node
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
-            api_url="http://localhost:8088",
+            api_base_url="http://localhost:8088",
             username="admin",
             password="admin",
         )
@@ -352,7 +352,7 @@ class TestGenDashboardToolSetup:
         """Read-only adapter should only expose read tools."""
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
-            api_url="http://localhost:8088",
+            api_base_url="http://localhost:8088",
             username="admin",
             password="admin",
         )
@@ -394,7 +394,7 @@ class TestGenDashboardToolSetup:
         """When datus_bi_core import fails, node should have no BI tools."""
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
-            api_url="http://localhost:8088",
+            api_base_url="http://localhost:8088",
             username="admin",
             password="admin",
         )
@@ -423,7 +423,7 @@ class TestGenDashboardAutoDetect:
         """When only one platform in dashboard_config and no explicit bi_platform, auto-detect it."""
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
-            api_url="http://localhost:8088",
+            api_base_url="http://localhost:8088",
             username="admin",
             password="admin",
         )
@@ -445,13 +445,13 @@ class TestGenDashboardAutoDetect:
         """When multiple platforms configured and no explicit bi_platform, no tools should be set up."""
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
-            api_url="http://localhost:8088",
+            api_base_url="http://localhost:8088",
             username="admin",
             password="admin",
         )
         real_agent_config.dashboard_config["grafana"] = DashboardConfig(
             platform="grafana",
-            api_url="http://localhost:3000",
+            api_base_url="http://localhost:3000",
             username="admin",
             password="admin",
         )
@@ -750,7 +750,7 @@ class TestGenDashboardTemplateContext:
         """write_query should only be marked available when dataset_db is configured."""
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
-            api_url="http://localhost:8088",
+            api_base_url="http://localhost:8088",
             username="admin",
             password="admin",
             dataset_db={"uri": "postgresql://superset:superset@localhost:5432/superset"},
@@ -808,7 +808,7 @@ class TestGenDashboardTemplateContext:
         """The rendered prompt should describe write_query as conditional, not mandatory."""
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
-            api_url="http://localhost:8088",
+            api_base_url="http://localhost:8088",
             username="admin",
             password="admin",
             dataset_db={"uri": "postgresql://superset:superset@localhost:5432/superset"},
@@ -857,7 +857,7 @@ class TestGenDashboardSkillContext:
         """Grafana nodes should switch the platform skill but keep shared validation."""
         real_agent_config.dashboard_config["grafana"] = DashboardConfig(
             platform="grafana",
-            api_url="http://localhost:3000",
+            api_base_url="http://localhost:3000",
             api_key="test-api-key",
         )
         real_agent_config.agentic_nodes["gen_dashboard"] = {

--- a/tests/unit_tests/cli/test_service_client.py
+++ b/tests/unit_tests/cli/test_service_client.py
@@ -201,7 +201,7 @@ class TestServiceClientRegistry:
 
     def test_discover_lists_all_service_types(self):
         cfg = _fake_agent_config(
-            bi_platforms={"superset": {"api_url": "x"}, "grafana": {"api_url": "y"}},
+            bi_platforms={"superset": {"api_base_url": "x"}, "grafana": {"api_base_url": "y"}},
             schedulers={"airflow": {"type": "airflow"}},
             semantic_layer={"metricflow": {"namespace": "x"}},
         )

--- a/tests/unit_tests/tools/func_tool/test_bi_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_bi_tools.py
@@ -243,7 +243,7 @@ def _build_tool(
             dataset_db["datasource_name"] = datasource_name
 
     dash_cfg = MagicMock()
-    dash_cfg.api_url = ""
+    dash_cfg.api_base_url = ""
     dash_cfg.username = ""
     dash_cfg.password = ""
     dash_cfg.api_key = ""


### PR DESCRIPTION
## Why

`services.bi_platforms.<x>.api_url` in `agent.yml` was misaligned with everything downstream:

- `datus_bi_core.BIAdapterBase.api_base_url` — instance attribute
- `SupersetAdapter.__init__(api_base_url=...)` — constructor parameter
- `services.schedulers.<x>.api_base_url` — neighbouring section in the same YAML file

The BI `api_url` key was the odd one out, which forced `BIFuncTool._build_adapter` to do `api_base_url=dash_cfg.api_url` translation, and forced users to juggle two names in the same file depending on which services subsection they were editing.

## Solution

Rename the YAML key and the `DashboardConfig` dataclass field to `api_base_url`:

- `DashboardConfig.api_url` → `api_base_url` (`datus/configuration/agent_config.py`)
- `init_dashboard()` reads `auth_params.get("api_base_url", ...)` instead of `api_url`; local variable renamed accordingly
- `BIFuncTool._build_adapter` now passes `dash_cfg.api_base_url` directly (no translation)
- `conf/agent.yml.example` and `tests/conf/agent.yml` updated
- Docs updated across `docs/{adapters,configuration,getting_started,subagent}/`

Breaking change to the YAML schema. No backward-compat shim — there are no production users yet.

The superset/bi-core adapter packages need no change; they already used `api_base_url` in their public API.

## Test Cases

Existing unit and integration test fixtures that constructed `DashboardConfig(api_url=...)` or passed `{"api_url": ...}` dicts into `bi_platforms` were updated to the new field name:

- `tests/unit_tests/tools/func_tool/test_bi_tools.py`
- `tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py`
- `tests/unit_tests/cli/test_service_client.py`
- `tests/integration/cli/test_service_commands.py`
- `tests/integration/agent/test_gen_dashboard_agentic.py`

Verification:

- `uv run pytest tests/unit_tests/ --cov=datus --cov-fail-under=80` — 10730 passed, coverage 82.57%
- `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` — 100% diff coverage
- `uv run ruff format . && uv run ruff check --fix .` — clean

No new test cases added — this is a pure mechanical rename that's already exercised by the existing `init_dashboard` / `BIFuncTool._build_adapter` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * BI platform configuration field renamed from api_url to api_base_url across supported platforms.

* **Documentation**
  * Updated configuration docs, examples, and getting-started guides (English and Chinese) to use api_base_url.

* **Tests**
  * Updated unit and integration tests and fixtures to reference api_base_url so test coverage matches the new config key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->