### PR TITLE
[Enhancement] Add current_model field to models response and derive BUILTIN_SUBAGENTS from SYS_SUB_AGENTS

### DIFF
--- a/datus/api/constants.py
+++ b/datus/api/constants.py
@@ -2,18 +2,13 @@
 
 import re
 
+from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
+
 # Header carrying the caller's user identifier for the open-source default auth.
 HEADER_USER_ID = "X-Datus-User-Id"
 
 # Allowed characters for header-provided user_id (also used as SessionManager scope).
 USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
-# Builtin subagents that come pre-configured
-BUILTIN_SUBAGENTS = {
-    "gen_sql",
-    "gen_report",
-    "gen_semantic_model",
-    "gen_metrics",
-    "gen_sql_summary",
-    "gen_ext_knowledge",
-}
+# Builtin subagents matching /agent visible list
+BUILTIN_SUBAGENTS = SYS_SUB_AGENTS - HIDDEN_SYS_SUB_AGENTS

--- a/datus/api/models/config_models.py
+++ b/datus/api/models/config_models.py
@@ -238,5 +238,6 @@ class ModelsData(BaseModel):
 
     models: List[ModelInfo] = Field(..., description="Flat list of available models")
     providers: List[str] = Field(..., description="Provider keys represented in this response")
+    current_model: Optional[str] = Field(None, description="Currently active model as 'provider/model'")
     fetched_at: Optional[str] = Field(None, description="ISO-8601 timestamp of the OpenRouter cache")
     source: str = Field(..., description="Where the data came from: cache or catalog")

--- a/datus/api/routes/models_routes.py
+++ b/datus/api/routes/models_routes.py
@@ -86,6 +86,38 @@ def _build_model_info(
     )
 
 
+def _resolve_current_model(
+    agent_config: Any,
+    models: List[ModelInfo],
+) -> Optional[str]:
+    """Return the currently active model as ``"provider/model"``.
+
+    Resolution order:
+      1. Explicit target from ``.datus/config.yml`` (provider + model).
+      2. Legacy ``agent.target`` pointing to a custom model entry.
+      3. First custom model in the list.
+      4. First provider model in the list.
+    """
+    target_provider = getattr(agent_config, "_target_provider", None)
+    target_model = getattr(agent_config, "_target_model", None)
+    if target_provider and target_model:
+        return f"{target_provider}/{target_model}"
+
+    target = getattr(agent_config, "target", None)
+    custom_models = getattr(agent_config, "models", None)
+    if target and isinstance(custom_models, dict) and target in custom_models:
+        return f"custom/{target}"
+
+    for m in models:
+        if m.provider == "custom":
+            return f"custom/{m.id}"
+
+    if models:
+        return f"{models[0].provider}/{models[0].id}"
+
+    return None
+
+
 @router.get(
     "/models",
     response_model=Result[ModelsData],
@@ -162,11 +194,14 @@ async def list_models(svc: ServiceDep) -> Result[ModelsData]:
         if any(m.provider == "custom" for m in models):
             seen_providers.append("custom")
 
+    current_model = _resolve_current_model(agent_config, models)
+
     return Result(
         success=True,
         data=ModelsData(
             models=models,
             providers=seen_providers,
+            current_model=current_model,
             fetched_at=load_cache_fetched_at() if used_cache else None,
             source="cache" if used_cache else "catalog",
         ),

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -16,6 +16,8 @@ from datus.prompts.prompt_manager import PromptManager
 from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.func_tool.platform_doc_search import PlatformDocSearchTool
+from datus.tools.func_tool.sub_agent_task_tool import BUILTIN_SUBAGENT_DESCRIPTIONS
+from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -39,18 +41,7 @@ VALID_TOOL_METHODS: dict[str, set[str]] = {
 
 VALID_TOOL_CATEGORIES = set(VALID_TOOL_METHODS.keys())
 
-# Built-in sub-agents available to all projects (descriptions keyed by name)
-BUILTIN_SUBAGENT_DESCRIPTIONS: dict[str, str] = {
-    "gen_sql": "Generate SQL queries",
-    "gen_report": "Generate reports",
-    "gen_semantic_model": "Generate semantic models",
-    "gen_metrics": "Generate metrics",
-    "gen_sql_summary": "Generate SQL summaries",
-    "gen_ext_knowledge": "Generate external knowledge",
-}
-
-# Re-export for backward compatibility
-BUILTIN_SUBAGENTS = BUILTIN_SUBAGENT_DESCRIPTIONS
+BUILTIN_SUBAGENTS = SYS_SUB_AGENTS - HIDDEN_SYS_SUB_AGENTS
 
 # Tool reference for each agent type
 SUBAGENT_TOOL_REFERENCE: dict[str, list[str]] = {
@@ -186,9 +177,9 @@ class AgentService:
                 "id": name,
                 "name": name,
                 "type": "builtin",
-                "description": desc,
+                "description": BUILTIN_SUBAGENT_DESCRIPTIONS.get(name, ""),
             }
-            for name, desc in sorted(BUILTIN_SUBAGENTS.items())
+            for name in sorted(BUILTIN_SUBAGENTS)
         ]
 
         # 2. Custom sub-agents from agent.yml

--- a/tests/unit_tests/api/routes/test_models_routes.py
+++ b/tests/unit_tests/api/routes/test_models_routes.py
@@ -20,6 +20,9 @@ def _make_svc(
     catalog: Dict[str, Any],
     available: Optional[Iterable[str]] = None,
     custom_models: Optional[Dict[str, Any]] = None,
+    target_provider: Optional[str] = None,
+    target_model: Optional[str] = None,
+    target: str = "",
 ) -> MagicMock:
     """Build a MagicMock svc with provider_catalog + provider_available wired up.
 
@@ -32,6 +35,9 @@ def _make_svc(
     svc.agent_config.provider_catalog = catalog
     svc.agent_config.provider_available.side_effect = lambda p: p in allowed
     svc.agent_config.models = custom_models if custom_models is not None else {}
+    svc.agent_config._target_provider = target_provider
+    svc.agent_config._target_model = target_model
+    svc.agent_config.target = target
     return svc
 
 
@@ -296,6 +302,10 @@ class TestDefensiveParsing:
         svc = MagicMock()
         svc.agent_config.provider_catalog = None
         svc.agent_config.provider_available.return_value = True
+        svc.agent_config.models = {}
+        svc.agent_config._target_provider = None
+        svc.agent_config._target_model = None
+        svc.agent_config.target = ""
 
         result = await list_models(svc)
         assert result.data.models == []
@@ -406,3 +416,80 @@ class TestCustomModels:
         assert len(custom_models) == 1
         assert custom_models[0].id == "my-ds"
         assert custom_models[0].model == "deepseek-chat"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Current model resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCurrentModel:
+    @pytest.mark.asyncio
+    async def test_provider_target_takes_priority(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        custom = {"my-ds": _custom_model("deepseek-chat", "deepseek")}
+        svc = _make_svc(
+            catalog=_basic_catalog(),
+            available={"openai"},
+            custom_models=custom,
+            target_provider="openai",
+            target_model="gpt-4.1",
+            target="my-ds",
+        )
+        result = await list_models(svc)
+
+        assert result.data.current_model == "openai/gpt-4.1"
+
+    @pytest.mark.asyncio
+    async def test_custom_target_used_when_no_provider_target(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        custom = {"my-ds": _custom_model("deepseek-chat", "deepseek")}
+        svc = _make_svc(
+            catalog=_basic_catalog(),
+            available=set(),
+            custom_models=custom,
+            target="my-ds",
+        )
+        result = await list_models(svc)
+
+        assert result.data.current_model == "custom/my-ds"
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_first_custom_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        custom = {"alpha": _custom_model("gpt-4", "openai")}
+        svc = _make_svc(
+            catalog=_basic_catalog(),
+            available={"openai"},
+            custom_models=custom,
+        )
+        result = await list_models(svc)
+
+        assert result.data.current_model == "custom/alpha"
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_first_provider_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        svc = _make_svc(catalog=_basic_catalog(), available={"openai"})
+        result = await list_models(svc)
+
+        assert result.data.current_model is not None
+        assert result.data.current_model.startswith("openai/")
+
+    @pytest.mark.asyncio
+    async def test_no_models_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(models_routes, "load_cached_model_details", lambda: None)
+        monkeypatch.setattr(models_routes, "load_cache_fetched_at", lambda: None)
+
+        svc = _make_svc(catalog=_basic_catalog(), available=set())
+        result = await list_models(svc)
+
+        assert result.data.current_model is None

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -12,6 +12,7 @@ from datus.api.services.agent_service import (
     AgentService,
     _validate_tools,
 )
+from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
 
 
 class TestValidateTools:
@@ -72,11 +73,10 @@ class TestConstants:
     def test_builtin_subagents_has_gen_sql(self):
         """BUILTIN_SUBAGENTS contains gen_sql entry."""
         assert "gen_sql" in BUILTIN_SUBAGENTS
-        assert isinstance(BUILTIN_SUBAGENTS["gen_sql"], str)
 
     def test_builtin_subagents_count(self):
         """BUILTIN_SUBAGENTS has expected number of agents."""
-        assert len(BUILTIN_SUBAGENTS) == 6
+        assert len(BUILTIN_SUBAGENTS) == len(SYS_SUB_AGENTS - HIDDEN_SYS_SUB_AGENTS)
 
     def test_valid_tool_categories_non_empty(self):
         """VALID_TOOL_CATEGORIES is non-empty."""


### PR DESCRIPTION

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The models endpoint now includes information about the currently active model, displayed as `provider/model` format, enabling users to identify which model is currently in use.

* **Improvements**
  * Builtin subagent visibility is now dynamically derived from system configuration instead of static definitions, ensuring only intended subagents are visible to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->