### PR TITLE
[Enhancement] Filter PlatformDocSearchTool availability by backing resources

### DIFF
--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -145,6 +145,188 @@ def classify_openai_compatible_error(error: Exception) -> tuple[ErrorCode, bool]
     return ErrorCode.MODEL_REQUEST_FAILED, False
 
 
+# ----------------------------------------------------------------------
+# Tool result summary helpers
+# ----------------------------------------------------------------------
+#
+# ``short_desc`` (= ``ActionHistory.output["summary"]``) is rendered in the
+# CLI and surfaced as ``shortDesc`` in the streaming SSE payload. Keep
+# these helpers in one place so every LLM adapter (openai/claude/...) emits
+# a consistent one-line human-readable summary.
+
+
+_SUMMARY_ERROR_MAX_CHARS = 100
+_SUMMARY_TEXT_MAX_CHARS = 80
+
+
+def _pluralize(count: int, noun: str) -> str:
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def _truncate_text(text: str, limit: int = _SUMMARY_TEXT_MAX_CHARS) -> str:
+    first_line = next((line for line in text.splitlines() if line.strip()), "").strip()
+    if not first_line:
+        return "Empty result"
+    if len(first_line) <= limit:
+        return first_line
+    return first_line[:limit].rstrip() + "…"
+
+
+def _looks_like_failure(data: dict) -> bool:
+    success = data.get("success")
+    if success is False or success == 0:
+        return True
+    error = data.get("error")
+    if isinstance(error, str) and error.strip():
+        return True
+    return False
+
+
+def _format_failure(data: dict) -> str:
+    error = data.get("error")
+    if not isinstance(error, str) or not error.strip():
+        return "Failed"
+    return f"Failed: {_truncate_text(error, _SUMMARY_ERROR_MAX_CHARS)}"
+
+
+def _detect_tool_failure(output_content: Any) -> bool:
+    """Return True when the tool's output payload signals failure.
+
+    Tools built on :class:`FuncToolResult` report errors via ``success=0`` /
+    non-empty ``error`` instead of raising. The Agents SDK therefore emits a
+    ``tool_call_output_item`` for them and we must inspect the payload to
+    render ✗ (and mark the action FAILED) correctly.
+    """
+    data: Optional[dict] = None
+    if isinstance(output_content, dict):
+        data = output_content
+    elif isinstance(output_content, str):
+        try:
+            parsed = json.loads(output_content)
+        except (TypeError, ValueError):
+            return False
+        if isinstance(parsed, dict):
+            data = parsed
+    if data is None:
+        return False
+    return _looks_like_failure(data)
+
+
+def _is_empty_result(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, (list, tuple, dict, str)) and len(value) == 0:
+        return True
+    return False
+
+
+def _format_generic_result(value: Any) -> str:
+    if isinstance(value, dict):
+        # Canonical FuncToolListResult envelope (items / total / has_more).
+        if "items" in value and isinstance(value["items"], list):
+            return _format_list_envelope(value)
+        for key in ("row_count", "affected_rows", "rows_affected"):
+            if isinstance(value.get(key), int):
+                return _pluralize(value[key], "row")
+        if isinstance(value.get("count"), int):
+            return _pluralize(value["count"], "item")
+        if isinstance(value.get("rows"), int):
+            return _pluralize(value["rows"], "row")
+        return "OK"
+    if isinstance(value, list):
+        return _pluralize(len(value), "item")
+    if isinstance(value, bool):
+        return "OK" if value else "Failed"
+    if isinstance(value, int):
+        return _pluralize(value, "row")
+    if isinstance(value, str):
+        return _truncate_text(value)
+    return "OK"
+
+
+def _format_list_envelope(value: dict) -> str:
+    items_n = len(value.get("items") or [])
+    total = value.get("total")
+    has_more = value.get("has_more")
+    base = _pluralize(items_n, "item")
+    if isinstance(total, int) and total != items_n:
+        base = f"{base} of {total}"
+    if has_more:
+        base = f"{base} (+more)"
+    return base
+
+
+# --- Tool-specific formatters ------------------------------------------------
+
+
+def _fmt_read_query(result: Any) -> str:
+    if isinstance(result, dict):
+        rows = result.get("original_rows")
+        if isinstance(rows, int):
+            return _pluralize(rows, "row")
+    if isinstance(result, list):
+        return _pluralize(len(result), "row")
+    return ""
+
+
+def _fmt_execute_write(result: Any) -> str:
+    if isinstance(result, dict):
+        for key in ("row_count", "affected_rows", "rows_affected"):
+            if isinstance(result.get(key), int):
+                return f"wrote {_pluralize(result[key], 'row')}"
+    return ""
+
+
+def _fmt_execute_ddl(result: Any) -> str:
+    if isinstance(result, dict) and result.get("message"):
+        return "DDL OK"
+    return ""
+
+
+def _fmt_describe_table(result: Any) -> str:
+    if not isinstance(result, dict):
+        return ""
+    columns = result.get("columns") or result.get("schema")
+    if isinstance(columns, list):
+        return _pluralize(len(columns), "column")
+    return ""
+
+
+def _fmt_get_table_ddl(result: Any) -> str:
+    if isinstance(result, dict) and result.get("definition"):
+        identifier = result.get("identifier") or result.get("table_name") or "table"
+        return f"DDL of {identifier}"
+    return ""
+
+
+def _fmt_load_skill(result: Any) -> str:
+    if isinstance(result, dict):
+        metadata = result.get("metadata") or {}
+        name = metadata.get("name") or result.get("name")
+        if name:
+            return f"loaded '{name}'"
+    return ""
+
+
+def _fmt_ask_user(result: Any) -> str:
+    if isinstance(result, dict):
+        content = result.get("content") or result.get("answer")
+        if isinstance(content, str) and content.strip():
+            return f'"{_truncate_text(content, 40)}"'
+    return ""
+
+
+_TOOL_SUMMARY_FORMATTERS: Dict[str, Any] = {
+    "read_query": _fmt_read_query,
+    "execute_write": _fmt_execute_write,
+    "execute_ddl": _fmt_execute_ddl,
+    "describe_table": _fmt_describe_table,
+    "get_table_ddl": _fmt_get_table_ddl,
+    "load_skill": _fmt_load_skill,
+    "ask_user": _fmt_ask_user,
+}
+
+
 class OpenAICompatibleModel(LLMBaseModel):
     """
     Base class for models that use OpenAI-compatible APIs.
@@ -1109,6 +1291,12 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     logger.warning(f"Unexpected output_content type: {type(output_content)}")
                                     result_summary = self._format_tool_result(str(output_content), tool_name)
 
+                                # Detect failure from FuncToolResult-shaped payload so the
+                                # CLI renders ✗ (and SSE reports FAILED) when the tool
+                                # returned success=0 / non-empty error, even though the
+                                # Agents SDK call itself did not raise.
+                                tool_failed = _detect_tool_failure(output_content)
+
                                 # Create complete action with both input and output
                                 # Put result_summary as the status message to replace default "Success"
                                 complete_action = ActionHistory(
@@ -1118,12 +1306,12 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     action_type=tool_name,
                                     input={"function_name": tool_name, "arguments": tool_info["arguments"]},
                                     output={
-                                        "success": True,
+                                        "success": not tool_failed,
                                         "raw_output": output_content,
                                         "summary": result_summary,
                                         "status_message": result_summary,
                                     },
-                                    status=ActionStatus.SUCCESS,
+                                    status=ActionStatus.FAILED if tool_failed else ActionStatus.SUCCESS,
                                     start_time=tool_info["start_time"],
                                 )
                                 complete_action.end_time = datetime.now()
@@ -1402,81 +1590,59 @@ class OpenAICompatibleModel(LLMBaseModel):
         action.output["usage"] = usage_info
 
     def _format_tool_result_from_dict(self, data: dict, tool_name: str = "") -> str:
-        """Format tool result from dict for display.
+        """Format a short one-line summary from a FuncToolResult-shaped dict.
 
-        Args:
-            data: Tool result as dict
-            tool_name: Name of the tool (optional)
-
-        Returns:
-            Formatted summary string
+        Priority:
+          1. Failure state (``success`` in (0, False) or non-empty ``error``)
+          2. Tool-specific formatter from ``_TOOL_SUMMARY_FORMATTERS``
+          3. Canonical ``FuncToolListResult`` envelope (``items``/``total``/``has_more``)
+          4. Common dict count fields (``row_count``/``affected_rows``/``count``)
+          5. Generic shape fallbacks (list/int/str/dict)
         """
-        _ = tool_name  # Reserved for future use
+        if _looks_like_failure(data):
+            return _format_failure(data)
 
-        # Handle different tool result formats
-        # Check for common result patterns
-        # Handle "result" field (can be int, list, or dict)
-        if "result" in data:
-            result_value = data.get("result")
-            if isinstance(result_value, list):
-                return f"{len(result_value)} items"
-            elif isinstance(result_value, int):
-                return f"{result_value} rows"
-            elif isinstance(result_value, dict):
-                # Try to extract count from nested dict
-                if "count" in result_value:
-                    return f"{result_value['count']} items"
-                else:
-                    return "Success"
-            else:
-                return "Success"
-        # Handle "rows" field
-        elif "rows" in data:
-            row_count = data.get("rows", 0)
-            return f"{row_count} rows" if isinstance(row_count, int) else "Success"
-        # Handle "items" field
-        elif "items" in data:
-            items_count = len(data.get("items", []))
-            return f"{items_count} items"
-        # Handle "success" field only
-        elif "success" in data and len(data) == 1:
-            return "Success" if data["success"] else "Failed"
-        # Handle "count" field
-        elif "count" in data:
-            return f"{data['count']} items"
-        else:
-            # Generic success for dict responses
-            return "Success"
+        result_value = data["result"] if "result" in data else data
+
+        if _is_empty_result(result_value):
+            return "Empty result"
+
+        formatter = _TOOL_SUMMARY_FORMATTERS.get(tool_name)
+        if formatter is not None:
+            try:
+                summary = formatter(result_value)
+                if summary:
+                    return summary
+            except Exception as fmt_err:  # pragma: no cover - defensive
+                logger.debug(f"Tool summary formatter for {tool_name} raised: {fmt_err}")
+
+        return _format_generic_result(result_value)
 
     def _format_tool_result(self, content: str, tool_name: str = "") -> str:
-        """Format tool result for display.
+        """Format a short one-line summary from a tool result string.
 
-        Args:
-            content: Tool result content (string)
-            tool_name: Name of the tool (optional, for future use)
-
-        Returns:
-            Formatted summary string
+        Strings typically come from MCP tools (JSON-encoded) or legacy
+        string-returning tools. JSON decodes to dict/list are delegated to
+        :meth:`_format_tool_result_from_dict`; plain strings collapse to
+        their first non-empty line (capped at 80 chars).
         """
         if not content:
             return "Empty result"
 
         try:
-            # Try to parse as JSON and delegate to _format_tool_result_from_dict
-            import json
-
             data = json.loads(content)
-            if isinstance(data, dict):
-                return self._format_tool_result_from_dict(data, tool_name)
-            elif isinstance(data, list):
-                return f"{len(data)} items"
-            else:
-                return f"{str(data)[:50]}"
+        except (TypeError, ValueError):
+            return _truncate_text(content)
 
-        except (json.JSONDecodeError, Exception):
-            # Not JSON, return truncated string
-            summary = content[:100].replace("\n", " ")
-            return f"{summary}..." if len(content) > 100 else f"{summary}"
+        if isinstance(data, dict):
+            return self._format_tool_result_from_dict(data, tool_name)
+        if isinstance(data, list):
+            return _pluralize(len(data), "item")
+        if isinstance(data, bool):
+            return "OK" if data else "Failed"
+        if isinstance(data, int):
+            return _pluralize(data, "row")
+        return _truncate_text(str(data))
 
     @property
     def model_specs(self) -> Dict[str, Dict[str, int]]:

--- a/datus/storage/document/store.py
+++ b/datus/storage/document/store.py
@@ -449,3 +449,34 @@ def document_store(platform: str) -> DocumentStore:
     doc_project = f"{active_project}__{_DOCUMENT_NS_PREFIX}{platform}"
     db = create_vector_connection(doc_project)
     return DocumentStore(embedding_model=get_document_embedding_model(), db=db)
+
+
+def list_indexed_platforms() -> List[str]:
+    """Enumerate platforms with an on-disk docstore dir for the active project.
+
+    Presence of a per-platform directory is treated as "indexed"; we avoid
+    calling ``has_data()`` per platform to keep the scan cheap.  A stale
+    directory whose table was manually dropped will let the tool be
+    exposed and fail at call time, which is an acceptable trade-off.
+    """
+    import os
+
+    from datus.storage import backend_holder
+    from datus.utils.path_manager import get_path_manager
+
+    active_project = get_path_manager().project_name
+    data_dir = getattr(backend_holder, "_data_dir", "")
+    if not active_project or not data_dir or not os.path.isdir(data_dir):
+        return []
+
+    prefix = f"{active_project}__{_DOCUMENT_NS_PREFIX}"
+    platforms: List[str] = []
+    try:
+        for entry in os.listdir(data_dir):
+            if entry.startswith(prefix):
+                platform = entry[len(prefix) :]
+                if platform:
+                    platforms.append(platform)
+    except OSError:
+        return []
+    return sorted(platforms)

--- a/datus/tools/func_tool/platform_doc_search.py
+++ b/datus/tools/func_tool/platform_doc_search.py
@@ -37,13 +37,40 @@ class PlatformDocSearchTool:
         return ["list_document_nav", "get_document", "search_document", "web_search_document"]
 
     def available_tools(self) -> List[Tool]:
-        """Return all platform doc search tools for LLM function calling."""
-        return [
-            trans_to_function_tool(self.list_document_nav),
-            trans_to_function_tool(self.get_document),
-            trans_to_function_tool(self.search_document),
-            trans_to_function_tool(self.web_search_document),
-        ]
+        """Return platform doc search tools, filtered by backing resource availability.
+
+        - Doc search trio (``list_document_nav`` / ``get_document`` /
+          ``search_document``) is exposed only when at least one platform
+          has an indexed docstore directory under the active project.
+        - ``web_search_document`` is exposed only when a Tavily key is
+          resolvable from ``agent_config.tavily_api_key`` or the
+          ``TAVILY_API_KEY`` environment variable.
+        """
+        import os
+
+        from datus.storage.document.store import list_indexed_platforms
+
+        tools: List[Tool] = []
+
+        if list_indexed_platforms():
+            tools.append(trans_to_function_tool(self.list_document_nav))
+            tools.append(trans_to_function_tool(self.get_document))
+            tools.append(trans_to_function_tool(self.search_document))
+        else:
+            logger.info(
+                "Skipping list_document_nav / get_document / search_document: "
+                "no indexed docstore found for the active project."
+            )
+
+        tavily_key = getattr(self.agent_config, "tavily_api_key", None) or os.environ.get("TAVILY_API_KEY")
+        if tavily_key:
+            tools.append(trans_to_function_tool(self.web_search_document))
+        else:
+            logger.info(
+                "Skipping web_search_document: neither agent.document.tavily_api_key nor TAVILY_API_KEY env var is set."
+            )
+
+        return tools
 
     def list_document_nav(
         self,

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -15,7 +15,11 @@ import pytest
 from agents.exceptions import ModelBehaviorError
 from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 
-from datus.models.openai_compatible import OpenAICompatibleModel, classify_openai_compatible_error
+from datus.models.openai_compatible import (
+    OpenAICompatibleModel,
+    _detect_tool_failure,
+    classify_openai_compatible_error,
+)
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.utils.exceptions import DatusException, ErrorCode
 
@@ -728,41 +732,136 @@ class TestFormatToolResultFromDict:
     def setup_method(self):
         self.model = _make_model()
 
+    # --- Generic result shapes ---------------------------------------------
+
     def test_result_is_list(self):
-        assert self.model._format_tool_result_from_dict({"result": [1, 2, 3]}) == "3 items"
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": [1, 2, 3]}) == "3 items"
+
+    def test_result_is_single_item_list_uses_singular(self):
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": [1]}) == "1 item"
 
     def test_result_is_int(self):
-        assert self.model._format_tool_result_from_dict({"result": 42}) == "42 rows"
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": 42}) == "42 rows"
 
     def test_result_is_dict_with_count(self):
-        assert self.model._format_tool_result_from_dict({"result": {"count": 7}}) == "7 items"
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": {"count": 7}}) == "7 items"
 
-    def test_result_is_dict_without_count(self):
-        assert self.model._format_tool_result_from_dict({"result": {"key": "val"}}) == "Success"
+    def test_result_is_dict_without_recognised_keys(self):
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": {"key": "val"}}) == "OK"
 
-    def test_result_is_other_type(self):
-        assert self.model._format_tool_result_from_dict({"result": "string"}) == "Success"
+    def test_result_is_string(self):
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": "string"}) == "string"
 
     def test_rows_field_int(self):
-        assert self.model._format_tool_result_from_dict({"rows": 10}) == "10 rows"
-
-    def test_rows_field_non_int(self):
-        assert self.model._format_tool_result_from_dict({"rows": "many"}) == "Success"
+        assert self.model._format_tool_result_from_dict({"success": 1, "rows": 10}) == "10 rows"
 
     def test_items_field(self):
-        assert self.model._format_tool_result_from_dict({"items": ["a", "b"]}) == "2 items"
+        assert self.model._format_tool_result_from_dict({"success": 1, "items": ["a", "b"]}) == "2 items"
+
+    def test_func_tool_list_envelope(self):
+        data = {"success": 1, "result": {"items": [{}, {}, {}], "total": 12, "has_more": True}}
+        assert self.model._format_tool_result_from_dict(data) == "3 items of 12 (+more)"
+
+    def test_func_tool_list_envelope_no_total(self):
+        data = {"success": 1, "result": {"items": [{}, {}], "total": None, "has_more": False}}
+        assert self.model._format_tool_result_from_dict(data) == "2 items"
+
+    def test_func_tool_list_envelope_total_equal_items(self):
+        # Single page: total matches items length; avoid redundant " of N".
+        data = {"success": 1, "result": {"items": [{}, {}], "total": 2, "has_more": False}}
+        assert self.model._format_tool_result_from_dict(data) == "2 items"
 
     def test_success_field_only_true(self):
-        assert self.model._format_tool_result_from_dict({"success": True}) == "Success"
+        # success-only dict becomes an OK signal (not a failure).
+        assert self.model._format_tool_result_from_dict({"success": True}) == "OK"
 
-    def test_success_field_only_false(self):
+    def test_success_field_only_false_is_failure(self):
         assert self.model._format_tool_result_from_dict({"success": False}) == "Failed"
 
     def test_count_field(self):
-        assert self.model._format_tool_result_from_dict({"count": 99}) == "99 items"
+        assert self.model._format_tool_result_from_dict({"success": 1, "count": 99}) == "99 items"
 
     def test_generic_dict(self):
-        assert self.model._format_tool_result_from_dict({"anything": "value"}) == "Success"
+        assert self.model._format_tool_result_from_dict({"success": 1, "anything": "value"}) == "OK"
+
+    # --- Failure prioritisation --------------------------------------------
+
+    def test_failure_with_success_flag_zero(self):
+        data = {"success": 0, "error": "syntax error near SELECT", "result": None}
+        assert self.model._format_tool_result_from_dict(data) == "Failed: syntax error near SELECT"
+
+    def test_failure_without_error_message(self):
+        assert self.model._format_tool_result_from_dict({"success": 0, "result": None}) == "Failed"
+
+    def test_failure_error_truncated(self):
+        long_error = "detail: " + ("x" * 300)
+        summary = self.model._format_tool_result_from_dict({"success": 0, "error": long_error})
+        assert summary.startswith("Failed: ")
+        # Error body capped at 100 chars plus the ellipsis marker.
+        assert len(summary) <= len("Failed: ") + 101
+
+    def test_failure_takes_priority_over_result_items(self):
+        # Even if a "result" with items exists, success=0 forces the failure branch.
+        data = {"success": 0, "error": "x", "result": {"items": [1, 2]}}
+        assert self.model._format_tool_result_from_dict(data) == "Failed: x"
+
+    def test_empty_result_dict(self):
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": {}}) == "Empty result"
+
+    def test_empty_result_list(self):
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": []}) == "Empty result"
+
+    def test_null_result(self):
+        assert self.model._format_tool_result_from_dict({"success": 1, "result": None}) == "Empty result"
+
+    # --- Tool-specific formatters ------------------------------------------
+
+    def test_read_query_uses_original_rows(self):
+        data = {
+            "success": 1,
+            "result": {
+                "original_rows": 42,
+                "original_columns": ["a", "b"],
+                "is_compressed": False,
+                "compressed_data": "...",
+            },
+        }
+        assert self.model._format_tool_result_from_dict(data, tool_name="read_query") == "42 rows"
+
+    def test_execute_write_uses_row_count(self):
+        data = {"success": 1, "result": {"row_count": 5, "sql": "UPDATE t SET x=1"}}
+        assert self.model._format_tool_result_from_dict(data, tool_name="execute_write") == "wrote 5 rows"
+
+    def test_execute_ddl_success_message(self):
+        data = {"success": 1, "result": {"message": "DDL executed successfully", "sql": "CREATE TABLE t(x INT)"}}
+        assert self.model._format_tool_result_from_dict(data, tool_name="execute_ddl") == "DDL OK"
+
+    def test_describe_table_columns(self):
+        data = {"success": 1, "result": {"columns": [{"name": "c"}] * 8}}
+        assert self.model._format_tool_result_from_dict(data, tool_name="describe_table") == "8 columns"
+
+    def test_get_table_ddl_identifier(self):
+        data = {
+            "success": 1,
+            "result": {"identifier": "public.orders", "table_name": "orders", "definition": "CREATE TABLE ..."},
+        }
+        assert self.model._format_tool_result_from_dict(data, tool_name="get_table_ddl") == "DDL of public.orders"
+
+    def test_load_skill_metadata_name(self):
+        data = {"success": 1, "result": {"content": "...", "metadata": {"name": "sql-best-practices"}}}
+        assert self.model._format_tool_result_from_dict(data, tool_name="load_skill") == "loaded 'sql-best-practices'"
+
+    def test_ask_user_content_truncated(self):
+        data = {"success": 1, "result": {"content": "  How many rows should we keep in the dashboard?  "}}
+        summary = self.model._format_tool_result_from_dict(data, tool_name="ask_user")
+        assert summary.startswith('"')
+        assert summary.endswith('"')
+
+    def test_tool_specific_formatter_falls_back_on_missing_fields(self):
+        # read_query without original_rows should degrade gracefully instead of crashing.
+        data = {"success": 1, "result": {"compressed_data": "..."}}
+        summary = self.model._format_tool_result_from_dict(data, tool_name="read_query")
+        assert summary == "OK"
 
 
 # ---------------------------------------------------------------------------
@@ -781,26 +880,79 @@ class TestFormatToolResult:
         assert self.model._format_tool_result(None) == "Empty result"
 
     def test_json_dict_delegates_to_from_dict(self):
-        result = self.model._format_tool_result('{"result": [1, 2]}')
+        result = self.model._format_tool_result('{"success": 1, "result": [1, 2]}')
         assert result == "2 items"
 
     def test_json_list(self):
         result = self.model._format_tool_result("[1, 2, 3]")
         assert result == "3 items"
 
-    def test_json_scalar(self):
+    def test_json_scalar_string(self):
         result = self.model._format_tool_result('"hello"')
-        assert "hello" in result
+        assert result == "hello"
 
     def test_plain_text_short(self):
         result = self.model._format_tool_result("short text")
-        assert "short text" in result
+        assert result == "short text"
 
-    def test_plain_text_long_truncated(self):
+    def test_plain_text_long_truncated_to_first_line(self):
         long_text = "x" * 200
         result = self.model._format_tool_result(long_text)
-        assert result.endswith("...")
-        assert len(result) <= 103  # 100 + "..."
+        assert result.endswith("…")
+        # First-line cap is 80 chars plus the ellipsis.
+        assert len(result) <= 81
+
+    def test_plain_text_multiline_keeps_first_non_empty_line(self):
+        assert self.model._format_tool_result("\n  first line  \nsecond line\n") == "first line"
+
+    def test_failure_json_payload(self):
+        payload = json.dumps({"success": 0, "error": "bad query", "result": None})
+        assert self.model._format_tool_result(payload) == "Failed: bad query"
+
+
+class TestDetectToolFailure:
+    """``_detect_tool_failure`` decides whether the tool output means FAILED/✗.
+
+    Without this, ``read_query('SELECT * FROM does_not_exist')`` still shows a
+    green ✓ in the CLI — the Agents SDK does not raise for FuncToolResult
+    payloads that report ``success=0`` internally.
+    """
+
+    def test_dict_with_success_zero_is_failure(self):
+        assert _detect_tool_failure({"success": 0, "error": "no such table", "result": None}) is True
+
+    def test_dict_with_success_false_is_failure(self):
+        assert _detect_tool_failure({"success": False, "error": "boom"}) is True
+
+    def test_dict_with_non_empty_error_is_failure(self):
+        # Some tools forget to flip ``success``; the error field alone should trip detection.
+        assert _detect_tool_failure({"error": "connection refused"}) is True
+
+    def test_dict_with_success_one_is_not_failure(self):
+        assert _detect_tool_failure({"success": 1, "result": [1, 2]}) is False
+
+    def test_dict_with_blank_error_is_not_failure(self):
+        assert _detect_tool_failure({"success": 1, "error": "  "}) is False
+
+    def test_json_string_failure(self):
+        payload = json.dumps({"success": 0, "error": "x"})
+        assert _detect_tool_failure(payload) is True
+
+    def test_json_string_success(self):
+        payload = json.dumps({"success": 1, "result": {"items": []}})
+        assert _detect_tool_failure(payload) is False
+
+    def test_non_json_string_defaults_to_not_failure(self):
+        # Plain-text tool outputs are treated as success; we only flip on a
+        # structured failure signal.
+        assert _detect_tool_failure("ok") is False
+
+    def test_list_payload_ignored(self):
+        assert _detect_tool_failure([{"success": 0}]) is False
+
+    def test_empty_inputs_are_not_failure(self):
+        assert _detect_tool_failure("") is False
+        assert _detect_tool_failure(None) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/document/test_store.py
+++ b/tests/unit_tests/storage/document/test_store.py
@@ -9,7 +9,12 @@ from unittest.mock import patch
 import pytest
 
 from datus.storage.document.schemas import PlatformDocChunk
-from datus.storage.document.store import DocumentStore, document_store, get_platform_doc_schema
+from datus.storage.document.store import (
+    DocumentStore,
+    document_store,
+    get_platform_doc_schema,
+    list_indexed_platforms,
+)
 from datus.storage.embedding_models import get_document_embedding_model
 from datus.utils.exceptions import DatusException
 
@@ -537,3 +542,50 @@ class TestDocumentStoreFactory:
         """Platform with SQL injection attempt should raise DatusException."""
         with pytest.raises(DatusException, match="Invalid platform name"):
             document_store("test; DROP TABLE")
+
+
+class TestListIndexedPlatforms:
+    """Filesystem-scan based enumeration used by PlatformDocSearchTool.available_tools."""
+
+    @staticmethod
+    def _patch_environment(project_name, data_dir):
+        path_manager = type("PM", (), {"project_name": project_name})()
+        return (
+            patch("datus.utils.path_manager.get_path_manager", return_value=path_manager),
+            patch("datus.storage.backend_holder._data_dir", data_dir),
+        )
+
+    def test_empty_when_no_project_name(self, tmp_path):
+        pm_patch, dir_patch = self._patch_environment("", str(tmp_path))
+        with pm_patch, dir_patch:
+            assert list_indexed_platforms() == []
+
+    def test_empty_when_data_dir_blank(self):
+        pm_patch, dir_patch = self._patch_environment("myproj", "")
+        with pm_patch, dir_patch:
+            assert list_indexed_platforms() == []
+
+    def test_empty_when_data_dir_missing(self, tmp_path):
+        missing = tmp_path / "does_not_exist"
+        pm_patch, dir_patch = self._patch_environment("myproj", str(missing))
+        with pm_patch, dir_patch:
+            assert list_indexed_platforms() == []
+
+    def test_returns_platforms_from_matching_dirs(self, tmp_path):
+        (tmp_path / "myproj__docstore__duckdb").mkdir()
+        (tmp_path / "myproj__docstore__snowflake").mkdir()
+        (tmp_path / "other_project__docstore__pg").mkdir()
+        (tmp_path / "myproj__something_else").mkdir()
+        (tmp_path / "myproj__docstore__").mkdir()
+
+        pm_patch, dir_patch = self._patch_environment("myproj", str(tmp_path))
+        with pm_patch, dir_patch:
+            platforms = list_indexed_platforms()
+
+        assert platforms == ["duckdb", "snowflake"]
+
+    def test_empty_when_no_matching_dirs(self, tmp_path):
+        (tmp_path / "unrelated_dir").mkdir()
+        pm_patch, dir_patch = self._patch_environment("myproj", str(tmp_path))
+        with pm_patch, dir_patch:
+            assert list_indexed_platforms() == []

--- a/tests/unit_tests/tools/func_tool/test_platform_doc_search.py
+++ b/tests/unit_tests/tools/func_tool/test_platform_doc_search.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 """Unit tests for PlatformDocSearchTool - CI level, zero external dependencies."""
 
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,6 +12,8 @@ from datus.tools.func_tool.platform_doc_search import PlatformDocSearchTool
 # Patch targets for locally-imported symbols inside platform_doc_search.py methods
 _SEARCH_TOOL_PATH = "datus.tools.search_tools.search_tool.SearchTool"
 _TAVILY_PATH = "datus.tools.search_tools.search_tool.search_by_tavily"
+_LIST_PLATFORMS_PATH = "datus.storage.document.store.list_indexed_platforms"
+_TRANS_PATH = "datus.tools.func_tool.platform_doc_search.trans_to_function_tool"
 
 
 @pytest.fixture
@@ -36,11 +39,89 @@ class TestAllToolsName:
 
 
 class TestAvailableTools:
-    def test_returns_four_tools(self, doc_search_tool):
-        with patch("datus.tools.func_tool.platform_doc_search.trans_to_function_tool") as mock_trans:
-            mock_trans.side_effect = lambda f: Mock(name=f.__name__)
-            tools = doc_search_tool.available_tools()
-        assert len(tools) == 4
+    """Availability filter matrix: trio gated by indexed platforms,
+    web_search_document gated by tavily key (config OR env)."""
+
+    @staticmethod
+    def _tool_names(tools):
+        return [t._name for t in tools]
+
+    @pytest.fixture
+    def _patch_trans(self):
+        with patch(_TRANS_PATH) as mock_trans:
+
+            def _fake(func):
+                mock = Mock()
+                mock._name = func.__name__
+                return mock
+
+            mock_trans.side_effect = _fake
+            yield mock_trans
+
+    def test_all_available(self, mock_agent_config, _patch_trans, monkeypatch):
+        mock_agent_config.tavily_api_key = "k"
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
+
+        with patch(_LIST_PLATFORMS_PATH, return_value=["duckdb"]):
+            tools = tool.available_tools()
+
+        names = self._tool_names(tools)
+        assert names == [
+            "list_document_nav",
+            "get_document",
+            "search_document",
+            "web_search_document",
+        ]
+
+    def test_only_web_when_no_platforms(self, mock_agent_config, _patch_trans, monkeypatch, caplog):
+        mock_agent_config.tavily_api_key = "k"
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
+
+        with caplog.at_level(logging.INFO, logger="datus.tools.func_tool.platform_doc_search"):
+            with patch(_LIST_PLATFORMS_PATH, return_value=[]):
+                tools = tool.available_tools()
+
+        assert self._tool_names(tools) == ["web_search_document"]
+        assert any("no indexed docstore" in rec.message for rec in caplog.records)
+        assert not any("web_search_document" in rec.message and "Skipping" in rec.message for rec in caplog.records)
+
+    def test_only_trio_when_no_tavily(self, mock_agent_config, _patch_trans, monkeypatch, caplog):
+        mock_agent_config.tavily_api_key = None
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
+
+        with caplog.at_level(logging.INFO, logger="datus.tools.func_tool.platform_doc_search"):
+            with patch(_LIST_PLATFORMS_PATH, return_value=["duckdb"]):
+                tools = tool.available_tools()
+
+        assert self._tool_names(tools) == ["list_document_nav", "get_document", "search_document"]
+        assert any("Skipping web_search_document" in rec.message for rec in caplog.records)
+
+    def test_empty_when_nothing_available(self, mock_agent_config, _patch_trans, monkeypatch, caplog):
+        mock_agent_config.tavily_api_key = None
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
+
+        with caplog.at_level(logging.INFO, logger="datus.tools.func_tool.platform_doc_search"):
+            with patch(_LIST_PLATFORMS_PATH, return_value=[]):
+                tools = tool.available_tools()
+
+        assert tools == []
+        messages = " | ".join(rec.message for rec in caplog.records)
+        assert "no indexed docstore" in messages
+        assert "Skipping web_search_document" in messages
+
+    def test_tavily_env_fallback(self, mock_agent_config, _patch_trans, monkeypatch):
+        mock_agent_config.tavily_api_key = None
+        monkeypatch.setenv("TAVILY_API_KEY", "envkey")
+        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
+
+        with patch(_LIST_PLATFORMS_PATH, return_value=[]):
+            tools = tool.available_tools()
+
+        assert self._tool_names(tools) == ["web_search_document"]
 
 
 class TestListDocumentNav:


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tool failures are now correctly detected and reported in streaming displays and CLI output.

* **New Features**
  * Tools conditionally appear based on configuration: document search tools when platforms are indexed, web search tools when API credentials are available.

* **Improvements**
  * Tool result formatting is now consistent with standardized failure detection and summary logic across different result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->