### PR TITLE
[Enhancement] Reorder /agent tabs and add @agent dispatch hint 

### DIFF
--- a/datus/cli/agent_app.py
+++ b/datus/cli/agent_app.py
@@ -62,7 +62,7 @@ class _Tab(Enum):
     CUSTOM = "custom"
 
 
-_TAB_CYCLE: Tuple[_Tab, ...] = (_Tab.BUILTIN, _Tab.CUSTOM)
+_TAB_CYCLE: Tuple[_Tab, ...] = (_Tab.CUSTOM, _Tab.BUILTIN)
 
 
 class _View(Enum):
@@ -129,7 +129,7 @@ class AgentApp:
         self._visible_custom: Set[str] = set(visible_custom_agents or [])
         self._seed_tab_arg = seed_tab
 
-        self._tab: _Tab = _Tab.BUILTIN
+        self._tab: _Tab = _Tab.CUSTOM
         self._view: _View = _View.AGENT_LIST
         self._list_cursor: int = 0
         self._list_offset: int = 0
@@ -298,8 +298,8 @@ class AgentApp:
     def _render_tab_strip(self) -> List[Tuple[str, str]]:
         parts: List[Tuple[str, str]] = [("", "  ")]
         for tab, label in (
-            (_Tab.BUILTIN, " Built-in "),
             (_Tab.CUSTOM, " Custom "),
+            (_Tab.BUILTIN, " Built-in "),
         ):
             style = "reverse bold" if tab == self._tab else ""
             parts.append((style, label))
@@ -310,10 +310,9 @@ class AgentApp:
     def _render_footer_hint(self) -> List[Tuple[str, str]]:
         if self._view == _View.AGENT_LIST:
             if self._tab == _Tab.BUILTIN:
-                hint = (
-                    "  \u2191\u2193 navigate   Enter set as current   e edit   "
-                    "Tab/\u2190\u2192 switch   Esc back   Ctrl+C cancel"
-                )
+                # Built-in agents are config-only in the TUI; ``Enter`` opens
+                # the override form (alias of ``e``) — never sets default.
+                hint = "  \u2191\u2193 navigate   Enter/e edit   Tab/\u2190\u2192 switch   Esc back   Ctrl+C cancel"
             else:
                 hint = (
                     "  \u2191\u2193 navigate   Enter set as current   e edit   a add   d delete   "
@@ -478,7 +477,15 @@ class AgentApp:
         exception: it isn't an agent, so Enter on that row launches the
         add wizard (consistent with the user's expectation that Enter
         "does the obvious thing").
+
+        Built-in rows do NOT support "set as default" via the TUI: those
+        agents are platform-internal nodes that the user only meaningfully
+        configures (``max_turns`` / ``model`` overrides). Enter therefore
+        aliases ``e`` on the Built-in tab and opens the override form.
         """
+        if self._tab == _Tab.BUILTIN:
+            self._on_list_edit()
+            return
         if self._tab == _Tab.CUSTOM and self._list_cursor == len(self._custom_names):
             self._exit_with(AgentSelection(kind="new_custom", return_to_tab="custom"))
             return

--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -10,7 +10,7 @@ Provides SQL keyword, table name, and column name autocompletion.
 import re
 import threading
 from abc import abstractmethod
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import pyarrow
 from prompt_toolkit.completion import Completer, Completion, PathCompleter
@@ -934,10 +934,121 @@ class _ContinuousPathCompleter(Completer):
                 yield comp
 
 
+class _AgentReferenceCompleter(Completer):
+    """``@Agent <name>`` completer.
+
+    The agent list is **not** a routing target the way Tables / Metrics are —
+    selecting one only injects a routing hint into the chat message so the
+    main chat agent delegates via its existing ``task`` tool
+    (:class:`~datus.tools.func_tool.sub_agent_task_tool.SubAgentTaskTool`).
+    The user's default agent stays put.
+
+    Visibility is delegated to a caller-supplied callable so this completer
+    stays in lock-step with ``/agent`` TUI rules (HIDDEN_SYS_SUB_AGENTS,
+    datasource scoping). The callable is re-invoked on each completion so a
+    datasource swap takes effect without rebuilding the completer.
+    """
+
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        visibility_provider: Optional[Callable[[], Set[str]]] = None,
+    ) -> None:
+        self.agent_config = agent_config
+        self._visibility_provider = visibility_provider
+        # Lazy: resolved on first lookup so importing autocomplete.py does
+        # not pull in the func_tool package eagerly (avoids circular imports
+        # in non-CLI test contexts).
+        self._builtin_descriptions: Optional[Dict[str, str]] = None
+
+    # ── description helpers ──────────────────────────────────────────
+
+    def _load_builtin_descriptions(self) -> Dict[str, str]:
+        if self._builtin_descriptions is None:
+            try:
+                from datus.tools.func_tool.sub_agent_task_tool import BUILTIN_SUBAGENT_DESCRIPTIONS
+
+                self._builtin_descriptions = dict(BUILTIN_SUBAGENT_DESCRIPTIONS)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("Failed to load builtin subagent descriptions: %s", e)
+                self._builtin_descriptions = {}
+        return self._builtin_descriptions
+
+    def _description_for(self, name: str) -> str:
+        """One-line description, suitable for menu rendering."""
+        builtin = self._load_builtin_descriptions().get(name)
+        if builtin:
+            text = builtin
+        else:
+            entry = (self.agent_config.agentic_nodes or {}).get(name) or {}
+            text = entry.get("agent_description") or ""
+        text = (text or "").strip().replace("\n", " ")
+        if len(text) > 80:
+            text = text[:77] + "..."
+        return text
+
+    # ── visibility ───────────────────────────────────────────────────
+
+    def visible_names(self) -> List[str]:
+        """Return sorted names eligible for ``@Agent`` mention.
+
+        Falls back to the raw ``agentic_nodes`` keys when no provider is
+        wired (non-interactive contexts / tests).
+        """
+        if self._visibility_provider is not None:
+            try:
+                names = set(self._visibility_provider() or set())
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("Agent visibility provider failed: %s", e)
+                names = set()
+        else:
+            names = set((self.agent_config.agentic_nodes or {}).keys())
+        # ``chat`` is the pseudo-default and is not a valid task() type, so
+        # never offer it as an @Agent target.
+        names.discard("chat")
+        return sorted(names)
+
+    def is_known(self, name: str) -> bool:
+        return name in set(self.visible_names())
+
+    # ── matching ─────────────────────────────────────────────────────
+
+    def fuzzy_match(self, text: str, limit: Optional[int] = None) -> List[str]:
+        """Return agent names whose lower-cased form contains ``text``."""
+        text = text.strip().lower()
+        if not text:
+            return []
+        if limit is None:
+            limit = 10
+        result: List[str] = []
+        for name in self.visible_names():
+            if text in name.lower():
+                result.append(name)
+                if len(result) >= limit:
+                    break
+        return result
+
+    def get_completions(self, document: Document, complete_event) -> Iterable[Completion]:
+        rest = document.text
+        prefix = rest.strip().lower()
+        for name in self.visible_names():
+            if prefix and prefix not in name.lower():
+                continue
+            desc = self._description_for(name)
+            display = f"🤖 {name}" + (f"  {desc}" if desc else "")
+            yield Completion(name, display=display, start_position=-len(rest))
+
+
 class AtReferenceCompleter(Completer):
     """Router completer: dispatch to different completers based on type"""
 
-    def __init__(self, agent_config: AgentConfig, sub_agent_name: str = "", available_subagents: set = None):
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        sub_agent_name: str = "",
+        available_subagents: set = None,
+        visibility_provider: Optional[Callable[[], Set[str]]] = None,
+    ):
         # Initialize specialized completers
         self.agent_config = agent_config
         self._sub_agent_name = sub_agent_name
@@ -968,18 +1079,21 @@ class AtReferenceCompleter(Completer):
             return paths
 
         self.file_completer = _ContinuousPathCompleter(PathCompleter(get_paths=get_search_paths))
+        self.agent_completer = _AgentReferenceCompleter(agent_config, visibility_provider=visibility_provider)
 
         self.completer_dict = {
             "Table": self.table_completer,
             "Metrics": self.metric_completer,
             "Sql": self.sql_completer,
             "File": self.file_completer,
+            "Agent": self.agent_completer,
         }
         self.type_options = {
             "Table": "📊 Table",
             "Metrics": "📈 Metrics",
             "Sql": "💻 Sql",
             "File": "📁 File",
+            "Agent": "🤖 Agent",
         }
 
         self.at_parser = AtReferenceParser()
@@ -1006,13 +1120,22 @@ class AtReferenceCompleter(Completer):
         self.metric_completer.reload_data()
         self.sql_completer.reload_data()
 
-    def parse_at_context(self, user_input: str) -> Tuple[List[TableSchema], List[Metric], List[ReferenceSql]]:
+    def parse_at_context(
+        self, user_input: str
+    ) -> Tuple[List[TableSchema], List[Metric], List[ReferenceSql], Optional[str]]:
+        """Extract ``@Table`` / ``@Metrics`` / ``@Sql`` / ``@Agent`` references.
+
+        The agent slot is a single optional name (the first ``@Agent <name>``
+        occurrence); unknown names are dropped so a typo never silently
+        flips routing. Subsequent ``@Agent`` mentions are ignored on purpose
+        to keep the dispatch hint deterministic.
+        """
         self.table_completer._ensure_loaded()
         self.metric_completer._ensure_loaded()
         self.sql_completer._ensure_loaded()
         user_input = user_input.strip()
         if not user_input:
-            return ([], [], [])
+            return ([], [], [], None)
         parse_result = self.at_parser.parse_input(user_input)
         tables = []
         metrics = []
@@ -1030,7 +1153,15 @@ class AtReferenceCompleter(Completer):
             for key in parse_result["sqls"]:
                 if key in self.sql_completer.flatten_data:
                     sqls.append(ReferenceSql.from_dict(self.sql_completer.flatten_data[key]))
-        return (tables, metrics, sqls)
+
+        agent_name: Optional[str] = parse_result.get("agent")
+        if agent_name and not self.agent_completer.is_known(agent_name):
+            logger.warning(
+                "@Agent reference '%s' is not a known/visible subagent; ignoring routing hint.",
+                agent_name,
+            )
+            agent_name = None
+        return (tables, metrics, sqls, agent_name)
 
     def _detect_sub_agent_from_input(self, text: str) -> str:
         """Detect sub-agent name from input line prefix like '/sub_agent_name ...'.
@@ -1089,6 +1220,7 @@ class AtReferenceCompleter(Completer):
                 metric_matches = self.metric_completer.fuzzy_match(type_prefix, limit=fuzzy_limit)
                 sql_matches = self.sql_completer.fuzzy_match(type_prefix, limit=fuzzy_limit)
                 file_matches = get_file_fuzzy_matches(type_prefix, path=self.workspace_root, max_matches=fuzzy_limit)
+                agent_matches = self.agent_completer.fuzzy_match(type_prefix, limit=fuzzy_limit)
                 # Yield fuzzy match results first
                 for match in table_matches:
                     # Extract the actual path from the match string
@@ -1120,6 +1252,16 @@ class AtReferenceCompleter(Completer):
                         f"@File {file_path}",  # Remove @ from completion
                         start_position=-len(prefix),
                         display=f"📁 {file_path}",
+                        style="class:fuzzy",
+                    )
+
+                for agent_name in agent_matches:
+                    desc = self.agent_completer._description_for(agent_name)
+                    display = f"🤖 {agent_name}" + (f"  {desc}" if desc else "")
+                    yield Completion(
+                        f"@Agent {agent_name}",
+                        start_position=-len(prefix),
+                        display=display,
                         style="class:fuzzy",
                     )
 
@@ -1360,20 +1502,24 @@ class AtReferenceParser:
             "Table": re.compile(rf"@Table\s+({REFERENCE_PATH_REGEX})", re.IGNORECASE),
             "Metrics": re.compile(rf"@Metrics\s+({REFERENCE_PATH_REGEX})", re.IGNORECASE),
             "Sqls": re.compile(rf"@Sql\s+({REFERENCE_PATH_REGEX})", re.IGNORECASE),
+            # Agent names follow Python identifier rules; the bare name is
+            # all the dispatcher needs (no nested path), so don't reuse the
+            # broader REFERENCE_PATH_REGEX (which would happily eat trailing
+            # words from the user's prompt).
+            "Agent": re.compile(r"@Agent\s+([A-Za-z_][\w-]*)", re.IGNORECASE),
         }
 
-    def parse_input(self, text: str) -> Dict[str, List[str]]:
+    def parse_input(self, text: str) -> Dict[str, Any]:
         """
         Parse text and extract all @reference paths.
 
-        Args:
-            text: Input text containing @references
-
-        Returns:
-            Dictionary with keys 'tables', 'metrics', 'reference_sql', 'files',
-            each containing a list of extracted paths
+        Returns a dict with:
+        - ``tables`` / ``metrics`` / ``sqls``: list of reference paths
+        - ``agent``: optional first ``@Agent <name>`` mention; subsequent
+          occurrences are ignored on purpose so the dispatch hint stays
+          deterministic.
         """
-        results = {"tables": [], "metrics": [], "sqls": []}
+        results: Dict[str, Any] = {"tables": [], "metrics": [], "sqls": [], "agent": None}
 
         # Extract Table references
         for match in self.patterns["Table"].finditer(text):
@@ -1392,5 +1538,10 @@ class AtReferenceParser:
             path = normalize_reference_path(match.group(1))
             if path:
                 results["sqls"].append(path)
+
+        # Extract first Agent mention only.
+        agent_match = self.patterns["Agent"].search(text)
+        if agent_match:
+            results["agent"] = agent_match.group(1)
 
         return results

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -204,6 +204,24 @@ class ChatCommands:
         )
         return node_input, current_node.type
 
+    @staticmethod
+    def _render_agent_dispatch_hint(message: str, agent_name: str) -> str:
+        """Append a routing hint that nudges the chat agent to delegate.
+
+        The chat agent already exposes a ``task`` FunctionTool wired to
+        :class:`SubAgentTaskTool`; ``@Agent <name>`` is therefore a soft
+        routing instruction rather than a node switch. Keeping the user's
+        original text intact (and only appending an ``[Agent dispatch]``
+        annotation) preserves the visible transcript while making the
+        delegation deterministic when the model reads the prompt.
+        """
+        annotation = (
+            f"[Agent dispatch] The user invoked @Agent {agent_name}. "
+            f'Use the task tool with type="{agent_name}" to delegate this request '
+            f"to that subagent rather than handling it directly."
+        )
+        return f"{message.rstrip()}\n\n{annotation}"
+
     def execute_chat_command(
         self,
         message: str,
@@ -262,7 +280,14 @@ class ChatCommands:
             return
 
         try:
-            at_tables, at_metrics, at_sqls = self.cli.at_completer.parse_at_context(message)
+            at_tables, at_metrics, at_sqls, at_agent = self.cli.at_completer.parse_at_context(message)
+            # ``@Agent <name>`` is a per-turn routing hint, not a default-agent
+            # override: ``current_subagent_name`` and the active node remain
+            # unchanged. The hint is appended to the message so the chat
+            # agent's existing ``task`` tool fires deterministically rather
+            # than relying on the LLM to spot the bare ``@Agent`` token.
+            if at_agent:
+                message = self._render_agent_dispatch_hint(message, at_agent)
 
             if interactive:
                 # Decision logic: determine if we need to create a new node

--- a/datus/cli/print_mode.py
+++ b/datus/cli/print_mode.py
@@ -62,7 +62,7 @@ class PrintModeRunner:
             patterns = [p.strip() for p in self.proxy_tool_patterns.split(",")]
             apply_proxy_tools(node, patterns)
 
-        at_tables, at_metrics, at_sqls = self.at_completer.parse_at_context(self.message)
+        at_tables, at_metrics, at_sqls, _at_agent = self.at_completer.parse_at_context(self.message)
         node_input = create_node_input(
             user_message=self.message,
             node=node,

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -216,7 +216,11 @@ class DatusCLI:
             else:
                 self._init_prompt_session()
         else:
-            self.at_completer = AtReferenceCompleter(self.agent_config, available_subagents=self.available_subagents)
+            self.at_completer = AtReferenceCompleter(
+                self.agent_config,
+                available_subagents=self.available_subagents,
+                visibility_provider=self._visible_subagents_for_default,
+            )
 
         # Last executed SQL and result
         self.last_sql = None
@@ -651,8 +655,10 @@ class DatusCLI:
         sql_completer = SQLCompleter()
         self.service_completer = ServiceCommandCompleter(self)
         self.at_completer = AtReferenceCompleter(
-            self.agent_config, available_subagents=self.available_subagents
-        )  # Router for @Table / @Metrics / @Sql inline references
+            self.agent_config,
+            available_subagents=self.available_subagents,
+            visibility_provider=self._visible_subagents_for_default,
+        )  # Router for @Table / @Metrics / @Sql / @Agent inline references
         self.slash_completer = SlashCommandCompleter()
 
         # Use merge_completers to combine completers
@@ -1077,18 +1083,21 @@ class DatusCLI:
         return visible
 
     def _cmd_agent(self, args: str):
-        """Open the unified agent management TUI (Built-in tab seed).
+        """Open the unified agent management TUI (Custom tab seed).
 
-        ``/agent`` with no args lands on the Built-in tab so users can
-        tweak ``model`` / ``max_turns`` overrides for system subagents.
-        ``/agent <name>`` keeps the legacy direct-setter shortcut for
-        scripting — no TUI is launched.
+        ``/agent`` with no args lands on the Custom tab — that's the
+        actionable surface for switching the default agent. The Built-in
+        tab is config-only in the TUI (``max_turns`` overrides), so
+        seeding it would land users on a tab where ``Enter`` no longer
+        sets a default. ``/agent <name>`` keeps the legacy direct-setter
+        shortcut for scripting — no TUI is launched, and built-in names
+        remain accepted for backward compatibility.
         """
         name = args.strip()
         if name:
             self._set_default_agent_by_name(name)
             return
-        self._open_agent_app(seed_tab="builtin")
+        self._open_agent_app(seed_tab="custom")
 
     def _cmd_subagent(self, args: str):
         """Open the unified agent management TUI (Custom tab seed).

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -54,6 +54,7 @@ from prompt_toolkit.layout.menus import CompletionsMenuControl
 from prompt_toolkit.lexers import Lexer
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.styles import Style
+from prompt_toolkit.utils import get_cwidth
 from prompt_toolkit.widgets import TextArea
 
 from datus.cli.cli_styles import PASTE_COLLAPSE_THRESHOLD
@@ -272,6 +273,75 @@ class DatusApp:
         """Current row ceiling for the pinned region (terminal-aware)."""
         return compute_pinned_max_rows(self._terminal_rows())
 
+    def _terminal_columns(self) -> int:
+        """Best-effort current terminal column count.
+
+        Mirrors :meth:`_terminal_rows`: prefer the live ``Application.output``
+        (resize-aware), fall back to ``shutil.get_terminal_size`` and finally
+        a sane default. Used by :meth:`_input_visual_line_count` so the input
+        bar grows when long text wraps onto extra visual rows.
+        """
+        app = getattr(self, "_app", None)
+        if app is not None:
+            try:
+                size = app.output.get_size()
+                if size and size.columns > 0:
+                    return int(size.columns)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            import shutil
+
+            size = shutil.get_terminal_size(fallback=(80, 24))
+            return int(size.columns)
+        except Exception:  # pragma: no cover - defensive
+            return 80
+
+    def _input_prompt_display_width(self) -> int:
+        """Display width (in cells) of the rendered input prompt.
+
+        Walks the FormattedText fragments returned by :meth:`_get_input_prompt`
+        and sums :func:`get_cwidth` per character so wide / CJK glyphs are
+        accounted for. Used to subtract the prompt cells from the first visual
+        line's available width when computing wrap counts.
+        """
+        try:
+            fragments = self._get_input_prompt()
+        except Exception:  # pragma: no cover - defensive
+            return 0
+        width = 0
+        for fragment in fragments:
+            try:
+                _, text = fragment[0], fragment[1]
+            except (IndexError, TypeError):  # pragma: no cover - defensive
+                continue
+            for ch in text:
+                width += get_cwidth(ch)
+        return width
+
+    def _input_visual_line_count(self) -> int:
+        """Rows the input would occupy after wrapping at the current width.
+
+        Splits the buffer text on hard newlines and, for each segment,
+        ceil-divides its display width by the available column count
+        (full terminal width minus the prompt width on the first segment).
+        Empty hard lines still count as one row, matching prompt_toolkit's
+        own renderer.
+        """
+        try:
+            text = self._input_area.buffer.text
+        except AttributeError:  # pragma: no cover - defensive
+            return 1
+        columns = max(self._terminal_columns(), 1)
+        prompt_width = self._input_prompt_display_width()
+        total = 0
+        for idx, line in enumerate(text.split("\n")):
+            usable = columns - (prompt_width if idx == 0 else 0)
+            usable = max(usable, 1)
+            line_width = sum(get_cwidth(ch) for ch in line)
+            total += max(1, -(-line_width // usable))
+        return max(total, 1)
+
     def _pinned_height_dimension(self) -> Dimension:
         """Height dimension callback for the pinned Window.
 
@@ -317,11 +387,8 @@ class DatusApp:
     # -- public API --------------------------------------------------------
 
     def _get_input_height(self) -> Dimension:
-        try:
-            line_count = self._input_area.buffer.document.line_count
-        except AttributeError:
-            line_count = 1
-        preferred = min(line_count, 15)
+        visual_lines = self._input_visual_line_count()
+        preferred = min(visual_lines, 15)
         return Dimension(min=1, preferred=max(preferred, 1), max=15)
 
     @staticmethod

--- a/datus/cli/web/chat_executor.py
+++ b/datus/cli/web/chat_executor.py
@@ -35,8 +35,11 @@ class ChatExecutor:
             return
 
         try:
-            # Get node and input using chat_commands logic
-            at_tables, at_metrics, at_sqls = cli.at_completer.parse_at_context(user_message)
+            # Get node and input using chat_commands logic. The Web path
+            # consumes only the data-reference slots; the @Agent routing
+            # hint is CLI-only for now (see plan: Web does not honour
+            # @Agent yet).
+            at_tables, at_metrics, at_sqls, _at_agent = cli.at_completer.parse_at_context(user_message)
 
             # Reuse chat_commands node management
             need_new_node = cli.chat_commands._should_create_new_node(current_subagent)

--- a/tests/unit_tests/cli/test_agent_app.py
+++ b/tests/unit_tests/cli/test_agent_app.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rich.console import Console
 
-from datus.cli.agent_app import AgentApp, AgentSelection, _Tab, _View
+from datus.cli.agent_app import AgentApp, _Tab, _View
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
 
 pytestmark = pytest.mark.ci
@@ -102,6 +102,13 @@ class TestListing:
         assert app._tab == _Tab.BUILTIN
         assert app._builtin_names[app._list_cursor] == "chat"
 
+    def test_default_tab_is_custom_without_seed(self):
+        """Without an explicit ``seed_tab`` the app lands on Custom — the
+        only tab that supports default-agent switching after the Built-in
+        tab became config-only."""
+        app = _build()
+        assert app._tab == _Tab.CUSTOM
+
     def test_visible_custom_filter_applies(self):
         cfg_nodes = {"alpha": {}, "beta": {}, "gamma": {}}
         app = _build(agentic_nodes=cfg_nodes, visible_custom_agents={"alpha", "gamma"})
@@ -114,29 +121,35 @@ class TestListing:
 
 
 class TestSetDefault:
-    def test_enter_on_builtin_row_sets_default(self):
-        """``Enter`` on any Built-in row (including ``chat``) sets that
-        agent as the session default. The edit form is NOT opened — that
-        flow now lives behind ``e``."""
-        app = _build()
+    def test_enter_on_builtin_row_opens_edit_form(self):
+        """``Enter`` on a Built-in row no longer sets default — Built-in
+        agents are platform-internal nodes that the TUI only lets users
+        configure (``max_turns`` overrides). Enter therefore aliases ``e``
+        and opens the override form so the keystroke still does something
+        useful."""
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
-        with patch.object(app._app, "exit") as exit_mock:
+        with patch.object(app._app, "exit") as exit_mock, patch.object(app._app.layout, "focus"):
             app._on_list_enter()
-        sel = exit_mock.call_args.kwargs["result"]
-        assert isinstance(sel, AgentSelection)
-        assert sel.kind == "set_default"
-        assert sel.name == "gen_sql"
+        exit_mock.assert_not_called()
+        assert app._view == _View.BUILTIN_EDIT
+        assert app._edit_target == "gen_sql"
 
-    def test_enter_on_chat_row_resets_default(self):
-        app = _build()
+    def test_enter_on_chat_row_in_builtin_tab_does_not_exit(self):
+        """``chat`` has no overridable fields and Built-in Enter no longer
+        sets default — the keystroke surfaces the same "no overrides"
+        error path that ``e`` produces, without exiting the app."""
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         chat_idx = app._builtin_names.index("chat")
         app._list_cursor = chat_idx
         with patch.object(app._app, "exit") as exit_mock:
             app._on_list_enter()
-        sel = exit_mock.call_args.kwargs["result"]
-        assert sel.kind == "set_default"
-        assert sel.name == "chat"
+        exit_mock.assert_not_called()
+        assert app._view == _View.AGENT_LIST
+        assert "chat" in (app._error_message or "")
 
     def test_enter_on_custom_agent_sets_default(self):
         app = _build(agentic_nodes={"alpha": {}, "beta": {}}, seed_tab="custom")
@@ -206,7 +219,8 @@ class TestCustomTabActions:
 
 class TestBuiltinEdit:
     def test_edit_key_on_builtin_opens_single_field_form(self):
-        app = _build()
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         # Pick a real built-in (not 'chat').
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
@@ -218,7 +232,8 @@ class TestBuiltinEdit:
 
     def test_edit_key_on_builtin_preselects_existing_max_turns(self):
         cfg_nodes = {"gen_sql": {"system_prompt": "gen_sql", "max_turns": 42}}
-        app = _build(agentic_nodes=cfg_nodes)
+        app = _build(agentic_nodes=cfg_nodes, seed_tab="builtin")
+        app._apply_seed()
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
         with patch.object(app._app.layout, "focus"):
@@ -230,7 +245,8 @@ class TestBuiltinEdit:
         ``model=None`` (cleared) when there is no pre-existing override
         on disk, regardless of what other fields the form might be
         showing."""
-        app = _build()
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
         with patch.object(app._app.layout, "focus"):
@@ -245,7 +261,8 @@ class TestBuiltinEdit:
         hand outside the UI), submitting the max_turns form must not
         silently drop it."""
         cfg_nodes = {"gen_sql": {"system_prompt": "gen_sql", "model": "my-internal", "max_turns": 10}}
-        app = _build(agentic_nodes=cfg_nodes)
+        app = _build(agentic_nodes=cfg_nodes, seed_tab="builtin")
+        app._apply_seed()
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
         with patch.object(app._app.layout, "focus"):
@@ -255,7 +272,8 @@ class TestBuiltinEdit:
         app._cfg.set_agentic_node_override.assert_called_once_with("gen_sql", model="my-internal", max_turns=42)
 
     def test_submit_clears_max_turns_when_empty(self):
-        app = _build()
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
         with patch.object(app._app.layout, "focus"):
@@ -265,7 +283,8 @@ class TestBuiltinEdit:
         app._cfg.set_agentic_node_override.assert_called_once_with("gen_sql", model=None, max_turns=None)
 
     def test_submit_rejects_non_integer_max_turns(self):
-        app = _build()
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
         with patch.object(app._app.layout, "focus"):
@@ -277,7 +296,8 @@ class TestBuiltinEdit:
         assert "integer" in (app._error_message or "")
 
     def test_submit_rejects_non_positive_max_turns(self):
-        app = _build()
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         gen_sql_idx = app._builtin_names.index("gen_sql")
         app._list_cursor = gen_sql_idx
         with patch.object(app._app.layout, "focus"):
@@ -290,7 +310,8 @@ class TestBuiltinEdit:
     def test_edit_key_on_chat_row_is_rejected(self):
         """``chat`` has no overridable fields — pressing ``e`` on that
         row surfaces an error instead of opening a half-populated form."""
-        app = _build()
+        app = _build(seed_tab="builtin")
+        app._apply_seed()
         chat_idx = app._builtin_names.index("chat")
         app._list_cursor = chat_idx
         app._on_list_edit()
@@ -304,16 +325,18 @@ class TestBuiltinEdit:
 
 
 class TestTabCycle:
-    def test_cycle_tab_forward_goes_builtin_to_custom(self):
+    def test_cycle_tab_forward_goes_custom_to_builtin(self):
+        """Custom is the actionable tab and lives first; Tab cycles
+        forward to the config-only Built-in tab and wraps back."""
         app = _build(agentic_nodes={"alpha": {}})
-        assert app._tab == _Tab.BUILTIN
-        app._cycle_tab(+1)
         assert app._tab == _Tab.CUSTOM
         app._cycle_tab(+1)
         assert app._tab == _Tab.BUILTIN
+        app._cycle_tab(+1)
+        assert app._tab == _Tab.CUSTOM
 
     def test_cycle_tab_backward(self):
         app = _build(agentic_nodes={"alpha": {}})
-        assert app._tab == _Tab.BUILTIN
-        app._cycle_tab(-1)
         assert app._tab == _Tab.CUSTOM
+        app._cycle_tab(-1)
+        assert app._tab == _Tab.BUILTIN

--- a/tests/unit_tests/cli/test_autocomplete.py
+++ b/tests/unit_tests/cli/test_autocomplete.py
@@ -236,7 +236,7 @@ class TestAtReferenceParser:
     def test_parse_empty_text(self):
         parser = AtReferenceParser()
         result = parser.parse_input("")
-        assert result == {"tables": [], "metrics": [], "sqls": []}
+        assert result == {"tables": [], "metrics": [], "sqls": [], "agent": None}
 
     def test_parse_table_reference(self):
         parser = AtReferenceParser()
@@ -756,16 +756,37 @@ class TestAtReferenceCompleterDetectSubAgent:
 class TestAtReferenceCompleterParseAtContext:
     def test_parse_empty_input(self, real_agent_config):
         completer = AtReferenceCompleter(real_agent_config)
-        tables, metrics, sqls = completer.parse_at_context("")
+        tables, metrics, sqls, agent = completer.parse_at_context("")
         assert tables == []
         assert metrics == []
         assert sqls == []
+        assert agent is None
 
     def test_parse_triggers_ensure_loaded(self, real_agent_config):
         completer = AtReferenceCompleter(real_agent_config)
         assert completer.table_completer._loaded is False
         completer.parse_at_context("@Table users")
         assert completer.table_completer._loaded is True
+
+    def test_parse_unknown_agent_drops_silently(self, real_agent_config):
+        """A misspelt agent name must NOT be returned as a routing hint —
+        otherwise the chat agent would try to delegate to a nonexistent
+        subagent. The visibility provider gates this so typos surface as
+        a no-op (with a logger warning) rather than a hard failure."""
+        completer = AtReferenceCompleter(
+            real_agent_config,
+            visibility_provider=lambda: {"gen_sql"},
+        )
+        _t, _m, _s, agent = completer.parse_at_context("@Agent unknown_xxx do something")
+        assert agent is None
+
+    def test_parse_known_agent_returned(self, real_agent_config):
+        completer = AtReferenceCompleter(
+            real_agent_config,
+            visibility_provider=lambda: {"gen_sql", "gen_report"},
+        )
+        _t, _m, _s, agent = completer.parse_at_context("@Agent gen_sql write me a query")
+        assert agent == "gen_sql"
 
 
 class TestAtReferenceCompleterGetCompletions:
@@ -785,7 +806,7 @@ class TestAtReferenceCompleterGetCompletions:
         doc = Document("@", cursor_position=1)
         completions = list(completer.get_completions(doc, None))
         texts = [c.text for c in completions]
-        for opt in ("Table", "Metrics", "Sql", "File"):
+        for opt in ("Table", "Metrics", "Sql", "File", "Agent"):
             assert opt in texts
 
     def test_plain_text_without_at_yields_nothing(self, real_agent_config):
@@ -820,3 +841,62 @@ class TestAtReferenceCompleterGetCompletions:
         completions = list(completer.get_completions(doc, None))
         texts = [c.text for c in completions]
         assert "Table" in texts
+
+
+# ---------------------------------------------------------------------------
+# AtReferenceCompleter: @Agent fuzzy completion and visibility provider
+# ---------------------------------------------------------------------------
+
+
+class TestAtReferenceCompleterAgent:
+    """``@Agent`` is a routing hint, not a path reference: the completer
+    must surface the agent name + description regardless of whether the
+    user has typed the literal ``@Agent`` prefix or just ``@<fuzzy>``,
+    and the visibility provider must gate the catalog so HIDDEN system
+    subagents and ``chat`` never appear."""
+
+    def test_visibility_provider_filters_chat_and_hidden(self, real_agent_config):
+        completer = AtReferenceCompleter(
+            real_agent_config,
+            visibility_provider=lambda: {"chat", "gen_sql", "feedback"},
+        )
+        # ``chat`` is dropped inside _AgentReferenceCompleter regardless of
+        # what the provider returns; HIDDEN agents (e.g. ``feedback``) are
+        # already filtered upstream by the real provider, so the contract
+        # we exercise here is that whatever the provider returns minus
+        # ``chat`` is what the completer offers.
+        names = completer.agent_completer.visible_names()
+        assert "chat" not in names
+        assert "gen_sql" in names
+
+    def test_fuzzy_match_returns_matching_agents(self, real_agent_config):
+        completer = AtReferenceCompleter(
+            real_agent_config,
+            visibility_provider=lambda: {"gen_sql", "gen_report", "scheduler"},
+        )
+        result = completer.agent_completer.fuzzy_match("gen")
+        assert set(result) == {"gen_sql", "gen_report"}
+
+    def test_at_prefix_surfaces_agent_completion(self, real_agent_config):
+        completer = AtReferenceCompleter(
+            real_agent_config,
+            visibility_provider=lambda: {"gen_sql"},
+        )
+        doc = Document("@gen_sq", cursor_position=7)
+        completions = list(completer.get_completions(doc, None))
+        texts = [c.text for c in completions]
+        assert "@Agent gen_sql" in texts
+
+    def test_at_agent_prefix_lists_remaining_agents(self, real_agent_config):
+        """Once the user has typed ``@Agent `` the router delegates to
+        ``_AgentReferenceCompleter.get_completions`` so the menu shows
+        every visible agent — that's the parity behaviour with
+        ``@Table ``."""
+        completer = AtReferenceCompleter(
+            real_agent_config,
+            visibility_provider=lambda: {"gen_sql", "gen_report"},
+        )
+        doc = Document("@Agent ", cursor_position=7)
+        completions = list(completer.get_completions(doc, None))
+        texts = {c.text for c in completions}
+        assert {"gen_sql", "gen_report"}.issubset(texts)

--- a/tests/unit_tests/cli/test_autocomplete.py
+++ b/tests/unit_tests/cli/test_autocomplete.py
@@ -123,12 +123,15 @@ class TestSQLCompleterGetCompletions:
         assert "users" in texts
 
     def test_select_context_suggests_columns(self):
+        """In a SELECT projection context the completer should surface
+        registered column names matching the current prefix — that's the
+        whole point of feeding ``update_tables`` ahead of completion."""
         c = SQLCompleter()
         c.update_tables({"users": ["id", "name"]})
         doc = Document("SELECT n", cursor_position=8)
-        list(c.get_completions(doc))
-        # Depending on what "previous word" is, columns may be suggested
-        # At minimum it should not raise
+        completions = list(c.get_completions(doc))
+        texts = [comp.text for comp in completions]
+        assert "name" in texts
 
     def test_keyword_completion(self):
         c = SQLCompleter()
@@ -379,7 +382,6 @@ class TestDynamicAtReferenceCompleterReloadData:
         iteration.
         """
         import threading
-        import time
 
         snapshots = [
             {f"snap0_{i}": {} for i in range(50)},
@@ -419,10 +421,13 @@ class TestDynamicAtReferenceCompleterReloadData:
         w2.start()
         w1.join()
         w2.join()
-        # Give the reader one more tick to catch any final torn state
-        time.sleep(0.05)
         stop.set()
         r.join()
+        # Final read on the main thread to ensure no torn state survives
+        # past join — mirrors the reader contract without depending on
+        # wall-clock timing (the previous time.sleep(0.05) was a debug
+        # artifact that made the test flaky on busy CI hosts).
+        c.fuzzy_match("snap")
 
         assert errors == []
         # Final snapshot must be one of the valid ones (all keys share the

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -49,8 +49,8 @@ class MinimalAtCompleter:
     """Minimal at-completer that returns empty context."""
 
     def parse_at_context(self, user_input):
-        """Return empty lists for tables, metrics, sqls."""
-        return ([], [], [])
+        """Return empty lists for tables, metrics, sqls and no agent hint."""
+        return ([], [], [], None)
 
 
 class MinimalCLI:
@@ -185,6 +185,38 @@ class TestChatCommandsInit:
         assert cmds.current_subagent_name is None
         assert cmds.chat_history == []
         assert cmds.last_actions == []
+
+
+# ===========================================================================
+# TestAgentDispatchHint
+# ===========================================================================
+
+
+class TestAgentDispatchHint:
+    """``@Agent <name>`` is wired as a *soft* routing hint, not a default-agent
+    switch. The chat agent's existing ``task`` FunctionTool fires when it
+    sees the hint annotation appended to the user message; the active node
+    and ``current_subagent_name`` must remain unchanged so the next turn
+    picks up where the user left off.
+    """
+
+    def test_hint_preserves_user_message_and_appends_annotation(self):
+        original = "@Agent gen_sql write me a query for sales by region"
+        rendered = ChatCommands._render_agent_dispatch_hint(original, "gen_sql")
+        assert rendered.startswith(original.rstrip())
+        # Annotation block must mention the agent name and the task tool
+        # so an LLM scan trivially routes the prompt.
+        assert "gen_sql" in rendered
+        assert "task tool" in rendered
+        assert 'type="gen_sql"' in rendered
+
+    def test_hint_strips_only_trailing_whitespace(self):
+        """Trailing whitespace from the user input shouldn't be propagated
+        into the annotation block, but the message content stays intact."""
+        rendered = ChatCommands._render_agent_dispatch_hint("hello world   \n  ", "gen_report")
+        # The trailing whitespace block is removed, then the annotation is
+        # appended after a single blank-line separator.
+        assert rendered.startswith("hello world\n\n[Agent dispatch]")
 
 
 # ===========================================================================

--- a/tests/unit_tests/cli/test_print_mode.py
+++ b/tests/unit_tests/cli/test_print_mode.py
@@ -54,7 +54,7 @@ def _make_runner(**overrides):
         patch("datus.cli.print_mode.AtReferenceCompleter") as mock_completer,
     ):
         mock_cfg.return_value = MagicMock(datasource_configs={})
-        mock_completer.return_value.parse_at_context.return_value = ([], [], [])
+        mock_completer.return_value.parse_at_context.return_value = ([], [], [], None)
         from datus.cli.print_mode import PrintModeRunner
 
         return PrintModeRunner(_make_args(**overrides))
@@ -254,7 +254,7 @@ class TestResumeSessionId:
             patch("datus.cli.print_mode.AtReferenceCompleter") as mock_completer,
         ):
             mock_cfg.return_value = MagicMock(datasource_configs={})
-            mock_completer.return_value.parse_at_context.return_value = ([], [], [])
+            mock_completer.return_value.parse_at_context.return_value = ([], [], [], None)
             from datus.cli.print_mode import PrintModeRunner
 
             runner = PrintModeRunner(_make_args(resume="session_abc"))
@@ -290,7 +290,7 @@ class TestResumeSessionId:
             patch("datus.cli.print_mode.AtReferenceCompleter") as mock_completer,
         ):
             mock_cfg.return_value = MagicMock(datasource_configs={})
-            mock_completer.return_value.parse_at_context.return_value = ([], [], [])
+            mock_completer.return_value.parse_at_context.return_value = ([], [], [], None)
             from datus.cli.print_mode import PrintModeRunner
 
             runner = PrintModeRunner(_make_args(resume="no_such_session"))
@@ -324,7 +324,7 @@ class TestResumeSessionId:
             patch("datus.cli.print_mode.AtReferenceCompleter") as mock_completer,
         ):
             mock_cfg.return_value = MagicMock(datasource_configs={})
-            mock_completer.return_value.parse_at_context.return_value = ([], [], [])
+            mock_completer.return_value.parse_at_context.return_value = ([], [], [], None)
             from datus.cli.print_mode import PrintModeRunner
 
             runner = PrintModeRunner(_make_args(resume="session_uuid123", subagent="gen_sql"))
@@ -366,7 +366,7 @@ class TestRunUsesFactory:
             patch("datus.cli.print_mode.AtReferenceCompleter") as mock_completer,
         ):
             mock_cfg.return_value = MagicMock(datasource_configs={})
-            mock_completer.return_value.parse_at_context.return_value = ([], [], [])
+            mock_completer.return_value.parse_at_context.return_value = ([], [], [], None)
             from datus.cli.print_mode import PrintModeRunner
 
             runner = PrintModeRunner(_make_args())

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -150,13 +150,16 @@ class TestMaybeScheduleStartupSync:
         cli.bg_sync.schedule.assert_not_called()
 
     def test_startup_sync_noop_without_bg_sync_attribute(self, cli):
-        """Early-init callers can invoke this before bg_sync is wired."""
+        """Early-init callers can invoke this before bg_sync is wired —
+        the method must short-circuit without fabricating the attribute,
+        otherwise the eventual real wiring in ``__init__`` would attach
+        to an empty placeholder instead of the real
+        :class:`BackgroundSchemaSyncManager`."""
         self._configure(cli, on_startup=True, current_ds="local_db")
-        # Ensure attribute missing
         if hasattr(cli, "bg_sync"):
             delattr(cli, "bg_sync")
-        # Must not raise
         cli._maybe_schedule_startup_sync()
+        assert not hasattr(cli, "bg_sync")
 
 
 class TestCmdExitShutsDownBgSync:
@@ -167,11 +170,21 @@ class TestCmdExitShutsDownBgSync:
         cli.bg_sync.shutdown.assert_called_once_with()
 
     def test_exit_works_without_bg_sync(self, cli):
+        """``_cmd_exit`` must still close the DB connector and return
+        ``EXIT_SENTINEL`` when bg_sync was never wired — that path runs
+        when the REPL aborts early (e.g. config load failure) before
+        ``BackgroundSchemaSyncManager`` is constructed in ``__init__``."""
+        from datus.cli.tui.app import EXIT_SENTINEL
+
         if hasattr(cli, "bg_sync"):
             delattr(cli, "bg_sync")
-        cli.db_connector = MagicMock()
-        # Must not raise even when bg_sync is absent
-        cli._cmd_exit("")
+        connector = MagicMock()
+        cli.db_connector = connector
+
+        result = cli._cmd_exit("")
+
+        assert result == EXIT_SENTINEL
+        connector.close.assert_called_once_with()
 
 
 class TestCommandType:

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -980,8 +980,9 @@ class TestCmdAgent:
 
     def test_cmd_agent_no_args_opens_unified_tui(self, cli):
         """'.agent' (no args) opens the unified :class:`AgentApp` seeded
-        on the Built-in tab. A ``set_default`` selection from the app
-        updates ``default_agent``."""
+        on the Custom tab — that's the only tab where ``Enter`` still
+        sets a default after Built-in became config-only. A
+        ``set_default`` selection from the app updates ``default_agent``."""
         from datus.cli.agent_app import AgentSelection
 
         cli.available_subagents = {"chat", "gen_sql"}
@@ -990,7 +991,7 @@ class TestCmdAgent:
             mock_cls.return_value.run.return_value = AgentSelection(kind="set_default", name="gen_sql")
             cli._cmd_agent("")
         mock_cls.assert_called_once()
-        assert mock_cls.call_args.kwargs["seed_tab"] == "builtin"
+        assert mock_cls.call_args.kwargs["seed_tab"] == "custom"
         assert cli.default_agent == "gen_sql"
 
     def test_cmd_subagent_opens_unified_tui_on_custom_tab(self, cli):

--- a/tests/unit_tests/cli/tui/test_app.py
+++ b/tests/unit_tests/cli/tui/test_app.py
@@ -634,6 +634,64 @@ class TestPasteCollapse:
         assert dim.preferred == 3
         assert dim.max == 15
 
+    def test_dynamic_height_includes_wrapped_lines(self, tui_app: DatusApp, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Visual rows count wrapped segments, not just hard newlines."""
+        from prompt_toolkit.document import Document
+
+        # Pin a narrow terminal so wrap math is deterministic.
+        monkeypatch.setattr(tui_app, "_terminal_columns", lambda: 20)
+        # Prompt "> " is 2 cells -> first line usable = 18; others = 20.
+
+        # Single hard line of 50 chars: first segment ceil(50/18)=3 rows.
+        tui_app.input_buffer.document = Document("a" * 50)
+        dim = tui_app._get_input_height()
+        assert dim.preferred == 3
+
+        # Mixed: long first line + short second + long third line.
+        # Line 1: 40 chars, usable 18 -> ceil(40/18)=3.
+        # Line 2: "ok" -> 1.
+        # Line 3: 25 chars, usable 20 -> ceil(25/20)=2.
+        tui_app.input_buffer.document = Document(("a" * 40) + "\nok\n" + ("b" * 25))
+        dim = tui_app._get_input_height()
+        assert dim.preferred == 6
+
+        # Wide / CJK characters take 2 cells each.
+        # 12 CJK chars = 24 cells; usable 18 -> ceil(24/18)=2.
+        tui_app.input_buffer.document = Document("中" * 12)
+        dim = tui_app._get_input_height()
+        assert dim.preferred == 2
+
+        # Cap stays at 15 even with very long input.
+        tui_app.input_buffer.document = Document("a" * 10000)
+        dim = tui_app._get_input_height()
+        assert dim.preferred == 15
+        assert dim.max == 15
+
+    def test_visual_line_count_handles_empty_buffer(self, tui_app: DatusApp) -> None:
+        """Empty input still occupies one visual row."""
+        assert tui_app._input_visual_line_count() == 1
+
+    def test_input_prompt_display_width_counts_wide_chars(self, tui_app: DatusApp) -> None:
+        """Prompt width must use cwidth so CJK prompts are not undercounted."""
+        # Default prompt is "> " -> 2 cells.
+        assert tui_app._input_prompt_display_width() == 2
+
+        tui_app._input_prompt_fn = lambda: "中> "
+        # "中" = 2 cells, "> " = 2 cells.
+        assert tui_app._input_prompt_display_width() == 4
+
+    def test_terminal_columns_falls_back_to_shutil(self, tui_app: DatusApp, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When the Application output reports zero columns, use shutil."""
+        from prompt_toolkit.data_structures import Size
+
+        # Force the primary path (Application.output) to report a useless size
+        # so the shutil fallback runs.
+        monkeypatch.setattr(tui_app._app.output, "get_size", lambda: Size(rows=24, columns=0))
+        import shutil
+
+        monkeypatch.setattr(shutil, "get_terminal_size", lambda fallback=(80, 24): Size(rows=fallback[1], columns=42))
+        assert tui_app._terminal_columns() == 42
+
     def test_clear_paste_state_method(self, tui_app: DatusApp) -> None:
         tui_app._stored_paste = "some text"
         tui_app._paste_collapsed = True

--- a/tests/unit_tests/cli/tui/test_app.py
+++ b/tests/unit_tests/cli/tui/test_app.py
@@ -584,14 +584,23 @@ class TestPasteCollapse:
         assert f"prefix {paste_text} suffix" == buffer.text
 
     def test_ctrl_e_noop_without_paste(self, tui_app: DatusApp) -> None:
+        """Every Ctrl+E binding must be filter-gated off when no paste
+        is stored — otherwise the keystroke would surprise users who
+        never bracketed-pasted into the input bar.
+
+        Collect the bindings up-front (rather than asserting inside the
+        loop and ``return``-ing on the first hit) so the contract holds
+        for ALL Ctrl+E bindings, not just whichever happens to come
+        first in the registry.
+        """
         from prompt_toolkit.keys import Keys
 
         assert tui_app._stored_paste is None
-        for binding in tui_app.key_bindings.bindings:
-            if Keys.ControlE in getattr(binding, "keys", ()):
-                assert not binding.filter()
-                return
-        pytest.fail("ControlE binding not found")
+        ctrl_e_bindings = [
+            binding for binding in tui_app.key_bindings.bindings if Keys.ControlE in getattr(binding, "keys", ())
+        ]
+        assert ctrl_e_bindings, "ControlE binding not found"
+        assert all(not binding.filter() for binding in ctrl_e_bindings)
 
     def test_placeholder_deleted_clears_state(self, tui_app: DatusApp) -> None:
         """When user deletes the placeholder text, stored paste is discarded."""

--- a/tests/unit_tests/utils/test_at_parser.py
+++ b/tests/unit_tests/utils/test_at_parser.py
@@ -38,3 +38,46 @@ def test_parse(parser: AtReferenceParser):
 
     assert len(parse_result["tables"]) == 1
     assert len(parse_result["metrics"]) == 1
+
+
+def test_parse_agent_basic(parser: AtReferenceParser):
+    """``@Agent <name>`` returns the bare agent name regardless of the
+    rest of the prompt — the consumer uses this as a routing hint into
+    the chat agent's ``task`` tool, not as a path."""
+    result = parser.parse_input("Please @Agent gen_sql write a query for me")
+    assert result["agent"] == "gen_sql"
+
+
+def test_parse_agent_first_match_wins(parser: AtReferenceParser):
+    """Subsequent ``@Agent`` mentions are dropped on purpose so the
+    dispatch hint stays deterministic — we don't want one prompt to
+    fan out to two subagents."""
+    result = parser.parse_input("@Agent gen_sql first @Agent gen_report second")
+    assert result["agent"] == "gen_sql"
+
+
+def test_parse_agent_case_insensitive(parser: AtReferenceParser):
+    result = parser.parse_input("hello @agent gen_sql world")
+    assert result["agent"] == "gen_sql"
+
+
+def test_parse_agent_coexists_with_other_references(parser: AtReferenceParser):
+    """``@Agent`` lives in its own slot — the table / metric extractors
+    must remain unaffected when an agent mention is present."""
+    result = parser.parse_input("@Agent gen_sql analyse @Table sales.orders for @Metrics core.revenue")
+    assert result["agent"] == "gen_sql"
+    assert result["tables"] == ["sales.orders"]
+    assert result["metrics"] == ["core.revenue"]
+
+
+def test_parse_agent_absent_returns_none(parser: AtReferenceParser):
+    result = parser.parse_input("Just @Table foo.bar nothing else")
+    assert result["agent"] is None
+
+
+def test_parse_agent_name_does_not_swallow_following_words(parser: AtReferenceParser):
+    """Identifier-only regex prevents the following sentence from being
+    pulled into the agent name — the consumer would otherwise treat
+    'gen_sql write me a query' as the agent name and fail visibility."""
+    result = parser.parse_input("@Agent gen_sql write me a query")
+    assert result["agent"] == "gen_sql"


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline `@Agent <name>` support in completions and chat, plus explicit agent-dispatch annotation when routing messages.

* **Improvements**
  * Agent management opens on the Custom tab by default; tab cycling order updated.
  * Input area height now accounts for visual line wrapping and terminal width.
  * Built-in list Enter action now opens the edit view for overridable items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->