### PR TITLE
[BugFix] Redact credentials in catalog/list URI response

### DIFF
--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -29,6 +29,7 @@ from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_table_name_parts
+from datus.utils.text_utils import redact_uri
 
 logger = get_logger(__name__)
 # Database types that do NOT support schema switching
@@ -596,5 +597,5 @@ def _get_uri(connector: BaseSqlConnector) -> str:
         return ""
     connection_string = getattr(connector, "connection_string", "")
     if connection_string:
-        return connection_string
+        return redact_uri(connection_string)
     return f"{connector.dialect}://"

--- a/datus/cli/datasource_manager.py
+++ b/datus/cli/datasource_manager.py
@@ -11,7 +11,6 @@ without requiring users to manually write conf/agent.yml files.
 """
 
 from getpass import getpass
-from urllib.parse import urlsplit, urlunsplit
 
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
@@ -23,24 +22,10 @@ from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.path_manager import get_path_manager
+from datus.utils.text_utils import redact_uri
 
 logger = get_logger(__name__)
 console = Console()
-
-
-def _redact_uri(uri: str) -> str:
-    """Redact any password in a database URI, keeping scheme/host/path visible."""
-    try:
-        parts = urlsplit(uri)
-    except ValueError:
-        return uri
-    if parts.password is None:
-        return uri
-    username = parts.username or ""
-    host = parts.hostname or ""
-    port = f":{parts.port}" if parts.port else ""
-    netloc = f"{username}:***@{host}{port}" if username else f"***@{host}{port}"
-    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 def _validate_datasource_name(name: str) -> tuple[bool, str]:
@@ -153,7 +138,7 @@ class DatasourceManager:
             if db_config.host:
                 console.print(f"    Host: {db_config.host}:{db_config.port}")
             if db_config.uri:
-                console.print(f"    URI: {_redact_uri(db_config.uri)}")
+                console.print(f"    URI: {redact_uri(db_config.uri)}")
             if db_config.database:
                 console.print(f"    Database: {db_config.database}")
             if db_config.schema:

--- a/datus/utils/text_utils.py
+++ b/datus/utils/text_utils.py
@@ -4,8 +4,26 @@
 
 import re
 import unicodedata
+from urllib.parse import urlsplit, urlunsplit
 
 LITELLM_EMPTY_PLACEHOLDER = "[System: Empty message content sanitised to satisfy protocol]"
+
+
+def redact_uri(uri: str) -> str:
+    """Redact any password in a database URI, keeping scheme/host/path visible."""
+    if not uri:
+        return uri
+    try:
+        parts = urlsplit(uri)
+    except ValueError:
+        return uri
+    if parts.password is None:
+        return uri
+    username = parts.username or ""
+    host = parts.hostname or ""
+    port = f":{parts.port}" if parts.port else ""
+    netloc = f"{username}:***@{host}{port}" if username else f"***@{host}{port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 def strip_litellm_placeholder(text: str) -> str:

--- a/datus/utils/text_utils.py
+++ b/datus/utils/text_utils.py
@@ -20,8 +20,15 @@ def redact_uri(uri: str) -> str:
     if parts.password is None:
         return uri
     username = parts.username or ""
-    host = parts.hostname or ""
-    port = f":{parts.port}" if parts.port else ""
+    hostname = parts.hostname or ""
+    # urlsplit strips IPv6 brackets from .hostname; restore them so the
+    # reconstructed netloc remains parseable (e.g. "[::1]:5432").
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    try:
+        port_num = parts.port
+    except ValueError:
+        port_num = None
+    port = f":{port_num}" if port_num is not None else ""
     netloc = f"{username}:***@{host}{port}" if username else f"***@{host}{port}"
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 

--- a/tests/unit_tests/utils/test_text_utils.py
+++ b/tests/unit_tests/utils/test_text_utils.py
@@ -7,6 +7,7 @@ from datus.utils.text_utils import (
     LITELLM_EMPTY_PLACEHOLDER,
     LitellmPlaceholderStreamFilter,
     clean_text,
+    redact_uri,
     strip_litellm_placeholder,
 )
 
@@ -190,3 +191,37 @@ class TestLitellmPlaceholderStreamFilter:
         for ch in LITELLM_EMPTY_PLACEHOLDER:
             f.feed(ch)
         assert f.finalize() == ""
+
+
+class TestRedactUri:
+    def test_empty_string_returns_empty(self):
+        assert redact_uri("") == ""
+
+    def test_none_returns_none(self):
+        assert redact_uri(None) is None
+
+    def test_uri_with_user_and_password_redacted(self):
+        assert redact_uri("mysql://alice:secret@db.example.com:3306/sales") == (
+            "mysql://alice:***@db.example.com:3306/sales"
+        )
+
+    def test_uri_with_password_only_redacted(self):
+        assert redact_uri("postgresql://:secret@host/db") == "postgresql://***@host/db"
+
+    def test_uri_without_password_unchanged(self):
+        uri = "postgresql://alice@db.example.com:5432/sales"
+        assert redact_uri(uri) == uri
+
+    def test_uri_without_credentials_unchanged(self):
+        uri = "sqlite:///tmp/local.db"
+        assert redact_uri(uri) == uri
+
+    def test_query_and_fragment_preserved(self):
+        assert redact_uri("postgresql://u:p@host:5432/db?sslmode=require#frag") == (
+            "postgresql://u:***@host:5432/db?sslmode=require#frag"
+        )
+
+    def test_invalid_uri_returned_as_is(self):
+        # Bracketed IPv6 with bad port triggers ValueError in urlsplit
+        weird = "http://[::1]:bad/path"
+        assert redact_uri(weird) == weird

--- a/tests/unit_tests/utils/test_text_utils.py
+++ b/tests/unit_tests/utils/test_text_utils.py
@@ -221,7 +221,18 @@ class TestRedactUri:
             "postgresql://u:***@host:5432/db?sslmode=require#frag"
         )
 
-    def test_invalid_uri_returned_as_is(self):
-        # Bracketed IPv6 with bad port triggers ValueError in urlsplit
+    def test_invalid_uri_without_password_returned_as_is(self):
+        # No password → early return, never touches the malformed port.
         weird = "http://[::1]:bad/path"
         assert redact_uri(weird) == weird
+
+    def test_ipv6_host_brackets_preserved(self):
+        assert redact_uri("postgresql://u:p@[::1]:5432/db") == "postgresql://u:***@[::1]:5432/db"
+
+    def test_ipv6_host_without_port_brackets_preserved(self):
+        assert redact_uri("postgresql://u:p@[::1]/db") == "postgresql://u:***@[::1]/db"
+
+    def test_malformed_port_with_password_omits_port(self):
+        # parts.port raises ValueError; we must not propagate, and the port
+        # is dropped from the redacted netloc rather than crashing.
+        assert redact_uri("http://u:p@example.com:bad/path") == "http://u:***@example.com/path"


### PR DESCRIPTION
The /api/v1/catalog/list endpoint returned the connector's raw connection string in DatabaseInfo.uri, exposing username and password to API clients. Mask the password while preserving scheme/user/host/path so the URI stays useful for display and debugging.

Extract redact_uri to datus/utils/text_utils.py and reuse it from both the API service and the CLI datasource manager.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Database connection URIs now redact passwords when shown in the CLI and other surfaces, replacing credentials with `***`.
* **New Feature**
  * Introduced a shared utility to consistently sanitize sensitive parts of URIs across the app.
* **Tests**
  * Added unit tests covering empty/malformed URIs, preservation of non-credential parts, and correct redaction of passwords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->