### PR TITLE
[BugFix] Fix gateway Slack response handling

### DIFF
--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -187,6 +187,16 @@ def _build_response_content(action: ActionHistory) -> List[IMessageContent]:
     return contents
 
 
+def _is_plain_assistant_response(action: ActionHistory) -> bool:
+    """Return True for completed assistant text that should render as markdown."""
+    if action.role != ActionRole.ASSISTANT or action.status != ActionStatus.SUCCESS:
+        return False
+    if action.action_type != "response":
+        return False
+    output = action.output if isinstance(action.output, dict) else {}
+    return output.get("is_thinking") is False
+
+
 def _build_thinking_content(action: ActionHistory) -> Optional[List[IMessageContent]]:
     """Extract text content from action for markdown display."""
     from datus.utils.text_utils import strip_litellm_placeholder
@@ -385,6 +395,10 @@ def action_to_sse_event(
         ):
             if not include_final_response:
                 return None  # ignore parsed final response
+            contents = _build_response_content(action)
+            if not contents:
+                return None
+        elif _is_plain_assistant_response(action):
             contents = _build_response_content(action)
             if not contents:
                 return None

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -723,8 +723,10 @@ class AgentConfig:
         # value at node build time and do not hot-reload.
         self.validation_config = ValidationConfig.from_dict(kwargs.get("validation", {}))
 
-        # Initialize channels configuration for Datus Gateway IM gateway
-        self.channels_config: Dict[str, Any] = kwargs.get("channels", {})
+        # Initialize channels configuration for Datus Gateway IM gateway.
+        # Keep this aligned with other config sections: channel credentials may
+        # use ${ENV_VAR} placeholders inside nested adapter-specific fields.
+        self.channels_config: Dict[str, Any] = _resolve_nested_value(kwargs.get("channels", {}))
 
         # Platform documentation fetch configs (datasource-independent)
         document_raw = kwargs.get("document", {}) or {}

--- a/docs/gateway/slack.md
+++ b/docs/gateway/slack.md
@@ -53,6 +53,8 @@ Using a manifest is the fastest way to create a correctly configured Slack App. 
         "mpim:history",
         "mpim:read",
         "mpim:write",
+        "reactions:read",
+        "reactions:write",
         "users:read"
       ]
     }
@@ -65,7 +67,9 @@ Using a manifest is the fastest way to create a correctly configured Slack App. 
         "message.channels",
         "message.groups",
         "message.im",
-        "message.mpim"
+        "message.mpim",
+        "reaction_added",
+        "reaction_removed"
       ]
     }
   }
@@ -75,7 +79,7 @@ Using a manifest is the fastest way to create a correctly configured Slack App. 
 5. Review the summary and click **Create**.
 
 !!! tip "Customize the manifest"
-    You can change `display_information.name` to any name you prefer. Add extra scopes (e.g., `reactions:write`, `files:write`) if needed for your use case.
+    You can change `display_information.name` to any name you prefer. Add extra scopes (e.g., `files:write`) if needed for your use case.
 
 ## Step 3: Generate Tokens
 
@@ -102,13 +106,14 @@ After the app is created, you need two tokens:
 
 ## Step 4: Invite the Bot to Channels
 
-In Slack, invite the bot to each channel where you want it to respond:
+In Slack, add the app to each channel where you want it to respond:
 
-```bash
-/invite @YourBotName
-```
+1. Open the target channel.
+2. Click the channel name at the top.
+3. Go to **Integrations** → **Add apps**.
+4. Select your Datus Agent app and click **Add**.
 
-The bot will only receive messages from channels it has been invited to.
+The bot will only receive channel messages from channels where the app has been added.
 
 ## Step 5: Configure Datus Agent
 
@@ -174,6 +179,8 @@ If you created the app from the manifest above, all scopes and events are alread
 | `mpim:history` | Read group direct messages |
 | `mpim:read` | View group DM info |
 | `mpim:write` | Start group DMs |
+| `reactions:read` | Receive user reaction feedback events |
+| `reactions:write` | Add/remove processing and completion reactions |
 | `users:read` | View user info |
 | `app_mentions:read` | Receive @mention events |
 
@@ -186,6 +193,8 @@ If you created the app from the manifest above, all scopes and events are alread
 | `message.im` | Direct message sent to the bot |
 | `message.mpim` | Message in a group DM |
 | `app_mention` | Bot is @mentioned |
+| `reaction_added` | User adds feedback reaction to a bot reply |
+| `reaction_removed` | User removes feedback reaction from a bot reply |
 
 ??? info "Manual setup (without manifest)"
     If you prefer to configure the app manually instead of using the manifest:
@@ -205,14 +214,15 @@ If you created the app from the manifest above, all scopes and events are alread
 
 ### Bot connects but doesn't receive messages
 
-- Ensure the bot is invited to the channel (`/invite @BotName`).
-- Verify event subscriptions are enabled and the four `message.*` events are added.
+- Ensure the Datus Agent app has been added to the channel via **Channel details → Integrations → Add apps**.
+- Verify event subscriptions are enabled and the `message.*` events are added.
 - Check that Socket Mode is enabled.
 
 ### "missing_scope" error
 
 - Go to **OAuth & Permissions → Bot Token Scopes** and add the missing scope.
 - Reinstall the app after adding new scopes.
+- If the missing scope is `reactions:write`, status reactions will fail until the app is reinstalled with that scope.
 
 ### Messages from bot trigger loops
 

--- a/docs/gateway/slack.zh.md
+++ b/docs/gateway/slack.zh.md
@@ -53,6 +53,8 @@ pip install "slack-sdk[socket_mode]"
         "mpim:history",
         "mpim:read",
         "mpim:write",
+        "reactions:read",
+        "reactions:write",
         "users:read"
       ]
     }
@@ -65,7 +67,9 @@ pip install "slack-sdk[socket_mode]"
         "message.channels",
         "message.groups",
         "message.im",
-        "message.mpim"
+        "message.mpim",
+        "reaction_added",
+        "reaction_removed"
       ]
     }
   }
@@ -75,7 +79,7 @@ pip install "slack-sdk[socket_mode]"
 5. 检查配置摘要，点击 **Create**。
 
 !!! tip "自定义 Manifest"
-    你可以将 `display_information.name` 修改为任意名称。如需额外功能，可添加更多权限范围（如 `reactions:write`、`files:write`）。
+    你可以将 `display_information.name` 修改为任意名称。如需额外功能，可添加更多权限范围（如 `files:write`）。
 
 ## 步骤 3：生成令牌
 
@@ -100,15 +104,16 @@ pip install "slack-sdk[socket_mode]"
 
     如果你的令牌以 `xoxp-` 开头，说明误复制了 User OAuth Token。
 
-## 步骤 4：邀请机器人到频道
+## 步骤 4：将机器人添加到频道
 
-在 Slack 中，将机器人邀请到你希望它响应消息的频道：
+在 Slack 中，将应用添加到你希望它响应消息的频道：
 
-```bash
-/invite @YourBotName
-```
+1. 打开目标频道。
+2. 点击顶部的频道名称。
+3. 进入 **Integrations** → **Add apps**。
+4. 选择你的 Datus Agent 应用并点击 **Add**。
 
-机器人只会接收到它已被邀请的频道中的消息。
+机器人只会接收到已添加该应用的频道中的消息。
 
 ## 步骤 5：配置 Datus Agent
 
@@ -174,6 +179,8 @@ Slack adapter 'slack-main' started.
 | `mpim:history` | 读取群组私聊消息 |
 | `mpim:read` | 查看群组私聊信息 |
 | `mpim:write` | 发起群组私聊 |
+| `reactions:read` | 接收用户反馈表情事件 |
+| `reactions:write` | 添加/移除处理中和完成状态表情 |
 | `users:read` | 查看用户信息 |
 | `app_mentions:read` | 接收 @提及 事件 |
 
@@ -186,6 +193,8 @@ Slack adapter 'slack-main' started.
 | `message.im` | 机器人收到私聊消息 |
 | `message.mpim` | 群组私聊中有新消息 |
 | `app_mention` | 机器人被 @提及 |
+| `reaction_added` | 用户对 bot 回复添加反馈表情 |
+| `reaction_removed` | 用户移除 bot 回复上的反馈表情 |
 
 ??? info "手动配置（不使用 Manifest）"
     如果你更倾向于手动配置应用：
@@ -205,14 +214,15 @@ Slack adapter 'slack-main' started.
 
 ### 机器人连接成功但收不到消息
 
-- 确保机器人已被邀请到频道（`/invite @BotName`）。
-- 确认事件订阅已启用，且已添加四个 `message.*` 事件。
+- 确保已通过 **频道详情 → Integrations → Add apps** 将 Datus Agent 应用添加到频道。
+- 确认事件订阅已启用，且已添加 `message.*` 事件。
 - 检查 Socket Mode 是否已启用。
 
 ### "missing_scope" 错误
 
 - 前往 **OAuth & Permissions → Bot Token Scopes** 添加缺少的权限范围。
 - 添加新权限后需要重新安装应用。
+- 如果缺少的是 `reactions:write`，在重新安装带该权限的应用前，状态表情会添加/移除失败。
 
 ### 机器人消息触发循环
 

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -733,6 +733,20 @@ class TestActionToSSEEvent:
         assert event.data.payload.content[0].type == "markdown"
         assert event.data.payload.content[0].payload == {"content": "1 table: orders"}
 
+    def test_plain_assistant_response_renders_as_markdown(self):
+        """Completed model response actions must not be mislabeled as thinking."""
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="response",
+            output={"raw_output": "Hello from the model", "is_thinking": False},
+        )
+        event = action_to_sse_event(action, event_id=6, message_id="msg-6")
+        assert event is not None
+        content = event.data.payload.content[0]
+        assert content.type == "markdown"
+        assert content.payload == {"content": "Hello from the model"}
+
     def test_empty_assistant_response_action_still_skipped_when_requested(self):
         """Empty wrapper responses do not create blank assistant bubbles."""
         action = _make_action(

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -706,6 +706,47 @@ class TestAgentConfigApiSection:
         assert cfg.api_config == api
 
 
+class TestAgentConfigChannels:
+    def _make(self, tmp_path, channels=None):
+        kwargs = dict(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            skip_init_dirs=True,
+        )
+        if channels is not None:
+            kwargs["channels"] = channels
+        return AgentConfig(**kwargs)
+
+    def test_channel_config_resolves_nested_env_values(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-test")
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+        cfg = self._make(
+            tmp_path,
+            channels={
+                "slack-main": {
+                    "adapter": "slack",
+                    "extra": {
+                        "app_token": "${SLACK_APP_TOKEN}",
+                        "bot_token": "${SLACK_BOT_TOKEN}",
+                    },
+                }
+            },
+        )
+
+        extra = cfg.channels_config["slack-main"]["extra"]
+        assert extra["app_token"] == "xapp-test"
+        assert extra["bot_token"] == "xoxb-test"
+
+
 class TestNormalizeProjectName:
     """Tests for the _normalize_project_name helper."""
 


### PR DESCRIPTION
## Why

Gateway Slack could post `(No response generated)` even when the model produced a final answer because completed assistant response actions were converted as `thinking` content and then filtered by the non-streaming Slack path. Gateway channel credentials also did not resolve nested environment placeholders, and Slack docs missed reaction scopes/events required by the implementation.

## Solution

- Render completed assistant `response` actions with `is_thinking=false` as markdown SSE content.
- Resolve `${ENV_VAR}` placeholders inside `agent.channels`.
- Update English and Chinese Slack gateway docs for reaction scopes/events and the Add apps channel flow.
- Add focused unit coverage.

## Test Cases

- `uv run pytest tests/unit_tests/api/services/test_action_sse_converter.py -q`
- `uv run pytest tests/unit_tests/api/services/test_chat_task_manager.py::TestChatTaskManagerBehavior::test_run_loop_emits_final_response_when_no_plain_assistant_response tests/unit_tests/api/services/test_chat_task_manager.py::TestChatTaskManagerBehavior::test_run_loop_skips_final_response_after_plain_assistant_response tests/unit_tests/api/services/test_chat_task_manager.py::TestChatTaskManagerBehavior::test_run_loop_dedupes_duplicate_plain_assistant_messages tests/unit_tests/api/services/test_chat_task_manager.py::TestIsThinkingDelta -q`
- `uv run pytest tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigChannels -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced assistant response handling to properly display non-thinking responses
- Added environment variable resolution for nested Slack channel configuration parameters

**Documentation**
- Updated Slack integration documentation with reaction event support and revised setup workflow, including new troubleshooting guidance (English and Chinese versions)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->