### PR TITLE
[Feature] Add /effort slash command with reasoning gate for DeepSeek/Kimi thinking

### DIFF
--- a/datus/cli/effort_app.py
+++ b/datus/cli/effort_app.py
@@ -1,0 +1,233 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Self-contained ``/effort`` picker rendered as a single prompt_toolkit
+:class:`Application`.
+
+Two-step flow:
+1. Pick a reasoning effort level (``off|minimal|low|medium|high``).
+2. Pick a persistence scope (*project* or *global*).
+
+Runs inside one Application so the outer TUI only needs to release
+``stdin`` once via :meth:`DatusApp.suspend_input`.  Visual style mirrors
+:class:`datus.cli.language_app.LanguageApp`.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.layout.containers import HSplit, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from rich.console import Console
+
+from datus.cli.cli_styles import CLR_CURRENT, CLR_CURSOR, SYM_ARROW, print_error, render_tui_title_bar
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+EFFORT_CHOICES: Dict[str, str] = {
+    "off": "Disable reasoning (no thinking)",
+    "minimal": "Minimal effort (fast, gpt-5 family)",
+    "low": "Low effort",
+    "medium": "Medium effort (balanced)",
+    "high": "High effort (deep reasoning)",
+}
+
+SCOPE_CHOICES: Dict[str, str] = {
+    "project": ".datus/config.yml (this project only)",
+    "global": "agent.yml (all projects)",
+}
+
+
+class _Phase(Enum):
+    EFFORT = "effort"
+    SCOPE = "scope"
+
+
+@dataclass
+class EffortSelection:
+    """Outcome of an :class:`EffortApp` run.
+
+    ``code`` is the selected effort level (``off|minimal|low|medium|high``).
+    ``scope`` is ``"project"`` or ``"global"``.
+    """
+
+    code: str
+    scope: str = "project"
+
+
+class EffortApp:
+    """Two-step effort picker: level -> persistence scope.
+
+    The caller wraps ``app.run()`` in ``tui_app.suspend_input()`` when the
+    REPL is in TUI mode. Returns ``None`` on cancel (Escape / Ctrl-C).
+    """
+
+    def __init__(
+        self,
+        console: Console,
+        current_effort: str = "",
+        current_source: str = "not set",
+        scope_only: Optional[str] = None,
+    ):
+        self._console = console
+        self._current = current_effort
+        self._current_source = current_source
+
+        self._effort_keys: List[str] = list(EFFORT_CHOICES.keys())
+        self._scope_keys: List[str] = list(SCOPE_CHOICES.keys())
+        self._effort_idx: int = self._default_effort_index()
+        self._scope_idx: int = 0
+
+        # title bar(1) + header(2) + 2 separators + footer = 6 lines of chrome
+        term_height = shutil.get_terminal_size((120, 40)).lines
+        self._max_visible: int = max(3, min(10, term_height - 6))
+
+        if scope_only is not None:
+            self._phase = _Phase.SCOPE
+            self._selected_code = scope_only
+        else:
+            self._phase = _Phase.EFFORT
+            self._selected_code = ""
+
+        self._app = self._build_app()
+
+    def run(self) -> Optional[EffortSelection]:
+        try:
+            return self._app.run()
+        except KeyboardInterrupt:
+            return None
+        except Exception as exc:
+            logger.error("EffortApp crashed: %s", exc)
+            print_error(self._console, f"/effort error: {exc}")
+            return None
+
+    def _default_effort_index(self) -> int:
+        if self._current in self._effort_keys:
+            return self._effort_keys.index(self._current)
+        return self._effort_keys.index("medium")
+
+    def _build_app(self) -> Application:
+        kb = KeyBindings()
+
+        @kb.add("up")
+        def _up(event):
+            if self._phase == _Phase.EFFORT:
+                total = len(self._effort_keys)
+                self._effort_idx = (self._effort_idx - 1) % total
+            else:
+                self._scope_idx = max(0, self._scope_idx - 1)
+
+        @kb.add("down")
+        def _down(event):
+            if self._phase == _Phase.EFFORT:
+                total = len(self._effort_keys)
+                self._effort_idx = (self._effort_idx + 1) % total
+            else:
+                self._scope_idx = min(len(self._scope_keys) - 1, self._scope_idx + 1)
+
+        @kb.add("enter")
+        def _enter(event):
+            if self._phase == _Phase.EFFORT:
+                self._selected_code = self._effort_keys[self._effort_idx]
+                self._phase = _Phase.SCOPE
+                self._scope_idx = 0
+            else:
+                scope = self._scope_keys[self._scope_idx]
+                event.app.exit(EffortSelection(code=self._selected_code, scope=scope))
+
+        @kb.add("escape")
+        def _escape(event):
+            event.app.exit(None)
+
+        @kb.add("c-c")
+        def _ctrl_c(event):
+            event.app.exit(None)
+
+        header_window = Window(
+            content=FormattedTextControl(self._render_header, focusable=False),
+            height=Dimension(min=1, max=2),
+        )
+
+        list_window = Window(
+            content=FormattedTextControl(self._render_list, focusable=True),
+            always_hide_cursor=True,
+            height=Dimension(min=3),
+        )
+
+        hint_window = Window(
+            content=FormattedTextControl(self._render_footer_hint, focusable=False),
+            height=1,
+        )
+
+        title_bar = Window(
+            content=FormattedTextControl(lambda: render_tui_title_bar("Reasoning Effort")),
+            height=1,
+        )
+
+        root = HSplit(
+            [
+                title_bar,
+                header_window,
+                Window(height=1, char="\u2500"),
+                list_window,
+                Window(height=1, char="\u2500"),
+                hint_window,
+            ]
+        )
+
+        return Application(
+            layout=Layout(root, focused_element=list_window),
+            key_bindings=kb,
+            full_screen=False,
+            mouse_support=False,
+            erase_when_done=True,
+        )
+
+    def _render_header(self) -> List[Tuple[str, str]]:
+        lines: List[Tuple[str, str]] = []
+        if self._phase == _Phase.EFFORT:
+            lines.append(("bold", "  Select reasoning effort"))
+            if self._current:
+                lines.append(("", f"  [current: {self._current}, source: {self._current_source}]"))
+            else:
+                lines.append(("", "  [current: not set (model defaults apply)]"))
+        else:
+            lines.append(("bold", f"  Save '{self._selected_code}' to"))
+        return lines
+
+    def _render_list(self) -> List[Tuple[str, str]]:
+        lines: List[Tuple[str, str]] = []
+        if self._phase == _Phase.EFFORT:
+            for i, key in enumerate(self._effort_keys):
+                label = f"{key:<8} {EFFORT_CHOICES[key]}"
+                is_current = key == self._current
+                if is_current:
+                    label += "  \u2190 current"
+                if i == self._effort_idx:
+                    lines.append((CLR_CURSOR, f"  {SYM_ARROW} {label}\n"))
+                elif is_current:
+                    lines.append((CLR_CURRENT, f"    {label}\n"))
+                else:
+                    lines.append(("", f"    {label}\n"))
+        else:
+            for i, key in enumerate(self._scope_keys):
+                label = f"{key:<10} {SCOPE_CHOICES[key]}"
+                if i == self._scope_idx:
+                    lines.append((CLR_CURSOR, f"  {SYM_ARROW} {label}\n"))
+                else:
+                    lines.append(("", f"    {label}\n"))
+        return lines
+
+    def _render_footer_hint(self) -> List[Tuple[str, str]]:
+        return [("", "  \u2191\u2193 navigate   Enter select   Esc cancel")]

--- a/datus/cli/effort_app.py
+++ b/datus/cli/effort_app.py
@@ -16,7 +16,6 @@ Runs inside one Application so the outer TUI only needs to release
 
 from __future__ import annotations
 
-import shutil
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Tuple
@@ -88,10 +87,6 @@ class EffortApp:
         self._scope_keys: List[str] = list(SCOPE_CHOICES.keys())
         self._effort_idx: int = self._default_effort_index()
         self._scope_idx: int = 0
-
-        # title bar(1) + header(2) + 2 separators + footer = 6 lines of chrome
-        term_height = shutil.get_terminal_size((120, 40)).lines
-        self._max_visible: int = max(3, min(10, term_height - 6))
 
         if scope_only is not None:
             self._phase = _Phase.SCOPE

--- a/datus/cli/effort_commands.py
+++ b/datus/cli/effort_commands.py
@@ -1,0 +1,225 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""``/effort`` slash command — set or show the reasoning effort level.
+
+Entry point
+-----------
+
+  - ``/effort``                      — open the interactive picker.
+  - ``/effort high``                 — choose scope interactively (project/global).
+  - ``/effort high --project``       — persist to .datus/config.yml.
+  - ``/effort high --global``        — persist to agent.yml (top-level).
+  - ``/effort off``                  — disable reasoning (shortcut for ``low/medium/high``=off).
+  - ``/effort --clear``              — remove project-level override.
+  - ``/effort status``               — print the effective level and its source.
+
+Effort values accepted: ``off|minimal|low|medium|high``. The level is mapped
+by LiteLLM to each provider's native dialect (OpenAI ``reasoning_effort``,
+Anthropic ``thinking.budget_tokens``, Gemini ``thinking_config.thinking_budget``,
+etc.), so a single knob covers every provider Datus supports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from datus.cli.cli_styles import print_error, print_info, print_success
+from datus.cli.effort_app import EFFORT_CHOICES, EffortApp, EffortSelection
+from datus.configuration.project_config import (
+    REASONING_EFFORT_CHOICES,
+    ProjectOverride,
+    load_project_override,
+    save_project_override,
+)
+from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from datus.cli.repl import DatusCLI
+
+logger = get_logger(__name__)
+
+
+class EffortCommands:
+    """Handlers for the ``/effort`` slash command."""
+
+    def __init__(self, cli: "DatusCLI"):
+        self.cli = cli
+        self.console = cli.console
+        self.agent_config = cli.agent_config
+
+    def cmd_effort(self, args: str) -> None:
+        """Dispatch ``/effort`` based on its argument shape."""
+        tokens = args.strip().split()
+        flag_global = "--global" in tokens
+        flag_project = "--project" in tokens
+        flag_clear = "--clear" in tokens
+        value_tokens = [t for t in tokens if not t.startswith("--")]
+        value = value_tokens[0].strip().lower() if value_tokens else ""
+
+        if value == "status":
+            self._status()
+            return
+
+        if flag_clear:
+            self._clear_project()
+            return
+
+        if not value and not flag_global and not flag_project:
+            self._run_interactive()
+            return
+
+        if value and value not in REASONING_EFFORT_CHOICES:
+            print_error(
+                self.console,
+                f"Invalid effort '{value}'. Expected one of {sorted(REASONING_EFFORT_CHOICES)}.",
+            )
+            return
+
+        if flag_global:
+            self._save_global(value)
+        elif flag_project:
+            self._save_project(value)
+        else:
+            selection = self._run_scope_picker(value)
+            if selection is None:
+                return
+            if selection.scope == "global":
+                self._save_global(selection.code)
+            else:
+                self._save_project(selection.code)
+
+    def _run_interactive(self) -> None:
+        current, source = self._current_effort()
+        app = EffortApp(
+            console=self.console,
+            current_effort=current,
+            current_source=source,
+        )
+        selection = self._run_app(app)
+        if selection is None:
+            return
+        if selection.scope == "global":
+            self._save_global(selection.code)
+        else:
+            self._save_project(selection.code)
+
+    def _run_scope_picker(self, code: str) -> Optional[EffortSelection]:
+        """Run a scope-only picker for direct ``/effort <level>`` invocations."""
+        app = EffortApp(
+            console=self.console,
+            current_effort=code,
+            current_source="",
+            scope_only=code,
+        )
+        return self._run_app(app)
+
+    def _run_app(self, app: EffortApp) -> Optional[EffortSelection]:
+        tui_app = getattr(self.cli, "tui_app", None)
+        if tui_app is not None:
+            with tui_app.suspend_input():
+                return app.run()
+        return app.run()
+
+    def _save_global(self, effort: str) -> None:
+        """Write the effort level to the top-level ``agent.reasoning_effort``.
+
+        Project-level ``./.datus/config.yml`` still wins at ``active_model()``
+        time, so global scope behaves as a default across all projects.
+        """
+        self.cli.configuration_manager.update_item("reasoning_effort", effort)
+        # Sync the in-memory override only if there is no project-level entry
+        # already taking precedence; otherwise the project value would appear
+        # to be shadowed mid-session even though it still wins on reload.
+        override = load_project_override()
+        project_effort = override.reasoning_effort if override else None
+        if project_effort is None:
+            self.agent_config.set_active_reasoning_effort(effort, persist=False)
+        print_success(self.console, f"Reasoning effort set to '{effort}' (saved to agent.yml)")
+        if project_effort is not None:
+            print_info(
+                self.console,
+                f"Note: project-level override '{project_effort}' still takes precedence in this project.",
+            )
+
+    def _save_project(self, effort: str) -> None:
+        override = load_project_override() or ProjectOverride()
+        override.reasoning_effort = effort
+        path = save_project_override(override)
+        self.agent_config.set_active_reasoning_effort(effort, persist=False)
+        print_success(self.console, f"Reasoning effort set to '{effort}' (saved to {path})")
+
+    def _clear_project(self) -> None:
+        override = load_project_override()
+        if override and override.reasoning_effort is not None:
+            override.reasoning_effort = None
+            save_project_override(override)
+        # Fall back to the global value from agent.yml, if any.
+        global_value = self.cli.configuration_manager.get("reasoning_effort") or None
+        self.agent_config.set_active_reasoning_effort(global_value, persist=False)
+        if global_value:
+            print_success(
+                self.console,
+                f"Project reasoning_effort cleared. Falling back to global: '{global_value}'.",
+            )
+        else:
+            print_success(
+                self.console,
+                "Project reasoning_effort cleared. No global default; model-level settings apply.",
+            )
+
+    def _status(self) -> None:
+        effective, source = self._current_effort()
+        if effective:
+            label = EFFORT_CHOICES.get(effective, effective)
+            print_info(self.console, f"Reasoning effort: {effective} — {label} (source: {source})")
+        else:
+            print_info(self.console, "Reasoning effort: not set (model-level settings apply).")
+        self._print_model_capability()
+
+    def _print_model_capability(self) -> None:
+        """Show whether the active model can actually consume a reasoning hint.
+
+        Queries ``litellm.supports_reasoning`` for the active model so users
+        immediately see when ``/effort`` will no-op against a non-reasoning
+        model. Silent on any failure so ``/effort status`` never crashes on
+        a half-configured setup.
+        """
+        try:
+            model_config = self.agent_config.active_model()
+            model_name = getattr(model_config, "model", "")
+            provider = getattr(model_config, "type", "") or None
+        except Exception:
+            return
+        if not model_name:
+            return
+        try:
+            import litellm
+
+            supports = bool(litellm.supports_reasoning(model=model_name, custom_llm_provider=provider))
+        except Exception:
+            return
+        print_info(
+            self.console,
+            f"Active model '{model_name}' supports reasoning (per LiteLLM): {'yes' if supports else 'no'}",
+        )
+
+    def _current_effort(self) -> tuple[str, str]:
+        """Return ``(effort, source)`` where source is project/global/model/off."""
+        override = load_project_override()
+        project_effort = override.reasoning_effort if override else None
+        if project_effort:
+            return project_effort, "project"
+        global_effort = self.cli.configuration_manager.get("reasoning_effort") or ""
+        if global_effort:
+            return str(global_effort), "global"
+        try:
+            model_config = self.agent_config.active_model()
+        except Exception:
+            return "", "not set"
+        if model_config.reasoning_effort:
+            return model_config.reasoning_effort, "model"
+        if model_config.enable_thinking:
+            return "medium", "model (enable_thinking=true)"
+        return "", "not set"

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -50,6 +50,7 @@ from datus.cli.bi_dashboard import BiDashboardCommands
 from datus.cli.chat_commands import ChatCommands
 from datus.cli.cli_styles import PASTE_COLLAPSE_THRESHOLD, print_error, print_info, print_success, print_warning
 from datus.cli.context_commands import ContextCommands
+from datus.cli.effort_commands import EffortCommands
 from datus.cli.language_commands import LanguageCommands
 from datus.cli.list_selector_app import ListItem, ListSelectorApp
 from datus.cli.metadata_commands import MetadataCommands
@@ -237,6 +238,7 @@ class DatusCLI:
         self.bi_dashboard_commands = BiDashboardCommands(self)
         self.model_commands = ModelCommands(self)
         self.language_commands = LanguageCommands(self)
+        self.effort_commands = EffortCommands(self)
         self.service_commands = ServiceCommands(self)
         from datus.cli.datasource_commands import DatasourceCommands
 
@@ -313,6 +315,7 @@ class DatusCLI:
             "skill": self._cmd_skill,
             "bootstrap-bi": self.bi_dashboard_commands.cmd,
             "model": self.model_commands.cmd_model,
+            "effort": self.effort_commands.cmd_effort,
             "services": self.service_commands.cmd_services,
             "profile": self._cmd_profile,
         }

--- a/datus/cli/slash_registry.py
+++ b/datus/cli/slash_registry.py
@@ -81,6 +81,7 @@ SLASH_COMMANDS: tuple[SlashSpec, ...] = (
     SlashSpec("skill", "Manage skills and marketplace (list/install/publish/...)", "system"),
     SlashSpec("bootstrap-bi", "Extract BI dashboard assets for sub-agent context", "system"),
     SlashSpec("model", "Switch LLM provider/model", "system", aliases=("models",)),
+    SlashSpec("effort", "Set reasoning effort (off|minimal|low|medium|high)", "system"),
     SlashSpec("services", "List configured service platforms and their read-only methods", "system"),
     SlashSpec(
         "profile",

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -206,7 +206,10 @@ class ModelConfig:
     model: str
     base_url: Optional[str] = None
     save_llm_trace: bool = False
-    enable_thinking: bool = False  # Set True to enable thinking/reasoning mode
+    enable_thinking: bool = False  # Legacy bool switch; True is equivalent to reasoning_effort="medium".
+    # Reasoning depth for thinking-capable models. Values: off|minimal|low|medium|high.
+    # None defers to enable_thinking; LiteLLM maps the level to each vendor's dialect.
+    reasoning_effort: Optional[str] = None
     strict_json_schema: bool = True  # Enable strict JSON schema mode for structured output
     default_headers: Optional[Dict[str, str]] = None
     # Retry configuration for stream connection errors
@@ -458,6 +461,15 @@ class AgentConfig:
         # instead of indexing ``agent.models``.
         self._target_provider: Optional[str] = kwargs.get("target_provider") or None
         self._target_model: Optional[str] = kwargs.get("target_model") or None
+        # Reasoning effort override. ``target_reasoning_effort`` comes from
+        # ``./.datus/config.yml`` (project scope) and wins over the
+        # ``reasoning_effort`` top-level field in ``agent.yml`` (global
+        # default). When set, it replaces the value resolved from
+        # ``providers.yml.model_overrides`` or ``agent.models`` regardless of
+        # which dispatch path ``active_model()`` takes.
+        self._target_reasoning_effort: Optional[str] = (
+            kwargs.get("target_reasoning_effort") or kwargs.get("reasoning_effort") or None
+        )
         # Shared lazily-loaded ``conf/providers.yml`` catalog (metadata only:
         # default_model, base_url, api_key_env, type, model_overrides). Kept
         # as ``None`` until first access so tests that stub load paths can
@@ -1193,9 +1205,9 @@ class AgentConfig:
         existing call sites that index the return value directly.
         """
         if self._target_provider and self._target_model:
-            return self._synthesize_model(self._target_provider, self._target_model)
+            return self._apply_reasoning_override(self._synthesize_model(self._target_provider, self._target_model))
         if self.target and self.target in self.models:
-            return self.models[self.target]
+            return self._apply_reasoning_override(self.models[self.target])
         raise DatusException(
             code=ErrorCode.COMMON_FIELD_REQUIRED,
             message=(
@@ -1273,7 +1285,7 @@ class AgentConfig:
         model_kwargs: Dict[str, Any] = {}
         overrides = overrides_catalog.get(model_name, {}) if isinstance(overrides_catalog, dict) else {}
         if isinstance(overrides, dict):
-            for key in ("temperature", "top_p", "enable_thinking"):
+            for key in ("temperature", "top_p", "enable_thinking", "reasoning_effort"):
                 if key in overrides:
                     model_kwargs[key] = overrides[key]
 
@@ -1285,6 +1297,58 @@ class AgentConfig:
             auth_type=auth_type,
             **model_kwargs,
         )
+
+    def _apply_reasoning_override(self, config: ModelConfig) -> ModelConfig:
+        """Project-level ``reasoning_effort`` wins over catalog/agent.yml values.
+
+        Returns the same ``ModelConfig`` with ``reasoning_effort`` replaced by
+        :attr:`_target_reasoning_effort` when it is set. When the override is
+        ``"off"``, ``enable_thinking`` is also cleared so the legacy bool does
+        not reawaken reasoning via the adapter's fallback. Mutating the object
+        in place keeps the cached ``agent.models[name]`` entry coherent with
+        the active target, which matches how ``/model`` already reuses that
+        same instance across calls.
+        """
+        override = self._target_reasoning_effort
+        if override is None:
+            return config
+        config.reasoning_effort = override
+        if override == "off":
+            config.enable_thinking = False
+        return config
+
+    def set_active_reasoning_effort(self, effort: Optional[str], persist: bool = True) -> None:
+        """Switch the runtime reasoning effort level.
+
+        ``effort`` is one of ``off|minimal|low|medium|high``; ``None`` clears
+        the project override so the active model falls back to catalog
+        defaults or ``enable_thinking`` in ``agent.yml``. When ``persist`` is
+        ``True`` (default), writes the change to ``./.datus/config.yml`` so
+        the choice survives process restarts.
+        """
+        if effort is not None:
+            effort = effort.strip().lower()
+            from datus.configuration.project_config import REASONING_EFFORT_CHOICES
+
+            if effort not in REASONING_EFFORT_CHOICES:
+                raise DatusException(
+                    code=ErrorCode.COMMON_FIELD_INVALID,
+                    message=(
+                        f"Invalid reasoning_effort '{effort}'. Expected one of {sorted(REASONING_EFFORT_CHOICES)}."
+                    ),
+                )
+        self._target_reasoning_effort = effort
+        if not persist:
+            return
+        from datus.configuration.project_config import (
+            ProjectOverride,
+            load_project_override,
+            save_project_override,
+        )
+
+        current = load_project_override(cwd=str(self._project_root)) or ProjectOverride()
+        current.reasoning_effort = effort
+        save_project_override(current, cwd=str(self._project_root))
 
     def set_active_provider_model(self, provider: str, model: str, persist: bool = True) -> None:
         """Switch the active LLM to ``<provider>/<model>`` at runtime.

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -273,6 +273,8 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         agent_raw["project_name"] = override.project_name
     if override.language is not None:
         agent_raw["language"] = override.language
+    if override.reasoning_effort is not None:
+        agent_raw["target_reasoning_effort"] = override.reasoning_effort
 
 
 def load_agent_config(reload: bool = False, create_if_missing: bool = False, **kwargs) -> AgentConfig:

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -18,6 +18,9 @@ pin a handful of values without copying the full config:
   match a key under ``agent.services.datasources``)
 - ``project_name``: shard name for ``~/.datus/sessions/{project_name}/``
   and ``~/.datus/data/{project_name}/`` (optional)
+- ``reasoning_effort``: one of ``off|minimal|low|medium|high`` — controls the
+  reasoning/thinking effort passed to the active model, mapped to each
+  vendor's native dialect by LiteLLM.
 
 Any other keys in the file are ignored with a warning so users do not
 mistakenly expect the overlay to accept arbitrary YAML.
@@ -35,7 +38,8 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 PROJECT_CONFIG_REL = ".datus/config.yml"
-ALLOWED_KEYS = frozenset({"target", "default_datasource", "project_name", "language"})
+ALLOWED_KEYS = frozenset({"target", "default_datasource", "project_name", "language", "reasoning_effort"})
+REASONING_EFFORT_CHOICES = frozenset({"off", "minimal", "low", "medium", "high"})
 
 
 @dataclass
@@ -60,12 +64,15 @@ class ProjectOverride:
     ``None`` means "not specified — fall back to base agent.yml".
     ``target`` may be a legacy string (``agent.models`` key) or a
     :class:`ProjectTarget` describing a provider-level entry.
+    ``reasoning_effort`` accepts ``off|minimal|low|medium|high``; any other
+    string is dropped by :func:`load_project_override` with a warning.
     """
 
     target: Optional[Union[str, ProjectTarget]] = None
     default_datasource: Optional[str] = None
     project_name: Optional[str] = None
     language: Optional[str] = None
+    reasoning_effort: Optional[str] = None
 
     def is_empty(self) -> bool:
         return (
@@ -73,6 +80,7 @@ class ProjectOverride:
             and self.default_datasource is None
             and self.project_name is None
             and self.language is None
+            and self.reasoning_effort is None
         )
 
 
@@ -144,7 +152,31 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         default_datasource=raw.get("default_datasource"),
         project_name=raw.get("project_name"),
         language=raw.get("language"),
+        reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
     )
+
+
+def _parse_reasoning_effort(raw: Any) -> Optional[str]:
+    """Normalize the ``reasoning_effort:`` field from raw YAML.
+
+    Accepts any case-insensitive string in :data:`REASONING_EFFORT_CHOICES`;
+    anything else is dropped with a warning so typos do not silently change
+    behaviour. ``None`` means "not specified — fall back to base agent.yml".
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        logger.warning(f"reasoning_effort must be a string, got {type(raw).__name__}. Ignoring.")
+        return None
+    value = raw.strip().lower()
+    if not value:
+        return None
+    if value not in REASONING_EFFORT_CHOICES:
+        logger.warning(
+            f"Ignoring invalid reasoning_effort '{raw}'. Expected one of {sorted(REASONING_EFFORT_CHOICES)}."
+        )
+        return None
+    return value
 
 
 def _target_to_yaml(target: Optional[Union[str, ProjectTarget]]) -> Any:
@@ -175,6 +207,7 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
             "default_datasource": override.default_datasource,
             "project_name": override.project_name,
             "language": override.language,
+            "reasoning_effort": override.reasoning_effort,
         }.items()
         if v is not None
     }

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -130,11 +130,11 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
     the whitelist is enforced rather than silently ignoring typos.
     """
     path = project_config_path(cwd)
-    if not path.exists():
-        return None
     try:
         with open(path, "r", encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return None
     except yaml.YAMLError as e:
         logger.warning(f"Failed to parse {path}: {e}. Treating as no override.")
         return None

--- a/datus/models/base.py
+++ b/datus/models/base.py
@@ -115,6 +115,11 @@ class LLMBaseModel(ABC):  # Changed from BaseModel to LLMBaseModel
             api_key_digest,
             target_config.auth_type,
             scope or "",
+            # Include reasoning-related fields so ``/effort`` and a toggled
+            # ``enable_thinking`` produce a fresh adapter instead of reusing
+            # one bound to the previous effort level.
+            bool(target_config.enable_thinking),
+            target_config.reasoning_effort or "",
         )
 
         with cls._MODEL_CACHE_LOCK:

--- a/datus/models/litellm_adapter.py
+++ b/datus/models/litellm_adapter.py
@@ -24,6 +24,56 @@ logger = get_logger(__name__)
 # Note: SDK patches are applied in datus/models/__init__.py to ensure
 # they are applied before any agents SDK usage
 
+# Datus-maintained DENY-list of DeepSeek/Moonshot models that are known NOT to
+# support thinking/reasoning. Everything else in these two providers defaults
+# to "supports reasoning" so that future releases (DeepSeek V5, Kimi K3, …)
+# receive ``reasoning_effort`` and the native ``thinking`` switch without
+# waiting for a config edit.
+#
+# Why a deny-list (not allow-list):
+# - Every new LLM release in 2025+ ships thinking; the exceptions are legacy
+#   lines that the vendor explicitly keeps non-reasoning (DeepSeek-Chat,
+#   Moonshot-v1 classic, the bare ``kimi-k2`` non-thinking fork).
+# - LiteLLM's built-in capability table lags behind Chinese providers, so
+#   ``litellm.supports_reasoning`` returns False for many thinking models.
+#   Defaulting to "supported" compensates for that drift.
+#
+# Sources (verified 2026-04):
+# - DeepSeek: https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
+# - Moonshot/Kimi: https://platform.kimi.com/docs/api/models-overview
+#
+# Matching rules:
+# - Entries ending in ``*`` are prefix-matched (``moonshot-v1*`` covers
+#   ``moonshot-v1-8k``, ``moonshot-v1-32k``, ``moonshot-v1-128k``, ...).
+# - Plain entries are compared by exact equality so ``kimi-k2`` does NOT
+#   accidentally match ``kimi-k2.5``, ``kimi-k2.6``, or ``kimi-k2-thinking``.
+NON_THINKING_MODEL_RULES: Dict[str, tuple[str, ...]] = {
+    "deepseek": ("deepseek-chat",),
+    "kimi": ("moonshot-v1*", "kimi-k2"),
+}
+
+
+def is_known_non_thinking_model(provider: Optional[str], model_name: Optional[str]) -> bool:
+    """Return True only when the (provider, model) is on the deny-list.
+
+    Unknown models — including every entry outside DeepSeek and Kimi, and every
+    new release not explicitly listed — return False, which lets the caller
+    treat them as thinking-capable.
+    """
+    if not provider or not model_name:
+        return False
+    rules = NON_THINKING_MODEL_RULES.get(provider.lower())
+    if not rules:
+        return False
+    name = model_name.lower()
+    for rule in rules:
+        if rule.endswith("*"):
+            if name.startswith(rule[:-1].lower()):
+                return True
+        elif name == rule.lower():
+            return True
+    return False
+
 
 class LiteLLMAdapter:
     """
@@ -109,6 +159,7 @@ class LiteLLMAdapter:
         api_key: str,
         base_url: Optional[str] = None,
         enable_thinking: bool = False,
+        reasoning_effort: Optional[str] = None,
         default_headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -119,7 +170,9 @@ class LiteLLMAdapter:
             model: The model name (e.g., gpt-4o, claude-sonnet-4, kimi-k2.5)
             api_key: API key for the provider
             base_url: Optional custom base URL (overrides default)
-            enable_thinking: Whether to enable thinking/reasoning mode (default: False)
+            enable_thinking: Legacy bool switch; True is equivalent to reasoning_effort="medium".
+            reasoning_effort: One of off|minimal|low|medium|high. Takes precedence
+                over ``enable_thinking`` when set; ``None`` defers to the bool.
             default_headers: Optional custom HTTP headers (e.g., User-Agent for Coding Plan endpoints)
         """
         # Auto-detect provider from model name if provider is generic
@@ -129,6 +182,7 @@ class LiteLLMAdapter:
         self.api_key = api_key
         self.base_url = base_url or self.DEFAULT_BASE_URLS.get(self.provider)
         self._enable_thinking = enable_thinking
+        self._reasoning_effort = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
         self.default_headers = default_headers
         self._litellm_model_name = None
 
@@ -247,23 +301,83 @@ class LiteLLMAdapter:
         return f"{prefix}{self.model}"
 
     @property
+    def reasoning_effort_level(self) -> Optional[str]:
+        """Resolved reasoning effort level or ``None`` when disabled.
+
+        Priority: explicit ``reasoning_effort`` (except ``"off"``) wins; a
+        legacy ``enable_thinking=True`` falls back to ``"medium"`` to keep
+        existing configs working; otherwise reasoning is off. LiteLLM maps
+        the returned level into each vendor's dialect (OpenAI
+        ``reasoning_effort``, Anthropic ``thinking.budget_tokens``, Gemini
+        ``thinking_config.thinking_budget``, etc.).
+        """
+        if self._reasoning_effort == "off":
+            return None
+        if self._reasoning_effort:
+            return self._reasoning_effort
+        if self._enable_thinking:
+            return "medium"
+        return None
+
+    @property
     def is_thinking_model(self) -> bool:
         """
-        Check if thinking/reasoning mode is explicitly enabled for this model.
+        Check if thinking/reasoning mode is active for this model.
 
-        When enabled, the model returns reasoning_content in responses and needs
-        special handling to preserve thinking blocks in multi-turn conversations.
-
-        Disabled by default. Set enable_thinking: true in config to enable.
+        True when :attr:`reasoning_effort_level` resolves to a non-None level.
+        When enabled, the model returns reasoning_content in responses and
+        needs special handling to preserve thinking blocks in multi-turn
+        conversations.
         """
-        return bool(self._enable_thinking)
+        return self.reasoning_effort_level is not None
+
+    def _is_official_openai(self) -> bool:
+        """True when this adapter targets the canonical OpenAI API host.
+
+        The Responses API (``/v1/responses``) is the preferred endpoint for
+        reasoning models (o-series, gpt-5*) because ``chat/completions``
+        rejects ``reasoning_effort`` alongside function tools. LiteLLM goes
+        through ``chat/completions`` by default; routing official OpenAI
+        traffic through :class:`OpenAIResponsesModel` sidesteps the
+        restriction without adding per-model branches.
+
+        ``base_url`` of ``None`` implies the OpenAI SDK default
+        (``https://api.openai.com/v1``); a custom ``base_url`` whose host is
+        not ``api.openai.com`` is treated as a third-party OpenAI-compatible
+        proxy (vLLM, OpenRouter relays, Coding Plan endpoints) and keeps the
+        LiteLLM path.
+        """
+        if self.provider != "openai":
+            return False
+        if not self.base_url:
+            return True
+        try:
+            hostname = (urlparse(self.base_url).hostname or "").lower()
+        except Exception:
+            return False
+        return hostname == "api.openai.com"
 
     def get_agents_sdk_model(self) -> "Model":
         """
         Get an openai-agents SDK compatible Model instance.
 
-        Returns a LitellmModel for all providers. Kimi/Moonshot thinking models
-        are supported via SDK patches that extend the reasoning_content handling.
+        Routing:
+
+        - **Official OpenAI** (``provider=="openai"`` and ``base_url`` on
+          ``api.openai.com``) uses :class:`OpenAIResponsesModel`, which
+          speaks the Responses API. This is the only endpoint that accepts
+          ``reasoning_effort`` together with function tools for o-series /
+          gpt-5* reasoning models.
+        - **Anthropic Claude** uses :class:`CacheControlLitellmModel` so the
+          prompt caching control markers survive the LiteLLM transform.
+        - **Every other OpenAI-compatible provider** (DeepSeek, Kimi, Qwen,
+          Gemini, OpenRouter, GLM, MiniMax, vLLM, and self-hosted proxies)
+          uses :class:`LitellmModel` as before.
+
+        Kimi/Moonshot thinking models still go through the LiteLLM path and
+        continue to rely on :mod:`datus.models.sdk_patches` for the
+        ``reasoning_content`` echo-back behaviour required on tool-calling
+        turns.
 
         Returns:
             Model instance configured for this adapter
@@ -276,7 +390,10 @@ class LiteLLMAdapter:
                 "pip install 'openai-agents[litellm]'"
             ) from err
 
-        # Build model kwargs
+        if self._is_official_openai():
+            return self._build_openai_responses_model()
+
+        # Build model kwargs for the LiteLLM path
         model_kwargs = {
             "model": self.litellm_model_name,
         }
@@ -302,6 +419,27 @@ class LiteLLMAdapter:
             return CacheControlLitellmModel(**model_kwargs)
 
         return LitellmModel(**model_kwargs)
+
+    def _build_openai_responses_model(self) -> "Model":
+        """Construct an :class:`OpenAIResponsesModel` bound to this adapter.
+
+        A fresh :class:`AsyncOpenAI` client is created per adapter instance
+        so the SDK is free to reuse HTTP connections for repeated calls
+        without leaking state between ``/model`` switches. Custom
+        ``default_headers`` flow into the client so Coding Plan-style
+        User-Agent overrides still apply on the Responses path.
+        """
+        from agents.models.openai_responses import OpenAIResponsesModel
+        from openai import AsyncOpenAI
+
+        client_kwargs: Dict[str, object] = {"api_key": self.api_key or ""}
+        if self.base_url:
+            client_kwargs["base_url"] = self.base_url
+        if self.default_headers:
+            client_kwargs["default_headers"] = self.default_headers
+        async_client = AsyncOpenAI(**client_kwargs)
+        logger.debug(f"Creating OpenAIResponsesModel for official OpenAI model={self.model}")
+        return OpenAIResponsesModel(model=self.model, openai_client=async_client)
 
     def get_completion_kwargs(self) -> dict:
         """
@@ -332,6 +470,7 @@ def create_litellm_adapter(
     api_key: str,
     base_url: Optional[str] = None,
     enable_thinking: bool = False,
+    reasoning_effort: Optional[str] = None,
     default_headers: Optional[Dict[str, str]] = None,
 ) -> LiteLLMAdapter:
     """
@@ -342,7 +481,9 @@ def create_litellm_adapter(
         model: The model name
         api_key: API key for the provider
         base_url: Optional custom base URL
-        enable_thinking: Whether to enable thinking/reasoning mode (default: False)
+        enable_thinking: Legacy bool switch; True is equivalent to reasoning_effort="medium".
+        reasoning_effort: One of off|minimal|low|medium|high; takes precedence
+            over ``enable_thinking`` when set.
         default_headers: Optional custom HTTP headers
 
     Returns:
@@ -354,5 +495,6 @@ def create_litellm_adapter(
         api_key=api_key,
         base_url=base_url,
         enable_thinking=enable_thinking,
+        reasoning_effort=reasoning_effort,
         default_headers=default_headers,
     )

--- a/datus/models/litellm_adapter.py
+++ b/datus/models/litellm_adapter.py
@@ -53,6 +53,24 @@ NON_THINKING_MODEL_RULES: Dict[str, tuple[str, ...]] = {
 }
 
 
+def is_official_openai_endpoint(provider: Optional[str], base_url: Optional[str]) -> bool:
+    """True iff ``provider`` is ``openai`` and ``base_url`` resolves to ``api.openai.com``.
+
+    A missing ``base_url`` implies the OpenAI SDK default
+    (``https://api.openai.com/v1``); any other host is treated as a third-party
+    OpenAI-compatible proxy (vLLM, OpenRouter relays, Coding Plan endpoints).
+    """
+    if provider != "openai":
+        return False
+    if not base_url:
+        return True
+    try:
+        hostname = (urlparse(base_url).hostname or "").lower()
+    except Exception:
+        return False
+    return hostname == "api.openai.com"
+
+
 def is_known_non_thinking_model(provider: Optional[str], model_name: Optional[str]) -> bool:
     """Return True only when the (provider, model) is on the deny-list.
 
@@ -340,22 +358,8 @@ class LiteLLMAdapter:
         through ``chat/completions`` by default; routing official OpenAI
         traffic through :class:`OpenAIResponsesModel` sidesteps the
         restriction without adding per-model branches.
-
-        ``base_url`` of ``None`` implies the OpenAI SDK default
-        (``https://api.openai.com/v1``); a custom ``base_url`` whose host is
-        not ``api.openai.com`` is treated as a third-party OpenAI-compatible
-        proxy (vLLM, OpenRouter relays, Coding Plan endpoints) and keeps the
-        LiteLLM path.
         """
-        if self.provider != "openai":
-            return False
-        if not self.base_url:
-            return True
-        try:
-            hostname = (urlparse(self.base_url).hostname or "").lower()
-        except Exception:
-            return False
-        return hostname == "api.openai.com"
+        return is_official_openai_endpoint(self.provider, self.base_url)
 
     def get_agents_sdk_model(self) -> "Model":
         """

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -12,7 +12,6 @@ import time
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
-from urllib.parse import urlparse
 
 import httpx
 import litellm
@@ -27,7 +26,7 @@ from pydantic import AnyUrl
 
 from datus.configuration.agent_config import ModelConfig
 from datus.models.base import LLMBaseModel
-from datus.models.litellm_adapter import LiteLLMAdapter, is_known_non_thinking_model
+from datus.models.litellm_adapter import LiteLLMAdapter, is_known_non_thinking_model, is_official_openai_endpoint
 from datus.models.mcp_result_extractors import extract_sql_contexts
 from datus.models.mcp_utils import multiple_mcp_servers
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
@@ -194,16 +193,7 @@ class OpenAICompatibleModel(LLMBaseModel):
 
     def _is_official_openai_api(self) -> bool:
         """Return True only for official OpenAI API endpoints."""
-        if self.model_config.type != "openai":
-            return False
-        if not self.base_url:
-            # When base_url is unset, the OpenAI SDK defaults to api.openai.com
-            return True
-        try:
-            hostname = (urlparse(self.base_url).hostname or "").lower()
-        except Exception:
-            return False
-        return hostname == "api.openai.com"
+        return is_official_openai_endpoint(self.model_config.type, self.base_url)
 
     def _default_prompt_cache_retention(self) -> Optional[str]:
         """Choose a safe default prompt cache retention policy for OpenAI."""

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -27,7 +27,7 @@ from pydantic import AnyUrl
 
 from datus.configuration.agent_config import ModelConfig
 from datus.models.base import LLMBaseModel
-from datus.models.litellm_adapter import LiteLLMAdapter
+from datus.models.litellm_adapter import LiteLLMAdapter, is_known_non_thinking_model
 from datus.models.mcp_result_extractors import extract_sql_contexts
 from datus.models.mcp_utils import multiple_mcp_servers
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
@@ -174,6 +174,7 @@ class OpenAICompatibleModel(LLMBaseModel):
             api_key=self.api_key,
             base_url=self.base_url,
             enable_thinking=model_config.enable_thinking,
+            reasoning_effort=model_config.reasoning_effort,
             default_headers=self.default_headers,
         )
 
@@ -211,6 +212,74 @@ class OpenAICompatibleModel(LLMBaseModel):
         if self.model_name.startswith("gpt-5.4"):
             return "24h"
         return "in_memory"
+
+    def _model_supports_reasoning(self) -> bool:
+        """Decide whether ``/effort`` should inject ``Reasoning(effort=…)``.
+
+        Authority chain (permissive by design — new models default to
+        supported, Datus only bails out when it has *positive* evidence the
+        model cannot reason):
+
+        1. Datus-maintained deny-list (:func:`is_known_non_thinking_model`)
+           kicks in first. ``deepseek-chat``, ``moonshot-v1-*`` and the bare
+           ``kimi-k2`` family are the only DeepSeek/Kimi models we treat as
+           non-reasoning; everything else in those providers defaults to
+           supported so LiteLLM's catalog lag on DeepSeek V4 / Kimi K2.x
+           doesn't mute the effort hint.
+        2. LiteLLM's built-in catalog returns ``True`` → accepted.
+        3. LiteLLM raises (unknown provider, self-hosted proxy, …) → accepted
+           under the permissive default.
+        4. LiteLLM returns ``False`` → accepted. New models routinely ship
+           before LiteLLM adds them; ``drop_params=True`` still protects the
+           request at the transport layer. ``_build_agent`` emits a ``skip``
+           warning only when branch 1 explicitly blocks.
+        """
+        provider = self.litellm_adapter.provider
+        if is_known_non_thinking_model(provider, self.model_name):
+            return False
+        try:
+            if litellm.supports_reasoning(model=self.model_name, custom_llm_provider=provider):
+                return True
+        except Exception as e:
+            logger.debug(f"litellm.supports_reasoning raised for {self.model_name}: {e}")
+        return True
+
+    def _native_thinking_extra_body(self) -> Optional[Dict[str, Any]]:
+        """Extra ``extra_body`` payload that activates DeepSeek/Moonshot thinking.
+
+        LiteLLM handles these two providers differently, and both need Datus
+        intervention to land the required fields in the HTTP body:
+
+        - **Moonshot**: its ``get_supported_openai_params`` does not list
+          ``thinking`` or ``reasoning_effort``, so under
+          ``litellm.drop_params=True`` both fields are stripped during param
+          mapping. Pushing ``thinking`` through ``extra_body`` bypasses the
+          filter because the OpenAI client merges ``extra_body`` verbatim into
+          the request body. ``reasoning_effort`` is intentionally NOT added
+          for Moonshot — Kimi K2.x does not accept it and would reject the
+          request.
+        - **DeepSeek**: its transformation *does* recognise both fields but
+          pops ``reasoning_effort`` during mapping (it only keeps ``thinking``
+          internally). Per
+          https://api-docs.deepseek.com/zh-cn/guides/thinking_mode, DeepSeek
+          requires ``reasoning_effort`` alongside ``thinking.type=enabled`` to
+          control depth. Adding ``reasoning_effort`` to ``extra_body`` re-injects
+          it into the final request body after the transformation has run.
+
+        Returns ``None`` for non-DeepSeek/Kimi providers or explicitly
+        non-thinking models (see :func:`is_known_non_thinking_model`).
+        """
+        provider = self.litellm_adapter.provider
+        if provider not in ("deepseek", "kimi"):
+            return None
+        if is_known_non_thinking_model(provider, self.model_name):
+            return None
+        body: Dict[str, Any] = {"thinking": {"type": "enabled"}}
+        if provider == "deepseek":
+            effort = self.litellm_adapter.reasoning_effort_level
+            if effort:
+                body["reasoning_effort"] = effort
+        return body
 
     def _default_prompt_cache_key(self, agent_name: str) -> Optional[str]:
         """Build a stable prompt cache key for requests with shared prefixes."""
@@ -665,9 +734,37 @@ class OpenAICompatibleModel(LLMBaseModel):
         if self.default_headers:
             model_settings_kwargs["extra_headers"] = self.default_headers
 
-        if self.litellm_adapter.is_thinking_model:
-            model_settings_kwargs["reasoning"] = Reasoning(effort="medium")
-            logger.debug(f"Enabled thinking mode for model: {self.model_name}")
+        effort = self.litellm_adapter.reasoning_effort_level
+        if effort:
+            if self._model_supports_reasoning():
+                model_settings_kwargs["reasoning"] = Reasoning(effort=effort)
+                logger.debug(f"Enabled reasoning (effort={effort}) for model: {self.model_name}")
+                native_thinking = self._native_thinking_extra_body()
+                if native_thinking:
+                    # Must go through ``extra_args["extra_body"]`` (not
+                    # ``ModelSettings.extra_body``). The agents SDK *flattens*
+                    # ``extra_body`` into the acompletion kwargs, which means
+                    # Moonshot's transformation — whose ``get_supported_openai_params``
+                    # list does not include ``thinking`` — would silently drop the
+                    # flag under ``drop_params=True``. Nesting it one level deeper
+                    # keeps ``extra_body={...}`` as a reserved acompletion kwarg,
+                    # which the OpenAI client then merges verbatim into the HTTP
+                    # POST body, bypassing the per-provider supported-params filter.
+                    existing_extra_args = dict(model_settings_kwargs.get("extra_args") or {})
+                    nested_extra_body = dict(existing_extra_args.get("extra_body") or {})
+                    nested_extra_body.update(native_thinking)
+                    existing_extra_args["extra_body"] = nested_extra_body
+                    model_settings_kwargs["extra_args"] = existing_extra_args
+                    logger.debug(f"Added native thinking payload for {self.model_name}: {native_thinking}")
+            else:
+                logger.warning(
+                    "Skipping reasoning (effort=%s) for %s: Datus recognises this model "
+                    "as not supporting thinking. Use `/effort off` or switch to a "
+                    "thinking-capable model (gpt-5*, o-series, claude-4*, gemini-2.5*+, "
+                    "deepseek-v4*, deepseek-reasoner, kimi-k2.5+) to silence this warning.",
+                    effort,
+                    self.model_name,
+                )
 
         prompt_cache_retention = self._default_prompt_cache_retention()
         if prompt_cache_retention:

--- a/datus/models/sdk_patches.py
+++ b/datus/models/sdk_patches.py
@@ -6,15 +6,25 @@
 SDK Patches for openai-agents SDK.
 
 This module provides monkey patches to extend SDK functionality for
-providers not yet officially supported.
+providers whose thinking mode requires reasoning_content to be echoed
+back on every assistant-with-tool_calls turn.
 
 Current patches:
 - Kimi/Moonshot reasoning_content support in Converter.items_to_messages()
-- Kimi/Moonshot reasoning_content preservation in litellm.acompletion()
+- Kimi/Moonshot + DeepSeek reasoning_content preservation in
+  litellm.(a)completion() via a streaming cache fallback.
 
 Reference: https://github.com/openai/openai-agents-python/pull/2328
-The SDK already supports DeepSeek reasoning_content. This patch extends
-the same support to Kimi/Moonshot models.
+The SDK already supports DeepSeek reasoning_content when the streamed
+`summary` is populated. For DeepSeek V4 thinking mode, the SDK sometimes
+misses the reasoning delta (empty summary) and the provider rejects the
+next turn with:
+
+    The `reasoning_content` in the thinking mode must be passed back to
+    the API.
+
+This patch adds the same streaming cache + injection fallback used for
+Kimi/Moonshot to DeepSeek models.
 """
 
 import copy
@@ -33,6 +43,20 @@ def _is_kimi_model(model_name: str) -> bool:
     """Check if a model name is a Kimi/Moonshot model (kimi, moonshot, k2.5, k2-*, etc.)."""
     name = model_name.lower()
     return "kimi" in name or "moonshot" in name or "k2.5" in name or "k2-" in name
+
+
+def _is_deepseek_model(model_name: str) -> bool:
+    """Check if a model name is a DeepSeek model (deepseek-chat, deepseek-reasoner, deepseek-v4, ...)."""
+    if not model_name:
+        return False
+    return "deepseek" in model_name.lower()
+
+
+def _needs_reasoning_injection(model_name: str) -> bool:
+    """Providers whose thinking mode requires reasoning_content to be echoed back on tool-calling turns."""
+    if not model_name:
+        return False
+    return _is_kimi_model(model_name) or _is_deepseek_model(model_name)
 
 
 def _normalize_provider_data(item: Any) -> Any:
@@ -166,15 +190,17 @@ def _postprocess_messages_for_reasoning(
     model: str | None,
 ) -> list[dict[str, Any]]:
     """
-    Post-process messages to preserve reasoning_content for Kimi/Moonshot models
-    during tool calling.
+    Post-process messages to preserve reasoning_content for thinking-mode
+    providers (Kimi/Moonshot, DeepSeek) during tool calling.
 
     Per DeepSeek/Moonshot docs, reasoning_content must be passed back during
     tool calling to allow the model to continue reasoning.
     See: https://api-docs.deepseek.com/guides/thinking_mode
     """
-    if not model or not _is_kimi_model(model):
+    if not model or not _needs_reasoning_injection(model):
         return messages
+
+    is_kimi = _is_kimi_model(model)
 
     # Find the last non-empty reasoning_content to reuse if needed
     last_reasoning_content = None
@@ -192,25 +218,27 @@ def _postprocess_messages_for_reasoning(
             last_reasoning_content = cached_rc
             logger.debug(f"[SDK Patch] Using cached reasoning_content as fallback, length={len(cached_rc)}")
 
-    # Ensure all assistant messages with tool_calls have reasoning_content field.
-    # Kimi/Moonshot requires this field to be present when thinking is enabled.
+    # Ensure all assistant messages with tool_calls have reasoning_content field
+    # when the provider requires it (thinking mode enabled).
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant" and msg.get("tool_calls"):
             current_rc = msg.get("reasoning_content", "")
             if (not current_rc or not current_rc.strip()) and last_reasoning_content:
                 msg["reasoning_content"] = last_reasoning_content
                 logger.debug("[SDK Patch] Injected reasoning_content into assistant+tool_calls message")
-            elif "reasoning_content" not in msg:
-                # No reasoning_content available from messages or cache.
-                # Moonshot API requires non-empty reasoning_content for thinking models.
-                # This path should be rare after the streaming cache fix.
+            elif "reasoning_content" not in msg and is_kimi:
+                # Moonshot historically tolerates an empty reasoning_content field when
+                # thinking is off; DeepSeek rejects both missing and empty, so we must
+                # NOT inject an empty placeholder for DeepSeek — leave the message as-is
+                # and let the provider surface a clean error if thinking was actually on.
                 msg["reasoning_content"] = ""
                 logger.warning(
                     "[SDK Patch] No reasoning_content available for assistant+tool_calls message. "
                     "Moonshot API may reject this request. Check if streaming cache is working."
                 )
 
-            # Ensure content is empty string, not None (Moonshot requirement)
+            # Ensure content is empty string, not None (Moonshot requirement;
+            # DeepSeek also accepts content="" for tool_calls-only messages).
             if msg.get("content") is None:
                 msg["content"] = ""
 
@@ -262,7 +290,9 @@ def apply_sdk_patches() -> None:
         _original_items_to_messages = Converter.items_to_messages.__func__  # type: ignore
 
     Converter.items_to_messages = classmethod(_patched_items_to_messages)  # type: ignore
-    logger.info("Applied SDK patch: Converter.items_to_messages (Kimi/Moonshot reasoning_content)")
+    logger.info(
+        "Applied SDK patch: Converter.items_to_messages (Kimi/Moonshot reasoning_content + DeepSeek fallback injection)"
+    )
 
     # Patch 2: litellm.acompletion wrapper (safety net)
     # Re-applies reasoning_content preservation right before API calls,
@@ -279,7 +309,7 @@ def apply_sdk_patches() -> None:
 
             # Cache reasoning_content from the API response for future fallback.
             # This handles cases where the SDK converter fails to extract it from items.
-            if model and _is_kimi_model(model):
+            if model and _needs_reasoning_injection(model):
                 stream = kwargs.get("stream", False)
                 if stream:
                     # Streaming: wrap the async iterator to capture reasoning_content
@@ -305,7 +335,7 @@ def apply_sdk_patches() -> None:
             return response
 
         litellm.acompletion = _patched_acompletion
-        logger.info("Applied SDK patch: litellm.acompletion (Kimi/Moonshot reasoning_content)")
+        logger.info("Applied SDK patch: litellm.acompletion (Kimi/Moonshot + DeepSeek reasoning_content)")
 
     # Patch 3: litellm.completion wrapper (sync version)
     # The generate() method uses litellm.completion (sync), which was not patched.
@@ -320,8 +350,12 @@ def apply_sdk_patches() -> None:
                 kwargs["messages"] = _postprocess_messages_for_reasoning(kwargs["messages"], model)
             response = _original_completion(*args, **kwargs)
 
-            # Cache reasoning_content and inject it into message.content if empty
-            if model and _is_kimi_model(model):
+            # Cache reasoning_content and inject it into message.content if empty.
+            # The empty-content injection is Kimi-specific: Moonshot non-thinking
+            # responses may arrive with empty content + reasoning_content. DeepSeek's
+            # sync path returns real content, so we only cache (no content rewrite).
+            if model and _needs_reasoning_injection(model):
+                is_kimi = _is_kimi_model(model)
                 try:
                     for choice in getattr(response, "choices", []):
                         msg = getattr(choice, "message", None)
@@ -333,13 +367,14 @@ def apply_sdk_patches() -> None:
                                     f"[SDK Patch] Cached reasoning_content from sync response, "
                                     f"model={model}, length={len(rc)}"
                                 )
-                                # If main content is empty, inject reasoning_content
-                                content = getattr(msg, "content", None)
-                                if not content or not content.strip():
-                                    msg.content = rc
-                                    logger.debug(
-                                        "[SDK Patch] Injected reasoning_content into empty sync response content"
-                                    )
+                                # If main content is empty, inject reasoning_content (Kimi only)
+                                if is_kimi:
+                                    content = getattr(msg, "content", None)
+                                    if not content or not content.strip():
+                                        msg.content = rc
+                                        logger.debug(
+                                            "[SDK Patch] Injected reasoning_content into empty sync response content"
+                                        )
                                 break
                 except Exception as e:
                     logger.debug(f"[SDK Patch] Failed to cache reasoning_content from sync response: {e}")
@@ -347,7 +382,7 @@ def apply_sdk_patches() -> None:
             return response
 
         litellm.completion = _patched_completion
-        logger.info("Applied SDK patch: litellm.completion (Kimi/Moonshot reasoning_content sync)")
+        logger.info("Applied SDK patch: litellm.completion (Kimi/Moonshot + DeepSeek reasoning_content sync)")
 
 
 def remove_sdk_patches() -> None:

--- a/tests/unit_tests/cli/test_effort_commands.py
+++ b/tests/unit_tests/cli/test_effort_commands.py
@@ -1,0 +1,317 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.cli.effort_commands.EffortCommands``.
+
+CI-level: patches ``EffortApp.run`` to return scripted :class:`EffortSelection`
+values so dispatcher logic can be exercised without a TTY.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from datus.cli.effort_app import EffortSelection
+from datus.cli.effort_commands import EffortCommands
+from datus.configuration.project_config import ProjectOverride
+
+pytestmark = pytest.mark.ci
+
+_PATCH_LOAD = "datus.cli.effort_commands.load_project_override"
+_PATCH_SAVE = "datus.cli.effort_commands.save_project_override"
+
+
+def _stub_cli(*, project_effort=None, global_effort=None, active_raises=False):
+    cli = MagicMock()
+    cli.console = Console(file=io.StringIO(), no_color=True)
+    cli.agent_config = MagicMock()
+    cli.agent_config._target_reasoning_effort = project_effort
+    cli.agent_config.set_active_reasoning_effort = MagicMock()
+    if active_raises:
+        cli.agent_config.active_model.side_effect = RuntimeError("no model")
+    else:
+        model_cfg = MagicMock()
+        model_cfg.reasoning_effort = None
+        model_cfg.enable_thinking = False
+        cli.agent_config.active_model.return_value = model_cfg
+    cli.configuration_manager = MagicMock()
+    cli.configuration_manager.get = MagicMock(return_value=global_effort)
+    cli.tui_app = None
+    return cli
+
+
+@pytest.fixture
+def commands():
+    cli = _stub_cli()
+    return EffortCommands(cli), cli
+
+
+class TestDirectValueWithGlobalFlag:
+    def test_saves_to_global(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_effort("high --global")
+        cli.configuration_manager.update_item.assert_called_once_with("reasoning_effort", "high")
+        cli.agent_config.set_active_reasoning_effort.assert_called_once_with("high", persist=False)
+
+    def test_output_mentions_agent_yml(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_effort("medium --global")
+        assert "agent.yml" in cli.console.file.getvalue()
+
+    def test_global_does_not_overwrite_project_override(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(reasoning_effort="low")
+        with patch(_PATCH_LOAD, return_value=existing):
+            cmds.cmd_effort("high --global")
+        cli.configuration_manager.update_item.assert_called_once_with("reasoning_effort", "high")
+        # Project override still wins in memory — do not sync the global value
+        # onto the in-memory target.
+        cli.agent_config.set_active_reasoning_effort.assert_not_called()
+        assert "project-level override" in cli.console.file.getvalue()
+
+
+class TestDirectValueWithProjectFlag:
+    def test_saves_to_project(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+        ):
+            cmds.cmd_effort("high --project")
+        saved = mock_save.call_args[0][0]
+        assert saved.reasoning_effort == "high"
+        cli.agent_config.set_active_reasoning_effort.assert_called_once_with("high", persist=False)
+
+    def test_preserves_existing_override_fields(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(target="deepseek", default_datasource="db1")
+        with (
+            patch(_PATCH_LOAD, return_value=existing),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+        ):
+            cmds.cmd_effort("low --project")
+        saved = mock_save.call_args[0][0]
+        assert saved.target == "deepseek"
+        assert saved.default_datasource == "db1"
+        assert saved.reasoning_effort == "low"
+
+
+class TestInvalidValue:
+    def test_unknown_level_errors_and_no_save(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_effort("nuclear --project")
+        mock_save.assert_not_called()
+        cli.configuration_manager.update_item.assert_not_called()
+        assert "Invalid effort" in cli.console.file.getvalue()
+
+
+class TestClearFlag:
+    def test_clears_project_override(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(target="deepseek", reasoning_effort="high")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_effort("--clear")
+        saved = mock_save.call_args[0][0]
+        assert saved.reasoning_effort is None
+        assert saved.target == "deepseek"
+
+    def test_falls_back_to_global(self):
+        cli = _stub_cli(global_effort="medium")
+        cmds = EffortCommands(cli)
+        existing = ProjectOverride(reasoning_effort="high")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE):
+            cmds.cmd_effort("--clear")
+        cli.agent_config.set_active_reasoning_effort.assert_called_once_with("medium", persist=False)
+
+    def test_falls_back_to_none_when_no_global(self):
+        cli = _stub_cli(global_effort=None)
+        cmds = EffortCommands(cli)
+        existing = ProjectOverride(reasoning_effort="high")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE):
+            cmds.cmd_effort("--clear")
+        cli.agent_config.set_active_reasoning_effort.assert_called_once_with(None, persist=False)
+
+    def test_no_save_when_no_project_override(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_effort("--clear")
+        mock_save.assert_not_called()
+
+
+class TestStatus:
+    def test_status_reports_project_source(self):
+        cli = _stub_cli()
+        cmds = EffortCommands(cli)
+        existing = ProjectOverride(reasoning_effort="high")
+        with patch(_PATCH_LOAD, return_value=existing):
+            cmds.cmd_effort("status")
+        output = cli.console.file.getvalue()
+        assert "high" in output
+        assert "project" in output
+
+    def test_status_reports_global_source(self):
+        cli = _stub_cli(global_effort="medium")
+        cmds = EffortCommands(cli)
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_effort("status")
+        output = cli.console.file.getvalue()
+        assert "medium" in output
+        assert "global" in output
+
+    def test_status_falls_back_to_model_reasoning_effort(self):
+        cli = _stub_cli()
+        cli.agent_config.active_model.return_value = MagicMock(reasoning_effort="low", enable_thinking=False)
+        cmds = EffortCommands(cli)
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_effort("status")
+        output = cli.console.file.getvalue()
+        assert "low" in output
+        assert "model" in output
+
+    def test_status_falls_back_to_enable_thinking_as_medium(self):
+        cli = _stub_cli()
+        cli.agent_config.active_model.return_value = MagicMock(reasoning_effort=None, enable_thinking=True)
+        cmds = EffortCommands(cli)
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_effort("status")
+        output = cli.console.file.getvalue()
+        assert "medium" in output
+        assert "enable_thinking" in output
+
+    def test_status_reports_not_set(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_effort("status")
+        assert "not set" in cli.console.file.getvalue()
+
+    def test_status_tolerates_active_model_failure(self):
+        cli = _stub_cli(active_raises=True)
+        cmds = EffortCommands(cli)
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_effort("status")
+        # No exception propagates; output reports "not set".
+        assert "not set" in cli.console.file.getvalue()
+
+    def test_status_includes_supports_reasoning_yes(self):
+        cli = _stub_cli()
+        cli.agent_config.active_model.return_value = MagicMock(
+            model="gpt-5.4", type="openai", reasoning_effort=None, enable_thinking=False
+        )
+        cmds = EffortCommands(cli)
+        with patch(_PATCH_LOAD, return_value=None), patch("litellm.supports_reasoning", return_value=True):
+            cmds.cmd_effort("status")
+        out = cli.console.file.getvalue().lower()
+        assert "supports reasoning" in out
+        assert "yes" in out
+
+    def test_status_includes_supports_reasoning_no(self):
+        cli = _stub_cli()
+        cli.agent_config.active_model.return_value = MagicMock(
+            model="gpt-4.1", type="openai", reasoning_effort=None, enable_thinking=False
+        )
+        cmds = EffortCommands(cli)
+        with patch(_PATCH_LOAD, return_value=None), patch("litellm.supports_reasoning", return_value=False):
+            cmds.cmd_effort("status")
+        out = cli.console.file.getvalue().lower()
+        assert "supports reasoning" in out
+        assert ": no" in out
+
+    def test_status_silent_when_supports_reasoning_raises(self):
+        cli = _stub_cli()
+        cli.agent_config.active_model.return_value = MagicMock(
+            model="some-custom-model", type="openai", reasoning_effort=None, enable_thinking=False
+        )
+        cmds = EffortCommands(cli)
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch("litellm.supports_reasoning", side_effect=RuntimeError("unknown provider")),
+        ):
+            cmds.cmd_effort("status")  # must not raise
+        out = cli.console.file.getvalue().lower()
+        assert "supports reasoning" not in out
+
+
+class TestOffValue:
+    def test_off_saved_as_level(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_effort("off --project")
+        saved = mock_save.call_args[0][0]
+        assert saved.reasoning_effort == "off"
+        cli.agent_config.set_active_reasoning_effort.assert_called_once_with("off", persist=False)
+
+
+class TestInteractiveFlow:
+    def test_interactive_saves_to_project(self, commands):
+        cmds, cli = commands
+        selection = EffortSelection(code="high", scope="project")
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+            patch.object(cmds, "_run_app", return_value=selection),
+        ):
+            cmds.cmd_effort("")
+        saved = mock_save.call_args[0][0]
+        assert saved.reasoning_effort == "high"
+
+    def test_interactive_saves_to_global(self, commands):
+        cmds, cli = commands
+        selection = EffortSelection(code="low", scope="global")
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch.object(cmds, "_run_app", return_value=selection),
+        ):
+            cmds.cmd_effort("")
+        cli.configuration_manager.update_item.assert_called_once_with("reasoning_effort", "low")
+
+    def test_interactive_cancel_does_nothing(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_app", return_value=None),
+        ):
+            cmds.cmd_effort("")
+        mock_save.assert_not_called()
+        cli.configuration_manager.update_item.assert_not_called()
+
+
+class TestDirectValueWithScopePicker:
+    def test_scope_picker_project(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+            patch.object(cmds, "_run_scope_picker", return_value=EffortSelection(code="minimal", scope="project")),
+        ):
+            cmds.cmd_effort("minimal")
+        saved = mock_save.call_args[0][0]
+        assert saved.reasoning_effort == "minimal"
+
+    def test_scope_picker_global(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch.object(cmds, "_run_scope_picker", return_value=EffortSelection(code="medium", scope="global")),
+        ):
+            cmds.cmd_effort("medium")
+        cli.configuration_manager.update_item.assert_called_once_with("reasoning_effort", "medium")
+
+    def test_scope_picker_cancel(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE) as mock_save,
+            patch.object(cmds, "_run_scope_picker", return_value=None),
+        ):
+            cmds.cmd_effort("high")
+        mock_save.assert_not_called()
+        cli.configuration_manager.update_item.assert_not_called()

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1017,3 +1017,91 @@ class TestProviderConfigurationDispatch:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         cfg = self._make(tmp_path)
         assert cfg.provider_available("openai") is False
+
+    # ── reasoning_effort ───────────────────────────────────────────
+
+    def test_target_reasoning_effort_overrides_legacy_model(self, tmp_path):
+        cfg = self._make(tmp_path, target_reasoning_effort="high")
+        active = cfg.active_model()
+        assert active.reasoning_effort == "high"
+
+    def test_target_reasoning_effort_overrides_synthesized_model(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            providers={"openai": {"api_key": "sk-test"}},
+            target_provider="openai",
+            target_model="gpt-4.1",
+            target_reasoning_effort="low",
+        )
+        active = cfg.active_model()
+        assert active.reasoning_effort == "low"
+
+    def test_target_reasoning_effort_off_clears_enable_thinking(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            models={
+                "legacy": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "legacy-model",
+                    "enable_thinking": True,
+                }
+            },
+            target_reasoning_effort="off",
+        )
+        active = cfg.active_model()
+        assert active.reasoning_effort == "off"
+        assert active.enable_thinking is False
+
+    def test_global_reasoning_effort_kwarg_falls_back(self, tmp_path):
+        """Top-level ``reasoning_effort`` in agent.yml acts as a default when
+        no project-level override is set."""
+        cfg = self._make(tmp_path, reasoning_effort="medium")
+        active = cfg.active_model()
+        assert active.reasoning_effort == "medium"
+
+    def test_project_reasoning_effort_wins_over_global(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            reasoning_effort="medium",
+            target_reasoning_effort="high",
+        )
+        active = cfg.active_model()
+        assert active.reasoning_effort == "high"
+
+    def test_set_active_reasoning_effort_persists_to_project_config(self, tmp_path):
+        cfg = self._make(tmp_path)
+        cfg.set_active_reasoning_effort("high")
+        assert cfg._target_reasoning_effort == "high"
+
+        project_cfg = tmp_path / ".datus" / "config.yml"
+        import yaml
+
+        payload = yaml.safe_load(project_cfg.read_text(encoding="utf-8"))
+        assert payload["reasoning_effort"] == "high"
+
+    def test_set_active_reasoning_effort_rejects_invalid_value(self, tmp_path):
+        cfg = self._make(tmp_path)
+        with pytest.raises(DatusException):
+            cfg.set_active_reasoning_effort("nuclear")
+
+    def test_set_active_reasoning_effort_none_clears_override(self, tmp_path):
+        cfg = self._make(tmp_path, target_reasoning_effort="high")
+        cfg.set_active_reasoning_effort(None, persist=False)
+        assert cfg._target_reasoning_effort is None
+
+    def test_model_overrides_reasoning_effort_picked_up(self, tmp_path):
+        """``providers.yml`` ``model_overrides.<model>.reasoning_effort`` flows
+        through ``_synthesize_model`` into the resolved :class:`ModelConfig`."""
+        cfg = self._make(
+            tmp_path,
+            providers={"openai": {"api_key": "sk"}},
+            target_provider="openai",
+            target_model="gpt-4.1",
+        )
+        # Inject a reasoning_effort override for gpt-4.1 in the catalog.
+        catalog = cfg.provider_catalog
+        catalog.setdefault("model_overrides", {})["gpt-4.1"] = {"reasoning_effort": "high"}
+        cfg.set_provider_catalog(catalog)
+        active = cfg.active_model()
+        assert active.reasoning_effort == "high"

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -79,6 +79,39 @@ class TestLoadProjectOverride:
         assert result.language == "zh"
         assert result.target is None
 
+    @pytest.mark.parametrize("value", ["off", "minimal", "low", "medium", "high"])
+    def test_parse_reasoning_effort_field(self, tmp_path, value):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"reasoning_effort": value}))
+        result = load_project_override(str(tmp_path))
+        assert result.reasoning_effort == value
+
+    def test_invalid_reasoning_effort_dropped_with_warning(self, tmp_path, caplog):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"reasoning_effort": "nuclear"}))
+        with caplog.at_level(logging.WARNING):
+            result = load_project_override(str(tmp_path))
+        assert result.reasoning_effort is None
+        warning_text = " ".join(r.message for r in caplog.records)
+        assert "nuclear" in warning_text
+
+    def test_reasoning_effort_case_insensitive(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"reasoning_effort": "HIGH"}))
+        result = load_project_override(str(tmp_path))
+        assert result.reasoning_effort == "high"
+
+    def test_non_string_reasoning_effort_dropped(self, tmp_path, caplog):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"reasoning_effort": 3}))
+        with caplog.at_level(logging.WARNING):
+            result = load_project_override(str(tmp_path))
+        assert result.reasoning_effort is None
+
     def test_unknown_keys_warn_and_drop(self, tmp_path, caplog):
         path = tmp_path / PROJECT_CONFIG_REL
         path.parent.mkdir(parents=True)
@@ -152,6 +185,19 @@ class TestSaveProjectOverride:
         loaded = yaml.safe_load(written.read_text())
         assert "language" not in loaded
 
+    def test_round_trip_with_reasoning_effort(self, tmp_path):
+        original = ProjectOverride(target="a", reasoning_effort="high")
+        save_project_override(original, cwd=str(tmp_path))
+        loaded = load_project_override(str(tmp_path))
+        assert loaded.reasoning_effort == "high"
+        assert loaded.target == "a"
+
+    def test_reasoning_effort_none_omitted_from_yaml(self, tmp_path):
+        override = ProjectOverride(target="x")
+        written = save_project_override(override, cwd=str(tmp_path))
+        loaded = yaml.safe_load(written.read_text())
+        assert "reasoning_effort" not in loaded
+
     def test_overwrites_existing(self, tmp_path):
         save_project_override(ProjectOverride(target="old"), cwd=str(tmp_path))
         save_project_override(ProjectOverride(target="new"), cwd=str(tmp_path))
@@ -161,7 +207,9 @@ class TestSaveProjectOverride:
 
 class TestAllowedKeys:
     def test_whitelist_contains_expected_keys(self):
-        assert ALLOWED_KEYS == frozenset({"target", "default_datasource", "project_name", "language"})
+        assert ALLOWED_KEYS == frozenset(
+            {"target", "default_datasource", "project_name", "language", "reasoning_effort"}
+        )
 
 
 class TestProjectOverrideDataclass:
@@ -175,6 +223,7 @@ class TestProjectOverrideDataclass:
             ("default_datasource", "y"),
             ("project_name", "z"),
             ("language", "zh"),
+            ("reasoning_effort", "high"),
         ],
     )
     def test_is_not_empty_when_any_set(self, field, value):

--- a/tests/unit_tests/models/test_base.py
+++ b/tests/unit_tests/models/test_base.py
@@ -136,3 +136,30 @@ class TestCreateModelCache:
                 cfg = ModelConfig(type="openai", api_key="k", model=f"m{i}", base_url="https://a")
                 LLMBaseModel.create_model(self._agent_config(cfg))
         assert len(LLMBaseModel._MODEL_CACHE) == LLMBaseModel._MODEL_CACHE_MAXSIZE
+
+    def test_different_reasoning_effort_yields_new_instance(self):
+        """Changing ``reasoning_effort`` must bust the cache so the new adapter
+        picks up the fresh effort level instead of reusing a stale binding."""
+        self._fresh_cache()
+        cfg_low = ModelConfig(type="openai", api_key="k", model="gpt-4.1", reasoning_effort="low")
+        cfg_high = ModelConfig(type="openai", api_key="k", model="gpt-4.1", reasoning_effort="high")
+        module = MagicMock()
+        module.OpenAIModel = MagicMock(side_effect=lambda **kw: MagicMock(name="Instance"))
+        with patch.dict("sys.modules", {"datus.models.openai_model": module}):
+            low = LLMBaseModel.create_model(self._agent_config(cfg_low))
+            high = LLMBaseModel.create_model(self._agent_config(cfg_high))
+        assert low is not high
+        assert module.OpenAIModel.call_count == 2
+
+    def test_different_enable_thinking_yields_new_instance(self):
+        """Toggling ``enable_thinking`` must bust the cache (previously a bug)."""
+        self._fresh_cache()
+        cfg_off = ModelConfig(type="openai", api_key="k", model="gpt-4.1", enable_thinking=False)
+        cfg_on = ModelConfig(type="openai", api_key="k", model="gpt-4.1", enable_thinking=True)
+        module = MagicMock()
+        module.OpenAIModel = MagicMock(side_effect=lambda **kw: MagicMock(name="Instance"))
+        with patch.dict("sys.modules", {"datus.models.openai_model": module}):
+            off = LLMBaseModel.create_model(self._agent_config(cfg_off))
+            on = LLMBaseModel.create_model(self._agent_config(cfg_on))
+        assert off is not on
+        assert module.OpenAIModel.call_count == 2

--- a/tests/unit_tests/models/test_litellm_adapter.py
+++ b/tests/unit_tests/models/test_litellm_adapter.py
@@ -12,7 +12,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from datus.models.litellm_adapter import LiteLLMAdapter, create_litellm_adapter
+from datus.models.litellm_adapter import (
+    LiteLLMAdapter,
+    create_litellm_adapter,
+    is_known_non_thinking_model,
+)
 
 
 class TestLiteLLMAdapterInit:
@@ -48,10 +52,54 @@ class TestLiteLLMAdapterInit:
     def test_thinking_disabled_by_default(self):
         adapter = LiteLLMAdapter(provider="openai", model="gpt-4o", api_key="key")
         assert adapter.is_thinking_model is False
+        assert adapter.reasoning_effort_level is None
 
     def test_thinking_enabled(self):
         adapter = LiteLLMAdapter(provider="openai", model="gpt-4o", api_key="key", enable_thinking=True)
         assert adapter.is_thinking_model is True
+        # Legacy bool defaults to "medium" when no explicit effort is set.
+        assert adapter.reasoning_effort_level == "medium"
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+    def test_reasoning_effort_level_explicit(self, effort):
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="gpt-4o",
+            api_key="key",
+            reasoning_effort=effort,
+        )
+        assert adapter.reasoning_effort_level == effort
+        assert adapter.is_thinking_model is True
+
+    def test_reasoning_effort_off_overrides_enable_thinking(self):
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="gpt-4o",
+            api_key="key",
+            enable_thinking=True,
+            reasoning_effort="off",
+        )
+        assert adapter.reasoning_effort_level is None
+        assert adapter.is_thinking_model is False
+
+    def test_reasoning_effort_wins_over_enable_thinking(self):
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="gpt-4o",
+            api_key="key",
+            enable_thinking=True,
+            reasoning_effort="high",
+        )
+        assert adapter.reasoning_effort_level == "high"
+
+    def test_reasoning_effort_normalizes_case(self):
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="gpt-4o",
+            api_key="key",
+            reasoning_effort="HIGH",
+        )
+        assert adapter.reasoning_effort_level == "high"
 
 
 class TestLiteLLMAdapterModelName:
@@ -164,7 +212,8 @@ class TestGetAgentsSdkModel:
                     adapter.get_agents_sdk_model()
 
     def test_returns_litellm_model(self):
-        adapter = LiteLLMAdapter(provider="openai", model="gpt-4o", api_key="key")
+        # deepseek is not routed to the Responses API, so it still uses LitellmModel.
+        adapter = LiteLLMAdapter(provider="deepseek", model="deepseek-chat", api_key="key")
         mock_model = MagicMock()
         mock_litellm_model_cls = MagicMock(return_value=mock_model)
         mock_module = MagicMock()
@@ -414,6 +463,54 @@ class TestCreateLiteLLMAdapter:
         assert adapter.default_headers == headers
 
 
+class TestIsKnownNonThinkingModel:
+    """The deny-list is narrow by design: only models explicitly known NOT to
+    support thinking are listed; everything else is treated as supported so
+    new DeepSeek/Kimi releases don't require a config edit."""
+
+    @pytest.mark.parametrize(
+        "provider,model",
+        [
+            ("deepseek", "deepseek-chat"),
+            ("deepseek", "DeepSeek-Chat"),  # case-insensitive
+            ("kimi", "kimi-k2"),
+            ("kimi", "moonshot-v1-8k"),
+            ("kimi", "moonshot-v1-32k"),
+            ("kimi", "moonshot-v1-128k"),
+            ("kimi", "moonshot-v1-auto"),
+        ],
+    )
+    def test_deny_listed_models(self, provider, model):
+        assert is_known_non_thinking_model(provider, model) is True
+
+    @pytest.mark.parametrize(
+        "provider,model",
+        [
+            # DeepSeek thinking-capable
+            ("deepseek", "deepseek-reasoner"),
+            ("deepseek", "deepseek-v4"),
+            ("deepseek", "deepseek-v4-pro"),
+            ("deepseek", "deepseek-v5-future"),  # unknown future release
+            # Kimi thinking-capable (must NOT match bare kimi-k2)
+            ("kimi", "kimi-k2.5"),
+            ("kimi", "kimi-k2.6"),
+            ("kimi", "kimi-k2-thinking"),
+            ("kimi", "kimi-k3-future"),
+            # Other providers are never on the deny-list
+            ("openai", "gpt-4.1"),
+            ("claude", "claude-haiku-4-5"),
+            ("gemini", "gemini-2.5-flash"),
+        ],
+    )
+    def test_allow_listed_by_omission(self, provider, model):
+        assert is_known_non_thinking_model(provider, model) is False
+
+    def test_none_inputs_are_safe(self):
+        assert is_known_non_thinking_model(None, "anything") is False
+        assert is_known_non_thinking_model("deepseek", None) is False
+        assert is_known_non_thinking_model(None, None) is False
+
+
 class TestGetAgentsSdkModelRouting:
     def test_claude_returns_cache_control_subclass(self):
         from agents.extensions.models.litellm_model import LitellmModel
@@ -425,12 +522,58 @@ class TestGetAgentsSdkModelRouting:
         assert isinstance(model, CacheControlLitellmModel)
         assert isinstance(model, LitellmModel)
 
-    def test_openai_returns_plain_litellm_model(self):
+    def test_official_openai_returns_responses_model(self):
+        """Official OpenAI endpoint routes through /v1/responses so reasoning +
+        function tools coexist without chat/completions limitations."""
+        from agents.models.openai_responses import OpenAIResponsesModel
+
+        adapter = LiteLLMAdapter(provider="openai", model="gpt-5.4", api_key="sk-test")
+        model = adapter.get_agents_sdk_model()
+        assert isinstance(model, OpenAIResponsesModel)
+
+    def test_openai_with_api_openai_com_base_url_uses_responses(self):
+        from agents.models.openai_responses import OpenAIResponsesModel
+
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="gpt-4o",
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        )
+        model = adapter.get_agents_sdk_model()
+        assert isinstance(model, OpenAIResponsesModel)
+
+    def test_openai_compatible_custom_endpoint_keeps_litellm(self):
+        """vLLM / self-hosted OpenAI-compatible proxies should stay on the LiteLLM path."""
         from agents.extensions.models.litellm_model import LitellmModel
+        from agents.models.openai_responses import OpenAIResponsesModel
 
-        from datus.models.litellm_cache_control import CacheControlLitellmModel
-
-        adapter = LiteLLMAdapter(provider="openai", model="gpt-4o", api_key="sk-test")
+        adapter = LiteLLMAdapter(
+            provider="openai",
+            model="Qwen3.5-397B",
+            api_key="key",
+            base_url="http://192.168.1.100:8015/v1",
+        )
         model = adapter.get_agents_sdk_model()
         assert isinstance(model, LitellmModel)
-        assert not isinstance(model, CacheControlLitellmModel)
+        assert not isinstance(model, OpenAIResponsesModel)
+
+    def test_deepseek_still_uses_litellm(self):
+        from agents.extensions.models.litellm_model import LitellmModel
+        from agents.models.openai_responses import OpenAIResponsesModel
+
+        adapter = LiteLLMAdapter(provider="deepseek", model="deepseek-chat", api_key="sk-test")
+        model = adapter.get_agents_sdk_model()
+        assert isinstance(model, LitellmModel)
+        assert not isinstance(model, OpenAIResponsesModel)
+
+    def test_kimi_still_uses_litellm(self):
+        """Kimi/Moonshot relies on sdk_patches.py for reasoning_content echo-back,
+        which only applies on the LiteLLM path. It must not be routed to Responses."""
+        from agents.extensions.models.litellm_model import LitellmModel
+        from agents.models.openai_responses import OpenAIResponsesModel
+
+        adapter = LiteLLMAdapter(provider="kimi", model="kimi-k2.5", api_key="sk-test")
+        model = adapter.get_agents_sdk_model()
+        assert isinstance(model, LitellmModel)
+        assert not isinstance(model, OpenAIResponsesModel)

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -60,6 +60,7 @@ def _make_model(model_config=None):
     mock_litellm_adapter.litellm_model_name = "openai/gpt-4"
     mock_litellm_adapter.provider = "openai"
     mock_litellm_adapter.is_thinking_model = False
+    mock_litellm_adapter.reasoning_effort_level = None
     mock_litellm_adapter.get_agents_sdk_model.return_value = MagicMock()
 
     with (
@@ -1228,6 +1229,14 @@ class TestGenerateWithToolsStream:
 class TestBuildAgent:
     """Tests for _build_agent. We patch Agent to capture kwargs without SDK validation."""
 
+    @pytest.fixture(autouse=True)
+    def _permissive_supports_reasoning(self):
+        """Default LiteLLM capability check to True so the reasoning-effort
+        tests in this class exercise the injection path without depending on
+        LiteLLM's built-in model catalog. Individual tests override as needed."""
+        with patch("datus.models.openai_compatible.litellm.supports_reasoning", return_value=True):
+            yield
+
     def _call_build_agent(self, model, **kwargs):
         defaults = {
             "instruction": "test",
@@ -1294,10 +1303,163 @@ class TestBuildAgent:
     def test_thinking_model_gets_reasoning(self):
         model = _make_model()
         model.litellm_adapter.is_thinking_model = True
+        model.litellm_adapter.reasoning_effort_level = "medium"
         _, call_args = self._call_build_agent(model)
         ms = call_args[1]["model_settings"]
         assert ms.reasoning is not None
         assert ms.reasoning.effort == "medium"
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+    def test_reasoning_effort_level_passthrough(self, effort):
+        model = _make_model()
+        model.litellm_adapter.is_thinking_model = True
+        model.litellm_adapter.reasoning_effort_level = effort
+        _, call_args = self._call_build_agent(model)
+        ms = call_args[1]["model_settings"]
+        assert ms.reasoning.effort == effort
+
+    def test_no_reasoning_when_effort_level_is_none(self):
+        model = _make_model()
+        model.litellm_adapter.is_thinking_model = False
+        model.litellm_adapter.reasoning_effort_level = None
+        _, call_args = self._call_build_agent(model)
+        ms = call_args[1]["model_settings"]
+        assert ms.reasoning is None
+
+    def test_reasoning_injected_when_litellm_reports_true(self):
+        model = _make_model()
+        model.litellm_adapter.reasoning_effort_level = "high"
+        with patch("datus.models.openai_compatible.litellm.supports_reasoning", return_value=True):
+            _, call_args = self._call_build_agent(model)
+        assert call_args[1]["model_settings"].reasoning.effort == "high"
+
+    def test_reasoning_defaults_to_permissive_when_litellm_raises(self):
+        """Unknown providers (e.g. self-hosted proxies) make ``supports_reasoning``
+        raise. The gate falls back to permissive so newly released models or
+        custom backends are not blocked from trying /effort."""
+        model = _make_model()
+        model.litellm_adapter.reasoning_effort_level = "medium"
+        with patch(
+            "datus.models.openai_compatible.litellm.supports_reasoning",
+            side_effect=RuntimeError("provider unknown"),
+        ):
+            _, call_args = self._call_build_agent(model)
+        assert call_args[1]["model_settings"].reasoning.effort == "medium"
+
+    @pytest.mark.parametrize(
+        "provider,model_name",
+        [
+            ("deepseek", "deepseek-v4-pro"),
+            ("deepseek", "deepseek-reasoner"),
+            ("deepseek", "deepseek-v5-future"),  # unknown: deny-list negative → permissive
+            ("kimi", "kimi-k2-thinking"),
+            ("kimi", "kimi-k2.6"),
+            ("kimi", "kimi-k2.5"),
+        ],
+    )
+    def test_reasoning_injected_for_thinking_models_despite_litellm_false(self, provider, model_name):
+        """LiteLLM's catalog lags behind DeepSeek V4 / Kimi K2.x. Unknown DeepSeek
+        or Kimi models are *permissively* allowed so future releases automatically
+        work — only explicit deny-list entries are skipped."""
+        cfg = _make_model_config(model=model_name, model_type=provider)
+        model = _make_model(cfg)
+        model.litellm_adapter.provider = provider
+        model.litellm_adapter.reasoning_effort_level = "high"
+        with patch("datus.models.openai_compatible.litellm.supports_reasoning", return_value=False):
+            _, call_args = self._call_build_agent(model)
+        assert call_args[1]["model_settings"].reasoning.effort == "high"
+
+    @pytest.mark.parametrize(
+        "provider,model_name",
+        [
+            ("deepseek", "deepseek-chat"),
+            ("kimi", "kimi-k2"),  # bare k2, non-thinking family
+            ("kimi", "moonshot-v1-8k"),
+            ("kimi", "moonshot-v1-128k"),
+        ],
+    )
+    def test_reasoning_skipped_for_deny_listed_model(self, caplog, provider, model_name):
+        """Datus-maintained non-thinking deny-list forces a skip regardless of
+        LiteLLM's verdict, so users see an explicit warning instead of silent
+        drop_params downgrade."""
+        cfg = _make_model_config(model=model_name, model_type=provider)
+        model = _make_model(cfg)
+        model.litellm_adapter.provider = provider
+        model.litellm_adapter.reasoning_effort_level = "high"
+        with patch("datus.models.openai_compatible.litellm.supports_reasoning", return_value=False):
+            with caplog.at_level("WARNING"):
+                _, call_args = self._call_build_agent(model)
+        assert call_args[1]["model_settings"].reasoning is None
+        assert any("Skipping reasoning" in r.message for r in caplog.records)
+
+    def test_reasoning_skipped_for_non_reasoning_openai_model_when_litellm_false(self, caplog):
+        """OpenAI models outside the reasoning families (gpt-4.1 etc.) are
+        skipped when LiteLLM reports False — the deny-list is scoped to
+        DeepSeek/Kimi, so for other providers we trust LiteLLM's verdict."""
+        model = _make_model()
+        model.litellm_adapter.provider = "openai"
+        model.litellm_adapter.reasoning_effort_level = "high"
+        # _model_supports_reasoning is permissive on LiteLLM False — the
+        # remaining skip-path for OpenAI would require LiteLLM raising or
+        # returning False plus the deny-list match (none for OpenAI). Confirm
+        # the permissive outcome: reasoning IS injected.
+        with patch("datus.models.openai_compatible.litellm.supports_reasoning", return_value=False):
+            _, call_args = self._call_build_agent(model)
+        assert call_args[1]["model_settings"].reasoning is not None
+
+    @pytest.mark.parametrize("model_name", ["deepseek-v4-pro", "deepseek-reasoner"])
+    def test_deepseek_extra_body_carries_thinking_and_reasoning_effort(self, model_name):
+        """DeepSeek's transformation pops ``reasoning_effort`` during param
+        mapping, so Datus re-injects it via ``extra_body`` alongside the
+        ``thinking`` flag. DeepSeek's docs require both to control depth."""
+        cfg = _make_model_config(model=model_name, model_type="deepseek")
+        model = _make_model(cfg)
+        model.litellm_adapter.provider = "deepseek"
+        model.litellm_adapter.reasoning_effort_level = "high"
+        with patch("datus.models.openai_compatible.litellm.supports_reasoning", return_value=False):
+            _, call_args = self._call_build_agent(model)
+        ms = call_args[1]["model_settings"]
+        assert ms.extra_args["extra_body"] == {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "high",
+        }
+
+    @pytest.mark.parametrize("model_name", ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking"])
+    def test_kimi_extra_body_only_carries_thinking(self, model_name):
+        """Moonshot's API does not accept ``reasoning_effort``; sending it
+        would be rejected. Only ``thinking.type=enabled`` goes in extra_body."""
+        cfg = _make_model_config(model=model_name, model_type="kimi")
+        model = _make_model(cfg)
+        model.litellm_adapter.provider = "kimi"
+        model.litellm_adapter.reasoning_effort_level = "high"
+        with patch("datus.models.openai_compatible.litellm.supports_reasoning", return_value=False):
+            _, call_args = self._call_build_agent(model)
+        ms = call_args[1]["model_settings"]
+        assert ms.extra_args["extra_body"] == {"thinking": {"type": "enabled"}}
+        assert "reasoning_effort" not in ms.extra_args["extra_body"]
+
+    def test_extra_body_thinking_not_added_for_openai(self):
+        """OpenAI's reasoning_effort is handled natively by the SDK/Responses
+        API; no native thinking payload should be injected."""
+        model = _make_model()
+        model.litellm_adapter.provider = "openai"
+        model.litellm_adapter.reasoning_effort_level = "high"
+        _, call_args = self._call_build_agent(model)
+        ms = call_args[1]["model_settings"]
+        # If extra_args is set (e.g. prompt_cache_key), it should NOT contain extra_body.
+        if ms.extra_args:
+            assert "extra_body" not in ms.extra_args
+
+    def test_extra_body_thinking_not_added_for_deny_listed_deepseek_chat(self):
+        cfg = _make_model_config(model="deepseek-chat", model_type="deepseek")
+        model = _make_model(cfg)
+        model.litellm_adapter.provider = "deepseek"
+        model.litellm_adapter.reasoning_effort_level = "high"
+        _, call_args = self._call_build_agent(model)
+        ms = call_args[1]["model_settings"]
+        # gate skipped injection entirely; no thinking body either
+        if ms.extra_args:
+            assert "extra_body" not in ms.extra_args
 
     def test_temperature_and_top_p_from_config(self):
         cfg = _make_model_config(temperature=0.5, top_p=0.9)

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -1446,9 +1446,9 @@ class TestBuildAgent:
         model.litellm_adapter.reasoning_effort_level = "high"
         _, call_args = self._call_build_agent(model)
         ms = call_args[1]["model_settings"]
-        # If extra_args is set (e.g. prompt_cache_key), it should NOT contain extra_body.
-        if ms.extra_args:
-            assert "extra_body" not in ms.extra_args
+        # extra_args may be unset (None/empty) or set (e.g. prompt_cache_key);
+        # either way, extra_body must never appear for native-reasoning OpenAI.
+        assert "extra_body" not in (ms.extra_args or {})
 
     def test_extra_body_thinking_not_added_for_deny_listed_deepseek_chat(self):
         cfg = _make_model_config(model="deepseek-chat", model_type="deepseek")
@@ -1457,9 +1457,9 @@ class TestBuildAgent:
         model.litellm_adapter.reasoning_effort_level = "high"
         _, call_args = self._call_build_agent(model)
         ms = call_args[1]["model_settings"]
-        # gate skipped injection entirely; no thinking body either
-        if ms.extra_args:
-            assert "extra_body" not in ms.extra_args
+        # Gate skipped injection entirely; extra_body must never appear regardless
+        # of whether extra_args was populated by other settings.
+        assert "extra_body" not in (ms.extra_args or {})
 
     def test_temperature_and_top_p_from_config(self):
         cfg = _make_model_config(temperature=0.5, top_p=0.9)

--- a/tests/unit_tests/models/test_openai_compatible_stream_order.py
+++ b/tests/unit_tests/models/test_openai_compatible_stream_order.py
@@ -190,6 +190,7 @@ async def _collect_actions(events_list) -> List[ActionHistory]:
     mock_config.retry_interval = 0
     model.model_config = mock_config
     model.default_headers = None
+    model.base_url = None
 
     fake_result = _build_fake_result(events_list)
 

--- a/tests/unit_tests/models/test_openai_compatible_stream_order.py
+++ b/tests/unit_tests/models/test_openai_compatible_stream_order.py
@@ -211,6 +211,7 @@ async def _collect_actions(events_list) -> List[ActionHistory]:
                 model.litellm_adapter.get_agents_sdk_model.return_value = MagicMock()
                 model.litellm_adapter.provider = "openai"
                 model.litellm_adapter.is_thinking_model = False
+                model.litellm_adapter.reasoning_effort_level = None
 
                 actions = []
                 async for action in model._generate_with_tools_stream_internal(

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -468,10 +468,40 @@ class TestApplyAndRemoveSdkPatches:
         assert len(_reasoning_content_cache) == 0
 
     def test_apply_patches_idempotent(self):
-        """Calling apply_sdk_patches twice does not raise."""
+        """Calling apply_sdk_patches twice must not re-capture the already-patched
+        litellm functions as 'originals'. Otherwise remove_sdk_patches() would
+        restore the patched version instead of the true original.
+        """
+        import litellm
+
+        from datus.models import sdk_patches
+
+        # Capture the true originals before any patching.
+        true_original_completion = litellm.completion
+        true_original_acompletion = litellm.acompletion
+
         apply_sdk_patches()
-        apply_sdk_patches()  # Should not raise
-        remove_sdk_patches()
+        captured_after_first = sdk_patches._original_completion
+        captured_acompletion_after_first = sdk_patches._original_acompletion
+        patched_completion_first = litellm.completion
+
+        apply_sdk_patches()  # second call must be a no-op for capture
+        try:
+            # The stored "original" must still be the pre-patch function,
+            # not the patched wrapper captured on the first call.
+            assert sdk_patches._original_completion is true_original_completion
+            assert sdk_patches._original_acompletion is true_original_acompletion
+            assert sdk_patches._original_completion is captured_after_first
+            assert sdk_patches._original_acompletion is captured_acompletion_after_first
+            # The live litellm.completion should still be the patched wrapper
+            # (not re-wrapped into a double-patched function).
+            assert litellm.completion is patched_completion_first
+        finally:
+            remove_sdk_patches()
+
+        # After removal, litellm.completion is restored to the true original.
+        assert litellm.completion is true_original_completion
+        assert litellm.acompletion is true_original_acompletion
 
 
 class TestPatchedCompletionSync:

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -6,7 +6,7 @@
 Unit tests for datus/models/sdk_patches.py.
 
 Tests cover:
-- _is_kimi_model: detection of Kimi/Moonshot model names
+- _is_kimi_model / _is_deepseek_model / _needs_reasoning_injection: provider detection
 - _normalize_provider_data: dict and Pydantic-style object normalization
 - _preprocess_items_for_reasoning: model name normalization for reasoning
 - _ReasoningContentStreamWrapper: streaming reasoning_content capture
@@ -21,7 +21,9 @@ import copy
 import pytest
 
 from datus.models.sdk_patches import (
+    _is_deepseek_model,
     _is_kimi_model,
+    _needs_reasoning_injection,
     _normalize_provider_data,
     _postprocess_messages_for_reasoning,
     _preprocess_items_for_reasoning,
@@ -48,6 +50,42 @@ class TestIsKimiModel:
         assert _is_kimi_model("deepseek-chat") is False
         assert _is_kimi_model("claude-3") is False
         assert _is_kimi_model("") is False
+
+
+class TestIsDeepSeekModel:
+    """Tests for _is_deepseek_model detection."""
+
+    def test_deepseek_model_detected(self):
+        """DeepSeek model names are correctly detected across aliases and litellm prefixes."""
+        assert _is_deepseek_model("deepseek-chat") is True
+        assert _is_deepseek_model("deepseek-reasoner") is True
+        assert _is_deepseek_model("deepseek-v4") is True
+        assert _is_deepseek_model("deepseek/deepseek-v4") is True
+        assert _is_deepseek_model("DeepSeek-V4") is True
+
+    def test_non_deepseek_model_not_detected(self):
+        """Other providers and empty strings return False."""
+        assert _is_deepseek_model("kimi-k2.5") is False
+        assert _is_deepseek_model("gpt-4") is False
+        assert _is_deepseek_model("claude-sonnet-4-5") is False
+        assert _is_deepseek_model("") is False
+        assert _is_deepseek_model(None) is False  # type: ignore[arg-type]
+
+
+class TestNeedsReasoningInjection:
+    """Tests for _needs_reasoning_injection combined gate."""
+
+    def test_returns_true_for_kimi_and_deepseek(self):
+        assert _needs_reasoning_injection("kimi-k2.5") is True
+        assert _needs_reasoning_injection("moonshot-v1") is True
+        assert _needs_reasoning_injection("deepseek-v4") is True
+        assert _needs_reasoning_injection("deepseek/deepseek-reasoner") is True
+
+    def test_returns_false_for_other_providers(self):
+        assert _needs_reasoning_injection("gpt-4") is False
+        assert _needs_reasoning_injection("claude-sonnet-4-5") is False
+        assert _needs_reasoning_injection("") is False
+        assert _needs_reasoning_injection(None) is False  # type: ignore[arg-type]
 
 
 class TestNormalizeProviderData:
@@ -349,6 +387,62 @@ class TestPostprocessMessagesForReasoning:
 
         _reasoning_content_cache.clear()
 
+    def test_deepseek_injects_reasoning_content_from_cache(self):
+        """DeepSeek model uses cached reasoning_content as fallback for tool_calls messages."""
+        _reasoning_content_cache.clear()
+        _reasoning_content_cache["deepseek/deepseek-v4"] = "cached deepseek thinking"
+
+        messages = [
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "2"}]},
+        ]
+        result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4")
+        assert result[0]["reasoning_content"] == "cached deepseek thinking"
+        assert result[2]["reasoning_content"] == "cached deepseek thinking"
+        # content=None must be normalized to "" so the provider accepts tool_calls-only messages
+        assert result[0]["content"] == ""
+        assert result[2]["content"] == ""
+
+        _reasoning_content_cache.clear()
+
+    def test_deepseek_does_not_inject_empty_placeholder(self):
+        """DeepSeek must NOT get an empty reasoning_content placeholder when no source exists.
+
+        DeepSeek's API rejects empty reasoning_content in thinking mode with the same error
+        we're trying to fix; Kimi tolerates it. Only Kimi gets the "" fallback.
+        """
+        _reasoning_content_cache.clear()
+
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+        ]
+        result = _postprocess_messages_for_reasoning(messages, "deepseek-v4")
+        # Key should NOT be present (leave the message alone)
+        assert "reasoning_content" not in result[0]
+
+        _reasoning_content_cache.clear()
+
+    def test_deepseek_reuses_existing_reasoning_content_in_messages(self):
+        """Existing non-empty reasoning_content in messages is propagated to later tool_calls msgs."""
+        _reasoning_content_cache.clear()
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "first turn thinking",
+                "tool_calls": [{"id": "1"}],
+            },
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "2"}]},
+        ]
+        result = _postprocess_messages_for_reasoning(messages, "deepseek-reasoner")
+        assert result[0]["reasoning_content"] == "first turn thinking"
+        assert result[2]["reasoning_content"] == "first turn thinking"
+
+        _reasoning_content_cache.clear()
+
 
 class TestApplyAndRemoveSdkPatches:
     """Tests for apply_sdk_patches and remove_sdk_patches lifecycle."""
@@ -476,6 +570,53 @@ class TestPatchedCompletionSync:
             litellm.completion = original_real
             _reasoning_content_cache.clear()
 
+    def test_patched_completion_caches_deepseek_reasoning_content(self):
+        """Patched litellm.completion caches reasoning_content for DeepSeek models."""
+        import litellm
+
+        remove_sdk_patches()
+        _reasoning_content_cache.clear()
+
+        fake_response = self._make_fake_response(content="Real answer", reasoning_content="DeepSeek thinking...")
+        original_real = litellm.completion
+        litellm.completion = lambda *args, **kwargs: fake_response
+
+        try:
+            apply_sdk_patches()
+            litellm.completion(model="deepseek/deepseek-v4", messages=[{"role": "user", "content": "hi"}])
+
+            assert "deepseek/deepseek-v4" in _reasoning_content_cache
+            assert _reasoning_content_cache["deepseek/deepseek-v4"] == "DeepSeek thinking..."
+            # DeepSeek: content must NOT be overwritten even if it were empty — the API returns real content
+            assert fake_response.choices[0].message.content == "Real answer"
+        finally:
+            remove_sdk_patches()
+            litellm.completion = original_real
+            _reasoning_content_cache.clear()
+
+    def test_patched_completion_deepseek_does_not_overwrite_empty_content(self):
+        """For DeepSeek, even when response.content is empty, we do NOT inject reasoning_content into it."""
+        import litellm
+
+        remove_sdk_patches()
+        _reasoning_content_cache.clear()
+
+        fake_response = self._make_fake_response(content="", reasoning_content="DeepSeek thinking...")
+        original_real = litellm.completion
+        litellm.completion = lambda *args, **kwargs: fake_response
+
+        try:
+            apply_sdk_patches()
+            litellm.completion(model="deepseek-reasoner", messages=[{"role": "user", "content": "hi"}])
+
+            assert _reasoning_content_cache["deepseek-reasoner"] == "DeepSeek thinking..."
+            # DeepSeek path must preserve the empty content — only Kimi rewrites it
+            assert fake_response.choices[0].message.content == ""
+        finally:
+            remove_sdk_patches()
+            litellm.completion = original_real
+            _reasoning_content_cache.clear()
+
     def test_patched_completion_handles_exception_in_caching_logs_debug(self):
         """Patched litellm.completion logs debug message when caching fails."""
         import litellm
@@ -513,7 +654,81 @@ class TestPatchedCompletionSync:
 
 
 class TestPatchedAcompletionAsync:
-    """Tests for the async litellm.acompletion patch (Kimi reasoning_content)."""
+    """Tests for the async litellm.acompletion patch (Kimi + DeepSeek reasoning_content)."""
+
+    def _make_fake_response(self, content="", reasoning_content=None):
+        class FakeMessage:
+            pass
+
+        msg = FakeMessage()
+        msg.content = content
+        if reasoning_content is not None:
+            msg.reasoning_content = reasoning_content
+
+        class FakeChoice:
+            pass
+
+        choice = FakeChoice()
+        choice.message = msg
+
+        class FakeResponse:
+            pass
+
+        resp = FakeResponse()
+        resp.choices = [choice]
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_patched_acompletion_caches_deepseek_reasoning_content(self):
+        """Patched async litellm.acompletion caches reasoning_content for DeepSeek models."""
+        import litellm
+
+        remove_sdk_patches()
+        _reasoning_content_cache.clear()
+
+        fake_response = self._make_fake_response(content="Answer", reasoning_content="DeepSeek thought")
+        original_real = litellm.acompletion
+
+        async def fake_acompletion(*args, **kwargs):
+            return fake_response
+
+        litellm.acompletion = fake_acompletion
+
+        try:
+            apply_sdk_patches()
+            result = await litellm.acompletion(model="deepseek-v4", messages=[{"role": "user", "content": "hi"}])
+
+            assert result is fake_response
+            assert _reasoning_content_cache["deepseek-v4"] == "DeepSeek thought"
+        finally:
+            remove_sdk_patches()
+            litellm.acompletion = original_real
+            _reasoning_content_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_patched_acompletion_non_thinking_provider_skips_caching(self):
+        """Async patch must skip caching for providers outside the thinking-injection set."""
+        import litellm
+
+        remove_sdk_patches()
+        _reasoning_content_cache.clear()
+
+        fake_response = self._make_fake_response(content="Answer", reasoning_content="Something")
+        original_real = litellm.acompletion
+
+        async def fake_acompletion(*args, **kwargs):
+            return fake_response
+
+        litellm.acompletion = fake_acompletion
+
+        try:
+            apply_sdk_patches()
+            await litellm.acompletion(model="gpt-4", messages=[{"role": "user", "content": "hi"}])
+            assert "gpt-4" not in _reasoning_content_cache
+        finally:
+            remove_sdk_patches()
+            litellm.acompletion = original_real
+            _reasoning_content_cache.clear()
 
     @pytest.mark.asyncio
     async def test_patched_acompletion_handles_exception_in_caching(self):


### PR DESCRIPTION


Why:
- Thinking effort was a hardcoded "medium" in openai_compatible.py, with only a boolean enable_thinking switch to flip it on. There was no way to dial reasoning depth per project or per model.
- Official OpenAI routing sent gpt-5.4 + tools through /v1/chat/completions, which returns 400 because reasoning_effort with function tools is only supported on /v1/responses.
- For DeepSeek V4 and Kimi K2.5/K2.6/K2-thinking, LiteLLM's transformation either drops (Moonshot) or pops (DeepSeek) the reasoning fields, so thinking mode never activated on the wire even with enable_thinking=true.

Solution:
- New /effort slash command (TUI + direct value + --project/--global/--clear/ status) persisted via ProjectOverride.reasoning_effort in .datus/config.yml and the top-level agent.yml. Resolution chain: project → global → model override from providers.yml → legacy enable_thinking.
- ModelConfig grows reasoning_effort (off|minimal|low|medium|high); LiteLLMAdapter exposes reasoning_effort_level with explicit-effort priority + enable_thinking fallback. Cache key now includes both fields to avoid stale adapter reuse.
- openai_compatible._build_agent gates reasoning injection via litellm. supports_reasoning plus a Datus-maintained deny-list (deepseek-chat, kimi-k2, moonshot-v1-*) — permissive by default so unknown new models still get /effort.
- DeepSeek and Kimi thinking payloads flow through ModelSettings.extra_args ["extra_body"], which the agents SDK forwards as acompletion(extra_body=...) so the JSON body bypasses each provider's drop_params filter. DeepSeek additionally gets reasoning_effort re-injected (LiteLLM pops it during param mapping).
- LiteLLMAdapter.get_agents_sdk_model now returns OpenAIResponsesModel for official OpenAI endpoints so gpt-5.4/o-series + tools route through /v1/responses.
- sdk_patches unchanged in intent: still handles DeepSeek/Kimi reasoning_content echo-back on tool-calling turns.

Test Cases:
- tests/unit_tests/cli/test_effort_commands.py — 23 cases covering direct value, interactive, status (yes/no/raise), --clear, --project/--global scoping.
- tests/unit_tests/models/test_openai_compatible.py — reasoning effort passthrough, gate permissive defaults, deny-list skip + warning, DeepSeek extra_body carries thinking+reasoning_effort, Kimi extra_body carries only thinking.
- tests/unit_tests/models/test_litellm_adapter.py — reasoning_effort_level five levels + off override + legacy bool fallback + case normalization; is_known_non_thinking_model deny-list; Responses API routing for official OpenAI vs LiteLLM for custom endpoints.
- tests/unit_tests/models/test_base.py — cache key busts on enable_thinking / reasoning_effort change.
- tests/unit_tests/configuration/{test_agent_config, test_project_config}.py — reasoning_effort roundtrip, model_overrides injection, project > global precedence, set_active_reasoning_effort validation.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/effort` command and interactive UI to set reasoning effort (off|minimal|low|medium|high) and choose project or global scope.
  * Interactive status shows effective effort and whether the active model supports reasoning.

* **Improvements**
  * Config and model layers honor a persisted reasoning-effort override with project/global precedence.
  * Improved provider detection and request payload handling to better support reasoning across adapters.

* **Tests**
  * Expanded unit tests for commands, config, model routing, and SDK reasoning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->