### PR TITLE
[Enhancement] Surface tool PROCESSING in CLI with subagent-aligned pinned row

### DIFF
--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -61,7 +61,11 @@ def _build_tool_call_content(action: ActionHistory) -> List[IMessageContent]:
 
 
 def _build_tool_result_content(action: ActionHistory) -> List[IMessageContent]:
-    """Build content for tool call completed event."""
+    """Build content for tool call completed event.
+
+    When the tool failed, the payload includes an `error` field so the frontend
+    can render the matching call-tool card in a failure state.
+    """
     output = action.output
 
     start_time = action.start_time
@@ -81,6 +85,13 @@ def _build_tool_result_content(action: ActionHistory) -> List[IMessageContent]:
         "shortDesc": short_desc,
         "result": output_dict.get("raw_output", output) if output_dict else output,
     }
+
+    error_message = output_dict.get("error") if output_dict else None
+    if not error_message and action.status == ActionStatus.FAILED:
+        error_message = action.messages or "Unknown error"
+    if error_message:
+        payload_data["error"] = error_message
+
     return [IMessageContent(type="call-tool-result", payload=payload_data)]
 
 
@@ -189,7 +200,11 @@ def _build_interaction_content(action: ActionHistory) -> List[IMessageContent]:
 
 
 def _build_subagent_complete_content(action: ActionHistory) -> List[IMessageContent]:
-    """Build content for sub-agent completion summary event."""
+    """Build content for sub-agent completion summary event.
+
+    When the sub-agent failed, the payload includes an `error` field so the
+    frontend can render the matching subagent card in a failure state.
+    """
     output = action.output if isinstance(action.output, dict) else {}
     duration = (action.end_time - action.start_time).total_seconds() if action.start_time and action.end_time else 0.0
     payload_data = {
@@ -197,6 +212,13 @@ def _build_subagent_complete_content(action: ActionHistory) -> List[IMessageCont
         "toolCount": output.get("tool_count", 0),
         "duration": duration,
     }
+
+    error_message = output.get("error")
+    if not error_message and action.status == ActionStatus.FAILED:
+        error_message = action.messages or "Unknown error"
+    if error_message:
+        payload_data["error"] = error_message
+
     return [IMessageContent(type="subagent-complete", payload=payload_data)]
 
 
@@ -265,8 +287,6 @@ def action_to_sse_event(
             if not is_first_delta:
                 sse_type = SSEDataType.APPEND_MESSAGE
             contents = [IMessageContent(type="thinking", payload={"content": delta_text})]
-        elif status == ActionStatus.FAILED:
-            contents = _build_error_content(action)
         elif action.action_type == SUBAGENT_COMPLETE_ACTION_TYPE:
             contents = _build_subagent_complete_content(action)
         elif role == ActionRole.TOOL and status == ActionStatus.PROCESSING:
@@ -289,6 +309,8 @@ def action_to_sse_event(
             role == ActionRole.ASSISTANT and status == ActionStatus.SUCCESS and action.action_type.endswith("_response")
         ):
             return None  # ignore parsed final response
+        elif status == ActionStatus.FAILED:
+            contents = _build_error_content(action)
         else:
             contents = _build_thinking_content(action)
             if contents is None:

--- a/datus/cli/action_display/display.py
+++ b/datus/cli/action_display/display.py
@@ -5,7 +5,7 @@
 """Public interface: ActionHistoryDisplay."""
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
 
 from rich.console import Console
 
@@ -146,23 +146,92 @@ class ActionHistoryDisplay:
         pending_task_tool_skips = 0
         deferred_groups: List[Tuple[dict, ActionHistory]] = []
 
-        for action in actions:
+        # Pre-scan to identify which top-level ``task`` tool calls wrap a
+        # sub-agent. ``subagent_complete.parent_action_id`` carries the
+        # bare ``call_id`` of the wrapping task tool, so any task tool
+        # whose normalised id (after stripping the ``complete_`` prefix
+        # that ``openai_compatible``/``claude_model``/``codex_model``
+        # apply to the SUCCESS action — see e.g. ``openai_compatible.py``
+        # ``action_id="complete_" + call_id``) appears here is a sub-agent
+        # invocation and must never be rendered as a standalone task —
+        # regardless of arrival order. The ActionBus may yield the outer
+        # ``task`` SUCCESS before the queued ``subagent_complete`` (see
+        # ``ActionBus.merge`` FIRST_COMPLETED race), and the end-of-turn
+        # full-screen reprint replays whatever order it received, so
+        # without this set the iterator below would render the task as
+        # a standalone block AND also render the collapsed/expanded
+        # sub-agent group, producing a duplicate such as
+        # ``⏺ explore(...)`` followed by ``⏴ explore(...) Done``.
+        subagent_complete_call_ids: Set[Optional[str]] = {
+            a.parent_action_id for a in actions if a.action_type == SUBAGENT_COMPLETE_ACTION_TYPE and a.parent_action_id
+        }
+
+        def _normalize_call_id(action_id: Optional[str]) -> Optional[str]:
+            """Strip the ``complete_`` prefix used by tool SUCCESS actions."""
+            if action_id and action_id.startswith("complete_"):
+                return action_id[len("complete_") :]
+            return action_id
+
+        # Verbose mode renders the sub-agent response after the Done line
+        # using the ``task`` tool action's output. Indexing by the bare
+        # ``call_id`` keeps the response paired with the right group even
+        # when the SUCCESS action carries the ``complete_`` prefix or
+        # arrives in a reversed order.
+        task_actions_by_call_id: Dict[Optional[str], ActionHistory] = {}
+        for a in actions:
+            if a.role != ActionRole.TOOL or not a.action_id:
+                continue
+            normalized = _normalize_call_id(a.action_id)
+            if normalized not in subagent_complete_call_ids:
+                continue
+            fn = a.input.get("function_name", "") if a.input else ""
+            if fn == "task":
+                task_actions_by_call_id[normalized] = a
+
+        # Locate the trailing plain ``response`` action (depth=0). Its body is
+        # the same text the wrapping ``*_response`` carries, and the wrapper's
+        # body is painted externally (``_render_final_response`` for redraw;
+        # ``_display_markdown_response(content)`` for resume), so rendering
+        # this one too would duplicate the final answer. Mid-turn ``response``
+        # actions — those emitted alongside tool calls, e.g. brief commentary
+        # the model writes before invoking a tool — must NOT be filtered here:
+        # the end-of-turn full-screen reprint clears scrollback, and skipping
+        # them is what makes that text disappear after the redraw.
+        last_plain_response_idx: Optional[int] = None
+        for i in range(len(actions) - 1, -1, -1):
+            a = actions[i]
+            if (
+                a.role == ActionRole.ASSISTANT
+                and a.depth == 0
+                and a.action_type == "response"
+                and a.status == ActionStatus.SUCCESS
+            ):
+                last_plain_response_idx = i
+                break
+
+        for idx, action in enumerate(actions):
             # INTERACTION actions: only shown during live interaction, skip in history replay
             if action.role == ActionRole.INTERACTION:
                 continue
             # Skip PROCESSING TOOL entries (only render SUCCESS/FAILED)
             if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
                 continue
-            # Skip assistant terminal response actions — they are rendered by
-            # the per-turn callback (``_render_turn_response``) or by the
-            # external ``_render_final_response`` pipeline. Walking them here
-            # would paint the main body twice (once from plain ``response``,
-            # once from the wrapping ``*_response``).
+            # Terminal wrapper (``chat_response`` etc.): body is painted by
+            # the per-turn callback / ``_render_final_response`` pipeline.
             if (
                 action.role == ActionRole.ASSISTANT
                 and action.action_type
-                and (action.action_type == "response" or action.action_type.endswith("_response"))
+                and action.action_type.endswith("_response")
                 and action.depth == 0
+            ):
+                continue
+            # Trailing plain ``response``: duplicates the wrapping
+            # ``*_response`` rendered externally — skip to avoid double paint.
+            if (
+                action.role == ActionRole.ASSISTANT
+                and action.action_type == "response"
+                and action.depth == 0
+                and idx == last_plain_response_idx
             ):
                 continue
 
@@ -176,9 +245,32 @@ class ActionHistoryDisplay:
                             group["first_action"], group["tool_count"], group["start_time"], action
                         )
                     else:
-                        deferred_groups.append((group, action))
+                        # Render the expanded group together with its task
+                        # tool response immediately when the task action is
+                        # already known. Falling back to the deferred queue
+                        # only happens for partial slices that do not yet
+                        # contain the outer task SUCCESS.
+                        task_action = task_actions_by_call_id.get(group_key)
+                        if task_action is not None:
+                            self._render_deferred_group(group, action, task_action, verbose)
+                        else:
+                            deferred_groups.append((group, action))
                     pending_task_tool_skips += 1
                 continue
+
+            # Order-independent skip: any task tool that wraps a sub-agent
+            # (its normalised id appears as a ``subagent_complete.parent_action_id``)
+            # is represented by the subagent group rendering above and must
+            # not also be rendered as a standalone main-agent action. The
+            # SUCCESS action carries an ``action_id`` of ``"complete_" +
+            # call_id`` (set by the model layer), while the PROCESSING
+            # action uses the bare ``call_id``; both must be skipped.
+            if action.role == ActionRole.TOOL and action.action_id:
+                normalized = _normalize_call_id(action.action_id)
+                if normalized in subagent_complete_call_ids:
+                    fn = action.input.get("function_name", "") if action.input else ""
+                    if fn == "task":
+                        continue
 
             # -- sub-agent group handling --
             if action.depth > 0:

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -790,10 +790,25 @@ class ActionRenderer:
     # -- processing animation -----------------------------------------------
 
     def render_processing(self, action: ActionHistory, frame: str) -> Text:
-        """Render blinking animation frame for a PROCESSING tool."""
+        """Render the static running indicator for a PROCESSING tool.
+
+        Output: ``{frame} 🔧 {function_name}({first_arg_summary})`` at depth=0
+        (no dim — matches the completed top-level tool header colour), and
+        ``  ⎿  {frame} 🔧 …`` inside a subagent group (depth>0) with
+        ``[dim]`` so it aligns with the other ``⎿`` tool rows under the
+        ``⏺`` header. Falls back to ``{frame} 🔧 {label}...`` when no
+        arguments were sent.
+        """
+        from datus.cli.action_display.tool_content import extract_args
+
         function_name = action.input.get("function_name", "") if action.input else ""
-        text = f"{frame} \U0001f527 {function_name or action.messages}..."
-        return Text.from_markup(f"[white]{text}[/white]")
+        label = function_name or action.messages or ""
+        args_lines = extract_args(action)
+        suffix = f"({_truncate_middle(args_lines[0], max_len=80)})" if args_lines else "..."
+        body = f"{frame} \U0001f527 {rich_escape(label)}{rich_escape(suffix)}"
+        if action.depth > 0:
+            return Text.from_markup(f"[dim]  \u23bf  {body}[/dim]")
+        return Text.from_markup(body)
 
     # -- utility renderables ------------------------------------------------
 

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -28,8 +28,9 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Blinking dot animation frames for PROCESSING status
-_BLINK_FRAMES = ["○", "●"]
+# Static PROCESSING symbol: hollow circle (○). No blink — the refresh loop
+# is still driven by ``_tick`` but the glyph is constant.
+_PROCESSING_SYMBOL = "\u25cb"
 
 # In compact mode, only show the last N subagent actions in the Live overlay
 _SUBAGENT_ROLLING_WINDOW_SIZE = 2
@@ -270,6 +271,7 @@ class InlineStreamingContext:
             "subagent_type": subagent_type,
             "first_action": first_action,
             "actions": [],
+            "processing_action": None,
         }
 
     def _update_subagent_display_sync(self, action: ActionHistory, group_key: Optional[str] = None) -> None:
@@ -279,6 +281,9 @@ class InlineStreamingContext:
             return
         if action.role == ActionRole.TOOL:
             group["tool_count"] += 1
+            pending = group.get("processing_action")
+            if pending is not None and pending.action_id == action.action_id:
+                group["processing_action"] = None
         if action.role == ActionRole.USER:
             return
         group["actions"].append(action)
@@ -615,12 +620,22 @@ class InlineStreamingContext:
 
             # -- Sub-agent action (depth > 0) --
             if action.depth > 0:
-                # Skip PROCESSING tools first — ensures the subagent group header
-                # is created from the same action as render_action_history uses.
+                group_key = action.parent_action_id
+                # PROCESSING tool inside subagent: record as the group's
+                # current blinking row without adding it to the completed
+                # tool list (the paired SUCCESS/FAILED follows with the
+                # same action_id and clears the slot).
                 if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
+                    if group_key not in self._subagent_groups:
+                        self._stop_processing_live()
+                        self._start_subagent_group(action, group_key)
+                    group = self._subagent_groups.get(group_key)
+                    if group is not None:
+                        group["processing_action"] = action
+                        with self._print_lock:
+                            self._update_subagent_groups_live()
                     self._processed_index += 1
                     continue
-                group_key = action.parent_action_id
                 if group_key not in self._subagent_groups:
                     # New sub-agent group: stop current Live, print header
                     self._stop_processing_live()
@@ -638,11 +653,15 @@ class InlineStreamingContext:
                 self._end_subagent_group_by_key(None, action)
                 continue
 
-            # TOOL with PROCESSING -> show blinking Live
+            # TOOL with PROCESSING -> pin blinking frame. Advance the index
+            # so the loop can consume the paired SUCCESS/FAILED action
+            # (PROCESSING and SUCCESS are *separate* ActionHistory entries
+            # sharing the same ``action_id``; the blink keeps repainting from
+            # ``_processing_action`` state on every refresh tick).
             if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
                 self._update_processing_live(action)
-                # Don't advance index yet; wait for status change
-                return
+                self._processed_index += 1
+                continue
 
             # Completed action (non-PROCESSING) -> print permanently
             self._stop_processing_live()
@@ -767,6 +786,7 @@ class InlineStreamingContext:
                 "subagent_type": subagent_type,
                 "first_action": first_action,
                 "actions": [],
+                "processing_action": None,
             }
             self._update_subagent_groups_live()
 
@@ -777,6 +797,9 @@ class InlineStreamingContext:
             return
         if action.role == ActionRole.TOOL:
             group["tool_count"] += 1
+            pending = group.get("processing_action")
+            if pending is not None and pending.action_id == action.action_id:
+                group["processing_action"] = None
         if action.role == ActionRole.USER:
             # Prompt already shown in header, skip
             return
@@ -922,15 +945,23 @@ class InlineStreamingContext:
             if first_action:
                 items.extend(self.display.renderer.render_subagent_header(first_action, self._verbose))
             actions_list = group.get("actions", [])
+            processing = group.get("processing_action")
             if self._verbose:
                 display_actions = actions_list
             else:
-                display_actions = actions_list[-_SUBAGENT_ROLLING_WINDOW_SIZE:]
+                # When a tool is mid-flight, the running row takes one of the
+                # ``_SUBAGENT_ROLLING_WINDOW_SIZE`` slots so the pinned block
+                # stays exactly ``_SUBAGENT_ROLLING_WINDOW_SIZE`` rows tall.
+                budget = _SUBAGENT_ROLLING_WINDOW_SIZE - (1 if processing is not None else 0)
+                budget = max(budget, 0)
+                display_actions = actions_list[-budget:] if budget else []
                 hidden = len(actions_list) - len(display_actions)
                 if hidden > 0:
                     items.append(Text.from_markup(f"[dim]  \u23bf  ... {hidden} earlier action(s) ...[/dim]"))
             for action in display_actions:
                 items.extend(self.display.renderer.render_subagent_action(action, self._verbose))
+            if processing is not None:
+                items.append(self.display.renderer.render_processing(processing, _PROCESSING_SYMBOL))
         return Group(*items) if items else Group(Text(""))
 
     def _build_subagent_live_lines(self) -> List["LiveDisplayLine"]:
@@ -957,9 +988,20 @@ class InlineStreamingContext:
             for action in group.get("actions", []):
                 tool_texts.extend(self.display.renderer.render_subagent_action(action, verbose=False))
             tool_texts = [t for t in tool_texts if (t.plain or "").strip()]
-            tail = tool_texts[-TOOL_LINES_PER_GROUP:]
+            processing = group.get("processing_action")
+            # Running row occupies one of the ``TOOL_LINES_PER_GROUP`` slots
+            # so the block below the ``⏺`` header is exactly
+            # ``TOOL_LINES_PER_GROUP`` rows tall whenever the subagent is
+            # in-flight.
+            tail_budget = TOOL_LINES_PER_GROUP - (1 if processing is not None else 0)
+            tail_budget = max(tail_budget, 0)
+            tail = tool_texts[-tail_budget:] if tail_budget else []
             for text in tail:
                 result.append(LiveDisplayLine(segments=[("class:subagent-live", text.plain)]))
+            if processing is not None:
+                text = self.display.renderer.render_processing(processing, _PROCESSING_SYMBOL)
+                if text.plain.strip():
+                    result.append(LiveDisplayLine(segments=[("class:processing-live", text.plain)]))
         return result
 
     @staticmethod
@@ -1012,9 +1054,12 @@ class InlineStreamingContext:
         from datus.cli.tui.live_display_state import LiveDisplayLine
 
         if self._processing_action is not None:
-            frame = _BLINK_FRAMES[self._tick % len(_BLINK_FRAMES)]
+            frame = _PROCESSING_SYMBOL
             renderable = self.display.renderer.render_processing(self._processing_action, frame)
-            self._live_state.set_lines([LiveDisplayLine(segments=[("class:processing-live", renderable.plain)])])
+            # Top-level PROCESSING uses ``processing-live-top`` (default fg)
+            # instead of the grey ``processing-live`` used for subagent
+            # internal rows.
+            self._live_state.set_lines([LiveDisplayLine(segments=[("class:processing-live-top", renderable.plain)])])
             return
         if self._subagent_groups:
             self._live_state.set_lines(self._build_subagent_live_lines())
@@ -1262,6 +1307,12 @@ class InlineStreamingContext:
         renderables = self.display.renderer.render_main_action(action, self._verbose)
         if not renderables:
             return
+        # Separate independent depth=0 events with a trailing blank line.
+        # Verbose tool rendering already appends ``Text("")`` — skip in that
+        # case to avoid doubling the gap.
+        last = renderables[-1]
+        if not (isinstance(last, Text) and last.plain == ""):
+            renderables = list(renderables) + [Text("")]
         if self._tui_mode:
             from datus.cli.tui.console_bridge import run_in_terminal_sync
 
@@ -1291,7 +1342,7 @@ class InlineStreamingContext:
             self._repaint_live()
             return
 
-        frame = _BLINK_FRAMES[self._tick % len(_BLINK_FRAMES)]
+        frame = _PROCESSING_SYMBOL
         renderable = self.display.renderer.render_processing(action, frame)
 
         with self._print_lock:

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -337,9 +337,6 @@ class ChatCommands:
                         # Skip USER actions (depth=0) — already printed by _echo_user_input
                         if action.role == ActionRole.USER and action.depth == 0:
                             continue
-                        # Skip TOOL PROCESSING entries — SUCCESS version follows
-                        if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
-                            continue
                         # Streaming text deltas go to their own queue. Sub-agent
                         # deltas (depth > 0) are ignored here — they'd pollute
                         # the main-agent accumulator; sub-agents have their own
@@ -466,8 +463,6 @@ class ChatCommands:
                                 if broker:
                                     await auto_submit_interaction(broker, action)
                             continue
-                        if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
-                            continue
                         if action.action_type == "thinking_delta":
                             if action.depth == 0:
                                 streaming_deltas.append(action)
@@ -582,15 +577,6 @@ class ChatCommands:
                         self.last_actions = all_actions
                         self.all_turn_actions.append((message, all_actions))
                         self._trace_verbose = False  # reset toggle for new chat round
-
-                    # End-of-turn full-screen reprint — mirrors the Ctrl+O
-                    # toggle so the viewport ends up with a clean, fully
-                    # re-rendered transcript. Rich gets to lay out the final
-                    # body in one pass (no incremental artefacts on tables /
-                    # code blocks). Interactive mode only; non-interactive
-                    # runs (``/print``, pipes) must not rewrite stdout.
-                    if interactive:
-                        self._full_screen_reprint(verbose=self._trace_verbose)
 
                 if interactive:
                     self.cli.console.print("[bold bright_black]Press Ctrl+O to toggle trace details.[/]")

--- a/datus/cli/cli_styles.py
+++ b/datus/cli/cli_styles.py
@@ -132,6 +132,10 @@ STATUS_BAR_STYLE: dict[str, str] = {
     # Pinned subagent/tool rolling-window lines match scrollback [dim].
     "subagent-live": LIVE_SECONDARY,
     "processing-live": LIVE_SECONDARY,
+    # Top-level running tool: default foreground (same colour as a completed
+    # main-agent tool header) — keeps the PROCESSING row visually in-line
+    # with the row that eventually replaces it.
+    "processing-live-top": "",
     # Pinned subagent header: plain cyan prefix, default colour goal.
     "subagent-header-live": "ansicyan",
     "subagent-header-goal-live": "",

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -233,7 +233,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         """Choose a safe default prompt cache retention policy for OpenAI."""
         if not self._is_official_openai_api():
             return None
-        if self.model_name.startswith("gpt-5.4"):
+        if self.model_name.startswith("gpt-5"):
             return "24h"
         return "in_memory"
 

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -141,6 +141,88 @@ class TestBuildToolResultContent:
         contents = _build_tool_result_content(action)
         assert contents[0].payload["duration"] == 0.0
 
+    def test_failed_tool_includes_error_from_output(self):
+        """Failed tool action includes an error field from output.error."""
+        action = _make_action(
+            action_id="complete_tool-77",
+            status=ActionStatus.FAILED,
+            input={"function_name": "run_sql"},
+            output={"error": "boom"},
+        )
+        contents = _build_tool_result_content(action)
+        assert contents[0].type == "call-tool-result"
+        assert contents[0].payload["error"] == "boom"
+
+    def test_failed_tool_falls_back_to_messages(self):
+        """Failed tool with no output.error uses action.messages as the error field."""
+        action = _make_action(
+            action_id="complete_tool-88",
+            status=ActionStatus.FAILED,
+            input={"function_name": "run_sql"},
+            output={},
+            messages="kaboom",
+        )
+        contents = _build_tool_result_content(action)
+        assert contents[0].payload["error"] == "kaboom"
+
+    def test_successful_tool_omits_error_field(self):
+        """Successful tool actions never carry an error field."""
+        action = _make_action(
+            action_id="complete_tool-89",
+            status=ActionStatus.SUCCESS,
+            input={"function_name": "run_sql"},
+            output={"raw_output": "data"},
+        )
+        contents = _build_tool_result_content(action)
+        assert "error" not in contents[0].payload
+
+
+class TestBuildSubagentCompleteContent:
+    """Tests for _build_subagent_complete_content."""
+
+    def test_success_omits_error_field(self):
+        """Successful sub-agent completion never carries an error field."""
+        from datus.api.services.action_sse_converter import _build_subagent_complete_content
+
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.SUCCESS,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output={"subagent_type": "explore", "tool_count": 5},
+        )
+        contents = _build_subagent_complete_content(action)
+        assert contents[0].type == "subagent-complete"
+        assert contents[0].payload["subagentType"] == "explore"
+        assert contents[0].payload["toolCount"] == 5
+        assert "error" not in contents[0].payload
+
+    def test_failed_includes_error_from_output(self):
+        """Failed sub-agent completion includes an error field from output.error."""
+        from datus.api.services.action_sse_converter import _build_subagent_complete_content
+
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.FAILED,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output={"subagent_type": "explore", "tool_count": 1, "error": "timeout"},
+        )
+        contents = _build_subagent_complete_content(action)
+        assert contents[0].payload["error"] == "timeout"
+
+    def test_failed_falls_back_to_messages(self):
+        """Failed sub-agent completion with no output.error uses action.messages."""
+        from datus.api.services.action_sse_converter import _build_subagent_complete_content
+
+        action = _make_action(
+            role=ActionRole.SYSTEM,
+            status=ActionStatus.FAILED,
+            action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+            output={"subagent_type": "explore"},
+            messages="cancelled",
+        )
+        contents = _build_subagent_complete_content(action)
+        assert contents[0].payload["error"] == "cancelled"
+
 
 class TestBuildUserContent:
     """Tests for _build_user_content."""
@@ -457,8 +539,8 @@ class TestBuildInteractionResultContent:
 class TestActionToSSEEvent:
     """Tests for the main action_to_sse_event dispatcher."""
 
-    def test_failed_action_produces_error_event(self):
-        """FAILED status maps to error content regardless of role."""
+    def test_assistant_failed_action_produces_error_event(self):
+        """ASSISTANT + FAILED falls through to the catch-all error branch."""
         action = _make_action(
             role=ActionRole.ASSISTANT,
             status=ActionStatus.FAILED,
@@ -472,6 +554,43 @@ class TestActionToSSEEvent:
         content = event.data.payload.content[0]
         assert content.type == "error"
         assert content.payload["content"] == "Timeout"
+
+    def test_tool_failed_produces_call_tool_result_with_error(self):
+        """TOOL + FAILED stays on the call-tool-result channel and adds an error field.
+
+        This preserves the callToolId / toolName pairing so the frontend can mark the
+        original call-tool card as failed instead of emitting an orphaned error event.
+        """
+        action = _make_action(
+            action_id="complete_tool-99",
+            role=ActionRole.TOOL,
+            status=ActionStatus.FAILED,
+            input={"function_name": "run_sql", "arguments": {"sql": "SELECT 1"}},
+            output={"error": "syntax error", "summary": "failed"},
+        )
+        event = action_to_sse_event(action, event_id=40, message_id="msg-40")
+        assert event is not None
+        content = event.data.payload.content[0]
+        assert content.type == "call-tool-result"
+        assert content.payload["callToolId"] == "tool-99"
+        assert content.payload["toolName"] == "run_sql"
+        assert content.payload["error"] == "syntax error"
+
+    def test_tool_failed_without_error_falls_back_to_messages(self):
+        """TOOL + FAILED with no output.error uses action.messages for the error field."""
+        action = _make_action(
+            action_id="complete_tool-100",
+            role=ActionRole.TOOL,
+            status=ActionStatus.FAILED,
+            input={"function_name": "run_sql"},
+            output={},
+            messages="connection lost",
+        )
+        event = action_to_sse_event(action, event_id=41, message_id="msg-41")
+        assert event is not None
+        content = event.data.payload.content[0]
+        assert content.type == "call-tool-result"
+        assert content.payload["error"] == "connection lost"
 
     def test_tool_processing_produces_call_tool(self):
         """TOOL + PROCESSING maps to call-tool content."""
@@ -794,16 +913,22 @@ class TestActionToSSEEvent:
         assert event is not None
         assert event.data.type == SSEDataType.CREATE_MESSAGE
 
-    def test_subagent_complete_failed_produces_error_event(self):
-        """subagent_complete with FAILED status produces error content, not subagent-complete."""
+    def test_subagent_complete_failed_produces_subagent_complete_with_error(self):
+        """subagent_complete + FAILED stays on the subagent-complete channel and adds an error field.
+
+        This keeps the subagentType / duration metadata so the frontend can mark the
+        original subagent card as failed instead of emitting an orphaned error event.
+        """
         action = _make_action(
             role=ActionRole.SYSTEM,
             status=ActionStatus.FAILED,
             action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
-            output={"error": "sub-agent timed out"},
+            output={"error": "sub-agent timed out", "subagent_type": "explore", "tool_count": 3},
         )
         event = action_to_sse_event(action, event_id=17, message_id="msg-17")
         assert event is not None
         content = event.data.payload.content[0]
-        assert content.type == "error"
-        assert "timed out" in content.payload["content"]
+        assert content.type == "subagent-complete"
+        assert content.payload["subagentType"] == "explore"
+        assert content.payload["toolCount"] == 3
+        assert content.payload["error"] == "sub-agent timed out"

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -432,6 +432,75 @@ class TestRenderProcessing:
         result = _renderer().render_processing(action, "\u25cb")
         assert isinstance(result, Text)
         assert "list_tables" in result.plain
+        assert result.plain.startswith("\u25cb ")
+
+    def test_processing_includes_first_argument(self):
+        """PROCESSING frame includes the first argument as `(key: value)` summary."""
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            input_data={
+                "function_name": "db_describe",
+                "arguments": {"table": "orders", "schema": "public"},
+            },
+        )
+        result = _renderer().render_processing(action, "\u25cf")
+        assert "db_describe" in result.plain
+        assert "(table: orders)" in result.plain
+
+    def test_processing_without_arguments_falls_back_to_ellipsis(self):
+        """PROCESSING frame falls back to `...` suffix when no arguments are present."""
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            messages="list_tables",
+            input_data={"function_name": "list_tables"},
+        )
+        result = _renderer().render_processing(action, "\u25cb")
+        assert result.plain.endswith("list_tables...")
+
+    def test_processing_truncates_long_argument_value(self):
+        """Long argument values get middle-truncated at 80 chars."""
+        long_sql = "SELECT " + "col, " * 50 + "last FROM t"
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            input_data={
+                "function_name": "execute_sql",
+                "arguments": {"sql": long_sql},
+            },
+        )
+        result = _renderer().render_processing(action, "\u25cb")
+        # Truncation helper inserts " ... " separator in the middle.
+        assert " ... " in result.plain
+        # Key label remains visible.
+        assert "sql:" in result.plain
+
+    def test_processing_indents_inside_subagent(self):
+        """PROCESSING row inside a subagent (depth>0) gets the `  ⎿  ` prefix."""
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            input_data={
+                "function_name": "db_describe",
+                "arguments": {"table": "orders"},
+            },
+        )
+        result = _renderer().render_processing(action, "\u25cb")
+        assert result.plain.startswith("  \u23bf  ")
+        assert "db_describe" in result.plain
+
+    def test_processing_no_indent_at_top_level(self):
+        """PROCESSING row at depth=0 is not indented."""
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=0,
+            input_data={"function_name": "list_tables"},
+        )
+        result = _renderer().render_processing(action, "\u25cb")
+        assert not result.plain.startswith("  \u23bf")
 
 
 # ── render_user_header / render_separator ──────────────────────────

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -662,6 +662,237 @@ class TestTuiPath:
         assert live_state.is_active() is True
 
 
+# ── Tool PROCESSING lifecycle (async path) ──────────────────────────
+
+
+@pytest.mark.ci
+class TestToolProcessingLifecycle:
+    """Cover the async ``_process_actions`` path for TOOL PROCESSING entries,
+    both at depth=0 (top-level) and depth>0 (inside subagent groups)."""
+
+    def test_top_level_processing_pins_frame_and_clears_on_success(self):
+        """A depth=0 TOOL PROCESSING pins a frame; the paired SUCCESS clears it."""
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+
+        call_id = "tool-call-xyz"
+        actions = [
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.PROCESSING,
+                action_id=call_id,
+                messages="db_describe",
+                input_data={"function_name": "db_describe", "arguments": {"table": "orders"}},
+            ),
+        ]
+        ctx = InlineStreamingContext(actions, display, live_state=live_state)
+
+        # First pass: PROCESSING entry -> pinned frame; index advances so the
+        # paired SUCCESS action (same action_id) can be consumed on arrival.
+        ctx._process_actions()
+        assert ctx._processing_action is actions[0]
+        assert live_state.is_active() is True
+        assert ctx._processed_index == 1
+
+        # SUCCESS arrives with the same action_id; streaming advances and clears pinned.
+        actions.append(
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                action_id=call_id,
+                messages="db_describe",
+                input_data={"function_name": "db_describe", "arguments": {"table": "orders"}},
+                output_data={"raw_output": {"rows": []}},
+                end_time=datetime.now() + timedelta(seconds=1),
+            )
+        )
+        ctx._process_actions()
+        assert ctx._processing_action is None
+        assert live_state.is_active() is False
+        assert ctx._processed_index == 2
+
+    def test_subagent_processing_sets_group_slot_and_paints_blink_row(self):
+        """A depth>0 TOOL PROCESSING sets ``processing_action`` on its group
+        and is rendered as an extra blinking row at the tail of the group."""
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        parent_id = "parent-proc"
+
+        # Existing subagent group already open with one completed tool.
+        ctx = InlineStreamingContext([], display, live_state=live_state)
+        seed = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=1,
+            action_type="gen_metrics",
+            messages="task",
+            input_data={"function_name": "db_sample"},
+            parent_action_id=parent_id,
+            end_time=datetime.now(),
+        )
+        ctx._start_subagent_group(seed, group_key=parent_id)
+        ctx._update_subagent_display(seed, group_key=parent_id)
+
+        # A new tool is now running inside the same subagent.
+        call_id = "inner-call"
+        processing = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="gen_metrics",
+            action_id=call_id,
+            messages="db_describe",
+            input_data={"function_name": "db_describe", "arguments": {"table": "orders"}},
+            parent_action_id=parent_id,
+        )
+        ctx.actions.append(processing)
+        ctx._process_actions()
+
+        assert ctx._subagent_groups[parent_id]["processing_action"] is processing
+        assert ctx._processing_action is None  # Top-level pinned must not be hijacked.
+
+        lines = ctx._build_subagent_live_lines()
+        plain = [" ".join(seg for _, seg in line.segments) for line in lines]
+        joined = " | ".join(plain)
+        assert "db_describe" in joined
+        # Explicitly assert the blink row uses the processing-live style.
+        styles = {style for line in lines for style, _ in line.segments}
+        assert "class:processing-live" in styles
+
+        # Paired SUCCESS arrives -> pending slot clears, completed tool joins the list.
+        success = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=1,
+            action_type="gen_metrics",
+            action_id=call_id,
+            messages="db_describe",
+            input_data={"function_name": "db_describe", "arguments": {"table": "orders"}},
+            output_data={"raw_output": {"rows": 10}},
+            parent_action_id=parent_id,
+            end_time=datetime.now() + timedelta(seconds=1),
+        )
+        ctx.actions.append(success)
+        ctx._process_actions()
+
+        group = ctx._subagent_groups[parent_id]
+        assert group["processing_action"] is None
+        assert any(a.action_id == call_id and a.status == ActionStatus.SUCCESS for a in group["actions"])
+        lines_after = ctx._build_subagent_live_lines()
+        styles_after = {style for line in lines_after for style, _ in line.segments}
+        assert "class:processing-live" not in styles_after
+
+    def test_subagent_block_height_stays_two_when_processing_active(self):
+        """With N completed tools + running row, the block is exactly
+        ``1 header + TOOL_LINES_PER_GROUP`` rows (running row occupies a slot)."""
+        from datus.cli.tui.live_display_state import TOOL_LINES_PER_GROUP, LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        ctx = InlineStreamingContext([], display, live_state=live_state)
+
+        parent_id = "parent-height"
+        first = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="gen_metrics",
+            parent_action_id=parent_id,
+        )
+        ctx._start_subagent_group(first, group_key=parent_id)
+        for i in range(4):
+            ctx._update_subagent_display(
+                _make_action(
+                    ActionRole.TOOL,
+                    ActionStatus.SUCCESS,
+                    depth=1,
+                    action_type="gen_metrics",
+                    input_data={"function_name": f"tool_{i}"},
+                    parent_action_id=parent_id,
+                    end_time=datetime.now(),
+                ),
+                group_key=parent_id,
+            )
+        ctx._subagent_groups[parent_id]["processing_action"] = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="gen_metrics",
+            input_data={"function_name": "db_describe", "arguments": {"table": "orders"}},
+            parent_action_id=parent_id,
+        )
+
+        lines = ctx._build_subagent_live_lines()
+        assert len(lines) == 1 + TOOL_LINES_PER_GROUP  # header + exactly 2 content rows
+        # Last content row is the running indicator (processing-live style).
+        assert any(style == "class:processing-live" for style, _ in lines[-1].segments)
+        # Previous content row is the most recent completed tool.
+        prev_text = "".join(seg for _, seg in lines[-2].segments)
+        assert "tool_3" in prev_text
+
+    def test_top_level_event_appends_blank_line_separator(self):
+        """Each independent depth=0 action prints a trailing blank line so
+        adjacent events are visually separated in the scrollback."""
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=120)
+        display = ActionHistoryDisplay(console)
+        ctx = InlineStreamingContext([], display)
+
+        success = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=0,
+            input_data={"function_name": "list_tables"},
+            end_time=datetime.now() + timedelta(milliseconds=200),
+        )
+        ctx._print_completed_action(success)
+        output = buf.getvalue()
+        # The tool row renders as `<status-dot> 🔧 ... \n  └─ …\n` and we now
+        # append an extra blank line at the end.
+        assert output.endswith("\n\n")
+
+    def test_subagent_renderable_includes_processing_row(self):
+        """Non-TUI Rich ``Live`` path also appends the blinking row per group."""
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        display = ActionHistoryDisplay(console)
+        ctx = InlineStreamingContext([], display)
+
+        parent_id = "parent-rich"
+        first = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=1,
+            action_type="gen_metrics",
+            input_data={"function_name": "list_tables"},
+            parent_action_id=parent_id,
+            end_time=datetime.now(),
+        )
+        ctx._start_subagent_group(first, group_key=parent_id)
+        ctx._update_subagent_display(first, group_key=parent_id)
+        ctx._subagent_groups[parent_id]["processing_action"] = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="gen_metrics",
+            input_data={"function_name": "db_describe", "arguments": {"table": "orders"}},
+            parent_action_id=parent_id,
+        )
+        group = ctx._build_subagent_groups_renderable()
+        rendered = " | ".join(str(r) for r in getattr(group, "renderables", []))
+        assert "db_describe" in rendered
+
+
 # ── Streaming markdown (thinking_delta in TUI mode) ─────────────────
 
 
@@ -830,7 +1061,7 @@ class TestStreamingMarkdown:
         proc_snap = live_state.snapshot()
         # One pinned line for the blinking processing tool.
         assert len(proc_snap) == 1
-        assert any(style == "class:processing-live" for style, _ in proc_snap[0].segments)
+        assert any(style == "class:processing-live-top" for style, _ in proc_snap[0].segments)
 
         # Stop processing → markdown tail reclaims the region.
         ctx._stop_processing_live()

--- a/tests/unit_tests/cli/test_action_history_display.py
+++ b/tests/unit_tests/cli/test_action_history_display.py
@@ -390,8 +390,9 @@ class TestNoSubAgentNormalFlow:
         assert len(ctx._subagent_groups) == 0
         assert len(printed) > 0
 
-    def test_processing_tool_pauses(self):
-        """depth=0 PROCESSING TOOL pauses _process_actions (returns without advancing)."""
+    def test_processing_tool_pins_frame_and_advances(self):
+        """depth=0 PROCESSING TOOL pins a blinking frame and advances the index
+        so the paired SUCCESS action can be consumed on arrival."""
         actions = []
         display = ActionHistoryDisplay()
         ctx = InlineStreamingContext(actions, display)
@@ -410,11 +411,13 @@ class TestNoSubAgentNormalFlow:
         )
 
         with patch.object(display.console, "print"):
-            with patch("datus.cli.action_display.streaming.Live"):
+            with patch("datus.cli.action_display.streaming.Live") as MockLive:
                 ctx._process_actions()
 
-        # Index should NOT advance past PROCESSING
-        assert ctx._processed_index == 0
+        # Index advances past PROCESSING; the blink keeps repainting via Rich Live.
+        assert ctx._processed_index == 1
+        # Non-TUI path instantiates Rich Live with the PROCESSING renderable.
+        assert MockLive.called
 
 
 @pytest.mark.ci
@@ -4683,6 +4686,181 @@ class TestPendingTaskToolSkips:
         assert "parse_temporal_expressions" in output
         subagent_standalone = [line for line in lines if "subagent" in line.lower() and "result" in line.lower()]
         assert len(subagent_standalone) == 0
+
+
+@pytest.mark.ci
+class TestSubagentTaskSkipOrderIndependence:
+    """The skip of standalone ``task`` tool calls must be order-independent.
+
+    The ActionBus may yield the outer ``task`` SUCCESS before the queued
+    ``subagent_complete`` (FIRST_COMPLETED race in ``ActionBus.merge``).
+    When that happens the action list slice handed to ``render_action_history``
+    has the task action *before* the subagent_complete that names it. The
+    counter-only skip (``pending_task_tool_skips``) misses this case and
+    renders BOTH a standalone ``⏺ explore(...) result - ✓ Success`` block
+    and the collapsed ``⏴ explore(...) Done ✓`` block.
+    """
+
+    def _build_reordered_actions(self, *, with_response: bool = False):
+        t0 = datetime(2025, 1, 1, 12, 0, 0)
+        t1 = datetime(2025, 1, 1, 12, 0, 1)
+        output_data = (
+            {"raw_output": '{"success": 1, "result": {"response": "found tables"}}'} if with_response else None
+        )
+        return [
+            _make_action(
+                ActionRole.USER,
+                ActionStatus.SUCCESS,
+                depth=1,
+                action_type="explore",
+                messages="User: Find tables",
+                input_data={"_task_description": "Find tables"},
+                start_time=t0,
+                parent_action_id="call_42",
+            ),
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                depth=1,
+                action_type="search_schema",
+                messages="search_schema",
+                input_data={"function_name": "search_schema"},
+                start_time=t0,
+                end_time=t1,
+                parent_action_id="call_42",
+            ),
+            # Reordered: task SUCCESS arrives BEFORE subagent_complete.
+            # The model layer (``openai_compatible``/``claude_model``/
+            # ``codex_model``) prefixes the SUCCESS action_id with
+            # ``complete_``; the matching ``subagent_complete`` carries
+            # the bare ``call_id`` in ``parent_action_id``.
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                depth=0,
+                action_type="task",
+                messages="task",
+                input_data={"function_name": "task", "type": "explore", "prompt": "Find tables"},
+                output_data=output_data,
+                start_time=t0,
+                end_time=t1,
+                action_id="complete_call_42",
+            ),
+            _make_action(
+                ActionRole.SYSTEM,
+                ActionStatus.SUCCESS,
+                depth=0,
+                action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+                messages="",
+                start_time=t0,
+                end_time=t1,
+                parent_action_id="call_42",
+            ),
+        ]
+
+    def test_compact_does_not_double_render_when_task_arrives_before_complete(self):
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        display = ActionHistoryDisplay(console)
+        display.render_action_history(self._build_reordered_actions(), verbose=False)
+
+        output = buf.getvalue()
+        # Only the collapsed marker should appear, never the expanded ⏺
+        # header that ``render_task_tool_as_subagent`` emits in compact mode.
+        assert "\u23f4" in output, "Expected collapsed ⏴ subagent marker"
+        assert "\u23fa" not in output, "Expanded ⏺ marker indicates duplicate render"
+        # ``result - …  ✓ Success`` is the unique compact-mode signature of
+        # ``render_task_tool_as_subagent`` — it must not appear here.
+        assert "result -" not in output
+
+    def _build_forward_actions(self, *, with_response: bool = False):
+        """Action ordering used during a normal end-of-turn reprint.
+
+        ``subagent_complete`` arrives first, then the outer ``task`` SUCCESS
+        action carrying the ``complete_`` prefix that
+        ``openai_compatible``/``claude_model``/``codex_model`` apply.
+        """
+        t0 = datetime(2025, 1, 1, 12, 0, 0)
+        t1 = datetime(2025, 1, 1, 12, 0, 1)
+        output_data = (
+            {"raw_output": '{"success": 1, "result": {"response": "found tables"}}'} if with_response else None
+        )
+        return [
+            _make_action(
+                ActionRole.USER,
+                ActionStatus.SUCCESS,
+                depth=1,
+                action_type="explore",
+                messages="User: Find tables",
+                input_data={"_task_description": "Find tables"},
+                start_time=t0,
+                parent_action_id="call_42",
+            ),
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                depth=1,
+                action_type="search_schema",
+                messages="search_schema",
+                input_data={"function_name": "search_schema"},
+                start_time=t0,
+                end_time=t1,
+                parent_action_id="call_42",
+            ),
+            _make_action(
+                ActionRole.SYSTEM,
+                ActionStatus.SUCCESS,
+                depth=0,
+                action_type=SUBAGENT_COMPLETE_ACTION_TYPE,
+                messages="",
+                start_time=t0,
+                end_time=t1,
+                parent_action_id="call_42",
+            ),
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                depth=0,
+                action_type="task",
+                messages="task",
+                input_data={"function_name": "task", "type": "explore", "prompt": "Find tables"},
+                output_data=output_data,
+                start_time=t0,
+                end_time=t1,
+                action_id="complete_call_42",
+            ),
+        ]
+
+    def test_compact_full_screen_reprint_with_complete_prefix(self):
+        """End-of-turn / Ctrl+O compact reprint must skip the ``complete_<call_id>`` task SUCCESS."""
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        display = ActionHistoryDisplay(console)
+        display.render_action_history(self._build_forward_actions(), verbose=False)
+
+        output = buf.getvalue()
+        assert "\u23f4" in output, "Expected collapsed ⏴ subagent marker"
+        assert "\u23fa" not in output, "Expanded ⏺ marker indicates duplicate render"
+        assert "result -" not in output
+
+    def test_verbose_renders_response_when_task_arrives_before_complete(self):
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        display = ActionHistoryDisplay(console)
+        display.render_action_history(self._build_reordered_actions(with_response=True), verbose=True)
+
+        output = buf.getvalue()
+        # Exactly one Done summary, group rendered expanded with response.
+        assert output.count("Done") == 1
+        assert "search_schema" in output
+        assert "found tables" in output
+        # ``result - …`` is the unique compact/verbose signature of
+        # ``render_task_tool_as_subagent`` and must not leak through —
+        # the response is owned by ``render_subagent_response``.
+        assert "result -" not in output
+        # Only one ``⏺`` marker (the subagent group header). A second one
+        # would indicate the standalone task render was produced too.
+        assert output.count("\u23fa") == 1
 
 
 @pytest.mark.ci


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Steady processing symbol replaces blinking animation; processing row is pinned for clearer live feedback
  * Tool rows include concise argument summaries and improved indentation/spacing for nested subagents
  * Removes automatic full-screen transcript reprint at turn end

* **Bug Fixes**
  * Prevents duplicate final-answer rendering and duplicate task/sub-agent entries when events arrive out of order
  * Ensures consistent trailing blank line behavior for completed top-level tools

* **New Features**
  * SSE payloads for tool/subagent completions may include an error field
  * Prompt cache retention rules extended for newer official models

* **Tests**
  * Expanded unit tests covering processing lifecycle, rendering formats, nesting, ordering, and SSE error handling

* **Style**
  * Added top-level processing style variant for consistent appearance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->