### PR TITLE
[BugFix] Render explore prompt with available tools

### DIFF
--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -202,9 +202,14 @@ class ExploreAgenticNode(AgenticNode):
 
         from datus.utils.node_utils import build_datasource_prompt_context
 
+        context_search_tool_names = []
+        if self.context_search_tools:
+            context_search_tool_names = [tool.name for tool in self.context_search_tools.available_tools()]
+
         context = {
             "has_db_tools": bool(self.db_func_tool),
-            "has_context_search_tools": bool(self.context_search_tools),
+            "has_context_search_tools": bool(context_search_tool_names),
+            "available_context_search_tools": context_search_tool_names,
             "has_filesystem_tools": bool(self.filesystem_func_tool),
             "has_date_parsing_tools": bool(self.date_parsing_tools),
             **build_datasource_prompt_context(self.agent_config),

--- a/datus/prompts/prompt_templates/explore_system_1.0.j2
+++ b/datus/prompts/prompt_templates/explore_system_1.0.j2
@@ -11,22 +11,47 @@ You are a data exploration expert. Your role is to gather context information fr
 - **NEVER execute INSERT, UPDATE, DELETE, DROP, ALTER, or any DDL/DML statements**
 {% endif -%}
 {% if has_context_search_tools -%}
+{% set context_tools = available_context_search_tools | default([]) -%}
 ### Context Search Tools (MUST USE)
-You **MUST** use context search tools to gather domain knowledge before concluding exploration. There are two retrieval paths — try **both** for comprehensive coverage:
+You **MUST** use the available context search tools below to gather domain knowledge before concluding exploration.
 
-**Path 1: Semantic Search** — when you know what to look for but not where it lives:
+{% if "search_metrics" in context_tools or "search_reference_sql" in context_tools or "search_knowledge" in context_tools or "search_semantic_objects" in context_tools -%}
+**Semantic Search** — when you know what to look for but not where it lives:
+{% if "search_metrics" in context_tools -%}
 - `search_metrics(query_text="...")` — semantic search for business metrics and KPIs by natural language
+{% endif -%}
+{% if "search_reference_sql" in context_tools -%}
 - `search_reference_sql(query_text="...")` — semantic search for existing SQL patterns and examples
+{% endif -%}
+{% if "search_knowledge" in context_tools -%}
 - `search_knowledge(query_text="...")` — semantic search for business domain knowledge and rules
+{% endif -%}
+{% if "search_semantic_objects" in context_tools -%}
 - `search_semantic_objects(query_text="...", kinds=["metric","column","table"])` — unified semantic search across all object types
+{% endif -%}
+{% endif -%}
 
-**Path 2: Tree Navigation** — browse the domain hierarchy and fetch by exact name:
-- `list_subject_tree()` — **call this FIRST** to get the full domain taxonomy with available metrics, reference SQL, and knowledge names
+{% if "list_subject_tree" in context_tools or "get_metrics" in context_tools or "get_reference_sql" in context_tools or "get_knowledge" in context_tools -%}
+**Tree Navigation** — browse the domain hierarchy and fetch by exact name:
+{% if "list_subject_tree" in context_tools -%}
+- `list_subject_tree()` — call this first to get the available domain taxonomy
+{% endif -%}
+{% if "get_metrics" in context_tools -%}
 - `get_metrics(subject_path=[...], name="...")` — fetch a specific metric by its path and name from the tree
+{% endif -%}
+{% if "get_reference_sql" in context_tools -%}
 - `get_reference_sql(subject_path=[...], name="...")` — fetch a specific reference SQL by its path and name from the tree
+{% endif -%}
+{% if "get_knowledge" in context_tools -%}
 - `get_knowledge(paths=[[...]])` — fetch specific knowledge entries by their full paths from the tree
+{% endif -%}
+{% endif -%}
 
-**Strategy**: Start with `list_subject_tree()` to understand what's available, then use `search_*` for semantic discovery and `get_*` for precise retrieval of items found in the tree.
+{% if "list_subject_tree" in context_tools -%}
+**Strategy**: Start with `list_subject_tree()` to understand what's available, then use the available `search_*` and `get_*` tools for discovery and precise retrieval.
+{% else -%}
+**Strategy**: Use the listed context search tools for semantic discovery and precise retrieval.
+{% endif -%}
 {% endif -%}
 {% if has_filesystem_tools -%}
 ### Filesystem Tools (Read-Only)

--- a/tests/unit_tests/agent/node/test_explore_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_explore_agentic_node.py
@@ -11,6 +11,8 @@ execute_stream flow, and integration with SubAgentTaskTool.
 NO MOCK EXCEPT LLM: The only mock is LLMBaseModel.create_model -> MockLLMModel.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from datus.agent.node.agentic_node import AgenticNode
@@ -186,6 +188,33 @@ class TestExploreAgenticNodeTools:
         assert "db_tools" in mapping
         assert "filesystem_tools" in mapping
         assert "date_parsing_tools" in mapping
+
+    def test_context_search_prompt_only_lists_available_tools(self, real_agent_config, mock_llm_create):
+        """Explore prompt should not advertise context tools that are not exposed."""
+        from datus.agent.node.explore_agentic_node import ExploreAgenticNode
+
+        node = ExploreAgenticNode(
+            node_id="test_explore_tools_7",
+            description="Test Explore node",
+            node_type=NodeType.TYPE_EXPLORE,
+            agent_config=real_agent_config,
+            node_name="explore",
+        )
+        node.context_search_tools = SimpleNamespace(
+            available_tools=lambda: [
+                SimpleNamespace(name="list_subject_tree"),
+                SimpleNamespace(name="search_reference_sql"),
+                SimpleNamespace(name="get_reference_sql"),
+            ]
+        )
+
+        prompt = node._get_system_prompt()
+
+        assert "`list_subject_tree()`" in prompt
+        assert "`search_reference_sql" in prompt
+        assert "`get_reference_sql" in prompt
+        assert "`search_knowledge" not in prompt
+        assert "`get_knowledge" not in prompt
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
## Why

The explore system prompt advertised all context search tools whenever a `ContextSearchTools` object existed, even if the runtime `available_tools()` list did not expose those tools. This could make the model call missing tools such as `search_knowledge`, `search_reference_sql`, or `list_subject_tree`, producing `Tool not found` errors in explore subagents.

## Solution

- Pass the actual `ContextSearchTools.available_tools()` names into the explore prompt context.
- Treat context search tools as available only when the actual list is non-empty.
- Render each context search tool instruction only when that specific tool is present.

## Test Cases

- `uv run pytest tests/unit_tests/agent/node/test_explore_agentic_node.py`
- `uv run ruff check datus/agent/node/explore_agentic_node.py tests/unit_tests/agent/node/test_explore_agentic_node.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The AI agent now accurately reflects which context search tools are available in its system prompt, ensuring instructions only reference tools that are actually accessible.

* **Tests**
  * Added test coverage for system prompt generation with context search tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->