### PR TITLE
[BugFix] Preserve DeepSeek reasoning content across tool turns

### DIFF
--- a/datus/models/sdk_patches.py
+++ b/datus/models/sdk_patches.py
@@ -201,6 +201,7 @@ def _postprocess_messages_for_reasoning(
         return messages
 
     is_kimi = _is_kimi_model(model)
+    is_deepseek = _is_deepseek_model(model)
 
     # Find the last non-empty reasoning_content to reuse if needed
     last_reasoning_content = None
@@ -218,15 +219,23 @@ def _postprocess_messages_for_reasoning(
             last_reasoning_content = cached_rc
             logger.debug(f"[SDK Patch] Using cached reasoning_content as fallback, length={len(cached_rc)}")
 
-    # Ensure all assistant messages with tool_calls have reasoning_content field
-    # when the provider requires it (thinking mode enabled).
+    # Ensure assistant messages preserve reasoning_content when the provider
+    # requires it. DeepSeek V4 Pro rejects follow-up requests if the final
+    # assistant message from a tool-using turn is missing reasoning_content,
+    # even though that final message has no tool_calls. Kimi/Moonshot keeps the
+    # narrower historical behavior and only patches assistant+tool_calls turns.
     for msg in messages:
-        if isinstance(msg, dict) and msg.get("role") == "assistant" and msg.get("tool_calls"):
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+
+        has_tool_calls = bool(msg.get("tool_calls"))
+        should_patch_message = has_tool_calls or is_deepseek
+        if should_patch_message:
             current_rc = msg.get("reasoning_content", "")
             if (not current_rc or not current_rc.strip()) and last_reasoning_content:
                 msg["reasoning_content"] = last_reasoning_content
-                logger.debug("[SDK Patch] Injected reasoning_content into assistant+tool_calls message")
-            elif "reasoning_content" not in msg and is_kimi:
+                logger.debug("[SDK Patch] Injected reasoning_content into assistant message")
+            elif has_tool_calls and "reasoning_content" not in msg and is_kimi:
                 # Moonshot historically tolerates an empty reasoning_content field when
                 # thinking is off; DeepSeek rejects both missing and empty, so we must
                 # NOT inject an empty placeholder for DeepSeek — leave the message as-is
@@ -239,7 +248,7 @@ def _postprocess_messages_for_reasoning(
 
             # Ensure content is empty string, not None (Moonshot requirement;
             # DeepSeek also accepts content="" for tool_calls-only messages).
-            if msg.get("content") is None:
+            if has_tool_calls and msg.get("content") is None:
                 msg["content"] = ""
 
     return messages

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -443,6 +443,43 @@ class TestPostprocessMessagesForReasoning:
 
         _reasoning_content_cache.clear()
 
+    def test_deepseek_injects_reasoning_content_into_final_assistant_message(self):
+        """DeepSeek V4 Pro requires final assistant messages from tool turns to keep reasoning_content."""
+        _reasoning_content_cache.clear()
+        _reasoning_content_cache["deepseek/deepseek-v4-pro"] = "final answer thinking"
+
+        messages = [
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": "Final answer after tool."},
+            {"role": "user", "content": "next question"},
+        ]
+        result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-pro")
+
+        assert result[0]["reasoning_content"] == "final answer thinking"
+        assert result[0]["content"] == ""
+        assert result[2]["reasoning_content"] == "final answer thinking"
+        assert result[2]["content"] == "Final answer after tool."
+
+        _reasoning_content_cache.clear()
+
+    def test_kimi_does_not_inject_reasoning_content_into_final_assistant_message(self):
+        """Kimi keeps the historical narrower assistant+tool_calls patch scope."""
+        _reasoning_content_cache.clear()
+        _reasoning_content_cache["kimi-k2.5"] = "cached thinking"
+
+        messages = [
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": "Final answer after tool."},
+        ]
+        result = _postprocess_messages_for_reasoning(messages, "kimi-k2.5")
+
+        assert result[0]["reasoning_content"] == "cached thinking"
+        assert "reasoning_content" not in result[2]
+
+        _reasoning_content_cache.clear()
+
 
 class TestApplyAndRemoveSdkPatches:
     """Tests for apply_sdk_patches and remove_sdk_patches lifecycle."""


### PR DESCRIPTION
## Why

DeepSeek V4 Pro rejects follow-up requests in thinking mode when assistant messages from a prior tool-using turn are replayed without `reasoning_content`. This shows up on the second user turn after a successful first turn with tool calls.

## Solution

- Reuse the last captured reasoning content for DeepSeek assistant messages, including the final assistant message after a tool call.
- Keep the narrower historical Kimi/Moonshot behavior limited to assistant messages with tool calls.
- Preserve `content=None` normalization only for tool-call assistant messages.

## Test Cases

- `uv run pytest tests/unit_tests/models/test_sdk_patches.py`
- `uv run ruff check datus/models/sdk_patches.py tests/unit_tests/models/test_sdk_patches.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced reasoning content handling for DeepSeek models to prevent request rejections during tool use.
  * Improved content normalization for assistant messages with tool calls.

* **Tests**
  * Added comprehensive test coverage for DeepSeek and Kimi model-specific message processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->