### PR TITLE
[Refactor] Align agent get/edit lookup to use id

### DIFF
--- a/datus/api/models/agent_models.py
+++ b/datus/api/models/agent_models.py
@@ -99,7 +99,8 @@ class EditAgentInput(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    name: str = Field(..., description="Agent name to edit")
+    id: str = Field(..., description="Agent id to edit")
+    name: Optional[str] = Field(..., description="Agent name to edit")
     description: Optional[str] = None
     prompt_template: Optional[str] = Field(default=None, alias="system_prompt")
     prompt_version: Optional[str] = Field(default=None, description="Prompt version (None = latest)")

--- a/datus/api/models/agent_models.py
+++ b/datus/api/models/agent_models.py
@@ -100,7 +100,7 @@ class EditAgentInput(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     id: str = Field(..., description="Agent id to edit")
-    name: Optional[str] = Field(..., description="Agent name to edit")
+    name: Optional[str] = Field(default=None, description="Agent name to edit")
     description: Optional[str] = None
     prompt_template: Optional[str] = Field(default=None, alias="system_prompt")
     prompt_version: Optional[str] = Field(default=None, description="Prompt version (None = latest)")

--- a/datus/api/routes/agent_routes.py
+++ b/datus/api/routes/agent_routes.py
@@ -42,16 +42,16 @@ async def get_agent_use_tools(
     "/agent",
     response_model=Result[dict],
     summary="Get Agent Detail",
-    description="Get configuration details for a specific agent by name",
+    description="Get configuration details for a specific agent by id",
 )
 async def get_agent(
     svc: ServiceDep,
-    name: str = Query(..., description="Agent name"),
+    agent_id: str = Query(..., description="Agent id"),
 ) -> Result[dict]:
     """Return agent configuration matching IAgentInfo."""
     agent_service = AgentService()
     return await agent_service.get_agent(
-        name=name,
+        agent_id=agent_id,
         agent_config=svc.agent_config,
     )
 

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -6,7 +6,6 @@ from the BUILTIN_SUBAGENTS set; custom agents are persisted in agent.yml.
 """
 
 import os
-import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -128,34 +127,34 @@ class AgentService:
 
     async def get_agent(
         self,
-        name: str,
+        agent_id: str,
         agent_config: AgentConfig,
     ) -> Result[dict]:
         """Return agent configuration matching IAgentInfo."""
 
         # 1. Check builtin agents
-        if name in BUILTIN_SUBAGENTS:
+        if agent_id in BUILTIN_SUBAGENTS:
             return Result(
                 success=True,
                 data={
                     "agent": {
-                        "id": name,
-                        "name": name,
+                        "id": agent_id,
+                        "name": agent_id,
                         "type": "builtin",
                     }
                 },
             )
 
-        # 2. Query custom sub-agent from agent.yml
+        # 2. Query custom sub-agent from agent.yml (dict keyed by name, treated as id)
         agentic_nodes = agent_config.agentic_nodes or {}
-        agent = agentic_nodes.get(name)
+        agent = agentic_nodes.get(agent_id)
         if not agent:
-            return Result(success=False, errorCode="AGENT_NOT_FOUND", errorMessage=f"Agent '{name}' not found")
+            return Result(success=False, errorCode="AGENT_NOT_FOUND", errorMessage=f"Agent '{agent_id}' not found")
 
         # 3. Read prompt template content from project template file
         agent_type = agent.get("type", "gen_sql")
         prompt_content = self._read_prompt_template(
-            agent_name=name,
+            agent_name=agent_id,
             agent_type=agent_type,
             version=agent.get("prompt_version"),
             agent_config=agent_config,
@@ -165,8 +164,8 @@ class AgentService:
             success=True,
             data={
                 "agent": {
-                    "id": name,
-                    "name": name,
+                    "id": agent_id,
+                    "name": agent_id,
                     "type": agent_type,
                     "description": agent.get("description", ""),
                     "system_prompt": prompt_content or agent.get("prompt_template", ""),
@@ -241,8 +240,7 @@ class AgentService:
                 errorMessage=f"Agent '{request.name}' already exists",
             )
 
-        # Create new agent entry
-        agent_id = str(uuid.uuid4().hex[:24])
+        # Create new agent entry (dict keyed by name, which acts as the id)
         agent_entry = {
             "type": request.type or "gen_sql",
             "description": request.description or "",
@@ -271,7 +269,7 @@ class AgentService:
         except Exception:
             logger.warning(f"Failed to copy prompt template for agent '{request.name}' (non-fatal)", exc_info=True)
 
-        return Result(success=True, data={"name": request.name, "id": agent_id})
+        return Result(success=True, data={"name": request.name, "id": request.name})
 
     def _resolve_template_version(self, template_base: str, version: Optional[str] = None) -> Optional[str]:
         """Resolve prompt template version via PromptManager; returns latest if version is None."""
@@ -385,16 +383,16 @@ class AgentService:
                     errorMessage=f"Invalid tool(s): {', '.join(invalid)}. Valid categories: {', '.join(sorted(VALID_TOOL_CATEGORIES))}",
                 )
 
-        # Find the agent
+        # Find the agent (dict keyed by name, treated as id)
         agentic_nodes = agent_config.agentic_nodes or {}
-        if request.name not in agentic_nodes:
+        if request.id not in agentic_nodes:
             return Result(
                 success=False,
                 errorCode="AGENT_NOT_FOUND",
-                errorMessage=f"Agent '{request.name}' not found",
+                errorMessage=f"Agent '{request.id}' not found",
             )
 
-        agent = agentic_nodes[request.name]
+        agent = agentic_nodes[request.id]
 
         # If prompt_template content is provided, save to template file
         prompt_content = request.prompt_template
@@ -402,18 +400,18 @@ class AgentService:
             version = request.prompt_version or agent.get("prompt_version")
             try:
                 self._save_prompt_template(
-                    agent_name=request.name,
+                    agent_name=request.id,
                     version=version,
                     content=prompt_content,
                     agent_config=agent_config,
                 )
             except Exception:
-                logger.warning(f"Failed to save prompt template for agent '{request.name}' (non-fatal)", exc_info=True)
+                logger.warning(f"Failed to save prompt template for agent '{request.id}' (non-fatal)", exc_info=True)
 
-        # Update only provided fields
-        update_data = request.model_dump(exclude={"name", "prompt_template"}, exclude_none=True)
+        # Update only provided fields (name is the dict key and acts as id, so exclude it)
+        update_data = request.model_dump(exclude={"id", "name", "prompt_template"}, exclude_none=True)
         if not update_data and prompt_content is None:
-            return Result(success=True, data={"name": request.name, "id": request.name})
+            return Result(success=True, data={"name": request.id, "id": request.id})
 
         # Merge update data into the agent entry
         agent.update(update_data)
@@ -421,4 +419,4 @@ class AgentService:
         # Save back to agent.yml
         _save_agentic_nodes(agent_config, agentic_nodes)
 
-        return Result(success=True, data={"name": request.name, "id": request.name})
+        return Result(success=True, data={"name": request.id, "id": request.id})

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -294,7 +294,7 @@ class TestEditAgent:
 
         svc = AgentService()
         result = await svc.edit_agent(
-            EditAgentInput(name="nonexistent_agent", description="updated"),
+            EditAgentInput(id="nonexistent_id", name="nonexistent_agent", description="updated"),
             real_agent_config,
         )
         assert result.success is False
@@ -306,7 +306,7 @@ class TestEditAgent:
 
         svc = AgentService()
         result = await svc.edit_agent(
-            EditAgentInput(name="some_agent", tools=["bad_tools.bad"]),
+            EditAgentInput(id="some_id", name="some_agent", tools=["bad_tools.bad"]),
             real_agent_config,
         )
         assert result.success is False
@@ -325,13 +325,14 @@ class TestEditAgent:
 
         svc = AgentService()
         # Create first
-        await svc.create_agent(
+        create_result = await svc.create_agent(
             CreateAgentInput(name="edit_me", type="gen_sql", description="original"),
             real_agent_config,
         )
+        agent_id = create_result.data["id"]
         # Edit
         result = await svc.edit_agent(
-            EditAgentInput(name="edit_me", description="updated description"),
+            EditAgentInput(id=agent_id, name="edit_me", description="updated description"),
             real_agent_config,
         )
         assert result.success is True

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -88,8 +88,9 @@ class TestConstants:
         assert set(SUBAGENT_TOOL_REFERENCE["gen_sql"]) == set(VALID_TOOL_METHODS.keys())
 
     def test_valid_tool_methods_db_tools_has_methods(self):
-        """db_tools category has at least one method."""
-        assert len(VALID_TOOL_METHODS["db_tools"]) > 0
+        """db_tools category exposes core query methods."""
+        assert "describe_table" in VALID_TOOL_METHODS["db_tools"]
+        assert "get_table_ddl" in VALID_TOOL_METHODS["db_tools"]
 
     def test_valid_tool_methods_filesystem_tools_contains_read_file(self):
         """filesystem_tools contains read_file."""
@@ -102,7 +103,7 @@ class TestAgentServiceInit:
     def test_init_succeeds(self):
         """AgentService can be instantiated."""
         svc = AgentService()
-        assert svc is not None
+        assert isinstance(svc, AgentService)
 
 
 class TestGetUseTools:
@@ -113,9 +114,7 @@ class TestGetUseTools:
         result = AgentService.get_use_tools("gen_sql")
         assert result.success is True
         assert isinstance(result.data, dict)
-        assert "tools" in result.data
-        assert isinstance(result.data["tools"], list)
-        assert len(result.data["tools"]) > 0
+        assert set(result.data["tools"]) == set(SUBAGENT_TOOL_REFERENCE["gen_sql"])
 
     def test_unknown_agent_type_returns_error(self):
         """get_use_tools returns error for unknown agent type."""
@@ -128,8 +127,7 @@ class TestGetUseTools:
         """get_use_tools returns tools for gen_report."""
         result = AgentService.get_use_tools("gen_report")
         assert result.success is True
-        assert isinstance(result.data, dict)
-        assert len(result.data["tools"]) > 0
+        assert set(result.data["tools"]) == set(SUBAGENT_TOOL_REFERENCE["gen_report"])
 
 
 @pytest.mark.asyncio
@@ -186,11 +184,12 @@ class TestGetAgent:
         svc = AgentService()
         # real_agent_config has agentic_nodes from conftest (e.g. 'gensql', 'chat', etc.)
         nodes = real_agent_config.agentic_nodes or {}
-        if nodes:
-            first_name = next(iter(nodes))
-            result = await svc.get_agent(first_name, real_agent_config)
-            assert result.success is True
-            assert result.data["agent"]["name"] == first_name
+        assert nodes, "real_agent_config fixture must provide agentic_nodes"
+        first_name = next(iter(nodes))
+        result = await svc.get_agent(first_name, real_agent_config)
+        assert result.success is True
+        assert result.data["agent"]["name"] == first_name
+        assert result.data["agent"]["id"] == first_name
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

The backend (Datus-backend) now looks up agents by `agent_id` in `get_agent` and by `request.id` in `edit_agent`, but the submodule still used `name`. Since `EditAgentInput` was updated to require `id`, callers of the submodule service and route would fail with a validation error without a matching interface here.

## Solution

- `AgentService.get_agent(agent_id, agent_config)`: renamed parameter from `name` to `agent_id`.
- `AgentService.edit_agent`: now looks up by `request.id` and excludes `{"id", "name", "prompt_template"}` from the update payload (name is the dict key and acts as the id in this file-based store).
- `AgentService.create_agent`: returns `{"id": request.name, "name": request.name}` since `agentic_nodes` is keyed by name; the previously generated uuid was never stored and not usable as a lookup id.
- `agent_routes.py`: `GET /api/v1/agent` now accepts `agent_id` query parameter instead of `name`.

## Test Cases

- Updated `tests/unit_tests/api/services/test_agent_service.py::TestEditAgent` to pass the new required `id` field on `EditAgentInput`.
- All 32 tests in `test_agent_service.py` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent identification now uses unique IDs instead of names for improved reliability.

* **Bug Fixes**
  * Consistent ID-based handling for agent lookup, creation and editing; name is optional when editing.

* **API Changes**
  * Agent retrieval endpoint requires an agent ID rather than a name.
  * Edit requests must include the agent's ID.

* **Tests**
  * Unit tests tightened for stricter identity and tool validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->