### PR TITLE
[BugFix] Fix reference template bootstrap parsing

### DIFF
--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -10,6 +10,7 @@ SQL query summarization and classification with support for filesystem tools,
 generation tools, and hooks.
 """
 
+import re
 from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
@@ -591,35 +592,98 @@ class SqlSummaryAgenticNode(AgenticNode):
             content = output.get("content", "")
             logger.info(f"extract_sql_summary_and_output_from_final_resp: {content} (type: {type(content)})")
 
+            def _extract_from_parsed(parsed: object) -> tuple[Optional[str], Optional[str]]:
+                if isinstance(parsed, dict):
+                    sql_summary_file = parsed.get("sql_summary_file")
+                    output_text = parsed.get("output")
+                    if sql_summary_file or output_text:
+                        return sql_summary_file, output_text
+                    logger.warning(f"Parsed JSON but missing expected keys: {parsed.keys()}")
+                return None, None
+
+            def _parse_json_payload(payload: str) -> tuple[Optional[str], Optional[str]]:
+                if not payload:
+                    return None, None
+                try:
+                    import json_repair
+
+                    parsed = json_repair.loads(payload)
+                    return _extract_from_parsed(parsed)
+                except Exception as e:
+                    logger.warning(f"Failed to parse JSON payload: {e}. Content: {payload[:200]}")
+                    return None, None
+
+            def _looks_relevant_json(payload: str) -> bool:
+                return "sql_summary_file" in payload or '"output"' in payload or "'output'" in payload
+
+            def _iter_json_object_candidates(text: str):
+                for start in [i for i, char in enumerate(text) if char == "{"]:
+                    in_string = False
+                    escape = False
+                    quote_char = ""
+                    depth = 0
+                    for pos in range(start, len(text)):
+                        char = text[pos]
+                        if in_string:
+                            if escape:
+                                escape = False
+                            elif char == "\\":
+                                escape = True
+                            elif char == quote_char:
+                                in_string = False
+                            continue
+                        if char in ('"', "'"):
+                            in_string = True
+                            quote_char = char
+                        elif char == "{":
+                            depth += 1
+                        elif char == "}":
+                            depth -= 1
+                            if depth == 0:
+                                candidate = text[start : pos + 1]
+                                if _looks_relevant_json(candidate):
+                                    yield candidate
+                                break
+
+            def _iter_json_payload_candidates(text: str):
+                # Prefer fenced blocks when present, but accept any fence label.
+                for match in re.finditer(r"```[^\n`]*\n?(.*?)```", text, flags=re.DOTALL | re.IGNORECASE):
+                    block = match.group(1).strip()
+                    if _looks_relevant_json(block):
+                        yield block
+
+                stripped = text.strip()
+                if stripped.startswith("{"):
+                    yield stripped
+
+                yield from _iter_json_object_candidates(text)
+
+                cleaned_json = strip_json_str(text)
+                if cleaned_json and cleaned_json != text:
+                    yield cleaned_json
+
             # Case 1: content is already a dict (most common)
             if isinstance(content, dict):
-                sql_summary_file = content.get("sql_summary_file")
-                output_text = content.get("output")
+                sql_summary_file, output_text = _extract_from_parsed(content)
                 if sql_summary_file or output_text:
                     logger.debug(f"Extracted from dict: sql_summary_file={sql_summary_file}")
                     return sql_summary_file, output_text
-                else:
-                    logger.warning(f"Dict format but missing expected keys: {content.keys()}")
 
             # Case 2: content is a JSON string (possibly wrapped in markdown code blocks)
             elif isinstance(content, str) and content.strip():
-                # Use strip_json_str to handle markdown code blocks and extract JSON
-                cleaned_json = strip_json_str(content)
-                if cleaned_json:
-                    try:
-                        import json_repair
+                # Free-form explanations can contain Jinja/SQL braces before the
+                # final JSON. Try all plausible JSON payloads instead of assuming
+                # the first "{" starts the response object.
+                for candidate in _iter_json_payload_candidates(content):
+                    sql_summary_file, output_text = _parse_json_payload(candidate)
+                    if sql_summary_file or output_text:
+                        logger.debug(f"Extracted from response JSON candidate: sql_summary_file={sql_summary_file}")
+                        return sql_summary_file, output_text
 
-                        parsed = json_repair.loads(cleaned_json)
-                        if isinstance(parsed, dict):
-                            sql_summary_file = parsed.get("sql_summary_file")
-                            output_text = parsed.get("output")
-                            if sql_summary_file or output_text:
-                                logger.debug(f"Extracted from JSON string: sql_summary_file={sql_summary_file}")
-                                return sql_summary_file, output_text
-                            else:
-                                logger.warning(f"Parsed JSON but missing expected keys: {parsed.keys()}")
-                    except Exception as e:
-                        logger.warning(f"Failed to parse cleaned JSON: {e}. Cleaned content: {cleaned_json[:200]}")
+                match = re.search(r'"sql_summary_file"\s*:\s*"([^"]+)"', content)
+                if match:
+                    logger.debug(f"Extracted sql_summary_file via regex: {match.group(1)}")
+                    return match.group(1), None
 
             logger.warning(f"Could not extract sql_summary_file from response. Content type: {type(content)}")
             return None, None

--- a/datus/storage/reference_template/README.md
+++ b/datus/storage/reference_template/README.md
@@ -5,11 +5,11 @@ This module handles the storage, processing, and analysis of parameterized Jinja
 ## Data Flow
 
 ```text
-Template Files → File Processor → Parameter Analysis → LLM Analysis → Storage
-      ↓                ↓                ↓                   ↓            ↓
-  Split blocks     Validation      Type inference        Metadata     Vector DB
-  Extract params   + Cleaning     + column resolution   Extraction    + Search
-                                  + sample values
+Template Files → File Processor → LLM Analysis → Parameter Analysis → Storage
+      ↓                ↓              ↓                  ↓             ↓
+  Split blocks     Validation     Metadata          Type inference   Vector DB
+  Extract params   + Cleaning     Extraction        + descriptions   + Search
+                                   via SQL summary   + sample values
 ```
 
 ### Processing Pipeline
@@ -17,9 +17,9 @@ Template Files → File Processor → Parameter Analysis → LLM Analysis → St
 1. **File Processing**: Extract template blocks from `.j2`/`.jinja2` files (split by `;`)
 2. **Parameter Extraction**: Use `jinja2.meta.find_undeclared_variables()` to discover parameters
 3. **Validation**: Validate Jinja2 syntax for each template block
-4. **Parameter Analysis**: Static SQL AST analysis to determine parameter types, resolve column references, and query sample values from the database
-5. **LLM Analysis**: Extract business metadata (name, summary, search_text, tags, subject_tree) using SqlSummaryAgenticNode
-6. **Merge**: Combine statically-analyzed parameter types with LLM-generated descriptions
+4. **LLM Analysis**: Extract business metadata (name, summary, search_text, tags, subject_tree) using SqlSummaryAgenticNode in workflow mode with `storage_type="reference_template"`
+5. **Parameter Analysis**: Static SQL AST analysis to determine parameter types, resolve column references, and query sample values from the database
+6. **Merge**: Combine statically-analyzed parameter types with LLM-generated descriptions and keyword allowed values
 7. **Storage**: Store enriched data in vector store for semantic search
 8. **Indexing**: Create search indices for efficient retrieval
 
@@ -94,13 +94,14 @@ The alias `T1` is resolved to `satscores`, producing `column_ref: "satscores.Cou
 
 ## Agent Tools
 
-Three tools are available for LLM agents to interact with reference templates:
+Reference template tools are available only when the reference template store contains entries. The full tool set is:
 
 | Tool | Purpose |
 |------|---------|
-| `search_reference_template` | Semantic search by natural language intent. Returns name, parameters, summary, tags (no template body). |
+| `search_reference_template` | Semantic search by natural language intent. Returns name, raw template body, parameters, summary, and tags. |
 | `get_reference_template` | Exact lookup by subject_path + name. Returns full template, parameters with sample_values, summary. |
-| `execute_reference_template` | Render template with parameters AND execute the SQL, returning query results in one step. |
+| `render_reference_template` | Render a template with parameters and return the SQL without executing it. |
+| `execute_reference_template` | Render template with parameters AND execute the SQL, returning query results in one step. Exposed only when the tool instance has a database function tool. |
 
 ### Dedicated System Prompt: `ref_tpl`
 
@@ -130,9 +131,9 @@ agentic_nodes:
 
 ### Performance Tuning
 
-- **`pool_size`**: Number of concurrent async tasks for LLM analysis (default: 1)
+- **`pool_size`**: Number of concurrent async tasks for LLM analysis. CLI default is `4`; the storage initializer default is `1`.
 - **Parallel processing**: Items are processed asynchronously with semaphore-controlled concurrency
-- Requires `--subject_tree` for parallel mode; without it, falls back to serial (pool_size=1)
+- Requires `--subject_tree` for parallel mode; without it, learning mode falls back to serial (`pool_size=1`) to avoid subject tree race conditions.
 
 ## Data Schema
 
@@ -150,6 +151,7 @@ agentic_nodes:
 - Templates are validated for Jinja2 syntax correctness
 - Parameters are automatically extracted from `{{ variable }}` expressions
 - A single file can contain multiple templates separated by `;`
+- Put each template delimiter at the end of a statement line; multiple templates on the same physical line are not reliably split.
 
 ### Output Format (after bootstrap)
 ```python

--- a/datus/storage/reference_template/reference_template_init.py
+++ b/datus/storage/reference_template/reference_template_init.py
@@ -4,7 +4,9 @@
 
 import asyncio
 import json
+import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
@@ -55,6 +57,29 @@ TEMPLATE_EXTRA_INSTRUCTIONS = (
     '    description: "Maximum number of rows to return"\n'
     "```"
 )
+
+
+def _resolve_generated_summary_file_path(
+    agent_config: AgentConfig,
+    node: SqlSummaryAgenticNode,
+    sql_summary_file: str,
+) -> Optional[Path]:
+    """Resolve a generated SQL summary path reported by the workflow node.
+
+    Workflow-mode generation accepts several model-reported path shapes:
+    bare filenames, ``sql_summaries/...``, ``subject/sql_summaries/...``,
+    and absolute paths inside the SQL-summary sandbox. Use the same resolver
+    as ``SqlSummaryAgenticNode._save_to_db`` so reference-template bootstrap
+    does not accidentally duplicate path prefixes when it reads the YAML back.
+    """
+    knowledge_base_dir = getattr(node, "knowledge_base_dir", None)
+    if isinstance(knowledge_base_dir, (str, os.PathLike)) and not hasattr(knowledge_base_dir, "mock_calls"):
+        from datus.cli.generation_hooks import resolve_kb_sandbox_path
+
+        resolved = resolve_kb_sandbox_path(sql_summary_file, "sql_summary", str(knowledge_base_dir))
+        return Path(resolved) if resolved else None
+
+    return Path(agent_config.path_manager.sql_summary_path()) / sql_summary_file
 
 
 def _enrich_dimension_sample_values(params: list, agent_config: AgentConfig) -> None:
@@ -239,7 +264,10 @@ async def process_template_item(
 
         logger.info(f"Generated template summary: {sql_summary_file}")
 
-        file_path = agent_config.path_manager.sql_summary_path() / sql_summary_file
+        file_path = _resolve_generated_summary_file_path(agent_config, node, sql_summary_file)
+        if file_path is None:
+            logger.warning(f"SQL summary file rejected by sandbox check: {sql_summary_file!r}")
+            return None
         import yaml
 
         try:

--- a/docs/knowledge_base/reference_template.md
+++ b/docs/knowledge_base/reference_template.md
@@ -36,14 +36,14 @@ datus-agent bootstrap-kb \
 
 ### Key Parameters
 
-| Parameter | Required | Description | Example |
-|-----------|----------|-------------|---------|
+| Parameter | Required for reference_template | Description | Example |
+|-----------|---------------------------------|-------------|---------|
 | `--datasource` | Yes | Database datasource | `analytics_db` |
-| `--components` | Yes | Components to initialize | `reference_template` |
-| `--template_dir` | Yes | Directory containing J2 template files | `/templates/queries` |
-| `--kb_update_strategy` | Yes | Update strategy | `overwrite`/`incremental` |
+| `--components` | Yes | Components to initialize. Set this to `reference_template`; otherwise the reference template component is not initialized. | `reference_template` |
+| `--template_dir` | Yes | Directory or single file containing J2 template files. If omitted, the reference template store is initialized empty and no template entries are loaded. | `/templates/queries` |
+| `--kb_update_strategy` | No | Update strategy. Defaults to `check`; use `overwrite` or `incremental` when loading templates intentionally. | `overwrite`/`incremental` |
 | `--validate-only` | No | Only validate, don't store | |
-| `--pool_size` | No | Concurrent processing threads (default: 1) | `8` |
+| `--pool_size` | No | Concurrent processing threads. CLI default is `4`; learning mode without `--subject_tree` forces effective concurrency to `1`. | `8` |
 | `--subject_tree` | No | Predefined subject tree categories | `Analytics/User/Activity,Reporting/Sales/Monthly` |
 
 ### Subject Tree Categorization
@@ -113,7 +113,7 @@ Semicolons inside Jinja2 block structures (`{% if %}`, `{% for %}`, etc.) are no
 
 ### Format Requirements
 
-1. **Semicolon Delimiter**: Templates in a multi-template file must be separated by `;`
+1. **Semicolon Delimiter**: Templates in a multi-template file must be separated by `;`. Put each template delimiter at the end of a statement line; multiple templates on the same physical line are not reliably split.
 2. **Valid Jinja2**: Templates must pass Jinja2 syntax validation
 3. **SQL Content**: Templates should produce valid SQL when rendered
 
@@ -175,15 +175,15 @@ The bootstrap process produces:
 ]
 ```
 
-This allows the LLM to know exactly what values are valid for each parameter when calling `execute_reference_template`.
+When a parameter's SQL context can be resolved, this gives the LLM concrete candidate values or allowed keywords to use when calling `execute_reference_template`. Parameters whose context cannot be inferred are still stored, but may not include sample values.
 
 ## Tools
 
-After bootstrapping, four tools are available to agents:
+After bootstrapping, template tools are available only when the reference template store contains entries. The complete tool set is:
 
 ### `search_reference_template`
 
-Search templates by natural language query. Returns matching templates with parameter metadata (name, type, summary, tags). Does not return the template body to save tokens.
+Search templates by natural language query. Returns matching templates with name, raw template body, parameter metadata, summary, and tags.
 
 ### `get_reference_template`
 
@@ -197,7 +197,7 @@ Render a template with provided parameter values using Jinja2. Returns the final
 
 Render a template and immediately execute the resulting SQL (read-only). Combines `render_reference_template` + `read_query` in a single step. Returns both the rendered SQL and the query result rows.
 
-Note: `execute_reference_template` creates an internal database connection automatically — you do not need to configure `db_tools` separately when using template tools.
+Note: `execute_reference_template` is exposed only when the tool instance has a database function tool. Chat and GenSQL nodes create or reuse a DB tool when wiring reference template tools, so they normally expose `execute_reference_template` when templates exist. Direct `ReferenceTemplateTools` instances without `db_func_tool` expose only search/get/render.
 
 ## Template-Only Mode
 
@@ -222,11 +222,11 @@ In this mode, the agent:
 ## Data Flow
 
 ```text
-Template Files (.j2)  →  File Processor  →  Parameter Analysis  →  LLM Analysis  →  Storage  →  Tools
-       |                       |                   |                    |               |           |
-   Parse blocks          Validate J2          Infer types           Generate        Vector DB   search/
-   Extract params        Extract params      Resolve aliases        summary &       + Indices  get/execute
-   Split by ;            Filter invalid      Query sample values    search_text
+Template Files (.j2)  →  File Processor  →  LLM Analysis  →  Parameter Analysis  →  Storage  →  Tools
+       |                       |                  |                    |                |           |
+   Parse blocks          Validate J2         Generate summary,   Infer types,       Vector DB   search/
+   Extract params        Extract params      search_text,        merge descriptions + Indices  get/render/
+   Split by ;            Filter invalid      subject_tree        query sample values            execute
 ```
 
 ### Processing Pipeline
@@ -235,9 +235,9 @@ Template Files (.j2)  →  File Processor  →  Parameter Analysis  →  LLM Ana
 2. **Block Splitting**: Split multi-template files by semicolons (respecting Jinja2 blocks)
 3. **Validation**: Validate Jinja2 syntax for each template block
 4. **Parameter Extraction**: Extract undeclared variables via `jinja2.meta.find_undeclared_variables()`
-5. **Parameter Analysis**: Infer parameter types, resolve table aliases to real table names, and query sample values from the database
-6. **LLM Analysis**: Generate business summary, search text, and parameter descriptions using SqlSummaryAgenticNode
-7. **Merge**: Combine statically-analyzed parameter types with LLM-generated descriptions
+5. **LLM Analysis**: Generate business summary, search text, subject tree, tags, and parameter descriptions using `SqlSummaryAgenticNode` in workflow mode with `storage_type="reference_template"`
+6. **Parameter Analysis**: Infer parameter types, resolve table aliases to real table names, and query sample values from the database
+7. **Merge**: Combine statically-analyzed parameter types with LLM-generated descriptions and keyword allowed values
 8. **Storage**: Store enriched template data in vector store
 9. **Indexing**: Create search indices for efficient retrieval
 

--- a/docs/knowledge_base/reference_template.zh.md
+++ b/docs/knowledge_base/reference_template.zh.md
@@ -36,14 +36,14 @@ datus-agent bootstrap-kb \
 
 ### 关键参数
 
-| 参数 | 必需 | 描述 | 示例 |
-|------|------|------|------|
+| 参数 | 使用 reference_template 时必需 | 描述 | 示例 |
+|------|-------------------------------|------|------|
 | `--datasource` | 是 | 数据库数据源 | `analytics_db` |
-| `--components` | 是 | 要初始化的组件 | `reference_template` |
-| `--template_dir` | 是 | 包含 J2 模板文件的目录 | `/templates/queries` |
-| `--kb_update_strategy` | 是 | 更新策略 | `overwrite`/`incremental` |
+| `--components` | 是 | 要初始化的组件。需要设置为 `reference_template`；否则不会初始化 reference template 组件。 | `reference_template` |
+| `--template_dir` | 是 | 包含 J2 模板文件的目录或单个文件。省略时只会初始化空的 reference template 存储，不会加载模板条目。 | `/templates/queries` |
+| `--kb_update_strategy` | 否 | 更新策略。默认是 `check`；明确加载模板时通常使用 `overwrite` 或 `incremental`。 | `overwrite`/`incremental` |
 | `--validate-only` | 否 | 仅验证，不存储 | |
-| `--pool_size` | 否 | 并发处理线程数（默认：1） | `8` |
+| `--pool_size` | 否 | 并发处理线程数。CLI 默认值是 `4`；不传 `--subject_tree` 的学习模式会把实际并发强制降为 `1`。 | `8` |
 | `--subject_tree` | 否 | 预定义主题树分类 | `Analytics/User/Activity,Reporting/Sales/Monthly` |
 
 ### 主题树分类
@@ -114,7 +114,7 @@ Jinja2 块结构（`{% if %}`、`{% for %}` 等）内部的分号不会被视为
 
 ### 格式要求
 
-1. **分号分隔符**：多模板文件中的模板必须用 `;` 分隔
+1. **分号分隔符**：多模板文件中的模板必须用 `;` 分隔。建议将每个模板的分隔分号放在语句行末；同一物理行上放多个模板时不会被可靠拆分。
 2. **合法 Jinja2**：模板必须通过 Jinja2 语法验证
 3. **SQL 内容**：模板渲染后应产生合法的 SQL
 
@@ -176,15 +176,15 @@ Bootstrap 过程会生成：
 ]
 ```
 
-这使得 LLM 在调用 `execute_reference_template` 时能够准确知道每个参数应该填什么值。
+当参数的 SQL 上下文可以被解析时，这些元数据会为 LLM 提供候选值或合法关键字，便于调用 `execute_reference_template`。无法推断上下文的参数仍会被存储，但可能不会包含候选值。
 
 ## 工具
 
-Bootstrap 完成后，Agent 可使用四个工具：
+Bootstrap 完成后，只有当 reference template 存储中存在模板条目时，Agent 才会暴露模板工具。完整工具集包括：
 
 ### `search_reference_template`
 
-通过自然语言查询搜索模板。返回匹配的模板元数据（名称、类型、摘要、标签），不返回模板正文以节省 token。
+通过自然语言查询搜索模板。返回匹配模板的名称、原始模板正文、参数元数据、摘要和标签。
 
 ### `get_reference_template`
 
@@ -198,7 +198,7 @@ Bootstrap 完成后，Agent 可使用四个工具：
 
 渲染模板并立即执行生成的 SQL（只读）。将 `render_reference_template` + `read_query` 合并为一步操作。返回渲染后的 SQL 和查询结果行。
 
-注意：`execute_reference_template` 会自动创建内部数据库连接 — 使用模板工具时不需要单独配置 `db_tools`。
+注意：只有当工具实例持有数据库函数工具时，`execute_reference_template` 才会暴露。Chat 和 GenSQL 节点在挂载 reference template tools 时会创建或复用 DB tool，因此模板存在时通常会暴露 `execute_reference_template`。直接创建且未传入 `db_func_tool` 的 `ReferenceTemplateTools` 实例只会暴露 search/get/render。
 
 ## 纯模板模式
 
@@ -223,11 +223,11 @@ agentic_nodes:
 ## 数据流
 
 ```text
-模板文件 (.j2)  →  文件处理器  →  参数分析  →  LLM 分析  →  存储  →  工具
+模板文件 (.j2)  →  文件处理器  →  LLM 分析  →  参数分析  →  存储  →  工具
      |                |             |             |          |         |
-  解析模板块      验证 J2 语法   推断类型       生成摘要   向量数据库  search/
-  提取参数        过滤无效模板   解析别名      和搜索文本   + 索引     get/execute
-  分号分割                     查询候选值
+  解析模板块      验证 J2 语法   生成摘要、    推断类型、  向量数据库  search/
+  提取参数        过滤无效模板   搜索文本、    合并描述    + 索引     get/render/
+  分号分割                       主题树       查询候选值             execute
 ```
 
 ### 处理流程
@@ -236,9 +236,9 @@ agentic_nodes:
 2. **模板分割**：按分号分割多模板文件（尊重 Jinja2 块结构）
 3. **语法验证**：验证每个模板块的 Jinja2 语法
 4. **参数提取**：通过 `jinja2.meta.find_undeclared_variables()` 提取未声明变量
-5. **参数分析**：推断参数类型，将表别名解析为真实表名，从数据库查询候选值
-6. **LLM 分析**：使用 SqlSummaryAgenticNode 生成业务摘要、搜索文本和参数描述
-7. **合并**：将静态分析的参数类型与 LLM 生成的描述合并
+5. **LLM 分析**：使用 `SqlSummaryAgenticNode` 的 workflow 模式生成业务摘要、搜索文本、主题树、标签和参数描述，并设置 `storage_type="reference_template"`
+6. **参数分析**：推断参数类型，将表别名解析为真实表名，从数据库查询候选值
+7. **合并**：将静态分析的参数类型与 LLM 生成的描述、关键字合法取值合并
 8. **存储入库**：将增强后的模板数据存入向量数据库
 9. **索引构建**：创建搜索索引以支持高效检索
 

--- a/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
@@ -312,6 +312,112 @@ class TestSqlSummaryExtractMethods:
         assert file_name == "summary.yaml"
         assert output == "Generated"
 
+    def test_extract_sql_summary_from_fenced_json_after_jinja_text(self, real_agent_config, mock_llm_create):
+        """Jinja placeholders before final JSON should not confuse extraction."""
+        node = _create_node(real_agent_config)
+
+        content = """
+SQL summary file has been created.
+
+The template contains `{{period_start_date}}` and `{{period_end_date}}`.
+
+```json
+{
+  "sql_summary_file": "subject/sql_summaries/summary.yaml",
+  "output": "Generated"
+}
+```
+"""
+
+        file_name, output = node._extract_sql_summary_and_output_from_response({"content": content})
+        assert file_name == "subject/sql_summaries/summary.yaml"
+        assert output == "Generated"
+
+    def test_extract_sql_summary_from_unfenced_json_after_jinja_text(self, real_agent_config, mock_llm_create):
+        """Free-form text may include Jinja braces before an unfenced final JSON object."""
+        node = _create_node(real_agent_config)
+
+        content = """
+Generated a summary for:
+{% if product_tag_id %}
+SELECT * FROM campaign WHERE FIND_IN_SET('{{ product_tag_id }}', ac_tags);
+{% endif %}
+
+Result:
+{"sql_summary_file": "sql_summaries/template_summary.yaml", "output": "Generated"}
+"""
+
+        file_name, output = node._extract_sql_summary_and_output_from_response({"content": content})
+        assert file_name == "sql_summaries/template_summary.yaml"
+        assert output == "Generated"
+
+    def test_extract_sql_summary_from_generic_fenced_block(self, real_agent_config, mock_llm_create):
+        """The parser should not require the markdown fence language to be exactly json."""
+        node = _create_node(real_agent_config)
+
+        content = """
+Done.
+
+```text
+{
+  "sql_summary_file": "summary_from_text_fence.yaml",
+  "output": "Generated"
+}
+```
+"""
+
+        file_name, output = node._extract_sql_summary_and_output_from_response({"content": content})
+        assert file_name == "summary_from_text_fence.yaml"
+        assert output == "Generated"
+
+    def test_extract_sql_summary_from_escaped_json_object(self, real_agent_config, mock_llm_create):
+        """JSON scanning should handle escaped quotes before closing the object."""
+        node = _create_node(real_agent_config)
+
+        content = (
+            'Done: {"note": "template mentions \\"quoted\\" text and C:\\\\tmp", '
+            '"sql_summary_file": "escaped_summary.yaml", "output": "Generated"}'
+        )
+
+        file_name, output = node._extract_sql_summary_and_output_from_response({"content": content})
+        assert file_name == "escaped_summary.yaml"
+        assert output == "Generated"
+
+    def test_extract_sql_summary_reports_missing_keys(self, real_agent_config, mock_llm_create):
+        """Relevant-looking JSON without expected keys should not produce a fabricated path."""
+        node = _create_node(real_agent_config)
+
+        file_name, output = node._extract_sql_summary_and_output_from_response(
+            {"content": '{"output_file": "wrong.yaml"}'}
+        )
+
+        assert file_name is None
+        assert output is None
+
+    def test_extract_sql_summary_handles_json_parse_failure(self, real_agent_config, mock_llm_create):
+        """A malformed relevant payload should fall through cleanly when JSON parsing fails."""
+        from unittest.mock import patch
+
+        node = _create_node(real_agent_config)
+
+        with patch("json_repair.loads", side_effect=ValueError("bad json")):
+            file_name, output = node._extract_sql_summary_and_output_from_response(
+                {"content": "```text\n{'output': 'Generated'}\n```"}
+            )
+
+        assert file_name is None
+        assert output is None
+
+    def test_extract_sql_summary_uses_regex_fallback(self, real_agent_config, mock_llm_create):
+        """If no valid JSON object exists, the legacy sql_summary_file fallback still works."""
+        node = _create_node(real_agent_config)
+
+        content = 'Summary saved. "sql_summary_file": "regex_fallback.yaml"'
+
+        file_name, output = node._extract_sql_summary_and_output_from_response({"content": content})
+        assert file_name == "regex_fallback.yaml"
+        assert output is None
+
     def test_extract_sql_summary_from_empty(self, real_agent_config, mock_llm_create):
         """_extract_sql_summary_and_output_from_response with empty content returns None."""
         node = _create_node(real_agent_config)

--- a/tests/unit_tests/storage/reference_template/test_reference_template_init.py
+++ b/tests/unit_tests/storage/reference_template/test_reference_template_init.py
@@ -388,6 +388,108 @@ class TestProcessTemplateItem:
         assert item["tags"] == "education,free_rate"
 
     @pytest.mark.asyncio
+    async def test_success_with_subject_prefixed_summary_path(self, tmp_path):
+        """LLM may report subject/sql_summaries/...; resolver should not duplicate prefixes."""
+        from unittest.mock import patch
+
+        import yaml
+
+        from datus.schemas.action_history import ActionHistory, ActionStatus
+        from datus.storage.reference_template.reference_template_init import process_template_item
+
+        kb_dir = tmp_path / "subject"
+        summary_dir = kb_dir / "sql_summaries"
+        summary_dir.mkdir(parents=True)
+        summary_file = summary_dir / "tpl_001.yaml"
+        summary_file.write_text(
+            yaml.dump(
+                {
+                    "name": "free_rate_query",
+                    "summary": "Query free meal rates by school type",
+                    "search_text": "free rate school type continuation",
+                    "subject_tree": "Education/FreeRate",
+                    "tags": "education,free_rate",
+                }
+            )
+        )
+
+        success_action = MagicMock(spec=ActionHistory)
+        success_action.status = ActionStatus.SUCCESS
+        success_action.output = {"sql_summary_file": "subject/sql_summaries/tpl_001.yaml"}
+        success_action.messages = []
+
+        async def mock_execute_stream(*args, **kwargs):
+            yield success_action
+
+        mock_node = MagicMock()
+        mock_node.knowledge_base_dir = str(kb_dir)
+        mock_node.execute_stream = mock_execute_stream
+
+        mock_config = MagicMock()
+        mock_config.path_manager.sql_summary_path.return_value = summary_dir
+        mock_config.current_datasource = "test_ns"
+
+        item = {
+            "template": "SELECT * FROM t WHERE x = '{{val}}'",
+            "filepath": "/tmp/test.j2",
+            "comment": "",
+            "parameters": '[{"name": "val"}]',
+        }
+
+        with patch(
+            "datus.storage.reference_template.reference_template_init.SqlSummaryAgenticNode",
+            return_value=mock_node,
+        ):
+            result = await process_template_item(item, mock_config, build_mode="overwrite")
+
+        assert result == "subject/sql_summaries/tpl_001.yaml"
+        assert item["name"] == "free_rate_query"
+        assert item["summary"] == "Query free meal rates by school type"
+        assert item["subject_tree"] == "Education/FreeRate"
+
+    @pytest.mark.asyncio
+    async def test_rejects_generated_summary_path_outside_sandbox(self, tmp_path):
+        """A generated summary path outside the SQL-summary sandbox is rejected."""
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionHistory, ActionStatus
+        from datus.storage.reference_template.reference_template_init import process_template_item
+
+        kb_dir = tmp_path / "subject"
+        (kb_dir / "sql_summaries").mkdir(parents=True)
+
+        success_action = MagicMock(spec=ActionHistory)
+        success_action.status = ActionStatus.SUCCESS
+        success_action.output = {"sql_summary_file": "../../outside.yaml"}
+        success_action.messages = []
+
+        async def mock_execute_stream(*args, **kwargs):
+            yield success_action
+
+        mock_node = MagicMock()
+        mock_node.knowledge_base_dir = str(kb_dir)
+        mock_node.execute_stream = mock_execute_stream
+
+        mock_config = MagicMock()
+        mock_config.path_manager.sql_summary_path.return_value = kb_dir / "sql_summaries"
+        mock_config.current_datasource = "test_ns"
+
+        item = {
+            "template": "SELECT * FROM t WHERE x = '{{val}}'",
+            "filepath": "/tmp/test.j2",
+            "comment": "",
+            "parameters": '[{"name": "val"}]',
+        }
+
+        with patch(
+            "datus.storage.reference_template.reference_template_init.SqlSummaryAgenticNode",
+            return_value=mock_node,
+        ):
+            result = await process_template_item(item, mock_config, build_mode="overwrite")
+
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_no_sql_summary_file_returns_none(self):
         """LLM returns success but no sql_summary_file in output."""
         from unittest.mock import patch


### PR DESCRIPTION
## Why

Reference template bootstrap could fail after SQL summary generation when the model returned a subject-prefixed summary path or when the final response included Jinja/template text before the JSON payload. The public reference template docs also described several behaviors that no longer matched the implementation.

## Solution

- Resolve generated SQL summary paths through the same KB sandbox logic used by SQL summary persistence, including bare, sql_summaries-prefixed, subject-prefixed, and absolute in-sandbox paths.
- Make SQL summary response extraction scan plausible JSON candidates instead of assuming the first brace starts the response object.
- Cover fenced JSON, generic fenced blocks, and unfenced JSON after Jinja text with focused unit tests.
- Align English and Chinese reference template docs with current CLI defaults, tool exposure behavior, processing order, and semicolon splitting limitations.

## Test Cases

- uv run pytest tests/unit_tests/agent/node/test_sql_summary_agentic_node.py::TestSqlSummaryExtractMethods -q
- uv run pytest tests/unit_tests/storage/reference_template/test_reference_template_init.py -q
- uv run pytest tests/unit_tests/cli/test_generation_hooks.py::TestResolveKbSandboxPath -q
- uv run --with-requirements requirements-docs.txt mkdocs build --strict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a render-only template tool; search now returns raw template bodies; execute-template tool exposure limited to instances with DB function tooling.
* **Bug Fixes**
  * More robust extraction of SQL-summary results from free-form model responses, with a regex fallback.
  * Safer template path handling to avoid opening untrusted locations.
* **Documentation**
  * Reordered processing flow (LLM analysis before static parameter analysis); clarified CLI defaults, pool_size behavior, tool-exposure rules, and template-splitting guidance.
* **Tests**
  * Added tests covering parsing robustness and template-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->