### PR TITLE
[Enhancement] Pinned TUI streaming region + accumulator-only body flow

### DIFF
--- a/datus/cli/action_display/display.py
+++ b/datus/cli/action_display/display.py
@@ -16,6 +16,7 @@ from datus.utils.loggings import get_logger
 if TYPE_CHECKING:
     from datus.cli.action_display.streaming import InlineStreamingContext
     from datus.cli.execution_state import InteractionBroker
+    from datus.cli.tui.live_display_state import LiveDisplayState
 
 logger = get_logger(__name__)
 
@@ -23,9 +24,15 @@ logger = get_logger(__name__)
 class ActionHistoryDisplay:
     """Display ActionHistory in a flat inline format (Claude Code style)"""
 
-    def __init__(self, console: Optional[Console] = None, enable_truncation: bool = True):
+    def __init__(
+        self,
+        console: Optional[Console] = None,
+        enable_truncation: bool = True,
+        live_state: Optional["LiveDisplayState"] = None,
+    ):
         self.console = console or Console()
         self.enable_truncation = enable_truncation
+        self.live_state = live_state
 
         # Create content generator with truncation setting
         self.content_generator = ActionContentGenerator(enable_truncation=enable_truncation)
@@ -146,8 +153,17 @@ class ActionHistoryDisplay:
             # Skip PROCESSING TOOL entries (only render SUCCESS/FAILED)
             if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
                 continue
-            # Skip node final actions (e.g. chat_response) — rendered separately
-            if action.role == ActionRole.ASSISTANT and action.action_type and action.action_type.endswith("_response"):
+            # Skip assistant terminal response actions — they are rendered by
+            # the per-turn callback (``_render_turn_response``) or by the
+            # external ``_render_final_response`` pipeline. Walking them here
+            # would paint the main body twice (once from plain ``response``,
+            # once from the wrapping ``*_response``).
+            if (
+                action.role == ActionRole.ASSISTANT
+                and action.action_type
+                and (action.action_type == "response" or action.action_type.endswith("_response"))
+                and action.depth == 0
+            ):
                 continue
 
             # -- subagent_complete action closes a group --
@@ -258,8 +274,16 @@ class ActionHistoryDisplay:
         history_turns: Optional[List[Tuple[str, List[ActionHistory]]]] = None,
         current_user_message: str = "",
         interaction_broker: Optional["InteractionBroker"] = None,
+        streaming_deltas: Optional[List[ActionHistory]] = None,
     ) -> "InlineStreamingContext":
-        """Create an inline streaming display context for actions (Claude Code style)"""
+        """Create an inline streaming display context for actions (Claude Code style).
+
+        ``streaming_deltas`` is an optional parallel queue for
+        ``thinking_delta`` actions; the caller populates it as delta events
+        arrive and clears it on each message boundary. The streaming context
+        reads from it for pinned-region live rendering and mid-run Ctrl+O
+        re-render of the main body.
+        """
         from datus.cli.action_display.streaming import InlineStreamingContext
 
         return InlineStreamingContext(
@@ -268,6 +292,8 @@ class ActionHistoryDisplay:
             history_turns=history_turns or [],
             current_user_message=current_user_message,
             interaction_broker=interaction_broker,
+            live_state=self.live_state,
+            streaming_deltas=streaming_deltas,
         )
 
     def stop_live(self) -> None:
@@ -287,6 +313,10 @@ class ActionHistoryDisplay:
                 logger.debug(f"Error restarting live display: {e}")
 
 
-def create_action_display(console: Optional[Console] = None, enable_truncation: bool = True) -> ActionHistoryDisplay:
+def create_action_display(
+    console: Optional[Console] = None,
+    enable_truncation: bool = True,
+    live_state: Optional["LiveDisplayState"] = None,
+) -> ActionHistoryDisplay:
     """Factory function to create ActionHistoryDisplay with truncation control"""
-    return ActionHistoryDisplay(console, enable_truncation)
+    return ActionHistoryDisplay(console, enable_truncation, live_state=live_state)

--- a/datus/cli/action_display/markdown_stream.py
+++ b/datus/cli/action_display/markdown_stream.py
@@ -1,0 +1,132 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Incremental markdown stream buffer for TUI pinned-region rendering.
+
+The buffer accepts LLM-generated ``thinking_delta`` text chunks and decides
+which prefix is "stable enough" to be flushed to the Rich scrollback area
+(final monokai-highlighted markdown) while the rest stays in the pinned
+live-render region as ``tail`` — the area users see being rewritten as new
+tokens arrive.
+
+Stable-boundary heuristic:
+
+1.  Hard boundary is ``"\\n\\n"`` (CommonMark blank line). Everything up to
+    the last blank line is eligible to flush.
+2.  Fence (``\\`\\`\\`\\`\\`\\``) guard: when the number of triple-backticks in
+    the whole text is odd, an unclosed fenced code block is in flight and
+    *nothing* is flushed — we must never hand a half-open code block to
+    Rich's markdown renderer or its styling would leak into subsequent
+    content.
+3.  Oversize guard: when the tail (the portion still pending) grows past
+    :data:`MAX_TAIL_BYTES`, we force a flush at the last ``"\\n"`` so the
+    Rich markdown renderer is not asked to re-parse a multi-KB string on
+    every token.
+
+This class is deliberately synchronous and pure-Python (no Rich / no
+prompt_toolkit); the streaming context runs it on its daemon refresh thread
+so external locking is the caller's responsibility.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+# Tail byte budget before triggering the oversize commit path. 4 KiB keeps
+# per-token Rich re-parsing latency well below one frame at 4 Hz.
+MAX_TAIL_BYTES = 4096
+
+
+class MarkdownStreamBuffer:
+    """Accumulate streaming markdown deltas and emit stable segments.
+
+    The buffer holds one growing string (``tail``). Each :meth:`append` call
+    returns the list of segments that have crossed the stability boundary
+    during that call, in order. Callers print those segments to the
+    permanent Rich scrollback area and render the remaining ``tail`` into
+    the pinned live region until the next delta arrives or the stream
+    terminates (in which case :meth:`flush` drains it).
+    """
+
+    def __init__(self) -> None:
+        self._tail: str = ""
+
+    def append(self, delta: str) -> List[str]:
+        """Append ``delta`` and return any newly stable segments.
+
+        Stable segments are always suffixed with the ``"\\n\\n"`` that
+        separated them from the next block, so printing ``"".join(segments)``
+        reproduces the original text exactly.
+        """
+        if not delta:
+            return []
+        self._tail += delta
+        stable, new_tail = self._split(self._tail)
+        # Oversize guard: if we still have a huge tail and fences are
+        # balanced, commit up to the last newline so Rich isn't asked to
+        # re-render a multi-KB chunk on every subsequent delta.
+        if len(new_tail) > MAX_TAIL_BYTES and new_tail.count("```") % 2 == 0:
+            nl = new_tail.rfind("\n")
+            if nl > 0:
+                stable.append(new_tail[: nl + 1])
+                new_tail = new_tail[nl + 1 :]
+        self._tail = new_tail
+        return stable
+
+    def append_raw(self, delta: str) -> None:
+        """Append ``delta`` without any stability detection.
+
+        Used by the accumulator-only flow: the pinned live region shows the
+        growing body token-by-token and the whole text is flushed to the
+        scrollback **only** when :meth:`flush` is called at message
+        boundaries. Nothing is ever pushed mid-stream, so there is no risk
+        of doubling up on a final one-shot render.
+        """
+        if not delta:
+            return
+        self._tail += delta
+
+    def flush(self) -> str:
+        """Return whatever is left in ``tail`` and clear the buffer.
+
+        Used on stream termination (final response arrived) and on user
+        interruption (Ctrl+C / ESC) so the scrollback preserves the exact
+        text the user saw.
+        """
+        pending = self._tail
+        self._tail = ""
+        return pending
+
+    def clear(self) -> None:
+        self._tail = ""
+
+    def get_tail(self) -> str:
+        return self._tail
+
+    def has_tail(self) -> bool:
+        return bool(self._tail)
+
+    @staticmethod
+    def _split(text: str) -> Tuple[List[str], str]:
+        """Split ``text`` into ``(stable_segments, new_tail)``.
+
+        Returns an empty ``stable_segments`` list when the text still has
+        an unclosed fence or no blank-line boundary has appeared yet.
+        """
+        if not text:
+            return [], ""
+        # Unclosed fenced code block: hold everything.
+        if text.count("```") % 2 == 1:
+            return [], text
+        # Commit up to the last blank-line boundary.
+        idx = text.rfind("\n\n")
+        if idx < 0:
+            return [], text
+        cut = idx + 2
+        stable = text[:cut]
+        tail = text[cut:]
+        if not stable.strip():
+            # Leading whitespace only — nothing meaningful to flush.
+            return [], text
+        return [stable], tail

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -5,15 +5,19 @@
 """InlineStreamingContext: unified processing pipeline for streaming and sync modes."""
 
 import asyncio
+import io
 import sys
 import threading
+import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
 
 from rich.console import Console, Group
 from rich.live import Live
+from rich.markdown import Markdown
 from rich.text import Text
 
+from datus.cli.action_display.markdown_stream import MarkdownStreamBuffer
 from datus.cli.action_display.renderers import _truncate_middle
 from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 from datus.utils.loggings import get_logger
@@ -21,6 +25,7 @@ from datus.utils.loggings import get_logger
 if TYPE_CHECKING:
     from datus.cli.action_display.display import ActionHistoryDisplay
     from datus.cli.execution_state import InteractionBroker
+    from datus.cli.tui.live_display_state import LiveDisplayLine, LiveDisplayState
 
 logger = get_logger(__name__)
 
@@ -29,6 +34,34 @@ _BLINK_FRAMES = ["○", "●"]
 
 # In compact mode, only show the last N subagent actions in the Live overlay
 _SUBAGENT_ROLLING_WINDOW_SIZE = 2
+
+
+def _tail_has_incomplete_table(text: str) -> bool:
+    """Should tail rendering fall back to plain text to avoid a broken table?
+
+    Rich's ``Markdown`` renderer needs at least a header row, a separator
+    row, and one body row to produce a box-drawing table; when only the
+    header (and optionally the separator) have been streamed, Rich emits a
+    corrupted half-grid. Once a body row is in, Rich renders a proper box
+    even mid-stream, so we deliberately *stop* falling back at that point
+    to honour the "live markdown" expectation — partial trailing cells are
+    accepted as visual noise that disappears the moment the next row
+    arrives.
+
+    Returns True (use plain text) only when:
+
+    * The tail contains at least one pipe line.
+    * The tail is not terminated by a blank line (``\\n\\n``).
+    * The pipe-line count is still ≤ 2 (i.e. header-only or header+separator).
+    """
+    if not text or "|" not in text:
+        return False
+    if text.endswith("\n\n"):
+        return False
+    pipe_lines = [line for line in text.splitlines() if "|" in line.strip()]
+    if not pipe_lines:
+        return False
+    return len(pipe_lines) <= 2
 
 
 class InlineStreamingContext:
@@ -52,8 +85,17 @@ class InlineStreamingContext:
         current_user_message: str = "",
         sync_mode: bool = False,
         interaction_broker: Optional["InteractionBroker"] = None,
+        live_state: Optional["LiveDisplayState"] = None,
+        streaming_deltas: Optional[List[ActionHistory]] = None,
     ):
         self.actions = actions_list
+        # Parallel queue holding ``thinking_delta`` actions only. Populated by
+        # the caller (``chat_commands.run_chat_stream``) as deltas stream in
+        # and cleared on paired terminal response actions. The streaming
+        # context consumes from here via ``_delta_processed_index`` so
+        # ``self.actions`` stays delta-free and structural.
+        self._deltas: List[ActionHistory] = streaming_deltas if streaming_deltas is not None else []
+        self._delta_processed_index: int = 0
         self.display = display_instance
         self._history_turns: List[Tuple[str, List[ActionHistory]]] = history_turns or []
         self._current_user_message = current_user_message
@@ -62,6 +104,10 @@ class InlineStreamingContext:
         self._tick = 0
         self._stop_event = threading.Event()
         self._refresh_thread: Optional[threading.Thread] = None
+        # WARNING: key-binding handlers on the prompt_toolkit loop must NOT
+        # acquire ``_print_lock``. The refresh daemon holds it while calling
+        # ``run_in_terminal_sync``; if a key handler tried to grab it on the
+        # main loop thread we would deadlock.
         self._print_lock = threading.Lock()
         self._live: Optional[Live] = None
         self._paused = False
@@ -75,6 +121,61 @@ class InlineStreamingContext:
         self._input_collector: Optional[Callable[[ActionHistory, Console], Optional[List[List[str]]]]] = None
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
         self._clear_header_callback: Optional[Callable[[], None]] = None
+        # TUI path: when provided, all subagent/processing rolling-window
+        # rendering is pushed into this shared state (painted by DatusApp's
+        # own layout) instead of Rich ``Live``, eliminating cursor-fights
+        # with ``patch_stdout(raw=True)``.
+        self._live_state: Optional["LiveDisplayState"] = live_state
+        self._tui_mode = live_state is not None
+        # Streaming markdown state (TUI mode only). ``_markdown_buffer`` holds
+        # the unstable tail rendered into the pinned region; stable segments
+        # are flushed above via ``_print_markdown_to_scrollback``. A single
+        # buffer is reused across turns (cleared by ``_finalize_markdown_stream``
+        # and ``__exit__``) to avoid per-delta allocations.
+        self._markdown_buffer: Optional[MarkdownStreamBuffer] = MarkdownStreamBuffer() if self._tui_mode else None
+        self._markdown_stream_has_streamed: bool = False
+        self._last_delta_time: float = 0.0
+        # Current PROCESSING action whose blink frame occupies the pinned
+        # region (TUI mode). ``_repaint_live`` reads this together with
+        # ``_tick`` to animate the frame.
+        self._processing_action: Optional[ActionHistory] = None
+        # ``action_id`` of every thinking_delta we've processed in the current
+        # turn. The paired terminal ASSISTANT SUCCESS action from
+        # ``openai_compatible`` / ``codex_model`` reuses the same id
+        # (``thinking_stream_id``), so matching on id — not on
+        # ``action_type`` suffix — catches the full matrix of ``"response"``
+        # and ``"*_response"`` names that otherwise leaks a duplicate body
+        # into the scrollback.
+        self._markdown_active_stream_ids: Set[str] = set()
+        # Stream ids whose paired terminal action has already been de-duped
+        # (so any later reprint — e.g. Ctrl+O — does not double-flush).
+        self._markdown_stream_consumed_ids: Set[str] = set()
+        # Latched for the rest of the current turn once we finalize a
+        # streaming response. Any *subsequent* main-agent ASSISTANT SUCCESS
+        # action in the same turn is an agent-node wrapper re-emission of
+        # the same body (e.g. ``chat_response`` from
+        # :mod:`chat_agentic_node` on top of the underlying
+        # ``openai_compatible.py`` ``"response"`` action) and must be
+        # dropped. Reset on ``__enter__``.
+        self._turn_finalized: bool = False
+        # Persistent flag: once we have flushed any non-empty main-agent
+        # body to the scrollback in this streaming context, the outer
+        # ``chat_commands._render_final_response`` pipeline should skip its
+        # ``_display_markdown_response`` step or the user sees the same
+        # body twice. Unlike ``_turn_finalized`` this flag is *not* cleared
+        # per-turn — the accumulator-only flow only produces one body per
+        # context, so one-shot latching is exactly right.
+        self._stream_body_finalized: bool = False
+        # Deferred reprint flag: ``_print_completed_action`` can't invoke
+        # ``_reprint_with_collapse`` directly because the caller
+        # (``_process_actions``) still needs to advance ``_processed_index``
+        # past the response action it just handled — otherwise the reprint
+        # slices ``self.actions[:_processed_index]`` *before* that response
+        # and renders nothing. The caller checks this flag immediately
+        # after ``_processed_index += 1`` and triggers the reprint from
+        # there so the final Markdown render includes the just-completed
+        # response action.
+        self._reprint_pending: bool = False
 
     @property
     def live(self) -> Optional[Live]:
@@ -134,14 +235,11 @@ class InlineStreamingContext:
         2. No Live animation is started.
         3. No thread, runs on the calling thread.
         INTERACTION actions are skipped (only shown during live interaction).
+        ``thinking_delta`` actions never reach ``self.actions`` in the new
+        split-queue design — no explicit guard needed.
         """
         while self._processed_index < len(self.actions):
             action = self.actions[self._processed_index]
-
-            # Skip thinking_delta actions in sync mode (transient streaming events)
-            if action.action_type == "thinking_delta":
-                self._processed_index += 1
-                continue
 
             # INTERACTION actions: skip in history replay (only shown during live interaction)
             if action.role == ActionRole.INTERACTION:
@@ -228,8 +326,13 @@ class InlineStreamingContext:
 
     def __enter__(self):
         self._processed_index = 0
+        self._delta_processed_index = 0
         self._stop_event.clear()
         self._paused = False
+        # Fresh turn: forget which response we've already finalized so the
+        # next stream's first paired completion triggers the full dedupe
+        # + reprint cycle again.
+        self._turn_finalized = False
 
         # Register with display instance
         self.display._current_context = self
@@ -248,8 +351,30 @@ class InlineStreamingContext:
         if self._refresh_thread:
             self._refresh_thread.join(timeout=2.0)
 
+        # Drain any deltas that arrived after the last refresh tick so
+        # _finalize_markdown_stream can still flush their stable segments.
+        if self._tui_mode:
+            try:
+                self._process_deltas()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("_process_deltas raised during exit drain: %s", exc)
+
         # Flush remaining actions after thread has stopped (no more concurrent access)
         self._flush_remaining_actions()
+
+        # Drain any markdown tail left over (interrupted stream, or a final
+        # response action that never arrived). Printing here preserves the
+        # "where the model stopped talking" context in the scrollback.
+        if self._tui_mode and self._markdown_buffer is not None and self._markdown_buffer.has_tail():
+            tail = self._markdown_buffer.flush()
+            if tail.strip():
+                try:
+                    self._print_markdown_to_scrollback(tail)
+                    # Mark the body as landed so the outer
+                    # ``_render_final_response`` does not paint it again.
+                    self._stream_body_finalized = True
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug("Markdown tail flush on exit failed: %s", exc)
 
         # Unregister
         if self.display._current_context is self:
@@ -308,14 +433,27 @@ class InlineStreamingContext:
                                 )
                         self.display.console.print("[bold bright_black]  \u23af switched to compact mode \u23af[/]")
                     self._reprint_history(verbose=self._verbose)
-                    # Restart Live for any remaining active subagent groups
+                    # Restart Live for any remaining active subagent groups.
+                    # In TUI mode the pinned region re-draws from LiveDisplayState
+                    # on its own; explicit re-emission handles non-TUI Rich Live.
                     if self._subagent_groups:
                         with self._print_lock:
                             self._update_subagent_groups_live()
 
             if not self._paused and not self._verbose_frozen:
+                if self._tui_mode:
+                    self._process_deltas()
                 self._process_actions()
                 self._tick += 1
+                if self._tui_mode:
+                    # Periodic repaint drives the processing-frame blink
+                    # animation (frame = _tick % 2) and picks up buffer
+                    # tail changes that arrive between ticks. In the
+                    # accumulator-only flow nothing is pushed mid-stream —
+                    # the final flush happens in ``_finalize_markdown_stream``
+                    # at the message boundary (caller clears the deltas
+                    # queue) and as an ``__exit__`` safety drain.
+                    self._repaint_live()
             self._stop_event.wait(timeout=0.25)
 
     # -- unified reprint history -------------------------------------------
@@ -340,19 +478,32 @@ class InlineStreamingContext:
             if self._history_turns:
 
                 def _render_turn_response(turn_actions: List[ActionHistory]) -> None:
+                    # Prefer the wrapper action (e.g. ``chat_response``) since
+                    # ``render_action_history`` already skips it. Fall back to
+                    # plain ``response`` for providers that don't emit a
+                    # wrapper — otherwise the turn ends without any visible
+                    # main-agent body.
+                    wrapper = None
+                    plain = None
                     for a in reversed(turn_actions):
                         if (
-                            a.role == ActionRole.ASSISTANT
-                            and a.action_type
-                            and a.action_type.endswith("_response")
-                            and a.depth == 0
-                            and a.status == ActionStatus.SUCCESS
+                            a.role != ActionRole.ASSISTANT
+                            or a.depth != 0
+                            or a.status != ActionStatus.SUCCESS
+                            or not a.action_type
                         ):
-                            self.display.renderer.print_renderables(
-                                self.display.console,
-                                self.display.renderer.render_main_action(a, verbose=verbose),
-                            )
+                            continue
+                        if a.action_type.endswith("_response") and a.action_type != "response":
+                            wrapper = a
                             break
+                        if a.action_type == "response" and plain is None:
+                            plain = a
+                    chosen = wrapper or plain
+                    if chosen is not None:
+                        self.display.renderer.print_renderables(
+                            self.display.console,
+                            self.display.renderer.render_main_action(chosen, verbose=verbose),
+                        )
 
                 self.display.render_multi_turn_history(
                     self._history_turns, verbose=verbose, per_turn_callback=_render_turn_response
@@ -371,6 +522,30 @@ class InlineStreamingContext:
                 a for a in self.actions[: self._processed_index] if not (a.role == ActionRole.USER and a.depth == 0)
             ]
             self.display.render_action_history(current_actions, verbose=verbose, _show_partial_done=False)
+            # 3a. Render the streaming main-agent body (from deltas accumulator)
+            # so mid-run Ctrl+O doesn't drop the text the user was reading.
+            # ``_response`` / plain ``response`` only arrive after deltas end,
+            # so the deltas queue is the only source of truth for the
+            # *in-flight* message body. We pick the last delta's
+            # ``accumulated`` field because each delta carries the full
+            # running text up to that point. After printing we reset the
+            # markdown buffer and latch ``_stream_body_finalized`` so the
+            # end-of-message ``_finalize_markdown_stream`` only commits the
+            # *incremental* tail that arrives after this point — avoiding a
+            # duplicate body in the scrollback.
+            if self._deltas:
+                last_accumulated = ""
+                for delta in reversed(self._deltas):
+                    if isinstance(delta.output, dict):
+                        candidate = delta.output.get("accumulated", "")
+                        if isinstance(candidate, str) and candidate:
+                            last_accumulated = candidate
+                            break
+                if last_accumulated.strip():
+                    self.display.console.print(Markdown(last_accumulated))
+                    if self._markdown_buffer is not None:
+                        self._markdown_buffer.clear()
+                    self._stream_body_finalized = True
             # 4. Optionally render active subagent groups (verbose snapshot)
             if show_active_groups:
                 for _group_key, group in self._subagent_groups.items():
@@ -397,14 +572,14 @@ class InlineStreamingContext:
     # -- core processing (async mode) --------------------------------------
 
     def _process_actions(self) -> None:
-        """Walk from _processed_index forward and handle each action."""
+        """Walk from _processed_index forward and handle each action.
+
+        ``thinking_delta`` actions are never seen here — the caller routes them
+        into a separate ``streaming_deltas`` queue consumed by
+        :meth:`_process_deltas`.
+        """
         while self._processed_index < len(self.actions):
             action = self.actions[self._processed_index]
-
-            # Streaming thinking deltas: skip in CLI (not supported yet)
-            if action.action_type == "thinking_delta":
-                self._processed_index += 1
-                continue
 
             # INTERACTION actions: collect input during live interaction, skip in history
             if action.role == ActionRole.INTERACTION:
@@ -484,11 +659,6 @@ class InlineStreamingContext:
         while self._processed_index < len(self.actions):
             action = self.actions[self._processed_index]
 
-            # Skip thinking_delta actions in flush (transient, already displayed via Live)
-            if action.action_type == "thinking_delta":
-                self._processed_index += 1
-                continue
-
             # INTERACTION actions: skip in flush (only shown during live interaction)
             if action.role == ActionRole.INTERACTION:
                 self._processed_index += 1
@@ -526,6 +696,17 @@ class InlineStreamingContext:
             for group_key in list(self._subagent_groups.keys()):
                 group = self._subagent_groups.pop(group_key)
                 first_action = group.get("first_action")
+                duration_sec = (datetime.now() - group["start_time"]).total_seconds() if group["start_time"] else 0.0
+                summary = f"  \u23bf  Done ({group['tool_count']} tool uses \u00b7 {duration_sec:.1f}s)"
+                if self._tui_mode:
+                    # Header lives in the pinned region (just cleared) —
+                    # emit ⏺ header + ⎿ Done together so the scrollback
+                    # still identifies which subagent this summary is for.
+                    if first_action is not None:
+                        self._print_subagent_summary_to_append(first_action, summary)
+                    else:
+                        self._print_to_append_area(f"[dim]{summary}[/dim]")
+                    continue
                 if first_action:
                     self.display.renderer.print_renderables(
                         self.display.console,
@@ -536,8 +717,6 @@ class InlineStreamingContext:
                         self.display.console,
                         self.display.renderer.render_subagent_action(buffered, self._verbose),
                     )
-                duration_sec = (datetime.now() - group["start_time"]).total_seconds()
-                summary = f"  \u23bf  Done ({group['tool_count']} tool uses \u00b7 {duration_sec:.1f}s)"
                 self.display.console.print(f"[dim]{summary}[/dim]")
 
     # -- sub-agent group display (async mode) --------------------------------
@@ -547,8 +726,43 @@ class InlineStreamingContext:
         """Truncate text in the middle if too long, keeping head and tail."""
         return _truncate_middle(text, max_len)
 
+    # -- TUI-mode append-area helpers ---------------------------------------
+
+    def _print_to_append_area(self, markup: str) -> None:
+        """Print ``markup`` above the pinned TUI region, or direct when no app.
+
+        Uses :func:`run_in_terminal_sync` so prompt_toolkit re-orchestrates
+        the bottom area; outside TUI the helper falls through to a direct
+        call (same behaviour as today).
+        """
+        from datus.cli.tui.console_bridge import run_in_terminal_sync
+
+        console = self.display.console
+        run_in_terminal_sync(lambda: console.print(markup))
+
+    def _print_subagent_summary_to_append(self, first_action: ActionHistory, summary: str) -> None:
+        """Emit ``⏺ header`` + ``⎿ Done(…)`` into the append area on group completion."""
+        from datus.cli.tui.console_bridge import run_in_terminal_sync
+
+        console = self.display.console
+        header_renderables = self.display.renderer.render_subagent_header(first_action, verbose=False)
+
+        def _emit() -> None:
+            for r in header_renderables:
+                console.print(r)
+            console.print(f"[dim]{summary}[/dim]")
+
+        run_in_terminal_sync(_emit)
+
     def _start_subagent_group(self, first_action: ActionHistory, group_key: Optional[str] = None) -> None:
-        """Create sub-agent group and update the Live display."""
+        """Create sub-agent group and update the Live display.
+
+        In TUI mode the group's ``⏺ header`` row is rendered as the first
+        line of the pinned block by :meth:`_build_subagent_live_lines`;
+        nothing is emitted to the append area here. On group completion
+        :meth:`_end_subagent_group_by_key` appends a ``header + Done``
+        summary to the scrollback so a permanent trace remains.
+        """
         subagent_type = first_action.action_type or "subagent"
 
         with self._print_lock:
@@ -580,6 +794,11 @@ class InlineStreamingContext:
 
         In compact mode, triggers a full reprint with completed groups collapsed.
         In verbose mode, permanently prints the completed group (header + actions + Done).
+
+        In TUI mode, the header was already printed on group-start (see
+        :meth:`_start_subagent_group`), the rolling window is pinned state
+        (cleared on group end), and we only need to append a collapsed Done
+        line so the append-area scrollback keeps a permanent trace.
         """
         self._stop_processing_live()
         self._stop_subagent_live()
@@ -591,20 +810,36 @@ class InlineStreamingContext:
         if group_key is not None:
             self._completed_group_ids.add(group_key)
 
+        end_time = end_action.end_time or datetime.now()
+        duration = ""
+        if group["start_time"]:
+            duration_sec = (end_time - group["start_time"]).total_seconds()
+            duration = f" \u00b7 {duration_sec:.1f}s"
+
+        tool_count = group["tool_count"]
+        summary = f"  \u23bf  Done ({tool_count} tool uses{duration})"
+
+        if self._tui_mode:
+            # TUI mode: emit ⏺ header + ⎿ Done into the append area as a
+            # permanent scrollback block so the reader knows which subagent
+            # this Done refers to. No reprint-with-collapse is performed.
+            first_action = group.get("first_action")
+            if first_action is not None:
+                self._print_subagent_summary_to_append(first_action, summary)
+            else:
+                self._print_to_append_area(f"[dim]{summary}[/dim]")
+            # Refresh the pinned region: either paint remaining subagent
+            # groups, or fall through to markdown tail / clear when none
+            # are active. Without this, a lingering snapshot of the
+            # just-ended group stays visible until the next tick.
+            self._repaint_live()
+            return
+
         if not self._verbose:
             # Compact mode: clear screen and reprint with completed groups collapsed
             self._reprint_with_collapse()
         else:
             # Verbose mode: permanently print the completed group
-            end_time = end_action.end_time or datetime.now()
-            duration = ""
-            if group["start_time"]:
-                duration_sec = (end_time - group["start_time"]).total_seconds()
-                duration = f" \u00b7 {duration_sec:.1f}s"
-
-            tool_count = group["tool_count"]
-            summary = f"  \u23bf  Done ({tool_count} tool uses{duration})"
-
             with self._print_lock:
                 first_action = group.get("first_action")
                 if first_action:
@@ -635,7 +870,17 @@ class InlineStreamingContext:
     # -- subagent Live display ------------------------------------------------
 
     def _update_subagent_groups_live(self) -> None:
-        """Start or update the Live display showing all active subagent groups."""
+        """Start or update the subagent rolling-window display.
+
+        In TUI mode (``self._tui_mode``), the rolling window is one input
+        to the shared pinned-region painter :meth:`_repaint_live`; the
+        painter resolves priority against processing-tool blink and
+        streaming markdown tail. Outside TUI, the legacy Rich ``Live``
+        path renders directly.
+        """
+        if self._tui_mode:
+            self._repaint_live()
+            return
         renderable = self._build_subagent_groups_renderable()
         if self._subagent_live is None:
             # ``redirect_stdout`` / ``redirect_stderr`` are set to ``False`` so
@@ -658,7 +903,14 @@ class InlineStreamingContext:
             self._subagent_live.update(renderable)
 
     def _stop_subagent_live(self) -> None:
-        """Stop the subagent Live display if running."""
+        """Stop the subagent rolling-window display."""
+        if self._tui_mode:
+            # The subagent groups dict is the source of truth — callers have
+            # already popped completed groups before invoking this. Ask the
+            # painter to repick the pinned content so processing frames or
+            # markdown tails can reclaim the region.
+            self._repaint_live()
+            return
         with self._print_lock:
             if self._subagent_live is not None:
                 try:
@@ -686,6 +938,280 @@ class InlineStreamingContext:
                 items.extend(self.display.renderer.render_subagent_action(action, self._verbose))
         return Group(*items) if items else Group(Text(""))
 
+    def _build_subagent_live_lines(self) -> List["LiveDisplayLine"]:
+        """Stack each active subagent as its own pinned block.
+
+        Each block = one header row (``⏺ subagent_type(goal)``) followed by
+        up to ``TOOL_LINES_PER_GROUP`` rolling tool-call rows for that same
+        subagent. Blocks are concatenated in group-creation order so the
+        visual flow is ``header1 → tools1 → header2 → tools2 → …`` — each
+        subagent's tools stay grouped under its own header instead of
+        interleaving across groups. The combined total is capped by
+        :data:`MAX_LIVE_LINES_TOTAL`.
+        """
+        from datus.cli.tui.live_display_state import TOOL_LINES_PER_GROUP, LiveDisplayLine
+
+        result: List["LiveDisplayLine"] = []
+        for _group_key, group in self._subagent_groups.items():
+            first_action = group.get("first_action")
+            if first_action is not None:
+                header_segments = self._build_subagent_header_segments(first_action)
+                if header_segments:
+                    result.append(LiveDisplayLine(segments=header_segments))
+            tool_texts: List[Text] = []
+            for action in group.get("actions", []):
+                tool_texts.extend(self.display.renderer.render_subagent_action(action, verbose=False))
+            tool_texts = [t for t in tool_texts if (t.plain or "").strip()]
+            tail = tool_texts[-TOOL_LINES_PER_GROUP:]
+            for text in tail:
+                result.append(LiveDisplayLine(segments=[("class:subagent-live", text.plain)]))
+        return result
+
+    @staticmethod
+    def _build_subagent_header_segments(first_action: ActionHistory) -> List[Tuple[str, str]]:
+        """Split the ⏺ header into a cyan name segment + default goal segment.
+
+        Mirrors the field layout of
+        :meth:`ActionRenderer.render_subagent_header` so the pinned-region
+        header stays in lock-step with the scrollback header without
+        re-parsing Rich markup back into prompt_toolkit styles.
+        """
+        subagent_type = first_action.action_type or "subagent"
+        prompt = first_action.messages or ""
+        if prompt.startswith("User: "):
+            prompt = prompt[6:]
+        description = ""
+        if first_action.input and isinstance(first_action.input, dict):
+            description = first_action.input.get("_task_description", "")
+        goal = description or (_truncate_middle(prompt, max_len=200) if prompt else "")
+
+        segments: List[Tuple[str, str]] = [("class:subagent-header-live", f"\u23fa {subagent_type}")]
+        if goal:
+            segments.append(("class:subagent-header-goal-live", f"({goal})"))
+        return segments
+
+    # -- pinned-region painter (TUI-mode priority multiplexer) --------------
+
+    def _repaint_live(self) -> None:
+        """Render the pinned region from current state (TUI mode only).
+
+        Priority, high → low:
+
+        1. ``_processing_action`` — blinking frame for a running tool.
+        2. ``_subagent_groups`` — rolling header + tool-tail lines.
+        3. Streaming markdown ``tail`` — the part the user is watching grow.
+        4. Nothing — clear so the region collapses to zero rows.
+
+        Each writer only updates its own state slot; this method combines
+        them on every call so the three layers never overwrite each other
+        out-of-order. Safe to call from the refresh daemon thread because
+        :class:`LiveDisplayState` is internally locked and its
+        ``invalidate_cb`` dispatches to the prompt_toolkit loop.
+        """
+        if not self._tui_mode or self._live_state is None:
+            return
+        if self._verbose_frozen:
+            # Frozen snapshot owns the screen; pinned region must not repaint.
+            self._live_state.clear()
+            return
+        from datus.cli.tui.live_display_state import LiveDisplayLine
+
+        if self._processing_action is not None:
+            frame = _BLINK_FRAMES[self._tick % len(_BLINK_FRAMES)]
+            renderable = self.display.renderer.render_processing(self._processing_action, frame)
+            self._live_state.set_lines([LiveDisplayLine(segments=[("class:processing-live", renderable.plain)])])
+            return
+        if self._subagent_groups:
+            self._live_state.set_lines(self._build_subagent_live_lines())
+            return
+        if self._markdown_buffer is not None and self._markdown_buffer.has_tail():
+            self._live_state.set_lines(self._build_markdown_tail_lines())
+            return
+        self._live_state.clear()
+
+    def _build_markdown_tail_lines(self) -> List["LiveDisplayLine"]:
+        """Render the current markdown tail into pinned ``LiveDisplayLine``s.
+
+        The tail is rendered via a throwaway ``Rich.Console`` capturing ANSI
+        to a string, then split per-line and converted to prompt_toolkit
+        :class:`FormattedText` fragments via
+        :class:`prompt_toolkit.formatted_text.ANSI`. When the rendered output
+        is taller than the current pinned-row budget (derived from the live
+        terminal height), only the bottom rows are kept (newest tokens live
+        at the end) with a leading ``…`` row.
+        """
+        from prompt_toolkit.formatted_text import ANSI
+
+        from datus.cli.tui.live_display_state import LiveDisplayLine
+
+        assert self._markdown_buffer is not None  # noqa: S101  guarded by caller
+        tail = self._markdown_buffer.get_tail()
+        if not tail:
+            return []
+        cols = max(20, getattr(self.display.console, "width", 80) or 80)
+        buf = io.StringIO()
+        rc = Console(
+            file=buf,
+            force_terminal=True,
+            color_system="truecolor",
+            width=cols,
+            legacy_windows=False,
+        )
+        # When the tail looks like a table that hasn't been terminated
+        # by a blank line, Rich's ``Markdown`` renderer garbles the
+        # half-formed grid (columns shift, borders break, next tokens
+        # land inside the wrong cell). Fall back to plain-text rendering
+        # for that case so the user sees a readable incremental table
+        # instead of a corrupted one; the completed version still lands
+        # in the scrollback as proper Markdown once the blank line
+        # arrives and the segment becomes stable.
+        if _tail_has_incomplete_table(tail):
+            rc.print(tail, markup=False, highlight=False)
+        else:
+            try:
+                rc.print(Markdown(tail))
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Rich markdown render raised on tail: %s", exc)
+                rc.print(tail, markup=False, highlight=False)
+        ansi = buf.getvalue().rstrip("\n")
+        if not ansi:
+            return []
+        all_lines = ansi.split("\n")
+        max_rows = self._live_state.max_rows() if self._live_state else len(all_lines)
+        if len(all_lines) > max_rows:
+            visible = all_lines[-(max_rows - 1) :]
+            lines: List[LiveDisplayLine] = [LiveDisplayLine(segments=[("class:markdown-stream-ellipsis", "…")])]
+            for ansi_line in visible:
+                lines.append(LiveDisplayLine(segments=list(ANSI(ansi_line).__pt_formatted_text__())))
+            return lines
+        return [LiveDisplayLine(segments=list(ANSI(ansi_line).__pt_formatted_text__())) for ansi_line in all_lines]
+
+    # -- thinking_delta handling --------------------------------------------
+
+    def _process_deltas(self) -> None:
+        """Drain new ``thinking_delta`` actions from the streaming_deltas queue.
+
+        Called on every refresh tick in TUI mode. Handles the caller's
+        per-message reset (``streaming_deltas.clear()``): if the queue shrank
+        below our cursor we finalize the markdown stream (flushing any
+        pending tail into the scrollback) and rewind. New deltas are
+        forwarded to :meth:`_handle_thinking_delta` in order.
+        """
+        if self._markdown_buffer is None:
+            return
+        current_len = len(self._deltas)
+        if current_len < self._delta_processed_index:
+            # Caller cleared the list — message boundary reached. Commit
+            # whatever tail is still buffered so it lands in the scrollback
+            # and reset our cursor.
+            self._finalize_markdown_stream()
+            self._delta_processed_index = 0
+            current_len = len(self._deltas)
+        while self._delta_processed_index < current_len:
+            action = self._deltas[self._delta_processed_index]
+            self._delta_processed_index += 1
+            if action.depth != 0:
+                continue
+            self._handle_thinking_delta(action)
+
+    def _handle_thinking_delta(self, action: ActionHistory) -> None:
+        """Append a streaming text delta into the markdown buffer (TUI mode).
+
+        Accumulator-only policy: the buffer never splits stable segments
+        during the stream, so nothing is pushed to the scrollback while
+        the user is still typing. The pinned region renders the growing
+        accumulator on every tick; the full body only lands in the
+        scrollback on :meth:`_finalize_markdown_stream`, which runs at the
+        message boundary. This guarantees the final transcript contains
+        exactly one copy of the main-agent response.
+        """
+        if self._markdown_buffer is None:
+            return
+        delta = ""
+        if isinstance(action.output, dict):
+            raw = action.output.get("delta", "")
+            if isinstance(raw, str):
+                delta = raw
+        if not delta:
+            return
+        self._last_delta_time = time.monotonic()
+        self._markdown_stream_has_streamed = True
+        if action.action_id:
+            self._markdown_active_stream_ids.add(action.action_id)
+        self._markdown_buffer.append_raw(delta)
+        self._repaint_live()
+
+    def _print_markdown_to_scrollback(self, segment: str) -> None:
+        """Print a stable markdown segment above the pinned region.
+
+        Uses :func:`run_in_terminal_sync` so prompt_toolkit keeps the pinned
+        live-region + status bar + input pinned at the bottom. The helper
+        must never be called while ``_print_lock`` is held — see the lock's
+        class-level warning — so this method is deliberately lock-free.
+        """
+        if not segment.strip():
+            return
+        from datus.cli.tui.console_bridge import run_in_terminal_sync
+
+        console = self.display.console
+        md = Markdown(segment)
+
+        def _emit() -> None:
+            console.print(md)
+
+        run_in_terminal_sync(_emit)
+
+    def _finalize_markdown_stream(self) -> None:
+        """Flush the accumulated body to the scrollback and reset state.
+
+        In the accumulator-only flow this is the *only* point where the
+        main-agent response lands in the Rich scrollback. Triggered by:
+        ``_process_deltas`` detecting the caller's
+        ``streaming_deltas.clear()`` (paired terminal action arrived),
+        ``_print_completed_action`` seeing the plain ``response`` action,
+        and ``__exit__`` as a safety drain.
+        """
+        if self._markdown_buffer is None:
+            return
+        tail = self._markdown_buffer.flush()
+        if tail.strip():
+            self._print_markdown_to_scrollback(tail)
+            # Latch: the outer pipeline's ``_display_markdown_response``
+            # should not repeat this body.
+            self._stream_body_finalized = True
+        self._markdown_stream_has_streamed = False
+        self._last_delta_time = 0.0
+        self._repaint_live()
+
+    @property
+    def has_streamed_response(self) -> bool:
+        """Whether this context has flushed a main-agent body to scrollback.
+
+        Consumed by ``chat_commands._render_final_response`` so it can skip
+        the one-shot ``_display_markdown_response`` step when the streaming
+        path has already landed the full body.
+        """
+        return self._stream_body_finalized
+
+    def _request_post_finalize_reprint(self) -> None:
+        """Clear the screen and reprint history once the main response is in.
+
+        Mimics a double Ctrl+O: compact-mode reprint of everything we've
+        seen so far, so Rich renders the final markdown from the completed
+        action list. Streaming tail passes sometimes leave a visual glitch
+        (half-parsed table border, stray inline code marker) which this
+        clean redraw wipes out. Failures are swallowed — the live scrollback
+        is still intact, so worst case the user keeps the pre-reprint view.
+        """
+        if not self._tui_mode:
+            return
+        if self._verbose_frozen:
+            return
+        try:
+            self._reprint_with_collapse()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("post-finalize reprint failed: %s", exc)
+
     def _format_subagent_action_items(self, action: ActionHistory) -> List[Text]:
         """Format a single subagent action as a list of Text renderables."""
         return self.display.renderer.render_subagent_action(action, self._verbose)
@@ -704,8 +1230,65 @@ class InlineStreamingContext:
             fn = action.input.get("function_name", "") if action.input else ""
             if fn == "task":
                 return
+        # Streaming-markdown de-dup: once this turn has emitted any
+        # thinking_delta, the next main-agent ASSISTANT SUCCESS action is
+        # the paired completion regardless of ``action_type`` (plain
+        # ``"response"`` from openai_compatible / codex vs ``"*_response"``
+        # from agent nodes) or whether the ``action_id`` lines up with the
+        # delta's ``thinking_stream_id`` (some providers mint a fresh id
+        # on the fallback path). The match stays narrow because:
+        #   * ``depth == 0`` excludes subagent responses.
+        #   * ``has_streamed`` is only true after we actually painted a
+        #     delta, so no non-streaming turn can be swallowed.
+        #
+        # After the first such finalize, ``_turn_finalized`` latches True
+        # so any *further* depth-0 ASSISTANT SUCCESS action in the same
+        # turn — i.e. an agent-node wrapper re-emission of the same body,
+        # like ``chat_agentic_node``'s ``chat_response`` action sitting on
+        # top of ``openai_compatible.py``'s ``"response"`` action — is also
+        # dropped. Without this latch the wrapper's body hits
+        # ``render_main_action`` and appears in the scrollback a second
+        # time right below the streamed version.
+        is_main_assistant_success = (
+            self._tui_mode
+            and action.role == ActionRole.ASSISTANT
+            and action.status == ActionStatus.SUCCESS
+            and action.depth == 0
+        )
+        # Accumulator-only dedup. Three signals can indicate the main-agent
+        # body has already been (or is being) flushed to the scrollback:
+        #   * ``_markdown_stream_has_streamed`` — deltas arrived but finalize
+        #     hasn't run yet (this call is the paired terminal action).
+        #   * ``_stream_body_finalized`` — ``_process_deltas`` already
+        #     detected the caller's ``streaming_deltas.clear()`` and flushed.
+        #   * ``_turn_finalized`` — a previous wrapper action in this turn
+        #     already went through the finalize path.
+        # Any of them means we must not re-render via ``render_main_action``.
+        if is_main_assistant_success and (
+            self._markdown_stream_has_streamed or self._stream_body_finalized or self._turn_finalized
+        ):
+            if action.action_id:
+                self._markdown_stream_consumed_ids.add(action.action_id)
+            self._markdown_active_stream_ids.clear()
+            if self._markdown_stream_has_streamed:
+                self._finalize_markdown_stream()
+            self._turn_finalized = True
+            return
+        if self._tui_mode and action.action_id and action.action_id in self._markdown_stream_consumed_ids:
+            return
         renderables = self.display.renderer.render_main_action(action, self._verbose)
         if not renderables:
+            return
+        if self._tui_mode:
+            from datus.cli.tui.console_bridge import run_in_terminal_sync
+
+            console = self.display.console
+            renderer = self.display.renderer
+
+            def _emit() -> None:
+                renderer.print_renderables(console, renderables)
+
+            run_in_terminal_sync(_emit)
             return
         with self._print_lock:
             self.display.renderer.print_renderables(self.display.console, renderables)
@@ -713,7 +1296,18 @@ class InlineStreamingContext:
     # -- blinking Live for PROCESSING tools --------------------------------
 
     def _update_processing_live(self, action: ActionHistory) -> None:
-        """Create or update the mini-Live for a PROCESSING tool."""
+        """Render the blinking frame for a PROCESSING tool.
+
+        In TUI mode the frame is just state (``_processing_action``) that
+        :meth:`_repaint_live` turns into a pinned line every tick, so the
+        blink animation follows the shared 4 Hz refresh loop. Outside TUI
+        the legacy Rich ``Live`` is still used.
+        """
+        if self._tui_mode:
+            self._processing_action = action
+            self._repaint_live()
+            return
+
         frame = _BLINK_FRAMES[self._tick % len(_BLINK_FRAMES)]
         renderable = self.display.renderer.render_processing(action, frame)
 
@@ -736,7 +1330,14 @@ class InlineStreamingContext:
                 self._live.update(renderable)
 
     def _stop_processing_live(self) -> None:
-        """Stop the current mini-Live if running."""
+        """Stop the current processing-tool display."""
+        if self._tui_mode:
+            # Drop the processing-frame state; :meth:`_repaint_live` then
+            # falls through to subagent rolling lines / markdown tail /
+            # clear depending on what else is active.
+            self._processing_action = None
+            self._repaint_live()
+            return
         with self._print_lock:
             if self._live is not None:
                 try:

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -8,7 +8,6 @@ import asyncio
 import io
 import sys
 import threading
-import time
 from datetime import datetime
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
 
@@ -134,7 +133,6 @@ class InlineStreamingContext:
         # and ``__exit__``) to avoid per-delta allocations.
         self._markdown_buffer: Optional[MarkdownStreamBuffer] = MarkdownStreamBuffer() if self._tui_mode else None
         self._markdown_stream_has_streamed: bool = False
-        self._last_delta_time: float = 0.0
         # Current PROCESSING action whose blink frame occupies the pinned
         # region (TUI mode). ``_repaint_live`` reads this together with
         # ``_tick`` to animate the frame.
@@ -166,16 +164,6 @@ class InlineStreamingContext:
         # per-turn — the accumulator-only flow only produces one body per
         # context, so one-shot latching is exactly right.
         self._stream_body_finalized: bool = False
-        # Deferred reprint flag: ``_print_completed_action`` can't invoke
-        # ``_reprint_with_collapse`` directly because the caller
-        # (``_process_actions``) still needs to advance ``_processed_index``
-        # past the response action it just handled — otherwise the reprint
-        # slices ``self.actions[:_processed_index]`` *before* that response
-        # and renders nothing. The caller checks this flag immediately
-        # after ``_processed_index += 1`` and triggers the reprint from
-        # there so the final Markdown render includes the just-completed
-        # response action.
-        self._reprint_pending: bool = False
 
     @property
     def live(self) -> Optional[Live]:
@@ -194,10 +182,6 @@ class InlineStreamingContext:
     def toggle_verbose(self) -> None:
         """Toggle verbose mode (called from Ctrl+O key callback)."""
         self._verbose_toggle_event.set()
-
-    def recreate_live_display(self):
-        """Compatibility shim: restart display after interaction."""
-        self.restart_display()
 
     def set_event_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """Set the asyncio event loop for broker.submit calls from daemon thread."""
@@ -1134,7 +1118,6 @@ class InlineStreamingContext:
                 delta = raw
         if not delta:
             return
-        self._last_delta_time = time.monotonic()
         self._markdown_stream_has_streamed = True
         if action.action_id:
             self._markdown_active_stream_ids.add(action.action_id)
@@ -1180,7 +1163,6 @@ class InlineStreamingContext:
             # should not repeat this body.
             self._stream_body_finalized = True
         self._markdown_stream_has_streamed = False
-        self._last_delta_time = 0.0
         self._repaint_live()
 
     @property
@@ -1192,25 +1174,6 @@ class InlineStreamingContext:
         path has already landed the full body.
         """
         return self._stream_body_finalized
-
-    def _request_post_finalize_reprint(self) -> None:
-        """Clear the screen and reprint history once the main response is in.
-
-        Mimics a double Ctrl+O: compact-mode reprint of everything we've
-        seen so far, so Rich renders the final markdown from the completed
-        action list. Streaming tail passes sometimes leave a visual glitch
-        (half-parsed table border, stray inline code marker) which this
-        clean redraw wipes out. Failures are swallowed — the live scrollback
-        is still intact, so worst case the user keeps the pre-reprint view.
-        """
-        if not self._tui_mode:
-            return
-        if self._verbose_frozen:
-            return
-        try:
-            self._reprint_with_collapse()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.debug("post-finalize reprint failed: %s", exc)
 
     def _format_subagent_action_items(self, action: ActionHistory) -> List[Text]:
         """Format a single subagent action as a list of Text renderables."""

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -290,16 +290,6 @@ class ChatCommands:
                         self.all_turn_actions = []
 
                 current_node = self.current_node
-
-                # Show session info for existing session
-                if not need_new_node or is_switch:
-                    session_info = asyncio.run(current_node.get_session_info())
-                    if session_info.get("session_id"):
-                        session_display = (
-                            f"[dim]Using existing session: {session_info['session_id']} "
-                            f"(tokens: {session_info['token_count']}, actions: {session_info['action_count']})[/]"
-                        )
-                        self.console.print(session_display)
             else:
                 # Non-interactive: always create a new node
                 self.current_node = self._create_new_node(None)
@@ -312,8 +302,20 @@ class ChatCommands:
             current_node.input = node_input
 
             # Initialize action history display
-            action_display = ActionHistoryDisplay(self.console)
+            action_display = ActionHistoryDisplay(self.console, live_state=getattr(self.cli, "live_state", None))
             incremental_actions = []
+            # Streaming text deltas (thinking_delta, depth=0) are routed to this
+            # separate queue so the main trace renderer never has to walk them
+            # again. The TUI streaming context pops deltas off this list as it
+            # repaints the pinned region, and drops the list on each paired
+            # terminal response so the accumulator resets per message.
+            streaming_deltas = []
+            # Will be set True after the streaming context exits if it has
+            # already flushed the main-agent body to the scrollback. When True,
+            # ``_render_final_response`` skips the one-shot
+            # ``_display_markdown_response`` step to avoid painting the body
+            # twice.
+            streamed_body = False
             node_final_action = None  # Node's final ASSISTANT action (e.g. chat_response)
             # Buffer for ASSISTANT text tagged as non-thinking by the model layer.
             # Tail text often duplicates the node's *_response; defer rendering
@@ -337,6 +339,14 @@ class ChatCommands:
                         # Skip TOOL PROCESSING entries — SUCCESS version follows
                         if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
                             continue
+                        # Streaming text deltas go to their own queue. Sub-agent
+                        # deltas (depth > 0) are ignored here — they'd pollute
+                        # the main-agent accumulator; sub-agents have their own
+                        # pinned-region path.
+                        if action.action_type == "thinking_delta":
+                            if action.depth == 0:
+                                streaming_deltas.append(action)
+                            continue
                         # Node final actions (e.g. chat_response) — keep for
                         # final response rendering but skip streaming trace.
                         # Only capture depth-0 (main node) responses; sub-agent
@@ -353,6 +363,26 @@ class ChatCommands:
                             pending_non_thinking = _drop_if_matches_final(
                                 pending_non_thinking, action, incremental_actions
                             )
+                            # Wrapper *_response closes the delta accumulator for
+                            # this message; reset so a follow-up turn doesn't see
+                            # the previous body in its replay.
+                            streaming_deltas.clear()
+                            continue
+                        # Plain "response" from the model layer (openai_compatible /
+                        # codex) is the paired terminal action for the delta
+                        # stream. Push it to the trace list and reset the delta
+                        # accumulator at the same time.
+                        if (
+                            action.role == ActionRole.ASSISTANT
+                            and action.depth == 0
+                            and action.action_type == "response"
+                            and action.status == ActionStatus.SUCCESS
+                        ):
+                            if pending_non_thinking is not None:
+                                incremental_actions.append(pending_non_thinking)
+                                pending_non_thinking = None
+                            incremental_actions.append(action)
+                            streaming_deltas.clear()
                             continue
                         # Defer ASSISTANT text flagged as non-thinking — it may
                         # be the tail text that duplicates the upcoming *_response.
@@ -383,6 +413,7 @@ class ChatCommands:
                     history_turns=self.all_turn_actions,
                     current_user_message=message,
                     interaction_broker=current_node.interaction_broker,
+                    streaming_deltas=streaming_deltas,
                 )
                 # Reprint the CLI banner at the top after Ctrl+O clears the screen.
                 banner_callback = getattr(self.cli, "_print_welcome", None)
@@ -416,6 +447,7 @@ class ChatCommands:
                             logger.info("KeyboardInterrupt caught, execution interrupted gracefully")
                         except ExecutionInterrupted:
                             logger.info("ExecutionInterrupted caught, execution stopped gracefully")
+                    streamed_body = bool(getattr(streaming_ctx, "has_streamed_response", False))
                 finally:
                     self.current_streaming_ctx = None
             else:
@@ -435,6 +467,10 @@ class ChatCommands:
                             continue
                         if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
                             continue
+                        if action.action_type == "thinking_delta":
+                            if action.depth == 0:
+                                streaming_deltas.append(action)
+                            continue
                         # Node final actions (e.g. chat_response) — keep for
                         # final response rendering but skip streaming trace.
                         # Only capture depth-0 (main node) responses; sub-agent
@@ -451,6 +487,19 @@ class ChatCommands:
                             pending_non_thinking = _drop_if_matches_final(
                                 pending_non_thinking, action, incremental_actions
                             )
+                            streaming_deltas.clear()
+                            continue
+                        if (
+                            action.role == ActionRole.ASSISTANT
+                            and action.depth == 0
+                            and action.action_type == "response"
+                            and action.status == ActionStatus.SUCCESS
+                        ):
+                            if pending_non_thinking is not None:
+                                incremental_actions.append(pending_non_thinking)
+                                pending_non_thinking = None
+                            incremental_actions.append(action)
+                            streaming_deltas.clear()
                             continue
                         # Defer ASSISTANT text flagged as non-thinking — it may
                         # be the tail text that duplicates the upcoming *_response.
@@ -473,7 +522,10 @@ class ChatCommands:
                         incremental_actions.append(pending_non_thinking)
                         pending_non_thinking = None
 
-                with action_display.display_streaming_actions(incremental_actions):
+                ns_streaming_ctx = action_display.display_streaming_actions(
+                    incremental_actions, streaming_deltas=streaming_deltas
+                )
+                with ns_streaming_ctx:
                     try:
                         self.cli.run_on_bg_loop(run_stream())
                     except KeyboardInterrupt:
@@ -481,6 +533,7 @@ class ChatCommands:
                         logger.info("KeyboardInterrupt caught, execution interrupted gracefully")
                     except ExecutionInterrupted:
                         logger.info("ExecutionInterrupted caught, execution stopped gracefully")
+                streamed_body = bool(getattr(ns_streaming_ctx, "has_streamed_response", False))
 
             # Display final response from the node's final action
             # (separated from incremental_actions to avoid streaming trace rendering)
@@ -508,13 +561,22 @@ class ChatCommands:
                     if sql:
                         self.add_in_sql_context(sql, clean_output, incremental_actions)
 
-                    self._render_final_response(final_action)
+                    self._render_final_response(final_action, skip_markdown_body=streamed_body)
 
                     # Merge node_final_action back for history tracking
                     all_actions = incremental_actions + ([node_final_action] if node_final_action else [])
                     self.last_actions = all_actions
                     self.all_turn_actions.append((message, all_actions))
                     self._trace_verbose = False  # reset toggle for new chat round
+
+                    # End-of-turn full-screen reprint — mirrors the Ctrl+O
+                    # toggle so the viewport ends up with a clean, fully
+                    # re-rendered transcript. Rich gets to lay out the final
+                    # body in one pass (no incremental artefacts on tables /
+                    # code blocks). Interactive mode only; non-interactive
+                    # runs (``/print``, pipes) must not rewrite stdout.
+                    if interactive:
+                        self._full_screen_reprint(verbose=self._trace_verbose)
 
                 if interactive:
                     self.cli.console.print("[bold bright_black]Press Ctrl+O to toggle trace details.[/]")
@@ -538,11 +600,19 @@ class ChatCommands:
             if _is_model_config_error(e):
                 self.console.print("[yellow]Hint: Use /model to configure or switch your model.[/]")
 
-    def _render_final_response(self, final_action: "ActionHistory") -> None:
+    def _render_final_response(self, final_action: "ActionHistory", skip_markdown_body: bool = False) -> None:
         """Render the final response output (SQL, markdown, etc.) from a node action.
 
         This is used both after streaming completes and when Ctrl+O re-renders.
         Side-effect free — does not modify history or state.
+
+        Args:
+            final_action: The node's terminal assistant action.
+            skip_markdown_body: When True, skip the final Markdown render of
+                the response body (the ``_display_markdown_response`` step).
+                Used when the streaming context has already flushed the
+                accumulated body to the scrollback — without this guard the
+                user sees the same answer twice.
         """
         if (
             not final_action
@@ -575,7 +645,7 @@ class ChatCommands:
         if ext_knowledge_file:
             self._display_ext_knowledge_file(ext_knowledge_file)
 
-        if clean_output:
+        if clean_output and not skip_markdown_body:
             self._display_markdown_response(clean_output)
 
     def _get_turn_token_usage_from_node(self, node) -> Optional[dict]:
@@ -918,6 +988,56 @@ class ChatCommands:
         else:
             self.console.print("[yellow]No active session.[/]")
 
+    def _full_screen_reprint(
+        self,
+        verbose: bool,
+        *,
+        mode_label: Optional[str] = None,
+        fallback_actions: Optional[List[ActionHistory]] = None,
+    ) -> None:
+        """Clear the screen and re-render the full multi-turn history.
+
+        The viewport ends up with exactly what Ctrl+O produces: banner →
+        optional mode label → every turn's trace + final response. The
+        scrollback is unchanged (``patch_stdout`` cannot erase it), so
+        earlier content remains reachable by scrolling up.
+
+        Args:
+            verbose: Render style for action trace lines.
+            mode_label: Optional banner text printed between the CLI banner
+                and the trace (used by Ctrl+O to show "switched to <mode>").
+            fallback_actions: When ``all_turn_actions`` is empty, render this
+                single action list instead. Used by Ctrl+O on the very first
+                turn before ``all_turn_actions.append`` runs.
+        """
+        self.console.clear()
+        sys.stdout.write("\033[3J")
+        sys.stdout.flush()
+        banner_callback = getattr(self.cli, "_print_welcome", None)
+        if banner_callback is not None:
+            banner_callback()
+        if mode_label:
+            self.console.print(f"[bold bright_black]  \u23af switched to {mode_label} mode \u23af[/]")
+        action_display = ActionHistoryDisplay(self.console, live_state=getattr(self.cli, "live_state", None))
+
+        def _render_turn_response(turn_actions: List[ActionHistory]) -> None:
+            """Callback to render the final response for each turn."""
+            final_action = self._find_node_final_action(turn_actions)
+            if final_action and final_action.depth == 0 and final_action.status == ActionStatus.SUCCESS:
+                # The viewport was just cleared — render the final Markdown
+                # body here. ``skip_markdown_body`` stays False because the
+                # streaming context's scrollback push is not visible in the
+                # viewport after the clear.
+                self._render_final_response(final_action)
+
+        if self.all_turn_actions:
+            action_display.render_multi_turn_history(
+                self.all_turn_actions, verbose=verbose, per_turn_callback=_render_turn_response
+            )
+        elif fallback_actions:
+            action_display.render_action_history(fallback_actions, verbose=verbose)
+            _render_turn_response(fallback_actions)
+
     def display_inline_trace_details(self, actions: List[ActionHistory]) -> None:
         """Toggle action history between compact and verbose modes (post-run Ctrl+O)."""
         if not actions:
@@ -925,28 +1045,11 @@ class ChatCommands:
             return
         self._trace_verbose = not self._trace_verbose
         mode_label = "verbose" if self._trace_verbose else "compact"
-        self.console.clear()
-        sys.stdout.write("\033[3J")
-        sys.stdout.flush()
-        banner_callback = getattr(self.cli, "_print_welcome", None)
-        if banner_callback is not None:
-            banner_callback()
-        self.console.print(f"[bold bright_black]  ⎯ switched to {mode_label} mode ⎯[/]")
-        action_display = ActionHistoryDisplay(self.console)
-
-        def _render_turn_response(turn_actions: List[ActionHistory]) -> None:
-            """Callback to render the final response for each turn."""
-            final_action = self._find_node_final_action(turn_actions)
-            if final_action and final_action.depth == 0 and final_action.status == ActionStatus.SUCCESS:
-                self._render_final_response(final_action)
-
-        if self.all_turn_actions:
-            action_display.render_multi_turn_history(
-                self.all_turn_actions, verbose=self._trace_verbose, per_turn_callback=_render_turn_response
-            )
-        else:
-            action_display.render_action_history(actions, verbose=self._trace_verbose)
-            _render_turn_response(actions)
+        self._full_screen_reprint(
+            verbose=self._trace_verbose,
+            mode_label=mode_label,
+            fallback_actions=actions,
+        )
 
         self.cli.console.print("[bold bright_black]Press Ctrl+O to toggle trace details.[/]")
 
@@ -1020,7 +1123,7 @@ class ChatCommands:
             from rich.rule import Rule
 
             self.console.print()
-            action_display = ActionHistoryDisplay(self.console)
+            action_display = ActionHistoryDisplay(self.console, live_state=getattr(self.cli, "live_state", None))
             last_assistant_actions = []
             current_user_msg = ""
 
@@ -1148,7 +1251,7 @@ class ChatCommands:
             messages = session_manager.get_session_messages(target_session_id)
             if messages:
                 self.console.print(f"\n[green]Session resumed![/] Showing {len(messages)} message(s):\n")
-                action_display = ActionHistoryDisplay(self.console)
+                action_display = ActionHistoryDisplay(self.console, live_state=getattr(self.cli, "live_state", None))
                 last_assistant_actions = []
                 for msg in messages:
                     role = msg.get("role", "unknown")
@@ -1308,7 +1411,7 @@ class ChatCommands:
                     f"\n[green]Rewound to before turn {turn_num}.[/] "
                     f"New session: [cyan]{new_session_id}[/] ({len(new_messages)} messages)\n"
                 )
-                action_display = ActionHistoryDisplay(self.console)
+                action_display = ActionHistoryDisplay(self.console, live_state=getattr(self.cli, "live_state", None))
                 for msg in new_messages:
                     role = msg.get("role", "unknown")
                     content = msg.get("content", "")

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -60,6 +60,7 @@ from datus.cli.status_bar import StatusBarProvider
 from datus.cli.sub_agent_commands import SubAgentCommands
 from datus.cli.tui import DatusApp, tui_enabled
 from datus.cli.tui.app import EXIT_SENTINEL
+from datus.cli.tui.live_display_state import LiveDisplayState
 from datus.configuration.agent_config_loader import configuration_manager, load_agent_config
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
@@ -198,6 +199,7 @@ class DatusCLI:
         # disabled via ``DATUS_TUI=0`` as an escape hatch.
         self._use_tui = self.interactive and tui_enabled()
         self.tui_app: Optional[DatusApp] = None
+        self.live_state: Optional[LiveDisplayState] = None
 
         self.at_completer: AtReferenceCompleter
         if self.interactive:
@@ -460,6 +462,7 @@ class DatusCLI:
                         "status-bar.tokens": "#9a9aaa",
                         "status-bar.ctx": "#9a9aaa",
                         "status-bar.running": "#ffb86c bold",
+                        "status-bar.dot": "#ffb86c bold",
                         "separator": "#444444",
                         # Slash-command autocomplete popup. Every row pins
                         # ``bg:default`` so the menu blends into the terminal
@@ -475,6 +478,18 @@ class DatusCLI:
                         "completion-menu.meta.completion": "bg:default fg:ansibrightblack",
                         "completion-menu.meta.completion.current": "noreverse bg:default fg:ansibrightcyan bold",
                         "hint": "#9a9aaa italic",
+                        # Pinned subagent/tool rolling-window lines. Dim grey
+                        # to match the scrollback ``[dim]`` styling used by the
+                        # Rich renderers so the visual weight stays consistent
+                        # between the pinned region and the append area.
+                        "subagent-live": "#6e6e6e",
+                        "processing-live": "#6e6e6e",
+                        # Pinned subagent header: plain cyan on the
+                        # "⏺ subagent_type" prefix, default colour on the
+                        # parenthesised goal so the prompt text does not
+                        # compete visually with the subagent name.
+                        "subagent-header-live": "ansicyan",
+                        "subagent-header-goal-live": "",
                     }
                 ),
             ]
@@ -517,6 +532,11 @@ class DatusCLI:
         # before constructing the app.
         completer = self.create_combined_completer()
 
+        # Build the shared live-render state first; DatusApp will wire its
+        # own ``invalidate`` into it once constructed (see LiveDisplayState
+        # docstring for the deferred-callback rationale).
+        self.live_state = LiveDisplayState()
+
         self.tui_app = DatusApp(
             status_tokens_fn=self._status_tokens_for_tui,
             dispatch_fn=self._dispatch_command_text,
@@ -525,6 +545,7 @@ class DatusCLI:
             lexer=PygmentsLexer(CustomSqlLexer),
             style=self._build_app_style(),
             input_prompt_fn=self._get_prompt_text,
+            live_display_state=self.live_state,
         )
 
         @self.tui_app.key_bindings.add("tab")

--- a/datus/cli/status_bar.py
+++ b/datus/cli/status_bar.py
@@ -12,6 +12,7 @@ usage. All token counters are expressed in KiB units where 1K = 1024 tokens.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Tuple
 
@@ -23,6 +24,23 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _TOKEN_UNIT = 1024  # 1K == 1024 tokens
+
+# Half-period of the running-indicator blink in seconds. The DatusApp
+# periodic invalidate runs at the same cadence so one full cycle (on → off →
+# on) takes ~1s on the terminal.
+_RUNNING_BLINK_HALF_PERIOD = 0.5
+
+
+def _running_blink_symbol(now: float | None = None) -> str:
+    """Return the current blink glyph for the ``running`` indicator.
+
+    Toggles between a filled and hollow dot every ``_RUNNING_BLINK_HALF_PERIOD``
+    seconds based on :func:`time.monotonic`, so successive calls inside the
+    same frame render the same glyph. ``now`` is exposed for deterministic
+    testing.
+    """
+    t = time.monotonic() if now is None else now
+    return "●" if int(t / _RUNNING_BLINK_HALF_PERIOD) % 2 == 0 else "○"
 
 
 def _humanize_tokens(n: int) -> str:
@@ -96,7 +114,23 @@ class StatusBarState:
         sep: Tuple[str, str] = ("class:status-bar.sep", " │ ")
         pad: Tuple[str, str] = ("class:status-bar", " ")
 
-        tokens: List[Tuple[str, str]] = [pad, ("class:status-bar.brand", "Datus")]
+        # Activity dot sits to the left of the brand. Solid when idle,
+        # pulsing between filled and hollow while the agent is running so
+        # users can spot the busy state at a glance. The running variant
+        # uses ``status-bar.running`` so CSS stays consistent with the old
+        # trailing indicator; the idle variant falls back to a neutral
+        # ``status-bar.dot`` tone.
+        if self.agent_running:
+            dot_token: Tuple[str, str] = ("class:status-bar.running", _running_blink_symbol())
+        else:
+            dot_token = ("class:status-bar.dot", "●")
+
+        tokens: List[Tuple[str, str]] = [
+            pad,
+            dot_token,
+            ("class:status-bar", " "),
+            ("class:status-bar.brand", "Datus"),
+        ]
         if self.plan_mode:
             tokens.extend([sep, ("class:status-bar.plan", "PLAN")])
         tokens.extend([sep, ("class:status-bar.agent", self.agent)])
@@ -121,12 +155,6 @@ class StatusBarState:
                 ("class:status-bar.ctx", self.context_display()),
             ]
         )
-        if self.agent_running:
-            # Trailing indicator signals that the REPL is busy. It is only
-            # surfaced by the TUI path, which sets ``agent_running`` via
-            # ``StatusBarProvider.current_state``; the legacy PromptSession
-            # never exposes a truthy value so its rendering is unchanged.
-            tokens.extend([sep, ("class:status-bar.running", "● running")])
         tokens.append(pad)
         return tokens
 

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -57,6 +57,7 @@ from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import TextArea
 
 from datus.cli.cli_styles import PASTE_COLLAPSE_THRESHOLD
+from datus.cli.tui.live_display_state import LiveDisplayState, compute_pinned_max_rows
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -101,11 +102,13 @@ class DatusApp:
         style: Optional[Style] = None,
         placeholder_fn: Optional[Callable[[], str]] = None,
         input_prompt_fn: Optional[Callable[[], str]] = None,
+        live_display_state: Optional[LiveDisplayState] = None,
     ) -> None:
         self._status_tokens_fn = status_tokens_fn
         self._dispatch_fn = dispatch_fn
         self._placeholder_fn = placeholder_fn or (lambda: "")
         self._input_prompt_fn = input_prompt_fn or (lambda: "> ")
+        self._live_state = live_display_state
 
         self._agent_running = threading.Event()
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="datus-tui-worker")
@@ -177,8 +180,32 @@ class DatusApp:
             filter=Condition(lambda: bool(self._ctrl_c_hint)),
         )
 
+        # Pinned live-render region for subagent rolling window, processing-
+        # tool blink, and streaming-markdown tail. Sits between the
+        # patch_stdout scroll area and the status bar.
+        #
+        # Height is derived from the *current* terminal size on every render
+        # (see :meth:`_pinned_max_rows`) so a larger terminal gets a larger
+        # pinned area — enough room for a full markdown table to stay
+        # box-rendered — while a narrow terminal is protected from having
+        # the input row squeezed off screen. ``dont_extend_height=True``
+        # plus ``wrap_lines=False`` means we never steal more than our
+        # declared budget, and prompt_toolkit shrinks us first when the
+        # input area needs to grow (multi-line paste, completions, etc.).
+        live_state_active = Condition(self._live_state_is_active)
+        self._live_region = ConditionalContainer(
+            content=Window(
+                content=FormattedTextControl(self._render_live_region),
+                height=self._pinned_height_dimension,
+                dont_extend_height=True,
+                wrap_lines=False,
+            ),
+            filter=live_state_active,
+        )
+
         root = HSplit(
             [
+                self._live_region,
                 self._make_separator(),
                 self._status_window,
                 self._make_separator(),
@@ -200,10 +227,82 @@ class DatusApp:
             erase_when_done=False,
         )
 
+        # Wire the live-region repaint callback now that ``self.invalidate`` is
+        # bound; :class:`LiveDisplayState` defaults to a no-op callback so
+        # constructing it before the app is still safe. The row-budget
+        # provider delegates to :meth:`_pinned_max_rows` so writers (the
+        # streaming refresh daemon) shape their line lists against the
+        # same ceiling prompt_toolkit applies to the Window.
+        if self._live_state is not None:
+            self._live_state.set_invalidate(self.invalidate)
+            self._live_state.set_max_rows_provider(self._pinned_max_rows)
+
     @staticmethod
     def _make_separator() -> Window:
         """Full-width horizontal rule rendered with box-drawing character."""
         return Window(height=1, char="\u2500", style="class:separator")
+
+    def _live_state_is_active(self) -> bool:
+        return self._live_state is not None and self._live_state.is_active()
+
+    def _terminal_rows(self) -> int:
+        """Best-effort current terminal row count.
+
+        Prefers the live ``Application.output`` (accurate and resize-aware),
+        falls back to a sensible default when the app hasn't attached to
+        a terminal yet (e.g. early construction, unit tests).
+        """
+        app = getattr(self, "_app", None)
+        if app is not None:
+            try:
+                size = app.output.get_size()
+                if size and size.rows > 0:
+                    return int(size.rows)
+            except Exception:
+                pass
+        try:
+            import shutil
+
+            size = shutil.get_terminal_size(fallback=(80, 24))
+            return int(size.lines)
+        except Exception:
+            return 24
+
+    def _pinned_max_rows(self) -> int:
+        """Current row ceiling for the pinned region (terminal-aware)."""
+        return compute_pinned_max_rows(self._terminal_rows())
+
+    def _pinned_height_dimension(self) -> Dimension:
+        """Height dimension callback for the pinned Window.
+
+        ``Dimension.preferred`` is anchored to the current content size so a
+        short markdown tail doesn't grab extra rows it doesn't need, while
+        ``max`` rises with the terminal so a full table can live-render in
+        box form once the body has enough visible rows.
+        """
+        cap = self._pinned_max_rows()
+        preferred = 1
+        if self._live_state is not None:
+            preferred = max(1, min(cap, self._live_state.line_count()))
+        return Dimension(min=1, preferred=preferred, max=cap)
+
+    def _render_live_region(self) -> FormattedText:
+        """Flatten every pinned line into a single multiline FormattedText.
+
+        Lines are joined with ``\\n`` so the hosting Window sizes naturally
+        to the pinned-line count (each line contributes one terminal row).
+        """
+        if self._live_state is None:
+            return FormattedText([])
+        snap = self._live_state.snapshot()
+        if not snap:
+            return FormattedText([])
+        fragments: List[Tuple[str, str]] = []
+        for idx, line in enumerate(snap):
+            if idx > 0:
+                fragments.append(("", "\n"))
+            fragments.extend(line.segments)
+        return FormattedText(fragments)
 
     def show_ctrl_c_hint(self) -> None:
         self._ctrl_c_hint = "Press Ctrl+C again to exit"
@@ -395,9 +494,17 @@ class DatusApp:
 
         async def _main() -> None:
             self._loop = asyncio.get_running_loop()
+            blink_task = asyncio.create_task(self._blink_invalidate_loop())
             try:
                 await self._app.run_async()
             finally:
+                blink_task.cancel()
+                try:
+                    await blink_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug("blink_invalidate_loop cleanup raised: %s", exc)
                 self._loop = None
 
         try:
@@ -411,6 +518,32 @@ class DatusApp:
         return self._exit_code
 
     # -- internals ---------------------------------------------------------
+
+    # Cadence of the periodic invalidate that drives the status-bar running
+    # indicator blink. Matched to ``status_bar._RUNNING_BLINK_HALF_PERIOD`` so
+    # one full glyph cycle takes ~1s. Only fires while the agent is running,
+    # so idle REPLs do not redraw the layout.
+    _BLINK_INTERVAL_SECONDS = 0.5
+
+    async def _blink_invalidate_loop(self) -> None:
+        """Keep the status-bar ``running`` dot pulsing by periodic re-renders.
+
+        prompt_toolkit only re-renders on invalidate; the running-indicator
+        glyph is derived from ``time.monotonic()`` so it only animates when
+        the layout is refreshed. This task provides that cadence, but stays
+        idle when no agent is running so no unnecessary layout work happens
+        on the REPL prompt path.
+        """
+        try:
+            while True:
+                await asyncio.sleep(self._BLINK_INTERVAL_SECONDS)
+                if self._agent_running.is_set():
+                    try:
+                        self._app.invalidate()
+                    except Exception as exc:  # pragma: no cover - defensive
+                        logger.debug("blink invalidate raised: %s", exc)
+        except asyncio.CancelledError:
+            raise
 
     def _safe_status_tokens(self) -> FormattedText:
         try:

--- a/datus/cli/tui/console_bridge.py
+++ b/datus/cli/tui/console_bridge.py
@@ -26,7 +26,7 @@ import asyncio
 from typing import Callable
 
 from prompt_toolkit.application import get_app_or_none
-from prompt_toolkit.application.run_in_terminal import run_in_terminal
+from prompt_toolkit.application.run_in_terminal import in_terminal, run_in_terminal
 
 
 def run_in_terminal_sync(func: Callable[[], None]) -> None:
@@ -34,32 +34,58 @@ def run_in_terminal_sync(func: Callable[[], None]) -> None:
 
     Safe to call from any thread. When no Application is active (non-TTY
     fallback path), simply invokes ``func`` directly.
+
+    Three paths:
+
+    * **On the prompt_toolkit event loop** (key-binding callbacks): dispatch
+      via :func:`run_in_terminal` and return immediately; blocking on the
+      future would deadlock the loop that must run the callback.
+    * **Off-loop thread (e.g. the streaming refresh daemon) with a live
+      Application**: ``asyncio.get_running_loop()`` raises, so we instead
+      submit a coroutine via :func:`asyncio.run_coroutine_threadsafe` against
+      ``app.loop`` and block on its completion. Using
+      :func:`run_in_terminal` here is unsafe because it calls
+      ``asyncio.ensure_future`` which needs a running loop on the calling
+      thread (Python 3.12+ no longer auto-creates one).
+    * **No Application**: direct call.
     """
     app = get_app_or_none()
     if app is None:
         func()
         return
 
-    future = run_in_terminal(func)
-
-    # Callers invoked from a prompt_toolkit key handler run on the same
-    # asyncio loop that schedules the ``run_in_terminal`` callback. Blocking
-    # that thread on ``future.result()`` deadlocks the loop. Detect the
-    # in-loop case and let the scheduled callback finish asynchronously.
     try:
         asyncio.get_running_loop()
+        on_event_loop = True
     except RuntimeError:
         on_event_loop = False
-    else:
-        on_event_loop = True
 
     if on_event_loop:
+        # Fire and forget — the callback is scheduled on the same loop and
+        # will run before control returns to the key handler.
+        run_in_terminal(func)
         return
 
-    # ``run_in_terminal`` returns an asyncio.Future; ``result()`` blocks until
-    # the callback completes on the Application event loop.
+    loop = getattr(app, "loop", None)
+    if loop is None:
+        # Application exists but its loop isn't running yet (pre-``run`` or
+        # post-shutdown). Safe to invoke directly — there's no pinned area
+        # to preserve.
+        func()
+        return
+
+    async def _wrap() -> None:
+        async with in_terminal():
+            func()
+
     try:
-        future.result()
+        cf = asyncio.run_coroutine_threadsafe(_wrap(), loop)
+    except RuntimeError:
+        # Loop closed between the getattr and the submit — just run inline.
+        func()
+        return
+    try:
+        cf.result()
     except Exception:  # pragma: no cover - defensive
         # Propagating would leak into background threads; callers that care
         # should wrap ``func`` themselves. Here we swallow to keep the TUI

--- a/datus/cli/tui/live_display_state.py
+++ b/datus/cli/tui/live_display_state.py
@@ -24,10 +24,6 @@ from typing import Callable, List, Optional, Tuple
 # rows (one header line + its rolling tool tail).
 TOOL_LINES_PER_GROUP = 2
 
-# Back-compat alias (older callers referred to a single per-group cap).
-MAX_LIVE_LINES_PER_GROUP = TOOL_LINES_PER_GROUP
-MAX_LIVE_LINES = TOOL_LINES_PER_GROUP
-
 # Hard safety cap — the pinned region never holds more than this many rows
 # regardless of what the terminal reports, to keep unbounded runaway fan-out
 # from eating unlimited memory. The *effective* ceiling per render is much
@@ -71,7 +67,7 @@ class LiveDisplayLine:
 class LiveDisplayState:
     """Thread-safe state for the TUI pinned live-render region.
 
-    The state holds at most ``MAX_LIVE_LINES`` rolling lines. All mutations
+    The state holds at most ``MAX_LIVE_LINES_TOTAL`` rolling lines. All mutations
     acquire an internal lock; reads (``snapshot``, ``is_active``, ``line_count``)
     also acquire it, so the main loop always sees consistent snapshots.
 
@@ -129,19 +125,27 @@ class LiveDisplayState:
         Writers are expected to pre-shape ``lines`` into a flat sequence;
         this method enforces the terminal-aware ceiling so even a writer
         that ignores :meth:`max_rows` cannot overflow the bottom area.
+        No-op when the trimmed payload equals the current state, so the
+        per-token streaming hot path doesn't wake prompt_toolkit's main
+        loop when nothing visible changed.
         """
         if not lines:
             with self._lock:
+                changed = bool(self._lines)
                 self._lines = []
                 cb = self._invalidate
-            cb()
+            if changed:
+                cb()
             return
         cap = self.max_rows()
         trimmed = list(lines[-cap:])
         with self._lock:
-            self._lines = trimmed
+            changed = trimmed != self._lines
+            if changed:
+                self._lines = trimmed
             cb = self._invalidate
-        cb()
+        if changed:
+            cb()
 
     def clear(self) -> None:
         with self._lock:

--- a/datus/cli/tui/live_display_state.py
+++ b/datus/cli/tui/live_display_state.py
@@ -1,0 +1,164 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Shared state for the pinned live-render region above the status bar.
+
+The :class:`DatusApp` TUI reads this state on its main event loop thread to
+paint the rolling subagent / processing-tool region. Writers (the
+``InlineStreamingContext`` refresh daemon) mutate the state and then invoke
+``invalidate_cb`` so prompt_toolkit schedules a single repaint that covers
+the live region, the status bar, and the input bar in one pass — without
+ever fighting ``patch_stdout(raw=True)`` for cursor position.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional, Tuple
+
+# Per-subagent pinned-window budget.
+#
+# Each active subagent contributes a block of ``1 + TOOL_LINES_PER_GROUP``
+# rows (one header line + its rolling tool tail).
+TOOL_LINES_PER_GROUP = 2
+
+# Back-compat alias (older callers referred to a single per-group cap).
+MAX_LIVE_LINES_PER_GROUP = TOOL_LINES_PER_GROUP
+MAX_LIVE_LINES = TOOL_LINES_PER_GROUP
+
+# Hard safety cap — the pinned region never holds more than this many rows
+# regardless of what the terminal reports, to keep unbounded runaway fan-out
+# from eating unlimited memory. The *effective* ceiling per render is much
+# lower, set dynamically from the current terminal height via
+# :meth:`LiveDisplayState.max_rows`.
+MAX_LIVE_LINES_TOTAL = 200
+
+# Rows reserved for the status bar, separators, hint, and a 1-line input
+# area. The actual input area may grow up to 15 rows when the user pastes
+# multi-line content; prompt_toolkit arbitrates that at render time by
+# shrinking us first (``dont_extend_height=True``).
+_PINNED_RESERVED_ROWS = 8
+# Floor so the pinned area still renders meaningfully on narrow terminals.
+_PINNED_MIN_ROWS = 3
+
+
+def compute_pinned_max_rows(terminal_rows: int) -> int:
+    """Return the pinned-region row budget for a terminal of ``terminal_rows``.
+
+    The result is clamped between :data:`_PINNED_MIN_ROWS` and
+    :data:`MAX_LIVE_LINES_TOTAL` and accounts for the other bottom-area
+    widgets via :data:`_PINNED_RESERVED_ROWS`.
+    """
+    if terminal_rows <= 0:
+        return _PINNED_MIN_ROWS
+    budget = terminal_rows - _PINNED_RESERVED_ROWS
+    if budget < _PINNED_MIN_ROWS:
+        return _PINNED_MIN_ROWS
+    if budget > MAX_LIVE_LINES_TOTAL:
+        return MAX_LIVE_LINES_TOTAL
+    return budget
+
+
+@dataclass
+class LiveDisplayLine:
+    """Single pinned line expressed as prompt_toolkit formatted-text fragments."""
+
+    segments: List[Tuple[str, str]] = field(default_factory=list)
+
+
+class LiveDisplayState:
+    """Thread-safe state for the TUI pinned live-render region.
+
+    The state holds at most ``MAX_LIVE_LINES`` rolling lines. All mutations
+    acquire an internal lock; reads (``snapshot``, ``is_active``, ``line_count``)
+    also acquire it, so the main loop always sees consistent snapshots.
+
+    ``invalidate_cb`` is a zero-arg callable the state invokes after each
+    mutation to ask prompt_toolkit to repaint. The callback must itself be
+    thread-safe (``prompt_toolkit.Application.invalidate`` qualifies because
+    it dispatches via ``loop.call_soon_threadsafe``).
+    """
+
+    def __init__(self, invalidate_cb: Optional[Callable[[], None]] = None) -> None:
+        self._lock = threading.Lock()
+        self._lines: List[LiveDisplayLine] = []
+        self._invalidate: Callable[[], None] = invalidate_cb or (lambda: None)
+        # Producer of the current pinned-row budget. ``DatusApp`` wires in a
+        # callable that reads the live terminal height so the cap shrinks
+        # when the user resizes down and grows when they resize up. When
+        # unset (non-TUI tests), the hard safety cap is used.
+        self._max_rows_cb: Callable[[], int] = lambda: MAX_LIVE_LINES_TOTAL
+
+    def set_invalidate(self, invalidate_cb: Callable[[], None]) -> None:
+        """Register or replace the repaint callback.
+
+        Used to break the chicken-and-egg between :class:`LiveDisplayState` and
+        ``DatusApp.invalidate``: the state is constructed first with a no-op
+        callback and the real one is attached after the app exists.
+        """
+        with self._lock:
+            self._invalidate = invalidate_cb
+
+    def set_max_rows_provider(self, provider: Callable[[], int]) -> None:
+        """Install a callable that returns the *current* pinned-row budget.
+
+        Writers call :meth:`max_rows` before shaping their line lists; the
+        provider is resolved on every call so terminal-resize events flow
+        through without further plumbing.
+        """
+        with self._lock:
+            self._max_rows_cb = provider
+
+    def max_rows(self) -> int:
+        """Return the current pinned-row ceiling (terminal-height aware)."""
+        try:
+            value = int(self._max_rows_cb())
+        except Exception:
+            value = MAX_LIVE_LINES_TOTAL
+        if value < _PINNED_MIN_ROWS:
+            return _PINNED_MIN_ROWS
+        if value > MAX_LIVE_LINES_TOTAL:
+            return MAX_LIVE_LINES_TOTAL
+        return value
+
+    def set_lines(self, lines: List[LiveDisplayLine]) -> None:
+        """Replace the pinned lines with ``lines`` (trimmed to ``max_rows()``).
+
+        Writers are expected to pre-shape ``lines`` into a flat sequence;
+        this method enforces the terminal-aware ceiling so even a writer
+        that ignores :meth:`max_rows` cannot overflow the bottom area.
+        """
+        if not lines:
+            with self._lock:
+                self._lines = []
+                cb = self._invalidate
+            cb()
+            return
+        cap = self.max_rows()
+        trimmed = list(lines[-cap:])
+        with self._lock:
+            self._lines = trimmed
+            cb = self._invalidate
+        cb()
+
+    def clear(self) -> None:
+        with self._lock:
+            changed = bool(self._lines)
+            self._lines = []
+            cb = self._invalidate
+        if changed:
+            cb()
+
+    def snapshot(self) -> List[LiveDisplayLine]:
+        with self._lock:
+            return list(self._lines)
+
+    def is_active(self) -> bool:
+        with self._lock:
+            return bool(self._lines)
+
+    def line_count(self) -> int:
+        with self._lock:
+            return len(self._lines)

--- a/tests/unit_tests/cli/action_display/test_markdown_stream.py
+++ b/tests/unit_tests/cli/action_display/test_markdown_stream.py
@@ -1,0 +1,191 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for :class:`MarkdownStreamBuffer`.
+
+Each test feeds the buffer a controlled sequence of deltas and asserts on the
+exact ``(stable_segments, tail)`` split. The invariants these tests pin down:
+
+* Stable segments + tail always reconstruct the concatenated input.
+* An unclosed fenced code block defers every commit.
+* Blank-line boundaries are the only block cut (no mid-paragraph cut).
+* Oversize tails trigger a last-newline commit to keep Rich re-parse bounded.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from datus.cli.action_display.markdown_stream import MAX_TAIL_BYTES, MarkdownStreamBuffer
+
+
+def _concat(stable: list[str], tail: str) -> str:
+    return "".join(stable) + tail
+
+
+class TestBasicBoundaries:
+    def test_empty_delta_is_noop(self) -> None:
+        buf = MarkdownStreamBuffer()
+        assert buf.append("") == []
+        assert buf.get_tail() == ""
+        assert not buf.has_tail()
+
+    def test_no_newline_keeps_everything_as_tail(self) -> None:
+        buf = MarkdownStreamBuffer()
+        assert buf.append("hello") == []
+        assert buf.get_tail() == "hello"
+        assert buf.has_tail()
+
+    def test_single_newline_is_not_a_block_boundary(self) -> None:
+        buf = MarkdownStreamBuffer()
+        assert buf.append("hello\n") == []
+        assert buf.get_tail() == "hello\n"
+
+    def test_blank_line_commits_paragraph(self) -> None:
+        buf = MarkdownStreamBuffer()
+        stable = buf.append("hello\n\n")
+        assert stable == ["hello\n\n"]
+        assert buf.get_tail() == ""
+        assert not buf.has_tail()
+
+    def test_two_paragraphs_split_at_blank_line(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Partial first delta: both paragraphs present, tail started.
+        stable = buf.append("hello\n\nworld")
+        assert stable == ["hello\n\n"]
+        assert buf.get_tail() == "world"
+
+    def test_incremental_chunks_reconstruct_input(self) -> None:
+        buf = MarkdownStreamBuffer()
+        all_stable: list[str] = []
+        for chunk in ["hel", "lo", "\n", "\n", "w", "orld", "\n\n", "end"]:
+            all_stable.extend(buf.append(chunk))
+        assert _concat(all_stable, buf.get_tail()) == "hello\n\nworld\n\nend"
+        # only two committed paragraphs; "end" remains
+        assert all_stable == ["hello\n\n", "world\n\n"]
+        assert buf.get_tail() == "end"
+
+
+class TestFenceGuard:
+    def test_unclosed_fence_keeps_entire_text_as_tail(self) -> None:
+        buf = MarkdownStreamBuffer()
+        assert buf.append("```py\nprint(1)\n") == []
+        assert buf.get_tail() == "```py\nprint(1)\n"
+
+    def test_closed_fence_with_trailing_blank_commits(self) -> None:
+        buf = MarkdownStreamBuffer()
+        stable = buf.append("```py\nprint(1)\n```\n\nnext")
+        # fence balanced (2 triple-backticks) + blank line after close → commit
+        assert stable == ["```py\nprint(1)\n```\n\n"]
+        assert buf.get_tail() == "next"
+
+    def test_prose_before_fence_waits_for_fence_close(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Even though "hello\n\n" is a clean block boundary, the unbalanced
+        # fence count forces the whole text back into the tail — we must
+        # never split a half-open code block away from its prefix and risk
+        # Rich rendering a mismatched fence on its own.
+        assert buf.append("hello\n\n```py\nprint(1)") == []
+        assert buf.get_tail() == "hello\n\n```py\nprint(1)"
+
+    def test_closed_fence_then_reopens_waits(self) -> None:
+        buf = MarkdownStreamBuffer()
+        stable = buf.append("```a\nx\n```\n\n```b\ny")
+        # 3 triple-backticks so far → odd → hold everything
+        assert stable == []
+        assert buf.get_tail() == "```a\nx\n```\n\n```b\ny"
+
+
+class TestTablesAndLists:
+    def test_complete_table_commits_after_blank_line(self) -> None:
+        buf = MarkdownStreamBuffer()
+        text = "| a | b |\n| - | - |\n| 1 | 2 |\n\ntrail"
+        stable = buf.append(text)
+        assert stable == ["| a | b |\n| - | - |\n| 1 | 2 |\n\n"]
+        assert buf.get_tail() == "trail"
+
+    def test_table_without_blank_line_stays_tail(self) -> None:
+        buf = MarkdownStreamBuffer()
+        text = "| a | b |\n| - | - |\n| 1 | 2 |\n"
+        assert buf.append(text) == []
+        assert buf.get_tail() == text
+
+    def test_list_commits_only_after_blank_line(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Streaming list items without a terminating blank line: no commit.
+        assert buf.append("- a\n- b\n- c\n") == []
+        assert buf.get_tail() == "- a\n- b\n- c\n"
+        # Blank line terminates the list → commit.
+        stable = buf.append("\n")
+        assert stable == ["- a\n- b\n- c\n\n"]
+        assert buf.get_tail() == ""
+
+
+class TestFlushAndClear:
+    def test_flush_returns_and_clears_tail(self) -> None:
+        buf = MarkdownStreamBuffer()
+        buf.append("partial")
+        assert buf.flush() == "partial"
+        assert buf.get_tail() == ""
+        assert not buf.has_tail()
+
+    def test_flush_on_empty_buffer(self) -> None:
+        buf = MarkdownStreamBuffer()
+        assert buf.flush() == ""
+
+    def test_clear_discards_tail_without_returning(self) -> None:
+        buf = MarkdownStreamBuffer()
+        buf.append("will be dropped")
+        buf.clear()
+        assert buf.get_tail() == ""
+        assert not buf.has_tail()
+
+
+class TestOversizeGuard:
+    def test_oversize_tail_commits_at_last_newline(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Build a tail well above MAX_TAIL_BYTES with balanced fences (none)
+        # and no blank-line boundary, but with internal newlines so the
+        # oversize commit can latch on.
+        line = "x" * 200 + "\n"
+        n = (MAX_TAIL_BYTES // len(line)) + 3
+        huge = line * n
+        stable = buf.append(huge)
+        # Oversize path must have committed at least one segment
+        assert stable
+        # The committed segment ends on a newline
+        assert stable[-1].endswith("\n")
+        # And reconstruction is exact
+        assert _concat(stable, buf.get_tail()) == huge
+
+    def test_oversize_does_not_fire_with_unclosed_fence(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Unclosed fence must keep the whole thing as tail regardless of size.
+        body = "`" * 0  # placeholder
+        text = "```py\n" + ("y" * (MAX_TAIL_BYTES + 100))
+        _ = body
+        assert buf.append(text) == []
+        assert buf.get_tail() == text
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "hello",
+            "hello\n\nworld\n\n",
+            "```py\nprint(1)\n```\n\n",
+            "a paragraph\nthat wraps\n\nanother\n\n",
+            "| x | y |\n| - | - |\n| 1 | 2 |\n\ntrailing text",
+        ],
+    )
+    def test_chunked_feed_matches_whole_input(self, text: str) -> None:
+        # Feed the text one character at a time and make sure the
+        # concatenated commits + final tail equal the input byte-for-byte.
+        buf = MarkdownStreamBuffer()
+        stable: list[str] = []
+        for ch in text:
+            stable.extend(buf.append(ch))
+        assert _concat(stable, buf.get_tail()) == text

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -502,3 +502,525 @@ class TestStreamingInteractionProcessing:
         output = buf.getvalue()
         assert "Previous question" in output
         assert "Confirmed" not in output
+
+
+# ── TUI path (LiveDisplayState injected) ─────────────────────────
+
+
+@pytest.mark.ci
+class TestTuiPath:
+    """When ``live_state`` is injected, rolling-window updates go through it
+    instead of Rich ``Live``."""
+
+    def _make_subagent_tool_action(self, parent_id: str, name: str) -> ActionHistory:
+        return _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=1,
+            action_type="task_tool",
+            messages=name,
+            input_data={"function_name": name},
+            parent_action_id=parent_id,
+        )
+
+    def test_subagent_block_has_header_and_tool_tail(self):
+        """Rolling window pins header + tool tail for a single subagent."""
+        from datus.cli.tui.live_display_state import TOOL_LINES_PER_GROUP, LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+
+        ctx = InlineStreamingContext([], display, live_state=live_state)
+        parent_id = "parent-tui"
+        first = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="gen_metrics",
+            messages="task",
+            parent_action_id=parent_id,
+        )
+        ctx._start_subagent_group(first, group_key=parent_id)
+
+        for i in range(4):
+            ctx._update_subagent_display(
+                self._make_subagent_tool_action(parent_id, f"tool_{i}"),
+                group_key=parent_id,
+            )
+
+        snap = live_state.snapshot()
+        assert live_state.is_active() is True
+        # Header + at most TOOL_LINES_PER_GROUP tool rows.
+        assert live_state.line_count() == 1 + TOOL_LINES_PER_GROUP
+        # Header line splits into "⏺ name" (cyan) + "(goal)" (default).
+        header_segments = snap[0].segments
+        styles = [style for style, _ in header_segments]
+        assert "class:subagent-header-live" in styles
+        name_text = "".join(txt for style, txt in header_segments if style == "class:subagent-header-live")
+        assert "gen_metrics" in name_text
+        # Tool tail comes after the header and shows the most-recent tools.
+        last_line_text = "".join(seg for _, seg in snap[-1].segments)
+        assert "tool_3" in last_line_text
+
+    def test_parallel_subagents_each_have_own_header_and_tools(self):
+        """Each active subagent renders as its own header + tool block."""
+        from datus.cli.tui.live_display_state import TOOL_LINES_PER_GROUP, LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        ctx = InlineStreamingContext([], display, live_state=live_state)
+
+        for parent_id, label in (("parent-A", "alpha"), ("parent-B", "beta")):
+            first = _make_action(
+                ActionRole.TOOL,
+                ActionStatus.PROCESSING,
+                depth=1,
+                action_type=label,
+                messages="task",
+                parent_action_id=parent_id,
+            )
+            ctx._start_subagent_group(first, group_key=parent_id)
+            for i in range(3):
+                ctx._update_subagent_display(
+                    self._make_subagent_tool_action(parent_id, f"{label}_tool_{i}"),
+                    group_key=parent_id,
+                )
+
+        snap = live_state.snapshot()
+        # Each group = 1 header + TOOL_LINES_PER_GROUP tool rows; two groups.
+        assert live_state.line_count() == 2 * (1 + TOOL_LINES_PER_GROUP)
+        # Block order must be header1, tools1..., header2, tools2... — NOT
+        # header1, header2, tools1, tools2.
+        block_size = 1 + TOOL_LINES_PER_GROUP
+
+        def _header_name(line) -> str:
+            return "".join(txt for style, txt in line.segments if style == "class:subagent-header-live")
+
+        assert "alpha" in _header_name(snap[0])
+        assert "beta" in _header_name(snap[block_size])
+        # alpha tool tail lands in rows 1..block_size-1 (immediately after header1).
+        alpha_tail = " ".join("".join(seg for _, seg in line.segments) for line in snap[1:block_size])
+        assert "alpha_tool_2" in alpha_tail
+        assert "beta_tool_2" not in alpha_tail
+
+    def test_end_subagent_group_clears_live_state_in_tui_mode(self):
+        """When the group ends, the pinned region clears (no reprint-with-collapse)."""
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        ctx = InlineStreamingContext([], display, live_state=live_state)
+
+        parent_id = "parent-end"
+        first = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="gen_metrics",
+            messages="task",
+            parent_action_id=parent_id,
+        )
+        ctx._start_subagent_group(first, group_key=parent_id)
+        ctx._update_subagent_display(self._make_subagent_tool_action(parent_id, "tool_end"), group_key=parent_id)
+        assert live_state.is_active() is True
+
+        end_action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            parent_action_id=parent_id,
+            end_time=datetime.now() + timedelta(seconds=3),
+        )
+        ctx._end_subagent_group_by_key(parent_id, end_action)
+        assert live_state.is_active() is False
+
+    def test_tui_mode_does_not_create_rich_live(self):
+        """Confirm Rich ``Live`` is never instantiated on the TUI path."""
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        ctx = InlineStreamingContext([], display, live_state=live_state)
+
+        proc_action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            messages="slow_tool",
+            input_data={"function_name": "slow_tool"},
+        )
+        ctx._update_processing_live(proc_action)
+        assert ctx._live is None
+        assert ctx._subagent_live is None
+        assert live_state.is_active() is True
+
+
+# ── Streaming markdown (thinking_delta in TUI mode) ─────────────────
+
+
+@pytest.mark.ci
+class TestStreamingMarkdown:
+    """Cover the thinking_delta → pinned region + scrollback pipeline."""
+
+    def _make_delta(self, delta: str, action_id: str = "stream-1") -> ActionHistory:
+        return _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.PROCESSING,
+            action_type="thinking_delta",
+            input_data={},
+            output_data={"delta": delta, "accumulated": delta},
+            action_id=action_id,
+        )
+
+    def _make_ctx(self):
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        ctx = InlineStreamingContext([], display, live_state=live_state)
+        return ctx, live_state, buf
+
+    def test_non_tui_mode_has_no_markdown_buffer(self):
+        """Without a LiveDisplayState, streaming markdown stays disabled."""
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        display = ActionHistoryDisplay(console)
+        ctx = InlineStreamingContext([], display)
+        assert ctx._markdown_buffer is None
+        assert ctx._tui_mode is False
+
+    def test_tui_mode_provisions_markdown_buffer(self):
+        ctx, _live_state, _buf = self._make_ctx()
+        assert ctx._markdown_buffer is not None
+        assert ctx._markdown_stream_has_streamed is False
+
+    def test_delta_populates_pinned_region(self):
+        """A partial delta with no blank-line boundary stays in the tail."""
+        ctx, live_state, buf = self._make_ctx()
+
+        ctx._handle_thinking_delta(self._make_delta("hello "))
+        ctx._handle_thinking_delta(self._make_delta("world"))
+
+        assert ctx._markdown_buffer.get_tail() == "hello world"
+        assert ctx._markdown_stream_has_streamed is True
+        assert live_state.is_active() is True
+        # Nothing stable yet, so the scrollback console remains empty.
+        assert "hello" not in buf.getvalue()
+
+    def test_delta_never_reaches_scrollback_until_finalize(self):
+        """Accumulator-only: mid-stream deltas never hit the scrollback.
+
+        Even when a delta ends with ``\\n\\n``, the buffer keeps the full
+        text — a single flush is performed by ``_finalize_markdown_stream``
+        at the message boundary so the final render is contiguous and
+        cannot be duplicated by the outer ``_display_markdown_response``.
+        """
+        ctx, live_state, buf = self._make_ctx()
+
+        ctx._handle_thinking_delta(self._make_delta("para one\n\n"))
+
+        # Full body stays in the buffer; pinned region paints it live.
+        assert ctx._markdown_buffer.get_tail() == "para one\n\n"
+        assert live_state.is_active() is True
+        assert "para one" not in buf.getvalue()
+
+        # Finalize lands the accumulator in the scrollback exactly once.
+        ctx._finalize_markdown_stream()
+        assert ctx._markdown_buffer.has_tail() is False
+        assert buf.getvalue().count("para one") == 1
+        assert ctx.has_streamed_response is True
+
+    def test_response_action_dedupes_when_stream_active(self):
+        """Paired terminal action triggers finalize + dedup of the main body.
+
+        With the accumulator-only flow, the body is nowhere in the
+        scrollback during the stream — it only lands there when the paired
+        response action arrives (directly, or indirectly via
+        ``streaming_deltas.clear()`` detection in ``_process_deltas``).
+        The response action itself must not pass through
+        ``render_main_action``; otherwise the body would appear twice.
+        """
+        ctx, _live_state, buf = self._make_ctx()
+
+        ctx._handle_thinking_delta(self._make_delta("streamed body\n\n", action_id="stream-xyz"))
+        # Accumulator-only: nothing in the scrollback yet.
+        assert "streamed body" not in buf.getvalue()
+        assert "stream-xyz" in ctx._markdown_active_stream_ids
+
+        # Terminal response arrives with the plain ``action_type="response"``
+        # shape emitted by openai_compatible.py after
+        # ``response.content_part.done``.
+        response_action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            action_type="response",
+            messages="streamed body",
+            output_data={"raw_output": "streamed body"},
+            action_id="stream-xyz",
+        )
+        ctx._print_completed_action(response_action)
+
+        # The body lands in the scrollback exactly once — via finalize.
+        assert buf.getvalue().count("streamed body") == 1
+        assert ctx.has_streamed_response is True
+        # Consumed id is retained for future reprint de-dup; active set cleared.
+        assert "stream-xyz" in ctx._markdown_stream_consumed_ids
+        assert "stream-xyz" not in ctx._markdown_active_stream_ids
+        assert ctx._markdown_stream_has_streamed is False
+
+    def test_response_action_without_stream_renders_normally(self):
+        """If no delta was seen (action_id not in active streams), render normally."""
+        ctx, _live_state, buf = self._make_ctx()
+        assert not ctx._markdown_active_stream_ids
+
+        response_action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            action_type="chat_response",
+            messages="fresh body",
+            output_data={"raw_output": "fresh body"},
+            action_id="resp-never-streamed",
+        )
+        ctx._print_completed_action(response_action)
+        # Markdown render path fired → body lands on the console.
+        assert "fresh body" in buf.getvalue()
+        assert "resp-never-streamed" not in ctx._markdown_stream_consumed_ids
+
+    def test_finalize_flushes_leftover_tail(self):
+        """Finalize flushes any pending tail even without a blank-line boundary."""
+        ctx, live_state, buf = self._make_ctx()
+        ctx._handle_thinking_delta(self._make_delta("tail only"))
+        assert ctx._markdown_buffer.has_tail()
+
+        ctx._finalize_markdown_stream()
+
+        assert ctx._markdown_buffer.has_tail() is False
+        assert ctx._markdown_stream_has_streamed is False
+        assert live_state.is_active() is False
+        assert "tail only" in buf.getvalue()
+
+    def test_repaint_priority_processing_over_markdown(self):
+        """Running tool blink takes the pinned region over markdown tail."""
+        ctx, live_state, _buf = self._make_ctx()
+
+        ctx._handle_thinking_delta(self._make_delta("md tail"))
+        md_snap = live_state.snapshot()
+        assert md_snap  # markdown tail occupying the region
+
+        proc = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            messages="busy_tool",
+            input_data={"function_name": "busy_tool"},
+        )
+        ctx._update_processing_live(proc)
+        proc_snap = live_state.snapshot()
+        # One pinned line for the blinking processing tool.
+        assert len(proc_snap) == 1
+        assert any(style == "class:processing-live" for style, _ in proc_snap[0].segments)
+
+        # Stop processing → markdown tail reclaims the region.
+        ctx._stop_processing_live()
+        restored = live_state.snapshot()
+        assert restored  # still painted with the tail
+        assert ctx._markdown_buffer.get_tail() == "md tail"
+
+    def test_repaint_priority_subagent_over_markdown(self):
+        """Active subagent block takes priority over streaming markdown tail."""
+        ctx, live_state, _buf = self._make_ctx()
+
+        ctx._handle_thinking_delta(self._make_delta("tail text"))
+        assert live_state.is_active() is True
+
+        parent_id = "parent-mix"
+        first = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="gen_metrics",
+            messages="task",
+            parent_action_id=parent_id,
+        )
+        ctx._start_subagent_group(first, group_key=parent_id)
+        snap = live_state.snapshot()
+        # At least one line is the subagent header (styled accordingly).
+        has_subagent_header = any(
+            any(style == "class:subagent-header-live" for style, _ in line.segments) for line in snap
+        )
+        assert has_subagent_header
+
+    def test_wrapper_response_after_stream_is_dropped(self):
+        """Regression: agent-node wrapper re-emissions must not re-render body.
+
+        ``chat_agentic_node`` often emits a ``chat_response`` action *after*
+        the underlying ``openai_compatible`` ``"response"`` action — same
+        turn, same body, different id. The first one drives finalize +
+        dedup; the wrapper falls into the ``_turn_finalized`` /
+        ``_stream_body_finalized`` branch and is silently dropped.
+        """
+        ctx, _live_state, buf = self._make_ctx()
+        ctx._handle_thinking_delta(self._make_delta("final body text\n\n", action_id="stream-1"))
+        # Accumulator-only: body is only in the buffer so far.
+        assert "final body text" not in buf.getvalue()
+
+        # First completion — the openai_compatible "response" (plain type) —
+        # triggers finalize; body lands in the scrollback exactly once.
+        ctx._print_completed_action(
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                action_type="response",
+                messages="final body text",
+                output_data={"raw_output": "final body text"},
+                action_id="stream-1",
+            )
+        )
+        assert ctx._turn_finalized is True
+        assert buf.getvalue().count("final body text") == 1
+
+        # Agent-node wrapper emission — same turn, *different* id, typical
+        # ``*_response`` action_type. Would previously re-render the body.
+        ctx._print_completed_action(
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                action_type="chat_response",
+                messages="final body text",
+                output_data={"raw_output": "final body text"},
+                action_id="wrapper-xyz",
+            )
+        )
+        assert buf.getvalue().count("final body text") == 1
+        assert "wrapper-xyz" in ctx._markdown_stream_consumed_ids
+
+    def test_unterminated_tail_with_paired_response_prints_once(self):
+        """Regression: last paragraph without trailing ``\\n\\n`` must not duplicate.
+
+        With the accumulator-only flow, the entire body stays in the buffer
+        (no intermediate flushes) and lands in the scrollback exactly once
+        when the paired response action triggers
+        ``_finalize_markdown_stream``.
+        """
+        ctx, _live_state, buf = self._make_ctx()
+        stream_id = "stream-unterminated"
+
+        ctx._handle_thinking_delta(self._make_delta("Please let me know\n\n", action_id=stream_id))
+        ctx._handle_thinking_delta(self._make_delta("what you need!", action_id=stream_id))
+        # Accumulator-only: buffer carries the full body until finalize.
+        assert ctx._markdown_buffer.get_tail() == "Please let me know\n\nwhat you need!"
+        assert "Please let me know" not in buf.getvalue()
+
+        # Paired response arrives with the same id and plain "response" type.
+        response_action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            action_type="response",
+            messages="",
+            output_data={"raw_output": "Please let me know\n\nwhat you need!"},
+            action_id=stream_id,
+        )
+        ctx._print_completed_action(response_action)
+        output = buf.getvalue()
+        # Both parts of the body appear exactly once — and only now.
+        assert output.count("what you need!") == 1
+        assert output.count("Please let me know") == 1
+
+    def test_incomplete_table_fallback_scope(self):
+        """Fallback is narrow: only header / header+separator trigger plain text.
+
+        Rich can already draw a correct box table from 3+ pipe rows, so we
+        *stop* falling back once the first body row arrives and let the
+        live pinned region show the real box-drawing rendering mid-stream.
+        """
+        from datus.cli.action_display.streaming import _tail_has_incomplete_table
+
+        # Only the header → fall back (Rich would lose the single pipe line).
+        assert _tail_has_incomplete_table("| a | b |") is True
+        # Header + separator → still fall back (Rich draws a broken grid).
+        assert _tail_has_incomplete_table("| a | b |\n| - | - |") is True
+        # Header + separator + body row → Rich can draw this correctly, so
+        # we hand it over even mid-stream for the "live markdown" feel.
+        assert _tail_has_incomplete_table("| a | b |\n| - | - |\n| 1 | 2 |\n") is False
+        # Closed with blank line → stable segment, not a fallback decision.
+        assert _tail_has_incomplete_table("| a | b |\n| - | - |\n| 1 | 2 |\n\n") is False
+        assert _tail_has_incomplete_table("plain prose\n") is False
+        assert _tail_has_incomplete_table("") is False
+
+        ctx, live_state, _buf = self._make_ctx()
+        # 3-row table tail — no fallback; pinned region carries Rich's
+        # ANSI output. We don't assert on exact glyphs (ANSI color codes
+        # vary) but the numeric values must remain visible.
+        ctx._handle_thinking_delta(self._make_delta("| x | y |\n| - | - |\n| 1 | 2 |"))
+        assert ctx._markdown_buffer.has_tail()
+        assert live_state.is_active() is True
+        snap = live_state.snapshot()
+        joined = "\n".join("".join(txt for _, txt in line.segments) for line in snap)
+        assert "1" in joined and "2" in joined
+
+    def test_verbose_frozen_forces_clear(self):
+        """Frozen verbose snapshot owns the screen — pinned region must clear."""
+        ctx, live_state, _buf = self._make_ctx()
+        ctx._handle_thinking_delta(self._make_delta("tail text"))
+        assert live_state.is_active() is True
+
+        ctx._verbose_frozen = True
+        ctx._repaint_live()
+        assert live_state.is_active() is False
+
+    def test_process_deltas_detects_clear_and_finalizes(self):
+        """``_process_deltas`` must finalize when the caller clears the queue.
+
+        The chat_commands pipeline calls ``streaming_deltas.clear()`` at
+        every message boundary. The streaming context — running on the
+        refresh daemon — should notice the queue shrank, flush the
+        accumulator to the scrollback, and reset its cursor so follow-up
+        deltas (next message) start fresh.
+        """
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        deltas: list[ActionHistory] = []
+        ctx = InlineStreamingContext([], display, live_state=live_state, streaming_deltas=deltas)
+
+        # Push two deltas through the public queue + run the pump.
+        deltas.append(self._make_delta("part a "))
+        deltas.append(self._make_delta("part b"))
+        ctx._process_deltas()
+        assert ctx._delta_processed_index == 2
+        assert ctx._markdown_buffer.get_tail() == "part a part b"
+        assert "part a" not in buf.getvalue()
+
+        # Caller signals message boundary by clearing the queue.
+        deltas.clear()
+        ctx._process_deltas()
+
+        # Body landed in the scrollback exactly once; cursor reset.
+        assert buf.getvalue().count("part a part b") == 1
+        assert ctx._delta_processed_index == 0
+        assert ctx._markdown_buffer.has_tail() is False
+        assert ctx.has_streamed_response is True
+
+    def test_has_streamed_response_is_false_without_deltas(self):
+        """Contexts that never painted a delta must not latch the flag.
+
+        Otherwise the outer ``_render_final_response`` would skip the
+        ``_display_markdown_response`` step on *every* turn, including
+        non-streaming providers that rely on it for their final output.
+        """
+        ctx, _live_state, _buf = self._make_ctx()
+        assert ctx.has_streamed_response is False
+        # Finalize with an empty buffer must not set the latch either.
+        ctx._finalize_markdown_stream()
+        assert ctx.has_streamed_response is False

--- a/tests/unit_tests/cli/test_action_history_display.py
+++ b/tests/unit_tests/cli/test_action_history_display.py
@@ -3267,14 +3267,6 @@ class TestInlineStreamingContextProperties:
         ctx.toggle_verbose()
         assert ctx._verbose_toggle_event.is_set()
 
-    def test_recreate_live_display_calls_restart(self):
-        """recreate_live_display is a compatibility shim for restart_display."""
-        display = ActionHistoryDisplay()
-        ctx = InlineStreamingContext([], display)
-        ctx._paused = True
-        ctx.recreate_live_display()
-        assert ctx._paused is False
-
 
 @pytest.mark.ci
 class TestInlineStreamingContextFlush:

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -1955,8 +1955,8 @@ class TestExecuteResponseProcessing:
         assert len(cmds.chat_history) == 1
         assert cmds.current_node is not None
 
-    def test_session_reuse_shows_session_info(self, real_agent_config, mock_llm_create):
-        """Second execute reusing same node shows 'Using existing session' info."""
+    def test_session_reuse_does_not_print_session_info(self, real_agent_config, mock_llm_create):
+        """Second execute reusing same node must not print the legacy session banner."""
         from tests.unit_tests.mock_llm_model import build_simple_response
 
         console = Console(file=io.StringIO(), no_color=True)
@@ -1965,15 +1965,13 @@ class TestExecuteResponseProcessing:
         mock_llm_create.reset(responses=[build_simple_response("First"), build_simple_response("Second")])
 
         cmds.execute_chat_command("First message")
-        # Clear console buffer for second call
         console.file = io.StringIO()
 
         cmds.execute_chat_command("Second message")
         output = _get_console_output(console)
 
         assert len(cmds.chat_history) == 2
-        # Second call reuses the node, may show session info
-        assert "Processing" in output or "Using existing session" in output
+        assert "Using existing session" not in output
 
 
 # ===========================================================================

--- a/tests/unit_tests/cli/test_status_bar.py
+++ b/tests/unit_tests/cli/test_status_bar.py
@@ -11,7 +11,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from datus.cli.status_bar import StatusBarProvider, StatusBarState, _humanize_tokens
+from datus.cli.status_bar import (
+    StatusBarProvider,
+    StatusBarState,
+    _humanize_tokens,
+    _running_blink_symbol,
+)
 from datus.utils.constants import DBType
 
 
@@ -135,35 +140,62 @@ class TestStatusBarState:
         styles = [style for style, _ in state.to_formatted_tokens()]
         assert "class:status-bar.connector" not in styles
 
-    def test_to_formatted_tokens_appends_running_segment_when_agent_running(self):
-        # The TUI path sets ``agent_running`` true while the worker thread is
-        # dispatching; the status bar must surface a ``● running`` indicator
-        # as the trailing segment so users can tell the REPL is busy at a
-        # glance even though input remains editable.
+    def test_to_formatted_tokens_leading_dot_uses_running_class_when_agent_running(self):
+        # While the TUI worker dispatches, the leading activity dot switches
+        # to the ``status-bar.running`` class and pulses between filled and
+        # hollow glyphs so users can spot the busy state at a glance.
         state = StatusBarState(agent="chat", agent_running=True)
         tokens = state.to_formatted_tokens()
         styles = [style for style, _ in tokens]
         texts = [text for _, text in tokens]
         assert "class:status-bar.running" in styles
-        running_text = texts[styles.index("class:status-bar.running")]
-        assert "running" in running_text
-        # The running token must be the last meaningful segment (followed
-        # only by the trailing pad so the bar has a breathing space at the
-        # terminal edge).
-        last_non_pad = None
-        for style, text in reversed(tokens):
-            if style == "class:status-bar":
-                continue
-            last_non_pad = style
-            break
-        assert last_non_pad == "class:status-bar.running"
+        running_idx = styles.index("class:status-bar.running")
+        brand_idx = styles.index("class:status-bar.brand")
+        # Dot must precede the Datus brand token.
+        assert running_idx < brand_idx
+        assert texts[running_idx] in ("●", "○")
+        # Idle dot class must not appear while running.
+        assert "class:status-bar.dot" not in styles
 
-    def test_to_formatted_tokens_omits_running_segment_when_idle(self):
-        # The legacy PromptSession path never sets ``agent_running`` true,
-        # so the running indicator must never appear outside the TUI.
+    def test_to_formatted_tokens_leading_dot_solid_when_idle(self):
+        # The idle state still shows a solid dot to the left of Datus; it
+        # never animates and uses the neutral ``status-bar.dot`` class so
+        # the running orange is reserved for the busy indicator.
         state = StatusBarState(agent="chat")
-        styles = [style for style, _ in state.to_formatted_tokens()]
+        tokens = state.to_formatted_tokens()
+        styles = [style for style, _ in tokens]
+        texts = [text for _, text in tokens]
         assert "class:status-bar.running" not in styles
+        assert "class:status-bar.dot" in styles
+        dot_idx = styles.index("class:status-bar.dot")
+        brand_idx = styles.index("class:status-bar.brand")
+        assert dot_idx < brand_idx
+        assert texts[dot_idx] == "●"
+
+    def test_to_formatted_tokens_running_dot_glyph_is_one_of_two_phases(self):
+        # Phase depends on the wall clock; either glyph is valid but the
+        # word "running" must NOT appear — the textual label was removed
+        # and only the dot remains as the indicator.
+        state = StatusBarState(agent="chat", agent_running=True)
+        tokens = state.to_formatted_tokens()
+        texts = [text for _, text in tokens]
+        running_idx = [i for i, (style, _) in enumerate(tokens) if style == "class:status-bar.running"][0]
+        assert texts[running_idx] in ("●", "○")
+        assert not any("running" in text for _, text in tokens)
+
+
+class TestRunningBlinkSymbol:
+    def test_toggles_each_half_period(self):
+        # Phase 0 → filled, phase 1 → hollow, phase 2 → filled, …
+        assert _running_blink_symbol(0.0) == "●"
+        assert _running_blink_symbol(0.25) == "●"
+        assert _running_blink_symbol(0.5) == "○"
+        assert _running_blink_symbol(0.99) == "○"
+        assert _running_blink_symbol(1.0) == "●"
+
+    def test_returns_a_valid_glyph_with_default_clock(self):
+        # Live call must not crash and must return one of the two glyphs.
+        assert _running_blink_symbol() in ("●", "○")
 
 
 class TestStatusBarProviderAgent:

--- a/tests/unit_tests/cli/test_tui_layout.py
+++ b/tests/unit_tests/cli/test_tui_layout.py
@@ -40,18 +40,23 @@ class TestCompletionsMenuWired:
         assert isinstance(inner_window.content, CompletionsMenuControl)
 
     def test_menu_sits_between_input_and_bottom_separator(self):
-        """The HSplit order status → input → menu → separator is what lets
-        the input slide back to the bottom of the terminal once the menu
-        collapses. Any other ordering regresses the rendering."""
+        """The HSplit order input → menu → separator is what lets the input
+        slide back to the bottom of the terminal once the menu collapses.
+        Any other ordering regresses the rendering. The pinned live region
+        now sits at the very top (index 0) but doesn't affect the input ↔
+        menu adjacency that this test guards."""
 
         app = _build_app()
         root = app.application.layout.container
         # DatusApp wraps the HSplit directly; grab the children list.
         children = list(root.get_children())
-        # Expected order: top_sep, status_window, mid_sep, input, menu, bottom_sep, hint.
-        assert len(children) == 7, f"unexpected HSplit child count: {len(children)}"
-        # The fifth child (index 4) must be the CompletionsMenu.
-        assert children[4] is app._completions_menu
+        # Expected order: live_region, top_sep, status, mid_sep, input, menu,
+        # bottom_sep, hint.
+        assert len(children) == 8, f"unexpected HSplit child count: {len(children)}"
+        # The menu must sit at index 5, immediately after the input (index 4;
+        # the TextArea is flattened into its wrapping Window by prompt_toolkit
+        # so the identity check is made on the menu itself).
+        assert children[5] is app._completions_menu
 
 
 class TestCompletionsMenuConfig:

--- a/tests/unit_tests/cli/tui/test_console_bridge.py
+++ b/tests/unit_tests/cli/tui/test_console_bridge.py
@@ -31,58 +31,110 @@ def test_runs_inline_when_no_application() -> None:
     assert called["count"] == 1
 
 
-def test_schedules_via_run_in_terminal_when_app_active() -> None:
+def test_schedules_via_run_in_terminal_when_on_event_loop() -> None:
+    """On the prompt_toolkit event loop, dispatch fires-and-forgets.
+
+    Fire-and-forget because blocking on the returned future would deadlock
+    the loop that has to run the scheduled callback. The no-await path is
+    taken only when ``asyncio.get_running_loop()`` succeeds on the calling
+    thread, so we simulate that with a patch.
+    """
     fake_future = mock.MagicMock()
-    fake_future.result.return_value = None
     fake_app = mock.MagicMock()
+    fake_loop = mock.MagicMock()
 
     with (
         mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
+        mock.patch("datus.cli.tui.console_bridge.asyncio.get_running_loop", return_value=fake_loop),
         mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future) as mocked_rit,
     ):
         fn = mock.MagicMock()
         run_in_terminal_sync(fn)
 
         mocked_rit.assert_called_once_with(fn)
-        # ``result()`` must be awaited so the caller can rely on the print
-        # having completed before returning control.
-        fake_future.result.assert_called_once()
+        # On-loop path must NOT block on the future — it would deadlock.
+        fake_future.result.assert_not_called()
+
+
+def test_submits_coroutine_from_off_loop_thread() -> None:
+    """Off the event loop with a live Application, submit via app.loop.
+
+    ``run_in_terminal`` needs a running loop on the calling thread (Python
+    3.12+); on the streaming refresh daemon there is none, so the bridge
+    hops to ``app.loop`` via :func:`asyncio.run_coroutine_threadsafe` and
+    blocks on the concurrent.futures.Future it returns.
+    """
+    fake_cf = mock.MagicMock()
+    fake_cf.result.return_value = None
+    fake_app = mock.MagicMock()
+
+    with (
+        mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
+        mock.patch(
+            "datus.cli.tui.console_bridge.asyncio.get_running_loop",
+            side_effect=RuntimeError("no loop"),
+        ),
+        mock.patch(
+            "datus.cli.tui.console_bridge.asyncio.run_coroutine_threadsafe",
+            return_value=fake_cf,
+        ) as mocked_submit,
+    ):
+        run_in_terminal_sync(lambda: None)
+
+    mocked_submit.assert_called_once()
+    _coro, loop_arg = mocked_submit.call_args.args
+    assert loop_arg is fake_app.loop
+    fake_cf.result.assert_called_once()
 
 
 def test_swallows_future_exceptions() -> None:
     # Exceptions raised on the prompt_toolkit loop thread must not leak
     # back to callers: a worker-thread callback failing silently is
     # preferable to the REPL crashing mid-dispatch.
-    fake_future = mock.MagicMock()
-    fake_future.result.side_effect = RuntimeError("boom")
+    fake_cf = mock.MagicMock()
+    fake_cf.result.side_effect = RuntimeError("boom")
     fake_app = mock.MagicMock()
 
     with (
         mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
-        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future) as mocked_rit,
+        mock.patch(
+            "datus.cli.tui.console_bridge.asyncio.get_running_loop",
+            side_effect=RuntimeError("no loop"),
+        ),
+        mock.patch(
+            "datus.cli.tui.console_bridge.asyncio.run_coroutine_threadsafe",
+            return_value=fake_cf,
+        ) as mocked_submit,
     ):
         run_in_terminal_sync(lambda: None)
 
     # The bridge both scheduled the callback and awaited its result even
     # though the result raised — the exception was swallowed, not re-raised.
-    mocked_rit.assert_called_once()
-    fake_future.result.assert_called_once()
+    mocked_submit.assert_called_once()
+    fake_cf.result.assert_called_once()
 
 
-def test_passes_exact_callable_without_wrapping() -> None:
-    # ``run_in_terminal`` accepts a no-arg callable; the bridge must not
-    # wrap it in a lambda (which would defeat introspection in hooks).
-    target = mock.MagicMock()
-    fake_future = mock.MagicMock()
-    fake_future.result.return_value = None
+def test_runs_inline_when_loop_missing_on_app() -> None:
+    """Application without a running loop (e.g. pre-run) → invoke directly.
+
+    There is no pinned area to preserve yet, so forwarding through
+    ``run_in_terminal`` would be needlessly indirect — the helper falls
+    through to an inline call.
+    """
     fake_app = mock.MagicMock()
+    fake_app.loop = None
+    called = {"count": 0}
+
+    def _fn() -> None:
+        called["count"] += 1
 
     with (
         mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
-        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future) as mocked_rit,
+        mock.patch(
+            "datus.cli.tui.console_bridge.asyncio.get_running_loop",
+            side_effect=RuntimeError("no loop"),
+        ),
     ):
-        run_in_terminal_sync(target)
-        # Positional argument identity check — our helper should forward the
-        # object unchanged.
-        (passed,), _kwargs = mocked_rit.call_args
-        assert passed is target
+        run_in_terminal_sync(_fn)
+
+    assert called["count"] == 1

--- a/tests/unit_tests/cli/tui/test_live_display_state.py
+++ b/tests/unit_tests/cli/tui/test_live_display_state.py
@@ -1,0 +1,107 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for :class:`datus.cli.tui.live_display_state.LiveDisplayState`."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from datus.cli.tui.live_display_state import MAX_LIVE_LINES_TOTAL, LiveDisplayLine, LiveDisplayState
+
+
+@pytest.mark.ci
+class TestLiveDisplayState:
+    def test_default_is_inactive(self) -> None:
+        state = LiveDisplayState()
+        assert state.is_active() is False
+        assert state.line_count() == 0
+        assert state.snapshot() == []
+
+    def test_set_lines_activates_and_invalidate_fires(self) -> None:
+        hits: list[int] = []
+        state = LiveDisplayState(invalidate_cb=lambda: hits.append(1))
+        state.set_lines(
+            [
+                LiveDisplayLine(segments=[("class:a", "first")]),
+                LiveDisplayLine(segments=[("class:a", "second")]),
+            ]
+        )
+        assert state.is_active() is True
+        assert state.line_count() == 2
+        assert state.snapshot()[0].segments == [("class:a", "first")]
+        assert state.snapshot()[1].segments == [("class:a", "second")]
+        assert hits, "invalidate_cb should fire after set_lines"
+
+    def test_set_lines_truncates_to_global_max(self) -> None:
+        state = LiveDisplayState()
+        lines = [LiveDisplayLine(segments=[("class:a", f"line {i}")]) for i in range(MAX_LIVE_LINES_TOTAL + 3)]
+        state.set_lines(lines)
+        assert state.line_count() == MAX_LIVE_LINES_TOTAL
+        kept = state.snapshot()
+        # Tail of the input is kept.
+        assert kept[-1].segments[0][1] == f"line {MAX_LIVE_LINES_TOTAL + 2}"
+
+    def test_dynamic_max_rows_provider_shrinks_cap(self) -> None:
+        """Custom provider (e.g. terminal-height-aware) tightens the cap."""
+        state = LiveDisplayState()
+        state.set_max_rows_provider(lambda: 5)
+        state.set_lines([LiveDisplayLine(segments=[("x", f"{i}")]) for i in range(20)])
+        assert state.line_count() == 5
+        # Last rows are retained (newest content is at the end).
+        kept = state.snapshot()
+        assert kept[0].segments[0][1] == "15"
+        assert kept[-1].segments[0][1] == "19"
+
+    def test_max_rows_provider_floor_and_ceiling(self) -> None:
+        """Providers returning garbage fall through to safe bounds."""
+        state = LiveDisplayState()
+        state.set_max_rows_provider(lambda: -1)
+        assert state.max_rows() >= 3  # _PINNED_MIN_ROWS
+        state.set_max_rows_provider(lambda: 10**9)
+        assert state.max_rows() == MAX_LIVE_LINES_TOTAL
+        state.set_max_rows_provider(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert state.max_rows() == MAX_LIVE_LINES_TOTAL
+
+    def test_clear_only_invalidates_when_had_content(self) -> None:
+        hits: list[int] = []
+        state = LiveDisplayState(invalidate_cb=lambda: hits.append(1))
+        state.clear()  # already empty
+        assert hits == []
+        state.set_lines([LiveDisplayLine(segments=[("class:a", "x")])])
+        state.clear()
+        # set + clear = two invalidations
+        assert len(hits) == 2
+
+    def test_set_invalidate_replaces_callback(self) -> None:
+        first_hits: list[int] = []
+        second_hits: list[int] = []
+        state = LiveDisplayState(invalidate_cb=lambda: first_hits.append(1))
+        state.set_invalidate(lambda: second_hits.append(1))
+        state.set_lines([LiveDisplayLine(segments=[("class:a", "x")])])
+        assert first_hits == []
+        assert second_hits == [1]
+
+    def test_snapshot_is_a_copy(self) -> None:
+        state = LiveDisplayState()
+        state.set_lines([LiveDisplayLine(segments=[("class:a", "x")])])
+        snap = state.snapshot()
+        snap.clear()
+        assert state.line_count() == 1, "external mutation of snapshot must not affect state"
+
+    def test_concurrent_writers_do_not_lose_lock(self) -> None:
+        state = LiveDisplayState()
+
+        def writer(char: str) -> None:
+            for i in range(200):
+                state.set_lines([LiveDisplayLine(segments=[("class:a", f"{char}{i}")])])
+
+        threads = [threading.Thread(target=writer, args=(c,)) for c in "abcd"]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # Just make sure we never crashed and the final state is consistent.
+        assert 0 <= state.line_count() <= MAX_LIVE_LINES_TOTAL


### PR DESCRIPTION
Move the subagent rolling window and the main-agent streaming body out of Rich Live into a prompt_toolkit pinned region driven by LiveDisplayState, and route ``thinking_delta`` actions through a dedicated accumulator so the final transcript contains exactly one copy of each response.

Pinned region (shared):
- ``LiveDisplayState`` is a thread-safe shared state the daemon writers mutate and ``DatusApp`` paints via a single ``ConditionalContainer`` between the scrollback and the status bar. Per-group cap (``TOOL_LINES_PER_GROUP=2``) and terminal-aware ceiling via ``compute_pinned_max_rows`` / ``set_max_rows_provider``.
- Each active subagent renders as its own block — cyan header + dim tool-tail rows — so parallel subagents stack without interleaving. Rich Live is kept as the non-TUI fallback.
- ``console_bridge.run_in_terminal_sync`` hops off-loop daemon threads onto ``app.loop`` via ``asyncio.run_coroutine_threadsafe(in_terminal())`` so the refresh thread can push to the append area safely on 3.12+.

Streaming markdown (accumulator-only):
- ``chat_commands`` splits the stream into ``incremental_actions`` (structural) and ``streaming_deltas`` (thinking_delta). Deltas clear at every paired response to reset per-message state.
- ``MarkdownStreamBuffer.append_raw`` accumulates the full body without stable-segment splitting; the pinned region shows the growing tail and ``_finalize_markdown_stream`` is the sole entry point that flushes the body to the scrollback — triggered by ``_process_deltas`` noticing the caller's clear, by the paired response action, or as an ``__exit__`` safety drain. A ``has_streamed_response`` latch lets ``_render_final_response`` skip ``_display_markdown_response`` so the body is never painted twice.
- End-of-turn ``_full_screen_reprint`` mirrors the Ctrl+O toggle so the viewport ends each turn with a clean Rich render; the helper is shared with ``display_inline_trace_details``.
- ``render_action_history`` now skips both plain ``response`` and ``*_response`` so replay paths never double up on the body.
- Status bar: running-state blink dot (●/○, 2Hz) moved to the left of the brand so the busy indicator is always visible.

Tests: add ``test_markdown_stream.py`` and ``test_live_display_state.py``; extend ``test_streaming.py`` with delta queue / finalize / dedup cases; refit ``test_console_bridge.py`` for the off-loop submit path.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pinned live-render area for real-time agent/subagent/tool output; live-region sizing and animated status-dot.

* **Bug Fixes**
  * Prevented duplicate assistant response rendering during streaming; improved de-duplication of paired finalizers.

* **Improvements**
  * More robust incremental markdown streaming and pinned-region flushing; Ctrl+O reprint restores in-flight content.
  * Safer terminal/async coordination for non-blocking TUI prints.

* **Tests**
  * Comprehensive unit tests for streaming, markdown buffering, live-state and TUI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->