### PR TITLE
[BugFix] Align DuckDB connect with duckdb_engine custom_user_agent

### DIFF
--- a/datus/tools/db_tools/duckdb_connector.py
+++ b/datus/tools/db_tools/duckdb_connector.py
@@ -69,10 +69,21 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             return
 
         try:
-            # Connect to DuckDB
-            self.connection = duckdb.connect(self.db_path)
+            # Align with the `custom_user_agent` that duckdb_engine auto-injects on every connect:
+            # without this, any same-process SQLAlchemy+duckdb_engine client (metricflow validator,
+            # dbt, etc.) hits DuckDB's config-consistency check and fails with
+            # "Can't open a connection to same database file with a different configuration".
+            try:
+                import sqlalchemy as _sa
+                from duckdb_engine import __version__ as _de_ver
 
-            # Configure settings
+                config = {"custom_user_agent": f"duckdb_engine/{_de_ver}(sqlalchemy/{_sa.__version__})"}
+                self.connection = duckdb.connect(self.db_path, config=config)
+            except ImportError:
+                self.connection = duckdb.connect(self.db_path)
+
+            # Per-session settings — kept as post-connect SET so they don't enter
+            # DuckDB's instance-config equality check.
             if self.memory_limit:
                 self.connection.execute(f"SET memory_limit='{self.memory_limit}'")
 

--- a/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
+++ b/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
@@ -1,0 +1,73 @@
+"""Unit tests for DuckdbConnector.connect() — guards the in-process config
+alignment that lets datus and SQLAlchemy+duckdb_engine clients coexist."""
+
+import sys
+
+import duckdb
+import pytest
+import sqlalchemy
+from sqlalchemy.pool import StaticPool
+
+from datus.tools.db_tools.config import DuckDBConfig
+from datus.tools.db_tools.duckdb_connector import DuckdbConnector
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "smoke.duckdb")
+
+
+def test_connect_and_close(db_path):
+    connector = DuckdbConnector(DuckDBConfig(db_path=db_path))
+    connector.connect()
+    assert connector.connection is not None
+    connector.connection.execute("SELECT 1").fetchone()
+
+    connector.close()
+    assert connector.connection is None
+
+
+def test_coexist_with_sqlalchemy_duckdb_engine(db_path):
+    """Regression: a second connection via SQLAlchemy+duckdb_engine on the same
+    file in the same process must succeed. Pre-fix, DuckDB rejected it with
+    'Can't open a connection to same database file with a different configuration'.
+    """
+    connector = DuckdbConnector(DuckDBConfig(db_path=db_path))
+    connector.connect()
+    connector.connection.execute("CREATE TABLE t(x INT)")
+    connector.connection.execute("INSERT INTO t VALUES (1)")
+
+    engine = sqlalchemy.create_engine(f"duckdb:///{db_path}", poolclass=StaticPool)
+    try:
+        raw = engine.raw_connection()
+        cur = raw.cursor()
+        cur.execute("SELECT COUNT(*) FROM t")
+        assert cur.fetchone()[0] == 1
+        raw.close()
+    finally:
+        engine.dispose()
+        connector.close()
+
+
+def test_falls_back_when_duckdb_engine_missing(db_path, monkeypatch):
+    """If duckdb_engine isn't installed, connect() falls back to a bare
+    duckdb.connect(self.db_path) without aligning custom_user_agent."""
+    monkeypatch.setitem(sys.modules, "duckdb_engine", None)
+
+    seen_kwargs: dict = {}
+    original_connect = duckdb.connect
+
+    def spy_connect(path, **kwargs):
+        seen_kwargs.update(kwargs)
+        return original_connect(path, **kwargs)
+
+    monkeypatch.setattr(duckdb, "connect", spy_connect)
+
+    connector = DuckdbConnector(DuckDBConfig(db_path=db_path))
+    connector.connect()
+    try:
+        assert connector.connection is not None
+        # Fallback path must NOT pass a config dict.
+        assert "config" not in seen_kwargs
+    finally:
+        connector.close()


### PR DESCRIPTION
## Why

Same-process SQLAlchemy + duckdb_engine clients (e.g. metricflow's `DataWarehouseModelValidator`, dbt, cube) cannot coexist with `DuckdbConnector`. The second connect fails with:

```
duckdb.duckdb.ConnectionException: Connection Error: Can't open a connection to
same database file with a different configuration than existing connections
```

Observed in production via LangSmith trace `019dc960-43cf-7732-a68e-e9d37f0f1845` — `validate_semantic` looped 7 times on the identical DuckDB ConnectionException, wasting ~120 s of LLM rewrites and ~1 M prompt tokens before exiting on user intervention. Only the first call returned a real YAML schema error; calls 2–8 were the system-level connection conflict masquerading as a validation error.

Root cause: `duckdb_engine.Dialect.connect` (`duckdb_engine/__init__.py:285-301`) always injects `custom_user_agent` into the config dict it passes to `duckdb.connect`. DuckDB's instance-config equality check rejects any key/value mismatch — including this telemetry-only one. `DuckdbConnector.connect` previously called `duckdb.connect(self.db_path)` with no config dict at all, so the two configs differed by exactly `custom_user_agent`.

## Solution

Pass a matching `custom_user_agent` (`duckdb_engine/{ver}(sqlalchemy/{ver})`) when datus opens its DuckDB connection so the second SQLAlchemy + duckdb_engine connect finds an identical instance config. Per-session settings (`memory_limit`, `enable_external_access`) remain post-connect `SET` since those don't participate in DuckDB's instance-config equality check.

If `duckdb_engine` is not installed (no SQLAlchemy DuckDB caller possible in the same process), fall back to a bare `duckdb.connect(self.db_path)`.

**Caveat — this is a hotfix, not a long-term fix.** It couples datus to a specific format string in duckdb_engine internals. The proper fix is to share the existing connector with metricflow's validator (no second connection), tracked separately.

## Test Cases

New unit tests in `tests/unit_tests/tools/db_tools/test_duckdb_connector.py`:

- `test_connect_and_close` — basic happy path: connect, execute SELECT 1, close.
- `test_coexist_with_sqlalchemy_duckdb_engine` — **regression test**: opens the DuckdbConnector first, then a SQLAlchemy + duckdb_engine connection on the same file in the same process; verifies the second connect succeeds and reads data written through the first.
- `test_falls_back_when_duckdb_engine_missing` — patches `sys.modules["duckdb_engine"] = None`, verifies bare connect path is taken (no `config` kwarg) and connect still succeeds.

Coverage:
- Overall: 81.23% (≥80% gate)
- Diff: 100% (5 / 5 changed lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced DuckDB connection initialization with customized user agent derived from dependency versions.
  * Added fallback connection mechanism when optional dependencies are unavailable.

* **Tests**
  * New test suite added for database connections, covering connection establishment, query execution, resource cleanup, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->