### PR TITLE
[BugFix] Persist Claude OAuth subscription multi-turn session

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -437,9 +437,14 @@ class ClaudeModel(OpenAICompatibleModel):
                             messages.extend(prior_items)
                     except Exception as e:
                         logger.warning(f"Failed to load session history; starting fresh: {e}")
+                # Anthropic ``text`` blocks must be a single string. The signature
+                # inherits ``prompt: Union[str, List[Dict[str, str]]]`` from the
+                # base class for legacy callers; defensively normalise list-shaped
+                # inputs so a future caller can't slip an invalid block past us.
+                prompt_text = prompt if isinstance(prompt, str) else json.dumps(prompt, ensure_ascii=False)
                 user_turn_message = {
                     "role": "user",
-                    "content": [{"type": "text", "text": prompt}],
+                    "content": [{"type": "text", "text": prompt_text}],
                 }
                 messages.append(user_turn_message)
                 tool_call_cache = {}
@@ -675,7 +680,14 @@ class ClaudeModel(OpenAICompatibleModel):
                 # via ``session.get_items()``. Mirror what openai-agents Runner
                 # would do via SQLiteSession.add_items, but driven by us since
                 # the native Anthropic loop bypasses Runner.run.
-                if session is not None:
+                #
+                # When the loop exits via ``max_turns`` exhaustion while still
+                # tool-calling, ``final_content`` stays "" — Anthropic rejects
+                # empty assistant text blocks on replay
+                # (``messages.{i}.content.{j}.text: text content blocks must be
+                # non-empty``), which would poison the session. Skip persistence
+                # in that case so the next turn starts from a clean slate.
+                if session is not None and final_content:
                     try:
                         assistant_turn_message = {
                             "role": "assistant",
@@ -684,6 +696,12 @@ class ClaudeModel(OpenAICompatibleModel):
                         await session.add_items([user_turn_message, assistant_turn_message])
                     except Exception as e:
                         logger.warning(f"Failed to persist session history for native Claude turn: {e}")
+                elif session is not None:
+                    logger.warning(
+                        "Skipping native Claude session persist: turn ended without final text "
+                        "(max_turns=%s exhausted while tool-calling).",
+                        max_turns,
+                    )
 
                 yield final_action
 

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -364,6 +364,7 @@ class ClaudeModel(OpenAICompatibleModel):
         func_tools: Optional[List[Any]] = None,
         action_history_manager: Optional[ActionHistoryManager] = None,
         interrupt_controller=None,
+        session: Optional[Any] = None,
         **kwargs,
     ) -> AsyncGenerator[ActionHistory, None]:
         """Async generator: native Anthropic API with real-time tool call ActionHistory.
@@ -422,12 +423,25 @@ class ClaudeModel(OpenAICompatibleModel):
                         for t in tools:
                             t.pop("cache_control", None)
                         tools[-1]["cache_control"] = {"type": "ephemeral"}
-                messages = [
-                    {
-                        "role": "user",
-                        "content": [{"type": "text", "text": f"{instruction}\n\n{prompt}"}],
-                    }
-                ]
+                # Load prior turns from the session so multi-turn chat works.
+                # Native Anthropic loop is not driven by openai-agents Runner, so
+                # we replay session history into ``messages`` ourselves.
+                # ``instruction`` is already carried by ``_build_system_param``;
+                # do NOT re-embed it in the user message here, otherwise persisted
+                # turns would carry duplicated system text.
+                messages: List[Dict[str, Any]] = []
+                if session is not None:
+                    try:
+                        prior_items = await session.get_items()
+                        if prior_items:
+                            messages.extend(prior_items)
+                    except Exception as e:
+                        logger.warning(f"Failed to load session history; starting fresh: {e}")
+                user_turn_message = {
+                    "role": "user",
+                    "content": [{"type": "text", "text": prompt}],
+                }
+                messages.append(user_turn_message)
                 tool_call_cache = {}
                 sql_contexts = []
                 final_content = ""
@@ -656,6 +670,21 @@ class ClaudeModel(OpenAICompatibleModel):
                 )
                 if action_history_manager is not None:
                     action_history_manager.add_action(final_action)
+
+                # Persist this turn into the session so the next turn replays it
+                # via ``session.get_items()``. Mirror what openai-agents Runner
+                # would do via SQLiteSession.add_items, but driven by us since
+                # the native Anthropic loop bypasses Runner.run.
+                if session is not None:
+                    try:
+                        assistant_turn_message = {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": final_content}],
+                        }
+                        await session.add_items([user_turn_message, assistant_turn_message])
+                    except Exception as e:
+                        logger.warning(f"Failed to persist session history for native Claude turn: {e}")
+
                 yield final_action
 
         except anthropic.AuthenticationError as e:
@@ -674,6 +703,7 @@ class ClaudeModel(OpenAICompatibleModel):
         max_turns: int = 10,
         func_tools: Optional[List[Any]] = None,
         action_history_manager: Optional[ActionHistoryManager] = None,
+        session: Optional[Any] = None,
         **kwargs,
     ) -> Dict:
         """Non-streaming wrapper: consumes _generate_with_mcp_stream and returns result dict."""
@@ -686,6 +716,7 @@ class ClaudeModel(OpenAICompatibleModel):
             max_turns=max_turns,
             func_tools=func_tools,
             action_history_manager=action_history_manager,
+            session=session,
             **kwargs,
         ):
             if action.role == ActionRole.ASSISTANT and action.action_type == "final_response":
@@ -725,6 +756,7 @@ class ClaudeModel(OpenAICompatibleModel):
                 max_turns=max_turns,
                 func_tools=tools,
                 action_history_manager=action_history_manager,
+                session=session,
                 **kwargs,
             )
 
@@ -782,6 +814,7 @@ class ClaudeModel(OpenAICompatibleModel):
                 func_tools=tools,
                 action_history_manager=action_history_manager,
                 interrupt_controller=kwargs.pop("interrupt_controller", None),
+                session=session,
                 **kwargs,
             ):
                 yield action

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -969,6 +969,90 @@ class TestGenerateWithMcpStream:
         assert session.add_items.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_session_skip_persist_when_final_content_empty(self):
+        """When ``max_turns`` is exhausted while still tool-calling, ``final_content``
+        stays empty. Persisting an empty assistant text block would be rejected by
+        Anthropic on replay (``text content blocks must be non-empty``), so the
+        guard must skip ``add_items`` entirely.
+        """
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        # Every turn keeps tool-calling; the loop exits via max_turns with no
+        # text response. Use max_turns=2 so the test is fast.
+        tool_block = _make_tool_use_block()
+        model.anthropic_client.messages.create.return_value = _make_response([tool_block])
+
+        func_tool = MagicMock()
+        func_tool.name = "read_query"
+        func_tool.description = ""
+        func_tool.params_json_schema = {"type": "object"}
+        func_tool.on_invoke_tool = AsyncMock(return_value="result")
+
+        session = MagicMock()
+        session.get_items = AsyncMock(return_value=[])
+        session.add_items = AsyncMock()
+
+        ahm = ActionHistoryManager()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            actions = []
+            async for action in model._generate_with_mcp_stream(
+                prompt="probe",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                max_turns=2,
+                func_tools=[func_tool],
+                action_history_manager=ahm,
+                session=session,
+            ):
+                actions.append(action)
+
+        # final_response still yielded so the caller gets a response.
+        final = next(a for a in actions if a.action_type == "final_response")
+        assert final.output["raw_output"] == ""
+        # Critically: we must NOT have persisted an empty assistant text block.
+        session.add_items.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prompt_list_variant_is_normalized_to_string(self):
+        """The ``prompt`` parameter signature accepts ``List[Dict[str, str]]`` for
+        legacy callers; the native Anthropic ``text`` field requires a string, so
+        list inputs must be serialised rather than handed through verbatim.
+        """
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        model.anthropic_client.messages.create.return_value = _make_response([_make_text_block("ok")])
+
+        list_prompt = [{"role": "user", "content": "structured-input"}]
+        ahm = ActionHistoryManager()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt=list_prompt,
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+            ):
+                pass
+
+        # The user message sent to Anthropic must carry a single string ``text``
+        # field; the list payload should have been json-serialised.
+        call_messages = model.anthropic_client.messages.create.call_args.kwargs["messages"]
+        user_text = call_messages[0]["content"][0]["text"]
+        assert isinstance(user_text, str)
+        assert "structured-input" in user_text
+
+    @pytest.mark.asyncio
     async def test_session_add_items_failure_does_not_break_turn(self):
         """If persistence fails after a successful turn, the user still gets the response."""
         from datus.schemas.action_history import ActionHistoryManager

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -177,7 +177,7 @@ class TestClaudeModelInit:
             model = ClaudeModel(_make_model_config())
         # Verify anthropic.Anthropic constructor was called (client is not merely assigned)
         mock_anthropic_cls.assert_called_once()
-        assert model.anthropic_client is not None
+        assert model.anthropic_client is mock_anthropic_cls.return_value
 
     def test_model_specs_contains_expected_models(self):
         model = _make_claude_model()
@@ -576,8 +576,13 @@ class TestDiagnoseOAuth401:
         cfg = _make_model_config(api_key="sk-ant-regular-key", auth_type="api_key")
         model = _make_claude_model(cfg)
         original_error = Exception("401 Unauthorized")
-        # Should return without raising
-        model._diagnose_oauth_401(original_error)
+        try:
+            result = model._diagnose_oauth_401(original_error)
+        except Exception as exc:  # pragma: no cover - failure path
+            pytest.fail(f"_diagnose_oauth_401 unexpectedly raised for non-OAuth token: {exc}")
+        # Helper is fire-and-return for non-OAuth tokens; verify it did not
+        # mutate state into an exception object or substitute the input error.
+        assert result is None
 
     def test_expired_token_raises_expired_error(self, tmp_path):
         """When credentials file shows expired token, raise CLAUDE_SUBSCRIPTION_TOKEN_EXPIRED."""

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -859,6 +859,142 @@ class TestGenerateWithMcpStream:
         assert actions[1].status == ActionStatus.FAILED
         assert actions[1].output["summary"] == "Failed"
 
+    @pytest.mark.asyncio
+    async def test_session_persists_user_and_assistant_across_turns(self):
+        """OAuth-subscription native path must persist multi-turn history through ``session``.
+
+        Regression: prior to the fix, ``_generate_with_mcp_stream`` ignored the
+        ``session`` parameter entirely, so subsequent turns started from an empty
+        history and the assistant could not see the user's prior message.
+        """
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        # Two independent invocations on the same session — turn 1 then turn 2.
+        resp1 = _make_response([_make_text_block("answer-1")])
+        resp2 = _make_response([_make_text_block("answer-2")])
+        model.anthropic_client.messages.create.side_effect = [resp1, resp2]
+
+        # Session stub mimicking AdvancedSQLiteSession's get_items / add_items contract.
+        session = MagicMock()
+        session_store: list = []
+        session.get_items = AsyncMock(side_effect=lambda: list(session_store))
+        session.add_items = AsyncMock(side_effect=lambda items: session_store.extend(items))
+
+        ahm = ActionHistoryManager()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            # Turn 1
+            async for _ in model._generate_with_mcp_stream(
+                prompt="hello",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+                session=session,
+            ):
+                pass
+
+            # After turn 1: session should contain user "hello" and assistant "answer-1".
+            assert session.add_items.await_count == 1
+            assert any(
+                isinstance(item, dict) and item.get("role") == "user" and "hello" in str(item.get("content"))
+                for item in session_store
+            ), f"user prompt not stored: {session_store}"
+            assert any(
+                isinstance(item, dict) and item.get("role") == "assistant" and "answer-1" in str(item.get("content"))
+                for item in session_store
+            ), f"assistant final not stored: {session_store}"
+
+            # Turn 2
+            async for _ in model._generate_with_mcp_stream(
+                prompt="follow up",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+                session=session,
+            ):
+                pass
+
+        # Anthropic API on turn 2 must have seen the prior turn's history.
+        assert model.anthropic_client.messages.create.call_count == 2
+        turn2_messages = model.anthropic_client.messages.create.call_args_list[1].kwargs["messages"]
+        flattened = str(turn2_messages)
+        assert "hello" in flattened, f"turn2 messages missing turn1 user: {turn2_messages}"
+        assert "answer-1" in flattened, f"turn2 messages missing turn1 assistant: {turn2_messages}"
+        assert "follow up" in flattened
+
+    @pytest.mark.asyncio
+    async def test_session_get_items_failure_falls_back_to_fresh_history(self):
+        """A broken session must not abort the turn — log and start fresh instead."""
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        model.anthropic_client.messages.create.return_value = _make_response([_make_text_block("ok")])
+
+        session = MagicMock()
+        session.get_items = AsyncMock(side_effect=RuntimeError("disk error"))
+        session.add_items = AsyncMock()
+
+        ahm = ActionHistoryManager()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            actions = []
+            async for action in model._generate_with_mcp_stream(
+                prompt="probe",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+                session=session,
+            ):
+                actions.append(action)
+
+        # Native turn still completed despite the load failure.
+        assert any(a.action_type == "final_response" for a in actions)
+        # And we still tried to persist this turn for the next call.
+        assert session.add_items.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_session_add_items_failure_does_not_break_turn(self):
+        """If persistence fails after a successful turn, the user still gets the response."""
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        model.anthropic_client.messages.create.return_value = _make_response([_make_text_block("ok")])
+
+        session = MagicMock()
+        session.get_items = AsyncMock(return_value=[])
+        session.add_items = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        ahm = ActionHistoryManager()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            actions = []
+            async for action in model._generate_with_mcp_stream(
+                prompt="probe",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+                session=session,
+            ):
+                actions.append(action)
+
+        # The final action is still yielded even though persistence raised.
+        assert any(a.action_type == "final_response" for a in actions)
+
 
 class TestGenerateWithMcpWrapper:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Why

CLI multi-turn chat silently lost prior-turn context for any user whose `target` resolved to a Claude provider with `auth_type: subscription` (OAuth subscription token). Symptoms: status bar `ctx` segment stuck at `0K/0K 0%`, follow-up turns answered as if the previous turn never happened, and the on-disk session DB had `agent_messages` rowcount 0 for every chat session under that project.

Tracing the data flow: `_generate_with_mcp_stream` is the OAuth/native Anthropic loop introduced in #487 to support OAuth Bearer tokens (LiteLLM forces `x-api-key`, incompatible with `Authorization: Bearer`). It bypasses openai-agents `Runner.run`, so the `session` argument handed in by `chat_agentic_node` to `generate_with_tools[_stream]` was silently dropped before reaching the loop. Every turn replayed an empty history.

Other providers (`openai_compatible` family, `codex`, plus Claude in `api_key` mode) all go through `Runner.run(... session=session)` and were unaffected.

## Solution

- `_generate_with_mcp_stream` now accepts `session` and:
  - replays prior turns via `await session.get_items()` before the loop
  - persists this turn via `await session.add_items([user_msg, assistant_msg])` after `final_response` is yielded
  - logs and falls back gracefully if either call raises (the chat turn must not abort because of session I/O)
- Threaded `session=session` through `generate_with_mcp`, `generate_with_tools` (line 718-732), and `generate_with_tools_stream` (line 778-792) so the wrappers no longer eat the parameter.
- Dropped the redundant `f"{instruction}\n\n{prompt}"` injection into `messages[0]`. `_build_system_param` already passes `instruction` via Anthropic's `system` parameter — embedding it again would repeat the system text in every persisted turn and pollute future replays.

## Test Cases

Added three unit tests under `TestGenerateWithMcpStream` (all pass; full claude_model suite green at 67/67):

- `test_session_persists_user_and_assistant_across_turns` — drives two turns through a stub session, asserts `add_items` is called and turn 2 sees turn 1's content in the messages payload sent to Anthropic. This is the happy-path regression for the bug.
- `test_session_get_items_failure_falls_back_to_fresh_history` — `get_items` raises; final response is still yielded and the new turn is still persisted.
- `test_session_add_items_failure_does_not_break_turn` — `add_items` raises; final response is still yielded.

End-to-end verified against the real Anthropic API using a `claude_subscription` config: a temporary `AdvancedSQLiteSession` on disk, two real turns, second turn correctly recalled the secret `424242` from turn 1, and `agent_messages` rowcount went from 0 → 2 → 4 across the two turns.

Diff coverage on the patch: 100% (16/16 changed lines).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-turn conversation support with optional session-based history replay and persistence so Claude retains context across turns.

* **Improvements**
  * Ensures the current user prompt is sent cleanly to the API and avoids duplicating system/instruction text; continues producing responses even if history retrieval or persistence fails.

* **Tests**
  * Added tests covering multi-turn persistence, prompt normalization, and resilience when history operations error or yield empty assistant text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->