### PR TITLE
[BugFix] fix cli markdown stream output

### DIFF
--- a/datus/cli/action_display/markdown_stream.py
+++ b/datus/cli/action_display/markdown_stream.py
@@ -13,16 +13,18 @@ tokens arrive.
 Stable-boundary heuristic:
 
 1.  Hard boundary is ``"\\n\\n"`` (CommonMark blank line). Everything up to
-    the last blank line is eligible to flush.
+    the last blank line is eligible to flush — this is the "markdown
+    segment ended" trigger.
 2.  Fence (``\\`\\`\\`\\`\\`\\``) guard: when the number of triple-backticks in
     the whole text is odd, an unclosed fenced code block is in flight and
     *nothing* is flushed — we must never hand a half-open code block to
     Rich's markdown renderer or its styling would leak into subsequent
     content.
-3.  Oversize guard: when the tail (the portion still pending) grows past
-    :data:`MAX_TAIL_BYTES`, we force a flush at the last ``"\\n"`` so the
-    Rich markdown renderer is not asked to re-parse a multi-KB string on
-    every token.
+3.  Overflow guard: when the tail (the portion still pending) grows past
+    :data:`MAX_TAIL_BYTES` bytes **or** :data:`MAX_TAIL_LINES` newlines
+    (i.e. exceeds the pinned-region budget), we force a commit at the
+    last ``"\\n"`` so everything above the live region's bottom line lands
+    in the scrollback instead of being silently trimmed.
 
 This class is deliberately synchronous and pure-Python (no Rich / no
 prompt_toolkit); the streaming context runs it on its daemon refresh thread
@@ -36,6 +38,13 @@ from typing import List, Tuple
 # Tail byte budget before triggering the oversize commit path. 4 KiB keeps
 # per-token Rich re-parsing latency well below one frame at 4 Hz.
 MAX_TAIL_BYTES = 4096
+
+# Line-count budget for the tail before the overflow guard fires. Matches
+# the pinned-region row budget (terminal_rows - reserved rows for status
+# bar + input). When the tail crosses this, everything up to the last
+# newline is committed to the scrollback so the live region stays in its
+# displayable window.
+MAX_TAIL_LINES = 20
 
 
 class MarkdownStreamBuffer:
@@ -51,37 +60,63 @@ class MarkdownStreamBuffer:
 
     def __init__(self) -> None:
         self._tail: str = ""
+        # Latched once any stable segment has been handed back to the caller
+        # for the scrollback. Downstream code (e.g. the Ctrl+O verbose
+        # snapshot) uses this to avoid re-painting the whole accumulated
+        # body and duplicating the already-committed prefix.
+        self._spilled: bool = False
 
     def append(self, delta: str) -> List[str]:
         """Append ``delta`` and return any newly stable segments.
 
-        Stable segments are always suffixed with the ``"\\n\\n"`` that
-        separated them from the next block, so printing ``"".join(segments)``
-        reproduces the original text exactly.
+        Two independent triggers can harvest a segment on each call:
+
+        * **Markdown segment end** — whenever ``"\\n\\n"`` appears in the
+          tail, everything up to the last such boundary is handed back
+          (via :meth:`_split`). The returned segment is ``"\\n\\n"``-
+          suffixed so ``"".join(segments) + tail`` reproduces the input.
+        * **Pinned-region overflow** — if the residual tail is still
+          taller than :data:`MAX_TAIL_LINES` newlines or larger than
+          :data:`MAX_TAIL_BYTES` bytes (and fences are balanced, and
+          we're not inside an unterminated markdown table), we cut
+          at the last ``"\\n"`` so the pinned region can actually render
+          what remains. The suffix kept in the tail is the unfinished
+          current line.
         """
         if not delta:
             return []
         self._tail += delta
         stable, new_tail = self._split(self._tail)
-        # Oversize guard: if we still have a huge tail and fences are
-        # balanced, commit up to the last newline so Rich isn't asked to
-        # re-render a multi-KB chunk on every subsequent delta.
-        if len(new_tail) > MAX_TAIL_BYTES and new_tail.count("```") % 2 == 0:
+        # Overflow guard: when the residual tail would overflow the
+        # pinned region (either by byte budget for Rich re-parse cost or
+        # by line budget for actual screen height), commit up to the
+        # last newline so the live area stays within its displayable
+        # window. Fences must be balanced — we never split a half-open
+        # code block away from its opener. Open markdown tables get the
+        # same protection: Rich's table renderer needs the header +
+        # separator lines to lay out any row, so a header-less fragment
+        # would paint the scrollback as a single mashed-pipe line.
+        over_budget = len(new_tail) > MAX_TAIL_BYTES or new_tail.count("\n") >= MAX_TAIL_LINES
+        if over_budget and new_tail.count("```") % 2 == 0 and not self._tail_is_in_open_table(new_tail):
             nl = new_tail.rfind("\n")
             if nl > 0:
-                stable.append(new_tail[: nl + 1])
-                new_tail = new_tail[nl + 1 :]
+                forced = new_tail[: nl + 1]
+                if forced.count("```") % 2 == 0 and forced.strip():
+                    stable.append(forced)
+                    new_tail = new_tail[nl + 1 :]
         self._tail = new_tail
+        if stable:
+            self._spilled = True
         return stable
 
     def append_raw(self, delta: str) -> None:
-        """Append ``delta`` without any stability detection.
+        """Append ``delta`` without any commit.
 
-        Used by the accumulator-only flow: the pinned live region shows the
-        growing body token-by-token and the whole text is flushed to the
-        scrollback **only** when :meth:`flush` is called at message
-        boundaries. Nothing is ever pushed mid-stream, so there is no risk
-        of doubling up on a final one-shot render.
+        Kept for callers that genuinely want a plain accumulator (no
+        mid-stream scrollback emission). The main CLI streaming path
+        uses :meth:`append` instead so long bodies stream upward into
+        the scrollback as soon as a markdown segment closes or the
+        pinned region overflows.
         """
         if not delta:
             return
@@ -96,16 +131,48 @@ class MarkdownStreamBuffer:
         """
         pending = self._tail
         self._tail = ""
+        self._spilled = False
         return pending
 
     def clear(self) -> None:
         self._tail = ""
+        self._spilled = False
 
     def get_tail(self) -> str:
         return self._tail
 
     def has_tail(self) -> bool:
         return bool(self._tail)
+
+    def has_spilled(self) -> bool:
+        """Whether any prefix paragraph has been handed off to the scrollback.
+
+        Consumed by the Ctrl+O verbose snapshot path so it prints only the
+        unspilled tail (instead of the full accumulated text) and avoids
+        painting the already-committed prefix a second time.
+        """
+        return self._spilled
+
+    @staticmethod
+    def _tail_is_in_open_table(text: str) -> bool:
+        """Return True when the tail looks like an unterminated markdown table.
+
+        A tail is "in an open table" when it is not ``\\n\\n``-terminated
+        and carries at least two pipe-bearing lines whose ``|`` count is
+        >= 2 — i.e. a header + separator (or more rows) is in flight and
+        the closing blank line has not arrived yet. The pipe-per-line
+        floor of 2 keeps prose references like an inline ``cmd | grep``
+        from being mistaken for a table row. Gives open tables the same
+        hold-until-closure protection that fenced code blocks already
+        get, so the scrollback never sees a header-less table fragment
+        (which Rich would collapse into a single mashed-pipe line).
+        """
+        if not text or "|" not in text:
+            return False
+        if text.endswith("\n\n"):
+            return False
+        pipe_lines = [line for line in text.splitlines() if line.count("|") >= 2]
+        return len(pipe_lines) >= 2
 
     @staticmethod
     def _split(text: str) -> Tuple[List[str], str]:

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -518,18 +518,29 @@ class InlineStreamingContext:
             # *incremental* tail that arrives after this point — avoiding a
             # duplicate body in the scrollback.
             if self._deltas:
-                last_accumulated = ""
-                for delta in reversed(self._deltas):
-                    if isinstance(delta.output, dict):
-                        candidate = delta.output.get("accumulated", "")
-                        if isinstance(candidate, str) and candidate:
-                            last_accumulated = candidate
-                            break
-                if last_accumulated.strip():
-                    self.display.console.print(Markdown(last_accumulated))
-                    if self._markdown_buffer is not None:
-                        self._markdown_buffer.clear()
+                if self._markdown_buffer is not None and self._markdown_buffer.has_spilled():
+                    # Overflow paragraphs have already been committed to the
+                    # scrollback during the stream; only the unspilled tail
+                    # is still live. Print just that tail so we don't repeat
+                    # the already-committed prefix.
+                    remaining = self._markdown_buffer.get_tail()
+                    if remaining.strip():
+                        self.display.console.print(Markdown(remaining))
+                    self._markdown_buffer.clear()
                     self._stream_body_finalized = True
+                else:
+                    last_accumulated = ""
+                    for delta in reversed(self._deltas):
+                        if isinstance(delta.output, dict):
+                            candidate = delta.output.get("accumulated", "")
+                            if isinstance(candidate, str) and candidate:
+                                last_accumulated = candidate
+                                break
+                    if last_accumulated.strip():
+                        self.display.console.print(Markdown(last_accumulated))
+                        if self._markdown_buffer is not None:
+                            self._markdown_buffer.clear()
+                        self._stream_body_finalized = True
             # 4. Optionally render active subagent groups (verbose snapshot)
             if show_active_groups:
                 for _group_key, group in self._subagent_groups.items():
@@ -1101,13 +1112,15 @@ class InlineStreamingContext:
     def _handle_thinking_delta(self, action: ActionHistory) -> None:
         """Append a streaming text delta into the markdown buffer (TUI mode).
 
-        Accumulator-only policy: the buffer never splits stable segments
-        during the stream, so nothing is pushed to the scrollback while
-        the user is still typing. The pinned region renders the growing
-        accumulator on every tick; the full body only lands in the
-        scrollback on :meth:`_finalize_markdown_stream`, which runs at the
-        message boundary. This guarantees the final transcript contains
-        exactly one copy of the main-agent response.
+        Each call pipes the delta through :meth:`MarkdownStreamBuffer.append`,
+        which commits a stable prefix whenever either trigger fires:
+        (a) a ``"\\n\\n"`` markdown-segment boundary appeared, or (b) the
+        residual tail would overflow the pinned-region budget, in which
+        case everything up to the last ``"\\n"`` is handed off. Those
+        committed segments are printed to the scrollback immediately so
+        the user sees long responses stream upward; only the unfinished
+        tail stays live in the pinned region. A ``_finalize_markdown_stream``
+        at the message boundary drains whatever tail is left.
         """
         if self._markdown_buffer is None:
             return
@@ -1121,7 +1134,14 @@ class InlineStreamingContext:
         self._markdown_stream_has_streamed = True
         if action.action_id:
             self._markdown_active_stream_ids.add(action.action_id)
-        self._markdown_buffer.append_raw(delta)
+        stable_segments = self._markdown_buffer.append(delta)
+        for segment in stable_segments:
+            self._print_markdown_to_scrollback(segment)
+        if stable_segments:
+            # A portion of the body has already landed in the scrollback,
+            # so the outer ``_render_final_response`` must not repaint
+            # the whole response again.
+            self._stream_body_finalized = True
         self._repaint_live()
 
     def _print_markdown_to_scrollback(self, segment: str) -> None:

--- a/tests/unit_tests/cli/action_display/test_markdown_stream.py
+++ b/tests/unit_tests/cli/action_display/test_markdown_stream.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 
 import pytest
 
-from datus.cli.action_display.markdown_stream import MAX_TAIL_BYTES, MarkdownStreamBuffer
+from datus.cli.action_display.markdown_stream import (
+    MAX_TAIL_BYTES,
+    MAX_TAIL_LINES,
+    MarkdownStreamBuffer,
+)
 
 
 def _concat(stable: list[str], tail: str) -> str:
@@ -167,6 +171,202 @@ class TestOversizeGuard:
         _ = body
         assert buf.append(text) == []
         assert buf.get_tail() == text
+
+
+class TestLineOverflow:
+    """The overflow trigger fires when the residual tail grows past
+    :data:`MAX_TAIL_LINES` newlines, regardless of whether a ``\\n\\n``
+    boundary exists. The commit happens at the last ``\\n`` so the
+    pinned region is left with just the unfinished current line."""
+
+    def test_line_overflow_without_blank_commits_at_last_newline(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Stream of single-line "lines" separated by a single newline —
+        # no ``\n\n`` ever appears. The overflow guard must still fire
+        # once the tail crosses the line budget, and the commit must
+        # split at the last ``\n`` so only the unfinished line remains.
+        lines = "".join(f"line {i}\n" for i in range(MAX_TAIL_LINES + 5))
+        text = lines + "unfinished"
+        stable = buf.append(text)
+        assert stable, "expected a line-overflow commit"
+        # Every committed segment ends on a newline — the last-line
+        # suffix must never be handed off mid-line.
+        assert stable[-1].endswith("\n")
+        # Only the unfinished trailing line stays live.
+        assert buf.get_tail() == "unfinished"
+        # Reconstruction: spilled + tail == original.
+        assert "".join(stable) + buf.get_tail() == text
+        # Spill latch reflects that a commit occurred.
+        assert buf.has_spilled()
+
+    def test_under_line_budget_does_not_force_commit(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Just under the line budget and no ``\n\n`` boundary → nothing
+        # committed yet; the tail rides live in the pinned region.
+        lines = "".join(f"line {i}\n" for i in range(MAX_TAIL_LINES - 1))
+        stable = buf.append(lines)
+        assert stable == []
+        assert buf.get_tail() == lines
+        assert not buf.has_spilled()
+
+    def test_unclosed_fence_blocks_line_overflow(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Once we're inside an unterminated code fence, balance is odd
+        # and no commit is allowed — not even the line-overflow guard
+        # may hand off a half-open code block to the scrollback.
+        body = "```py\n" + "".join(f"code line {i}\n" for i in range(MAX_TAIL_LINES + 5))
+        stable = buf.append(body)
+        assert stable == []
+        assert buf.get_tail() == body
+        assert not buf.has_spilled()
+
+    def test_paragraph_boundary_still_takes_precedence(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # When a ``\n\n`` boundary is already in the tail, the
+        # paragraph-boundary path commits up to that boundary first.
+        # The residual tail is below the line budget so the overflow
+        # guard doesn't fire.
+        text = "para\n\nnext"
+        stable = buf.append(text)
+        assert stable == ["para\n\n"]
+        assert buf.get_tail() == "next"
+        assert buf.has_spilled()
+
+    def test_spill_latch_cleared_on_flush(self) -> None:
+        buf = MarkdownStreamBuffer()
+        buf.append("".join(f"line {i}\n" for i in range(MAX_TAIL_LINES + 5)) + "rest")
+        assert buf.has_spilled()
+        _ = buf.flush()
+        assert not buf.has_spilled()
+        assert buf.get_tail() == ""
+
+    def test_spill_latch_cleared_on_clear(self) -> None:
+        buf = MarkdownStreamBuffer()
+        buf.append("".join(f"line {i}\n" for i in range(MAX_TAIL_LINES + 5)) + "rest")
+        assert buf.has_spilled()
+        buf.clear()
+        assert not buf.has_spilled()
+        assert buf.get_tail() == ""
+
+    def test_incremental_feed_reconstructs_long_body(self) -> None:
+        buf = MarkdownStreamBuffer()
+        body = "".join(f"paragraph {i} line A\nline B\n\n" for i in range(MAX_TAIL_LINES + 10))
+        stable_all: list[str] = []
+        for ch in body:
+            stable_all.extend(buf.append(ch))
+        # Combined commits plus final flush reproduce the full input
+        # byte-for-byte — no duplication, no loss.
+        assert "".join(stable_all) + buf.flush() == body
+
+
+class TestTableGuard:
+    """Open markdown tables must receive the same hold-until-closure
+    protection that fenced code blocks get. Otherwise the overflow guard
+    would cut header-less row fragments into the scrollback, where Rich
+    renders them as a single mashed-pipe line (no header → no table
+    layout → every ``|`` collapsed onto one row)."""
+
+    @staticmethod
+    def _build_table(row_count: int) -> str:
+        header = "| c1 | c2 |\n| -- | -- |\n"
+        rows = "".join(f"| r{i} | v{i} |\n" for i in range(row_count))
+        return header + rows
+
+    def test_open_table_blocks_line_overflow(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # 30 rows + header + separator = 32 lines, well above MAX_TAIL_LINES,
+        # and no trailing blank line: the table is still open. The overflow
+        # guard must hold the whole thing instead of slicing at the last
+        # newline.
+        body = self._build_table(30)
+        stable = buf.append(body)
+        assert stable == []
+        assert buf.get_tail() == body
+        assert not buf.has_spilled()
+
+    def test_closed_table_flushes_whole_block(self) -> None:
+        buf = MarkdownStreamBuffer()
+        body = self._build_table(30)
+        # Open table: held.
+        assert buf.append(body) == []
+        # Closing ``\n`` completes the blank-line boundary; the entire
+        # table becomes one stable segment via the normal ``\n\n`` path.
+        stable = buf.append("\n")
+        assert stable == [body + "\n"]
+        assert buf.get_tail() == ""
+        assert buf.has_spilled()
+
+    def test_pipe_in_prose_does_not_trigger_guard(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Inline pipe references in prose — each line has at most one
+        # ``|`` — must not be mistaken for a table. The overflow guard
+        # stays active and splits at the last newline as usual.
+        lines = "".join(f"Use the pipe operator `a | b` on line {i}\n" for i in range(MAX_TAIL_LINES + 5))
+        text = lines + "trailing"
+        stable = buf.append(text)
+        assert stable, "prose with inline single-pipe must still overflow-split"
+        assert stable[-1].endswith("\n")
+        assert buf.get_tail() == "trailing"
+        assert "".join(stable) + buf.get_tail() == text
+
+    def test_table_then_prose_splits_at_table_close(self) -> None:
+        buf = MarkdownStreamBuffer()
+        text = "| a | b |\n| - | - |\n| 1 | 2 |\n\nnext prose"
+        stable = buf.append(text)
+        assert stable == ["| a | b |\n| - | - |\n| 1 | 2 |\n\n"]
+        assert buf.get_tail() == "next prose"
+        assert buf.has_spilled()
+
+    def test_long_prose_still_overflow_splits(self) -> None:
+        """Regression: non-table prose over the line budget keeps splitting."""
+        buf = MarkdownStreamBuffer()
+        lines = "".join(f"line {i}\n" for i in range(MAX_TAIL_LINES + 5))
+        text = lines + "unfinished"
+        stable = buf.append(text)
+        assert stable, "plain prose overflow must still hand off a prefix"
+        assert buf.get_tail() == "unfinished"
+
+    def test_long_code_block_still_holds(self) -> None:
+        """Regression: open fenced code block continues to hold regardless
+        of the new table guard."""
+        buf = MarkdownStreamBuffer()
+        body = "```py\n" + "".join(f"code_line_{i}()\n" for i in range(MAX_TAIL_LINES + 5))
+        stable = buf.append(body)
+        assert stable == []
+        assert buf.get_tail() == body
+
+    def test_reconstruction_round_trip_with_long_table(self) -> None:
+        buf = MarkdownStreamBuffer()
+        body = self._build_table(40) + "\nafter the table text\n\ntrailer"
+        stable_all: list[str] = []
+        for ch in body:
+            stable_all.extend(buf.append(ch))
+        # Final flush plus all committed segments must reproduce the
+        # exact input — no duplication, no loss, regardless of where
+        # the guard fired.
+        assert "".join(stable_all) + buf.flush() == body
+
+
+class TestAppendRawSimple:
+    """``append_raw`` is the plain accumulator — it never commits mid-
+    stream so the whole text rides in the tail until :meth:`flush`."""
+
+    def test_append_raw_holds_everything_until_flush(self) -> None:
+        buf = MarkdownStreamBuffer()
+        # Even a body large enough to blow every threshold stays live
+        # until the caller flushes it.
+        body = "".join(f"line {i}\n" for i in range(MAX_TAIL_LINES + 5))
+        buf.append_raw(body)
+        assert buf.get_tail() == body
+        assert not buf.has_spilled()
+        assert buf.flush() == body
+        assert buf.get_tail() == ""
+
+    def test_append_raw_empty_delta_is_noop(self) -> None:
+        buf = MarkdownStreamBuffer()
+        buf.append_raw("")
+        assert buf.get_tail() == ""
+        assert not buf.has_spilled()
 
 
 class TestRoundTrip:

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -716,44 +716,48 @@ class TestStreamingMarkdown:
         # Nothing stable yet, so the scrollback console remains empty.
         assert "hello" not in buf.getvalue()
 
-    def test_delta_never_reaches_scrollback_until_finalize(self):
-        """Accumulator-only: mid-stream deltas never hit the scrollback.
+    def test_paragraph_boundary_streams_to_scrollback(self):
+        """Markdown segment end (``\\n\\n``) commits the prefix immediately.
 
-        Even when a delta ends with ``\\n\\n``, the buffer keeps the full
-        text — a single flush is performed by ``_finalize_markdown_stream``
-        at the message boundary so the final render is contiguous and
-        cannot be duplicated by the outer ``_display_markdown_response``.
+        Long bodies must stream upward into the scrollback as soon as a
+        paragraph closes, so the pinned region stays within the live
+        budget. The outer ``_display_markdown_response`` is blocked from
+        repainting because ``has_streamed_response`` is latched as soon
+        as any segment has been handed off.
         """
         ctx, live_state, buf = self._make_ctx()
 
-        ctx._handle_thinking_delta(self._make_delta("para one\n\n"))
+        ctx._handle_thinking_delta(self._make_delta("para one\n\nhead of two"))
 
-        # Full body stays in the buffer; pinned region paints it live.
-        assert ctx._markdown_buffer.get_tail() == "para one\n\n"
+        # The closed paragraph landed in the scrollback right away.
+        assert buf.getvalue().count("para one") == 1
+        # The unfinished second paragraph rides live in the pinned region.
+        assert ctx._markdown_buffer.get_tail() == "head of two"
         assert live_state.is_active() is True
-        assert "para one" not in buf.getvalue()
+        # Spill latch is set so ``_render_final_response`` will skip the
+        # one-shot repaint of the full body.
+        assert ctx.has_streamed_response is True
 
-        # Finalize lands the accumulator in the scrollback exactly once.
+        # Finalize drains the residual tail exactly once — no duplicate
+        # of the already-committed paragraph.
         ctx._finalize_markdown_stream()
         assert ctx._markdown_buffer.has_tail() is False
         assert buf.getvalue().count("para one") == 1
-        assert ctx.has_streamed_response is True
+        assert buf.getvalue().count("head of two") == 1
 
     def test_response_action_dedupes_when_stream_active(self):
-        """Paired terminal action triggers finalize + dedup of the main body.
+        """Paired terminal action must not duplicate the streamed body.
 
-        With the accumulator-only flow, the body is nowhere in the
-        scrollback during the stream — it only lands there when the paired
-        response action arrives (directly, or indirectly via
-        ``streaming_deltas.clear()`` detection in ``_process_deltas``).
-        The response action itself must not pass through
-        ``render_main_action``; otherwise the body would appear twice.
+        A delta that closes a paragraph with ``\\n\\n`` already lands in
+        the scrollback during the stream; the paired response action
+        arrives later and must be suppressed by ``render_main_action``
+        so the body doesn't appear twice.
         """
         ctx, _live_state, buf = self._make_ctx()
 
         ctx._handle_thinking_delta(self._make_delta("streamed body\n\n", action_id="stream-xyz"))
-        # Accumulator-only: nothing in the scrollback yet.
-        assert "streamed body" not in buf.getvalue()
+        # Paragraph boundary already committed the body to the scrollback.
+        assert buf.getvalue().count("streamed body") == 1
         assert "stream-xyz" in ctx._markdown_active_stream_ids
 
         # Terminal response arrives with the plain ``action_type="response"``
@@ -869,11 +873,11 @@ class TestStreamingMarkdown:
         """
         ctx, _live_state, buf = self._make_ctx()
         ctx._handle_thinking_delta(self._make_delta("final body text\n\n", action_id="stream-1"))
-        # Accumulator-only: body is only in the buffer so far.
-        assert "final body text" not in buf.getvalue()
+        # Paragraph boundary already committed the body during the stream.
+        assert buf.getvalue().count("final body text") == 1
 
         # First completion — the openai_compatible "response" (plain type) —
-        # triggers finalize; body lands in the scrollback exactly once.
+        # triggers finalize; the residual tail is empty so no extra print.
         ctx._print_completed_action(
             _make_action(
                 ActionRole.ASSISTANT,
@@ -905,19 +909,21 @@ class TestStreamingMarkdown:
     def test_unterminated_tail_with_paired_response_prints_once(self):
         """Regression: last paragraph without trailing ``\\n\\n`` must not duplicate.
 
-        With the accumulator-only flow, the entire body stays in the buffer
-        (no intermediate flushes) and lands in the scrollback exactly once
-        when the paired response action triggers
-        ``_finalize_markdown_stream``.
+        A paragraph that closes mid-stream commits straight to the
+        scrollback; whatever follows without a trailing ``\\n\\n`` rides in
+        the tail until ``_finalize_markdown_stream`` drains it. The
+        combined output must contain each span exactly once.
         """
         ctx, _live_state, buf = self._make_ctx()
         stream_id = "stream-unterminated"
 
         ctx._handle_thinking_delta(self._make_delta("Please let me know\n\n", action_id=stream_id))
         ctx._handle_thinking_delta(self._make_delta("what you need!", action_id=stream_id))
-        # Accumulator-only: buffer carries the full body until finalize.
-        assert ctx._markdown_buffer.get_tail() == "Please let me know\n\nwhat you need!"
-        assert "Please let me know" not in buf.getvalue()
+        # Closed paragraph is already in the scrollback; unfinished tail
+        # still rides live in the pinned region.
+        assert ctx._markdown_buffer.get_tail() == "what you need!"
+        assert buf.getvalue().count("Please let me know") == 1
+        assert "what you need!" not in buf.getvalue()
 
         # Paired response arrives with the same id and plain "response" type.
         response_action = _make_action(
@@ -930,7 +936,9 @@ class TestStreamingMarkdown:
         )
         ctx._print_completed_action(response_action)
         output = buf.getvalue()
-        # Both parts of the body appear exactly once — and only now.
+        # Both parts of the body appear exactly once across the whole
+        # scrollback — mid-stream commit for paragraph #1, finalize for
+        # the unterminated tail of paragraph #2.
         assert output.count("what you need!") == 1
         assert output.count("Please let me know") == 1
 


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Streamed markdown content now displays incrementally to scrollback as it arrives, improving UI responsiveness
  * Buffer overflow detection now uses dual thresholds: byte size and line count limits
  * Markdown tables and code fence blocks are preserved without incorrect splitting during streaming

* **Bug Fixes**
  * Resolved duplication of previously-streamed content in scrollback during history replay

<!-- end of auto-generated comment: release notes by coderabbit.ai -->