### PR TITLE
[Refactor] Bump datus-*-core deps; make datus-scheduler-core a direct dep

### DIFF
--- a/datus/cli/service_client.py
+++ b/datus/cli/service_client.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
+from datus_scheduler_core.registry import SchedulerAdapterRegistry
+
 from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
@@ -242,21 +244,15 @@ def _probe_semantic_adapter(agent_config: "AgentConfig", service_name: str) -> b
 
 
 def _probe_scheduler_adapter(agent_config: "AgentConfig", service_name: str) -> bool:
-    """True when both ``datus-scheduler-core`` and the platform adapter
-    package are importable / registered.
+    """True when the platform adapter package is importable / registered.
 
-    A scheduler service entry has a ``type`` field (e.g. ``airflow``)
-    that points at a platform-specific adapter. Checking only that
-    ``datus_scheduler_core`` imports is not enough — core is the base
-    framework; the per-platform adapter (``datus-scheduler-airflow`` /
+    ``datus-scheduler-core`` is a hard dependency, so its presence is
+    guaranteed; a scheduler service entry has a ``type`` field (e.g.
+    ``airflow``) that points at a platform-specific adapter, and the
+    per-platform adapter (``datus-scheduler-airflow`` /
     ``datus-scheduler-dolphinscheduler`` / ...) is what actually
     registers ``SchedulerAdapterRegistry`` entries.
     """
-    try:
-        from datus_scheduler_core.registry import SchedulerAdapterRegistry
-    except ImportError:
-        return False
-
     # Read the platform from the service's config.
     platform = "airflow"
     try:

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -8,11 +8,13 @@ from pathlib import Path
 from typing import List, Optional
 
 from agents import Tool
+from datus_scheduler_core.models import SchedulerJobPayload
+from datus_scheduler_core.registry import SchedulerAdapterRegistry
 
 from datus.configuration.agent_config import AgentConfig
 from datus.tools import BaseTool
 from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
-from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.exceptions import DatusException
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -35,17 +37,7 @@ class SchedulerTools(BaseTool):
     # ── Adapter factory ────────────────────────────────────────────────────
 
     def _get_adapter(self):
-        """Lazily create a scheduler adapter from the configured scheduler."""
-        try:
-            from datus_scheduler_core.registry import SchedulerAdapterRegistry
-        except ImportError as exc:
-            raise DatusException(
-                ErrorCode.COMMON_MISSING_DEPENDENCY,
-                message_args={},
-                message="datus-scheduler-core is required for scheduler tools. "
-                "Install it with: pip install datus-scheduler-core",
-            ) from exc
-
+        """Create a scheduler adapter from the configured scheduler."""
         config = self._selected_scheduler_config()
         platform = config.get("type", "airflow")
 
@@ -91,11 +83,6 @@ class SchedulerTools(BaseTool):
         Returns:
             FuncToolResult with result containing job_id and status.
         """
-        try:
-            from datus_scheduler_core.models import SchedulerJobPayload
-        except ImportError as exc:
-            return FuncToolResult(success=0, error=f"datus-scheduler-core not installed: {exc}")
-
         # Read SQL file
         try:
             sql_path = Path(sql_file_path).expanduser()
@@ -110,7 +97,7 @@ class SchedulerTools(BaseTool):
         # Submit
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -165,11 +152,6 @@ class SchedulerTools(BaseTool):
             FuncToolResult with result containing job_id and status.
         """
         try:
-            from datus_scheduler_core.models import SchedulerJobPayload
-        except ImportError as exc:
-            return FuncToolResult(success=0, error=f"datus-scheduler-core not installed: {exc}")
-
-        try:
             sql_path = Path(sql_file_path).expanduser()
             if not sql_path.exists():
                 return FuncToolResult(success=0, error=f"SQL file not found: {sql_file_path}")
@@ -181,7 +163,7 @@ class SchedulerTools(BaseTool):
 
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -229,7 +211,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -265,7 +247,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -318,7 +300,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -382,7 +364,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -411,7 +393,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -440,7 +422,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -490,11 +472,6 @@ class SchedulerTools(BaseTool):
         if job_type not in ("sql", "sparksql"):
             return FuncToolResult(success=0, error=f"Unsupported job_type '{job_type}'. Use 'sql' or 'sparksql'.")
 
-        try:
-            from datus_scheduler_core.models import SchedulerJobPayload
-        except ImportError as exc:
-            return FuncToolResult(success=0, error=f"datus-scheduler-core not installed: {exc}")
-
         # Read SQL file
         try:
             sql_path = Path(sql_file_path).expanduser()
@@ -516,7 +493,7 @@ class SchedulerTools(BaseTool):
 
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -578,7 +555,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:
@@ -618,7 +595,7 @@ class SchedulerTools(BaseTool):
         """
         try:
             adapter = self._get_adapter()
-        except (ImportError, ValueError, DatusException) as exc:
+        except (ValueError, DatusException) as exc:
             return FuncToolResult(success=0, error=str(exc))
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "datus-db-core>=0.1.1",
+    "datus-db-core>=0.1.3",
     "datus-storage-base>=0.1.2,<0.2.0",
     "python-dotenv==1.0.0",
     "pandas==2.1.4",
@@ -70,7 +70,9 @@ dependencies = [
     "tabulate>=0.9.0",
     "datus-semantic-core>=0.2.0",
     # BI platform adapters (core models & interfaces)
-    "datus-bi-core>=0.1.1",
+    "datus-bi-core>=0.1.2",
+    # Workflow scheduler adapters (core framework)
+    "datus-scheduler-core>=0.1.1",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ lxml>=5.0.0
 markdown-it-py>=3.0.0
 tabulate>=0.9.0
 datus-storage-base==0.1.2rc2
-datus-db-core>=0.1.1
-datus-semantic-core>=0.1.1
-datus-bi-core>=0.1.1
+datus-db-core>=0.1.3
+datus-semantic-core>=0.2.0
+datus-bi-core>=0.1.2
+datus-scheduler-core>=0.1.1

--- a/tests/unit_tests/cli/test_service_client.py
+++ b/tests/unit_tests/cli/test_service_client.py
@@ -456,63 +456,39 @@ class TestAdapterProbes:
         with patch.dict("sys.modules", {"datus_bi_core": stub_module}):
             assert _probe_bi_adapter(None, "superset") is False
 
-    def test_scheduler_probe_needs_core_package_importable(self):
-        from datus.cli.service_client import _probe_scheduler_adapter
-
-        # Force ImportError on the ``datus_scheduler_core.registry`` submodule
-        # import used by the probe. Zeroing both entries is defensive — other
-        # tests in the suite may have registered mock modules under either
-        # path, and sys.modules entries survive until patch.dict restores.
-        with patch.dict(
-            "sys.modules",
-            {"datus_scheduler_core": None, "datus_scheduler_core.registry": None},
-        ):
-            assert _probe_scheduler_adapter(None, "airflow") is False
-
     def test_scheduler_probe_checks_platform_registration(self):
-        """Core installed but platform adapter missing → probe returns False.
+        """Platform adapter missing → probe returns False.
 
-        ``datus-scheduler-core`` is typically present; the real-world gap is
-        the platform-specific package (e.g. ``datus-scheduler-airflow``) that
-        registers the adapter into ``SchedulerAdapterRegistry``.
+        ``datus-scheduler-core`` is a hard dep and always importable; the
+        real-world gap is the platform-specific package (e.g.
+        ``datus-scheduler-airflow``) that registers the adapter into
+        ``SchedulerAdapterRegistry``.
         """
         from datus.cli.service_client import _probe_scheduler_adapter
 
-        core_module = MagicMock()
-        core_module.registry.SchedulerAdapterRegistry.get_adapter_class.return_value = None
-        core_module.registry.SchedulerAdapterRegistry.has_adapter.return_value = None
-        core_module.registry.SchedulerAdapterRegistry.get.return_value = None
+        mock_registry = MagicMock()
+        mock_registry.get_adapter_class.return_value = None
+        mock_registry.has_adapter.return_value = None
+        mock_registry.get.return_value = None
         cfg = SimpleNamespace(
             get_scheduler_config=lambda name: {"type": "airflow"},
         )
-        with patch.dict(
-            "sys.modules",
-            {
-                "datus_scheduler_core": core_module,
-                "datus_scheduler_core.registry": core_module.registry,
-            },
-        ):
+        with patch("datus.cli.service_client.SchedulerAdapterRegistry", mock_registry):
             assert _probe_scheduler_adapter(cfg, "airflow_local") is False
 
     def test_scheduler_probe_returns_true_when_platform_registered(self):
         from datus.cli.service_client import _probe_scheduler_adapter
 
-        core_module = MagicMock()
-        core_module.registry.SchedulerAdapterRegistry.get_adapter_class.return_value = object()
+        mock_registry = MagicMock()
+        mock_registry.get_adapter_class.return_value = object()
         cfg = SimpleNamespace(
             get_scheduler_config=lambda name: {"type": "airflow"},
         )
-        with patch.dict(
-            "sys.modules",
-            {
-                "datus_scheduler_core": core_module,
-                "datus_scheduler_core.registry": core_module.registry,
-            },
-        ):
+        with patch("datus.cli.service_client.SchedulerAdapterRegistry", mock_registry):
             assert _probe_scheduler_adapter(cfg, "airflow_local") is True
             # The getter was asked about the platform from the config, not the
             # service name (which is only a user-chosen alias).
-            core_module.registry.SchedulerAdapterRegistry.get_adapter_class.assert_called_with("airflow")
+            mock_registry.get_adapter_class.assert_called_with("airflow")
 
     def test_probe_helper_defensive_on_exception(self):
         from datus.cli.service_client import _probe

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -118,18 +118,10 @@ class TestGetAdapter:
     def test_success_with_mocked_registry(self):
         mock_adapter = MagicMock()
         tools = SchedulerTools(_make_agent_config())
-        with patch(
-            "datus.tools.func_tool.scheduler_tools.SchedulerAdapterRegistry",
-            create=True,
-        ):
-            # The import happens inside _get_adapter; patch sys.modules so it resolves
-            mock_registry = MagicMock()
-            mock_registry.create_adapter.return_value = mock_adapter
-            with patch.dict(
-                "sys.modules",
-                {"datus_scheduler_core.registry": MagicMock(SchedulerAdapterRegistry=mock_registry)},
-            ):
-                adapter = tools._get_adapter()
+        mock_registry = MagicMock()
+        mock_registry.create_adapter.return_value = mock_adapter
+        with patch("datus.tools.func_tool.scheduler_tools.SchedulerAdapterRegistry", mock_registry):
+            adapter = tools._get_adapter()
         assert adapter is mock_adapter
 
     def test_airflow_injects_project_name_as_file_scope_only(self):
@@ -158,10 +150,7 @@ class TestGetAdapter:
 
         mock_registry = MagicMock()
         mock_registry.create_adapter.return_value = MagicMock()
-        with patch.dict(
-            "sys.modules",
-            {"datus_scheduler_core.registry": MagicMock(SchedulerAdapterRegistry=mock_registry)},
-        ):
+        with patch("datus.tools.func_tool.scheduler_tools.SchedulerAdapterRegistry", mock_registry):
             tools._get_adapter()
 
         call_kwargs = mock_registry.create_adapter.call_args.kwargs
@@ -190,10 +179,7 @@ class TestGetAdapter:
 
         mock_registry = MagicMock()
         mock_registry.create_adapter.return_value = MagicMock()
-        with patch.dict(
-            "sys.modules",
-            {"datus_scheduler_core.registry": MagicMock(SchedulerAdapterRegistry=mock_registry)},
-        ):
+        with patch("datus.tools.func_tool.scheduler_tools.SchedulerAdapterRegistry", mock_registry):
             tools._get_adapter()
 
         call_kwargs = mock_registry.create_adapter.call_args.kwargs
@@ -215,10 +201,7 @@ class TestGetAdapter:
 
         mock_registry = MagicMock()
         mock_registry.create_adapter.return_value = MagicMock()
-        with patch.dict(
-            "sys.modules",
-            {"datus_scheduler_core.registry": MagicMock(SchedulerAdapterRegistry=mock_registry)},
-        ):
+        with patch("datus.tools.func_tool.scheduler_tools.SchedulerAdapterRegistry", mock_registry):
             tools._get_adapter()
 
         call_kwargs = mock_registry.create_adapter.call_args.kwargs


### PR DESCRIPTION
## Why

Three of agent-1's four ``datus-*-core`` dependencies just shipped new PyPI releases
(``datus-bi-core 0.1.2``, ``datus-db-core 0.1.3``, ``datus-scheduler-core 0.1.1``).
Our ``pyproject.toml`` is still pinned one rev behind.

While updating the pins, ``datus-scheduler-core`` stood out: it's imported in
``datus/tools/func_tool/scheduler_tools.py`` and ``datus/cli/service_client.py``
via lazy ``try: from datus_scheduler_core... / except ImportError:`` blocks
repeated 4+ times, because the package was treated as *optional* (actually
pulled in transitively via ``datus-scheduler-airflow``, or by nightly CI's
editable install). That's inconsistent with how ``datus-db-core`` and
``datus-semantic-core`` — the other hard-dep cores — are imported (plain
top-level). It also leaves a weird error path that only fires if someone
uninstalls a transitive dep.

Making ``datus-scheduler-core`` a direct dep lets us delete those try/except
tangles and match the idiom used elsewhere.

## Solution

``pyproject.toml``
- ``datus-db-core``: ``>=0.1.1`` → ``>=0.1.3``
- ``datus-bi-core``: ``>=0.1.1`` → ``>=0.1.2``
- ``datus-scheduler-core``: **new direct dep**, ``>=0.1.1``
- ``datus-semantic-core``: already ``>=0.2.0`` (no change needed)

``datus/tools/func_tool/scheduler_tools.py``
- Hoist ``SchedulerJobPayload`` and ``SchedulerAdapterRegistry`` to top-level imports.
- Drop the try/except in ``_get_adapter`` that raised ``COMMON_MISSING_DEPENDENCY``.
- Drop 3 per-method ``try: from datus_scheduler_core.models import SchedulerJobPayload / except ImportError: return FuncToolResult(...)`` blocks.
- Simplify 11 ``except (ImportError, ValueError, DatusException)`` call sites to ``except (ValueError, DatusException)`` — ``ImportError`` can no longer originate from the local lazy imports.

``datus/cli/service_client.py``
- Hoist ``SchedulerAdapterRegistry`` import to module scope.
- Drop the ``try/except ImportError: return False`` fallback in ``_probe_scheduler_adapter``; the probe now focuses on platform-adapter registration (``datus-scheduler-airflow`` etc.), which is still optional.

## Test Cases

- ``tests/unit_tests/tools/func_tool/test_scheduler_tools.py::TestGetAdapter`` (4 tests) — rewritten to ``patch(\"datus.tools.func_tool.scheduler_tools.SchedulerAdapterRegistry\", ...)`` instead of ``patch.dict(sys.modules, ...)``. The latter relied on the lazy import being re-evaluated per call, which no longer happens.
- ``tests/unit_tests/cli/test_service_client.py::TestAdapterProbes`` (3 tests) —
  - Deleted ``test_scheduler_probe_needs_core_package_importable`` (its premise no longer exists: scheduler-core is always importable).
  - Rewrote the other two probe tests to patch ``datus.cli.service_client.SchedulerAdapterRegistry``.
- Local verification:
  - ``uv run pytest tests/unit_tests/tools/func_tool/test_scheduler_tools.py -q`` → **64 passed, 6 skipped**
  - ``uv run pytest tests/unit_tests/cli/test_service_client.py::TestAdapterProbes -q`` → **7 passed**
  - ``uv run ruff format .`` / ``ruff check --fix .`` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * datus-scheduler-core is now a required dependency.
  * Bumped minimum versions: datus-db-core>=0.1.3 and datus-bi-core>=0.1.2.
  * Scheduler adapter availability is resolved via the configured scheduler type (e.g., airflow).

* **Tests**
  * Unit tests updated to mock the scheduler adapter registry directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->