### PR TITLE
[Tool] Relax normal permission prompts for benign tools

### DIFF
--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -11,8 +11,8 @@ layered on top via ``PermissionConfig.merge_with`` (last-match-wins).
 
 The three profiles embody three security postures:
 
-* ``normal``:    read-only tools allowed, all writes ASK, named
-  destructive tools DENY. Default for new installs.
+* ``normal``:    read-only tools, semantic tools, and skill loading allowed,
+  all other writes ASK, named destructive tools DENY. Default for new installs.
 * ``auto``:      Normal + workspace writes auto-execute, BI/scheduler
   non-trigger writes auto, DB writes still ASK.
 * ``dangerous``: everything ALLOW. Filesystem EXTERNAL paths still
@@ -36,7 +36,7 @@ def _rule(tool: str, pattern: str, permission: PermissionLevel) -> PermissionRul
 
 
 # --- Normal ------------------------------------------------------------------
-# default=ASK + explicit reads ALLOW + named destructives DENY + MCP/skills ASK.
+# default=ASK + semantic/read/skill-load ALLOW + named destructives DENY + MCP/script ASK.
 _NORMAL_RULES = [
     # context search / date utilities
     _rule("context_search_tools", "*", PermissionLevel.ALLOW),
@@ -56,6 +56,11 @@ _NORMAL_RULES = [
     _rule("semantic_tools", "search_*", PermissionLevel.ALLOW),
     _rule("semantic_tools", "get_*", PermissionLevel.ALLOW),
     _rule("semantic_tools", "query_metrics", PermissionLevel.ALLOW),
+    # semantic generation helpers
+    _rule("semantic_tools", "check_semantic_object_exists", PermissionLevel.ALLOW),
+    _rule("semantic_tools", "end_*_generation", PermissionLevel.ALLOW),
+    _rule("semantic_tools", "generate_*_id", PermissionLevel.ALLOW),
+    _rule("semantic_tools", "*", PermissionLevel.ALLOW),
     # scheduler read + destructive deny
     _rule("scheduler_tools", "list_*", PermissionLevel.ALLOW),
     _rule("scheduler_tools", "get_*", PermissionLevel.ALLOW),
@@ -65,6 +70,8 @@ _NORMAL_RULES = [
     _rule("filesystem_tools", "list_*", PermissionLevel.ALLOW),
     _rule("filesystem_tools", "directory_tree", PermissionLevel.ALLOW),
     _rule("filesystem_tools", "search_files", PermissionLevel.ALLOW),
+    _rule("filesystem_tools", "glob", PermissionLevel.ALLOW),
+    _rule("filesystem_tools", "grep", PermissionLevel.ALLOW),
     # plan read
     _rule("tools", "todo_read", PermissionLevel.ALLOW),
     # ``ask_user`` IS the user-interaction channel — gating "may I ask
@@ -76,14 +83,16 @@ _NORMAL_RULES = [
     _rule("tools", "list_*", PermissionLevel.ALLOW),
     _rule("tools", "search_*", PermissionLevel.ALLOW),
     _rule("tools", "get_*", PermissionLevel.ALLOW),
+    _rule("tools", "validate_skill", PermissionLevel.ALLOW),
     # sub-agent delegation: ALLOW. The ``task()`` tool just spawns a
     # subagent; the tools the subagent actually invokes are gated by the
     # subagent's own PermissionHooks instance. Double-prompting here would
     # fire on nearly every chat interaction for zero safety benefit.
     _rule("sub_agent_tools", "*", PermissionLevel.ALLOW),
-    # mcp + skills: ASK (explicit so future defaults can shift default_permission)
+    # mcp: ASK; skill loading ALLOW, but skill script execution still ASK.
     _rule("mcp.*", "*", PermissionLevel.ASK),
-    _rule("skills", "*", PermissionLevel.ASK),
+    _rule("skills", "*", PermissionLevel.ALLOW),
+    _rule("skills", "skill_execute_command", PermissionLevel.ASK),
 ]
 
 NORMAL = PermissionConfig(
@@ -106,10 +115,7 @@ _AUTO_EXTRA_RULES = [
     # plan writes
     _rule("tools", "todo_write", PermissionLevel.ALLOW),
     _rule("tools", "todo_update", PermissionLevel.ALLOW),
-    # generation finalize helpers
-    _rule("semantic_tools", "end_*_generation", PermissionLevel.ALLOW),
     _rule("semantic_tools", "validate_semantic", PermissionLevel.ALLOW),
-    _rule("semantic_tools", "generate_*_id", PermissionLevel.ALLOW),
     # bi write (excluding delete_*, which stays DENY from NORMAL via earlier rule)
     _rule("bi_tools", "create_*", PermissionLevel.ALLOW),
     _rule("bi_tools", "update_*", PermissionLevel.ALLOW),

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -44,6 +44,8 @@ class TestNormalProfile:
         assert _resolve(config, "db_tools", "list_tables") == PermissionLevel.ALLOW
         assert _resolve(config, "bi_tools", "list_dashboards") == PermissionLevel.ALLOW
         assert _resolve(config, "filesystem_tools", "read_file") == PermissionLevel.ALLOW
+        assert _resolve(config, "filesystem_tools", "glob") == PermissionLevel.ALLOW
+        assert _resolve(config, "filesystem_tools", "grep") == PermissionLevel.ALLOW
 
     def test_writes_ask(self):
         """Normal ASKs on all write-ish tools via default_permission."""
@@ -59,10 +61,11 @@ class TestNormalProfile:
         assert _resolve(config, "bi_tools", "delete_chart") == PermissionLevel.DENY
         assert _resolve(config, "scheduler_tools", "delete_job") == PermissionLevel.DENY
 
-    def test_mcp_and_skills_ask(self):
+    def test_mcp_asks_skill_loading_allowed(self):
         config = NORMAL
         assert _resolve(config, "mcp.filesystem", "read_file") == PermissionLevel.ASK
-        assert _resolve(config, "skills", "any-skill") == PermissionLevel.ASK
+        assert _resolve(config, "skills", "any-skill") == PermissionLevel.ALLOW
+        assert _resolve(config, "skills", "skill_execute_command") == PermissionLevel.ASK
 
     def test_sub_agent_delegation_allowed(self):
         """``task()`` delegation is ALLOW — the subagent's own hooks gate its calls."""
@@ -85,8 +88,24 @@ class TestNormalProfile:
         assert _resolve(config, "tools", "list_document_nav") == PermissionLevel.ALLOW
         assert _resolve(config, "tools", "search_document") == PermissionLevel.ALLOW
         assert _resolve(config, "tools", "get_anything") == PermissionLevel.ALLOW
+        assert _resolve(config, "tools", "validate_skill") == PermissionLevel.ALLOW
         # Writes still ASK via default.
         assert _resolve(config, "tools", "todo_write") == PermissionLevel.ASK
+
+    def test_generation_helpers_allowed(self):
+        """GenerationTools helpers ride the ``semantic_tools`` category and
+        should not trigger permission prompts in normal mode."""
+        config = NORMAL
+        assert _resolve(config, "semantic_tools", "check_semantic_object_exists") == PermissionLevel.ALLOW
+        assert _resolve(config, "semantic_tools", "generate_sql_summary_id") == PermissionLevel.ALLOW
+        assert _resolve(config, "semantic_tools", "end_semantic_model_generation") == PermissionLevel.ALLOW
+        assert _resolve(config, "semantic_tools", "end_metric_generation") == PermissionLevel.ALLOW
+
+    def test_all_semantic_tools_allowed(self):
+        config = NORMAL
+        assert _resolve(config, "semantic_tools", "validate_semantic") == PermissionLevel.ALLOW
+        assert _resolve(config, "semantic_tools", "attribution_analyze") == PermissionLevel.ALLOW
+        assert _resolve(config, "semantic_tools", "future_semantic_tool") == PermissionLevel.ALLOW
 
 
 class TestAutoProfile:
@@ -125,10 +144,11 @@ class TestAutoProfile:
         assert _resolve(config, "db_tools", "execute_write") == PermissionLevel.ASK
         assert _resolve(config, "db_tools", "transfer_query_result") == PermissionLevel.ASK
 
-    def test_mcp_and_skills_still_ask(self):
+    def test_mcp_still_asks_skill_loading_allowed(self):
         config = AUTO
         assert _resolve(config, "mcp.filesystem", "read_file") == PermissionLevel.ASK
-        assert _resolve(config, "skills", "any-skill") == PermissionLevel.ASK
+        assert _resolve(config, "skills", "any-skill") == PermissionLevel.ALLOW
+        assert _resolve(config, "skills", "skill_execute_command") == PermissionLevel.ASK
 
 
 class TestDangerousProfile:


### PR DESCRIPTION
## Why

The normal permission profile was prompting for several benign helper tools during semantic generation, skill loading, skill validation, and local file discovery. These prompts interrupted common workflows even though the operations are read-only or validation-oriented.

## Solution

Allow semantic tools broadly in the normal profile, including generation finalizers and validation helpers. Allow skill loading while keeping skill command execution gated behind ASK. Allow filesystem glob/grep and validate_skill so discovery and skill authoring checks do not prompt. Updated the profile tests to lock in the new normal and auto behavior.

## Test Cases

- `pytest tests/unit_tests/tools/permission/test_profiles.py`

No integration/nightly tests were added because this change only updates permission profile rule resolution and is covered by focused unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded permissions for semantic tools and filesystem operations.
  * Refined skill execution permission behavior to allow skill loading while maintaining security controls on command execution.
  * Enhanced permission validation for tool access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->