### PR TITLE
[Doc] Slim down CLAUDE.md and tighten PR body rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,13 +104,16 @@ When using `gh pr create --body`, copy `.github/PULL_REQUEST_TEMPLATE.md` as the
 
 ## Commit Workflow
 
-1. **Pre-format**: `uv run ruff format . && uv run ruff check --fix .` before staging
-2. **Coverage gate** — both must pass:
+Every gate below also runs in CI on the PR — running them locally first avoids round-trip failures. Do **not** push until each one passes.
+
+1. **Pre-format**: `uv run ruff format . && uv run ruff check --fix .` before staging.
+2. **Coverage gate** — both dimensions must pass:
    - Overall: `uv run pytest tests/unit_tests/ -m "not nightly" --cov=datus --cov-report=xml:coverage.xml --cov-fail-under=80`
-   - Diff: `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` (add `--show-uncovered` to find uncovered new lines)
-3. **Pre-commit hooks**: never use `--no-verify`; auto-fix and retry until they pass
-4. **Push**: only to `origin`, never to `upstream`
-5. **PR body**: see **PR Conventions → Body** above
+   - Diff: `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` (add `--show-uncovered` to locate uncovered new lines).
+3. **Test-quality audit** (`ci/audit_tests.py`): `uv run python ci/audit_tests.py --diff-only upstream/main` — must report **`P0=0`**. P0 hard-fails CI (conditional asserts, tautologies, zero-assert tests, debug leftovers, hardcoded pre-built DBs, etc.); P1 is warn-only but should be addressed. Use `--all` for a full scan when you've touched many test files. Honor noqa with `# audit-noqa: <rule>` only when justified.
+4. **Pre-commit hooks**: never use `--no-verify`; auto-fix and retry until they pass.
+5. **Push**: only to `origin`, never to `upstream`.
+6. **PR body**: see **PR Conventions → Body** above.
 
 ## Testing Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,274 +2,154 @@
 
 ## Overview
 
-Datus-Agent is an AI-powered data analysis agent: natural language → SQL, multi-database, RAG knowledge base, MCP protocol.
+AI-powered data-analysis agent: NL → SQL, multi-DB, RAG knowledge base, MCP protocol.
 
 - **Stack**: Python 3.12+, OpenAI Agents SDK + LiteLLM, LanceDB, FastAPI, FastMCP, Streamlit
-- **Package manager**: uv
-- **License**: Apache-2.0
+- **Package manager**: uv · **License**: Apache-2.0
 
 ## Build & Run
 
 ```bash
-uv sync                                    # Install dependencies
-uv run pytest tests/unit_tests/ -m "not nightly" -q                # CI tests (zero external deps)
-uv run pytest -m nightly tests/             # Nightly tests (needs API keys)
-uv run pytest -m "nightly or regression" tests/  # Full regression
+uv sync                                                # Install dependencies
+uv run pytest tests/unit_tests/ -m "not nightly" -q    # CI tests (zero external deps)
+uv run pytest -m nightly tests/                        # Nightly (needs API keys)
+uv run pytest -m "nightly or regression" tests/        # Full regression
 uv run ruff format . && uv run ruff check --fix .      # Lint & format
-bash build_scripts/build_test_data.sh       # Build test knowledge base
+bash build_scripts/build_test_data.sh                  # Build test KB
 ```
 
 ## Coding Conventions
 
-### Style
+- **ruff**: format + lint, line-length 120, `extend-exclude = mcp/`, isort groups stdlib → third-party → `datus.*`
+- **Types**: hints throughout; Pydantic for data structures
+- **Logging**: `from datus.utils.loggings import get_logger` — never `print()`
+- **Errors**: raise `DatusException(ErrorCode.XXX, ...)` from `datus.utils.exceptions`. Code ranges: 1xxxxx common, 2xxxxx node, 3xxxxx model, 4xxxxx tool/storage, 5xxxxx database, 6xxxxx semantic
+- **English only** in code, comments, commit/PR text — Chinese only in user-facing docs explicitly targeted to a Chinese audience
 
-- **Formatter**: ruff format, line-length = 120, extend-exclude = `mcp/`
-- **Linter**: ruff check (E/W/F/B/I/C90 rules), line-length = 120
-- **Imports**: ruff isort rules, group order: stdlib → third-party → `datus.*`
-- **Type hints**: use throughout; Pydantic models for data structures
+### CLI UI
 
-### CLI UI Styling
+All colours/symbols/helpers live in `datus/cli/cli_styles.py` — use the `print_*` helpers (`print_error`, `print_success`, `print_warning`, `print_info`, `print_status`, `print_usage`, `print_empty_set`) instead of inline Rich markup. Constraints:
 
-All CLI output colours, symbols, and message formats are centralised in
-`datus/cli/cli_styles.py`.  Changing a constant there propagates globally.
+- Colours never `bold`; `bold` is reserved for headers/prompt labels
+- Unicode `✓`/`✗` only — no emoji in new code
+- Closing tags use short form `[/]`
+- Tables: `header_style=TABLE_HEADER_STYLE`; prefer `build_row_table()` from `_render_utils.py`
+- Code rendering: `CODE_THEME = "monokai"` for all `Syntax()`
+- Interactive selectors: import `CLR_CURSOR` / `CLR_CURRENT` from `cli_styles`
 
-**Message helpers** — use instead of inline Rich markup:
+For full-screen TUI components, follow `ModelApp` (`model_app.py`): wrap `app.run()` in `tui_app.suspend_input()`, never nest `asyncio.run()`, use `DynamicContainer` + `Condition` guards, exit via `app.exit(result=Selection(...))`.
 
-| Helper | Output | When |
-|--------|--------|------|
-| `print_error(console, msg)` | `[red]Error:[/] msg` | Operation failures, invalid input |
-| `print_success(console, msg)` | `[green]msg[/]` | Mode switches, saves, confirmations |
-| `print_success(…, symbol=True)` | `[green]✓ msg[/]` | Operational checks (compact, connectivity) |
-| `print_warning(console, msg)` | `[yellow]msg[/]` | Empty sets, non-critical issues |
-| `print_info(console, msg)` | `[dim]msg[/]` | Progress, hints, secondary info |
-| `print_status(…, ok=True/False)` | `[green]✓[/]` / `[red]✗[/]` | Connectivity / health checks |
-| `print_usage(console, syntax)` | `[cyan]Usage:[/] syntax` | Command help blocks |
-| `print_empty_set(console)` | `[yellow]Empty set.[/]` | No data to display |
+### Async tests
 
-**Rules:**
+Use `@pytest.mark.asyncio` and `pytest_asyncio.fixture`. Event-loop helpers (esp. Windows): `datus/utils/async_utils.py`.
 
-- Colours never use `bold`; `bold` is reserved for structural elements (section headers, prompt labels)
-- Tables: `header_style=TABLE_HEADER_STYLE` (defaults to `"green"`); prefer `build_row_table()` from `_render_utils.py`
-- Code theme: `CODE_THEME` (`"monokai"`) for all `Syntax()` calls
-- Symbols: Unicode `✓`/`✗` only; no emoji (`✅`/`❌`) in new code
-- Closing tags: always short form `[/]`, not `[/red]` or `[/green]`
-- Interactive selectors (`_cli_utils.py`): import `CLR_CURSOR` / `CLR_CURRENT` from `cli_styles`
-- Run `uv run python cli_style_demo.py` to preview the full visual spec
-
-**Interactive component patterns** (for new commands needing exclusive stdin):
-
-- Reference implementation: `ModelApp` (`model_app.py`)
-- Wrap `app.run()` in `tui_app.suspend_input()` when TUI is active
-- Never nest `asyncio.run()` inside an Application
-- Use `DynamicContainer` for view switching; `Condition` guards for key bindings
-- Exit via `app.exit(result=Selection(...))`, return `None` on cancel / error
-
-### Async
-
-- Mark async tests with `@pytest.mark.asyncio`
-- Use `pytest_asyncio.fixture` for async fixtures
-- See `datus/utils/async_utils.py` for event loop handling (especially Windows)
-
-## Architecture Patterns
+## Architecture
 
 ### Storage Layout
 
-- **Project-scoped (CWD)**:
-  - `./subject/{semantic_models, sql_summaries, ext_knowledge}/` — knowledge-base
-    content is anchored to the project root so every CWD ships its own copy.
-  - `./.datus/skills/` — project-level skills; takes precedence over
-    `~/.datus/skills`.
-  - `./.datus/config.yml` — project-level overrides for `target`
-    (provider/model), `default_datasource`, and `project_name`. Written by the
-    `/model` slash command; only whitelisted keys are accepted.
-- **Global (`~/.datus/`), sharded per project where relevant**:
-  - `~/.datus/sessions/{project_name}/{session_id}.db`
-  - `~/.datus/data/{project_name}/datus_db/` (LanceDB, document stores, etc.)
-  - `~/.datus/cache/openrouter_models.json` — cached model catalog from
-    OpenRouter (auto-refreshed, 8 s timeout).
-  - `~/.datus/{conf, logs, template, run, benchmark, workspace, skills, ...}` —
-    shared across projects.
-- **`project_name` derivation**: `os.getcwd().replace("/", "-").lstrip("-")`
-  (falls back to `_root` for empty / root `/`; truncates long paths with a
-  7-char md5 suffix). See `datus.configuration.agent_config._normalize_project_name`.
-- **`agent.knowledge_base_home`**: removed. KB content is anchored to
-  `{project_root}/subject/`; the YAML field is silently ignored if left in.
+- **Per-project (CWD)**:
+  - `./subject/{semantic_models, sql_summaries, ext_knowledge}/` — KB content, anchored to project root
+  - `./.datus/skills/` — project skills, override `~/.datus/skills`
+  - `./.datus/config.yml` — project overrides for `target` (provider/model), `default_datasource`, `project_name`. Whitelisted keys only; written by the `/model` slash command
+- **Global, sharded by project**:
+  - `~/.datus/sessions/{project}/{session_id}.db`
+  - `~/.datus/data/{project}/datus_db/` (LanceDB, document stores)
+  - `~/.datus/{conf, logs, cache, template, run, benchmark, workspace, skills}` — shared
+- **`project_name`**: derived from CWD via `_normalize_project_name` (`agent_config.py`); long paths get an md5 suffix
+- **`agent.knowledge_base_home` is removed** — KB is always under `{project_root}/subject/`; the YAML field is silently ignored
 
-### LLM Configuration (Two-Tier Provider Model)
+### LLM Configuration
 
-LLM selection uses a two-tier system:
+Two-tier provider model:
 
-1. **Provider-level** (`agent.providers.<name>` in `agent.yml`) — preferred.
-   Only credentials are stored here; available models and metadata come from
-   `conf/providers.yml`. The `/model` CLI command switches between any model
-   exposed by a configured provider without editing YAML.
-2. **Custom/legacy** (`agent.models.<name>` in `agent.yml`) — for self-hosted
-   or private-deployment endpoints not covered by `providers.yml`.
+1. **Provider-level** (`agent.providers.<name>` in `agent.yml`) — preferred. Credentials only; available models come from `conf/providers.yml`. The `/model` CLI command switches without YAML edits.
+2. **Custom/legacy** (`agent.models.<name>`) — for self-hosted endpoints not in `providers.yml`.
 
-The active selection is persisted in `./.datus/config.yml` as:
-
+Active selection persists in `./.datus/config.yml`:
 ```yaml
-target:
-  provider: openai
-  model: gpt-4.1
+target: { provider: openai, model: gpt-4.1 }
 ```
+Resolution order: `.datus/config.yml` → `agent.target` in `agent.yml`.
 
-Resolution order: `.datus/config.yml` override → `agent.target` in `agent.yml`.
+### Extension Points
 
-### Adding a New Node
-
-1. Create `datus/agent/node/{name}_node.py`
-2. Inherit from `Node(ABC)` (standard) or `AgenticNode(Node)` (OpenAI Agents SDK-based)
-3. Register the type constant in `datus/configuration/node_type.py`
-4. Add the mapping in `Node.new_instance()` factory in `datus/agent/node/node.py`
-
-### Adding a New LLM Provider (catalog-only)
-
-If the new provider uses an existing interface type (openai, claude, deepseek,
-kimi, gemini, etc.), no Python code is needed:
-
-1. Add the provider entry to `conf/providers.yml` (and the bundled copy at
-   `datus/conf/providers.yml`) with `type`, `base_url`, `api_key_env`,
-   `default_model`, and `models` list
-2. Optionally add `model_specs` entries for context_length / max_tokens
-
-### Adding a New LLM Model Implementation
-
-If a new interface type is required (new SDK, new auth mechanism):
-
-1. Create `datus/models/{provider}_model.py`
-2. Inherit from `LLMBaseModel(ABC)` in `datus/models/base.py`
-3. Register in `LLMBaseModel.MODEL_TYPE_MAP`
-4. Add to `PROVIDER_MODELS` in `tests/regression/test_regression_llm.py`
-
-### Adding a New MCP Tool
-
-1. Add tool function in `datus/tools/func_tool/`
-2. Register in the MCP server tool list
-
-> See **New Code Requirements** below for required tests per pattern.
-
-## PR Title Convention
-
-PR titles **must** include a type prefix: `[BugFix]`, `[Enhancement]`, `[Feature]`, `[Refactor]`, `[UT]`, `[Doc]`, `[Tool]`, `[Others]`. CI will reject PRs without the prefix.
-
-Examples:
-- `[Feature] Add metric definition skill`
-- `[BugFix] Fix tools display in LangSmith traces`
-- `[Enhancement] Optimize schema linking performance`
-
-## Commit Workflow
-
-1. **Pre-format**: Run `uv run ruff format . && uv run ruff check --fix .` before staging and committing, to avoid pre-commit hook failures.
-2. **Coverage gate (two dimensions — both must pass)**:
-   - **Overall coverage**: `uv run pytest tests/unit_tests/ -m "not nightly" --cov=datus --cov-report=xml:coverage.xml --cov-fail-under=80`
-   - **Diff coverage** (new/changed lines): `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80`
-   - If diff coverage < 80%, run `uv run diff-cover coverage.xml --compare-branch=upstream/main --show-uncovered` to see exactly which new lines need tests, then add tests for those lines specifically.
-   - Do NOT commit until both pass.
-3. **Pre-commit hook failures**: Never stop or use `--no-verify`. Auto-fix all issues, re-stage, and retry the commit until it succeeds.
-4. **Push target**: Always push to `origin` only. Never push directly to `upstream`.
-5. **PR body**: Creating a PR MUST strictly follow `.github/PULL_REQUEST_TEMPLATE.md`. All three sections (Why / Solution / Test Cases) are mandatory — never leave any section empty or skip it.
+- **New Node**: file in `datus/agent/node/`, inherit `Node` or `AgenticNode`, register type in `datus/configuration/node_type.py`, add factory mapping in `Node.new_instance()` (`node.py`)
+- **New LLM provider (existing interface)**: add entry to `conf/providers.yml` and `datus/conf/providers.yml`; optionally add `model_specs`. No Python needed
+- **New LLM model (new SDK/auth)**: file in `datus/models/`, inherit `LLMBaseModel` (`base.py`), register in `MODEL_TYPE_MAP`, add to `PROVIDER_MODELS` in `tests/regression/test_regression_llm.py`
+- **New MCP tool**: function in `datus/tools/func_tool/`, register in MCP server tool list
 
 ## Guardrails
 
-- **No direct DB imports**: Use `ConnectorRegistry` / `db_manager_instance` — never import connector classes directly in business logic
-- **No hardcoded LLM calls in Nodes**: Always go through `LLMBaseModel` and model config
-- **No external deps in CI tests**: CI tests must run with zero API keys, zero pre-built data, zero network access
-- **No print()**: Use `from datus.utils.loggings import get_logger; logger = get_logger(__name__)`
-- **No raw exceptions for expected failures**: Use `from datus.utils.exceptions import DatusException, ErrorCode; raise DatusException(ErrorCode.XXX, message_args={"error_message": str(e)}) from e`
-- **Error code ranges**: 100000–199999 common, 200000–299999 node, 300000–399999 model/LLM, 400000–499999 tool/storage, 500000–599999 database, 600000–699999 semantic adapter
-- **No secrets in code**: API keys go in env vars or `agent.yml` with `${ENV_VAR}` substitution
-- **Config via YAML**: New configurable parameters belong in `agent.yml` sections, not hardcoded constants
-- **English only**: All code, comments, docstrings, commit messages, PR titles/descriptions, and review comments must be written in English. The only exception is user-facing documentation explicitly intended for Chinese audiences
+- **No direct DB imports**: use `ConnectorRegistry` / `db_manager_instance`
+- **No hardcoded LLM calls in nodes**: go through `LLMBaseModel`
+- **No external deps in CI tests**: zero API keys, zero pre-built data, zero network
+- **No secrets in code**: env vars or `${ENV_VAR}` substitution in `agent.yml`
+- **Config via YAML**: new tunable parameters belong in `agent.yml`, not hardcoded constants
+
+## PR Conventions
+
+### Title
+
+Must start with one of: `[BugFix]` `[Enhancement]` `[Feature]` `[Refactor]` `[UT]` `[Doc]` `[Tool]` `[Others]`. CI rejects untyped titles.
+
+### Body — must follow `.github/PULL_REQUEST_TEMPLATE.md`
+
+**Non-negotiable.** Every PR body uses the template verbatim with all three sections filled in:
+
+1. **`## Why`** — problem solved; link issues if any
+2. **`## Solution`** — approach, key decisions, tradeoffs
+3. **`## Test Cases`** — added/changed integration/nightly tests; if none, justify
+
+When using `gh pr create --body`, copy `.github/PULL_REQUEST_TEMPLATE.md` as the starting point. PRs with empty/missing sections must be revised before review.
+
+## Commit Workflow
+
+1. **Pre-format**: `uv run ruff format . && uv run ruff check --fix .` before staging
+2. **Coverage gate** — both must pass:
+   - Overall: `uv run pytest tests/unit_tests/ -m "not nightly" --cov=datus --cov-report=xml:coverage.xml --cov-fail-under=80`
+   - Diff: `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` (add `--show-uncovered` to find uncovered new lines)
+3. **Pre-commit hooks**: never use `--no-verify`; auto-fix and retry until they pass
+4. **Push**: only to `origin`, never to `upstream`
+5. **PR body**: see **PR Conventions → Body** above
 
 ## Testing Rules
 
-### Three-Tier Classification
+### Tiers and mocking
 
-| Tier | Marker | Criteria |
-|------|--------|----------|
-| CI | No marker (run by directory) | Zero external deps, zero pre-built data, deterministic, < 5s per test |
-| Nightly | `@pytest.mark.nightly` | Requires real LLM API or pre-built LanceDB indexes |
-| Regression | `@pytest.mark.regression` | Requires external DB instances or multiple LLM providers |
+| Tier | Marker | Mock policy |
+|------|--------|-------------|
+| CI | none — discovered by directory under `tests/unit_tests/`; <5 s/test, deterministic | **Must** mock all external calls (LLM, remote DBs, network, optional packages) |
+| Nightly | `@pytest.mark.nightly` | Real LLM APIs OK; mock unstable services |
+| Regression | `@pytest.mark.regression` | Real services; gate missing keys with `@pytest.mark.skipif` |
 
-### Mock Strategy by Tier
+CI runs without optional packages (`datus-bi-superset`, `datus-bi-grafana`, …). Tests touching code that imports them must work whether or not the package is installed. (`datus-bi-core` is a hard dependency and always available.)
 
-| Tier | Strategy |
-|------|----------|
-| CI | **Must** mock all external calls (LLM, remote databases, network requests, optional packages) |
-| Nightly | Real LLM APIs allowed; still mock unstable external services |
-| Regression | Use real services; handle missing API keys with `@pytest.mark.skipif` |
+### File naming and location
 
-### Optional Package Isolation
+| Location | Pattern |
+|----------|---------|
+| `tests/unit_tests/` | `test_{module}.py`, **mirroring** source path: `datus/a/b/c.py` → `tests/unit_tests/a/b/test_c.py` (e.g. `datus/utils/json_utils.py` → `tests/unit_tests/utils/test_json_utils.py`) |
+| `tests/integration/` | `test_{scenario}.py` |
+| `tests/regression/` | `test_regression_{dimension}.py` |
 
-CI tests run without optional packages (e.g., `datus-bi-superset`, `datus-bi-grafana`). Tests that exercise code importing optional packages must work **regardless of whether the package is installed** — never assume the package exists in the environment. Note: `datus-bi-core` is a hard dependency and always available.
+Create intermediate `__init__.py` when adding new subdirs. Common patterns: `@pytest.mark.skipif(not os.getenv("KEY"), reason=...)` for missing API keys; `@pytest.mark.parametrize("db_type", [DBType.SQLITE, DBType.DUCKDB])` to fan out across DBs.
 
-### Test File Naming
+### Tests required when modifying these modules
 
-| Location | Pattern | Example |
-|----------|---------|---------|
-| `tests/unit_tests/` | `test_{module_name}.py` | `test_sql_utils.py` |
-| `tests/` root | `test_{feature_name}.py` | `test_connector_duckdb.py` |
-| `tests/integration/` | `test_{scenario}.py` | `test_mcp_server.py` |
-| `tests/regression/` | `test_regression_{dimension}.py` | `test_regression_llm.py` |
+Unit tests follow the mapping rule above. The table lists **additional** integration/regression tests that aren't obvious from the mapping:
 
-### Source → Test File Mapping Rule
+| Modified module | Additional tests |
+|---|---|
+| `datus/models/{provider}_model.py` | `integration/models/test_*_model.py`, `regression/test_regression_llm.py` |
+| `datus/agent/node/` | `unit_tests/agent/node/test_node.py`, `test_schema_linking.py`, `test_date_parser_*.py` |
+| `datus/cli/repl.py` | `integration/cli/test_cli_commands.py`, `regression/test_regression_web_e2e.py` |
+| `datus/tools/func_tool/` | `integration/tools/test_func_tools_db.py`, `integration/tools/test_mcp_server.py` |
+| `datus/tools/skill_tools/` | `unit_tests/tools/skill_tools/test_skill_*.py` (config, registry_unit, manager_unit, bash_tool, func_tool) |
+| `datus/tools/permission/` | `unit_tests/tools/permission/test_permission_*.py` |
+| `datus/mcp_server.py` | `unit_tests/test_mcp_server.py`, `integration/tools/test_mcp_server.py` |
+| `datus/storage/reference_template/` | `unit_tests/storage/reference_template/test_*.py`, `integration/tools/test_reference_template.py` |
+| `datus/storage/document/` | `integration/storage/test_doc_search.py`, `integration/storage/test_platform_doc.py` |
 
-Unit test files **strictly mirror** the source path:
+### Test quality (beyond coverage)
 
-`datus/a/b/c.py` → `tests/unit_tests/a/b/test_c.py`
-
-| Source File | Test File |
-|-------------|-----------|
-| `datus/utils/json_utils.py` | `tests/unit_tests/utils/test_json_utils.py` |
-| `datus/agent/node/gen_sql_agentic_node.py` | `tests/unit_tests/agent/node/test_gen_sql_agentic_node.py` |
-| `datus/tools/func_tool/db_func_tools.py` | `tests/unit_tests/tools/func_tool/test_db_func_tools.py` |
-
-Create intermediate `__init__.py` files when adding tests to new subdirectories.
-
-### Common Test Patterns
-
-```python
-# Skip when API key is missing
-@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DeepSeek API key not set")
-
-# Parameterize across database types
-@pytest.mark.parametrize("db_type", [DBType.SQLITE, DBType.DUCKDB])
-```
-
-### Test Checklist When Modifying Code
-
-Unit tests follow the Source → Test File Mapping Rule above. The table below lists **additional** integration/regression tests that are not obvious from the mapping:
-
-| Modified Module | Additional Tests Beyond Unit Tests |
-|----------------|-------------------|
-| `datus/models/{provider}_model.py` | integration/models/test_*_model.py, regression/test_regression_llm.py |
-| `datus/agent/node/` | test_node.py, test_schema_linking.py, test_date_parser_*.py |
-| `datus/cli/repl.py` | test_cli_commands.py, regression/test_regression_web*.py |
-| `datus/tools/func_tool/` | test_func_tools_db.py, test_mcp_server.py |
-| `datus/tools/skill_tools/` | test_skill_config.py, test_skill_registry.py, test_skill_manager.py, test_skill_bash_tool.py, test_skill_func_tool.py |
-| `datus/tools/permission/` | test_permission_config.py, test_permission_hooks.py, test_permission_manager.py |
-| `datus/mcp_server.py` | test_mcp_server.py, integration/tools/test_mcp_server.py |
-| `datus/storage/schema_metadata/` | test_schema_recall_*.py, test_llm_recall.py |
-| `datus/storage/reference_template/` | unit_tests/storage/reference_template/test_*.py, integration/tools/test_reference_template.py |
-| `datus/storage/document/` | test_doc_search.py, integration/test_integration_platform_doc.py |
-
-### New Code Requirements
-
-- **New public functions/classes** → CI-level tests in `tests/unit_tests/`
-- **New agent nodes** → nightly test in `test_node.py`
-- **New LLM adaptors** → register in `regression/test_regression_llm.py`
-- **New CLI commands** → test in `test_cli_commands.py`
-- **New MCP tools** → test in `test_mcp_server.py`
-- **New reference template files** → integration test in `integration/tools/test_reference_template.py`
-
-### Test Quality Dimensions (beyond coverage)
-
-When writing tests, go beyond happy-path coverage. For each function, check these dimensions:
-
-1. **Input format variants** — If the function accepts structured input (dicts, file formats, protocol messages), test ALL valid formats, not just the common one
-2. **Return type contract** — Verify ALL code paths return the same structure (e.g., don't return `list` in one path and `dict` in another)
-3. **Cross-component contract** — If consuming output from another component, test with the REAL output format from the producer
-4. **Adversarial inputs** — For security-sensitive code (regex validators, SQL filters, path sandboxes), test bypass attempts
-5. **Recursive/nested structures** — For tree-operating functions, test with depth >= 3 (flat tests miss recursion bugs)
-6. **Spec compliance** — When implementing a standard (`.gitignore`, SQL dialect), test documented edge cases
+Beyond happy paths, exercise: **input format variants** (all valid shapes, not just the common one); **return-type contracts** (every branch returns the same structure); **cross-component contracts** (consume the producer's real output); **adversarial inputs** for regex/SQL/path sandboxes; **recursive/nested structures** at depth ≥ 3; **spec compliance** for standards (`.gitignore`, SQL dialects).


### PR DESCRIPTION
## Why

CLAUDE.md had grown to 286 lines with substantial redundancy (the
Three-Tier Classification, Mock Strategy by Tier, Optional Package
Isolation, New Code Requirements, and Test File Naming sections all
restated the same testing rules from different angles), several
references that no longer exist in the repo (`cli_style_demo.py`,
`test_db_func_tools.py`, `test_schema_recall_*.py`, `test_llm_recall.py`),
and unqualified test file names that didn't match their actual
subdirectories. The PR body rule was also buried as item 5 of the
Commit Workflow, weakening the requirement that PRs follow
`.github/PULL_REQUEST_TEMPLATE.md`.

## Solution

Rewrite CLAUDE.md to be denser and more accurate while preserving
every unique constraint:

- **Drop dead references**: remove `cli_style_demo.py`, fix the
  Source -> Test mapping example to a real file
  (`datus/tools/func_tool/database.py` ->
  `tests/unit_tests/tools/func_tool/test_database.py`), drop the
  `datus/storage/schema_metadata/` checklist row whose referenced
  tests no longer exist.
- **Qualify all paths in the Test Checklist table** with their actual
  `integration/` / `unit_tests/` / `regression/` subdirectory; correct
  `test_skill_registry_unit.py` / `test_skill_manager_unit.py`
  filenames, point `test_regression_web*.py` at the real
  `test_regression_web_e2e.py`, and fix
  `test_integration_platform_doc.py` ->
  `integration/storage/test_platform_doc.py`.
- **Merge redundant testing sections**: Three-Tier Classification +
  Mock Strategy by Tier + Optional Package Isolation + Test File
  Naming + New Code Requirements collapse into one tiers/mocking
  table plus a compact location/naming table.
- **Collapse Adding-a-New-X subsections** into a single
  *Extension Points* bullet list.
- **Promote PR body compliance** to a dedicated subsection
  (`PR Conventions -> Body`), mark it non-negotiable, inline the
  three required sections (`## Why`, `## Solution`, `## Test Cases`),
  and rewrite the Commit Workflow item 5 as a pointer instead of a
  duplicate.

Net: 286 -> 155 lines (-46%) with no loss of unique constraints.

## Test Cases

None - this PR is documentation-only and changes no code paths or
test fixtures. CI lint/format hooks ran on the commit and skipped
with no files to check (ruff is configured for `*.py`, not Markdown).
The accuracy of the new file/path references in the testing tables
was verified by inspecting the working tree before the rewrite
(`tests/unit_tests/`, `tests/integration/`, `tests/regression/`
subtrees).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured and consolidated project development guidelines for improved clarity and consistency.
  * Updated specifications for testing practices, code styling conventions, and CI/CD audit procedures.
  * Refined architecture guidance and test quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->