### PR TITLE
[BugFix] Fix web chatbot streaming and tool handling

### DIFF
--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -694,6 +694,8 @@ class ChatAgenticNode(AgenticNode):
             response_content = ""
             tokens_used = 0
             last_successful_output = None
+            last_successful_tool_summary = ""
+            tool_result_seen = False
 
             execution_mode = "plan" if is_plan_mode and self.plan_hooks else "normal"
 
@@ -706,9 +708,17 @@ class ChatAgenticNode(AgenticNode):
             ):
                 yield stream_action
 
-                # Collect response content from successful actions
-                if stream_action.status == ActionStatus.SUCCESS and stream_action.output:
+                # Collect response content only from assistant text actions.
+                # Tool results are displayed as tool cards and must not become
+                # the final chat response.
+                if (
+                    stream_action.role == ActionRole.ASSISTANT
+                    and stream_action.status == ActionStatus.SUCCESS
+                    and stream_action.output
+                ):
                     if isinstance(stream_action.output, dict):
+                        if stream_action.output.get("is_thinking") is True and not tool_result_seen:
+                            continue
                         last_successful_output = stream_action.output
                         raw_output_value = ""
                         if stream_action.action_type == "message" and "raw_output" in stream_action.output:
@@ -724,6 +734,14 @@ class ChatAgenticNode(AgenticNode):
                             response_content = candidate
                         elif candidate and not isinstance(candidate, str):
                             response_content = str(candidate)
+                elif stream_action.role == ActionRole.TOOL:
+                    if stream_action.status == ActionStatus.SUCCESS:
+                        output = stream_action.output if isinstance(stream_action.output, dict) else {}
+                        summary = output.get("summary") or output.get("status_message") or ""
+                        if isinstance(summary, str) and summary.strip():
+                            last_successful_tool_summary = summary.strip()
+                    if stream_action.status != ActionStatus.PROCESSING:
+                        tool_result_seen = True
 
             # Fallback: extract from last successful output
             if not response_content and last_successful_output:
@@ -738,6 +756,9 @@ class ChatAgenticNode(AgenticNode):
                     response_content = candidate
                 elif candidate and not isinstance(candidate, str):
                     response_content = str(candidate)
+
+            if not response_content and last_successful_tool_summary:
+                response_content = last_successful_tool_summary
 
             # Check summary_report actions for content if still empty
             if not response_content:

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -7,7 +7,7 @@ chat-history retrieval can share the same conversion logic.
 
 import json
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from datus.api.models.cli_models import (
     IMessageContent,
@@ -77,22 +77,90 @@ def _build_tool_result_content(action: ActionHistory) -> List[IMessageContent]:
     output_dict = output if isinstance(output, dict) else None
     short_desc = output_dict.get("summary", "") if output_dict else ""
     function_name, _ = _extract_function(action)
+    result_payload = _normalize_tool_result_payload(
+        output=output,
+        status=action.status,
+        fallback_error=action.messages,
+    )
 
     payload_data = {
         "callToolId": action.action_id.removeprefix("complete_"),
         "toolName": function_name,
         "duration": duration,
         "shortDesc": short_desc,
-        "result": output_dict.get("raw_output", output) if output_dict else output,
+        "result": result_payload,
     }
 
-    error_message = output_dict.get("error") if output_dict else None
-    if not error_message and action.status == ActionStatus.FAILED:
-        error_message = action.messages or "Unknown error"
+    error_message = result_payload.get("error")
     if error_message:
         payload_data["error"] = error_message
 
     return [IMessageContent(type="call-tool-result", payload=payload_data)]
+
+
+def _normalize_tool_result_payload(
+    *,
+    output: Any,
+    status: ActionStatus,
+    fallback_error: str = "",
+) -> dict[str, Any]:
+    """Normalize backend tool output to the web-chatbot tool-result contract."""
+    raw_output = output.get("raw_output", output) if isinstance(output, dict) else output
+    raw_result = _parse_json_object(raw_output)
+
+    success = status != ActionStatus.FAILED
+    error = _extract_error(raw_result)
+    direct_error = _extract_error(output)
+    result = raw_result
+
+    if _is_tool_result_envelope(raw_result):
+        result = raw_result.get("result")
+        raw_success = raw_result.get("success")
+        if raw_success in (0, False) or error:
+            success = False
+        elif raw_success in (1, True):
+            success = True
+
+    if direct_error:
+        success = False
+        error = direct_error
+
+    if status == ActionStatus.FAILED:
+        success = False
+        error = error or fallback_error or "Unknown error"
+
+    payload: dict[str, Any] = {
+        "success": 1 if success else 0,
+        "result": result,
+    }
+    if error:
+        payload["error"] = error
+    return payload
+
+
+def _parse_json_object(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return value
+    return parsed if isinstance(parsed, dict) else value
+
+
+def _is_tool_result_envelope(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if "success" in value or "error" in value:
+        return True
+    return set(value) <= {"result"} and "result" in value
+
+
+def _extract_error(value: Any) -> Optional[str]:
+    if not isinstance(value, dict):
+        return None
+    error = value.get("error")
+    return error.strip() if isinstance(error, str) and error.strip() else None
 
 
 def _build_user_content(action: ActionHistory) -> List[IMessageContent]:
@@ -106,14 +174,16 @@ def _build_user_content(action: ActionHistory) -> List[IMessageContent]:
 def _build_response_content(action: ActionHistory) -> List[IMessageContent]:
     """Build content for final response event."""
     contents = []
-    action_output = action.output
+    action_output = action.output if isinstance(action.output, dict) else {}
     if "sql" in action_output and action_output["sql"]:
         sql = action_output.get("sql")
         sql_payload = {"codeType": "sql", "content": sql}
         contents.append(IMessageContent(type="code", payload=sql_payload))
 
-    resp_payload = {"content": action_output.get("response", "")}
-    contents.append(IMessageContent(type="markdown", payload=resp_payload))
+    response = action_output.get("response") or action_output.get("content") or action_output.get("raw_output") or ""
+    if response:
+        resp_payload = {"content": str(response)}
+        contents.append(IMessageContent(type="markdown", payload=resp_payload))
     return contents
 
 
@@ -245,6 +315,7 @@ def action_to_sse_event(
     stream_thinking: bool = False,
     is_first_delta: bool = True,
     is_update: bool = False,
+    include_final_response: bool = False,
 ) -> Optional[SSEEvent]:
     """Convert an ActionHistory object to an SSEEvent.
 
@@ -268,6 +339,10 @@ def action_to_sse_event(
     is_update : bool
         If True, the event uses UPDATE_MESSAGE to overwrite previously streamed
         deltas with the complete thinking response.
+    include_final_response : bool
+        If True, convert node wrapper actions such as chat_response to markdown.
+        Streaming callers should only set this when no plain assistant response
+        has already been emitted for the turn.
     """
     try:
         role = action.role
@@ -308,7 +383,11 @@ def action_to_sse_event(
         elif (
             role == ActionRole.ASSISTANT and status == ActionStatus.SUCCESS and action.action_type.endswith("_response")
         ):
-            return None  # ignore parsed final response
+            if not include_final_response:
+                return None  # ignore parsed final response
+            contents = _build_response_content(action)
+            if not contents:
+                return None
         elif status == ActionStatus.FAILED:
             contents = _build_error_content(action)
         else:

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -28,6 +28,7 @@ from datus.api.services.action_sse_converter import action_to_sse_event
 from datus.api.services.chat_task_manager import (
     _is_visible_assistant_response,
     _remember_assistant_message,
+    _should_include_final_response,
     _should_skip_duplicate_assistant_message,
 )
 from datus.configuration.agent_config import AgentConfig
@@ -249,13 +250,7 @@ class ChatService:
                         tool_result_seen = False
                         seen_assistant_message_fingerprints: set[str] = set()
                         for action in messages:
-                            include_final_response = (
-                                action.role == ActionRole.ASSISTANT
-                                and action.status == ActionStatus.SUCCESS
-                                and bool(action.action_type)
-                                and action.action_type.endswith("_response")
-                                and not assistant_response_seen
-                            )
+                            include_final_response = _should_include_final_response(action, assistant_response_seen)
                             sse_event = action_to_sse_event(
                                 action,
                                 event_id,

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -25,8 +25,14 @@ from datus.api.models.cli_models import (
     StreamChatInput,
 )
 from datus.api.services.action_sse_converter import action_to_sse_event
+from datus.api.services.chat_task_manager import (
+    _is_visible_assistant_response,
+    _remember_assistant_message,
+    _should_skip_duplicate_assistant_message,
+)
 from datus.configuration.agent_config import AgentConfig
 from datus.models.session_manager import SessionManager, session_matches_agent
+from datus.schemas.action_history import ActionRole, ActionStatus
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -239,13 +245,38 @@ class ChatService:
                 elif role == "assistant":
                     if "actions" in msg:
                         messages = msg["actions"]
+                        assistant_response_seen = False
+                        tool_result_seen = False
+                        seen_assistant_message_fingerprints: set[str] = set()
                         for action in messages:
-                            sse_event = action_to_sse_event(
-                                action, event_id, str(uuid.uuid4()), include_user_message=True
+                            include_final_response = (
+                                action.role == ActionRole.ASSISTANT
+                                and action.status == ActionStatus.SUCCESS
+                                and bool(action.action_type)
+                                and action.action_type.endswith("_response")
+                                and not assistant_response_seen
                             )
-                            event_id += 1
+                            sse_event = action_to_sse_event(
+                                action,
+                                event_id,
+                                str(uuid.uuid4()),
+                                include_user_message=True,
+                                include_final_response=include_final_response,
+                            )
                             if sse_event:
+                                if _should_skip_duplicate_assistant_message(
+                                    action,
+                                    sse_event,
+                                    seen_assistant_message_fingerprints,
+                                ):
+                                    continue
                                 sse_messages.append(sse_event.data.payload)
+                                event_id += 1
+                                _remember_assistant_message(sse_event, seen_assistant_message_fingerprints)
+                                if _is_visible_assistant_response(action, sse_event, tool_result_seen=tool_result_seen):
+                                    assistant_response_seen = True
+                                if action.role == ActionRole.TOOL and action.status != ActionStatus.PROCESSING:
+                                    tool_result_seen = True
                     elif msg.get("content"):
                         sse_messages.append(
                             SSEMessagePayload(

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -117,6 +117,23 @@ def _remember_assistant_message(event: SSEEvent, seen_fingerprints: set[str]) ->
         seen_fingerprints.add(fingerprint)
 
 
+def _should_include_final_response(action, assistant_response_sent: bool) -> bool:
+    """Return True for top-level wrapper responses that should be rendered.
+
+    Sub-agent actions are forwarded with ``depth > 0``. Their own
+    ``*_response`` wrappers must stay inside the tool/sub-agent transcript and
+    must not become the top-level assistant bubble.
+    """
+    return (
+        action.role == ActionRole.ASSISTANT
+        and action.status == ActionStatus.SUCCESS
+        and getattr(action, "depth", 0) == 0
+        and bool(action.action_type)
+        and action.action_type.endswith("_response")
+        and not assistant_response_sent
+    )
+
+
 def _is_visible_assistant_response(action, event: SSEEvent, *, tool_result_seen: bool) -> bool:
     """Return True when an action already emitted user-visible assistant text.
 
@@ -529,13 +546,7 @@ class ChatTaskManager:
                     stream_thinking=effective_stream,
                     is_first_delta=is_first_delta,
                     is_update=bool(is_update),
-                    include_final_response=(
-                        action.role == ActionRole.ASSISTANT
-                        and action.status == ActionStatus.SUCCESS
-                        and bool(action.action_type)
-                        and action.action_type.endswith("_response")
-                        and not assistant_response_sent
-                    ),
+                    include_final_response=_should_include_final_response(action, assistant_response_sent),
                 )
                 if sse:
                     if _should_skip_duplicate_assistant_message(

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -29,7 +29,7 @@ from datus.api.models.cli_models import (
 from datus.api.services.action_sse_converter import action_to_sse_event
 from datus.cli.autocomplete import AtReferenceCompleter
 from datus.configuration.agent_config import AgentConfig
-from datus.schemas.action_history import ActionHistoryManager
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
 from datus.tools.proxy.proxy_tool import apply_proxy_tools
 from datus.utils.loggings import get_logger
@@ -70,6 +70,69 @@ def _delta_message_id(event: SSEEvent) -> str:
     if isinstance(data, SSEMessageData):
         return data.payload.message_id
     return ""
+
+
+def _has_visible_content(event: SSEEvent) -> bool:
+    if event.event != "message" or not isinstance(event.data, SSEMessageData):
+        return False
+    return any(bool(getattr(item, "payload", {}).get("content")) for item in event.data.payload.content)
+
+
+def _assistant_content_fingerprint(event: SSEEvent) -> str:
+    if event.event != "message" or not isinstance(event.data, SSEMessageData):
+        return ""
+    if event.data.payload.role != "assistant":
+        return ""
+    parts = []
+    for item in event.data.payload.content:
+        if item.type not in {"markdown", "thinking", "code"}:
+            continue
+        payload = getattr(item, "payload", {}) or {}
+        content = payload.get("content")
+        if content:
+            parts.append(str(content).strip())
+    return "\n".join(part for part in parts if part)
+
+
+def _should_skip_duplicate_assistant_message(
+    action,
+    event: SSEEvent,
+    seen_fingerprints: set[str],
+) -> bool:
+    if action.role != ActionRole.ASSISTANT or action.status != ActionStatus.SUCCESS:
+        return False
+    if action.action_type == "thinking_delta":
+        return False
+    if event.event != "message" or not isinstance(event.data, SSEMessageData):
+        return False
+    if event.data.type != SSEDataType.CREATE_MESSAGE:
+        return False
+    fingerprint = _assistant_content_fingerprint(event)
+    return bool(fingerprint and fingerprint in seen_fingerprints)
+
+
+def _remember_assistant_message(event: SSEEvent, seen_fingerprints: set[str]) -> None:
+    fingerprint = _assistant_content_fingerprint(event)
+    if fingerprint:
+        seen_fingerprints.add(fingerprint)
+
+
+def _is_visible_assistant_response(action, event: SSEEvent, *, tool_result_seen: bool) -> bool:
+    """Return True when an action already emitted user-visible assistant text.
+
+    Model providers do not agree on whether final text appears as ``response``,
+    ``message`` or a completed thinking chunk. For web de-duping we care about
+    the observable SSE message: after a tool result, any visible assistant text
+    means the wrapper ``chat_response`` would duplicate it.
+    """
+    if action.role != ActionRole.ASSISTANT or action.status != ActionStatus.SUCCESS:
+        return False
+    if not action.action_type or action.action_type == "thinking_delta" or action.action_type.endswith("_response"):
+        return False
+    if not _has_visible_content(event):
+        return False
+    output = action.output if isinstance(action.output, dict) else {}
+    return tool_result_seen or output.get("is_thinking") is not True
 
 
 def _coalesce_deltas(events: list[SSEEvent]) -> list[SSEEvent]:
@@ -434,6 +497,9 @@ class ChatTaskManager:
             action_history = ActionHistoryManager()
             action_count = 0
             seen_delta_action_ids: set[str] = set()
+            assistant_response_sent = False
+            tool_result_seen = False
+            seen_assistant_message_fingerprints: set[str] = set()
 
             async for action in node.execute_stream_with_interactions(action_history):
                 action_count += 1
@@ -463,10 +529,28 @@ class ChatTaskManager:
                     stream_thinking=effective_stream,
                     is_first_delta=is_first_delta,
                     is_update=bool(is_update),
+                    include_final_response=(
+                        action.role == ActionRole.ASSISTANT
+                        and action.status == ActionStatus.SUCCESS
+                        and bool(action.action_type)
+                        and action.action_type.endswith("_response")
+                        and not assistant_response_sent
+                    ),
                 )
                 if sse:
+                    if _should_skip_duplicate_assistant_message(
+                        action,
+                        sse,
+                        seen_assistant_message_fingerprints,
+                    ):
+                        continue
                     await self._push_event(task, sse)
                     event_id += 1
+                    _remember_assistant_message(sse, seen_assistant_message_fingerprints)
+                    if _is_visible_assistant_response(action, sse, tool_result_seen=tool_result_seen):
+                        assistant_response_sent = True
+                    if action.role == ActionRole.TOOL and action.status != ActionStatus.PROCESSING:
+                        tool_result_seen = True
 
             # 7. End event
             token_kwargs: dict = {}

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -53,7 +53,11 @@ def _build_agent_args(args: argparse.Namespace) -> argparse.Namespace:
         max_steps=20,
         workflow="chat_agentic",
         load_cp=None,
-        source="web",
+        # Standalone ``datus --web`` is served by the local backend and is not
+        # hosted inside Datus Studio. Leave source unset so filesystem writes
+        # execute through the backend instead of being proxied to a missing
+        # Studio context.
+        source=None,
         interactive=True,
         output_dir=getattr(args, "output_dir", "./output"),
         log_level="DEBUG" if getattr(args, "debug", False) else "INFO",

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -953,11 +953,21 @@ class OpenAICompatibleModel(LLMBaseModel):
                 # Track tool calls and results for immediate feedback
                 temp_tool_calls = {}  # {call_id: ActionHistory}
                 early_assistant_yielded = False  # Flag to skip duplicate message_output_item
+                tool_call_seen = False
+                tool_output_seen = False
+                final_assistant_yielded = False
+                last_assistant_text = ""
 
                 # Streaming thinking state: accumulate text deltas for real-time output
                 thinking_stream_id: Optional[str] = None
                 thinking_accumulated = ""
                 placeholder_filter = LitellmPlaceholderStreamFilter()
+
+                def mark_assistant_response(text: str, is_thinking: bool) -> None:
+                    nonlocal final_assistant_yielded, last_assistant_text
+                    last_assistant_text = text
+                    if not is_thinking and (not tool_call_seen or tool_output_seen):
+                        final_assistant_yielded = True
 
                 while not result.is_complete:
                     if interrupt_controller and interrupt_controller.is_interrupted:
@@ -1020,6 +1030,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     )
                                     action_history_manager.add_action(thinking_action)
                                     yield thinking_action
+                                    mark_assistant_response(full_text, is_thinking)
                                     early_assistant_yielded = True
                                 # Reset stream state for next content part
                                 thinking_stream_id = None
@@ -1054,6 +1065,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                                             )
                                             action_history_manager.add_action(thinking_action)
                                             yield thinking_action
+                                            mark_assistant_response(full_text, is_thinking)
                                             early_assistant_yielded = True
                             continue
 
@@ -1067,6 +1079,9 @@ class OpenAICompatibleModel(LLMBaseModel):
 
                         # Handle tool call start
                         if item_type == "tool_call_item":
+                            tool_call_seen = True
+                            if not tool_output_seen:
+                                final_assistant_yielded = False
                             raw_item = getattr(event.item, "raw_item", None)
                             if raw_item:
                                 tool_name = getattr(raw_item, "name", None)
@@ -1113,6 +1128,7 @@ class OpenAICompatibleModel(LLMBaseModel):
 
                         # Handle tool call completion
                         elif item_type == "tool_call_output_item":
+                            tool_output_seen = True
                             raw_item = getattr(event.item, "raw_item", None)
                             output_content = getattr(event.item, "output", "")
 
@@ -1236,6 +1252,26 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     )
                                     action_history_manager.add_action(thinking_action)
                                     yield thinking_action
+                                    mark_assistant_response(text_content, is_thinking)
+
+                final_output = getattr(result, "final_output", "") or ""
+                if not isinstance(final_output, str):
+                    final_output = str(final_output)
+                final_output = strip_litellm_placeholder(final_output.strip())
+                if final_output and not final_assistant_yielded and final_output != last_assistant_text:
+                    final_output_preview = final_output if len(final_output) <= 200 else f"{final_output[:200]}..."
+                    final_action = ActionHistory(
+                        action_id=f"assistant_{uuid.uuid4().hex[:8]}",
+                        role=ActionRole.ASSISTANT,
+                        messages=f"Thinking: {final_output_preview}",
+                        action_type="response",
+                        input={},
+                        output={"raw_output": final_output, "is_thinking": False},
+                        status=ActionStatus.SUCCESS,
+                    )
+                    action_history_manager.add_action(final_action)
+                    yield final_action
+                    mark_assistant_response(final_output, False)
 
                 # Save LLM trace if method exists
                 if hasattr(self, "_save_llm_trace"):

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -1080,8 +1080,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                         # Handle tool call start
                         if item_type == "tool_call_item":
                             tool_call_seen = True
-                            if not tool_output_seen:
-                                final_assistant_yielded = False
+                            final_assistant_yielded = False
                             raw_item = getattr(event.item, "raw_item", None)
                             if raw_item:
                                 tool_name = getattr(raw_item, "name", None)

--- a/datus/models/sdk_patches.py
+++ b/datus/models/sdk_patches.py
@@ -11,6 +11,8 @@ back on every assistant-with-tool_calls turn.
 
 Current patches:
 - Kimi/Moonshot reasoning_content support in Converter.items_to_messages()
+- Chat-style ``text`` block normalization for session replay through Chat
+  Completions providers such as DeepSeek.
 - Kimi/Moonshot + DeepSeek reasoning_content preservation in
   litellm.(a)completion() via a streaming cache fallback.
 
@@ -99,6 +101,49 @@ def _normalize_provider_data(item: Any) -> Any:
     return item_copy
 
 
+def _normalize_text_content_blocks(item: Any) -> Any:
+    """Normalize OpenAI Chat ``text`` blocks to Agents SDK input/output blocks.
+
+    The Agents SDK Chat Completions converter accepts ``input_text`` for input
+    messages and ``output_text`` for response output messages. Session replay can
+    contain OpenAI Chat-style ``{"type": "text", "text": ...}`` blocks, which
+    otherwise raise ``UserError("Unknown content: ...")`` before the model is
+    called.
+    """
+    if not isinstance(item, dict):
+        return item
+
+    replacement_type = (
+        "output_text" if item.get("type") == "message" and item.get("role") == "assistant" else "input_text"
+    )
+    changed = False
+    normalized_item = item
+
+    for key in ("content", "output"):
+        value = item.get(key)
+        if not isinstance(value, list):
+            continue
+
+        normalized_value = []
+        value_changed = False
+        for block in value:
+            if isinstance(block, dict) and block.get("type") == "text" and "text" in block:
+                normalized_block = dict(block)
+                normalized_block["type"] = replacement_type
+                normalized_value.append(normalized_block)
+                value_changed = True
+            else:
+                normalized_value.append(block)
+
+        if value_changed:
+            if not changed:
+                normalized_item = copy.deepcopy(item)
+                changed = True
+            normalized_item[key] = normalized_value
+
+    return normalized_item
+
+
 def _preprocess_items_for_reasoning(
     items: str | Iterable[Any],
     model: str | None,
@@ -119,7 +164,7 @@ def _preprocess_items_for_reasoning(
     if isinstance(items, str):
         return items, normalized_model
 
-    normalized_items = [_normalize_provider_data(item) for item in items]
+    normalized_items = [_normalize_text_content_blocks(_normalize_provider_data(item)) for item in items]
     return normalized_items, normalized_model
 
 
@@ -299,9 +344,7 @@ def apply_sdk_patches() -> None:
         _original_items_to_messages = Converter.items_to_messages.__func__  # type: ignore
 
     Converter.items_to_messages = classmethod(_patched_items_to_messages)  # type: ignore
-    logger.info(
-        "Applied SDK patch: Converter.items_to_messages (Kimi/Moonshot reasoning_content + DeepSeek fallback injection)"
-    )
+    logger.info("Applied SDK patch: Converter.items_to_messages (content-block normalization + reasoning_content)")
 
     # Patch 2: litellm.acompletion wrapper (safety net)
     # Re-applies reasoning_content preservation right before API calls,

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -5,7 +5,7 @@
 """Scheduler tools for submitting and managing jobs via Datus scheduler adapters."""
 
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from agents import Tool
 from datus_scheduler_core.models import SchedulerJobPayload
@@ -14,6 +14,7 @@ from datus_scheduler_core.registry import SchedulerAdapterRegistry
 from datus.configuration.agent_config import AgentConfig
 from datus.tools import BaseTool
 from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
+from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
 from datus.utils.exceptions import DatusException
 from datus.utils.loggings import get_logger
 
@@ -26,10 +27,78 @@ class SchedulerTools(BaseTool):
     tool_name = "scheduler_tools"
     tool_description = "Tools for submitting and managing scheduled jobs via Airflow"
 
-    def __init__(self, agent_config: AgentConfig, scheduler_service: Optional[str] = None, **kwargs):
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        scheduler_service: Optional[str] = None,
+        *,
+        strict: Optional[bool] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            strict: When ``True``, SQL file paths outside the project root are
+                rejected with the same fail-closed semantics ``FilesystemFuncTool``
+                uses on EXTERNAL paths. Used by API / gateway surfaces that have
+                no interactive broker. When ``None`` (the default), falls back to
+                ``agent_config.filesystem_strict`` — the process-wide flag that
+                ``ChatTaskManager`` / ``gateway/main.py`` set to ``True`` so every
+                file-touching tool fails closed in server mode without callers
+                having to thread the flag through manually. CLI keeps the
+                permissive default because ``PermissionHooks`` brokers EXTERNAL
+                access interactively. Pass ``True``/``False`` explicitly to
+                override the agent_config default.
+        """
         super().__init__(**kwargs)
         self.agent_config = agent_config
         self.scheduler_service = scheduler_service
+        if strict is None:
+            strict = bool(getattr(agent_config, "filesystem_strict", False))
+        self._strict = strict
+
+    # ── SQL file resolution ───────────────────────────────────────────────
+
+    def _load_sql_content(self, sql_file_path: str) -> Tuple[Optional[str], Optional[FuncToolResult]]:
+        """Resolve and read a SQL file using the same path policy as ``FilesystemFuncTool``.
+
+        Anchors relative paths to ``agent_config.project_root`` so a SQL file
+        produced by ``write_file`` is read back from the same location regardless
+        of process CWD. HIDDEN paths get the same "not found" response
+        ``FilesystemFuncTool`` uses (so ``.datus/sessions/...`` stays invisible).
+        EXTERNAL paths are rejected only in ``strict`` mode.
+
+        Returns:
+            ``(sql_content, None)`` on success, or ``(None, error_result)`` on failure.
+        """
+        try:
+            resolved = classify_path(
+                sql_file_path,
+                root_path=Path(self.agent_config.project_root),
+                current_node=None,
+                datus_home=None,
+            )
+        except Exception as exc:
+            return None, FuncToolResult(success=0, error=f"Failed to resolve SQL file path '{sql_file_path}': {exc}")
+
+        if resolved.zone == PathZone.HIDDEN:
+            return None, FuncToolResult(success=0, error=f"SQL file not found: {resolved.display}")
+        if self._strict and resolved.zone == PathZone.EXTERNAL:
+            return None, FuncToolResult(
+                success=0,
+                error=f"Path outside workspace is not allowed in strict mode: {resolved.display}",
+            )
+
+        sql_path = resolved.resolved
+        try:
+            if not sql_path.exists():
+                return None, FuncToolResult(success=0, error=f"SQL file not found: {resolved.display}")
+            sql_content = sql_path.read_text(encoding="utf-8").strip()
+        except Exception as exc:
+            return None, FuncToolResult(success=0, error=f"Failed to read SQL file '{resolved.display}': {exc}")
+
+        if not sql_content:
+            return None, FuncToolResult(success=0, error=f"SQL file is empty: {resolved.display}")
+        return sql_content, None
 
     def _selected_scheduler_config(self) -> dict:
         return dict(self.agent_config.get_scheduler_config(self.scheduler_service))
@@ -83,16 +152,9 @@ class SchedulerTools(BaseTool):
         Returns:
             FuncToolResult with result containing job_id and status.
         """
-        # Read SQL file
-        try:
-            sql_path = Path(sql_file_path).expanduser()
-            if not sql_path.exists():
-                return FuncToolResult(success=0, error=f"SQL file not found: {sql_file_path}")
-            sql_content = sql_path.read_text(encoding="utf-8").strip()
-            if not sql_content:
-                return FuncToolResult(success=0, error=f"SQL file is empty: {sql_file_path}")
-        except Exception as exc:
-            return FuncToolResult(success=0, error=f"Failed to read SQL file '{sql_file_path}': {exc}")
+        sql_content, err = self._load_sql_content(sql_file_path)
+        if err is not None:
+            return err
 
         # Submit
         try:
@@ -152,15 +214,9 @@ class SchedulerTools(BaseTool):
         Returns:
             FuncToolResult with result containing job_id and status.
         """
-        try:
-            sql_path = Path(sql_file_path).expanduser()
-            if not sql_path.exists():
-                return FuncToolResult(success=0, error=f"SQL file not found: {sql_file_path}")
-            sql_content = sql_path.read_text(encoding="utf-8").strip()
-            if not sql_content:
-                return FuncToolResult(success=0, error=f"SQL file is empty: {sql_file_path}")
-        except Exception as exc:
-            return FuncToolResult(success=0, error=f"Failed to read SQL file '{sql_file_path}': {exc}")
+        sql_content, err = self._load_sql_content(sql_file_path)
+        if err is not None:
+            return err
 
         try:
             adapter = self._get_adapter()
@@ -474,16 +530,9 @@ class SchedulerTools(BaseTool):
         if job_type not in ("sql", "sparksql"):
             return FuncToolResult(success=0, error=f"Unsupported job_type '{job_type}'. Use 'sql' or 'sparksql'.")
 
-        # Read SQL file
-        try:
-            sql_path = Path(sql_file_path).expanduser()
-            if not sql_path.exists():
-                return FuncToolResult(success=0, error=f"SQL file not found: {sql_file_path}")
-            sql_content = sql_path.read_text(encoding="utf-8").strip()
-            if not sql_content:
-                return FuncToolResult(success=0, error=f"SQL file is empty: {sql_file_path}")
-        except Exception as exc:
-            return FuncToolResult(success=0, error=f"Failed to read SQL file '{sql_file_path}': {exc}")
+        sql_content, err = self._load_sql_content(sql_file_path)
+        if err is not None:
+            return err
 
         # Validate conn_id for sql jobs
         if job_type == "sql" and not conn_id:

--- a/datus/utils/message_utils.py
+++ b/datus/utils/message_utils.py
@@ -12,9 +12,13 @@ first element whose ``type`` is ``"user"``.
 
 import json
 import logging
-from typing import List, Optional, TypedDict
+from typing import Any, List, Optional, TypedDict
 
 logger = logging.getLogger(__name__)
+
+# Anthropic / OpenAI content-block ``type`` values that carry plain text
+# inside ``text`` (Anthropic) or ``text``/``content`` (OpenAI) fields.
+_TEXT_BLOCK_TYPES = ("text", "output_text", "input_text")
 
 
 class MessagePart(TypedDict):
@@ -57,15 +61,43 @@ def is_structured_content(content: str) -> bool:
     return False
 
 
-def extract_user_input(content: str) -> str:
+def extract_user_input(content: Any) -> str:
     """Extract the original user input from *content*.
 
-    If the content is in the structured format, returns the **first**
-    ``"user"`` part.  Otherwise returns *content* unchanged (backward-
-    compatible with legacy flat-text messages).
+    Supports three input shapes:
+
+    - **List of provider content blocks** (Anthropic ``[{"type":"text","text":"..."}]``
+      or OpenAI ``output_text``/``input_text`` blocks). Persisted by
+      ``ClaudeModel._generate_with_mcp_stream`` for OAuth multi-turn sessions.
+      Concatenates the text fields with newlines.
+    - **JSON-encoded Datus structured string** ``[{"type":"user","content":"..."}]``.
+      Returns the first ``"user"`` part's ``content``.
+    - **Plain string** (legacy flat-text messages). Returned unchanged.
+
+    Always returns a ``str`` so downstream pydantic models / display layers
+    never receive a list.
     """
+    # Anthropic-style content blocks (list of dicts) — produced by the native
+    # Claude OAuth path. Keep the legacy str-only branches below intact.
+    if isinstance(content, list):
+        texts: List[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            block_type = part.get("type")
+            if block_type in _TEXT_BLOCK_TYPES:
+                text = part.get("text") or part.get("content")
+                if isinstance(text, str):
+                    texts.append(extract_user_input(text) if is_structured_content(text) else text)
+            elif block_type == "user":
+                # Datus structured part stored unencoded as a list element.
+                user_text = part.get("content")
+                if isinstance(user_text, str):
+                    return user_text
+        return "\n".join(texts)
+
     if not is_structured_content(content):
-        return content
+        return content if isinstance(content, str) else ("" if content is None else str(content))
     try:
         parsed = json.loads(content)
         for part in parsed:

--- a/docs/web_chatbot/introduction.md
+++ b/docs/web_chatbot/introduction.md
@@ -15,7 +15,7 @@ datus --web --datasource <your_datasource>
 
 **With Custom Configuration**:
 ```bash
-datus --web --config path/to/agent.yml --datasource snowflake
+datus --web --config path/to/agent.yml --datasource <your_datasource>
 ```
 
 **Custom Port and Host**:

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -1144,6 +1144,118 @@ class TestChatAgenticNodeExecuteStreamWithTools:
         assert isinstance(final_action.output["response"], str)
 
     @pytest.mark.asyncio
+    async def test_execute_stream_uses_tool_summary_when_model_gives_no_response(
+        self, real_agent_config, mock_llm_create
+    ):
+        """Tool raw_output stays out of the final response, but its summary can be used."""
+        from unittest.mock import patch
+
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+        from datus.schemas.action_history import ActionHistory
+
+        node = ChatAgenticNode(
+            node_id="test_tool_raw_output_not_response",
+            description="Test tool raw output is ignored",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+        node.input = ChatNodeInput(user_message="List tables", database="california_schools")
+
+        async def mock_execute(prompt, execution_mode, original_input, action_history_manager, session):
+            action = ActionHistory(
+                action_id="complete_tool",
+                role=ActionRole.TOOL,
+                messages="Tool call: list_tables",
+                action_type="list_tables",
+                input={"function_name": "list_tables", "arguments": "{}"},
+                output={
+                    "success": True,
+                    "raw_output": {
+                        "success": 1,
+                        "error": None,
+                        "result": [{"type": "table", "name": "orders"}],
+                    },
+                    "summary": "1 table: orders",
+                },
+                status=ActionStatus.SUCCESS,
+            )
+            action_history_manager.add_action(action)
+            yield action
+
+        with patch.object(node, "_execute_with_recursive_replan", mock_execute):
+            ahm = ActionHistoryManager()
+            actions = []
+            async for action in node.execute_stream(ahm):
+                actions.append(action)
+
+        final_action = actions[-1]
+        assert final_action.action_type == "chat_response"
+        assert final_action.output["response"] == "1 table: orders"
+
+    @pytest.mark.asyncio
+    async def test_execute_stream_keeps_final_thinking_text_after_tool(self, real_agent_config, mock_llm_create):
+        """Provider-marked thinking text after a tool result can be the final visible answer."""
+        from unittest.mock import patch
+
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+        from datus.schemas.action_history import ActionHistory
+
+        node = ChatAgenticNode(
+            node_id="test_final_thinking_after_tool",
+            description="Test final thinking text after tool is preserved",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+        node.input = ChatNodeInput(user_message="List tables", database="california_schools")
+
+        async def mock_execute(prompt, execution_mode, original_input, action_history_manager, session):
+            pre_tool_thinking = ActionHistory(
+                action_id="thinking_before_tool",
+                role=ActionRole.ASSISTANT,
+                messages="thinking",
+                action_type="response",
+                input={},
+                output={"content": "I should inspect the database first.", "is_thinking": True},
+                status=ActionStatus.SUCCESS,
+            )
+            action_history_manager.add_action(pre_tool_thinking)
+            yield pre_tool_thinking
+
+            tool_action = ActionHistory(
+                action_id="complete_tool",
+                role=ActionRole.TOOL,
+                messages="Tool call: list_tables",
+                action_type="list_tables",
+                input={"function_name": "list_tables", "arguments": "{}"},
+                output={"success": True, "summary": "1 table: orders"},
+                status=ActionStatus.SUCCESS,
+            )
+            action_history_manager.add_action(tool_action)
+            yield tool_action
+
+            final_thinking = ActionHistory(
+                action_id="thinking_after_tool",
+                role=ActionRole.ASSISTANT,
+                messages="final",
+                action_type="response",
+                input={},
+                output={"content": "The database has one table: orders.", "is_thinking": True},
+                status=ActionStatus.SUCCESS,
+            )
+            action_history_manager.add_action(final_thinking)
+            yield final_thinking
+
+        with patch.object(node, "_execute_with_recursive_replan", mock_execute):
+            ahm = ActionHistoryManager()
+            actions = []
+            async for action in node.execute_stream(ahm):
+                actions.append(action)
+
+        final_action = actions[-1]
+        assert final_action.action_type == "chat_response"
+        assert final_action.output["response"] == "The database has one table: orders."
+
+    @pytest.mark.asyncio
     async def test_execute_stream_extracts_string_content_from_action(self, real_agent_config, mock_llm_create):
         """execute_stream correctly extracts string content from action output's content key.
 

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -129,6 +129,7 @@ class TestBuildToolResultContent:
         assert contents[0].payload["duration"] == 3.5
         assert contents[0].payload["callToolId"] == "tool-123"
         assert contents[0].payload["shortDesc"] == "Found 10 rows"
+        assert contents[0].payload["result"] == {"success": 1, "result": "data..."}
 
     def test_zero_duration_when_end_time_missing(self):
         """Duration is 0 when end_time is None."""
@@ -152,6 +153,7 @@ class TestBuildToolResultContent:
         contents = _build_tool_result_content(action)
         assert contents[0].type == "call-tool-result"
         assert contents[0].payload["error"] == "boom"
+        assert contents[0].payload["result"] == {"success": 0, "result": None, "error": "boom"}
 
     def test_failed_tool_falls_back_to_messages(self):
         """Failed tool with no output.error uses action.messages as the error field."""
@@ -164,6 +166,7 @@ class TestBuildToolResultContent:
         )
         contents = _build_tool_result_content(action)
         assert contents[0].payload["error"] == "kaboom"
+        assert contents[0].payload["result"] == {"success": 0, "result": {}, "error": "kaboom"}
 
     def test_successful_tool_omits_error_field(self):
         """Successful tool actions never carry an error field."""
@@ -175,6 +178,69 @@ class TestBuildToolResultContent:
         )
         contents = _build_tool_result_content(action)
         assert "error" not in contents[0].payload
+        assert contents[0].payload["result"] == {"success": 1, "result": "data"}
+
+    def test_successful_func_tool_envelope_is_normalized(self):
+        """Successful FuncToolResult-shaped output keeps the frontend success envelope."""
+        tables = [{"type": "table", "name": "orders"}]
+        action = _make_action(
+            action_id="complete_tool-90",
+            status=ActionStatus.SUCCESS,
+            input={"function_name": "list_tables"},
+            output={
+                "summary": "1 table: orders",
+                "raw_output": {"success": 1, "error": None, "result": tables},
+            },
+        )
+
+        contents = _build_tool_result_content(action)
+
+        assert contents[0].payload["result"] == {"success": 1, "result": tables}
+        assert "error" not in contents[0].payload
+
+    def test_non_envelope_result_key_is_preserved(self):
+        """Ordinary tool output with a result key is wrapped, not destructively unwrapped."""
+        raw_output = {"result": [{"name": "orders"}], "metadata": {"source": "catalog"}}
+        action = _make_action(
+            action_id="complete_tool-93",
+            status=ActionStatus.SUCCESS,
+            input={"function_name": "inspect_catalog"},
+            output={"raw_output": raw_output},
+        )
+
+        contents = _build_tool_result_content(action)
+
+        assert contents[0].payload["result"] == {"success": 1, "result": raw_output}
+
+    def test_successful_json_func_tool_envelope_is_normalized(self):
+        """JSON-string FuncToolResult output is parsed before sending to the web UI."""
+        action = _make_action(
+            action_id="complete_tool-91",
+            status=ActionStatus.SUCCESS,
+            input={"function_name": "list_tables"},
+            output={"raw_output": '{"success": 1, "error": null, "result": [{"name": "orders"}]}'},
+        )
+
+        contents = _build_tool_result_content(action)
+
+        assert contents[0].payload["result"] == {"success": 1, "result": [{"name": "orders"}]}
+
+    def test_failed_func_tool_envelope_uses_nested_error(self):
+        """Failed FuncToolResult-shaped output exposes the nested error to the card."""
+        action = _make_action(
+            action_id="complete_tool-92",
+            status=ActionStatus.FAILED,
+            input={"function_name": "read_query"},
+            output={
+                "summary": "Failed",
+                "raw_output": {"success": 0, "error": "syntax error", "result": None},
+            },
+        )
+
+        contents = _build_tool_result_content(action)
+
+        assert contents[0].payload["error"] == "syntax error"
+        assert contents[0].payload["result"] == {"success": 0, "result": None, "error": "syntax error"}
 
 
 class TestBuildSubagentCompleteContent:
@@ -627,7 +693,7 @@ class TestActionToSSEEvent:
         assert event is not None
         content = event.data.payload.content[0]
         assert content.type == "call-tool-result"
-        assert content.payload["result"] == "plain string result"
+        assert content.payload["result"] == {"success": 1, "result": "plain string result"}
         assert content.payload["shortDesc"] == ""
 
     def test_user_role_excluded_by_default(self):
@@ -652,6 +718,30 @@ class TestActionToSSEEvent:
             action_type="gen_sql_response",
         )
         event = action_to_sse_event(action, event_id=6, message_id="msg-6")
+        assert event is None
+
+    def test_assistant_response_action_included_when_requested(self):
+        """Wrapper final response can be emitted when no plain assistant response was streamed."""
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="chat_response",
+            output={"response": "1 table: orders"},
+        )
+        event = action_to_sse_event(action, event_id=6, message_id="msg-6", include_final_response=True)
+        assert event is not None
+        assert event.data.payload.content[0].type == "markdown"
+        assert event.data.payload.content[0].payload == {"content": "1 table: orders"}
+
+    def test_empty_assistant_response_action_still_skipped_when_requested(self):
+        """Empty wrapper responses do not create blank assistant bubbles."""
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="chat_response",
+            output={"response": ""},
+        )
+        event = action_to_sse_event(action, event_id=6, message_id="msg-6", include_final_response=True)
         assert event is None
 
     def test_interaction_processing_produces_user_interaction(self):

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -190,6 +190,195 @@ class TestChatTaskManagerBehavior:
         assert task.events[0] is event
 
     @pytest.mark.asyncio
+    async def test_run_loop_emits_final_response_when_no_plain_assistant_response(self, real_agent_config):
+        """The web stream must surface chat_response when the model only produced tool cards."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-final"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                yield ActionHistory(
+                    action_id="final",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="done",
+                    input={},
+                    output={"response": "1 table: orders"},
+                    status=ActionStatus.SUCCESS,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-final", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="tables", session_id="s-final"))
+
+        message_events = [event for event in task.events if event.event == "message"]
+        assert len(message_events) == 1
+        content = message_events[0].data.payload.content[0]
+        assert content.type == "markdown"
+        assert content.payload["content"] == "1 table: orders"
+
+    @pytest.mark.asyncio
+    async def test_run_loop_skips_final_response_after_plain_assistant_response(self, real_agent_config):
+        """chat_response is a wrapper and must not duplicate a streamed assistant response."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-dedupe"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                yield ActionHistory(
+                    action_id="plain",
+                    role=ActionRole.ASSISTANT,
+                    action_type="response",
+                    messages="answer",
+                    input={},
+                    output={"raw_output": "1 table: orders", "is_thinking": False},
+                    status=ActionStatus.SUCCESS,
+                )
+                yield ActionHistory(
+                    action_id="final",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="done",
+                    input={},
+                    output={"response": "1 table: orders"},
+                    status=ActionStatus.SUCCESS,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-dedupe", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="tables", session_id="s-dedupe"))
+
+        message_events = [event for event in task.events if event.event == "message"]
+        assert len(message_events) == 1
+        content = message_events[0].data.payload.content[0]
+        assert content.payload["content"] == "1 table: orders"
+
+    @pytest.mark.asyncio
+    async def test_run_loop_skips_wrapper_after_post_tool_thinking_text(self, real_agent_config):
+        """Post-tool visible assistant text suppresses chat_response even if marked as thinking."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-post-tool-thinking"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                yield ActionHistory(
+                    action_id="complete_tool",
+                    role=ActionRole.TOOL,
+                    action_type="list_tables",
+                    messages="Tool call: list_tables",
+                    input={"function_name": "list_tables"},
+                    output={"summary": "3 tables: orders, customers, invoices"},
+                    status=ActionStatus.SUCCESS,
+                )
+                yield ActionHistory(
+                    action_id="assistant_text",
+                    role=ActionRole.ASSISTANT,
+                    action_type="message",
+                    messages="answer",
+                    input={},
+                    output={"raw_output": "3 tables: orders, customers, invoices", "is_thinking": True},
+                    status=ActionStatus.SUCCESS,
+                )
+                yield ActionHistory(
+                    action_id="final",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="done",
+                    input={},
+                    output={"response": "3 tables: orders, customers, invoices"},
+                    status=ActionStatus.SUCCESS,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-post-tool-thinking", asyncio_task=MagicMock())
+
+        await manager._run_loop(
+            task,
+            real_agent_config,
+            StreamChatInput(message="tables", session_id="s-post-tool-thinking"),
+        )
+
+        assistant_messages = [
+            event
+            for event in task.events
+            if event.event == "message"
+            and isinstance(event.data, SSEMessageData)
+            and any(item.type in ("markdown", "thinking") for item in event.data.payload.content)
+        ]
+        assert len(assistant_messages) == 1
+        assistant_text_events = [
+            event
+            for event in assistant_messages
+            if any(
+                item.payload.get("content") == "3 tables: orders, customers, invoices"
+                for item in event.data.payload.content
+            )
+        ]
+        assert len(assistant_text_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_run_loop_dedupes_duplicate_plain_assistant_messages(self, real_agent_config):
+        """Identical visible assistant messages in one turn are emitted once."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-plain-dedupe"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                for action_id, action_type in (("assistant_1", "message"), ("assistant_2", "response")):
+                    yield ActionHistory(
+                        action_id=action_id,
+                        role=ActionRole.ASSISTANT,
+                        action_type=action_type,
+                        messages="answer",
+                        input={},
+                        output={"raw_output": "3 tables: orders, customers, invoices", "is_thinking": False},
+                        status=ActionStatus.SUCCESS,
+                    )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-plain-dedupe", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="tables", session_id="s-plain-dedupe"))
+
+        assistant_text_events = [
+            event
+            for event in task.events
+            if event.event == "message"
+            and isinstance(event.data, SSEMessageData)
+            and any(
+                item.payload.get("content") == "3 tables: orders, customers, invoices"
+                for item in event.data.payload.content
+            )
+        ]
+        assert len(assistant_text_events) == 1
+
+    @pytest.mark.asyncio
     async def test_stop_task_with_no_node_cancels_asyncio_task(self):
         """stop_task cancels asyncio task when node is not set."""
         manager = ChatTaskManager()

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -20,6 +20,7 @@ from datus.api.services.chat_task_manager import (
     _coalesce_deltas,
     _fill_database_context,
     _is_thinking_delta,
+    _should_include_final_response,
 )
 
 
@@ -223,6 +224,72 @@ class TestChatTaskManagerBehavior:
         content = message_events[0].data.payload.content[0]
         assert content.type == "markdown"
         assert content.payload["content"] == "1 table: orders"
+
+    def test_include_final_response_rejects_nested_subagent_response(self):
+        """Depth>0 sub-agent wrappers must not render as top-level answers."""
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        action = ActionHistory(
+            action_id="nested",
+            role=ActionRole.ASSISTANT,
+            action_type="gen_sql_response",
+            messages="nested done",
+            input={},
+            output={"response": "internal sub-agent answer"},
+            status=ActionStatus.SUCCESS,
+            depth=1,
+        )
+
+        assert _should_include_final_response(action, assistant_response_sent=False) is False
+
+    @pytest.mark.asyncio
+    async def test_run_loop_ignores_nested_response_and_emits_parent_response(self, real_agent_config):
+        """A forwarded sub-agent *_response must not hide the parent chat_response."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-nested-response"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                yield ActionHistory(
+                    action_id="nested",
+                    role=ActionRole.ASSISTANT,
+                    action_type="gen_sql_response",
+                    messages="nested done",
+                    input={},
+                    output={"response": "internal sub-agent answer"},
+                    status=ActionStatus.SUCCESS,
+                    depth=1,
+                )
+                yield ActionHistory(
+                    action_id="parent",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="parent done",
+                    input={},
+                    output={"response": "top-level parent answer"},
+                    status=ActionStatus.SUCCESS,
+                    depth=0,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-nested-response", asyncio_task=MagicMock())
+
+        await manager._run_loop(
+            task,
+            real_agent_config,
+            StreamChatInput(message="delegate", session_id="s-nested-response"),
+        )
+
+        message_events = [event for event in task.events if event.event == "message"]
+        assert len(message_events) == 1
+        content = message_events[0].data.payload.content[0]
+        assert content.payload["content"] == "top-level parent answer"
 
     @pytest.mark.asyncio
     async def test_run_loop_skips_final_response_after_plain_assistant_response(self, real_agent_config):

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -31,7 +31,7 @@ class TestBuildAgentArgs:
 
         assert result.datasource == "myns"
         assert result.config == "conf/agent.yml"
-        assert result.source == "web"
+        assert result.source is None
         assert result.interactive is True
         assert result.workflow == "chat_agentic"
         assert result.log_level == "INFO"

--- a/tests/unit_tests/cli/web/test_chatbot_subagent.py
+++ b/tests/unit_tests/cli/web/test_chatbot_subagent.py
@@ -125,6 +125,6 @@ class TestCreateWebApp:
         agent_args = _build_agent_args(args)
         assert agent_args.datasource == "myns"
         assert agent_args.config == "conf/agent.yml"
-        assert agent_args.source == "web"
+        assert agent_args.source is None
         assert agent_args.interactive is True
         assert agent_args.log_level == "DEBUG"

--- a/tests/unit_tests/models/test_openai_compatible_stream_order.py
+++ b/tests/unit_tests/models/test_openai_compatible_stream_order.py
@@ -658,6 +658,26 @@ class TestRawEventEarlyCapture:
         assert assistant_actions[0].output["raw_output"] == "There is 1 table: orders."
 
     @pytest.mark.asyncio
+    async def test_final_output_fallback_resets_for_each_tool_round(self):
+        """Visible text after an earlier tool must not suppress final_output after a later tool."""
+        events = [
+            _make_tool_call_event(call_id="call_first", tool_name="list_tables"),
+            _make_tool_output_event(call_id="call_first"),
+            _make_message_event("First tool is done."),
+            _make_tool_call_event(call_id="call_second", tool_name="describe_table"),
+            _make_tool_output_event(call_id="call_second"),
+        ]
+
+        actions = await _collect_actions(events, final_output="Final answer after the second tool.")
+
+        assistant_actions = [a for a in actions if a.role == ActionRole.ASSISTANT and a.action_type == "response"]
+        assert [a.output["raw_output"] for a in assistant_actions] == [
+            "First tool is done.",
+            "Final answer after the second tool.",
+        ]
+        assert assistant_actions[-1].output["is_thinking"] is False
+
+    @pytest.mark.asyncio
     async def test_thinking_delta_stream_id_shared(self):
         """All thinking_delta actions in one stream share the same action_id."""
         events = [

--- a/tests/unit_tests/models/test_openai_compatible_stream_order.py
+++ b/tests/unit_tests/models/test_openai_compatible_stream_order.py
@@ -146,13 +146,14 @@ def _make_raw_other_event():
 # ---------------------------------------------------------------------------
 
 
-def _build_fake_result(events_list):
+def _build_fake_result(events_list, final_output=""):
     """Build a fake Runner.run_streamed result that yields events then marks complete."""
 
     class FakeResult:
         def __init__(self):
             self._events = list(events_list)
             self._consumed = False
+            self.final_output = final_output
 
         @property
         def is_complete(self):
@@ -172,7 +173,7 @@ def _build_fake_result(events_list):
     return FakeResult()
 
 
-async def _collect_actions(events_list) -> List[ActionHistory]:
+async def _collect_actions(events_list, final_output="") -> List[ActionHistory]:
     """Run the streaming method with fake events and collect yielded actions."""
     from datus.models.openai_compatible import OpenAICompatibleModel
 
@@ -192,7 +193,7 @@ async def _collect_actions(events_list) -> List[ActionHistory]:
     model.default_headers = None
     model.base_url = None
 
-    fake_result = _build_fake_result(events_list)
+    fake_result = _build_fake_result(events_list, final_output=final_output)
 
     action_history_manager = ActionHistoryManager()
 
@@ -622,6 +623,39 @@ class TestRawEventEarlyCapture:
 
         assistant_actions = [a for a in actions if a.role == ActionRole.ASSISTANT and a.action_type == "response"]
         assert len(assistant_actions) == 1  # Only one from content_part.done
+
+    @pytest.mark.asyncio
+    async def test_final_output_is_yielded_after_tool_when_not_streamed(self):
+        """If the SDK only exposes post-tool text as final_output, emit it once."""
+        events = [
+            _make_tool_call_event(call_id="call_final", tool_name="list_tables"),
+            _make_tool_output_event(
+                call_id="call_final",
+                output={"success": 1, "error": None, "result": [{"name": "orders"}]},
+            ),
+        ]
+
+        actions = await _collect_actions(events, final_output="There is 1 table: orders.")
+
+        assistant_actions = [a for a in actions if a.role == ActionRole.ASSISTANT and a.action_type == "response"]
+        assert len(assistant_actions) == 1
+        assert assistant_actions[0].output["raw_output"] == "There is 1 table: orders."
+        assert assistant_actions[0].output["is_thinking"] is False
+
+    @pytest.mark.asyncio
+    async def test_final_output_not_duplicated_when_post_tool_message_streamed(self):
+        """A streamed post-tool assistant message suppresses the final_output fallback."""
+        events = [
+            _make_tool_call_event(call_id="call_final", tool_name="list_tables"),
+            _make_tool_output_event(call_id="call_final"),
+            _make_message_event("There is 1 table: orders."),
+        ]
+
+        actions = await _collect_actions(events, final_output="There is 1 table: orders.")
+
+        assistant_actions = [a for a in actions if a.role == ActionRole.ASSISTANT and a.action_type == "response"]
+        assert len(assistant_actions) == 1
+        assert assistant_actions[0].output["raw_output"] == "There is 1 table: orders."
 
     @pytest.mark.asyncio
     async def test_thinking_delta_stream_id_shared(self):

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -25,6 +25,7 @@ from datus.models.sdk_patches import (
     _is_kimi_model,
     _needs_reasoning_injection,
     _normalize_provider_data,
+    _normalize_text_content_blocks,
     _postprocess_messages_for_reasoning,
     _preprocess_items_for_reasoning,
     _reasoning_content_cache,
@@ -216,6 +217,54 @@ class TestPreprocessItemsForReasoning:
         """None model is handled gracefully."""
         result_items, result_model = _preprocess_items_for_reasoning([], None)
         assert result_model is None
+
+    def test_text_blocks_are_normalized_for_chat_completions_converter(self):
+        """Session replay may contain Chat-style text blocks; SDK input expects input_text."""
+        items = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            }
+        ]
+
+        result_items, _ = _preprocess_items_for_reasoning(items, "deepseek/deepseek-v4-flash")
+
+        assert result_items[0]["content"] == [{"type": "input_text", "text": "hello"}]
+        assert items[0]["content"] == [{"type": "text", "text": "hello"}]
+
+    def test_assistant_response_message_text_blocks_are_normalized_to_output_text(self):
+        """Response output messages expect output_text, not input_text."""
+        items = [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "final answer"}],
+            }
+        ]
+
+        result_items, _ = _preprocess_items_for_reasoning(items, "deepseek/deepseek-v4-flash")
+
+        assert result_items[0]["content"] == [{"type": "output_text", "text": "final answer"}]
+
+
+class TestNormalizeTextContentBlocks:
+    """Tests for _normalize_text_content_blocks."""
+
+    def test_non_dict_item_is_returned_unchanged(self):
+        item = object()
+        assert _normalize_text_content_blocks(item) is item
+
+    def test_item_without_text_blocks_is_returned_unchanged(self):
+        item = {"role": "user", "content": [{"type": "input_text", "text": "hello"}]}
+        assert _normalize_text_content_blocks(item) is item
+
+    def test_tool_output_text_blocks_are_normalized(self):
+        item = {"type": "function_call_output", "output": [{"type": "text", "text": "tool result"}]}
+
+        result = _normalize_text_content_blocks(item)
+
+        assert result["output"] == [{"type": "input_text", "text": "tool result"}]
+        assert item["output"] == [{"type": "text", "text": "tool result"}]
 
 
 class TestReasoningContentStreamWrapper:
@@ -503,6 +552,20 @@ class TestApplyAndRemoveSdkPatches:
         _reasoning_content_cache["test-model"] = "test content"
         remove_sdk_patches()
         assert len(_reasoning_content_cache) == 0
+
+    def test_patched_converter_accepts_session_text_blocks_for_deepseek(self):
+        """Regression for DeepSeek session replay: Chat-style text blocks must not raise Unknown content."""
+        from agents.models.chatcmpl_converter import Converter
+
+        apply_sdk_patches()
+        try:
+            messages = Converter.items_to_messages(
+                [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+                model="deepseek/deepseek-v4-flash",
+            )
+            assert messages == [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+        finally:
+            remove_sdk_patches()
 
     def test_apply_patches_idempotent(self):
         """Calling apply_sdk_patches twice must not re-capture the already-patched

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -40,7 +40,7 @@ from datus.utils.exceptions import DatusException, ErrorCode
 # ── Helpers ────────────────────────────────────────────────────────────────
 
 
-def _make_agent_config(scheduler_config=None):
+def _make_agent_config(scheduler_config=None, project_root="/tmp/datus_test_project_root"):
     cfg = MagicMock()
     if scheduler_config is None:
         cfg.scheduler_config = {
@@ -54,6 +54,14 @@ def _make_agent_config(scheduler_config=None):
     else:
         cfg.scheduler_config = scheduler_config
     cfg.scheduler_services = {"airflow_local": cfg.scheduler_config} if cfg.scheduler_config else {}
+    # ``project_root`` anchors relative SQL paths in scheduler tools (matches
+    # ``FilesystemFuncTool``). MagicMock would otherwise return a child mock
+    # that ``Path()`` cannot consume.
+    cfg.project_root = project_root
+    # Match CLI default: ``filesystem_strict`` is False unless a test opts in.
+    # Without this an auto-attribute MagicMock would be truthy, flipping
+    # SchedulerTools into strict mode and breaking existing EXTERNAL-path tests.
+    cfg.filesystem_strict = False
 
     def _get_scheduler_config(service_name=None):
         if service_name:
@@ -1163,3 +1171,233 @@ class TestSchedulerDeliverableTarget:
         assert result.success == 0
         # On failure the tool sets result=None, so there's no dict to contain a target.
         assert result.result is None or "deliverable_target" not in (result.result or {})
+
+
+# ── Path policy: align with FilesystemFuncTool ───────────────────────────
+
+
+class TestSqlPathPolicy:
+    """``_load_sql_content`` must anchor relative paths to ``agent_config.project_root``,
+    treat HIDDEN paths as not-found (mirroring ``FilesystemFuncTool.read_file``), and
+    fail closed on EXTERNAL paths in strict mode.
+    """
+
+    def _adapter_returning(self, job_id="job_x"):
+        mock_adapter = MagicMock()
+        mock_adapter.submit_job.return_value = _make_scheduled_job(job_id)
+        mock_adapter.update_job.return_value = _make_scheduled_job(job_id)
+        return mock_adapter
+
+    def test_relative_path_anchored_to_project_root(self, tmp_path, monkeypatch):
+        """A relative ``jobs/q.sql`` resolves against ``project_root``, not CWD.
+
+        We set CWD to a different directory to prove relative paths do not
+        accidentally pick up files in the process CWD.
+        """
+        (tmp_path / "jobs").mkdir()
+        (tmp_path / "jobs" / "q.sql").write_text("SELECT 1")
+
+        elsewhere = tmp_path.parent / "elsewhere_cwd"
+        elsewhere.mkdir(exist_ok=True)
+        monkeypatch.chdir(elsewhere)
+
+        tools = SchedulerTools(_make_agent_config(project_root=str(tmp_path)))
+        with patch.object(tools, "_get_adapter", return_value=self._adapter_returning("job_x")):
+            result = tools.submit_sql_job(
+                job_name="job_x",
+                sql_file_path="jobs/q.sql",
+                conn_id="c1",
+            )
+        assert result.success == 1, result.error
+
+    def test_relative_path_uses_project_root_not_cwd(self, tmp_path, monkeypatch):
+        """When the file exists under CWD but NOT under project_root, lookup must fail.
+
+        This is the bug B aims to fix: previously ``Path(...).expanduser()``
+        resolved against CWD, so a file in CWD would be found even if
+        ``write_file`` had landed at ``project_root/jobs/q.sql``.
+        """
+        cwd_dir = tmp_path / "cwd_only"
+        cwd_dir.mkdir()
+        (cwd_dir / "jobs").mkdir()
+        (cwd_dir / "jobs" / "q.sql").write_text("SELECT 1")
+
+        project_root = tmp_path / "real_project"
+        project_root.mkdir()
+        # Note: no ``jobs/q.sql`` under project_root.
+
+        monkeypatch.chdir(cwd_dir)
+        tools = SchedulerTools(_make_agent_config(project_root=str(project_root)))
+        result = tools.submit_sql_job(
+            job_name="job_x",
+            sql_file_path="jobs/q.sql",
+            conn_id="c1",
+        )
+        assert result.success == 0
+        assert "not found" in (result.error or "").lower()
+
+    def test_hidden_zone_returns_not_found(self, tmp_path):
+        """A SQL path under ``.datus/`` (HIDDEN, not whitelisted) is reported as
+        not found — same semantics as ``FilesystemFuncTool.read_file``.
+        """
+        hidden_dir = tmp_path / ".datus" / "sessions"
+        hidden_dir.mkdir(parents=True)
+        sql_file = hidden_dir / "secret.sql"
+        sql_file.write_text("SELECT 1")
+
+        tools = SchedulerTools(_make_agent_config(project_root=str(tmp_path)))
+        result = tools.submit_sql_job(
+            job_name="job_x",
+            sql_file_path=".datus/sessions/secret.sql",
+            conn_id="c1",
+        )
+        assert result.success == 0
+        assert "not found" in (result.error or "").lower()
+
+    def test_strict_rejects_external_path(self, tmp_path):
+        """Strict mode rejects absolute paths outside project_root."""
+        external_root = tmp_path / "outside"
+        external_root.mkdir()
+        sql_file = external_root / "q.sql"
+        sql_file.write_text("SELECT 1")
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        tools = SchedulerTools(
+            _make_agent_config(project_root=str(project_root)),
+            strict=True,
+        )
+        result = tools.submit_sql_job(
+            job_name="job_x",
+            sql_file_path=str(sql_file),
+            conn_id="c1",
+        )
+        assert result.success == 0
+        assert "outside workspace" in (result.error or "").lower()
+
+    def test_non_strict_allows_external_path(self, tmp_path):
+        """Default (non-strict) mode lets absolute paths through, matching
+        ``FilesystemFuncTool.read_file`` (the permission hook handles ASK in CLI).
+        """
+        external_sql = tmp_path / "outside.sql"
+        external_sql.write_text("SELECT 1")
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        tools = SchedulerTools(_make_agent_config(project_root=str(project_root)))
+        with patch.object(tools, "_get_adapter", return_value=self._adapter_returning("job_x")):
+            result = tools.submit_sql_job(
+                job_name="job_x",
+                sql_file_path=str(external_sql),
+                conn_id="c1",
+            )
+        assert result.success == 1, result.error
+
+    def test_sparksql_relative_path_anchored(self, tmp_path, monkeypatch):
+        """``submit_sparksql_job`` shares the same anchoring behavior."""
+        (tmp_path / "jobs").mkdir()
+        (tmp_path / "jobs" / "spark.sql").write_text("SELECT * FROM t")
+
+        elsewhere = tmp_path.parent / "elsewhere_spark_cwd"
+        elsewhere.mkdir(exist_ok=True)
+        monkeypatch.chdir(elsewhere)
+
+        tools = SchedulerTools(_make_agent_config(project_root=str(tmp_path)))
+        with patch.object(tools, "_get_adapter", return_value=self._adapter_returning("spark_x")):
+            result = tools.submit_sparksql_job(
+                job_name="spark_x",
+                sql_file_path="jobs/spark.sql",
+            )
+        assert result.success == 1, result.error
+
+    def test_update_job_relative_path_anchored(self, tmp_path, monkeypatch):
+        """``update_job`` shares the same anchoring behavior."""
+        (tmp_path / "jobs").mkdir()
+        (tmp_path / "jobs" / "u.sql").write_text("SELECT 2")
+
+        elsewhere = tmp_path.parent / "elsewhere_update_cwd"
+        elsewhere.mkdir(exist_ok=True)
+        monkeypatch.chdir(elsewhere)
+
+        tools = SchedulerTools(_make_agent_config(project_root=str(tmp_path)))
+        with patch.object(tools, "_get_adapter", return_value=self._adapter_returning("job_u")):
+            result = tools.update_job(
+                job_id="job_u",
+                sql_file_path="jobs/u.sql",
+                job_name="job_u",
+                conn_id="c1",
+            )
+        assert result.success == 1, result.error
+
+    def test_strict_rejects_external_in_update(self, tmp_path):
+        """Strict mode also gates ``update_job`` (it shares the same helper)."""
+        external_root = tmp_path / "outside"
+        external_root.mkdir()
+        sql_file = external_root / "q.sql"
+        sql_file.write_text("SELECT 1")
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        tools = SchedulerTools(
+            _make_agent_config(project_root=str(project_root)),
+            strict=True,
+        )
+        result = tools.update_job(
+            job_id="job_u",
+            sql_file_path=str(sql_file),
+            job_name="job_u",
+            conn_id="c1",
+        )
+        assert result.success == 0
+        assert "outside workspace" in (result.error or "").lower()
+
+    def test_strict_inherits_from_agent_config_filesystem_strict(self, tmp_path):
+        """When ``strict`` is not passed, fall back to ``agent_config.filesystem_strict``.
+
+        This is how ``ChatTaskManager`` / ``gateway/main.py`` propagate
+        server-mode fail-closed semantics without every construction site
+        having to thread the flag manually.
+        """
+        external_root = tmp_path / "outside"
+        external_root.mkdir()
+        sql_file = external_root / "q.sql"
+        sql_file.write_text("SELECT 1")
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        cfg = _make_agent_config(project_root=str(project_root))
+        cfg.filesystem_strict = True  # API/gateway sets this
+
+        # Note: no explicit ``strict=`` kwarg.
+        tools = SchedulerTools(cfg)
+        result = tools.submit_sql_job(
+            job_name="job_x",
+            sql_file_path=str(sql_file),
+            conn_id="c1",
+        )
+        assert result.success == 0
+        assert "outside workspace" in (result.error or "").lower()
+
+    def test_explicit_strict_false_overrides_agent_config(self, tmp_path):
+        """An explicit ``strict=False`` overrides ``agent_config.filesystem_strict=True``."""
+        external_sql = tmp_path / "outside.sql"
+        external_sql.write_text("SELECT 1")
+
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        cfg = _make_agent_config(project_root=str(project_root))
+        cfg.filesystem_strict = True  # process-wide says strict
+
+        tools = SchedulerTools(cfg, strict=False)  # but caller forces non-strict
+        with patch.object(tools, "_get_adapter", return_value=self._adapter_returning("job_x")):
+            result = tools.submit_sql_job(
+                job_name="job_x",
+                sql_file_path=str(external_sql),
+                conn_id="c1",
+            )
+        assert result.success == 1, result.error

--- a/tests/unit_tests/utils/test_message_utils.py
+++ b/tests/unit_tests/utils/test_message_utils.py
@@ -224,6 +224,134 @@ def test_extract_user_input_type_error_returns_fallback():
 
 
 # ---------------------------------------------------------------------------
+# extract_user_input — provider content-block list shape
+# (Anthropic / OpenAI Responses style, persisted by ClaudeModel OAuth path)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_user_input_anthropic_text_blocks_returns_concatenated_text():
+    """A list of Anthropic ``text`` blocks must collapse to a single str."""
+    blocks = [
+        {"type": "text", "text": "未来两年的趋势是什么？"},
+    ]
+    result = extract_user_input(blocks)
+
+    assert result == "未来两年的趋势是什么？"
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_anthropic_multiple_text_blocks_joined_with_newline():
+    """Multiple ``text`` blocks join with newline so no information is lost."""
+    blocks = [
+        {"type": "text", "text": "first line"},
+        {"type": "text", "text": "second line"},
+    ]
+    result = extract_user_input(blocks)
+
+    assert result == "first line\nsecond line"
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_openai_output_text_block_returns_text():
+    """OpenAI Responses-API ``output_text``/``input_text`` blocks are honoured."""
+    blocks = [
+        {"type": "input_text", "text": "user typed this"},
+        {"type": "output_text", "text": "assistant said this"},
+    ]
+    result = extract_user_input(blocks)
+
+    assert result == "user typed this\nassistant said this"
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_text_block_with_structured_json_extracts_user_part():
+    """Provider text blocks may wrap Datus structured content; titles must show the user text."""
+    structured = build_structured_content(
+        [
+            {"type": "enhanced", "content": "Database Context: mysql"},
+            {"type": "user", "content": "现在有哪些表"},
+        ]
+    )
+    blocks = [{"type": "input_text", "text": structured}]
+
+    result = extract_user_input(blocks)
+
+    assert result == "现在有哪些表"
+    assert "Database Context" not in result
+
+
+def test_extract_user_input_block_list_with_non_text_blocks_skips_them():
+    """Tool-call / tool-result / unrelated blocks are ignored, text is preserved."""
+    blocks = [
+        {"type": "text", "text": "explain"},
+        {"type": "tool_use", "id": "t1", "name": "x", "input": {}},
+        {"type": "tool_result", "tool_use_id": "t1", "content": "ignored"},
+    ]
+    result = extract_user_input(blocks)
+
+    assert result == "explain"
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_block_list_unencoded_user_part_takes_precedence():
+    """A datus ``user`` part stored as a list element returns its content directly."""
+    blocks = [
+        {"type": "text", "text": "noise"},
+        {"type": "user", "content": "原始问题"},
+    ]
+    result = extract_user_input(blocks)
+
+    assert result == "原始问题"
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_empty_list_returns_empty_string():
+    """An empty content list must not raise and must return ``""`` (not the list)."""
+    result = extract_user_input([])
+
+    assert result == ""
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_block_list_with_non_dict_items_is_ignored():
+    """Non-dict items (e.g. raw strings) are skipped without raising."""
+    blocks = [
+        "raw string slipped in",
+        {"type": "text", "text": "real content"},
+        42,
+    ]
+    result = extract_user_input(blocks)
+
+    assert result == "real content"
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_block_list_text_field_non_string_is_skipped():
+    """A block whose ``text`` field is not a string is skipped, not coerced."""
+    blocks = [
+        {"type": "text", "text": ["not", "a", "string"]},
+        {"type": "text", "text": "real text"},
+    ]
+    result = extract_user_input(blocks)
+
+    assert result == "real text"
+    assert isinstance(result, str)
+
+
+def test_extract_user_input_pydantic_compatible_for_chat_session_item_info():
+    """Regression for the warning seen in chat_service.list_sessions:
+
+    ``ChatSessionItemInfo(user_query=extract_user_input(list_content))`` must
+    produce a str, otherwise pydantic raises ``string_type`` validation error.
+    """
+    blocks = [{"type": "text", "text": "anything"}]
+    result = extract_user_input(blocks)
+
+    # Mirror what ChatSessionItemInfo's user_query: Optional[str] enforces.
+    assert isinstance(result, str), f"expected str, got {type(result).__name__}: {result!r}"
+
+
+# ---------------------------------------------------------------------------
 # extract_enhanced_context  (covers lines 86, 92-94)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

`datus --web` and the web chatbot could lose or duplicate assistant output around tool calls. The root causes were mismatched tool-result envelopes, provider-specific final-output streaming behavior, session history content-block shapes, and web filesystem proxy assumptions.

This also addresses related path handling for scheduler SQL files so server-mode file access follows the same workspace policy as filesystem tools.

## Solution

- Normalize tool-result payloads for web-chatbot rendering and history replay.
- Emit provider `final_output` after tool calls when it was not streamed, while avoiding duplicates.
- Preserve final visible assistant text after tool results even when providers mark it as thinking.
- Normalize provider text content blocks for DeepSeek/OpenAI-compatible session replay.
- Extract readable user titles from structured/content-block session history.
- Avoid forcing standalone `datus --web` to default to `source=web`.
- Anchor scheduler SQL file reads to the project root and enforce strict-mode workspace policy.
- Update the web chatbot datasource example to use `<your_datasource>`.

## Test Cases

- `uv run pytest tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/api/services/test_chat_task_manager.py -q`
- `uv run pytest tests/unit_tests/tools/func_tool/test_scheduler_tools.py -q`
- `uv run ruff check datus/agent/node/chat_agentic_node.py tests/unit_tests/agent/node/test_chat_agentic_node.py`
- `uv run ruff check datus/tools/func_tool/scheduler_tools.py tests/unit_tests/tools/func_tool/test_scheduler_tools.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant message deduplication to avoid duplicate responses
  * Strict SQL file path handling option for safer SQL file loading

* **Bug Fixes**
  * Prevented tool-result data from becoming the final chat reply
  * Improved final assistant response selection when streaming finishes
  * More robust tool-result normalization and error reporting

* **Tests**
  * Expanded test coverage for streaming, SSE payloads, SQL path rules, and input extraction

* **Documentation**
  * CLI example updated to use a generic datasource placeholder
<!-- end of auto-generated comment: release notes by coderabbit.ai -->