### PR TITLE
[BugFix] Fix BI bootstrap adapter handling

### DIFF
--- a/datus/cli/bi_dashboard.py
+++ b/datus/cli/bi_dashboard.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import dataclass
 from getpass import getpass
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
 from urllib.parse import urlparse
 
 import pandas as pd
@@ -137,7 +137,7 @@ class BiDashboardCommands:
                 return
 
             with self.console.status("Loading charts..."):
-                chart_metas = adapter.list_charts(dashboard_id)
+                chart_metas = self._items_from_adapter_result(adapter.list_charts(dashboard_id))
             if not chart_metas:
                 self.console.print("[yellow]No charts found in this dashboard.[/]")
                 return
@@ -177,7 +177,7 @@ class BiDashboardCommands:
                 return
 
             with self.console.status("Loading datasets..."):
-                datasets = adapter.list_datasets(dashboard_id)
+                datasets = self._items_from_adapter_result(adapter.list_datasets(dashboard_id))
 
             result = assembler.assemble(dashboard, chart_selections_ref, chart_selections_metrics, datasets)
 
@@ -196,7 +196,9 @@ class BiDashboardCommands:
     def _prompt_options(self) -> DashboardCliOptions:
         platforms = sorted(self._adapter_registry)
         if not platforms:
-            raise ValueError("No BI adapter implementations found. Install one with: pip install datus-agent[bi]")
+            raise ValueError(
+                "No BI adapter implementations found. Install the Superset adapter with: pip install datus-bi-superset"
+            )
         platform = self._prompt_input("Select BI platform", default=platforms[0], choices=platforms)
         if platform not in self._adapter_registry:
             raise ValueError(f"Unsupported platform '{platform}'")
@@ -325,7 +327,8 @@ class BiDashboardCommands:
         adapter_cls = self._adapter_registry.get(options.platform)
         if adapter_cls is None:
             raise ValueError(
-                f"Unsupported platform '{options.platform}'. Install it with: pip install datus-bi-{options.platform}"
+                f"Unsupported platform '{options.platform}'. "
+                "Install the Superset adapter with: pip install datus-bi-superset"
             )
         return adapter_cls(
             api_base_url=options.api_base_url, auth_params=options.auth_params, dialect=self.agent_config.db_type
@@ -413,6 +416,14 @@ class BiDashboardCommands:
                     chart_detail = None
                 charts.append(chart_detail or chart_meta)
         return charts
+
+    def _items_from_adapter_result(self, result: Any) -> list[Any]:
+        if result is None:
+            return []
+        items = getattr(result, "items", None)
+        if items is not None and not callable(items):
+            return list(items or [])
+        return list(result)
 
     def _load_chart_selections(
         self,

--- a/docs/getting_started/data_engineering_quickstart.md
+++ b/docs/getting_started/data_engineering_quickstart.md
@@ -146,7 +146,8 @@ agent:
       scheduler_service: airflow_prod
 ```
 
-Then start Datus on the workbench database:
+Then start Datus with the `lever_duckdb` datasource, which points at the
+workbench DuckDB file:
 
 ```bash
 cd "$DACOMP_HOME"
@@ -256,12 +257,14 @@ What to expect:
 
 ## Step 8: Promote the Marts Table to the Superset Serving DB
 
-The marts table above was built in `lever_duckdb`. Before dashboard generation can
-create Superset assets, copy that table into the BI-registered
-`superset_serving` Postgres datasource referenced by `dataset_db.datasource_ref`.
+The marts table above was built through the `lever_duckdb` datasource. Before
+dashboard generation can create Superset assets, copy that table into the
+BI-registered `superset_serving` Postgres datasource referenced by
+`dataset_db.datasource_ref`. These names are Datus datasource names from
+`agent.yml`, not physical database or catalog names inside DuckDB or Postgres.
 
 ```text
-Please create or replace superset_serving.public.lever__requisition_enhanced by copying lever_duckdb.marts.lever__requisition_enhanced, then verify the transferred row count.
+Please copy the source table marts.lever__requisition_enhanced from the lever_duckdb datasource into the superset_serving datasource as public.lever__requisition_enhanced, replacing the target table if it already exists. Then verify the source and target row counts.
 ```
 
 After this step, the table exists in the same database Superset knows as

--- a/docs/getting_started/data_engineering_quickstart.zh.md
+++ b/docs/getting_started/data_engineering_quickstart.zh.md
@@ -141,7 +141,7 @@ agent:
       scheduler_service: airflow_prod
 ```
 
-然后连接到这个 DuckDB 工作库启动 Datus：
+然后使用 `lever_duckdb` datasource 启动 Datus；它指向上面的 DuckDB 工作库：
 
 ```bash
 cd "$DACOMP_HOME"
@@ -245,11 +245,13 @@ Trigger daily_lever_requisition_enhanced once now and show me the latest run sta
 
 ## 步骤 8：把 marts 表同步到 Superset serving DB
 
-上面的 marts 表是在 `lever_duckdb` 里生成的。创建仪表盘之前，需要先把它复制到
+上面的 marts 表是通过 `lever_duckdb` datasource 生成的。创建仪表盘之前，需要先把它复制到
 `dataset_db.datasource_ref` 指向的 BI 注册数据库 `superset_serving`（Postgres）。
+这里的 `lever_duckdb` 和 `superset_serving` 都是 `agent.yml` 里的 Datus
+datasource 名称，不是 DuckDB 或 Postgres 内部真实的 database/catalog 名。
 
 ```text
-Please create or replace superset_serving.public.lever__requisition_enhanced by copying lever_duckdb.marts.lever__requisition_enhanced, then verify the transferred row count.
+Please copy the source table marts.lever__requisition_enhanced from the lever_duckdb datasource into the superset_serving datasource as public.lever__requisition_enhanced, replacing the target table if it already exists. Then verify the source and target row counts.
 ```
 
 完成后，这张表就位于 Superset 通过 `bi_database_name: examples` 识别的数据库中。

--- a/docs/subagent/gen_dashboard.md
+++ b/docs/subagent/gen_dashboard.md
@@ -183,7 +183,7 @@ All sensitive values support `${ENV_VAR}` substitution.
 ### Two-step flow
 
 ```bash
-Use gen_job to write daily revenue for the last 90 days into serving_pg.bi_public.rpt_revenue_daily.
+Use gen_job to write daily revenue for the last 90 days into the `serving_pg` datasource as `bi_public.rpt_revenue_daily`.
 ```
 
 After the table is ready:

--- a/docs/subagent/gen_dashboard.zh.md
+++ b/docs/subagent/gen_dashboard.zh.md
@@ -183,7 +183,7 @@ agent:
 ### 两步流程
 
 ```bash
-用 gen_job 把过去 90 天每日营收写入 serving_pg.bi_public.rpt_revenue_daily。
+用 gen_job 把过去 90 天每日营收写入 `serving_pg` datasource，目标表为 `bi_public.rpt_revenue_daily`。
 ```
 
 表准备好之后：

--- a/tests/unit_tests/tools/bi_tools/test_bi_dashboard_no_adapter.py
+++ b/tests/unit_tests/tools/bi_tools/test_bi_dashboard_no_adapter.py
@@ -13,6 +13,11 @@ import pytest
 from datus_bi_core import AuthParam
 
 
+class _PaginatedResult:
+    def __init__(self, items):
+        self.items = items
+
+
 class TestNoAdapterInstalled:
     """Verify graceful errors when no BI adapter plugins are available."""
 
@@ -29,7 +34,7 @@ class TestNoAdapterInstalled:
 
     def test_prompt_options_raises_when_no_adapters(self, empty_registry_commands):
         """_prompt_options should raise ValueError when registry is empty."""
-        with pytest.raises(ValueError, match="No BI adapter implementations found.*pip install datus-agent"):
+        with pytest.raises(ValueError, match="No BI adapter implementations found.*pip install datus-bi-superset"):
             empty_registry_commands._prompt_options()
 
     def test_create_adapter_raises_for_unknown_platform(self, empty_registry_commands):
@@ -44,3 +49,15 @@ class TestNoAdapterInstalled:
         )
         with pytest.raises(ValueError, match="Unsupported platform 'superset'.*pip install datus-bi-superset"):
             empty_registry_commands._create_adapter(options)
+
+    def test_items_from_adapter_result_accepts_paginated_result(self, empty_registry_commands):
+        """Adapter list methods may return a PaginatedResult envelope."""
+        items = [object(), object()]
+
+        assert empty_registry_commands._items_from_adapter_result(_PaginatedResult(items)) == items
+
+    def test_items_from_adapter_result_accepts_plain_sequence(self, empty_registry_commands):
+        """Legacy adapters may still return a plain sequence."""
+        items = [object(), object()]
+
+        assert empty_registry_commands._items_from_adapter_result(items) == items


### PR DESCRIPTION
## Why

`bootstrap-bi` could fail or give misleading guidance in two common setup paths:

- new BI adapters return paginated list envelopes, while the CLI still treated chart and dataset listings as plain sequences;
- when no BI adapter is installed, the CLI suggested installing `datus-agent` instead of the Superset adapter package.

The data engineering and dashboard docs also used datasource-looking names in a way that could be confused with physical DuckDB/Postgres database or catalog names.

## Solution

- Normalize BI adapter list results by unwrapping `.items` before the existing hydrate and assemble flow.
- Update the missing-adapter hint to point users to `pip install datus-bi-superset`.
- Add unit coverage for both paginated and plain-sequence adapter returns.
- Clarify the quickstart and dashboard docs so datasource names are described as Datus datasource identifiers.

## Test Cases

- `uv run pytest tests/unit_tests/tools/bi_tools/test_bi_dashboard_no_adapter.py`
- `uv run --with 'mkdocs>=1.6,<2' --with 'mkdocs-material>=9.5.0' --with 'mkdocs-static-i18n>=1.2.3' --with 'mike>=2.1.3' --with 'pymdown-extensions>=10.2,<11' mkdocs build --strict`
- `git diff --check -- datus/cli/bi_dashboard.py tests/unit_tests/tools/bi_tools/test_bi_dashboard_no_adapter.py docs/getting_started/data_engineering_quickstart.md docs/getting_started/data_engineering_quickstart.zh.md docs/subagent/gen_dashboard.md docs/subagent/gen_dashboard.zh.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messages for missing adapters to recommend installing the Superset adapter specifically.

* **Documentation**
  * Clarified datasource naming conventions and configuration in quickstart guides.
  * Improved serving database documentation for dashboard generation workflows.
  * Enhanced explanations of datasource references and table destinations across English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->