### PR TITLE
[Refactor] Remove deprecated GET /api/v1/chat/model endpoint

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -521,16 +521,3 @@ class ChatHistoryData(BaseModel):
     """Chat history data."""
 
     messages: List[SSEMessagePayload] = Field(default_factory=list, description="chat history messages")
-
-
-class ChatModelInfo(BaseModel):
-    """Chat model identity."""
-
-    type: str = Field(..., description="Model provider type (e.g., 'openai', 'claude')")
-    model: str = Field(..., description="Model identifier (e.g., 'gpt-4', 'claude-3-sonnet')")
-
-
-class ChatModelData(BaseModel):
-    """Current chat model data."""
-
-    current: ChatModelInfo = Field(..., description="The model currently active for chat")

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -26,7 +26,6 @@ from datus.api.models.chat_models import (
 )
 from datus.api.models.cli_models import (
     ChatHistoryData,
-    ChatModelData,
     ChatSessionData,
     CompactSessionData,
     CompactSessionInput,
@@ -245,21 +244,6 @@ async def get_chat_history(
     session_id: str = Query(..., description="Session ID to retrieve history for"),
 ) -> Result[ChatHistoryData]:
     return svc.chat.get_history(session_id, user_id=ctx.user_id)
-
-
-# ========== Current Chat Model ==========
-
-
-@router.get(
-    "/model",
-    response_model=Result[ChatModelData],
-    summary="Get Current Chat Model",
-    description="Return the active chat model identity (type and model)",
-)
-async def get_chat_model(
-    svc: ServiceDep,
-) -> Result[ChatModelData]:
-    return svc.chat.get_model()
 
 
 # ========== User Interaction ==========

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -14,8 +14,6 @@ from datus.agent.node.chat_agentic_node import ChatAgenticNode
 from datus.api.models.base_models import Result
 from datus.api.models.cli_models import (
     ChatHistoryData,
-    ChatModelData,
-    ChatModelInfo,
     ChatSessionData,
     ChatSessionItemInfo,
     CompactSessionData,
@@ -87,23 +85,6 @@ class ChatService:
         """Check if a session exists on disk."""
         session_mgr = SessionManager(session_dir=self._session_dir, scope=user_id)
         return session_mgr.session_exists(session_id)
-
-    def get_model(self) -> Result[ChatModelData]:
-        """Return the currently active chat model identity."""
-        try:
-            active = self.agent_config.active_model()
-            return Result[ChatModelData](
-                success=True,
-                data=ChatModelData(
-                    current=ChatModelInfo(type=active.type, model=active.model),
-                ),
-            )
-        except DatusException as e:
-            logger.warning("No active model: %s", e.message)
-            return Result[ChatModelData](success=False, errorCode=e.code.name, errorMessage=e.message)
-        except Exception as e:
-            logger.error(f"Failed to get active model: {e}")
-            return Result[ChatModelData](success=False, errorCode="MODEL_LOOKUP_ERROR", errorMessage=str(e))
 
     def list_sessions(
         self,

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -133,42 +133,6 @@ class TestChatServiceDeleteSession:
         assert chat_svc.session_exists("to-delete") is False
 
 
-class TestChatServiceGetModel:
-    """Tests for get_model."""
-
-    def test_get_model_returns_active_model_identity(self, chat_svc):
-        """get_model returns the active ModelConfig's type and model."""
-        result = chat_svc.get_model()
-        assert result.success is True
-        assert result.data is not None
-        assert result.data.current.type == "openai"
-        assert result.data.current.model == "mock-model"
-
-    def test_get_model_reflects_active_model_changes(self, chat_svc):
-        """get_model follows the AgentConfig.active_model() result."""
-        fake_active = MagicMock(type="claude", model="claude-3-sonnet")
-        with patch.object(chat_svc.agent_config, "active_model", return_value=fake_active):
-            result = chat_svc.get_model()
-
-        assert result.success is True
-        assert result.data.current.type == "claude"
-        assert result.data.current.model == "claude-3-sonnet"
-
-    def test_get_model_handles_lookup_error(self, chat_svc):
-        """get_model returns a typed error when active_model() raises."""
-        with patch.object(
-            chat_svc.agent_config,
-            "active_model",
-            side_effect=ValueError("no model"),
-        ):
-            result = chat_svc.get_model()
-
-        assert result.success is False
-        assert result.errorCode == "MODEL_LOOKUP_ERROR"
-        assert "no model" in (result.errorMessage or "")
-        assert result.data is None
-
-
 class TestChatServiceGetHistory:
     """Tests for get_history."""
 

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -23,9 +23,10 @@ def chat_svc(real_agent_config):
 class TestChatServiceInit:
     """Tests for ChatService initialization."""
 
-    def test_init_with_real_config(self, chat_svc):
+    def test_init_with_real_config(self, chat_svc, real_agent_config):
         """ChatService initializes with real agent config and task manager."""
-        assert chat_svc is not None
+        assert chat_svc.agent_config is real_agent_config
+        assert isinstance(chat_svc._task_manager, ChatTaskManager)
 
     def test_init_stores_properties(self, real_agent_config):
         """ChatService stores agent_config and task_manager."""
@@ -34,9 +35,9 @@ class TestChatServiceInit:
         assert svc.agent_config is real_agent_config
         assert svc._task_manager is tm
 
-    def test_init_sets_session_dir(self, chat_svc):
+    def test_init_sets_session_dir(self, chat_svc, real_agent_config):
         """ChatService sets _session_dir from agent_config."""
-        assert chat_svc._session_dir is not None
+        assert chat_svc._session_dir == real_agent_config.session_dir
 
 
 class TestChatServiceSessionExists:
@@ -140,7 +141,7 @@ class TestChatServiceGetHistory:
         """get_history for unknown session returns empty messages."""
         result = chat_svc.get_history("nonexistent-session")
         assert result.success is True
-        assert result.data is not None
+        assert result.data.messages == []
 
     def test_get_history_empty_session_returns_success(self, chat_svc):
         """get_history for empty session returns success with empty messages."""
@@ -197,7 +198,8 @@ class TestChatServiceCompactSession:
     """Tests for compact_session."""
 
     async def test_compact_nonexistent_session(self, real_agent_config, mock_llm_create):
-        """compact_session for nonexistent session returns error."""
+        """compact_session auto-creates and compacts a fresh empty session — the call must
+        never raise, and the typed Result must round-trip the requested session_id."""
         from datus.api.models.cli_models import CompactSessionInput
 
         svc = ChatService(
@@ -207,8 +209,9 @@ class TestChatServiceCompactSession:
         )
         request = CompactSessionInput(session_id="nonexistent")
         result = await svc.compact_session(request)
-        # Should handle gracefully
-        assert result is not None
+
+        assert result.success is True
+        assert result.data.session_id == "nonexistent"
 
     async def test_compact_persists_summary_into_session(self, real_agent_config, mock_llm_create):
         """End-to-end: compact must keep the .db alive and write a
@@ -303,7 +306,8 @@ class TestChatServiceStreamChat:
             events.append(event)
             if len(events) > 5:
                 break
-        assert len(events) >= 0
+        assert len(events) >= 1
+        assert events[0].event == "session"
 
     async def test_stream_chat_duplicate_session_yields_error(self, real_agent_config, mock_llm_create):
         """stream_chat for duplicate session_id yields error event."""


### PR DESCRIPTION
## Why

The current chat model identity is now surfaced via the `current_model`
field on `GET /api/v1/models` (added in #649), so the dedicated
`GET /api/v1/chat/model` endpoint is redundant and should be retired
to keep the public API surface small and consistent.

## Solution

- Delete the `GET /api/v1/chat/model` route in `datus/api/routes/chat_routes.py`.
- Remove `ChatService.get_model()` and its logger branches.
- Delete the now-unused `ChatModelData` / `ChatModelInfo` payload models from `datus/api/models/cli_models.py`.
- Prune the corresponding `TestChatServiceGetModel` test class from `tests/unit_tests/api/services/test_chat_service.py`.

No remaining callers reference these symbols (verified via repo-wide grep). Clients that need the active chat model should read `current_model` from `GET /api/v1/models`.

## Test Cases

- `uv run pytest tests/unit_tests/api/services/test_chat_service.py tests/unit_tests/api/routes/test_chat_routes.py` — 41 passed.
- Full unit suite: `uv run pytest tests/unit_tests/ --cov=datus --cov-report=xml:coverage.xml --cov-fail-under=80` — total coverage 81.90% (gate met); the 2 failures + 14 errors are pre-existing environmental failures on `main` (missing local benchmark data) and unrelated to this change.
- `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` — no diff lines needing coverage (pure deletion).
- No new integration/nightly tests added — this PR only removes an API endpoint and its dead-code callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the API endpoint that provided details about the currently active chat model (type and identifier).

* **Tests**
  * Removed unit tests that verified model identity resolution, reactions to active-model changes, and error handling for model-info retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->