### PR TITLE
[Refactor] Unify service default selection across BI / Scheduler / Semantic 

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -180,14 +180,21 @@ agent:
         username: ${STARROCKS_USER}
         password: ${STARROCKS_PASSWORD}
         database: ${STARROCKS_DATABASE}
+    # Default selection across BI / Scheduler / Semantic follows one rule:
+    # explicit call-site arg → ``./.datus/config.yml`` project pin → YAML
+    # ``default: true`` flag → single-entry shortcut → raise on ambiguity.
+    # Mark at most one entry per section with ``default: true``.
     semantic_layer:
       metricflow: {}
+      # metricflow:                 # alternative: pin as global default
+      #   default: true
     bi_platforms:
       superset:
         type: superset
         api_base_url: http://localhost:8088
         username: admin
         password: admin
+        # default: true             # uncomment to make this the global default BI
         extra: # Special configurations for different platforms
           provider: db
     schedulers:
@@ -197,6 +204,7 @@ agent:
         api_base_url: http://localhost:8080/api/v1
         username: ${AIRFLOW_USERNAME}
         password: ${AIRFLOW_PASSWORD}
+        # default: true             # uncomment to make this the global default scheduler
         dags_folder: /path/to/airflow/dags
         dag_discovery_timeout: 60
         dag_discovery_poll_interval: 5

--- a/datus/cli/action_display/display.py
+++ b/datus/cli/action_display/display.py
@@ -366,15 +366,16 @@ class ActionHistoryDisplay:
         history_turns: Optional[List[Tuple[str, List[ActionHistory]]]] = None,
         current_user_message: str = "",
         interaction_broker: Optional["InteractionBroker"] = None,
-        streaming_deltas: Optional[List[ActionHistory]] = None,
+        streaming_deltas: Optional[Dict[str, List[ActionHistory]]] = None,
     ) -> "InlineStreamingContext":
         """Create an inline streaming display context for actions (Claude Code style).
 
-        ``streaming_deltas`` is an optional parallel queue for
-        ``thinking_delta`` actions; the caller populates it as delta events
-        arrive and clears it on each message boundary. The streaming context
-        reads from it for pinned-region live rendering and mid-run Ctrl+O
-        re-render of the main body.
+        ``streaming_deltas`` is an optional per-message dict of
+        ``thinking_delta`` actions, keyed by ``action_id`` (the
+        ``thinking_stream_id`` shared across all deltas + the paired
+        terminal response). The producer only appends to its own bucket;
+        the streaming context drains buckets via per-bucket cursors and
+        drops a bucket when it processes the matching terminal response.
         """
         from datus.cli.action_display.streaming import InlineStreamingContext
 

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -86,16 +86,28 @@ class InlineStreamingContext:
         sync_mode: bool = False,
         interaction_broker: Optional["InteractionBroker"] = None,
         live_state: Optional["LiveDisplayState"] = None,
-        streaming_deltas: Optional[List[ActionHistory]] = None,
+        streaming_deltas: Optional[Dict[str, List[ActionHistory]]] = None,
     ):
         self.actions = actions_list
-        # Parallel queue holding ``thinking_delta`` actions only. Populated by
-        # the caller (``chat_commands.run_chat_stream``) as deltas stream in
-        # and cleared on paired terminal response actions. The streaming
-        # context consumes from here via ``_delta_processed_index`` so
-        # ``self.actions`` stays delta-free and structural.
-        self._deltas: List[ActionHistory] = streaming_deltas if streaming_deltas is not None else []
-        self._delta_processed_index: int = 0
+        # Per-message dict of ``thinking_delta`` actions. The caller
+        # (``chat_commands.run_chat_stream``) appends each delta to a
+        # bucket keyed by ``action.action_id`` (the ``thinking_stream_id``
+        # shared across all deltas + paired terminal response in a single
+        # message). Buckets only grow; the consumer drops a bucket when
+        # it processes the matching terminal response. Keying by
+        # ``action_id`` eliminates the data race the previous shared list
+        # had — the producer no longer mutates anything but its own
+        # bucket via ``append``.
+        self._deltas: Dict[str, List[ActionHistory]] = streaming_deltas if streaming_deltas is not None else {}
+        # Per-bucket consumption cursor. ``_process_deltas`` walks each
+        # bucket forward from its cursor; ``_print_completed_action``
+        # drains and pops the bucket on the matching terminal response.
+        self._delta_cursors: Dict[str, int] = {}
+        # ``action_id`` of the bucket that currently owns the live pinned
+        # tail. Used by ``_reprint_history`` for the Ctrl+O snapshot and
+        # by ``_drain_bucket`` to insert a finalize boundary when
+        # switching from one message's deltas to another's.
+        self._active_message_id: Optional[str] = None
         self.display = display_instance
         self._history_turns: List[Tuple[str, List[ActionHistory]]] = history_turns or []
         self._current_user_message = current_user_message
@@ -315,7 +327,11 @@ class InlineStreamingContext:
 
     def __enter__(self):
         self._processed_index = 0
-        self._delta_processed_index = 0
+        # Cursors and active-bucket pointer are owned by the consumer; the
+        # ``_deltas`` dict itself is owned by the caller (``chat_commands``)
+        # so we never reset it here.
+        self._delta_cursors = {}
+        self._active_message_id = None
         self._stop_event.clear()
         self._paused = False
         # Fresh turn: forget which response we've already finalized so the
@@ -511,18 +527,20 @@ class InlineStreamingContext:
                 a for a in self.actions[: self._processed_index] if not (a.role == ActionRole.USER and a.depth == 0)
             ]
             self.display.render_action_history(current_actions, verbose=verbose, _show_partial_done=False)
-            # 3a. Render the streaming main-agent body (from deltas accumulator)
-            # so mid-run Ctrl+O doesn't drop the text the user was reading.
-            # ``_response`` / plain ``response`` only arrive after deltas end,
-            # so the deltas queue is the only source of truth for the
-            # *in-flight* message body. We pick the last delta's
-            # ``accumulated`` field because each delta carries the full
-            # running text up to that point. After printing we reset the
-            # markdown buffer and latch ``_stream_body_finalized`` so the
-            # end-of-message ``_finalize_markdown_stream`` only commits the
-            # *incremental* tail that arrives after this point — avoiding a
-            # duplicate body in the scrollback.
-            if self._deltas:
+            # 3a. Render the streaming main-agent body (from the active
+            # message's delta bucket) so mid-run Ctrl+O doesn't drop the
+            # text the user was reading. ``_response`` / plain ``response``
+            # only arrive after deltas end, so the bucket is the only
+            # source of truth for the *in-flight* message body. We pick
+            # the last delta's ``accumulated`` field because each delta
+            # carries the full running text up to that point. After
+            # printing we reset the markdown buffer and latch
+            # ``_stream_body_finalized`` so the end-of-message
+            # ``_finalize_markdown_stream`` only commits the *incremental*
+            # tail that arrives after this point — avoiding a duplicate
+            # body in the scrollback.
+            active_bucket = self._resolve_active_bucket()
+            if active_bucket:
                 if self._markdown_buffer is not None and self._markdown_buffer.has_spilled():
                     # Overflow paragraphs have already been committed to the
                     # scrollback during the stream; only the unspilled tail
@@ -535,7 +553,7 @@ class InlineStreamingContext:
                     self._stream_body_finalized = True
                 else:
                     last_accumulated = ""
-                    for delta in reversed(self._deltas):
+                    for delta in reversed(active_bucket):
                         if isinstance(delta.output, dict):
                             candidate = delta.output.get("accumulated", "")
                             if isinstance(candidate, str) and candidate:
@@ -1129,30 +1147,77 @@ class InlineStreamingContext:
     # -- thinking_delta handling --------------------------------------------
 
     def _process_deltas(self) -> None:
-        """Drain new ``thinking_delta`` actions from the streaming_deltas queue.
+        """Drain new ``thinking_delta`` actions from per-message buckets.
 
-        Called on every refresh tick in TUI mode. Handles the caller's
-        per-message reset (``streaming_deltas.clear()``): if the queue shrank
-        below our cursor we finalize the markdown stream (flushing any
-        pending tail into the scrollback) and rewind. New deltas are
-        forwarded to :meth:`_handle_thinking_delta` in order.
+        Called on every refresh tick in TUI mode. Each message owns its
+        own bucket under ``self._deltas[action_id]``; the producer only
+        appends to its own bucket, so iteration is race-free as long as
+        we re-read ``len(bucket)`` per iteration. The matching terminal
+        ``*_response`` / ``response`` action triggers the bucket pop in
+        :meth:`_print_completed_action` (see :meth:`_drop_bucket`).
         """
         if self._markdown_buffer is None:
             return
-        current_len = len(self._deltas)
-        if current_len < self._delta_processed_index:
-            # Caller cleared the list — message boundary reached. Commit
-            # whatever tail is still buffered so it lands in the scrollback
-            # and reset our cursor.
-            self._finalize_markdown_stream()
-            self._delta_processed_index = 0
-            current_len = len(self._deltas)
-        while self._delta_processed_index < current_len:
-            action = self._deltas[self._delta_processed_index]
-            self._delta_processed_index += 1
+        # Snapshot keys so a producer-side ``setdefault`` for a new
+        # message during iteration doesn't break the loop. Buckets we
+        # don't see this tick simply land on the next one.
+        for message_id in list(self._deltas):
+            self._drain_bucket(message_id)
+
+    def _drain_bucket(self, message_id: str) -> None:
+        """Forward all unread deltas in one bucket through the markdown buffer.
+
+        On a switch from one in-flight message to another we finalize the
+        previous message's tail first, mirroring the per-message boundary
+        the old shared-list flow expressed via ``streaming_deltas.clear()``.
+        """
+        if self._markdown_buffer is None:
+            return
+        bucket = self._deltas.get(message_id)
+        if bucket is None:
+            return
+        cursor = self._delta_cursors.get(message_id, 0)
+        # ``len`` is GIL-atomic and the bucket only grows, so this snapshot
+        # bounds the loop safely; any deltas appended after we read ``n``
+        # are picked up on the next tick (or by the drain inside
+        # ``_print_completed_action``).
+        n = len(bucket)
+        while cursor < n:
+            action = bucket[cursor]
+            cursor += 1
             if action.depth != 0:
                 continue
+            if self._active_message_id != message_id:
+                if self._active_message_id is not None:
+                    self._finalize_markdown_stream()
+                self._active_message_id = message_id
             self._handle_thinking_delta(action)
+        self._delta_cursors[message_id] = cursor
+
+    def _drop_bucket(self, message_id: Optional[str]) -> None:
+        """Remove a bucket once its terminal response has been processed."""
+        if not message_id:
+            return
+        self._deltas.pop(message_id, None)
+        self._delta_cursors.pop(message_id, None)
+        if self._active_message_id == message_id:
+            self._active_message_id = None
+
+    def _resolve_active_bucket(self) -> List[ActionHistory]:
+        """Return the in-flight message's delta bucket, or empty list.
+
+        Prefers ``_active_message_id`` (the bucket the consumer is
+        currently rendering into the pinned region). Falls back to the
+        most-recently inserted bucket so a Ctrl+O snapshot fired before
+        the consumer's first delta tick still surfaces the in-flight
+        body. Returns an empty list when no bucket exists.
+        """
+        bucket_id = self._active_message_id
+        if bucket_id is None or bucket_id not in self._deltas:
+            bucket_id = next(reversed(self._deltas), None) if self._deltas else None
+        if bucket_id is None:
+            return []
+        return self._deltas.get(bucket_id, [])
 
     def _handle_thinking_delta(self, action: ActionHistory) -> None:
         """Append a streaming text delta into the markdown buffer (TUI mode).
@@ -1214,10 +1279,9 @@ class InlineStreamingContext:
 
         In the accumulator-only flow this is the *only* point where the
         main-agent response lands in the Rich scrollback. Triggered by:
-        ``_process_deltas`` detecting the caller's
-        ``streaming_deltas.clear()`` (paired terminal action arrived),
-        ``_print_completed_action`` seeing the plain ``response`` action,
-        and ``__exit__`` as a safety drain.
+        ``_drain_bucket`` switching active messages, ``_print_completed_action``
+        seeing the paired terminal response, and ``__exit__`` as a safety
+        drain.
         """
         if self._markdown_buffer is None:
             return
@@ -1283,12 +1347,19 @@ class InlineStreamingContext:
             and action.status == ActionStatus.SUCCESS
             and action.depth == 0
         )
+        # Drain any trailing deltas in this message's bucket before the
+        # terminal-response branches below run. Covers the race where the
+        # producer appended the last few deltas and the terminal action
+        # between two refresh ticks — without the drain those deltas
+        # would be dropped along with the bucket.
+        if is_main_assistant_success and action.action_id and action.action_id in self._deltas:
+            self._drain_bucket(action.action_id)
         # Accumulator-only dedup. Three signals can indicate the main-agent
         # body has already been (or is being) flushed to the scrollback:
         #   * ``_markdown_stream_has_streamed`` — deltas arrived but finalize
         #     hasn't run yet (this call is the paired terminal action).
-        #   * ``_stream_body_finalized`` — ``_process_deltas`` already
-        #     detected the caller's ``streaming_deltas.clear()`` and flushed.
+        #   * ``_stream_body_finalized`` — ``_finalize_markdown_stream``
+        #     has already pushed body segments into the scrollback.
         #   * ``_turn_finalized`` — a previous wrapper action in this turn
         #     already went through the finalize path.
         # Any of them means we must not re-render via ``render_main_action``.
@@ -1300,10 +1371,17 @@ class InlineStreamingContext:
             self._markdown_active_stream_ids.clear()
             if self._markdown_stream_has_streamed:
                 self._finalize_markdown_stream()
+            self._drop_bucket(action.action_id)
             self._turn_finalized = True
             return
         if self._tui_mode and action.action_id and action.action_id in self._markdown_stream_consumed_ids:
+            self._drop_bucket(action.action_id)
             return
+        # Non-stream path: terminal response without any preceding delta
+        # (e.g. wrapper *_response with a fresh id). Drop a bucket if one
+        # somehow exists for safety, then fall through to normal render.
+        if is_main_assistant_success:
+            self._drop_bucket(action.action_id)
         renderables = self.display.renderer.render_main_action(action, self._verbose)
         if not renderables:
             return

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -330,12 +330,16 @@ class ChatCommands:
             # Initialize action history display
             action_display = ActionHistoryDisplay(self.console, live_state=getattr(self.cli, "live_state", None))
             incremental_actions = []
-            # Streaming text deltas (thinking_delta, depth=0) are routed to this
-            # separate queue so the main trace renderer never has to walk them
-            # again. The TUI streaming context pops deltas off this list as it
-            # repaints the pinned region, and drops the list on each paired
-            # terminal response so the accumulator resets per message.
-            streaming_deltas = []
+            # Streaming text deltas (thinking_delta, depth=0) are routed to a
+            # per-message bucket keyed by ``action.action_id`` (the
+            # ``thinking_stream_id`` shared across all deltas + the paired
+            # terminal response in one message). The producer only appends
+            # to its own bucket; the TUI streaming context drains buckets
+            # via per-bucket cursors and drops a bucket when it processes
+            # the matching terminal response. A dict avoids the data race
+            # the previous shared-list approach had between the producer
+            # (asyncio bg loop) and the consumer (refresh daemon thread).
+            streaming_deltas: dict[str, list[ActionHistory]] = {}
             # Will be set True after the streaming context exits if it has
             # already flushed the main-agent body to the scrollback. When True,
             # ``_render_final_response`` skips the one-shot
@@ -367,8 +371,8 @@ class ChatCommands:
                         # the main-agent accumulator; sub-agents have their own
                         # pinned-region path.
                         if action.action_type == "thinking_delta":
-                            if action.depth == 0:
-                                streaming_deltas.append(action)
+                            if action.depth == 0 and action.action_id:
+                                streaming_deltas.setdefault(action.action_id, []).append(action)
                             continue
                         # Node final actions (e.g. chat_response) — keep for
                         # final response rendering but skip streaming trace.
@@ -386,15 +390,12 @@ class ChatCommands:
                             pending_non_thinking = _drop_if_matches_final(
                                 pending_non_thinking, action, incremental_actions
                             )
-                            # Wrapper *_response closes the delta accumulator for
-                            # this message; reset so a follow-up turn doesn't see
-                            # the previous body in its replay.
-                            streaming_deltas.clear()
                             continue
                         # Plain "response" from the model layer (openai_compatible /
                         # codex) is the paired terminal action for the delta
-                        # stream. Push it to the trace list and reset the delta
-                        # accumulator at the same time.
+                        # stream. Push it to the trace list; the consumer drops
+                        # the matching delta bucket when it processes this
+                        # action via ``_print_completed_action``.
                         if (
                             action.role == ActionRole.ASSISTANT
                             and action.depth == 0
@@ -405,7 +406,6 @@ class ChatCommands:
                                 incremental_actions.append(pending_non_thinking)
                                 pending_non_thinking = None
                             incremental_actions.append(action)
-                            streaming_deltas.clear()
                             continue
                         # Defer ASSISTANT text flagged as non-thinking — it may
                         # be the tail text that duplicates the upcoming *_response.
@@ -489,8 +489,8 @@ class ChatCommands:
                                     await auto_submit_interaction(broker, action)
                             continue
                         if action.action_type == "thinking_delta":
-                            if action.depth == 0:
-                                streaming_deltas.append(action)
+                            if action.depth == 0 and action.action_id:
+                                streaming_deltas.setdefault(action.action_id, []).append(action)
                             continue
                         # Node final actions (e.g. chat_response) — keep for
                         # final response rendering but skip streaming trace.
@@ -508,7 +508,6 @@ class ChatCommands:
                             pending_non_thinking = _drop_if_matches_final(
                                 pending_non_thinking, action, incremental_actions
                             )
-                            streaming_deltas.clear()
                             continue
                         if (
                             action.role == ActionRole.ASSISTANT
@@ -520,7 +519,6 @@ class ChatCommands:
                                 incremental_actions.append(pending_non_thinking)
                                 pending_non_thinking = None
                             incremental_actions.append(action)
-                            streaming_deltas.clear()
                             continue
                         # Defer ASSISTANT text flagged as non-thinking — it may
                         # be the tail text that duplicates the upcoming *_response.

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -763,6 +763,7 @@ class DatusCLI:
         self._print_welcome()
         self._warn_no_model()
         self._warn_no_datasource()
+        self._bootstrap_services()
 
         while True:
             try:
@@ -818,6 +819,7 @@ class DatusCLI:
         self._print_welcome()
         self._warn_no_model()
         self._warn_no_datasource()
+        self._bootstrap_services()
 
         # Prefill support mirrors the PromptSession path: ``.rewind`` stores
         # the replayed user message in ``_prefill_input`` and expects the
@@ -1890,6 +1892,21 @@ class DatusCLI:
         """Print a one-time hint when no datasource is configured."""
         if not self.agent_config.services.datasources:
             self.console.print("[yellow]No datasources configured. Use /datasource to add one.[/]")
+
+    def _bootstrap_services(self) -> None:
+        """Pin project defaults and kick off background adapter installs.
+
+        Skipped silently in non-interactive sessions (CI, ``echo |
+        datus-cli``, MCP / API hosts) — see ``service_bootstrap._is_interactive``
+        for the exact guard. Failures inside the bootstrap never abort
+        startup.
+        """
+        try:
+            from datus.cli import service_bootstrap
+
+            service_bootstrap.run(self)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"service bootstrap failed: {exc}")
 
     def prompt_input(self, message: str, default: str = "", choices: list = None, multiline: bool = False):
         """

--- a/datus/cli/service_adapter_installer.py
+++ b/datus/cli/service_adapter_installer.py
@@ -1,0 +1,276 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Adapter package auto-installer + hot-reloader for the ``/services`` TUI.
+
+When the user picks a ``type`` for a new ``services.bi_platforms`` or
+``services.schedulers`` entry, the underlying adapter package
+(``datus-bi-<type>`` / ``datus-scheduler-<type>``) might not be
+installed yet. The TUI calls into this module to:
+
+1. Detect whether the adapter is already importable
+   (:func:`is_adapter_installed`).
+2. Run ``pip install`` for the missing package
+   (:func:`ensure_adapter`) — the install runs through
+   ``sys.executable -m pip`` so it targets the same interpreter that
+   loaded ``datus-cli`` (works for venv / pipx / uv-installed CLIs).
+3. Import the adapter module and refresh the BI / scheduler registries
+   without restarting the process (:func:`hot_reload_adapter`).
+
+Pure Python on purpose — the module has no prompt_toolkit dependency so
+it can be unit-tested by monkey-patching ``subprocess.run`` and
+``importlib.util.find_spec``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+# Section → (pip-prefix, import-prefix). Append the lower-cased ``type``
+# field to either prefix to obtain the actual pip distribution name and
+# the importable module name. The mapping mirrors the package naming
+# convention documented in the data-engineering quickstart guide
+# (``datus-bi-superset`` ships ``datus_bi_superset``;
+# ``datus-scheduler-airflow`` ships ``datus_scheduler_airflow``).
+_PKG_PREFIXES: dict[str, Tuple[str, str]] = {
+    "bi_platforms": ("datus-bi-", "datus_bi_"),
+    "schedulers": ("datus-scheduler-", "datus_scheduler_"),
+    "semantic_layer": ("datus-semantic-", "datus_semantic_"),
+}
+
+
+# Entry-point group each section's adapter packages register under.
+# ``datus-bi-<x>`` exposes ``datus.bi_adapters`` → ``<x> = datus_bi_<x>:register``;
+# ``datus-scheduler-<x>`` exposes ``datus.schedulers`` similarly. Importing
+# the module alone does NOT register the adapter — registration runs only
+# inside the ``register`` callable that the entry-point points at, so
+# :func:`hot_reload_adapter` resolves and calls it directly. Bypasses the
+# caching that ``adapter_registry.discover_adapters()`` would otherwise
+# apply on second-and-later calls.
+_EP_GROUPS: dict[str, str] = {
+    "bi_platforms": "datus.bi_adapters",
+    "schedulers": "datus.schedulers",
+    "semantic_layer": "datus.semantic_adapters",
+}
+
+
+@dataclass
+class InstallResult:
+    """Outcome of :func:`ensure_adapter`.
+
+    ``ok`` is the only field callers must inspect; the rest is captured
+    so the TUI can render a tail of pip's output and surface a precise
+    failure message in the error bar.
+    """
+
+    ok: bool
+    package: str
+    import_name: str
+    stdout: str = ""
+    stderr: str = ""
+    error: Optional[str] = None
+
+
+def package_for(section: str, adapter_type: str) -> Tuple[str, str]:
+    """Return ``(pip_pkg_name, import_module_name)`` for ``(section, type)``.
+
+    Raises :class:`ValueError` for unsupported sections / blank types so
+    the caller stops early instead of issuing a malformed pip command
+    like ``pip install datus-bi-`` (which pip happily accepts and
+    spends 30 seconds resolving before failing).
+    """
+    prefixes = _PKG_PREFIXES.get(section)
+    if prefixes is None:
+        raise ValueError(f"Unsupported service section: {section!r}")
+    type_token = (adapter_type or "").strip().lower()
+    if not type_token:
+        raise ValueError("adapter_type must be a non-empty string")
+    pkg_prefix, import_prefix = prefixes
+    return f"{pkg_prefix}{type_token}", f"{import_prefix}{type_token}"
+
+
+def is_adapter_installed(section: str, adapter_type: str) -> bool:
+    """True when the adapter module is already importable."""
+    try:
+        _, import_name = package_for(section, adapter_type)
+    except ValueError:
+        return False
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except (ImportError, ValueError):
+        # ``find_spec`` raises ``ValueError`` on partially-initialized
+        # parent packages and ``ImportError`` when an ancestor is
+        # missing. Both cases mean "not importable".
+        return False
+
+
+def ensure_adapter(
+    section: str,
+    adapter_type: str,
+    *,
+    line_callback: Optional[Callable[[str], None]] = None,
+) -> InstallResult:
+    """Install the adapter package via ``sys.executable -m pip`` if missing.
+
+    ``line_callback`` (when provided) receives one line of pip
+    stdout/stderr at a time so the TUI can display a live tail. The
+    function blocks until pip exits — the caller is expected to run it
+    on a worker thread when the UI must stay responsive.
+    """
+    try:
+        pkg, import_name = package_for(section, adapter_type)
+    except ValueError as exc:
+        return InstallResult(ok=False, package="", import_name="", error=str(exc))
+
+    if is_adapter_installed(section, adapter_type):
+        return InstallResult(ok=True, package=pkg, import_name=import_name)
+
+    cmd = [sys.executable, "-m", "pip", "install", pkg]
+    logger.info("Installing adapter package: %s", " ".join(cmd))
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception as exc:  # pragma: no cover - exercised via mocked subprocess
+        return InstallResult(ok=False, package=pkg, import_name=import_name, error=str(exc))
+
+    stdout = proc.stdout or ""
+    stderr = proc.stderr or ""
+    if line_callback is not None:
+        for line in stdout.splitlines():
+            line_callback(line)
+        for line in stderr.splitlines():
+            line_callback(line)
+    if proc.returncode != 0:
+        return InstallResult(
+            ok=False,
+            package=pkg,
+            import_name=import_name,
+            stdout=stdout,
+            stderr=stderr,
+            error=f"pip install exited with code {proc.returncode}",
+        )
+
+    importlib.invalidate_caches()
+    return InstallResult(
+        ok=True,
+        package=pkg,
+        import_name=import_name,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def hot_reload_adapter(section: str, adapter_type: str) -> bool:
+    """Import the freshly-installed adapter module and call its registrar.
+
+    Adapter packages declare their registration callable through an
+    entry-point (``datus.bi_adapters`` / ``datus.schedulers``); importing
+    the package itself does **not** register the adapter — the registrar
+    is only invoked when something walks those entry points. We do that
+    walk explicitly here so a pip install + this function brings the
+    adapter online without a process restart, even when the registry's
+    own ``discover_adapters()`` has already cached an earlier (empty)
+    scan.
+
+    Returns ``True`` when at least one ``register`` call succeeded for
+    the requested ``adapter_type``. Returns ``False`` when the package
+    is missing or its entry point fails to load.
+    """
+    try:
+        _, import_name = package_for(section, adapter_type)
+    except ValueError:
+        return False
+    # Refresh importlib's loader cache so a freshly-installed
+    # distribution's metadata is visible to ``entry_points()`` below.
+    importlib.invalidate_caches()
+    try:
+        if import_name in sys.modules:
+            importlib.reload(sys.modules[import_name])
+        else:
+            importlib.import_module(import_name)
+    except ImportError as exc:
+        logger.debug("Hot reload of %s failed: %s", import_name, exc)
+        return False
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Hot reload of %s raised: %s", import_name, exc)
+        return False
+
+    registered = False
+    ep_group = _EP_GROUPS.get(section)
+    if ep_group:
+        try:
+            import importlib.metadata as metadata
+
+            entries = metadata.entry_points()
+            # Python 3.10+ exposes ``select(group=..., name=...)``; pre-3.10
+            # returns a ``dict``-shaped object. Fall back gracefully.
+            if hasattr(entries, "select"):
+                candidates = list(entries.select(group=ep_group, name=adapter_type))
+            else:  # pragma: no cover - legacy Python
+                candidates = [ep for ep in entries.get(ep_group, []) if ep.name == adapter_type]
+            for ep in candidates:
+                try:
+                    register_fn = ep.load()
+                except Exception as exc:
+                    logger.warning("Failed to load entry point %s: %s", ep, exc)
+                    continue
+                if callable(register_fn):
+                    try:
+                        register_fn()
+                        registered = True
+                    except Exception as exc:
+                        logger.warning("`%s` register() raised: %s", import_name, exc)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Entry-point lookup for %s failed: %s", import_name, exc)
+
+    # Best-effort refresh of the BI registry's own discovery state so
+    # callers that go through ``discover_adapters()`` (e.g. the listing
+    # path in ``service_client``) see the new entry too.
+    if section == "bi_platforms":
+        try:
+            from datus_bi_core import adapter_registry  # type: ignore[import-not-found]
+        except ImportError:
+            return registered
+        discover = getattr(adapter_registry, "discover_adapters", None)
+        if callable(discover):
+            try:
+                discover()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("adapter_registry.discover_adapters() raised: %s", exc)
+    elif section == "semantic_layer":
+        try:
+            from datus.tools.semantic_tools.registry import semantic_adapter_registry
+        except ImportError:
+            return registered
+        discover = getattr(semantic_adapter_registry, "discover_adapters", None)
+        if callable(discover):
+            try:
+                discover()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("semantic_adapter_registry.discover_adapters() raised: %s", exc)
+
+    return registered
+
+
+__all__ = [
+    "InstallResult",
+    "ensure_adapter",
+    "hot_reload_adapter",
+    "is_adapter_installed",
+    "package_for",
+]

--- a/datus/cli/service_bootstrap.py
+++ b/datus/cli/service_bootstrap.py
@@ -1,0 +1,292 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""REPL startup hook that pins service defaults and installs adapter packages.
+
+Runs once per interactive REPL launch, **before** the prompt loop opens, to:
+
+1. **Pin defaults to the project**: for each ``services.<section>`` (BI,
+   Scheduler, Semantic), if no project pin is already set in
+   ``./.datus/config.yml`` and the YAML resolves a deterministic default
+   (single entry, or one entry flagged ``default: true``), write that
+   choice back as the project pin so subsequent runs are explicit. When
+   multiple entries are configured without a default, prompt the user to
+   pick one synchronously.
+
+2. **Install missing adapter packages in the background**: every
+   configured service whose adapter Python package is not importable
+   (``datus-bi-<x>``, ``datus-scheduler-<x>``, ``datus-semantic-<x>``)
+   gets a ``pip install`` kicked off on a daemon thread, then a
+   ``hot_reload_adapter`` so it becomes usable without a restart.
+
+Hard guardrails — both must hold or the entire bootstrap is skipped:
+
+- ``sys.stdin.isatty()`` AND ``sys.stdout.isatty()`` (no piped or
+  CI-style invocations).
+- ``DATUS_DISABLE_SERVICE_BOOTSTRAP`` env var unset (escape hatch for
+  Docker / batch / regression suites).
+
+Failures inside this module never abort startup; they print a one-line
+message and move on. The user can always re-run ``/services`` to fix
+anything by hand.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+
+from datus.cli.cli_styles import print_error, print_info, print_success
+from datus.cli.service_adapter_installer import (
+    InstallResult,
+    ensure_adapter,
+    hot_reload_adapter,
+    is_adapter_installed,
+)
+from datus.cli.service_client import service_type_label
+from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from datus.cli.repl import DatusCLI
+
+logger = get_logger(__name__)
+
+
+# Section -> (services-dict accessor, active-getter, active-setter,
+# default-flag resolver). One row per section keeps the bootstrap loop
+# uniform and makes adding new service types a single-row change.
+_SECTION_SPECS: Tuple[Tuple[str, str, str, str, str], ...] = (
+    # (section,            services_attr,            active_getter,       active_setter,         default_resolver)
+    ("bi_platforms", "dashboard_config", "active_dashboard", "set_active_dashboard", "default_dashboard_service"),
+    ("schedulers", "scheduler_services", "active_scheduler", "set_active_scheduler", "default_scheduler_service"),
+    ("semantic_layer", "semantic_layer_configs", "active_semantic", "set_active_semantic", "default_semantic_adapter"),
+)
+
+
+def _is_interactive() -> bool:
+    """Return True only when both stdin and stdout are TTYs and the
+    escape hatch env var is unset."""
+    if os.environ.get("DATUS_DISABLE_SERVICE_BOOTSTRAP"):
+        return False
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except (AttributeError, OSError):
+        return False
+
+
+def run(cli: "DatusCLI") -> None:
+    """Entry point — pin project defaults synchronously, then kick off
+    the background install pass.
+
+    The synchronous default-pinning step blocks startup briefly (only
+    visible to the user when an interactive picker fires); the install
+    pass returns immediately and runs to completion on a daemon thread.
+    Either step is a no-op when ``_is_interactive()`` returns False.
+    """
+    if not _is_interactive():
+        return
+
+    agent_config = getattr(cli, "agent_config", None)
+    if agent_config is None:
+        return
+
+    for section, services_attr, getter, setter, resolver in _SECTION_SPECS:
+        try:
+            _bootstrap_default(cli, section, services_attr, getter, setter, resolver)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("bootstrap_default(%s) failed: %s", section, exc)
+
+    try:
+        background_install_missing(cli)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("background_install_missing failed: %s", exc)
+
+
+def _bootstrap_default(
+    cli: "DatusCLI",
+    section: str,
+    services_attr: str,
+    getter_name: str,
+    setter_name: str,
+    resolver_name: str,
+) -> None:
+    """Pin a project default for one section if not already pinned.
+
+    Skips silently when the section is empty (the resolver itself raises
+    on use), the project pin already names a configured service, or the
+    user cancels the picker.
+    """
+    agent_config = cli.agent_config
+    label = service_type_label(section)
+    services = getattr(agent_config, services_attr, {}) or {}
+    if not services:
+        return
+
+    getter = getattr(agent_config, getter_name, None)
+    current_pin = getter() if callable(getter) else None
+    if current_pin and current_pin in services:
+        return
+
+    setter = getattr(agent_config, setter_name, None)
+    if not callable(setter):
+        return
+
+    resolver = getattr(agent_config, resolver_name, None)
+    auto_pick: Optional[str] = None
+    if callable(resolver):
+        try:
+            auto_pick = resolver()
+        except Exception as exc:
+            # ``default_*_service`` raises when ``default: true`` is on more
+            # than one entry — surface it once and skip; the user can fix
+            # the YAML or re-run the bootstrap by relaunching the REPL.
+            print_error(cli.console, f"Cannot pick default {label}: {exc}", prefix=False)
+            return
+
+    if auto_pick is None and len(services) > 1:
+        auto_pick = quick_pick_service(cli, section, list(services.keys()))
+
+    if not auto_pick:
+        return
+
+    try:
+        setter(auto_pick)
+    except Exception as exc:
+        print_error(cli.console, f"Failed to pin default {label}: {exc}", prefix=False)
+        return
+    print_success(cli.console, f"Pinned project default {label}: {auto_pick}", symbol=True)
+
+
+def quick_pick_service(cli: "DatusCLI", section: str, names: List[str]) -> Optional[str]:
+    """Tiny synchronous picker shown when a section has multiple entries
+    and no default. Returns the chosen service name, or ``None`` when
+    the user types ``q``/blank.
+
+    Deliberately not a prompt_toolkit Application — we're called before
+    the main TUI starts, but we want to stay portable to plain
+    PromptSession launches too. ``input()`` works in both cases because
+    ``_is_interactive()`` already verified stdin is a TTY.
+    """
+    label = service_type_label(section)
+    cli.console.print(
+        f"\n[bold]Multiple {label} services configured but no default set. Pick one to pin as the project default:[/]"
+    )
+    for i, name in enumerate(names, 1):
+        cli.console.print(f"  [cyan]{i}[/]) {name}")
+    cli.console.print("  [dim]q) skip — leave unpinned (will warn on first use)[/]")
+    while True:
+        try:
+            choice = input(f"Choice [1-{len(names)}]: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return None
+        if not choice or choice.lower() in ("q", "skip"):
+            return None
+        try:
+            idx = int(choice) - 1
+        except ValueError:
+            print_error(cli.console, "Please enter a number or `q` to skip.", prefix=False)
+            continue
+        if 0 <= idx < len(names):
+            return names[idx]
+        print_error(cli.console, f"Out of range. Pick 1-{len(names)} or `q`.", prefix=False)
+
+
+def background_install_missing(cli: "DatusCLI") -> None:
+    """Spawn a daemon thread that pip-installs any configured service
+    whose adapter package is not importable.
+
+    Returns immediately. Failures inside the worker print a one-line
+    message via ``cli.console`` (which is thread-safe for plain
+    ``print``); they do not raise and they do not retry. The user can
+    re-run ``/services <section>`` to retry a failed install
+    interactively.
+    """
+    targets = _missing_install_targets(cli.agent_config)
+    if not targets:
+        return
+    thread = threading.Thread(target=_install_worker, args=(cli, targets), daemon=True)
+    thread.start()
+
+
+def _missing_install_targets(agent_config: Any) -> List[Tuple[str, str]]:
+    """Walk all three sections, return ``(section, adapter_type)`` for
+    every configured service whose adapter package is not installed.
+
+    The adapter type is read from the section-specific config object;
+    BI uses ``DashboardConfig.adapter_type`` (alias may differ), while
+    Scheduler / Semantic store the type as a dict key or ``type`` field.
+    """
+    targets: List[Tuple[str, str]] = []
+    bi = getattr(agent_config, "dashboard_config", {}) or {}
+    for name, cfg in bi.items():
+        adapter_type = (getattr(cfg, "adapter_type", "") or name).strip().lower()
+        if adapter_type and not is_adapter_installed("bi_platforms", adapter_type):
+            targets.append(("bi_platforms", adapter_type))
+
+    schedulers = getattr(agent_config, "scheduler_services", {}) or {}
+    for name, cfg in schedulers.items():
+        if not isinstance(cfg, dict):
+            continue
+        adapter_type = str(cfg.get("type") or name).strip().lower()
+        if adapter_type and not is_adapter_installed("schedulers", adapter_type):
+            targets.append(("schedulers", adapter_type))
+
+    semantic = getattr(agent_config, "semantic_layer_configs", {}) or {}
+    for name, cfg in semantic.items():
+        # ``init_semantic_layer`` already enforces ``key == type``, so
+        # using the name directly is safe.
+        adapter_type = str(name).strip().lower()
+        if adapter_type and not is_adapter_installed("semantic_layer", adapter_type):
+            targets.append(("semantic_layer", adapter_type))
+
+    # Deduplicate — multiple BI aliases of the same adapter type would
+    # otherwise trigger ``pip install`` once per alias.
+    seen: set = set()
+    unique: List[Tuple[str, str]] = []
+    for entry in targets:
+        if entry in seen:
+            continue
+        seen.add(entry)
+        unique.append(entry)
+    return unique
+
+
+def _install_worker(cli: "DatusCLI", targets: List[Tuple[str, str]]) -> None:
+    for section, adapter_type in targets:
+        result = _safe_ensure(section, adapter_type)
+        if result is None:
+            continue
+        if result.ok:
+            try:
+                hot_reload_adapter(section, adapter_type)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("hot_reload_adapter(%s, %s) raised: %s", section, adapter_type, exc)
+            print_info(
+                cli.console,
+                f"Installed {result.package} in background. Run /services {service_type_label(section)} to verify.",
+            )
+        else:
+            print_error(
+                cli.console,
+                f"Background install of {result.package or adapter_type} failed: "
+                f"{result.error or 'unknown error'}. Re-run /services {service_type_label(section)} to retry.",
+                prefix=False,
+            )
+
+
+def _safe_ensure(section: str, adapter_type: str) -> Optional[InstallResult]:
+    try:
+        return ensure_adapter(section, adapter_type)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("ensure_adapter(%s, %s) raised: %s", section, adapter_type, exc)
+        return None
+
+
+__all__ = [
+    "run",
+    "quick_pick_service",
+    "background_install_missing",
+]

--- a/datus/cli/service_commands.py
+++ b/datus/cli/service_commands.py
@@ -27,13 +27,14 @@ import asyncio
 import inspect
 import json
 import shlex
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from rich.table import Table
 
 from datus.cli._render_utils import build_kv_table, build_row_table
-from datus.cli.cli_styles import TABLE_HEADER_STYLE, print_error, print_info, print_warning
+from datus.cli.cli_styles import TABLE_HEADER_STYLE, print_error, print_info, print_success, print_warning
 from datus.cli.service_client import ServiceClient, ServiceClientRegistry, service_type_label
+from datus.cli.service_config_app import ServiceConfigApp, ServiceConfigSelection
 from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
@@ -71,14 +72,53 @@ class ServiceCommands:
     # ------------------------------------------------------------------ #
 
     def cmd_services(self, args: str = "") -> None:
-        """Handler for the ``/services`` command."""
+        """Handler for the ``/services`` command.
+
+        Token shapes:
+
+        - empty / ``config`` / ``configure`` / ``edit`` — open the
+          configuration TUI on the default Dashboard tab. Bare
+          ``/services`` lands on the menu directly so the TUI is the
+          primary entry point.
+        - ``dashboard`` / ``scheduler`` — open the TUI with the matching
+          tab pre-selected.
+        - ``list`` — render the read-only listing (kept for scripting /
+          quick inspection without entering the TUI).
+        """
+        token = (args or "").strip().lower()
+        if token in ("dashboard", "bi", "bi_platforms"):
+            self._run_config_menu(initial_tab="dashboard")
+            return
+        if token in ("scheduler", "schedulers"):
+            self._run_config_menu(initial_tab="scheduler")
+            return
+        if token in ("semantic", "semantic_layer"):
+            self._run_config_menu(initial_tab="semantic")
+            return
+        if not token or token in ("config", "configure", "edit"):
+            self._run_config_menu(initial_tab="dashboard")
+            return
+        if token == "list":
+            self._render_listing()
+            return
+        # Unknown sub-token — show the listing and a hint instead of
+        # bailing silently.
+        self._render_listing()
+        print_info(
+            self.cli.console,
+            "Use `/services dashboard`, `/services scheduler`, or `/services semantic` to open the configuration TUI.",
+        )
+
+    # ------------------------------------------------------------------ #
+    # Listing (legacy read-only behaviour)
+    # ------------------------------------------------------------------ #
+
+    def _render_listing(self) -> None:
         rows = self.registry.list_services()
         if not rows:
             print_warning(
                 self.cli.console,
-                "No services configured. Add entries under "
-                "`services.bi_platforms`, `services.schedulers`, or "
-                "`services.semantic_layer` in agent.yml.",
+                "No services configured. Run `/services dashboard` or `/services scheduler` to configure one.",
             )
             return
         table = Table(title="Configured services", show_header=True, header_style=TABLE_HEADER_STYLE)
@@ -88,6 +128,305 @@ class ServiceCommands:
         for name, section, status in rows:
             table.add_row(name, service_type_label(section), status)
         self.cli.console.print(table)
+
+    # ------------------------------------------------------------------ #
+    # TUI configuration menu
+    # ------------------------------------------------------------------ #
+
+    _MAX_CONFIG_LOOPS = 32
+
+    def _run_config_menu(self, *, initial_tab: str) -> None:
+        """Loop the configuration TUI until the user cancels.
+
+        Each round re-reads ``agent_config.dashboard_config`` /
+        ``scheduler_services`` so edits persisted in the previous round
+        are visible immediately. The loop bound is a safety net against
+        runaway re-entry, not a UX limit — typical sessions exit after
+        one or two iterations.
+        """
+        seed_tab = initial_tab
+        seed_status: Optional[str] = None
+        for _ in range(self._MAX_CONFIG_LOOPS):
+            app = ServiceConfigApp(
+                self.cli.agent_config,
+                self.cli.console,
+                initial_tab=seed_tab,
+                status_message=seed_status,
+            )
+            seed_status = None
+            selection = self._run_app(app)
+            if selection is None:
+                return
+            if selection.section == "schedulers":
+                seed_tab = "scheduler"
+            elif selection.section == "semantic_layer":
+                seed_tab = "semantic"
+            else:
+                seed_tab = "dashboard"
+            seed_status = self._apply_selection(selection)
+            # Force the registry / dashboard_config to reflect the YAML
+            # changes before the next App invocation paints its list.
+            self._refresh_after_change()
+
+    def _run_app(self, app: ServiceConfigApp) -> Optional[ServiceConfigSelection]:
+        tui_app = getattr(self.cli, "tui_app", None)
+        if tui_app is not None:
+            with tui_app.suspend_input():
+                return app.run()
+        return app.run()
+
+    def _refresh_after_change(self) -> None:
+        """Drop cached service clients so the next listing rebuilds them."""
+        self._registry = None
+
+    # ------------------------------------------------------------------ #
+    # Selection dispatch
+    # ------------------------------------------------------------------ #
+
+    def _apply_selection(self, sel: ServiceConfigSelection) -> Optional[str]:
+        """Persist ``sel`` and return a status line for the next App round."""
+        if sel.action == "save":
+            return self._do_save(sel)
+        if sel.action == "delete":
+            return self._do_delete(sel)
+        if sel.action == "test":
+            return self._do_test(sel)
+        if sel.action == "set_default":
+            return self._do_set_global_default(sel)
+        if sel.action == "set_project_default":
+            return self._do_set_project_default(sel)
+        return None
+
+    def _do_save(self, sel: ServiceConfigSelection) -> Optional[str]:
+        from datus.cli.service_adapter_installer import ensure_adapter, hot_reload_adapter
+
+        adapter_type = str(sel.payload.get("type") or "").strip().lower()
+        if not adapter_type:
+            print_error(self.cli.console, "Cannot save: missing `type` in payload.", prefix=False)
+            return None
+        # 1. Make sure the adapter package is installed in this interpreter.
+        result = ensure_adapter(sel.section, adapter_type)
+        if not result.ok:
+            print_error(
+                self.cli.console,
+                f"Adapter install failed for `{result.package or adapter_type}`: {result.error or 'unknown error'}",
+                prefix=False,
+            )
+            if result.stderr:
+                print_info(self.cli.console, result.stderr.strip().splitlines()[-1])
+            return f"Saving `{sel.name}` skipped — adapter install failed."
+        if result.package:
+            print_success(self.cli.console, f"Adapter `{result.package}` ready.", symbol=True)
+        hot_reload_adapter(sel.section, adapter_type)
+
+        # 2. Merge into the in-memory + on-disk YAML and reload AgentConfig.
+        if not self._merge_service_entry(sel.section, sel.name, sel.payload):
+            return f"Saving `{sel.name}` failed — see error above."
+
+        # 3. Probe with the freshly-loaded config; report but do not
+        #    rollback on failure.
+        probe_ok, probe_msg = self._probe(sel.section, sel.name)
+        status_bits: List[str] = [f"Saved `{sel.name}`."]
+        if probe_ok:
+            print_success(self.cli.console, f"Probe ok: {probe_msg}", symbol=True)
+            status_bits.append(f"Connected ({probe_msg}).")
+        else:
+            print_error(self.cli.console, f"Probe failed: {probe_msg}", prefix=False)
+            status_bits.append(f"Probe failed: {probe_msg}")
+        status_bits.append("Press `p` to set as project default.")
+        return " ".join(status_bits)
+
+    def _do_delete(self, sel: ServiceConfigSelection) -> Optional[str]:
+        from datus.configuration.agent_config_loader import configuration_manager
+
+        mgr = configuration_manager()
+        services = dict(mgr.get("services", {}) or {})
+        section_dict = dict(services.get(sel.section, {}) or {})
+        if sel.name not in section_dict:
+            print_warning(self.cli.console, f"`{sel.name}` not found in `services.{sel.section}`.")
+            return f"`{sel.name}` not found."
+        section_dict.pop(sel.name, None)
+        services[sel.section] = section_dict
+        try:
+            mgr.update_item("services", services, delete_old_key=True, save=True)
+        except Exception as exc:
+            print_error(self.cli.console, f"Failed to delete `{sel.name}`: {exc}", prefix=False)
+            return f"Delete `{sel.name}` failed."
+        # Clear the project-level default if it pointed at the deleted entry.
+        # Semantic layers don't yet expose a project-level default API,
+        # so skip the cleanup for that section.
+        if sel.section in ("bi_platforms", "schedulers"):
+            active_attr = "active_dashboard" if sel.section == "bi_platforms" else "active_scheduler"
+            active_fn = getattr(self.cli.agent_config, active_attr, None)
+            if callable(active_fn) and active_fn() == sel.name:
+                setter = getattr(
+                    self.cli.agent_config,
+                    "set_active_dashboard" if sel.section == "bi_platforms" else "set_active_scheduler",
+                    None,
+                )
+                if callable(setter):
+                    setter(None)
+        self._reload_agent_config()
+        print_success(self.cli.console, f"Deleted `{sel.name}` from `services.{sel.section}`.", symbol=True)
+        return f"Deleted `{sel.name}`."
+
+    def _do_test(self, sel: ServiceConfigSelection) -> Optional[str]:
+        ok, msg = self._probe(sel.section, sel.name)
+        if ok:
+            print_success(self.cli.console, f"Probe ok for `{sel.name}`: {msg}", symbol=True)
+            return f"Probe ok for `{sel.name}`."
+        print_error(self.cli.console, f"Probe failed for `{sel.name}`: {msg}", prefix=False)
+        return f"Probe failed for `{sel.name}`: {msg}"
+
+    def _do_set_global_default(self, sel: ServiceConfigSelection) -> Optional[str]:
+        from datus.configuration.agent_config_loader import configuration_manager
+
+        if sel.section != "schedulers":
+            return None
+        mgr = configuration_manager()
+        services = dict(mgr.get("services", {}) or {})
+        schedulers = dict(services.get("schedulers", {}) or {})
+        if sel.name not in schedulers:
+            print_warning(self.cli.console, f"`{sel.name}` not found in `services.schedulers`.")
+            return f"`{sel.name}` not found."
+        for name, raw in schedulers.items():
+            if not isinstance(raw, dict):
+                continue
+            if name == sel.name:
+                raw["default"] = True
+            else:
+                raw.pop("default", None)
+            schedulers[name] = raw
+        services["schedulers"] = schedulers
+        try:
+            mgr.update_item("services", services, save=True)
+        except Exception as exc:
+            print_error(self.cli.console, f"Failed to set default scheduler: {exc}", prefix=False)
+            return f"Set default `{sel.name}` failed."
+        self._reload_agent_config()
+        print_success(self.cli.console, f"`{sel.name}` is now the global default scheduler.", symbol=True)
+        return f"`{sel.name}` set as global default."
+
+    def _do_set_project_default(self, sel: ServiceConfigSelection) -> Optional[str]:
+        if sel.section == "bi_platforms":
+            setter = getattr(self.cli.agent_config, "set_active_dashboard", None)
+            label = "dashboard"
+        elif sel.section == "schedulers":
+            setter = getattr(self.cli.agent_config, "set_active_scheduler", None)
+            label = "scheduler"
+        else:
+            return None
+        if not callable(setter):
+            print_error(self.cli.console, "AgentConfig does not support project-level defaults.", prefix=False)
+            return None
+        try:
+            setter(sel.name or None)
+        except Exception as exc:
+            print_error(self.cli.console, f"Failed to update project default: {exc}", prefix=False)
+            return f"Project default update failed: {exc}"
+        if sel.name:
+            print_success(self.cli.console, f"Project {label} default → `{sel.name}`.", symbol=True)
+            return f"Project {label} default = `{sel.name}`."
+        print_success(self.cli.console, f"Cleared project {label} default.", symbol=True)
+        return f"Cleared project {label} default."
+
+    # ------------------------------------------------------------------ #
+    # Persistence + probe helpers
+    # ------------------------------------------------------------------ #
+
+    def _merge_service_entry(self, section: str, name: str, payload: Dict[str, Any]) -> bool:
+        from datus.configuration.agent_config_loader import configuration_manager
+
+        mgr = configuration_manager()
+        services = dict(mgr.get("services", {}) or {})
+        section_dict = dict(services.get(section, {}) or {})
+        # Strip empty-string credentials so the YAML stays terse and the
+        # "leave password blank to keep existing" UX matches the on-disk
+        # shape (no key vs empty key both mean "no credential" to the
+        # adapter, but no key reads cleaner).
+        cleaned: Dict[str, Any] = {}
+        for k, v in payload.items():
+            if isinstance(v, str) and v == "":
+                continue
+            if isinstance(v, dict) and not v:
+                continue
+            cleaned[k] = v
+        section_dict[name] = cleaned
+        services[section] = section_dict
+        try:
+            mgr.update_item("services", services, save=True)
+        except Exception as exc:
+            print_error(self.cli.console, f"Failed to write `services.{section}.{name}`: {exc}", prefix=False)
+            return False
+        self._reload_agent_config()
+        return True
+
+    def _probe(self, section: str, name: str) -> Tuple[bool, str]:
+        """Run a read-only adapter call as a connectivity smoke test.
+
+        Returns ``(ok, message)`` so the caller can both print and pass
+        a one-liner up to the App's status row. Any exception from the
+        adapter is caught — the goal is signal, not stack traces.
+        """
+        try:
+            if section == "bi_platforms":
+                from datus.tools.func_tool.bi_tools import BIFuncTool
+
+                tool = BIFuncTool(self.cli.agent_config, bi_service=name)
+                rows = tool.list_dashboards()
+                count = self._count_envelope(rows)
+                return True, f"{count} dashboards"
+            if section == "schedulers":
+                from datus.tools.func_tool.scheduler_tools import SchedulerTools
+
+                tool = SchedulerTools(self.cli.agent_config, scheduler_service=name)
+                rows = tool.list_scheduler_jobs()
+                count = self._count_envelope(rows)
+                return True, f"{count} scheduler jobs"
+            if section == "semantic_layer":
+                # MetricFlow's ``list_metrics`` requires a bound
+                # datasource; use the registry probe instead so we can
+                # confirm ``hot_reload_adapter`` actually wired the
+                # adapter without forcing the user to pre-bind a DB.
+                from datus.tools.semantic_tools.registry import semantic_adapter_registry
+
+                metadata = semantic_adapter_registry.get_metadata(name)
+                if metadata is not None:
+                    return True, f"adapter `{name}` registered"
+                return False, f"adapter `{name}` not registered after install"
+        except Exception as exc:
+            return False, str(exc) or exc.__class__.__name__
+        return False, f"Unsupported section `{section}`"
+
+    @staticmethod
+    def _count_envelope(payload: Any) -> int:
+        if isinstance(payload, dict):
+            inner = payload.get("result", payload)
+            if isinstance(inner, dict) and "items" in inner and isinstance(inner["items"], list):
+                return len(inner["items"])
+            if isinstance(inner, list):
+                return len(inner)
+        if isinstance(payload, list):
+            return len(payload)
+        return 0
+
+    def _reload_agent_config(self) -> None:
+        """Reload ``agent.yml`` so in-memory ``services.*`` matches disk."""
+        try:
+            from datus.configuration.agent_config_loader import load_agent_config
+        except Exception:
+            return
+        try:
+            fresh = load_agent_config(reload=True)
+        except Exception as exc:
+            logger.warning("Failed to reload agent config after services edit: %s", exc)
+            return
+        # Carry forward project-level service overrides on the new
+        # config — they're loaded by ``_apply_project_override`` so a
+        # plain reload picks them up automatically. We just swap the
+        # CLI's reference so subsequent calls see the new state.
+        self.cli.agent_config = fresh
+        self._registry = None
 
     def dispatch(self, cmd: str, args: str) -> bool:
         """Handle a ``/<service>`` or ``/<service>.<method>`` command.

--- a/datus/cli/service_commands.py
+++ b/datus/cli/service_commands.py
@@ -253,17 +253,16 @@ class ServiceCommands:
             print_error(self.cli.console, f"Failed to delete `{sel.name}`: {exc}", prefix=False)
             return f"Delete `{sel.name}` failed."
         # Clear the project-level default if it pointed at the deleted entry.
-        # Semantic layers don't yet expose a project-level default API,
-        # so skip the cleanup for that section.
-        if sel.section in ("bi_platforms", "schedulers"):
-            active_attr = "active_dashboard" if sel.section == "bi_platforms" else "active_scheduler"
-            active_fn = getattr(self.cli.agent_config, active_attr, None)
+        active_map = {
+            "bi_platforms": ("active_dashboard", "set_active_dashboard"),
+            "schedulers": ("active_scheduler", "set_active_scheduler"),
+            "semantic_layer": ("active_semantic", "set_active_semantic"),
+        }
+        if sel.section in active_map:
+            getter_name, setter_name = active_map[sel.section]
+            active_fn = getattr(self.cli.agent_config, getter_name, None)
             if callable(active_fn) and active_fn() == sel.name:
-                setter = getattr(
-                    self.cli.agent_config,
-                    "set_active_dashboard" if sel.section == "bi_platforms" else "set_active_scheduler",
-                    None,
-                )
+                setter = getattr(self.cli.agent_config, setter_name, None)
                 if callable(setter):
                     setter(None)
         self._reload_agent_config()
@@ -278,34 +277,37 @@ class ServiceCommands:
         print_error(self.cli.console, f"Probe failed for `{sel.name}`: {msg}", prefix=False)
         return f"Probe failed for `{sel.name}`: {msg}"
 
+    _SET_DEFAULT_SECTIONS = ("bi_platforms", "schedulers", "semantic_layer")
+
     def _do_set_global_default(self, sel: ServiceConfigSelection) -> Optional[str]:
         from datus.configuration.agent_config_loader import configuration_manager
 
-        if sel.section != "schedulers":
+        if sel.section not in self._SET_DEFAULT_SECTIONS:
             return None
+        label = service_type_label(sel.section)
         mgr = configuration_manager()
         services = dict(mgr.get("services", {}) or {})
-        schedulers = dict(services.get("schedulers", {}) or {})
-        if sel.name not in schedulers:
-            print_warning(self.cli.console, f"`{sel.name}` not found in `services.schedulers`.")
+        section_dict = dict(services.get(sel.section, {}) or {})
+        if sel.name not in section_dict:
+            print_warning(self.cli.console, f"`{sel.name}` not found in `services.{sel.section}`.")
             return f"`{sel.name}` not found."
-        for name, raw in schedulers.items():
+        for name, raw in section_dict.items():
             if not isinstance(raw, dict):
                 continue
             if name == sel.name:
                 raw["default"] = True
             else:
                 raw.pop("default", None)
-            schedulers[name] = raw
-        services["schedulers"] = schedulers
+            section_dict[name] = raw
+        services[sel.section] = section_dict
         try:
             mgr.update_item("services", services, save=True)
         except Exception as exc:
-            print_error(self.cli.console, f"Failed to set default scheduler: {exc}", prefix=False)
+            print_error(self.cli.console, f"Failed to set default {label}: {exc}", prefix=False)
             return f"Set default `{sel.name}` failed."
         self._reload_agent_config()
-        print_success(self.cli.console, f"`{sel.name}` is now the global default scheduler.", symbol=True)
-        return f"`{sel.name}` set as global default."
+        print_success(self.cli.console, f"`{sel.name}` is now the global default {label}.", symbol=True)
+        return f"`{sel.name}` set as global default {label}."
 
     def _do_set_project_default(self, sel: ServiceConfigSelection) -> Optional[str]:
         if sel.section == "bi_platforms":
@@ -314,6 +316,9 @@ class ServiceCommands:
         elif sel.section == "schedulers":
             setter = getattr(self.cli.agent_config, "set_active_scheduler", None)
             label = "scheduler"
+        elif sel.section == "semantic_layer":
+            setter = getattr(self.cli.agent_config, "set_active_semantic", None)
+            label = "semantic layer"
         else:
             return None
         if not callable(setter):

--- a/datus/cli/service_config_app.py
+++ b/datus/cli/service_config_app.py
@@ -247,7 +247,10 @@ class ServiceConfigApp:
                 _Entry(
                     name=name,
                     adapter_type=adapter_type,
-                    is_default=(len(dashboards) == 1),
+                    # ``is_default`` reflects the explicit YAML flag — the
+                    # single-entry shortcut is an implicit fallback handled
+                    # by the resolver, not a label we want to surface.
+                    is_default=bool(getattr(cfg, "default", False)),
                     is_project_default=(name == active),
                     raw=raw,
                 )
@@ -279,6 +282,8 @@ class ServiceConfigApp:
         # safe — every entry maps a YAML key (e.g. ``metricflow``) to a
         # dict whose ``type`` field equals that key.
         services = getattr(self._cfg, "semantic_layer_configs", {}) or {}
+        active_fn = getattr(self._cfg, "active_semantic", None)
+        active = active_fn() if callable(active_fn) else None
         out: List[_Entry] = []
         for name in sorted(services.keys()):
             cfg = dict(services[name])
@@ -287,8 +292,8 @@ class ServiceConfigApp:
                 _Entry(
                     name=name,
                     adapter_type=adapter_type,
-                    is_default=(len(services) == 1),
-                    is_project_default=False,
+                    is_default=bool(cfg.get("default")),
+                    is_project_default=(name == active),
                     raw=cfg,
                 )
             )
@@ -416,15 +421,18 @@ class ServiceConfigApp:
     def _render_footer_hint(self) -> List[Tuple[str, str]]:
         if self._view == _View.LIST:
             if self._tab == _Tab.SEMANTIC:
-                # No `e edit` / `p project default` — metricflow has no
-                # editable parameters and semantic layers don't yet
-                # support project-level defaults.
-                base = "  \u2191\u2193 navigate   \u21b5 open   x delete   t test   Tab switch   Esc cancel"
+                # ``e edit`` is hidden on this tab — metricflow has no
+                # editable fields. ``d`` / ``p`` work the same as on the
+                # other tabs.
+                base = (
+                    "  \u2191\u2193 navigate   \u21b5 open   x delete   t test   "
+                    "d global default   p project default   Tab switch   Esc cancel"
+                )
             else:
-                base = "  \u2191\u2193 navigate   \u21b5 open   e edit   x delete   t test   p project default"
-                if self._tab == _Tab.SCHEDULER:
-                    base += "   d global default"
-                base += "   Tab switch   Esc cancel"
+                base = (
+                    "  \u2191\u2193 navigate   \u21b5 open   e edit   x delete   t test   "
+                    "d global default   p project default   Tab switch   Esc cancel"
+                )
         elif self._view == _View.TYPE_PICKER:
             base = "  \u2191\u2193 navigate   \u21b5 select   Esc back"
         else:
@@ -444,7 +452,7 @@ class ServiceConfigApp:
             if i < len(entries):
                 entry = entries[i]
                 marker = "*" if entry.is_project_default else " "
-                default_tag = " [default]" if entry.is_default and self._tab == _Tab.SCHEDULER else ""
+                default_tag = " [default]" if entry.is_default else ""
                 label = f"{marker} {entry.name:<22} {entry.adapter_type:<14}{default_tag}"
                 style = CLR_CURRENT if entry.is_project_default else ""
             else:
@@ -760,12 +768,14 @@ class ServiceConfigApp:
             self._app.exit(result=self._result)
 
     def _on_set_default(self) -> None:
-        if self._tab != _Tab.SCHEDULER:
-            return
         entries = self._entries_for(self._tab)
         if 0 <= self._list_cursor < len(entries):
             entry = entries[self._list_cursor]
-            self._result = ServiceConfigSelection(action="set_default", section="schedulers", name=entry.name)
+            self._result = ServiceConfigSelection(
+                action="set_default",
+                section=self._tab_section(),
+                name=entry.name,
+            )
             self._app.exit(result=self._result)
 
     def _on_set_project_default(self) -> None:
@@ -776,11 +786,6 @@ class ServiceConfigApp:
         is *already* the project default exits with the same action and
         an empty ``name`` so :class:`ServiceCommands` clears the override.
         """
-        # Semantic layers don't yet have a project-level default API on
-        # ``AgentConfig`` — silently ignore ``p`` on this tab so users
-        # don't get a misleading "saved" status.
-        if self._tab == _Tab.SEMANTIC:
-            return
         entries = self._entries_for(self._tab)
         if not (0 <= self._list_cursor < len(entries)):
             return
@@ -807,7 +812,6 @@ class ServiceConfigApp:
         is_list = Condition(lambda: self._view == _View.LIST)
         is_type = Condition(lambda: self._view == _View.TYPE_PICKER)
         is_form = Condition(lambda: self._view == _View.FORM)
-        is_scheduler_list = Condition(lambda: self._view == _View.LIST and self._tab == _Tab.SCHEDULER)
 
         @kb.add("up", filter=is_list)
         def _(event):
@@ -846,7 +850,7 @@ class ServiceConfigApp:
         def _(event):
             self._on_test()
 
-        @kb.add("d", filter=is_scheduler_list)
+        @kb.add("d", filter=is_list)
         def _(event):
             self._on_set_default()
 

--- a/datus/cli/service_config_app.py
+++ b/datus/cli/service_config_app.py
@@ -1,0 +1,952 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Self-contained ``/services`` configuration TUI.
+
+Two-tab picker (Dashboard / Scheduler) modeled on
+:class:`datus.cli.model_app.ModelApp`. The whole interaction — list,
+adapter-type picker, credential form — lives inside **one**
+prompt_toolkit Application so the outer :class:`DatusApp` only needs to
+release ``stdin`` once via :meth:`DatusApp.suspend_input`.
+
+Slow side effects (``pip install``, connection probe, project-default
+prompt) are deliberately *not* run inside the Application. The App
+returns a :class:`ServiceConfigSelection` describing the user's intent
+and :class:`ServiceCommands` orchestrates the install / probe / persist
+chain on the outer console, then re-enters the App so the list reflects
+the new state.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.layout.containers import (
+    ConditionalContainer,
+    DynamicContainer,
+    HSplit,
+    Window,
+)
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.widgets import TextArea
+from rich.console import Console
+
+from datus.cli.cli_styles import CLR_CURRENT, CLR_CURSOR, SYM_ARROW, render_tui_title_bar
+from datus.configuration.agent_config import AgentConfig
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+# Built-in adapter types per section. Picked from the documented set in
+# the data-engineering quickstart guide; users are free to extend this
+# list at runtime by passing ``extra_types`` to :class:`ServiceConfigApp`
+# (e.g. when a private adapter is registered before the TUI opens).
+_BUILTIN_TYPES: Dict[str, Tuple[str, ...]] = {
+    "bi_platforms": ("superset", "grafana"),
+    "schedulers": ("airflow",),
+    "semantic_layer": ("metricflow",),
+}
+
+
+_MASKED_PLACEHOLDER = "••••••••"
+
+
+class _Tab(Enum):
+    DASHBOARD = "dashboard"
+    SCHEDULER = "scheduler"
+    SEMANTIC = "semantic"
+
+
+_TAB_CYCLE: Tuple[_Tab, ...] = (_Tab.DASHBOARD, _Tab.SCHEDULER, _Tab.SEMANTIC)
+
+
+_SECTION_OF: Dict[_Tab, str] = {
+    _Tab.DASHBOARD: "bi_platforms",
+    _Tab.SCHEDULER: "schedulers",
+    _Tab.SEMANTIC: "semantic_layer",
+}
+
+
+_TAB_OF_SECTION: Dict[str, _Tab] = {v: k for k, v in _SECTION_OF.items()}
+
+
+class _View(Enum):
+    LIST = "list"
+    TYPE_PICKER = "type_picker"
+    FORM = "form"
+
+
+@dataclass
+class ServiceConfigSelection:
+    """Outcome of a :class:`ServiceConfigApp` run.
+
+    ``action`` discriminates the payload:
+
+    - ``"save"`` — caller should ``ensure_adapter`` → ``hot_reload_adapter``
+      → probe → persist + ask "set as project default?". ``payload``
+      carries the YAML-shaped service dict; ``name`` carries the entry
+      key.
+    - ``"delete"`` — caller should drop ``services.<section>.<name>``.
+    - ``"test"`` — caller should run a connection probe against the
+      already-saved entry and surface the result.
+    - ``"set_default"`` — flip the global ``default: true`` flag (only
+      issued from the Scheduler tab).
+    """
+
+    action: str
+    section: str
+    name: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _Entry:
+    """Row in the LIST view — pre-flattened from ``DashboardConfig`` /
+    ``scheduler_services``. Built by :meth:`ServiceConfigApp._load_entries`."""
+
+    name: str
+    adapter_type: str
+    is_default: bool  # global ``default: true`` (scheduler) or single-entry
+    is_project_default: bool  # project-level pin from .datus/config.yml
+    raw: Dict[str, Any]
+
+
+class ServiceConfigApp:
+    """Two-tab service configuration picker.
+
+    The caller is expected to:
+
+    1. Wrap ``app.run()`` in :meth:`DatusApp.suspend_input` when the REPL
+       is in TUI mode (no-op otherwise).
+    2. Apply the returned :class:`ServiceConfigSelection` via
+       :class:`ServiceCommands` and re-enter the app so the LIST reflects
+       the post-write state.
+    """
+
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        console: Console,
+        *,
+        initial_tab: str = "dashboard",
+        extra_types: Optional[Dict[str, Tuple[str, ...]]] = None,
+        status_message: Optional[str] = None,
+    ) -> None:
+        self._cfg = agent_config
+        self._console = console
+        self._extra_types = extra_types or {}
+        if initial_tab == "scheduler":
+            self._tab: _Tab = _Tab.SCHEDULER
+        elif initial_tab == "semantic":
+            self._tab = _Tab.SEMANTIC
+        else:
+            self._tab = _Tab.DASHBOARD
+        self._view: _View = _View.LIST
+        self._list_cursor: int = 0
+        self._list_offset: int = 0
+        self._error_message: Optional[str] = None
+        self._status_message: Optional[str] = status_message
+        self._result: Optional[ServiceConfigSelection] = None
+
+        # Type-picker state
+        self._type_choices: List[str] = []
+        self._type_cursor: int = 0
+
+        # Form state
+        self._form_section: str = "bi_platforms"
+        self._form_name: str = ""
+        self._form_type: str = ""
+        self._form_is_edit: bool = False
+        self._form_focus_order: List[TextArea] = []
+        self._form_focus_idx: int = 0
+
+        # Cached per-tab snapshots so the LIST view paints without
+        # recomputing on every render.
+        self._dashboard_entries: List[_Entry] = []
+        self._scheduler_entries: List[_Entry] = []
+        self._semantic_entries: List[_Entry] = []
+        self._reload_entries()
+
+        # Form widgets — built up-front so key bindings can reference
+        # them. Only the ones relevant to ``_form_section`` get wired
+        # into the focus chain at form-entry time.
+        self._fld_name = TextArea(height=1, multiline=False, prompt="name:            ", focus_on_click=True)
+        self._fld_api_base_url = TextArea(height=1, multiline=False, prompt="api_base_url:    ", focus_on_click=True)
+        self._fld_username = TextArea(height=1, multiline=False, prompt="username:        ", focus_on_click=True)
+        self._fld_password = TextArea(
+            height=1, multiline=False, prompt="password:        ", password=True, focus_on_click=True
+        )
+        self._fld_api_key = TextArea(
+            height=1, multiline=False, prompt="api_key:         ", password=True, focus_on_click=True
+        )
+        self._fld_datasource_ref = TextArea(height=1, multiline=False, prompt="datasource_ref:  ", focus_on_click=True)
+        self._fld_bi_database = TextArea(height=1, multiline=False, prompt="bi_database_name:", focus_on_click=True)
+        self._fld_dags_folder = TextArea(height=1, multiline=False, prompt="dags_folder:     ", focus_on_click=True)
+
+        term_height = shutil.get_terminal_size((120, 40)).lines
+        # title(1) + tabs(1) + 2 sep(2) + error(1) + status(1) + footer(1) = 7
+        self._max_visible: int = max(3, min(15, term_height - 7))
+
+        self._app = self._build_application()
+
+    # ─────────────────────────────────────────────────────────────────
+    # Public API
+    # ─────────────────────────────────────────────────────────────────
+
+    def run(self) -> Optional[ServiceConfigSelection]:
+        try:
+            return self._app.run()
+        except KeyboardInterrupt:
+            return None
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("ServiceConfigApp crashed: %s", exc)
+            return None
+
+    # ─────────────────────────────────────────────────────────────────
+    # Data loading
+    # ─────────────────────────────────────────────────────────────────
+
+    def _reload_entries(self) -> None:
+        self._dashboard_entries = self._build_dashboard_entries()
+        self._scheduler_entries = self._build_scheduler_entries()
+        self._semantic_entries = self._build_semantic_entries()
+
+    def _build_dashboard_entries(self) -> List[_Entry]:
+        dashboards = getattr(self._cfg, "dashboard_config", {}) or {}
+        active_fn = getattr(self._cfg, "active_dashboard", None)
+        active = active_fn() if callable(active_fn) else None
+        out: List[_Entry] = []
+        for name in sorted(dashboards.keys()):
+            cfg = dashboards[name]
+            adapter_type = getattr(cfg, "adapter_type", "") or name
+            raw = {
+                "type": adapter_type,
+                "api_base_url": getattr(cfg, "api_base_url", "") or "",
+                "username": getattr(cfg, "username", "") or "",
+                "password": getattr(cfg, "password", "") or "",
+                "api_key": getattr(cfg, "api_key", "") or "",
+                "extra": getattr(cfg, "extra", {}) or {},
+            }
+            dataset_db = getattr(cfg, "dataset_db", None)
+            if dataset_db is not None:
+                raw["dataset_db"] = {
+                    "datasource_ref": getattr(dataset_db, "datasource_ref", "") or "",
+                    "bi_database_name": getattr(dataset_db, "bi_database_name", None),
+                }
+            out.append(
+                _Entry(
+                    name=name,
+                    adapter_type=adapter_type,
+                    is_default=(len(dashboards) == 1),
+                    is_project_default=(name == active),
+                    raw=raw,
+                )
+            )
+        return out
+
+    def _build_scheduler_entries(self) -> List[_Entry]:
+        services = getattr(self._cfg, "scheduler_services", {}) or {}
+        active_fn = getattr(self._cfg, "active_scheduler", None)
+        active = active_fn() if callable(active_fn) else None
+        out: List[_Entry] = []
+        for name in sorted(services.keys()):
+            cfg = dict(services[name])
+            adapter_type = str(cfg.get("type") or "").strip().lower() or name
+            out.append(
+                _Entry(
+                    name=name,
+                    adapter_type=adapter_type,
+                    is_default=bool(cfg.get("default")),
+                    is_project_default=(name == active),
+                    raw=cfg,
+                )
+            )
+        return out
+
+    def _build_semantic_entries(self) -> List[_Entry]:
+        # ``init_semantic_layer`` already enforces ``key == type`` and
+        # resolves env vars, so iterating ``semantic_layer_configs`` is
+        # safe — every entry maps a YAML key (e.g. ``metricflow``) to a
+        # dict whose ``type`` field equals that key.
+        services = getattr(self._cfg, "semantic_layer_configs", {}) or {}
+        out: List[_Entry] = []
+        for name in sorted(services.keys()):
+            cfg = dict(services[name])
+            adapter_type = str(cfg.get("type") or name).strip().lower()
+            out.append(
+                _Entry(
+                    name=name,
+                    adapter_type=adapter_type,
+                    is_default=(len(services) == 1),
+                    is_project_default=False,
+                    raw=cfg,
+                )
+            )
+        return out
+
+    def _entries_for(self, tab: _Tab) -> List[_Entry]:
+        if tab == _Tab.DASHBOARD:
+            return self._dashboard_entries
+        if tab == _Tab.SCHEDULER:
+            return self._scheduler_entries
+        return self._semantic_entries
+
+    # ─────────────────────────────────────────────────────────────────
+    # Layout construction
+    # ─────────────────────────────────────────────────────────────────
+
+    def _build_application(self) -> Application:
+        title_bar = Window(
+            content=FormattedTextControl(lambda: render_tui_title_bar("Datus Services")),
+            height=1,
+        )
+        tab_window = Window(
+            content=FormattedTextControl(self._render_tab_strip, focusable=False),
+            height=1,
+        )
+        list_window = Window(
+            content=FormattedTextControl(self._render_list, focusable=True),
+            always_hide_cursor=True,
+            height=Dimension(min=3),
+        )
+        type_window = Window(
+            content=FormattedTextControl(self._render_type_picker, focusable=True),
+            always_hide_cursor=True,
+            height=Dimension(min=3),
+        )
+        bi_form = HSplit(
+            [
+                Window(FormattedTextControl(self._render_form_header, focusable=False), height=Dimension(min=1, max=3)),
+                self._fld_name,
+                self._fld_api_base_url,
+                self._fld_username,
+                self._fld_password,
+                self._fld_api_key,
+                self._fld_datasource_ref,
+                self._fld_bi_database,
+            ]
+        )
+        scheduler_form = HSplit(
+            [
+                Window(FormattedTextControl(self._render_form_header, focusable=False), height=Dimension(min=1, max=3)),
+                self._fld_name,
+                self._fld_api_base_url,
+                self._fld_username,
+                self._fld_password,
+                self._fld_dags_folder,
+            ]
+        )
+
+        def _body_container():
+            if self._view == _View.TYPE_PICKER:
+                return type_window
+            if self._view == _View.FORM:
+                return bi_form if self._form_section == "bi_platforms" else scheduler_form
+            return list_window
+
+        body = DynamicContainer(_body_container)
+
+        error_window = ConditionalContainer(
+            content=Window(
+                FormattedTextControl(lambda: [("class:service-app.error", f"  {self._error_message or ''}")]),
+                height=1,
+            ),
+            filter=Condition(lambda: bool(self._error_message)),
+        )
+        status_window = ConditionalContainer(
+            content=Window(
+                FormattedTextControl(lambda: [("class:service-app.status", f"  {self._status_message or ''}")]),
+                height=1,
+            ),
+            filter=Condition(lambda: bool(self._status_message)),
+        )
+        hint_window = Window(
+            content=FormattedTextControl(self._render_footer_hint, focusable=False),
+            height=1,
+        )
+
+        root = HSplit(
+            [
+                title_bar,
+                tab_window,
+                Window(height=1, char="\u2500"),
+                body,
+                error_window,
+                status_window,
+                Window(height=1, char="\u2500"),
+                hint_window,
+            ]
+        )
+
+        return Application(
+            layout=Layout(root, focused_element=None),
+            key_bindings=self._build_key_bindings(),
+            full_screen=False,
+            mouse_support=False,
+            erase_when_done=True,
+        )
+
+    # ─────────────────────────────────────────────────────────────────
+    # Rendering
+    # ─────────────────────────────────────────────────────────────────
+
+    def _render_tab_strip(self) -> List[Tuple[str, str]]:
+        parts: List[Tuple[str, str]] = [("", "  ")]
+        for tab, label in (
+            (_Tab.DASHBOARD, " Dashboard "),
+            (_Tab.SCHEDULER, " Scheduler "),
+            (_Tab.SEMANTIC, " Semantic "),
+        ):
+            style = "reverse bold" if tab == self._tab else ""
+            parts.append((style, label))
+            parts.append(("", " "))
+        parts.append(("class:service-app.tabs-hint", "  (Tab or \u2190/\u2192 to switch)"))
+        return parts
+
+    def _render_footer_hint(self) -> List[Tuple[str, str]]:
+        if self._view == _View.LIST:
+            if self._tab == _Tab.SEMANTIC:
+                # No `e edit` / `p project default` — metricflow has no
+                # editable parameters and semantic layers don't yet
+                # support project-level defaults.
+                base = "  \u2191\u2193 navigate   \u21b5 open   x delete   t test   Tab switch   Esc cancel"
+            else:
+                base = "  \u2191\u2193 navigate   \u21b5 open   e edit   x delete   t test   p project default"
+                if self._tab == _Tab.SCHEDULER:
+                    base += "   d global default"
+                base += "   Tab switch   Esc cancel"
+        elif self._view == _View.TYPE_PICKER:
+            base = "  \u2191\u2193 navigate   \u21b5 select   Esc back"
+        else:
+            base = "  Tab next field   \u21b5 submit on last field   Ctrl+S submit   Esc back"
+        return [("class:service-app.hint", base)]
+
+    def _render_list(self) -> List[Tuple[str, str]]:
+        entries = self._entries_for(self._tab)
+        total_rows = len(entries) + 1  # +1 for the trailing "Add" row
+        self._clamp_cursor(total_rows)
+        visible = self._visible_slice(total_rows)
+        lines: List[Tuple[str, str]] = []
+        start, end = visible
+        if end - start < total_rows:
+            lines.append(("class:service-app.scroll", f"  ({start + 1}-{end} of {total_rows})\n"))
+        for i in range(start, end):
+            if i < len(entries):
+                entry = entries[i]
+                marker = "*" if entry.is_project_default else " "
+                default_tag = " [default]" if entry.is_default and self._tab == _Tab.SCHEDULER else ""
+                label = f"{marker} {entry.name:<22} {entry.adapter_type:<14}{default_tag}"
+                style = CLR_CURRENT if entry.is_project_default else ""
+            else:
+                label = f"  + Add new {self._tab.value}\u2026"
+                style = "class:service-app.accent"
+            if i == self._list_cursor:
+                lines.append((CLR_CURSOR, f"  {SYM_ARROW} {label}\n"))
+            else:
+                lines.append((style, f"    {label}\n"))
+        return lines
+
+    def _render_type_picker(self) -> List[Tuple[str, str]]:
+        self._type_cursor = max(0, min(self._type_cursor, len(self._type_choices) - 1))
+        if self._tab == _Tab.DASHBOARD:
+            section_label = "BI dashboard"
+        elif self._tab == _Tab.SCHEDULER:
+            section_label = "scheduler"
+        else:
+            section_label = "semantic layer"
+        lines: List[Tuple[str, str]] = [
+            ("bold", f"  Pick adapter type for new {section_label}:\n"),
+        ]
+        for i, type_name in enumerate(self._type_choices):
+            installed = self._is_installed(self._tab_section(), type_name)
+            tag = "(installed)" if installed else "(will pip install)"
+            label = f"{type_name:<18} {tag}"
+            if i == self._type_cursor:
+                lines.append((CLR_CURSOR, f"  {SYM_ARROW} {label}\n"))
+            else:
+                lines.append(("", f"    {label}\n"))
+        return lines
+
+    def _render_form_header(self) -> List[Tuple[str, str]]:
+        verb = "Edit" if self._form_is_edit else "Create"
+        section_label = "BI dashboard" if self._form_section == "bi_platforms" else "scheduler"
+        type_label = self._form_type or "(?)"
+        return [
+            ("bold", f"  {verb} {section_label}: type={type_label}\n"),
+            ("class:service-app.dim", "  Leave password blank to keep existing.\n"),
+        ]
+
+    # ─────────────────────────────────────────────────────────────────
+    # Cursor helpers
+    # ─────────────────────────────────────────────────────────────────
+
+    def _clamp_cursor(self, total: int) -> None:
+        if total <= 0:
+            self._list_cursor = 0
+            return
+        if self._list_cursor >= total:
+            self._list_cursor = total - 1
+        if self._list_cursor < 0:
+            self._list_cursor = 0
+
+    def _visible_slice(self, total: int) -> Tuple[int, int]:
+        max_visible = self._max_visible
+        if total <= max_visible:
+            self._list_offset = 0
+            return 0, total
+        if self._list_cursor < self._list_offset:
+            self._list_offset = self._list_cursor
+        elif self._list_cursor >= self._list_offset + max_visible:
+            self._list_offset = self._list_cursor - max_visible + 1
+        start = max(0, min(self._list_offset, total - max_visible))
+        return start, start + max_visible
+
+    # ─────────────────────────────────────────────────────────────────
+    # Section / type helpers
+    # ─────────────────────────────────────────────────────────────────
+
+    def _tab_section(self) -> str:
+        return _SECTION_OF[self._tab]
+
+    def _is_installed(self, section: str, adapter_type: str) -> bool:
+        # Imported lazily so unit tests can monkey-patch the helper.
+        from datus.cli.service_adapter_installer import is_adapter_installed
+
+        return is_adapter_installed(section, adapter_type)
+
+    def _types_for(self, section: str) -> List[str]:
+        builtin = _BUILTIN_TYPES.get(section, ())
+        extra = self._extra_types.get(section, ())
+        # ``dict.fromkeys`` preserves order while removing duplicates so
+        # the picker is deterministic regardless of test injection.
+        return list(dict.fromkeys((*builtin, *extra)))
+
+    # ─────────────────────────────────────────────────────────────────
+    # State transitions
+    # ─────────────────────────────────────────────────────────────────
+
+    def _enter_list(self) -> None:
+        self._view = _View.LIST
+        self._error_message = None
+
+    def _enter_type_picker(self) -> None:
+        self._type_choices = self._types_for(self._tab_section())
+        self._type_cursor = 0
+        self._view = _View.TYPE_PICKER
+        self._error_message = None
+
+    def _enter_form_for_new(self, adapter_type: str) -> None:
+        section = self._tab_section()
+        # Semantic adapters currently have no user-editable parameters;
+        # creating one is a single decision (``which type?``) so we skip
+        # the FORM view entirely and emit ``save`` straight from the
+        # type-picker. The on-disk shape is just ``{type: <type>}`` —
+        # ``init_semantic_layer`` requires the YAML key to equal ``type``.
+        if section == "semantic_layer":
+            self._result = ServiceConfigSelection(
+                action="save",
+                section=section,
+                name=adapter_type,
+                payload={"type": adapter_type},
+            )
+            self._app.exit(result=self._result)
+            return
+        self._form_section = section
+        self._form_type = adapter_type
+        self._form_name = ""
+        self._form_is_edit = False
+        for ta in (
+            self._fld_name,
+            self._fld_api_base_url,
+            self._fld_username,
+            self._fld_password,
+            self._fld_api_key,
+            self._fld_datasource_ref,
+            self._fld_bi_database,
+            self._fld_dags_folder,
+        ):
+            ta.text = ""
+        self._fld_name.text = adapter_type  # convenient default
+        # Switch view *before* focusing — ``Layout.focus()`` walks the
+        # currently visible container tree, and DynamicContainer only
+        # exposes the form's TextAreas once ``_body_container()`` returns
+        # the form. Focusing while still in LIST view raises
+        # ``ValueError: Window does not appear in the layout``.
+        self._view = _View.FORM
+        self._wire_form_focus()
+        self._error_message = None
+
+    def _enter_form_for_edit(self, entry: _Entry) -> None:
+        self._form_section = self._tab_section()
+        self._form_type = entry.adapter_type
+        self._form_name = entry.name
+        self._form_is_edit = True
+        raw = entry.raw or {}
+        self._fld_name.text = entry.name
+        self._fld_api_base_url.text = str(raw.get("api_base_url", "") or "")
+        self._fld_username.text = str(raw.get("username", "") or "")
+        # Mask saved password / api_key so the user can keep them by
+        # leaving the field untouched. Submit logic checks for the
+        # placeholder before overwriting.
+        self._fld_password.text = _MASKED_PLACEHOLDER if raw.get("password") else ""
+        self._fld_api_key.text = _MASKED_PLACEHOLDER if raw.get("api_key") else ""
+        if self._form_section == "bi_platforms":
+            dsdb = raw.get("dataset_db") or {}
+            self._fld_datasource_ref.text = str(dsdb.get("datasource_ref", "") or "")
+            self._fld_bi_database.text = str(dsdb.get("bi_database_name") or "")
+        else:
+            self._fld_dags_folder.text = str(raw.get("dags_folder", "") or "")
+        # See ``_enter_form_for_new`` — switch view before focusing.
+        self._view = _View.FORM
+        self._wire_form_focus()
+        self._error_message = None
+
+    def _wire_form_focus(self) -> None:
+        if self._form_section == "bi_platforms":
+            self._form_focus_order = [
+                self._fld_name,
+                self._fld_api_base_url,
+                self._fld_username,
+                self._fld_password,
+                self._fld_api_key,
+                self._fld_datasource_ref,
+                self._fld_bi_database,
+            ]
+        else:
+            self._form_focus_order = [
+                self._fld_name,
+                self._fld_api_base_url,
+                self._fld_username,
+                self._fld_password,
+                self._fld_dags_folder,
+            ]
+        self._form_focus_idx = 0
+        self._app.layout.focus(self._form_focus_order[0])
+
+    # ─────────────────────────────────────────────────────────────────
+    # Submit handlers
+    # ─────────────────────────────────────────────────────────────────
+
+    def _submit_form(self) -> None:
+        name = self._fld_name.text.strip()
+        if not name:
+            self._error_message = "name is required"
+            return
+        if self._form_section == "bi_platforms":
+            payload = self._build_bi_payload()
+        else:
+            payload = self._build_scheduler_payload()
+        if payload is None:
+            return  # error already set
+        # Reject collisions on add (edit is allowed to keep the same name).
+        if not self._form_is_edit:
+            existing_names = {e.name for e in self._entries_for(self._tab)}
+            if name in existing_names:
+                self._error_message = f"`{name}` already exists in this tab"
+                return
+        self._result = ServiceConfigSelection(
+            action="save",
+            section=self._form_section,
+            name=name,
+            payload=payload,
+        )
+        self._app.exit(result=self._result)
+
+    def _build_bi_payload(self) -> Optional[Dict[str, Any]]:
+        api_base_url = self._fld_api_base_url.text.strip()
+        if not api_base_url:
+            self._error_message = "api_base_url is required"
+            return None
+        # password / api_key: keep existing if user left the masked
+        # placeholder untouched. Empty string clears the field.
+        password = self._read_secret(self._fld_password.text, edit=self._form_is_edit, key="password")
+        api_key = self._read_secret(self._fld_api_key.text, edit=self._form_is_edit, key="api_key")
+        datasource_ref = self._fld_datasource_ref.text.strip()
+        bi_database = self._fld_bi_database.text.strip()
+        payload: Dict[str, Any] = {
+            "type": self._form_type,
+            "api_base_url": api_base_url,
+            "username": self._fld_username.text.strip(),
+        }
+        if password is not None:
+            payload["password"] = password
+        if api_key is not None:
+            payload["api_key"] = api_key
+        if datasource_ref or bi_database:
+            dataset_db: Dict[str, Any] = {}
+            if datasource_ref:
+                dataset_db["datasource_ref"] = datasource_ref
+            if bi_database:
+                dataset_db["bi_database_name"] = bi_database
+            payload["dataset_db"] = dataset_db
+        return payload
+
+    def _build_scheduler_payload(self) -> Optional[Dict[str, Any]]:
+        api_base_url = self._fld_api_base_url.text.strip()
+        password = self._read_secret(self._fld_password.text, edit=self._form_is_edit, key="password")
+        payload: Dict[str, Any] = {
+            "type": self._form_type,
+            "api_base_url": api_base_url,
+            "username": self._fld_username.text.strip(),
+        }
+        if password is not None:
+            payload["password"] = password
+        dags_folder = self._fld_dags_folder.text.strip()
+        if dags_folder:
+            payload["dags_folder"] = dags_folder
+        return payload
+
+    @staticmethod
+    def _read_secret(raw: str, *, edit: bool, key: str) -> Optional[str]:
+        """Translate masked / empty / new input into the saved value.
+
+        - Edit + placeholder untouched → ``None`` (caller keeps existing).
+        - Edit + empty → empty string (clears the field).
+        - Add + empty → ``None`` (don't write the key at all).
+        - Otherwise → raw text.
+        """
+        del key  # currently only used for symmetry; reserved for richer logging
+        if edit and raw == _MASKED_PLACEHOLDER:
+            return None
+        if not edit and not raw:
+            return None
+        return raw
+
+    # ─────────────────────────────────────────────────────────────────
+    # Key-binding-driven actions
+    # ─────────────────────────────────────────────────────────────────
+
+    def _on_list_enter(self) -> None:
+        entries = self._entries_for(self._tab)
+        if self._list_cursor >= len(entries):
+            self._enter_type_picker()
+            return
+        # Semantic entries have no editable fields — keep ENTER on the
+        # "Add new" row as the only way into the type picker, and ignore
+        # it on existing rows.
+        if self._tab == _Tab.SEMANTIC:
+            return
+        self._enter_form_for_edit(entries[self._list_cursor])
+
+    def _on_edit(self) -> None:
+        if self._tab == _Tab.SEMANTIC:
+            return
+        entries = self._entries_for(self._tab)
+        if 0 <= self._list_cursor < len(entries):
+            self._enter_form_for_edit(entries[self._list_cursor])
+
+    def _on_delete(self) -> None:
+        entries = self._entries_for(self._tab)
+        if 0 <= self._list_cursor < len(entries):
+            entry = entries[self._list_cursor]
+            self._result = ServiceConfigSelection(action="delete", section=self._tab_section(), name=entry.name)
+            self._app.exit(result=self._result)
+
+    def _on_test(self) -> None:
+        entries = self._entries_for(self._tab)
+        if 0 <= self._list_cursor < len(entries):
+            entry = entries[self._list_cursor]
+            self._result = ServiceConfigSelection(action="test", section=self._tab_section(), name=entry.name)
+            self._app.exit(result=self._result)
+
+    def _on_set_default(self) -> None:
+        if self._tab != _Tab.SCHEDULER:
+            return
+        entries = self._entries_for(self._tab)
+        if 0 <= self._list_cursor < len(entries):
+            entry = entries[self._list_cursor]
+            self._result = ServiceConfigSelection(action="set_default", section="schedulers", name=entry.name)
+            self._app.exit(result=self._result)
+
+    def _on_set_project_default(self) -> None:
+        """Pin (or clear) the project-level default for the highlighted entry.
+
+        Pressing ``p`` on a non-default row exits with
+        ``action="set_project_default"``; pressing ``p`` on the row that
+        is *already* the project default exits with the same action and
+        an empty ``name`` so :class:`ServiceCommands` clears the override.
+        """
+        # Semantic layers don't yet have a project-level default API on
+        # ``AgentConfig`` — silently ignore ``p`` on this tab so users
+        # don't get a misleading "saved" status.
+        if self._tab == _Tab.SEMANTIC:
+            return
+        entries = self._entries_for(self._tab)
+        if not (0 <= self._list_cursor < len(entries)):
+            return
+        entry = entries[self._list_cursor]
+        target_name = "" if entry.is_project_default else entry.name
+        self._result = ServiceConfigSelection(
+            action="set_project_default",
+            section=self._tab_section(),
+            name=target_name,
+        )
+        self._app.exit(result=self._result)
+
+    def _on_type_picker_enter(self) -> None:
+        if not self._type_choices:
+            return
+        self._enter_form_for_new(self._type_choices[self._type_cursor])
+
+    # ─────────────────────────────────────────────────────────────────
+    # Key bindings
+    # ─────────────────────────────────────────────────────────────────
+
+    def _build_key_bindings(self) -> KeyBindings:
+        kb = KeyBindings()
+        is_list = Condition(lambda: self._view == _View.LIST)
+        is_type = Condition(lambda: self._view == _View.TYPE_PICKER)
+        is_form = Condition(lambda: self._view == _View.FORM)
+        is_scheduler_list = Condition(lambda: self._view == _View.LIST and self._tab == _Tab.SCHEDULER)
+
+        @kb.add("up", filter=is_list)
+        def _(event):
+            total = len(self._entries_for(self._tab)) + 1
+            self._list_cursor = (self._list_cursor - 1) % total
+            self._error_message = None
+
+        @kb.add("down", filter=is_list)
+        def _(event):
+            total = len(self._entries_for(self._tab)) + 1
+            self._list_cursor = (self._list_cursor + 1) % total
+            self._error_message = None
+
+        @kb.add("pageup", filter=is_list)
+        def _(event):
+            self._list_cursor = max(0, self._list_cursor - 10)
+
+        @kb.add("pagedown", filter=is_list)
+        def _(event):
+            total = len(self._entries_for(self._tab)) + 1
+            self._list_cursor = min(total - 1, self._list_cursor + 10)
+
+        @kb.add("enter", filter=is_list)
+        def _(event):
+            self._on_list_enter()
+
+        @kb.add("e", filter=is_list)
+        def _(event):
+            self._on_edit()
+
+        @kb.add("x", filter=is_list)
+        def _(event):
+            self._on_delete()
+
+        @kb.add("t", filter=is_list)
+        def _(event):
+            self._on_test()
+
+        @kb.add("d", filter=is_scheduler_list)
+        def _(event):
+            self._on_set_default()
+
+        @kb.add("p", filter=is_list)
+        def _(event):
+            self._on_set_project_default()
+
+        @kb.add("tab", filter=is_list)
+        def _(event):
+            self._cycle_tab(+1)
+
+        @kb.add("s-tab", filter=is_list)
+        def _(event):
+            self._cycle_tab(-1)
+
+        @kb.add("right", filter=is_list)
+        def _(event):
+            self._cycle_tab(+1)
+
+        @kb.add("left", filter=is_list)
+        def _(event):
+            self._cycle_tab(-1)
+
+        @kb.add("escape", filter=is_list)
+        def _(event):
+            event.app.exit(result=None)
+
+        # Type-picker ----------------------------------------------------
+        @kb.add("up", filter=is_type)
+        def _(event):
+            if self._type_choices:
+                self._type_cursor = (self._type_cursor - 1) % len(self._type_choices)
+
+        @kb.add("down", filter=is_type)
+        def _(event):
+            if self._type_choices:
+                self._type_cursor = (self._type_cursor + 1) % len(self._type_choices)
+
+        @kb.add("enter", filter=is_type)
+        def _(event):
+            self._on_type_picker_enter()
+
+        @kb.add("escape", filter=is_type)
+        def _(event):
+            self._enter_list()
+
+        # Form -----------------------------------------------------------
+        @kb.add("tab", filter=is_form)
+        def _(event):
+            self._advance_form_focus(+1)
+
+        @kb.add("s-tab", filter=is_form)
+        def _(event):
+            self._advance_form_focus(-1)
+
+        @kb.add("down", filter=is_form)
+        def _(event):
+            self._advance_form_focus(+1)
+
+        @kb.add("up", filter=is_form)
+        def _(event):
+            self._advance_form_focus(-1)
+
+        @kb.add("enter", filter=is_form)
+        def _(event):
+            if self._form_focus_idx >= len(self._form_focus_order) - 1:
+                self._submit_form()
+            else:
+                self._advance_form_focus(+1)
+
+        @kb.add("c-s", filter=is_form)
+        def _(event):
+            self._submit_form()
+
+        @kb.add("escape", filter=is_form)
+        def _(event):
+            self._enter_list()
+
+        # Global cancel --------------------------------------------------
+        @kb.add("c-c")
+        def _(event):
+            event.app.exit(result=None)
+
+        return kb
+
+    def _advance_form_focus(self, delta: int) -> None:
+        if not self._form_focus_order:
+            return
+        self._form_focus_idx = (self._form_focus_idx + delta) % len(self._form_focus_order)
+        self._app.layout.focus(self._form_focus_order[self._form_focus_idx])
+
+    def _cycle_tab(self, direction: int = 1) -> None:
+        try:
+            idx = _TAB_CYCLE.index(self._tab)
+        except ValueError:
+            idx = 0
+        self._tab = _TAB_CYCLE[(idx + direction) % len(_TAB_CYCLE)]
+        self._list_cursor = 0
+        self._list_offset = 0
+        self._error_message = None
+
+
+__all__ = ["ServiceConfigApp", "ServiceConfigSelection"]

--- a/datus/cli/slash_registry.py
+++ b/datus/cli/slash_registry.py
@@ -83,7 +83,7 @@ SLASH_COMMANDS: tuple[SlashSpec, ...] = (
     SlashSpec("model", "Switch LLM provider/model", "system", aliases=("models",)),
     SlashSpec("effort", "Set reasoning effort (off|minimal|low|medium|high)", "system"),
     SlashSpec("init", "Generate AGENTS.md for the current project", "system"),
-    SlashSpec("services", "List configured service platforms and their read-only methods", "system"),
+    SlashSpec("services", "Configure dashboards/schedulers (TUI) or list read-only methods", "system"),
     SlashSpec(
         "profile",
         "Switch the permission profile (normal / auto / dangerous)",

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -596,6 +596,16 @@ class AgentConfig:
         self._target_reasoning_effort: Optional[str] = (
             kwargs.get("target_reasoning_effort") or kwargs.get("reasoning_effort") or None
         )
+        # Project-level active service overrides forwarded by
+        # ``_apply_project_override`` from ``./.datus/config.yml``. ``None``
+        # means "no project override" — service resolution falls back to
+        # the explicit call-site argument, then the global ``default: true``
+        # flag, then the unique-entry shortcut. Validated lazily at the
+        # consumer ( ``BIFuncTool._resolved_platform`` /
+        # ``AgentConfig.get_scheduler_config``) so a missing service name
+        # does not block ``AgentConfig`` construction itself.
+        self._active_dashboard: Optional[str] = kwargs.get("active_dashboard") or None
+        self._active_scheduler: Optional[str] = kwargs.get("active_scheduler") or None
         # Shared lazily-loaded ``conf/providers.yml`` catalog (metadata only:
         # default_model, base_url, api_key_env, type, model_overrides). Kept
         # as ``None`` until first access so tests that stub load paths can
@@ -1030,6 +1040,22 @@ class AgentConfig:
                 )
             return self.scheduler_services[service_name]
 
+        # Project-level override from ``./.datus/config.yml`` wins over the
+        # global ``default: true`` flag so a project can pin a different
+        # scheduler than the workspace-wide default without rewriting
+        # agent.yml. A stale override (service deleted from agent.yml) is
+        # ignored with a warning so the user sees one clear error rather
+        # than a confusing "no scheduler configured" later.
+        active_override = self._active_scheduler
+        if active_override:
+            if active_override in self.scheduler_services:
+                return self.scheduler_services[active_override]
+            logger.warning(
+                "Project override active_scheduler=`%s` is not configured under "
+                "`agent.services.schedulers`; falling back to global default.",
+                active_override,
+            )
+
         default_service = self.default_scheduler_service()
         if default_service:
             return self.scheduler_services[default_service]
@@ -1047,6 +1073,67 @@ class AgentConfig:
                 "set `scheduler_service` on the scheduler node."
             ),
         )
+
+    def active_dashboard(self) -> Optional[str]:
+        """Return the project-level default BI service, or ``None``.
+
+        Read by :class:`BIFuncTool._resolved_platform` between the explicit
+        ``bi_service`` argument and the unique-entry shortcut. ``None``
+        means "no project override — fall back to the unique-entry
+        shortcut or raise on ambiguity".
+        """
+        return self._active_dashboard
+
+    def active_scheduler(self) -> Optional[str]:
+        """Return the project-level default scheduler service, or ``None``.
+
+        Read by :meth:`get_scheduler_config` between the explicit
+        ``service_name`` argument and the global ``default: true`` flag.
+        """
+        return self._active_scheduler
+
+    def set_active_dashboard(self, name: Optional[str], persist: bool = True) -> None:
+        """Pin (or clear) the project-level default BI service.
+
+        ``name=None`` clears the override. When ``persist`` is ``True``
+        (default), writes ``./.datus/config.yml`` so the choice survives
+        process restarts. Validation against ``services.bi_platforms`` is
+        skipped here — :meth:`active_dashboard` is consulted lazily by
+        consumers, which surface a clear "service not configured" error
+        if the override has gone stale.
+        """
+        cleaned = (name or "").strip() or None
+        self._active_dashboard = cleaned
+        if persist:
+            self._persist_project_field("dashboard", cleaned)
+
+    def set_active_scheduler(self, name: Optional[str], persist: bool = True) -> None:
+        """Pin (or clear) the project-level default scheduler service.
+
+        Mirrors :meth:`set_active_dashboard` for the scheduler section.
+        """
+        cleaned = (name or "").strip() or None
+        self._active_scheduler = cleaned
+        if persist:
+            self._persist_project_field("scheduler", cleaned)
+
+    def _persist_project_field(self, field_name: str, value: Optional[str]) -> None:
+        """Update a single top-level field in ``./.datus/config.yml``.
+
+        Reuses the same project_root resolution as
+        :meth:`set_active_provider_model` so the write target matches the
+        rest of the project-override surface. ``None`` clears the field
+        from the saved YAML rather than writing an empty string.
+        """
+        from datus.configuration.project_config import (
+            ProjectOverride,
+            load_project_override,
+            save_project_override,
+        )
+
+        current = load_project_override(cwd=str(self._project_root)) or ProjectOverride()
+        setattr(current, field_name, value)
+        save_project_override(current, cwd=str(self._project_root))
 
     def default_semantic_adapter(self) -> Optional[str]:
         if len(self.semantic_layer_configs) == 1:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -451,6 +451,11 @@ class DashboardConfig:
     # to enable multi-instance deployments where the alias differs from the
     # adapter type (``platform=superset_prod``, ``adapter_type=superset``).
     adapter_type: str = ""
+    # YAML ``default: true`` flag. When set, this service is the global
+    # default returned by :meth:`AgentConfig.default_dashboard_service`.
+    # At most one entry under ``services.bi_platforms`` may carry this
+    # flag; multiple defaults are rejected at config load time.
+    default: bool = False
 
 
 logger = get_logger(__name__)
@@ -606,6 +611,7 @@ class AgentConfig:
         # does not block ``AgentConfig`` construction itself.
         self._active_dashboard: Optional[str] = kwargs.get("active_dashboard") or None
         self._active_scheduler: Optional[str] = kwargs.get("active_scheduler") or None
+        self._active_semantic: Optional[str] = kwargs.get("active_semantic") or None
         # Shared lazily-loaded ``conf/providers.yml`` catalog (metadata only:
         # default_model, base_url, api_key_env, type, model_overrides). Kept
         # as ``None`` until first access so tests that stub load paths can
@@ -1074,13 +1080,38 @@ class AgentConfig:
             ),
         )
 
+    def default_dashboard_service(self) -> Optional[str]:
+        """Return the dashboard service marked as the global default, or ``None``.
+
+        Mirrors :meth:`default_scheduler_service`: at most one entry under
+        ``services.bi_platforms`` may carry ``default: true`` (multiple
+        defaults are an explicit error so the user fixes the config rather
+        than us silently picking one). When no entry is flagged, fall
+        through to the single-entry shortcut so simple deployments still
+        Just Work without writing the flag.
+        """
+        defaults = [name for name, cfg in self.dashboard_config.items() if getattr(cfg, "default", False)]
+        if len(defaults) > 1:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    "Multiple BI services are marked with `default: true` in "
+                    "`agent.services.bi_platforms`. Keep at most one default dashboard."
+                ),
+            )
+        if defaults:
+            return defaults[0]
+        if len(self.dashboard_config) == 1:
+            return next(iter(self.dashboard_config))
+        return None
+
     def active_dashboard(self) -> Optional[str]:
         """Return the project-level default BI service, or ``None``.
 
         Read by :class:`BIFuncTool._resolved_platform` between the explicit
-        ``bi_service`` argument and the unique-entry shortcut. ``None``
-        means "no project override — fall back to the unique-entry
-        shortcut or raise on ambiguity".
+        ``bi_service`` argument and the global ``default: true`` flag.
+        ``None`` means "no project override — fall back to
+        ``default_dashboard_service`` or raise on ambiguity".
         """
         return self._active_dashboard
 
@@ -1091,6 +1122,14 @@ class AgentConfig:
         ``service_name`` argument and the global ``default: true`` flag.
         """
         return self._active_scheduler
+
+    def active_semantic(self) -> Optional[str]:
+        """Return the project-level default semantic adapter, or ``None``.
+
+        Read by :meth:`resolve_semantic_adapter` between the explicit
+        ``adapter_type`` argument and the global ``default: true`` flag.
+        """
+        return self._active_semantic
 
     def set_active_dashboard(self, name: Optional[str], persist: bool = True) -> None:
         """Pin (or clear) the project-level default BI service.
@@ -1117,6 +1156,16 @@ class AgentConfig:
         if persist:
             self._persist_project_field("scheduler", cleaned)
 
+    def set_active_semantic(self, name: Optional[str], persist: bool = True) -> None:
+        """Pin (or clear) the project-level default semantic adapter.
+
+        Mirrors :meth:`set_active_dashboard` for the semantic_layer section.
+        """
+        cleaned = (name or "").strip() or None
+        self._active_semantic = cleaned
+        if persist:
+            self._persist_project_field("semantic", cleaned)
+
     def _persist_project_field(self, field_name: str, value: Optional[str]) -> None:
         """Update a single top-level field in ``./.datus/config.yml``.
 
@@ -1136,18 +1185,42 @@ class AgentConfig:
         save_project_override(current, cwd=str(self._project_root))
 
     def default_semantic_adapter(self) -> Optional[str]:
+        """Return the semantic adapter marked as the global default, or ``None``.
+
+        Mirrors :meth:`default_scheduler_service` /
+        :meth:`default_dashboard_service`: at most one entry under
+        ``services.semantic_layer`` may carry ``default: true``; multiple
+        defaults are rejected here so the user fixes the YAML rather than
+        having us silently pick one. Falls back to the single-entry
+        shortcut when no entry is flagged.
+        """
+        defaults = [name for name, cfg in self.semantic_layer_configs.items() if cfg.get("default")]
+        if len(defaults) > 1:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    "Multiple semantic layers are marked with `default: true` in "
+                    "`agent.services.semantic_layer`. Keep at most one default semantic adapter."
+                ),
+            )
+        if defaults:
+            return defaults[0]
         if len(self.semantic_layer_configs) == 1:
             return next(iter(self.semantic_layer_configs))
-        if not self.semantic_layer_configs:
-            # MetricFlow is currently the built-in default semantic adapter.
-            return "metricflow"
         return None
 
     def resolve_semantic_adapter(self, adapter_type: Optional[str] = None) -> Optional[str]:
+        """Resolve the active semantic adapter name.
+
+        Order: explicit ``adapter_type`` argument -> project-level pin
+        (``./.datus/config.yml`` ``semantic:``) -> global ``default: true``
+        flag / single-entry shortcut. Raises when no semantic layer is
+        configured at all, or when multiple are configured without a clear
+        default — this matches the Dashboard / Scheduler resolution
+        contract so all three sections behave identically.
+        """
         normalized = str(adapter_type or "").lower().strip()
         if normalized:
-            if not self.semantic_layer_configs:
-                return normalized
             if normalized in self.semantic_layer_configs:
                 return normalized
             raise DatusException(
@@ -1158,6 +1231,25 @@ class AgentConfig:
                 ),
             )
 
+        if not self.semantic_layer_configs:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    "No semantic layer configured under `agent.services.semantic_layer`. "
+                    "Add an entry (e.g. `metricflow: {}`) or run `/services semantic` to configure one."
+                ),
+            )
+
+        active_override = self._active_semantic
+        if active_override:
+            if active_override in self.semantic_layer_configs:
+                return active_override
+            logger.warning(
+                "Project override active_semantic=`%s` is not configured under "
+                "`agent.services.semantic_layer`; falling back to global default.",
+                active_override,
+            )
+
         default_adapter = self.default_semantic_adapter()
         if default_adapter:
             return default_adapter
@@ -1165,7 +1257,7 @@ class AgentConfig:
             ErrorCode.COMMON_CONFIG_ERROR,
             message=(
                 "Multiple semantic layers are configured in `agent.services.semantic_layer`, "
-                "set `semantic_adapter` on the semantic node."
+                "set `semantic_adapter` on the semantic node or mark one entry with `default: true`."
             ),
         )
 
@@ -1854,6 +1946,7 @@ class AgentConfig:
                 extra=_resolve_nested_value(auth_params.get("extra", {})),
                 dataset_db=dataset_db,
                 adapter_type=adapter_type,
+                default=bool(auth_params.get("default", False)),
             )
 
     def init_scheduler_services(self, param: Dict[str, Any]):

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -270,6 +270,16 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         agent_raw["language"] = override.language
     if override.reasoning_effort is not None:
         agent_raw["target_reasoning_effort"] = override.reasoning_effort
+    # ``dashboard`` / ``scheduler`` overrides reach AgentConfig through
+    # dedicated kwargs so the project-level pin is consulted between the
+    # explicit call-site argument and the global default flag at lookup
+    # time. Validation is deferred to the consumer (``BIFuncTool`` /
+    # ``get_scheduler_config``) since the named service may be added later
+    # in the same process; failing here would block CLI startup.
+    if override.dashboard is not None:
+        agent_raw["active_dashboard"] = override.dashboard
+    if override.scheduler is not None:
+        agent_raw["active_scheduler"] = override.scheduler
 
 
 def load_agent_config(reload: bool = False, create_if_missing: bool = False, **kwargs) -> AgentConfig:

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -280,6 +280,8 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         agent_raw["active_dashboard"] = override.dashboard
     if override.scheduler is not None:
         agent_raw["active_scheduler"] = override.scheduler
+    if override.semantic is not None:
+        agent_raw["active_semantic"] = override.semantic
 
 
 def load_agent_config(reload: bool = False, create_if_missing: bool = False, **kwargs) -> AgentConfig:

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -25,6 +25,10 @@ pin a handful of values without copying the full config:
   ``AgentConfig.get_scheduler_config`` when no explicit ``scheduler_service``
   is passed at the call site. Takes precedence over the global
   ``default: true`` flag in ``agent.yml``.
+- ``semantic``: project-level default semantic adapter (must match a key
+  under ``agent.services.semantic_layer``). Resolved by
+  ``AgentConfig.resolve_semantic_adapter`` between the explicit
+  ``adapter_type`` argument and the global ``default: true`` flag.
 - ``project_name``: shard name for ``~/.datus/sessions/{project_name}/``
   and ``~/.datus/data/{project_name}/`` (optional)
 - ``reasoning_effort``: one of ``off|minimal|low|medium|high`` — controls the
@@ -53,6 +57,7 @@ ALLOWED_KEYS = frozenset(
         "default_datasource",
         "dashboard",
         "scheduler",
+        "semantic",
         "project_name",
         "language",
         "reasoning_effort",
@@ -91,6 +96,7 @@ class ProjectOverride:
     default_datasource: Optional[str] = None
     dashboard: Optional[str] = None
     scheduler: Optional[str] = None
+    semantic: Optional[str] = None
     project_name: Optional[str] = None
     language: Optional[str] = None
     reasoning_effort: Optional[str] = None
@@ -101,6 +107,7 @@ class ProjectOverride:
             and self.default_datasource is None
             and self.dashboard is None
             and self.scheduler is None
+            and self.semantic is None
             and self.project_name is None
             and self.language is None
             and self.reasoning_effort is None
@@ -175,6 +182,7 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         default_datasource=raw.get("default_datasource"),
         dashboard=_parse_optional_string(raw.get("dashboard"), key="dashboard"),
         scheduler=_parse_optional_string(raw.get("scheduler"), key="scheduler"),
+        semantic=_parse_optional_string(raw.get("semantic"), key="semantic"),
         project_name=raw.get("project_name"),
         language=raw.get("language"),
         reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
@@ -250,6 +258,7 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
             "default_datasource": override.default_datasource,
             "dashboard": override.dashboard,
             "scheduler": override.scheduler,
+            "semantic": override.semantic,
             "project_name": override.project_name,
             "language": override.language,
             "reasoning_effort": override.reasoning_effort,

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -16,6 +16,15 @@ pin a handful of values without copying the full config:
     alias for the legacy string form (selects ``agent.models.my-internal``).
 - ``default_datasource``: which datasource to connect to on startup (must
   match a key under ``agent.services.datasources``)
+- ``dashboard``: project-level default BI service (must match a key under
+  ``agent.services.bi_platforms``). Resolved by ``BIFuncTool`` /
+  ``AgentConfig.dashboard_config`` when no explicit ``bi_service`` is
+  passed at the call site.
+- ``scheduler``: project-level default scheduler service (must match a key
+  under ``agent.services.schedulers``). Resolved by ``SchedulerTools`` /
+  ``AgentConfig.get_scheduler_config`` when no explicit ``scheduler_service``
+  is passed at the call site. Takes precedence over the global
+  ``default: true`` flag in ``agent.yml``.
 - ``project_name``: shard name for ``~/.datus/sessions/{project_name}/``
   and ``~/.datus/data/{project_name}/`` (optional)
 - ``reasoning_effort``: one of ``off|minimal|low|medium|high`` — controls the
@@ -38,7 +47,17 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 PROJECT_CONFIG_REL = ".datus/config.yml"
-ALLOWED_KEYS = frozenset({"target", "default_datasource", "project_name", "language", "reasoning_effort"})
+ALLOWED_KEYS = frozenset(
+    {
+        "target",
+        "default_datasource",
+        "dashboard",
+        "scheduler",
+        "project_name",
+        "language",
+        "reasoning_effort",
+    }
+)
 REASONING_EFFORT_CHOICES = frozenset({"off", "minimal", "low", "medium", "high"})
 
 
@@ -70,6 +89,8 @@ class ProjectOverride:
 
     target: Optional[Union[str, ProjectTarget]] = None
     default_datasource: Optional[str] = None
+    dashboard: Optional[str] = None
+    scheduler: Optional[str] = None
     project_name: Optional[str] = None
     language: Optional[str] = None
     reasoning_effort: Optional[str] = None
@@ -78,6 +99,8 @@ class ProjectOverride:
         return (
             self.target is None
             and self.default_datasource is None
+            and self.dashboard is None
+            and self.scheduler is None
             and self.project_name is None
             and self.language is None
             and self.reasoning_effort is None
@@ -150,10 +173,30 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
     return ProjectOverride(
         target=_parse_target(raw.get("target")),
         default_datasource=raw.get("default_datasource"),
+        dashboard=_parse_optional_string(raw.get("dashboard"), key="dashboard"),
+        scheduler=_parse_optional_string(raw.get("scheduler"), key="scheduler"),
         project_name=raw.get("project_name"),
         language=raw.get("language"),
         reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
     )
+
+
+def _parse_optional_string(raw: Any, *, key: str) -> Optional[str]:
+    """Coerce a YAML scalar into ``Optional[str]`` for ProjectOverride fields.
+
+    Empty strings collapse to ``None`` so the override behaves the same as
+    "not specified" rather than overriding the agent.yml value with an
+    empty string. Non-string values are dropped with a warning so a
+    ``dashboard: 123`` typo fails loudly instead of silently selecting
+    the integer.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        logger.warning(f"{key} must be a string, got {type(raw).__name__}. Ignoring.")
+        return None
+    value = raw.strip()
+    return value or None
 
 
 def _parse_reasoning_effort(raw: Any) -> Optional[str]:
@@ -205,6 +248,8 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
         for k, v in {
             "target": _target_to_yaml(override.target),
             "default_datasource": override.default_datasource,
+            "dashboard": override.dashboard,
+            "scheduler": override.scheduler,
             "project_name": override.project_name,
             "language": override.language,
             "reasoning_effort": override.reasoning_effort,

--- a/datus/tools/func_tool/bi_tools.py
+++ b/datus/tools/func_tool/bi_tools.py
@@ -60,16 +60,17 @@ class BIFuncTool:
     def _resolved_platform(self) -> Optional[str]:
         """Return the BI platform name to use.
 
-        Preference order:
+        Preference order (matches ``get_scheduler_config`` /
+        ``resolve_semantic_adapter``):
         1. Explicit ``bi_service`` passed to the constructor.
         2. Project-level default from ``./.datus/config.yml`` (read via
            ``agent_config.active_dashboard()``). A stale override that
-           does not match any configured BI service is ignored so the
-           code falls through to the unique / ambiguous branches and
-           surfaces a clearer error.
-        3. Auto-pick when ``agent_config.dashboard_config`` has exactly one entry.
-        4. Raise ``DatusException`` when multiple are configured and no
-           ``bi_service`` disambiguates — mirrors ``SemanticTools`` behavior.
+           does not match any configured BI service is ignored with a
+           warning so the code falls through to the global default.
+        3. Global ``default: true`` flag (or single-entry shortcut) via
+           ``agent_config.default_dashboard_service()``.
+        4. Raise ``DatusException`` when multiple are configured without
+           a disambiguating flag.
         """
         if self.bi_service:
             return self.bi_service
@@ -81,14 +82,18 @@ class BIFuncTool:
             active = active_fn()
             if active and active in dashboard_config:
                 return active
-        if len(dashboard_config) == 1:
-            return next(iter(dashboard_config))
+        default_fn = getattr(self.agent_config, "default_dashboard_service", None)
+        if callable(default_fn):
+            default = default_fn()
+            if default:
+                return default
         if len(dashboard_config) > 1:
             raise DatusException(
                 ErrorCode.COMMON_CONFIG_ERROR,
                 message=(
                     f"Multiple BI platforms configured ({list(dashboard_config.keys())}); "
-                    "pass `bi_service` explicitly to disambiguate."
+                    "pass `bi_service` explicitly, mark one entry with `default: true`, "
+                    "or pin one via `/services dashboard` and `p`."
                 ),
             )
         return None

--- a/datus/tools/func_tool/bi_tools.py
+++ b/datus/tools/func_tool/bi_tools.py
@@ -62,8 +62,13 @@ class BIFuncTool:
 
         Preference order:
         1. Explicit ``bi_service`` passed to the constructor.
-        2. Auto-pick when ``agent_config.dashboard_config`` has exactly one entry.
-        3. Raise ``DatusException`` when multiple are configured and no
+        2. Project-level default from ``./.datus/config.yml`` (read via
+           ``agent_config.active_dashboard()``). A stale override that
+           does not match any configured BI service is ignored so the
+           code falls through to the unique / ambiguous branches and
+           surfaces a clearer error.
+        3. Auto-pick when ``agent_config.dashboard_config`` has exactly one entry.
+        4. Raise ``DatusException`` when multiple are configured and no
            ``bi_service`` disambiguates — mirrors ``SemanticTools`` behavior.
         """
         if self.bi_service:
@@ -71,6 +76,11 @@ class BIFuncTool:
         if self.agent_config is None:
             return None
         dashboard_config = getattr(self.agent_config, "dashboard_config", {}) or {}
+        active_fn = getattr(self.agent_config, "active_dashboard", None)
+        if callable(active_fn):
+            active = active_fn()
+            if active and active in dashboard_config:
+                return active
         if len(dashboard_config) == 1:
             return next(iter(dashboard_config))
         if len(dashboard_config) > 1:

--- a/docs/configuration/bi_platforms.md
+++ b/docs/configuration/bi_platforms.md
@@ -74,9 +74,33 @@ by name.
 
 - `bi_platform` selects one entry from `services.bi_platforms`.
 - The config key should match the platform name (`superset`, `grafana`, ...).
-- If `bi_platform` is omitted and only one BI platform is configured, Datus
-  auto-selects it.
-- If multiple BI platforms are configured, set `bi_platform` explicitly.
+- If `bi_platform` is omitted, Datus consults `./.datus/config.yml`'s
+  `dashboard:` field (project-level pin) before falling back to "auto-pick
+  the unique entry".
+- If multiple BI platforms are configured and no project pin is set, set
+  `bi_platform` explicitly at the call site.
+
+## Configuring through the CLI (`/services`)
+
+Run `/services` inside the Datus REPL to enter the configuration TUI
+directly (Dashboard tab by default; pass `/services scheduler` to land on
+the Scheduler tab; `/services list` keeps the legacy read-only listing).
+The two-tab TUI lets you:
+
+- Add a new dashboard with `Enter` on the trailing `+ Add new dashboard` row.
+  When you pick a `type` whose adapter package isn't installed yet
+  (`datus-bi-superset`, `datus-bi-grafana`, …), Datus runs
+  `pip install` for you and hot-reloads the registry — no restart needed.
+- Edit credentials with `e`, delete an entry with `x`, run a connectivity
+  probe with `t`.
+- Pin a project-level default with `p`. The pin is written to
+  `./.datus/config.yml` as `dashboard: <name>` and outranks the auto-pick
+  rule for the current project only. Press `p` again on the pinned row to
+  clear it.
+
+Service definitions are written to `~/.datus/conf/agent.yml`, so the same
+credentials are shared across every project. Only the active selection is
+project-local.
 
 ## Ownership
 

--- a/docs/configuration/bi_platforms.md
+++ b/docs/configuration/bi_platforms.md
@@ -72,13 +72,31 @@ by name.
 
 ## Selection rules
 
-- `bi_platform` selects one entry from `services.bi_platforms`.
-- The config key should match the platform name (`superset`, `grafana`, ...).
-- If `bi_platform` is omitted, Datus consults `./.datus/config.yml`'s
-  `dashboard:` field (project-level pin) before falling back to "auto-pick
-  the unique entry".
-- If multiple BI platforms are configured and no project pin is set, set
-  `bi_platform` explicitly at the call site.
+`BIFuncTool._resolved_platform` resolves the active BI service in this
+order — identical to Scheduler and Semantic resolution:
+
+1. Explicit `bi_service` argument at the call site (or `bi_platform` on
+   the agentic node).
+2. Project-level pin in `./.datus/config.yml`'s `dashboard:` field.
+3. Global `default: true` flag — at most one entry under
+   `services.bi_platforms` may carry it; multiple defaults are rejected
+   at config load time so the user fixes the YAML rather than us silently
+   picking one.
+4. Single-entry shortcut when only one BI service is configured.
+5. Otherwise raise `Multiple BI platforms configured` so the operator
+   sets a default explicitly.
+
+Set the global default in YAML:
+
+```yaml
+agent:
+  services:
+    bi_platforms:
+      superset:
+        type: superset
+        default: true     # global default — picked when no project pin set
+        ...
+```
 
 ## Configuring through the CLI (`/services`)
 
@@ -93,10 +111,19 @@ The two-tab TUI lets you:
   `pip install` for you and hot-reloads the registry — no restart needed.
 - Edit credentials with `e`, delete an entry with `x`, run a connectivity
   probe with `t`.
-- Pin a project-level default with `p`. The pin is written to
-  `./.datus/config.yml` as `dashboard: <name>` and outranks the auto-pick
-  rule for the current project only. Press `p` again on the pinned row to
+- Set the **global** `default: true` flag with `d`. Pressing `d` on a row
+  marks it as the workspace-wide default and clears the flag from every
+  other entry, so you cannot end up with two defaults.
+- Pin a **project-level** default with `p`. The pin is written to
+  `./.datus/config.yml` as `dashboard: <name>` and outranks the global
+  flag for the current project only. Press `p` again on the pinned row to
   clear it.
+
+On the first interactive launch, if a section is configured but has no
+project pin, Datus auto-pins the only entry (or the one flagged
+`default: true`) to `./.datus/config.yml` so subsequent runs are
+explicit. When multiple entries are configured without a default, the
+launch prompts for a quick choice.
 
 Service definitions are written to `~/.datus/conf/agent.yml`, so the same
 credentials are shared across every project. Only the active selection is

--- a/docs/configuration/bi_platforms.zh.md
+++ b/docs/configuration/bi_platforms.zh.md
@@ -68,11 +68,25 @@ agent:
 
 ## 选择规则
 
-- `bi_platform` 决定使用 `services.bi_platforms` 中的哪一条。
-- 配置 key 应与平台名一致（`superset`、`grafana`、…）。
-- 若 `bi_platform` 留空，Datus 会先读 `./.datus/config.yml` 的 `dashboard:`
-  字段（项目级别 pin），再退回到「唯一条目自动选」规则。
-- 若配置了多个 BI 平台、且没有项目级 pin，调用处必须显式传 `bi_platform`。
+`BIFuncTool._resolved_platform` 解析活动 BI 服务的顺序与 Scheduler / Semantic 完全一致:
+
+1. 调用处显式传入的 `bi_service`(或 agentic node 上的 `bi_platform`)。
+2. `./.datus/config.yml` 中的项目级 pin —— `dashboard:` 字段。
+3. YAML 中的全局 `default: true` 标志:整个 `services.bi_platforms` 中至多一条可标 default,多于一条会在配置加载阶段直接报错,以避免静默选错。
+4. 单条快捷:仅有一条 BI 服务时,自动使用它。
+5. 否则抛 `Multiple BI platforms configured`,提示设置默认值。
+
+YAML 中标记全局默认:
+
+```yaml
+agent:
+  services:
+    bi_platforms:
+      superset:
+        type: superset
+        default: true     # 全局默认:在没有项目级 pin 时被选用
+        ...
+```
 
 ## 通过 CLI 配置（`/services`）
 
@@ -84,9 +98,12 @@ tab；`/services scheduler` 直接落到 Scheduler tab；`/services list` 退回
   时若对应 adapter 包（`datus-bi-superset` / `datus-bi-grafana` …）尚未安
   装，Datus 会自动 `pip install` 并热加载 registry，**无需重启**。
 - `e` 编辑凭据，`x` 删除条目，`t` 触发一次连通性 probe。
-- `p` 把当前光标项设为项目级 default。pin 会写到 `./.datus/config.yml` 的
-  `dashboard: <name>` 字段，仅对当前项目生效，优先级高于「自动唯一项」规则。
+- `d` 把当前光标项设为**全局** `default: true` 并清空其他条目的 default,确保不会出现两个默认。
+- `p` 把当前光标项设为**项目级** default。pin 会写到 `./.datus/config.yml` 的
+  `dashboard: <name>` 字段，仅对当前项目生效，优先级高于全局 default。
   在已 pin 的行上再按一次 `p` 清除。
+
+首次进入交互式 REPL 时,Datus 会对每个 section 自动跑一遍 bootstrap:若该 section 还没有项目级 pin,而 YAML 中能解析出明确的默认值(单条快捷或唯一标 `default: true` 的条目),Datus 会自动写入项目级 pin,把隐式选择固化为显式选择。如果配置了多条但都未标 default,启动时会弹出一个轻量选择器让你当场选择。
 
 service 定义会写入 `~/.datus/conf/agent.yml`，跨项目共享凭据；只有 active
 选择属于项目级。

--- a/docs/configuration/bi_platforms.zh.md
+++ b/docs/configuration/bi_platforms.zh.md
@@ -1,0 +1,113 @@
+# BI 平台配置
+
+BI 平台连接配置在 `agent.services.bi_platforms` 下。
+
+## 结构
+
+承载 BI 平台读、Datus 写的 serving DB 注册为**普通 Datus datasource**，BI
+平台条目通过 `dataset_db.datasource_ref` 引用它，连接池、schema 元数据、凭据
+全部与 Datus 其它部分共享。
+
+```yaml
+agent:
+  services:
+    datasources:
+      # 现有源数仓（BI 侧只读）
+      src_warehouse:
+        type: starrocks
+        host: ${SRC_WAREHOUSE_HOST}
+        port: 9030
+        username: ${SRC_WAREHOUSE_USER}
+        password: ${SRC_WAREHOUSE_PASSWORD}
+        database: warehouse
+
+      # serving DB —— Datus 写入、BI 平台读取
+      serving_pg:
+        type: postgresql
+        host: 127.0.0.1
+        port: 5433
+        database: superset_examples
+        schema: bi_public
+        username: ${SERVING_WRITE_USER}
+        password: ${SERVING_WRITE_PASSWORD}
+
+    bi_platforms:
+      superset:
+        type: superset
+        api_base_url: http://localhost:8088
+        username: ${SUPERSET_USER}
+        password: ${SUPERSET_PASSWORD}
+        dataset_db:
+          datasource_ref: serving_pg          # ← 引用 services.datasources.serving_pg
+          bi_database_name: examples          # Superset Settings > Database Connections 里看到的名字
+
+      grafana:
+        type: grafana
+        api_base_url: http://localhost:3000
+        api_key: ${GRAFANA_API_KEY}
+        dataset_db:
+          datasource_ref: serving_pg
+          bi_database_name: PostgreSQL
+
+  agentic_nodes:
+    gen_dashboard:
+      bi_platform: superset
+```
+
+## `dataset_db` 字段
+
+`dataset_db` 是叠在 Datus datasource 之上的 BI 专属层，只承载 BI 相关字段：
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `datasource_ref` | 是 | `services.datasources` 中某个条目的名字。Datus 用它进行 schema 内省与写入。 |
+| `bi_database_name` | 推荐 | 同一份 DB 在 BI 平台内部的别名。`gen_dashboard` 通过 `list_bi_databases()` 匹配它来解出 `database_id`，给 `create_dataset` 用。 |
+
+旧的 inline 写法（`dataset_db: {uri: "..."}` 或 `dataset_db: {type: ..., host: ..., ...}`）已经不再受支持，把连接字段挪到
+`services.datasources` 后用 ref 引用即可。
+
+## 选择规则
+
+- `bi_platform` 决定使用 `services.bi_platforms` 中的哪一条。
+- 配置 key 应与平台名一致（`superset`、`grafana`、…）。
+- 若 `bi_platform` 留空，Datus 会先读 `./.datus/config.yml` 的 `dashboard:`
+  字段（项目级别 pin），再退回到「唯一条目自动选」规则。
+- 若配置了多个 BI 平台、且没有项目级 pin，调用处必须显式传 `bi_platform`。
+
+## 通过 CLI 配置（`/services`）
+
+在 Datus REPL 内执行 `/services` 即可直接进入交互式 TUI（默认 Dashboard
+tab；`/services scheduler` 直接落到 Scheduler tab；`/services list` 退回
+到原先的只读列表）：
+
+- 列表最后一行 `+ Add new dashboard`，按 `Enter` 进入新增流程。选择 `type`
+  时若对应 adapter 包（`datus-bi-superset` / `datus-bi-grafana` …）尚未安
+  装，Datus 会自动 `pip install` 并热加载 registry，**无需重启**。
+- `e` 编辑凭据，`x` 删除条目，`t` 触发一次连通性 probe。
+- `p` 把当前光标项设为项目级 default。pin 会写到 `./.datus/config.yml` 的
+  `dashboard: <name>` 字段，仅对当前项目生效，优先级高于「自动唯一项」规则。
+  在已 pin 的行上再按一次 `p` 清除。
+
+service 定义会写入 `~/.datus/conf/agent.yml`，跨项目共享凭据；只有 active
+选择属于项目级。
+
+## 所有权
+
+仪表盘创建被拆成三步：
+
+1. `gen_job` 或 `scheduler` 在 `dataset_db.datasource_ref` 对应的 serving DB 里
+   准备 / 刷新数据。
+2. `gen_dashboard` 基于 BI 已注册数据库中的现成表 / SQL dataset 创建 dataset /
+   chart / dashboard。
+3. `bi-validation` 通过 `ValidationHook.on_end` 自动跑创建后的校验。
+
+源 DB 凭据不会泄露给 Superset / Grafana —— BI 端只看见以 `bi_database_name`
+注册的 serving DB。
+
+## 注意
+
+- `services.bi_platforms` 是 BI 凭据唯一的运行时来源。
+- 顶层 `dashboard:` 字段在运行时不再被读取。
+- `services.bi_platforms.<x>.dataset_db.datasource_ref` 必须指向一个已存在的
+  `services.datasources.<datasource_ref>` 条目；Datus 在启动时会校验，野指针
+  会直接报错。

--- a/docs/configuration/schedulers.md
+++ b/docs/configuration/schedulers.md
@@ -32,12 +32,40 @@ agent:
 
 ## Selection Rules
 
-- `scheduler_service` selects one scheduler instance from `services.schedulers`.
-- If only one scheduler is configured, Datus can use it automatically.
-- If multiple schedulers are configured, either:
-  - set `scheduler_service`, or
-  - mark exactly one scheduler with `default: true`.
-- Do not configure more than one `default: true`.
+`get_scheduler_config(service_name)` resolves the active scheduler in this
+order:
+
+1. Explicit `service_name` argument at the call site.
+2. Project-level pin in `./.datus/config.yml`'s top-level `scheduler:` field.
+3. Global `default: true` flag (must be unique across `services.schedulers`).
+4. Single-entry shortcut when only one scheduler is configured.
+
+A stale project pin (the named service no longer exists in agent.yml) is
+ignored with a warning so the lookup falls through to the global default.
+
+## Configuring through the CLI (`/services`)
+
+Run `/services scheduler` inside the Datus REPL to enter the
+configuration TUI on the Scheduler tab (bare `/services` lands on the
+Dashboard tab; `/services list` keeps the legacy read-only listing). The
+two-tab TUI lets you:
+
+- Add a new scheduler with `Enter` on the trailing `+ Add new scheduler`
+  row. Only `airflow` (`datus-scheduler-airflow`) ships today; if the
+  adapter package isn't installed yet, Datus runs `pip install` for you
+  and hot-reloads the registry — no restart needed.
+- Edit credentials with `e`, delete with `x`, run a connectivity probe
+  with `t`.
+- Toggle the **global** `default: true` flag with `d`. Pressing `d` on a
+  row sets it as the workspace-wide default and clears the flag from every
+  other entry, so you cannot end up with two defaults.
+- Pin a **project-level** default with `p` — the value lands in
+  `./.datus/config.yml` as `scheduler: <name>` and outranks the global
+  flag for the current project only. Press `p` again on the pinned row to
+  clear it.
+
+Service definitions are written to `~/.datus/conf/agent.yml` (shared across
+projects); only the active selection is project-local.
 
 ## Notes
 

--- a/docs/configuration/schedulers.md
+++ b/docs/configuration/schedulers.md
@@ -67,6 +67,12 @@ two-tab TUI lets you:
 Service definitions are written to `~/.datus/conf/agent.yml` (shared across
 projects); only the active selection is project-local.
 
+On the first interactive launch, if no project pin exists, Datus
+auto-pins the only entry (or the one flagged `default: true`) to
+`./.datus/config.yml` so subsequent runs are explicit. When multiple
+entries are configured without a default, the launch prompts for a quick
+choice. Set `DATUS_DISABLE_SERVICE_BOOTSTRAP=1` to opt out (CI / Docker).
+
 ## Notes
 
 - `services.schedulers` is now the only runtime source for scheduler config.

--- a/docs/configuration/schedulers.zh.md
+++ b/docs/configuration/schedulers.zh.md
@@ -60,6 +60,8 @@ tab（裸 `/services` 落在 Dashboard tab；`/services list` 退回只读列表
 service 定义会写入 `~/.datus/conf/agent.yml`，跨项目共享；只有 active 选择
 属于项目级。
 
+首次进入交互式 REPL 时,Datus 会对该 section 跑一遍 bootstrap:若尚无项目级 pin,而能从 YAML 中解析出明确的默认值(单条快捷或唯一标 `default: true` 的条目),Datus 会自动写入项目级 pin。若配置了多条但都未标 default,启动时会弹出一个轻量选择器。CI / Docker 等无人值守环境可设置 `DATUS_DISABLE_SERVICE_BOOTSTRAP=1` 关闭。
+
 ## 注意
 
 - `services.schedulers` 是 scheduler 配置唯一的运行时来源。

--- a/docs/configuration/schedulers.zh.md
+++ b/docs/configuration/schedulers.zh.md
@@ -1,0 +1,66 @@
+# 调度器配置
+
+调度器服务配置在 `agent.services.schedulers` 下。
+
+## 结构
+
+```yaml
+agent:
+  services:
+    schedulers:
+      airflow_prod:
+        type: airflow
+        api_base_url: ${AIRFLOW_URL}
+        username: ${AIRFLOW_USER}
+        password: ${AIRFLOW_PASSWORD}
+        dags_folder: ${AIRFLOW_DAGS_DIR}
+        default: true
+        connections:
+          starrocks_default: StarRocks production
+
+      airflow_dev:
+        type: airflow
+        api_base_url: ${AIRFLOW_DEV_URL}
+        username: ${AIRFLOW_DEV_USER}
+        password: ${AIRFLOW_DEV_PASSWORD}
+        dags_folder: /tmp/airflow-dags
+
+  agentic_nodes:
+    scheduler:
+      scheduler_service: airflow_prod
+```
+
+## 选择规则
+
+`get_scheduler_config(service_name)` 按下列顺序解析活动 scheduler：
+
+1. 调用处显式传入的 `service_name`。
+2. `./.datus/config.yml` 顶层 `scheduler:` 字段（项目级 pin）。
+3. 全局 `default: true` 标记（在 `services.schedulers` 中必须唯一）。
+4. 唯一条目兜底：只配置了一个 scheduler 时直接使用。
+
+若项目级 pin 已失效（指向一个 agent.yml 里不再存在的 service），Datus 会打
+warning 并退回到全局 default。
+
+## 通过 CLI 配置（`/services`）
+
+在 Datus REPL 内执行 `/services scheduler` 直接进入交互式 TUI 的 Scheduler
+tab（裸 `/services` 落在 Dashboard tab；`/services list` 退回只读列表）：
+
+- 列表最后一行 `+ Add new scheduler`，按 `Enter` 进入新增流程。当前仅
+  `airflow`（`datus-scheduler-airflow`）受支持；若 adapter 包尚未安装，
+  Datus 会自动 `pip install` 并热加载 registry，**无需重启**。
+- `e` 编辑凭据，`x` 删除条目，`t` 触发一次连通性 probe。
+- `d` 切换**全局** `default: true`：按 `d` 把光标项设为 workspace 级
+  default 并自动清掉其他条目的该字段，避免出现「多 default」。
+- `p` 设置**项目级** default：值写入 `./.datus/config.yml` 的
+  `scheduler: <name>`，只对当前项目生效，优先级高于全局标记。在已 pin 的
+  行上再按一次 `p` 清除。
+
+service 定义会写入 `~/.datus/conf/agent.yml`，跨项目共享；只有 active 选择
+属于项目级。
+
+## 注意
+
+- `services.schedulers` 是 scheduler 配置唯一的运行时来源。
+- 顶层 `scheduler:` 字段在运行时不再被读取。

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -37,3 +37,23 @@ agent:
 - Datus prefers the current `services.datasources` entry and the project semantic model directory to build runtime config automatically.
 - MetricFlow validation reads YAML files from the configured project semantic model directory directly, including generated files under gitignored project paths.
 - `config_path` is only needed when you want MetricFlow to read a specific `agent.yml` file directly.
+
+## Configuring through the CLI (`/services`)
+
+Run `/services semantic` inside the Datus REPL (or press `Tab` from any
+other tab) to enter the configuration TUI on the **Semantic** tab. The
+tab lets you:
+
+- Add a new semantic layer by pressing `Enter` on the trailing `+ Add
+  new semantic` row. Only `metricflow` (`datus-semantic-metricflow`)
+  ships today and **takes no parameters** — picking it from the type
+  picker is enough. If the adapter package isn't installed, Datus runs
+  `pip install datus-semantic-metricflow` for you and hot-reloads the
+  registry — no restart needed.
+- Delete an entry with `x` and run a registration probe with `t`.
+- `e edit` and `p project default` are intentionally hidden on this tab:
+  metricflow has no editable fields, and semantic layers don't yet expose
+  a project-level default API.
+
+Service definitions are written to `~/.datus/conf/agent.yml` as
+`services.semantic_layer.<type>: {type: <type>}`.

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -1,8 +1,16 @@
 # Semantic Layer Configuration
 
 Semantic adapters are configured under `agent.services.semantic_layer`.
+At least one entry must be configured — running a semantic node with an
+empty `services.semantic_layer` block now raises
+`No semantic layer configured` instead of silently falling back to a
+hard-coded `metricflow` default.
 
-When you use MetricFlow with default settings, the entire `semantic_layer` block can be omitted. Datus defaults to `metricflow`.
+> **Migration note**: previous Datus releases inserted an implicit
+> `metricflow` default when the section was missing. The default now
+> requires an explicit YAML entry. The bundled `conf/agent.yml.example`
+> already ships with `metricflow: {}`, so fresh installs continue to
+> Just Work.
 
 ## Structure
 
@@ -13,6 +21,7 @@ agent:
       metricflow:
         timeout: 300
         config_path: ./conf/agent.yml   # optional advanced override
+        default: true                   # global default — picked when no project pin set
 
   agentic_nodes:
     gen_semantic_model:
@@ -24,12 +33,26 @@ agent:
 
 ## Selection Rules
 
-- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup. Comparison is case-insensitive and trims surrounding whitespace, so `MetricFlow` and ` metricflow ` also match.
-- Semantic nodes choose the adapter with `semantic_adapter`.
-- There is no `default: true` for semantic adapters.
-- If both `services.semantic_layer` and `semantic_adapter` are omitted, Datus defaults to `metricflow`.
-- If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.
-- If multiple semantic layers are configured, set `semantic_adapter` explicitly.
+`AgentConfig.resolve_semantic_adapter` resolves the active semantic
+adapter in this order — identical to BI Dashboard and Scheduler
+resolution:
+
+1. Explicit `adapter_type` argument at the call site (or
+   `semantic_adapter` on the agentic node).
+2. Project-level pin in `./.datus/config.yml`'s `semantic:` field.
+3. Global `default: true` flag — at most one entry under
+   `services.semantic_layer` may carry it; multiple defaults are
+   rejected at config load time.
+4. Single-entry shortcut when only one semantic adapter is configured.
+5. Otherwise raise:
+   - `No semantic layer configured ...` when the section is empty.
+   - `Multiple semantic layers are configured ...` when there are
+     multiple without a default.
+
+The key under `services.semantic_layer` **must equal the adapter type**
+(for example `metricflow`). If a `type:` field is present, it must match
+the key; otherwise Datus raises a configuration error at startup.
+Comparison is case-insensitive and trims surrounding whitespace.
 
 ## MetricFlow Notes
 
@@ -51,9 +74,20 @@ tab lets you:
   `pip install datus-semantic-metricflow` for you and hot-reloads the
   registry — no restart needed.
 - Delete an entry with `x` and run a registration probe with `t`.
-- `e edit` and `p project default` are intentionally hidden on this tab:
-  metricflow has no editable fields, and semantic layers don't yet expose
-  a project-level default API.
+- Toggle the **global** `default: true` flag with `d`. Pressing `d`
+  marks the current row as default and clears the flag from every other
+  entry.
+- Pin a **project-level** default with `p` — the value lands in
+  `./.datus/config.yml` as `semantic: <name>` and outranks the global
+  flag for the current project only. Press `p` again on the pinned row
+  to clear it.
+- `e edit` is hidden on this tab: metricflow has no editable fields.
 
 Service definitions are written to `~/.datus/conf/agent.yml` as
 `services.semantic_layer.<type>: {type: <type>}`.
+
+On the first interactive launch, if no project pin exists, Datus
+auto-pins the only entry (or the one flagged `default: true`) to
+`./.datus/config.yml` so subsequent runs are explicit. When multiple
+entries are configured without a default, the launch prompts for a quick
+choice. Set `DATUS_DISABLE_SERVICE_BOOTSTRAP=1` to opt out (CI / Docker).

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -1,8 +1,8 @@
 # 语义层配置（Semantic Layer）
 
-语义适配器统一配置在 `agent.services.semantic_layer` 下。
+语义适配器统一配置在 `agent.services.semantic_layer` 下。**至少要配置一条**——空 section 不再静默 fallback 到 metricflow,而是 raise `No semantic layer configured`。
 
-如果你使用的是 MetricFlow 的默认配置，整个 `semantic_layer` 段可以省略；Datus 会默认使用 `metricflow`。
+> **迁移说明**:旧版本会在 section 缺失时隐式注入 metricflow 默认值,新版要求显式写入 yaml 条目。`conf/agent.yml.example` 已经默认带上 `metricflow: {}`,新装用户开箱仍能用。
 
 ## 配置结构
 
@@ -13,6 +13,7 @@ agent:
       metricflow:
         timeout: 300
         config_path: ./conf/agent.yml   # 可选的高级覆盖项
+        default: true                   # 全局默认:无 project pin 时被选用
 
   agentic_nodes:
     gen_semantic_model:
@@ -24,12 +25,17 @@ agent:
 
 ## 选择规则
 
-- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。比较时会先对 key 与 `type` 做 lowercase + trim 处理，因此 `MetricFlow` 或 ` metricflow ` 也会被视为与 `metricflow` 匹配。
-- 语义相关节点通过 `semantic_adapter` 选择适配器。
-- 语义适配器不支持 `default: true`。
-- 如果 `services.semantic_layer` 和 `semantic_adapter` 都省略，Datus 会默认使用 `metricflow`。
-- 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。
-- 如果配置了多个 semantic layer，则必须显式填写 `semantic_adapter`。
+`AgentConfig.resolve_semantic_adapter` 解析活动语义适配器的顺序与 BI Dashboard / Scheduler 完全一致:
+
+1. 调用处显式传入的 `adapter_type`(或 agentic node 上的 `semantic_adapter`)。
+2. `./.datus/config.yml` 中的项目级 pin —— `semantic:` 字段。
+3. YAML 全局 `default: true` 标志:`services.semantic_layer` 中至多一条可标 default,多于一条会在加载阶段直接报错。
+4. 单条快捷:仅有一条 semantic adapter 时,自动使用它。
+5. 否则抛错:
+   - section 为空 → `No semantic layer configured ...`
+   - 多条无 default → `Multiple semantic layers are configured ...`
+
+`services.semantic_layer` 下的 key **必须等于 adapter type**(例如 `metricflow`)。如果同时写了 `type:` 字段,其值必须与 key 一致,否则 Datus 会在启动时抛出配置错误。比较时会先 lowercase + trim,因此 `MetricFlow`、` metricflow ` 都会被视为与 `metricflow` 匹配。
 
 ## MetricFlow 说明
 
@@ -44,6 +50,10 @@ agent:
 
 - 在尾部的 `+ Add new semantic` 行按 `Enter` 新增一个语义层。目前仅支持 `metricflow`（`datus-semantic-metricflow`），并且**无需任何参数** —— 在 type picker 中选中它即可。如果适配器包尚未安装，Datus 会自动执行 `pip install datus-semantic-metricflow` 并热加载注册表，无需重启进程。
 - 用 `x` 删除条目；用 `t` 触发一次注册探测。
-- 此 tab 不显示 `e edit` 与 `p project default`：metricflow 当前没有可编辑字段，语义层也尚未提供 project-level default 的 API。
+- `d` 切换**全局** `default: true`:按 `d` 把光标项设为默认,并自动清掉其他条目的 default。
+- `p` 设置**项目级** default:值写入 `./.datus/config.yml` 的 `semantic: <name>`,只对当前项目生效,优先级高于全局标记。在已 pin 的行上再按一次 `p` 清除。
+- 此 tab 不显示 `e edit`:metricflow 当前没有可编辑字段。
 
 新建条目会写入 `~/.datus/conf/agent.yml`，形态为 `services.semantic_layer.<type>: {type: <type>}`。
+
+首次进入交互式 REPL 时,Datus 会跑一遍 bootstrap:若尚无项目级 pin,而 YAML 中能解析出明确的默认值(单条快捷或唯一标 `default: true`),Datus 会自动写入项目级 pin。若多条都未标 default,启动时会弹出一个轻量选择器。CI / Docker 等无人值守环境可设置 `DATUS_DISABLE_SERVICE_BOOTSTRAP=1` 关闭。

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -37,3 +37,13 @@ agent:
 - Datus 默认会基于当前 `services.datasources` 中选中的数据源和项目语义模型目录自动构建运行时配置。
 - MetricFlow 验证会直接读取配置中的项目语义模型目录，包括位于 gitignore 项目路径下的生成 YAML。
 - 仅当你需要 MetricFlow 直接读取某个指定的 `agent.yml` 时才需要设置 `config_path`。
+
+## 通过 CLI 配置（`/services`）
+
+在 Datus REPL 中运行 `/services semantic`（或者从其他 tab 按 `Tab` 切过来）会进入配置 TUI 的 **Semantic** tab。该 tab 支持：
+
+- 在尾部的 `+ Add new semantic` 行按 `Enter` 新增一个语义层。目前仅支持 `metricflow`（`datus-semantic-metricflow`），并且**无需任何参数** —— 在 type picker 中选中它即可。如果适配器包尚未安装，Datus 会自动执行 `pip install datus-semantic-metricflow` 并热加载注册表，无需重启进程。
+- 用 `x` 删除条目；用 `t` 触发一次注册探测。
+- 此 tab 不显示 `e edit` 与 `p project default`：metricflow 当前没有可编辑字段，语义层也尚未提供 project-level default 的 API。
+
+新建条目会写入 `~/.datus/conf/agent.yml`，形态为 `services.semantic_layer.<type>: {type: <type>}`。

--- a/docs/getting_started/data_engineering_quickstart.md
+++ b/docs/getting_started/data_engineering_quickstart.md
@@ -8,30 +8,34 @@ DAComp is **not bundled** with `datus-agent`. This tutorial uses a small
 quickstart package derived from the DAComp Lever example, so you do not need to
 download the full DAComp archive.
 
-Download and unpack the quickstart data and local Docker stack:
+First create and enter the working directory:
 
 ```bash
 mkdir -p ~/datus-quickstart-data
 cd ~/datus-quickstart-data
+```
 
+Then run the bash block below — it downloads and unpacks the quickstart data
+and local Docker stack, exports `DACOMP_HOME` / `DATUS_QUICKSTART_STACK`,
+creates a writable DuckDB workbench, and finally prints the two `export`
+statements so you can paste them into another shell:
+
+```bash
 curl -L -o datus-de-lever-quickstart-v1.zip \
   https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-de-lever-quickstart-v1.zip
 curl -L -o datus-data-engineering-quickstart-stack-v1.zip \
   https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-data-engineering-quickstart-stack-v1.zip
 
-unzip datus-de-lever-quickstart-v1.zip
-unzip datus-data-engineering-quickstart-stack-v1.zip
-```
+unzip -o datus-de-lever-quickstart-v1.zip
+unzip -o datus-data-engineering-quickstart-stack-v1.zip
 
-Point `DACOMP_HOME` at the extracted data directory, point
-`DATUS_QUICKSTART_STACK` at the extracted Docker stack, and create a writable
-DuckDB workbench:
-
-```bash
-export DACOMP_HOME=/absolute/path/to/datus-de-lever-quickstart
-export DATUS_QUICKSTART_STACK=/absolute/path/to/datus-data-engineering-quickstart-stack
+export DACOMP_HOME="$(pwd)/datus-de-lever-quickstart"
+export DATUS_QUICKSTART_STACK="$(pwd)/datus-data-engineering-quickstart-stack"
 cp "$DACOMP_HOME/lever_start.duckdb" "$DACOMP_HOME/lever_workbench.duckdb"
 cd "$DACOMP_HOME"
+
+echo "export DACOMP_HOME=$DACOMP_HOME"
+echo "export DATUS_QUICKSTART_STACK=$DATUS_QUICKSTART_STACK"
 ```
 
 The rest of this guide assumes the example directory contains:
@@ -94,6 +98,14 @@ Install Datus plus the adapters used in this walkthrough:
 ```bash
 pip install datus-agent datus-bi-superset datus-postgresql datus-scheduler-airflow
 ```
+
+You can skip `datus-bi-superset` and `datus-scheduler-airflow` here and let
+`/services` install them on demand: when you create a Superset dashboard
+entry or an Airflow scheduler entry through `/services dashboard` /
+`/services scheduler`, Datus runs `pip install` for you and hot-reloads the
+registry without restarting the CLI. See
+[BI platforms](../configuration/bi_platforms.md#configuring-through-the-cli-services)
+and [Schedulers](../configuration/schedulers.md#configuring-through-the-cli-services).
 
 ## Step 4: Configure `agent.yml`
 

--- a/docs/getting_started/data_engineering_quickstart.zh.md
+++ b/docs/getting_started/data_engineering_quickstart.zh.md
@@ -7,29 +7,33 @@
 DAComp **不包含**在 `datus-agent` 仓库中。本文使用一个从 DAComp Lever
 示例整理出来的小型 quickstart 数据包，不需要下载完整 DAComp 压缩包。
 
-下载并解压 quickstart 数据包和本地 Docker stack：
+先创建并进入工作目录：
 
 ```bash
 mkdir -p ~/datus-quickstart-data
 cd ~/datus-quickstart-data
+```
 
+然后直接执行下面这段 bash，会下载并解压 quickstart 数据包和本地 Docker
+stack，导出 `DACOMP_HOME` / `DATUS_QUICKSTART_STACK`，复制一份可写的 DuckDB
+工作库，最后打印两个环境变量供后续步骤使用：
+
+```bash
 curl -L -o datus-de-lever-quickstart-v1.zip \
   https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-de-lever-quickstart-v1.zip
 curl -L -o datus-data-engineering-quickstart-stack-v1.zip \
   https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-data-engineering-quickstart-stack-v1.zip
 
-unzip datus-de-lever-quickstart-v1.zip
-unzip datus-data-engineering-quickstart-stack-v1.zip
-```
+unzip -o datus-de-lever-quickstart-v1.zip
+unzip -o datus-data-engineering-quickstart-stack-v1.zip
 
-然后把 `DACOMP_HOME` 指向本地解压后的数据目录，把 `DATUS_QUICKSTART_STACK`
-指向本地解压后的 Docker stack，并复制一份可写的 DuckDB 工作库：
-
-```bash
-export DACOMP_HOME=/absolute/path/to/datus-de-lever-quickstart
-export DATUS_QUICKSTART_STACK=/absolute/path/to/datus-data-engineering-quickstart-stack
+export DACOMP_HOME="$(pwd)/datus-de-lever-quickstart"
+export DATUS_QUICKSTART_STACK="$(pwd)/datus-data-engineering-quickstart-stack"
 cp "$DACOMP_HOME/lever_start.duckdb" "$DACOMP_HOME/lever_workbench.duckdb"
 cd "$DACOMP_HOME"
+
+echo "export DACOMP_HOME=$DACOMP_HOME"
+echo "export DATUS_QUICKSTART_STACK=$DATUS_QUICKSTART_STACK"
 ```
 
 后续步骤默认这个目录下至少有这些文件：
@@ -90,6 +94,12 @@ Airflow 的 compose 文件会挂载 `${DACOMP_HOME}`，并暴露一个名为
 ```bash
 pip install datus-agent datus-bi-superset datus-postgresql datus-scheduler-airflow
 ```
+
+也可以跳过 `datus-bi-superset` 与 `datus-scheduler-airflow`，让 `/services`
+按需安装：通过 `/services dashboard` 或 `/services scheduler` 新建对应条目
+时，Datus 会自动 `pip install` 并热加载 registry，无需重启 CLI。详见
+[BI 平台](../configuration/bi_platforms.zh.md#通过-cli-配置-services)
+与 [调度器](../configuration/schedulers.zh.md#通过-cli-配置-services)。
 
 ## 步骤 4：配置 `agent.yml`
 

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -1215,14 +1215,15 @@ class TestStreamingMarkdown:
         ctx._repaint_live()
         assert live_state.is_active() is False
 
-    def test_process_deltas_detects_clear_and_finalizes(self):
-        """``_process_deltas`` must finalize when the caller clears the queue.
+    def test_process_deltas_finalizes_on_terminal_response(self):
+        """Per-message bucket: terminal response triggers finalize + bucket drop.
 
-        The chat_commands pipeline calls ``streaming_deltas.clear()`` at
-        every message boundary. The streaming context — running on the
-        refresh daemon — should notice the queue shrank, flush the
-        accumulator to the scrollback, and reset its cursor so follow-up
-        deltas (next message) start fresh.
+        chat_commands routes deltas into ``streaming_deltas[action_id]``
+        and never clears the dict. The streaming context drains each
+        bucket forward via a per-bucket cursor and finalizes the body
+        when the matching terminal ``response`` action is processed by
+        :meth:`_print_completed_action`. Replaces the legacy
+        ``streaming_deltas.clear()`` boundary signal.
         """
         from datus.cli.tui.live_display_state import LiveDisplayState
 
@@ -1230,26 +1231,99 @@ class TestStreamingMarkdown:
         console = Console(file=buf, no_color=True)
         live_state = LiveDisplayState()
         display = ActionHistoryDisplay(console, live_state=live_state)
-        deltas: list[ActionHistory] = []
+        deltas: dict[str, list[ActionHistory]] = {}
         ctx = InlineStreamingContext([], display, live_state=live_state, streaming_deltas=deltas)
 
-        # Push two deltas through the public queue + run the pump.
-        deltas.append(self._make_delta("part a "))
-        deltas.append(self._make_delta("part b"))
+        stream_id = "stream-msg-1"
+        deltas.setdefault(stream_id, []).append(self._make_delta("part a ", action_id=stream_id))
+        deltas.setdefault(stream_id, []).append(self._make_delta("part b", action_id=stream_id))
         ctx._process_deltas()
-        assert ctx._delta_processed_index == 2
+
+        assert ctx._delta_cursors[stream_id] == 2
+        assert ctx._active_message_id == stream_id
         assert ctx._markdown_buffer.get_tail() == "part a part b"
         assert "part a" not in buf.getvalue()
 
-        # Caller signals message boundary by clearing the queue.
-        deltas.clear()
-        ctx._process_deltas()
+        # Terminal response arrives — drains any trailing deltas (none
+        # here), finalizes the tail, drops the bucket.
+        response_action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            action_type="response",
+            messages="",
+            output_data={"raw_output": "part a part b"},
+            action_id=stream_id,
+        )
+        ctx._print_completed_action(response_action)
 
-        # Body landed in the scrollback exactly once; cursor reset.
         assert buf.getvalue().count("part a part b") == 1
-        assert ctx._delta_processed_index == 0
+        assert stream_id not in deltas
+        assert stream_id not in ctx._delta_cursors
+        assert ctx._active_message_id is None
         assert ctx._markdown_buffer.has_tail() is False
         assert ctx.has_streamed_response is True
+
+    def test_process_deltas_handles_concurrent_buckets(self):
+        """Mid-tick race: A's deltas + terminal land while B's deltas accumulate.
+
+        Producer can append to a new bucket B before the consumer
+        processes A's terminal. The drain must pick up both buckets in
+        insertion order, finalize A's tail when switching to B, and
+        leave B intact for its own terminal-response handling.
+        """
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+        deltas: dict[str, list[ActionHistory]] = {}
+        ctx = InlineStreamingContext([], display, live_state=live_state, streaming_deltas=deltas)
+
+        # Bucket A — message #1.
+        a_id = "stream-A"
+        deltas.setdefault(a_id, []).append(self._make_delta("alpha\n\n", action_id=a_id))
+        # Bucket B — message #2 starts before A's terminal is observed.
+        b_id = "stream-B"
+        deltas.setdefault(b_id, []).append(self._make_delta("beta", action_id=b_id))
+
+        ctx._process_deltas()
+
+        # Both buckets advanced their cursors; switch from A → B
+        # finalized A's tail (paragraph closed, so already in scrollback)
+        # and now active is B.
+        assert ctx._delta_cursors[a_id] == 1
+        assert ctx._delta_cursors[b_id] == 1
+        assert ctx._active_message_id == b_id
+        assert "alpha" in buf.getvalue()
+
+        # Terminal A arrives later; bucket A is already fully drained,
+        # so the dedup branch just drops the bucket. The active body
+        # the user is still watching is B's.
+        ctx._print_completed_action(
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                action_type="response",
+                output_data={"raw_output": "alpha"},
+                action_id=a_id,
+            )
+        )
+        assert a_id not in deltas
+        # Terminal B arrives and finalizes its own tail.
+        ctx._print_completed_action(
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                action_type="response",
+                output_data={"raw_output": "beta"},
+                action_id=b_id,
+            )
+        )
+        assert b_id not in deltas
+        assert "beta" in buf.getvalue()
+        assert buf.getvalue().count("alpha") == 1
+        assert buf.getvalue().count("beta") == 1
 
     def test_has_streamed_response_is_false_without_deltas(self):
         """Contexts that never painted a delta must not latch the flag.

--- a/tests/unit_tests/cli/test_service_adapter_installer.py
+++ b/tests/unit_tests/cli/test_service_adapter_installer.py
@@ -1,0 +1,284 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for ``datus.cli.service_adapter_installer``.
+
+CI-level: ``subprocess.run`` and ``importlib.util.find_spec`` are
+monkey-patched so no real pip / network access happens.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from datus.cli import service_adapter_installer as sai
+
+
+class TestPackageFor:
+    def test_bi_platforms_mapping(self):
+        pkg, mod = sai.package_for("bi_platforms", "Superset")
+        assert pkg == "datus-bi-superset"
+        assert mod == "datus_bi_superset"
+
+    def test_schedulers_mapping(self):
+        pkg, mod = sai.package_for("schedulers", "AIRFLOW")
+        assert pkg == "datus-scheduler-airflow"
+        assert mod == "datus_scheduler_airflow"
+
+    def test_semantic_layer_mapping(self):
+        pkg, mod = sai.package_for("semantic_layer", "MetricFlow")
+        assert pkg == "datus-semantic-metricflow"
+        assert mod == "datus_semantic_metricflow"
+
+    def test_unknown_section_raises(self):
+        with pytest.raises(ValueError):
+            sai.package_for("unknown_section", "x")
+
+    def test_blank_type_raises(self):
+        with pytest.raises(ValueError):
+            sai.package_for("bi_platforms", "   ")
+
+
+class TestIsAdapterInstalled:
+    def test_returns_true_when_spec_found(self, monkeypatch):
+        monkeypatch.setattr(
+            sai.importlib.util,
+            "find_spec",
+            lambda name: SimpleNamespace(name=name),
+        )
+        assert sai.is_adapter_installed("bi_platforms", "superset") is True
+
+    def test_returns_false_when_spec_missing(self, monkeypatch):
+        monkeypatch.setattr(sai.importlib.util, "find_spec", lambda name: None)
+        assert sai.is_adapter_installed("bi_platforms", "superset") is False
+
+    def test_swallows_import_error(self, monkeypatch):
+        def _raise(name):
+            raise ImportError("ancestor missing")
+
+        monkeypatch.setattr(sai.importlib.util, "find_spec", _raise)
+        assert sai.is_adapter_installed("bi_platforms", "superset") is False
+
+    def test_unknown_section_returns_false(self):
+        assert sai.is_adapter_installed("unknown_section", "x") is False
+
+
+class TestEnsureAdapter:
+    def test_returns_ok_when_already_installed(self, monkeypatch):
+        monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: True)
+        called = []
+        monkeypatch.setattr(sai.subprocess, "run", lambda *a, **k: called.append(a) or None)
+        result = sai.ensure_adapter("bi_platforms", "superset")
+        assert result.ok is True
+        assert result.package == "datus-bi-superset"
+        assert called == []  # no pip invocation when already installed
+
+    def test_runs_pip_when_missing_and_succeeds(self, monkeypatch):
+        monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        captured = {}
+
+        def fake_run(cmd, capture_output, text, check):
+            captured["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout="installed\n", stderr="")
+
+        monkeypatch.setattr(sai.subprocess, "run", fake_run)
+        monkeypatch.setattr(sai.importlib, "invalidate_caches", lambda: None)
+
+        result = sai.ensure_adapter("schedulers", "airflow")
+        assert result.ok is True
+        assert result.package == "datus-scheduler-airflow"
+        assert captured["cmd"][:3] == [sai.sys.executable, "-m", "pip"]
+        assert "datus-scheduler-airflow" in captured["cmd"]
+
+    def test_pip_failure_surfaces_error(self, monkeypatch):
+        monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(
+            sai.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="ERROR: not found"),
+        )
+        result = sai.ensure_adapter("bi_platforms", "ghost")
+        assert result.ok is False
+        assert "exited with code 1" in (result.error or "")
+        assert "ERROR" in result.stderr
+
+    def test_unknown_section_returns_error(self):
+        result = sai.ensure_adapter("unknown_section", "x")
+        assert result.ok is False
+        assert "Unsupported" in (result.error or "")
+
+    def test_semantic_layer_runs_pip_for_metricflow(self, monkeypatch):
+        """Creating a semantic_layer service must trigger
+        ``pip install datus-semantic-metricflow`` when the package isn't
+        already importable — this is the entire point of the new tab."""
+        monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        captured = {}
+
+        def fake_run(cmd, capture_output, text, check):
+            captured["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout="installed\n", stderr="")
+
+        monkeypatch.setattr(sai.subprocess, "run", fake_run)
+        monkeypatch.setattr(sai.importlib, "invalidate_caches", lambda: None)
+
+        result = sai.ensure_adapter("semantic_layer", "metricflow")
+        assert result.ok is True
+        assert result.package == "datus-semantic-metricflow"
+        assert "datus-semantic-metricflow" in captured["cmd"]
+
+    def test_line_callback_receives_pip_output(self, monkeypatch):
+        monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(
+            sai.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="line1\nline2", stderr="warn"),
+        )
+        monkeypatch.setattr(sai.importlib, "invalidate_caches", lambda: None)
+
+        seen = []
+        sai.ensure_adapter("bi_platforms", "superset", line_callback=seen.append)
+        assert "line1" in seen
+        assert "line2" in seen
+        assert "warn" in seen
+
+
+class _FakeEntryPoint:
+    """Drop-in for :class:`importlib.metadata.EntryPoint` for tests.
+
+    Only the surface ``hot_reload_adapter`` touches is implemented:
+    ``name`` (used by selection) and ``load()`` (returns the register
+    callable). The real EntryPoint resolves the attribute behind the
+    colon at load-time; this stub returns whatever the test gave it.
+    """
+
+    def __init__(self, name, register_fn):
+        self.name = name
+        self._fn = register_fn
+
+    def load(self):
+        return self._fn
+
+
+class _FakeEntryPoints:
+    """Behaves like the ``EntryPoints`` returned by ``entry_points()``."""
+
+    def __init__(self, by_group):
+        self._by_group = by_group  # dict[group_name, list[_FakeEntryPoint]]
+
+    def select(self, *, group=None, name=None):
+        eps = list(self._by_group.get(group or "", []))
+        if name is not None:
+            eps = [ep for ep in eps if ep.name == name]
+        return eps
+
+
+class TestHotReloadAdapter:
+    def test_returns_false_for_unknown_section(self):
+        assert sai.hot_reload_adapter("unknown_section", "x") is False
+
+    def test_imports_module_and_runs_entry_point_register(self, monkeypatch):
+        """Adapter packages don't auto-register on import — ``hot_reload_adapter``
+        must explicitly load the matching entry-point and call its register
+        callable. Otherwise an entry-point-only adapter (the actual shape
+        of ``datus-bi-superset`` and ``datus-scheduler-airflow``) ends up
+        importable but absent from ``adapter_registry``."""
+        called = []
+        register = lambda: called.append("register")  # noqa: E731
+
+        monkeypatch.setattr(sai.importlib, "import_module", lambda name: object())
+        monkeypatch.delitem(sai.sys.modules, "datus_scheduler_airflow", raising=False)
+        fake = _FakeEntryPoints({"datus.schedulers": [_FakeEntryPoint("airflow", register)]})
+        import importlib.metadata as metadata
+
+        monkeypatch.setattr(metadata, "entry_points", lambda: fake)
+        assert sai.hot_reload_adapter("schedulers", "airflow") is True
+        assert called == ["register"]
+
+    def test_returns_false_when_entry_point_missing(self, monkeypatch):
+        """No matching entry point → nothing was registered → False.
+        The caller (``ServiceCommands._do_save``) keys on this to surface
+        a "package installed but adapter not registered" error rather
+        than letting the probe fail with a deeper exception."""
+        monkeypatch.setattr(sai.importlib, "import_module", lambda name: object())
+        monkeypatch.delitem(sai.sys.modules, "datus_scheduler_airflow", raising=False)
+        empty = _FakeEntryPoints({})
+        import importlib.metadata as metadata
+
+        monkeypatch.setattr(metadata, "entry_points", lambda: empty)
+        assert sai.hot_reload_adapter("schedulers", "airflow") is False
+
+    def test_reloads_already_imported_module(self, monkeypatch):
+        cached = {}
+        sentinel = object()
+
+        def fake_reload(mod):
+            cached["reloaded"] = mod
+            return mod
+
+        register = lambda: cached.setdefault("registered", True)  # noqa: E731
+        monkeypatch.setitem(sai.sys.modules, "datus_scheduler_airflow", sentinel)
+        monkeypatch.setattr(sai.importlib, "reload", fake_reload)
+        fake = _FakeEntryPoints({"datus.schedulers": [_FakeEntryPoint("airflow", register)]})
+        import importlib.metadata as metadata
+
+        monkeypatch.setattr(metadata, "entry_points", lambda: fake)
+        assert sai.hot_reload_adapter("schedulers", "airflow") is True
+        assert cached["reloaded"] is sentinel
+        assert cached["registered"] is True
+
+    def test_import_failure_returns_false(self, monkeypatch):
+        def boom(name):
+            raise ImportError("nope")
+
+        monkeypatch.setattr(sai.importlib, "import_module", boom)
+        monkeypatch.delitem(sai.sys.modules, "datus_scheduler_airflow", raising=False)
+        assert sai.hot_reload_adapter("schedulers", "airflow") is False
+
+    def test_bi_branch_invokes_register_then_discover(self, monkeypatch):
+        """For BI we still call ``discover_adapters`` after the explicit
+        register call so the registry's own cached scan stays consistent
+        for callers that walk it themselves (e.g. the listing path)."""
+        monkeypatch.setattr(sai.importlib, "import_module", lambda name: object())
+        monkeypatch.delitem(sai.sys.modules, "datus_bi_superset", raising=False)
+        register_calls = []
+        discover_calls = []
+
+        fake = _FakeEntryPoints(
+            {"datus.bi_adapters": [_FakeEntryPoint("superset", lambda: register_calls.append(True))]}
+        )
+        import importlib.metadata as metadata
+
+        monkeypatch.setattr(metadata, "entry_points", lambda: fake)
+
+        fake_registry = SimpleNamespace(discover_adapters=lambda: discover_calls.append(True))
+        fake_module = SimpleNamespace(adapter_registry=fake_registry)
+        with patch.dict(sai.sys.modules, {"datus_bi_core": fake_module}):
+            assert sai.hot_reload_adapter("bi_platforms", "superset") is True
+        assert register_calls == [True]
+        assert discover_calls == [True]
+
+    def test_semantic_branch_uses_semantic_entry_point_group(self, monkeypatch):
+        """Semantic adapter packages register under ``datus.semantic_adapters``
+        — verify ``hot_reload_adapter`` looks up that group (not the BI /
+        scheduler ones) and runs the matching ``register`` callable."""
+        monkeypatch.setattr(sai.importlib, "import_module", lambda name: object())
+        monkeypatch.delitem(sai.sys.modules, "datus_semantic_metricflow", raising=False)
+        register_calls = []
+        discover_calls = []
+
+        fake = _FakeEntryPoints(
+            {"datus.semantic_adapters": [_FakeEntryPoint("metricflow", lambda: register_calls.append(True))]}
+        )
+        import importlib.metadata as metadata
+
+        monkeypatch.setattr(metadata, "entry_points", lambda: fake)
+
+        fake_registry = SimpleNamespace(discover_adapters=lambda: discover_calls.append(True))
+        fake_module = SimpleNamespace(semantic_adapter_registry=fake_registry)
+        with patch.dict(sai.sys.modules, {"datus.tools.semantic_tools.registry": fake_module}):
+            assert sai.hot_reload_adapter("semantic_layer", "metricflow") is True
+        assert register_calls == [True]
+        assert discover_calls == [True]

--- a/tests/unit_tests/cli/test_service_bootstrap.py
+++ b/tests/unit_tests/cli/test_service_bootstrap.py
@@ -1,0 +1,330 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for ``datus.cli.service_bootstrap``.
+
+CI-level: ``sys.stdin.isatty`` / ``sys.stdout.isatty`` /
+``ensure_adapter`` / ``hot_reload_adapter`` are monkey-patched, no real
+TTY interaction or pip invocations happen.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from datus.cli import service_bootstrap as sb
+
+# Captured before any test patches it — restored by tests that exercise
+# the actual install pass.
+_REAL_BACKGROUND_INSTALL = sb.background_install_missing
+
+
+def _fake_cli(agent_config) -> SimpleNamespace:
+    """Minimal stub matching the surface ``service_bootstrap`` reads."""
+    return SimpleNamespace(
+        agent_config=agent_config,
+        console=Console(file=io.StringIO(), no_color=True, force_terminal=False),
+    )
+
+
+def _make_agent(
+    *,
+    dashboards=None,
+    schedulers=None,
+    semantic=None,
+    active_dash=None,
+    active_sched=None,
+    active_semantic=None,
+    default_dash=None,
+    default_sched=None,
+    default_semantic=None,
+):
+    cfg = MagicMock()
+    cfg.dashboard_config = dashboards or {}
+    cfg.scheduler_services = schedulers or {}
+    cfg.semantic_layer_configs = semantic or {}
+    cfg.active_dashboard = MagicMock(return_value=active_dash)
+    cfg.active_scheduler = MagicMock(return_value=active_sched)
+    cfg.active_semantic = MagicMock(return_value=active_semantic)
+    cfg.default_dashboard_service = MagicMock(return_value=default_dash)
+    cfg.default_scheduler_service = MagicMock(return_value=default_sched)
+    cfg.default_semantic_adapter = MagicMock(return_value=default_semantic)
+    cfg.set_active_dashboard = MagicMock()
+    cfg.set_active_scheduler = MagicMock()
+    cfg.set_active_semantic = MagicMock()
+    return cfg
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Guards: stdin/stdout TTY + DATUS_DISABLE_SERVICE_BOOTSTRAP
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestInteractiveGuard:
+    def test_skips_when_stdin_not_a_tty(self, monkeypatch):
+        monkeypatch.setattr(sb.sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(sb.sys.stdout, "isatty", lambda: True)
+        cfg = _make_agent(dashboards={"superset": MagicMock(default=False)}, default_dash="superset")
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        cfg.set_active_dashboard.assert_not_called()
+
+    def test_skips_when_stdout_not_a_tty(self, monkeypatch):
+        monkeypatch.setattr(sb.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(sb.sys.stdout, "isatty", lambda: False)
+        cfg = _make_agent(dashboards={"superset": MagicMock(default=False)}, default_dash="superset")
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        cfg.set_active_dashboard.assert_not_called()
+
+    def test_skips_when_env_disables_bootstrap(self, monkeypatch):
+        monkeypatch.setattr(sb.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(sb.sys.stdout, "isatty", lambda: True)
+        monkeypatch.setenv("DATUS_DISABLE_SERVICE_BOOTSTRAP", "1")
+        cfg = _make_agent(dashboards={"superset": MagicMock(default=False)}, default_dash="superset")
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        cfg.set_active_dashboard.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# bootstrap_default — pinning logic per section
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _force_interactive(monkeypatch):
+    """Default interactive context for the rest of the suite."""
+    monkeypatch.setattr(sb.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sb.sys.stdout, "isatty", lambda: True)
+    monkeypatch.delenv("DATUS_DISABLE_SERVICE_BOOTSTRAP", raising=False)
+    # Stop the install-pass thread from doing real work in every test —
+    # individual tests that care monkey-patch back to a real function.
+    monkeypatch.setattr(sb, "background_install_missing", lambda cli: None)
+
+
+class TestBootstrapDefault:
+    def test_skips_empty_section_silently(self):
+        cfg = _make_agent()  # all sections empty
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        cfg.set_active_dashboard.assert_not_called()
+        cfg.set_active_scheduler.assert_not_called()
+        cfg.set_active_semantic.assert_not_called()
+
+    def test_skips_when_already_pinned(self):
+        cfg = _make_agent(
+            dashboards={"superset": MagicMock(default=False)},
+            active_dash="superset",  # already pinned — bootstrap should leave alone
+            default_dash="superset",
+        )
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        cfg.set_active_dashboard.assert_not_called()
+
+    def test_pins_single_entry_implicitly(self):
+        cfg = _make_agent(
+            dashboards={"superset": MagicMock(default=False)},
+            default_dash="superset",  # single-entry shortcut returns the only key
+        )
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        cfg.set_active_dashboard.assert_called_once_with("superset")
+
+    def test_pins_yaml_default_flag(self):
+        """When ``default: true`` is set on one of multiple entries, the
+        bootstrap should pin that one without asking."""
+        cfg = _make_agent(
+            dashboards={"superset": MagicMock(default=False), "grafana": MagicMock(default=True)},
+            default_dash="grafana",
+        )
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        cfg.set_active_dashboard.assert_called_once_with("grafana")
+
+    def test_picker_invoked_when_ambiguous(self):
+        cfg = _make_agent(
+            dashboards={"superset": MagicMock(default=False), "grafana": MagicMock(default=False)},
+            default_dash=None,  # multiple entries, no default
+        )
+        cli = _fake_cli(cfg)
+        with patch.object(sb, "quick_pick_service", return_value="grafana") as picker:
+            sb.run(cli)
+        picker.assert_called_once()
+        cfg.set_active_dashboard.assert_called_once_with("grafana")
+
+    def test_picker_cancel_leaves_unpinned(self):
+        cfg = _make_agent(
+            dashboards={"a": MagicMock(default=False), "b": MagicMock(default=False)},
+            default_dash=None,
+        )
+        cli = _fake_cli(cfg)
+        with patch.object(sb, "quick_pick_service", return_value=None):
+            sb.run(cli)
+        cfg.set_active_dashboard.assert_not_called()
+
+    def test_resolver_exception_does_not_abort_other_sections(self):
+        """If the dashboard resolver raises (e.g. multiple ``default: true``),
+        the bootstrap surfaces an error but still processes the next
+        sections."""
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        cfg = _make_agent(
+            dashboards={"a": MagicMock(default=True), "b": MagicMock(default=True)},
+            schedulers={"airflow": {"type": "airflow"}},
+            default_sched="airflow",
+        )
+        cfg.default_dashboard_service.side_effect = DatusException(
+            ErrorCode.COMMON_CONFIG_ERROR, message="multiple default true"
+        )
+        cli = _fake_cli(cfg)
+        sb.run(cli)
+        # Dashboard pin skipped, but scheduler still pinned.
+        cfg.set_active_dashboard.assert_not_called()
+        cfg.set_active_scheduler.assert_called_once_with("airflow")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# background_install_missing — adapter pip flow
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestBackgroundInstall:
+    def test_only_processes_missing_packages(self, monkeypatch):
+        # Two BI services, only one is missing. Use SimpleNamespace so
+        # ``getattr(cfg, 'adapter_type', '')`` returns the literal value
+        # rather than a child MagicMock.
+        bi_one = SimpleNamespace(adapter_type="superset")
+        bi_two = SimpleNamespace(adapter_type="grafana")
+        cfg = _make_agent(
+            dashboards={"superset": bi_one, "grafana": bi_two},
+            default_dash="superset",  # pin already happens
+        )
+        cli = _fake_cli(cfg)
+
+        installed = {("bi_platforms", "superset")}  # superset is already installed
+        monkeypatch.setattr(
+            sb,
+            "is_adapter_installed",
+            lambda section, t: (section, t) in installed,
+        )
+        ensure_calls: list = []
+
+        def fake_ensure(section, adapter_type):
+            ensure_calls.append((section, adapter_type))
+            return sb.InstallResult(ok=True, package=f"datus-bi-{adapter_type}", import_name="x")
+
+        monkeypatch.setattr(sb, "ensure_adapter", fake_ensure)
+        monkeypatch.setattr(sb, "hot_reload_adapter", lambda *_: True)
+        monkeypatch.setattr(
+            sb.threading,
+            "Thread",
+            lambda target, args, daemon: SimpleNamespace(start=lambda: target(*args)),
+        )
+        # Run the actual install pass (override the autouse stub).
+        monkeypatch.setattr(sb, "background_install_missing", _REAL_BACKGROUND_INSTALL)
+
+        sb.run(cli)
+
+        # ``superset`` filtered out, only ``grafana`` triggers an install.
+        assert ensure_calls == [("bi_platforms", "grafana")]
+
+    def test_install_failure_is_non_blocking(self, monkeypatch):
+        bi = SimpleNamespace(adapter_type="ghost")
+        cfg = _make_agent(
+            dashboards={"ghost": bi},
+            default_dash="ghost",
+        )
+        cli = _fake_cli(cfg)
+
+        monkeypatch.setattr(sb, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(
+            sb,
+            "ensure_adapter",
+            lambda *args, **kwargs: sb.InstallResult(
+                ok=False, package="datus-bi-ghost", import_name="datus_bi_ghost", error="not found"
+            ),
+        )
+        hot_reload_called = []
+        monkeypatch.setattr(sb, "hot_reload_adapter", lambda *a: hot_reload_called.append(a))
+        monkeypatch.setattr(
+            sb.threading,
+            "Thread",
+            lambda target, args, daemon: SimpleNamespace(start=lambda: target(*args)),
+        )
+        monkeypatch.setattr(sb, "background_install_missing", _REAL_BACKGROUND_INSTALL)
+
+        sb.run(cli)
+
+        # ``hot_reload_adapter`` must not be called when the install failed —
+        # ``ensure_adapter`` returning ``ok=False`` is a hard stop.
+        assert hot_reload_called == []
+
+    def test_dedupes_targets(self, monkeypatch):
+        """Two BI aliases of the same adapter type should only kick off
+        one ``pip install``."""
+        bi_a = SimpleNamespace(adapter_type="superset")
+        bi_b = SimpleNamespace(adapter_type="superset")  # same adapter, different alias
+        cfg = _make_agent(
+            dashboards={"alias_a": bi_a, "alias_b": bi_b},
+            default_dash="alias_a",
+        )
+        cli = _fake_cli(cfg)
+        monkeypatch.setattr(sb, "is_adapter_installed", lambda *_: False)
+        ensure_calls: list = []
+        monkeypatch.setattr(
+            sb,
+            "ensure_adapter",
+            lambda section, t: (
+                ensure_calls.append((section, t)) or sb.InstallResult(ok=True, package=f"datus-bi-{t}", import_name="x")
+            ),
+        )
+        monkeypatch.setattr(sb, "hot_reload_adapter", lambda *_: True)
+        monkeypatch.setattr(
+            sb.threading,
+            "Thread",
+            lambda target, args, daemon: SimpleNamespace(start=lambda: target(*args)),
+        )
+        monkeypatch.setattr(sb, "background_install_missing", _REAL_BACKGROUND_INSTALL)
+
+        sb.run(cli)
+        assert ensure_calls == [("bi_platforms", "superset")]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# quick_pick_service — synchronous chooser
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestQuickPickService:
+    def test_returns_chosen_index(self, monkeypatch):
+        cli = SimpleNamespace(console=Console(file=io.StringIO(), no_color=True, force_terminal=False))
+        monkeypatch.setattr("builtins.input", lambda _: "2")
+        assert sb.quick_pick_service(cli, "bi_platforms", ["superset", "grafana"]) == "grafana"
+
+    def test_returns_none_on_blank(self, monkeypatch):
+        cli = SimpleNamespace(console=Console(file=io.StringIO(), no_color=True, force_terminal=False))
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        assert sb.quick_pick_service(cli, "schedulers", ["airflow"]) is None
+
+    def test_returns_none_on_q(self, monkeypatch):
+        cli = SimpleNamespace(console=Console(file=io.StringIO(), no_color=True, force_terminal=False))
+        monkeypatch.setattr("builtins.input", lambda _: "q")
+        assert sb.quick_pick_service(cli, "schedulers", ["airflow"]) is None
+
+    def test_reprompts_on_out_of_range(self, monkeypatch):
+        cli = SimpleNamespace(console=Console(file=io.StringIO(), no_color=True, force_terminal=False))
+        responses = iter(["99", "1"])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        assert sb.quick_pick_service(cli, "bi_platforms", ["a", "b"]) == "a"
+
+    def test_reprompts_on_non_numeric(self, monkeypatch):
+        cli = SimpleNamespace(console=Console(file=io.StringIO(), no_color=True, force_terminal=False))
+        responses = iter(["abc", "2"])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        assert sb.quick_pick_service(cli, "bi_platforms", ["a", "b"]) == "b"

--- a/tests/unit_tests/cli/test_service_commands.py
+++ b/tests/unit_tests/cli/test_service_commands.py
@@ -1191,24 +1191,91 @@ class TestTestAndDefaultEdgeCases:
         assert committed["stale_token"] == "not-a-dict"
         assert committed["airflow"]["default"] is True
 
-    def test_set_global_default_only_for_schedulers_section(self):
-        """Calling ``set_default`` with a ``bi_platforms`` section is a no-op."""
+    def test_set_global_default_works_for_bi_platforms(self):
+        """``set_default`` is now generic across BI / Scheduler / Semantic.
+        For bi_platforms, the YAML ``default`` flag flips on the chosen
+        entry and clears from the others, mirroring the scheduler test
+        above."""
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        mgr = MagicMock()
+        mgr.get = MagicMock(
+            return_value={
+                "bi_platforms": {
+                    "superset": {"type": "superset", "default": True},
+                    "grafana": {"type": "grafana"},
+                }
+            }
+        )
+        with (
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+            patch.object(ServiceCommands, "_reload_agent_config"),
+        ):
+            cmd._apply_selection(ServiceConfigSelection(action="set_default", section="bi_platforms", name="grafana"))
+        mgr.update_item.assert_called_once()
+        committed = mgr.update_item.call_args.args[1]["bi_platforms"]
+        assert committed["grafana"]["default"] is True
+        assert "default" not in committed["superset"]
+
+    def test_set_global_default_works_for_semantic_layer(self):
+        """Same generic pathway for semantic_layer."""
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        mgr = MagicMock()
+        mgr.get = MagicMock(
+            return_value={
+                "semantic_layer": {
+                    "metricflow": {"type": "metricflow", "default": True},
+                    "dbt": {"type": "dbt"},
+                }
+            }
+        )
+        with (
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+            patch.object(ServiceCommands, "_reload_agent_config"),
+        ):
+            cmd._apply_selection(ServiceConfigSelection(action="set_default", section="semantic_layer", name="dbt"))
+        mgr.update_item.assert_called_once()
+        committed = mgr.update_item.call_args.args[1]["semantic_layer"]
+        assert committed["dbt"]["default"] is True
+        assert "default" not in committed["metricflow"]
+
+    def test_set_global_default_unknown_section_returns_none(self):
         from datus.cli.service_config_app import ServiceConfigSelection
 
         cmd, _ = _make_commands_with_bi_stub()
         with patch("datus.configuration.agent_config_loader.configuration_manager") as mgr_factory:
-            result = cmd._apply_selection(
-                ServiceConfigSelection(action="set_default", section="bi_platforms", name="x")
-            )
+            result = cmd._apply_selection(ServiceConfigSelection(action="set_default", section="datasources", name="x"))
         assert result is None
         mgr_factory.assert_not_called()
+
+    def test_set_project_default_for_semantic_layer(self):
+        """semantic_layer is now wired into ``_do_set_project_default``;
+        the section's ``set_active_semantic`` setter must be invoked with
+        the chosen name."""
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cli = _fake_cli()
+        setter = MagicMock()
+        cli.agent_config = SimpleNamespace(
+            services=SimpleNamespace(bi_platforms={}, schedulers={}, semantic_layer={}),
+            set_active_semantic=setter,
+        )
+        cmd = ServiceCommands(cli)
+        result = cmd._apply_selection(
+            ServiceConfigSelection(action="set_project_default", section="semantic_layer", name="metricflow")
+        )
+        setter.assert_called_once_with("metricflow")
+        assert result and "metricflow" in result
 
     def test_set_project_default_unknown_section_returns_none(self):
         from datus.cli.service_config_app import ServiceConfigSelection
 
         cmd, _ = _make_commands_with_bi_stub()
         result = cmd._apply_selection(
-            ServiceConfigSelection(action="set_project_default", section="semantic_layer", name="x")
+            ServiceConfigSelection(action="set_project_default", section="datasources", name="x")
         )
         assert result is None
 

--- a/tests/unit_tests/cli/test_service_commands.py
+++ b/tests/unit_tests/cli/test_service_commands.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from datus.cli.service_client import READ_METHODS, ServiceClient, ServiceClientRegistry
 from datus.cli.service_commands import ServiceCommands
@@ -113,18 +115,20 @@ class TestDispatchServiceListing:
         assert cmd.dispatch(".superset", "") is False
 
     def test_cmd_services_lists_all(self):
+        """The ``list`` sub-token preserves the read-only listing path."""
         cmd, cli = _make_commands_with_bi_stub()
-        cmd.cmd_services("")
+        cmd.cmd_services("list")
         # Printed a table (Table object, not a string).
         assert cli.console.print.call_count == 1
 
     def test_cmd_services_empty_prints_hint(self):
+        """``list`` on an empty config still emits the "no services" hint."""
         cli = _fake_cli()
         cli.agent_config = SimpleNamespace(
             services=SimpleNamespace(bi_platforms={}, schedulers={}, semantic_layer={}),
         )
         cmd = ServiceCommands(cli)
-        cmd.cmd_services("")
+        cmd.cmd_services("list")
         # Should have printed at least one yellow hint message.
         msg = str(cli.console.print.call_args_list[0])
         assert "No services configured" in msg
@@ -754,6 +758,618 @@ class TestQueryEnvelopeRendering:
 
         # Falls back to K/V table rendering (no unwrapping).
         assert any(isinstance(c.args[0], Table) for c in cli.console.print.call_args_list)
+
+
+class TestServiceConfigDispatch:
+    """``cmd_services`` token dispatch — the TUI path is invoked by
+    ``dashboard`` / ``scheduler`` / ``config`` tokens; bare and ``list``
+    tokens render the read-only listing instead."""
+
+    def test_bare_token_opens_menu_on_dashboard_tab(self):
+        """Bare ``/services`` lands directly in the TUI; the listing is
+        only emitted on ``/services list``."""
+        cmd, _ = _make_commands_with_bi_stub()
+        with patch.object(ServiceCommands, "_run_config_menu") as menu:
+            cmd.cmd_services("")
+        menu.assert_called_once()
+        assert menu.call_args.kwargs == {"initial_tab": "dashboard"}
+
+    def test_list_token_renders_listing(self):
+        cmd, cli = _make_commands_with_bi_stub()
+        with patch.object(ServiceCommands, "_run_config_menu") as menu:
+            cmd.cmd_services("list")
+        menu.assert_not_called()
+        assert cli.console.print.call_count >= 1
+
+    def test_dashboard_token_opens_menu_with_dashboard_tab(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        with patch.object(ServiceCommands, "_run_config_menu") as menu:
+            cmd.cmd_services("dashboard")
+        menu.assert_called_once()
+        assert menu.call_args.kwargs == {"initial_tab": "dashboard"}
+
+    def test_scheduler_token_opens_menu_with_scheduler_tab(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        with patch.object(ServiceCommands, "_run_config_menu") as menu:
+            cmd.cmd_services("scheduler")
+        menu.assert_called_once()
+        assert menu.call_args.kwargs == {"initial_tab": "scheduler"}
+
+    def test_unknown_token_falls_back_to_listing_with_hint(self):
+        cmd, cli = _make_commands_with_bi_stub()
+        with patch.object(ServiceCommands, "_run_config_menu") as menu:
+            cmd.cmd_services("foobar")
+        menu.assert_not_called()
+        rendered = " ".join(str(c) for c in cli.console.print.call_args_list)
+        assert "/services dashboard" in rendered or "/services scheduler" in rendered
+
+
+class TestApplySelectionPersistence:
+    """``_apply_selection`` orchestrates install → probe → persist for save,
+    and the right ``configuration_manager`` calls for delete /
+    set_default / set_project_default."""
+
+    def _commands_with_writable_cli(self):
+        cli = _fake_cli()
+        # Set ``services`` shape so the listing path doesn't crash.
+        cli.agent_config = SimpleNamespace(
+            services=SimpleNamespace(bi_platforms={"old": {}}, schedulers={}, semantic_layer={}),
+            set_active_dashboard=MagicMock(),
+            set_active_scheduler=MagicMock(),
+            active_dashboard=MagicMock(return_value=None),
+            active_scheduler=MagicMock(return_value=None),
+        )
+        return ServiceCommands(cli), cli
+
+    def test_save_runs_install_probe_and_persists(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, cli = self._commands_with_writable_cli()
+        sel = ServiceConfigSelection(
+            action="save",
+            section="bi_platforms",
+            name="superset",
+            payload={"type": "superset", "api_base_url": "http://x", "username": "u"},
+        )
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"bi_platforms": {}, "schedulers": {}, "semantic_layer": {}})
+        with (
+            patch("datus.cli.service_adapter_installer.ensure_adapter") as ensure,
+            patch("datus.cli.service_adapter_installer.hot_reload_adapter") as hot,
+            patch("datus.cli.service_commands.ServiceCommands._probe", return_value=(True, "5 dashboards")),
+            patch("datus.cli.service_commands.ServiceCommands._reload_agent_config"),
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+        ):
+            ensure.return_value = SimpleNamespace(
+                ok=True, package="datus-bi-superset", import_name="datus_bi_superset", stdout="", stderr=""
+            )
+            status = cmd._apply_selection(sel)
+        ensure.assert_called_once_with("bi_platforms", "superset")
+        hot.assert_called_once_with("bi_platforms", "superset")
+        mgr.update_item.assert_called_once()
+        kwargs = mgr.update_item.call_args
+        assert kwargs.args[0] == "services"
+        assert "Saved" in (status or "")
+        assert "Connected" in (status or "")
+
+    def test_save_persists_even_when_probe_fails(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = self._commands_with_writable_cli()
+        sel = ServiceConfigSelection(
+            action="save",
+            section="bi_platforms",
+            name="superset",
+            payload={"type": "superset", "api_base_url": "http://broken"},
+        )
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"bi_platforms": {}})
+        with (
+            patch("datus.cli.service_adapter_installer.ensure_adapter") as ensure,
+            patch("datus.cli.service_adapter_installer.hot_reload_adapter"),
+            patch(
+                "datus.cli.service_commands.ServiceCommands._probe",
+                return_value=(False, "Connection refused"),
+            ),
+            patch("datus.cli.service_commands.ServiceCommands._reload_agent_config"),
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+        ):
+            ensure.return_value = SimpleNamespace(
+                ok=True, package="datus-bi-superset", import_name="datus_bi_superset", stdout="", stderr=""
+            )
+            status = cmd._apply_selection(sel)
+        # YAML still written — probe failure is informational, not fatal.
+        mgr.update_item.assert_called_once()
+        assert "Probe failed" in (status or "")
+
+    def test_save_skipped_on_install_failure(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = self._commands_with_writable_cli()
+        sel = ServiceConfigSelection(
+            action="save",
+            section="bi_platforms",
+            name="ghost",
+            payload={"type": "ghost", "api_base_url": "http://x"},
+        )
+        mgr = MagicMock()
+        with (
+            patch("datus.cli.service_adapter_installer.ensure_adapter") as ensure,
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+        ):
+            ensure.return_value = SimpleNamespace(
+                ok=False,
+                package="datus-bi-ghost",
+                import_name="datus_bi_ghost",
+                stdout="",
+                stderr="not found",
+                error="exit 1",
+            )
+            status = cmd._apply_selection(sel)
+        mgr.update_item.assert_not_called()
+        assert "skipped" in (status or "").lower() or "fail" in (status or "").lower()
+
+    def test_delete_persists_with_delete_old_key_true(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = self._commands_with_writable_cli()
+        sel = ServiceConfigSelection(action="delete", section="bi_platforms", name="old")
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"bi_platforms": {"old": {}}, "schedulers": {}})
+        with (
+            patch("datus.cli.service_commands.ServiceCommands._reload_agent_config"),
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+        ):
+            cmd._apply_selection(sel)
+        # delete_old_key=True so the YAML key is dropped, not just blanked.
+        mgr.update_item.assert_called_once()
+        assert mgr.update_item.call_args.kwargs.get("delete_old_key") is True
+
+    def test_set_global_default_clears_others(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = self._commands_with_writable_cli()
+        sel = ServiceConfigSelection(action="set_default", section="schedulers", name="airflow_dev")
+        mgr = MagicMock()
+        mgr.get = MagicMock(
+            return_value={
+                "schedulers": {
+                    "airflow_prod": {"type": "airflow", "default": True},
+                    "airflow_dev": {"type": "airflow"},
+                },
+            }
+        )
+        with (
+            patch("datus.cli.service_commands.ServiceCommands._reload_agent_config"),
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+        ):
+            cmd._apply_selection(sel)
+        mgr.update_item.assert_called_once()
+        # The committed payload should mark the new entry default and strip the old one.
+        committed = mgr.update_item.call_args.args[1]
+        schedulers = committed["schedulers"]
+        assert schedulers["airflow_dev"]["default"] is True
+        assert "default" not in schedulers["airflow_prod"]
+
+    def test_set_project_default_calls_setter(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, cli = self._commands_with_writable_cli()
+        sel = ServiceConfigSelection(action="set_project_default", section="bi_platforms", name="superset")
+        cmd._apply_selection(sel)
+        cli.agent_config.set_active_dashboard.assert_called_once_with("superset")
+
+    def test_set_project_default_clears_when_name_empty(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, cli = self._commands_with_writable_cli()
+        sel = ServiceConfigSelection(action="set_project_default", section="schedulers", name="")
+        cmd._apply_selection(sel)
+        cli.agent_config.set_active_scheduler.assert_called_once_with(None)
+
+
+class TestRunConfigMenu:
+    """``_run_config_menu`` loops the TUI; ``_run_app`` wraps stdin via
+    ``tui_app.suspend_input`` when the outer REPL is in TUI mode.
+    Direct unit coverage of these helpers because the integration path
+    (real prompt_toolkit Application) is impossible to exercise headless."""
+
+    def test_loop_exits_when_app_returns_none(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        with patch.object(ServiceCommands, "_run_app", return_value=None) as run_app:
+            cmd._run_config_menu(initial_tab="dashboard")
+        assert run_app.call_count == 1
+
+    def test_loop_iterates_then_exits(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        scripted = [
+            ServiceConfigSelection(action="test", section="bi_platforms", name="superset"),
+            None,  # second iteration cancels
+        ]
+        with (
+            patch.object(ServiceCommands, "_run_app", side_effect=scripted) as run_app,
+            patch.object(ServiceCommands, "_apply_selection", return_value="status") as apply_sel,
+            patch.object(ServiceCommands, "_refresh_after_change") as refresh,
+        ):
+            cmd._run_config_menu(initial_tab="dashboard")
+        assert run_app.call_count == 2
+        apply_sel.assert_called_once()
+        refresh.assert_called_once()
+
+    def test_seed_tab_follows_section_of_last_selection(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        sequences = [
+            ServiceConfigSelection(action="test", section="schedulers", name="airflow"),
+            None,
+        ]
+        captured_tabs = []
+
+        def fake_run_app(self_inner, app):
+            # Inspect the tab the App was constructed with.
+            captured_tabs.append(app._tab.value)
+            return sequences.pop(0)
+
+        with (
+            patch.object(ServiceCommands, "_run_app", new=fake_run_app),
+            patch.object(ServiceCommands, "_apply_selection", return_value=None),
+        ):
+            cmd._run_config_menu(initial_tab="dashboard")
+        # First app starts on dashboard (initial_tab); second app re-seeded
+        # to scheduler because the prior selection.section == "schedulers".
+        assert captured_tabs == ["dashboard", "scheduler"]
+
+    def test_run_app_uses_suspend_input_when_tui_active(self):
+        cmd, cli = _make_commands_with_bi_stub()
+        # Simulate an outer TUI App with ``suspend_input`` context manager.
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=None)
+        ctx.__exit__ = MagicMock(return_value=False)
+        cli.tui_app = MagicMock()
+        cli.tui_app.suspend_input = MagicMock(return_value=ctx)
+
+        fake_app = MagicMock()
+        fake_app.run = MagicMock(return_value="ran-with-suspend")
+        result = cmd._run_app(fake_app)
+        assert result == "ran-with-suspend"
+        ctx.__enter__.assert_called_once()
+        ctx.__exit__.assert_called_once()
+
+    def test_run_app_runs_directly_without_tui(self):
+        cmd, cli = _make_commands_with_bi_stub()
+        cli.tui_app = None  # outer REPL not in TUI mode
+        fake_app = MagicMock()
+        fake_app.run = MagicMock(return_value="ran-direct")
+        assert cmd._run_app(fake_app) == "ran-direct"
+
+    def test_refresh_after_change_drops_registry_cache(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        assert cmd._registry is not None  # primed by _make_commands_with_bi_stub
+        cmd._refresh_after_change()
+        assert cmd._registry is None
+
+
+class TestApplySelectionMissingType:
+    """Save with no ``type`` payload short-circuits without YAML write."""
+
+    def test_save_with_missing_type_returns_none(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cli = _fake_cli()
+        cli.agent_config = SimpleNamespace(
+            services=SimpleNamespace(bi_platforms={}, schedulers={}, semantic_layer={}),
+        )
+        cmd = ServiceCommands(cli)
+        sel = ServiceConfigSelection(action="save", section="bi_platforms", name="x", payload={})
+        with patch("datus.configuration.agent_config_loader.configuration_manager") as mgr_factory:
+            result = cmd._apply_selection(sel)
+        assert result is None
+        mgr_factory.assert_not_called()
+
+    def test_unknown_action_returns_none(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        sel = ServiceConfigSelection(action="garbled", section="bi_platforms", name="x")
+        assert cmd._apply_selection(sel) is None
+
+
+class TestDeleteEdgeCases:
+    """``_do_delete`` covers absent entries, persistence failure, and
+    automatic clearing of a project pin that pointed at the deleted entry."""
+
+    def _fresh_cmd(self):
+        cli = _fake_cli()
+        cli.agent_config = SimpleNamespace(
+            services=SimpleNamespace(bi_platforms={"old": {}}, schedulers={}, semantic_layer={}),
+            active_dashboard=MagicMock(return_value="old"),
+            active_scheduler=MagicMock(return_value=None),
+            set_active_dashboard=MagicMock(),
+            set_active_scheduler=MagicMock(),
+        )
+        return ServiceCommands(cli), cli
+
+    def test_delete_missing_entry_warns(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, cli = self._fresh_cmd()
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"bi_platforms": {}})
+        with patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr):
+            status = cmd._apply_selection(ServiceConfigSelection(action="delete", section="bi_platforms", name="ghost"))
+        mgr.update_item.assert_not_called()
+        assert "not found" in (status or "")
+
+    def test_delete_persistence_exception_surfaces(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = self._fresh_cmd()
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"bi_platforms": {"old": {}}})
+        mgr.update_item = MagicMock(side_effect=RuntimeError("disk full"))
+        with patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr):
+            status = cmd._apply_selection(ServiceConfigSelection(action="delete", section="bi_platforms", name="old"))
+        assert "failed" in (status or "").lower()
+
+    def test_delete_clears_project_default_when_pointing_at_removed(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, cli = self._fresh_cmd()
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"bi_platforms": {"old": {}}})
+        with (
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+            patch.object(ServiceCommands, "_reload_agent_config"),
+        ):
+            cmd._apply_selection(ServiceConfigSelection(action="delete", section="bi_platforms", name="old"))
+        cli.agent_config.set_active_dashboard.assert_called_once_with(None)
+
+
+class TestTestAndDefaultEdgeCases:
+    def test_test_action_reports_ok(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        with patch.object(ServiceCommands, "_probe", return_value=(True, "5 dashboards")):
+            status = cmd._apply_selection(
+                ServiceConfigSelection(action="test", section="bi_platforms", name="superset")
+            )
+        assert "Probe ok" in (status or "")
+
+    def test_set_global_default_missing_entry_warns(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"schedulers": {}})
+        with patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr):
+            status = cmd._apply_selection(
+                ServiceConfigSelection(action="set_default", section="schedulers", name="ghost")
+            )
+        mgr.update_item.assert_not_called()
+        assert "not found" in (status or "")
+
+    def test_set_global_default_persistence_exception(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={"schedulers": {"airflow": {"type": "airflow"}}})
+        mgr.update_item = MagicMock(side_effect=RuntimeError("disk full"))
+        with patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr):
+            status = cmd._apply_selection(
+                ServiceConfigSelection(action="set_default", section="schedulers", name="airflow")
+            )
+        assert "failed" in (status or "").lower()
+
+    def test_set_global_default_skips_non_dict_entries(self):
+        """Defensive: a non-dict entry under ``schedulers`` (legacy YAML
+        glitch) is left alone instead of crashing the loop."""
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        mgr = MagicMock()
+        mgr.get = MagicMock(
+            return_value={
+                "schedulers": {
+                    "airflow": {"type": "airflow"},
+                    "stale_token": "not-a-dict",  # malformed entry
+                }
+            }
+        )
+        with (
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+            patch.object(ServiceCommands, "_reload_agent_config"),
+        ):
+            cmd._apply_selection(ServiceConfigSelection(action="set_default", section="schedulers", name="airflow"))
+        mgr.update_item.assert_called_once()
+        committed = mgr.update_item.call_args.args[1]["schedulers"]
+        # Non-dict entry preserved verbatim; default flag flipped on the airflow entry.
+        assert committed["stale_token"] == "not-a-dict"
+        assert committed["airflow"]["default"] is True
+
+    def test_set_global_default_only_for_schedulers_section(self):
+        """Calling ``set_default`` with a ``bi_platforms`` section is a no-op."""
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        with patch("datus.configuration.agent_config_loader.configuration_manager") as mgr_factory:
+            result = cmd._apply_selection(
+                ServiceConfigSelection(action="set_default", section="bi_platforms", name="x")
+            )
+        assert result is None
+        mgr_factory.assert_not_called()
+
+    def test_set_project_default_unknown_section_returns_none(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cmd, _ = _make_commands_with_bi_stub()
+        result = cmd._apply_selection(
+            ServiceConfigSelection(action="set_project_default", section="semantic_layer", name="x")
+        )
+        assert result is None
+
+    def test_set_project_default_setter_missing(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cli = _fake_cli()
+        # Strip the setters so the helper sees ``None``.
+        cli.agent_config = SimpleNamespace(
+            services=SimpleNamespace(bi_platforms={}, schedulers={}, semantic_layer={}),
+        )
+        cmd = ServiceCommands(cli)
+        result = cmd._apply_selection(
+            ServiceConfigSelection(action="set_project_default", section="bi_platforms", name="x")
+        )
+        # Setter unavailable → command logs an error and returns None.
+        assert result is None
+
+    def test_set_project_default_setter_raises(self):
+        from datus.cli.service_config_app import ServiceConfigSelection
+
+        cli = _fake_cli()
+        cli.agent_config = SimpleNamespace(
+            services=SimpleNamespace(bi_platforms={}, schedulers={}, semantic_layer={}),
+            set_active_dashboard=MagicMock(side_effect=RuntimeError("disk full")),
+            set_active_scheduler=MagicMock(),
+        )
+        cmd = ServiceCommands(cli)
+        result = cmd._apply_selection(
+            ServiceConfigSelection(action="set_project_default", section="bi_platforms", name="x")
+        )
+        assert "failed" in (result or "").lower()
+
+
+class TestMergeServiceEntry:
+    def test_strips_blank_strings_and_empty_dicts(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={})
+        with (
+            patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr),
+            patch.object(ServiceCommands, "_reload_agent_config"),
+        ):
+            ok = cmd._merge_service_entry(
+                "bi_platforms",
+                "superset",
+                {"type": "superset", "api_base_url": "http://x", "username": "", "extra": {}},
+            )
+        assert ok is True
+        committed = mgr.update_item.call_args.args[1]["bi_platforms"]["superset"]
+        assert "username" not in committed  # empty string stripped
+        assert "extra" not in committed  # empty dict stripped
+        assert committed["api_base_url"] == "http://x"
+
+    def test_persistence_exception_returns_false(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        mgr = MagicMock()
+        mgr.get = MagicMock(return_value={})
+        mgr.update_item = MagicMock(side_effect=RuntimeError("disk full"))
+        with patch("datus.configuration.agent_config_loader.configuration_manager", return_value=mgr):
+            assert cmd._merge_service_entry("bi_platforms", "x", {"type": "superset"}) is False
+
+
+class TestProbeImplementation:
+    """``_probe`` runs a real (mocked) ``BIFuncTool`` / ``SchedulerTools``
+    call so connection errors surface as ``(False, message)``."""
+
+    def test_probe_bi_success_counts_envelope(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        fake_tool = MagicMock()
+        fake_tool.list_dashboards = MagicMock(return_value={"success": 1, "result": {"items": [{"id": 1}, {"id": 2}]}})
+        with patch("datus.tools.func_tool.bi_tools.BIFuncTool", return_value=fake_tool):
+            ok, msg = cmd._probe("bi_platforms", "superset")
+        assert ok is True
+        assert "2 dashboards" in msg
+
+    def test_probe_scheduler_success(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        fake_tool = MagicMock()
+        fake_tool.list_scheduler_jobs = MagicMock(return_value=[{"name": "a"}, {"name": "b"}])
+        with patch("datus.tools.func_tool.scheduler_tools.SchedulerTools", return_value=fake_tool):
+            ok, msg = cmd._probe("schedulers", "airflow")
+        assert ok is True
+        assert "2 scheduler jobs" in msg
+
+    def test_probe_exception_is_caught(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        fake_tool = MagicMock()
+        fake_tool.list_dashboards = MagicMock(side_effect=RuntimeError("connection refused"))
+        with patch("datus.tools.func_tool.bi_tools.BIFuncTool", return_value=fake_tool):
+            ok, msg = cmd._probe("bi_platforms", "superset")
+        assert ok is False
+        assert "connection refused" in msg
+
+    def test_probe_unsupported_section(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        ok, msg = cmd._probe("unknown_section", "x")
+        assert ok is False
+        assert "Unsupported section" in msg
+
+    def test_probe_semantic_returns_true_when_metadata_registered(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        fake_registry = SimpleNamespace(get_metadata=lambda name: {"name": name})
+        with patch.dict(
+            "sys.modules",
+            {"datus.tools.semantic_tools.registry": SimpleNamespace(semantic_adapter_registry=fake_registry)},
+        ):
+            ok, msg = cmd._probe("semantic_layer", "metricflow")
+        assert ok is True
+        assert "metricflow" in msg
+        assert "registered" in msg
+
+    def test_probe_semantic_returns_false_when_metadata_missing(self):
+        cmd, _ = _make_commands_with_bi_stub()
+        fake_registry = SimpleNamespace(get_metadata=lambda name: None)
+        with patch.dict(
+            "sys.modules",
+            {"datus.tools.semantic_tools.registry": SimpleNamespace(semantic_adapter_registry=fake_registry)},
+        ):
+            ok, msg = cmd._probe("semantic_layer", "metricflow")
+        assert ok is False
+        assert "not registered" in msg
+
+
+class TestCountEnvelope:
+    @pytest.mark.parametrize(
+        "payload,expected",
+        [
+            ({"items": [1, 2, 3]}, 3),
+            ({"result": {"items": [1, 2]}}, 2),
+            ({"result": [1, 2, 3, 4]}, 4),
+            ([1, 2], 2),
+            ("scalar", 0),
+            ({}, 0),
+        ],
+    )
+    def test_count(self, payload, expected):
+        assert ServiceCommands._count_envelope(payload) == expected
+
+
+class TestReloadAgentConfig:
+    def test_swaps_cli_agent_config_on_success(self):
+        cmd, cli = _make_commands_with_bi_stub()
+        fresh = SimpleNamespace(name="fresh")
+        with patch(
+            "datus.configuration.agent_config_loader.load_agent_config",
+            return_value=fresh,
+        ):
+            cmd._reload_agent_config()
+        assert cli.agent_config is fresh
+        assert cmd._registry is None
+
+    def test_load_failure_keeps_existing_agent_config(self):
+        cmd, cli = _make_commands_with_bi_stub()
+        original = cli.agent_config
+        with patch(
+            "datus.configuration.agent_config_loader.load_agent_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            cmd._reload_agent_config()
+        assert cli.agent_config is original
 
 
 class TestAsyncExecution:

--- a/tests/unit_tests/cli/test_service_config_app.py
+++ b/tests/unit_tests/cli/test_service_config_app.py
@@ -1,0 +1,479 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for :class:`datus.cli.service_config_app.ServiceConfigApp`.
+
+Mirrors the test conventions of ``test_model_app.py``: the prompt_toolkit
+Application is never run under a pty — each test constructs a
+``ServiceConfigApp``, drives its state machine via the ``_on_*`` /
+``_submit_form`` action methods and asserts what the app would have
+returned to ``ServiceCommands``.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from datus.cli.service_config_app import (
+    ServiceConfigApp,
+    ServiceConfigSelection,
+    _Tab,
+    _View,
+)
+
+
+def _stub_agent_config(*, dashboards=None, schedulers=None, semantic=None, active_dash=None, active_sched=None):
+    """Minimal in-memory ``AgentConfig`` shim sufficient for the App."""
+    cfg = SimpleNamespace()
+    cfg.dashboard_config = dashboards or {}
+    cfg.scheduler_services = schedulers or {}
+    cfg.semantic_layer_configs = semantic or {}
+    cfg.active_dashboard = MagicMock(return_value=active_dash)
+    cfg.active_scheduler = MagicMock(return_value=active_sched)
+    return cfg
+
+
+def _build_app(**kwargs) -> ServiceConfigApp:
+    cfg = _stub_agent_config(**kwargs)
+    # ``is_adapter_installed`` is monkey-patched by individual tests when
+    # they care; default to True so the type picker doesn't try to pip
+    # install.
+    with patch("datus.cli.service_config_app.ServiceConfigApp._is_installed", return_value=True):
+        app = ServiceConfigApp(cfg, Console(file=io.StringIO(), no_color=True))
+    return app
+
+
+def _dash_cfg(adapter_type="superset", api_base_url="http://x", username="u", password="p"):
+    cfg = MagicMock()
+    cfg.adapter_type = adapter_type
+    cfg.api_base_url = api_base_url
+    cfg.username = username
+    cfg.password = password
+    cfg.api_key = ""
+    cfg.extra = {}
+    cfg.dataset_db = SimpleNamespace(datasource_ref="serving_db", bi_database_name="examples")
+    return cfg
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Tab cycling + LIST view
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestTabCycle:
+    def test_initial_tab_dashboard(self):
+        app = _build_app()
+        assert app._tab == _Tab.DASHBOARD
+
+    def test_initial_tab_scheduler_when_requested(self):
+        cfg = _stub_agent_config()
+        with patch("datus.cli.service_config_app.ServiceConfigApp._is_installed", return_value=True):
+            app = ServiceConfigApp(cfg, Console(file=io.StringIO()), initial_tab="scheduler")
+        assert app._tab == _Tab.SCHEDULER
+
+    def test_cycle_swaps_tabs(self):
+        app = _build_app()
+        app._cycle_tab(+1)
+        assert app._tab == _Tab.SCHEDULER
+        app._cycle_tab(+1)
+        assert app._tab == _Tab.SEMANTIC
+        app._cycle_tab(+1)
+        assert app._tab == _Tab.DASHBOARD
+
+    def test_initial_tab_semantic_when_requested(self):
+        cfg = _stub_agent_config()
+        with patch("datus.cli.service_config_app.ServiceConfigApp._is_installed", return_value=True):
+            app = ServiceConfigApp(cfg, Console(file=io.StringIO()), initial_tab="semantic")
+        assert app._tab == _Tab.SEMANTIC
+
+
+class TestListEntries:
+    def test_dashboard_list_renders_entries_and_add_row(self):
+        app = _build_app(dashboards={"superset": _dash_cfg()})
+        # Total rows = entries + 1 (Add row)
+        entries = app._entries_for(_Tab.DASHBOARD)
+        assert len(entries) == 1
+        rendered = app._render_list()
+        flat = "".join(text for _, text in rendered)
+        assert "superset" in flat
+        assert "Add new dashboard" in flat
+
+    def test_scheduler_default_flag_marks_entry(self):
+        app = _build_app(
+            schedulers={
+                "airflow_prod": {"type": "airflow", "default": True},
+                "airflow_dev": {"type": "airflow"},
+            },
+        )
+        app._tab = _Tab.SCHEDULER
+        entries = app._entries_for(_Tab.SCHEDULER)
+        names = {e.name: e.is_default for e in entries}
+        assert names == {"airflow_prod": True, "airflow_dev": False}
+
+    def test_project_default_marker_set_from_active_dashboard(self):
+        app = _build_app(
+            dashboards={"superset": _dash_cfg(), "grafana": _dash_cfg("grafana")},
+            active_dash="grafana",
+        )
+        entries = {e.name: e.is_project_default for e in app._entries_for(_Tab.DASHBOARD)}
+        assert entries == {"superset": False, "grafana": True}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Add → TYPE_PICKER → FORM
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestAddNewFlow:
+    def test_enter_on_add_row_opens_type_picker(self):
+        app = _build_app()
+        app._list_cursor = 0  # only Add row when no entries
+        with patch.object(app._app, "exit"):
+            app._on_list_enter()
+        assert app._view == _View.TYPE_PICKER
+        assert "superset" in app._type_choices
+
+    def test_type_picker_selection_enters_form(self):
+        app = _build_app()
+        app._enter_type_picker()
+        app._type_cursor = 0  # superset
+        with patch.object(app._app.layout, "focus"):
+            app._on_type_picker_enter()
+        assert app._view == _View.FORM
+        assert app._form_type == "superset"
+        assert app._form_is_edit is False
+
+    def test_form_submit_for_new_bi_emits_save(self):
+        app = _build_app()
+        app._enter_type_picker()
+        app._type_cursor = 0
+        with patch.object(app._app.layout, "focus"):
+            app._on_type_picker_enter()
+        app._fld_name.text = "my_superset"
+        app._fld_api_base_url.text = "http://localhost:8088"
+        app._fld_username.text = "admin"
+        app._fld_password.text = "secret"
+        app._fld_datasource_ref.text = "serving_db"
+        with patch.object(app._app, "exit") as mock_exit:
+            app._submit_form()
+        result = mock_exit.call_args.kwargs["result"]
+        assert isinstance(result, ServiceConfigSelection)
+        assert result.action == "save"
+        assert result.section == "bi_platforms"
+        assert result.name == "my_superset"
+        assert result.payload["type"] == "superset"
+        assert result.payload["api_base_url"] == "http://localhost:8088"
+        assert result.payload["password"] == "secret"
+        assert result.payload["dataset_db"] == {"datasource_ref": "serving_db"}
+
+    def test_form_rejects_blank_api_base_url_for_bi(self):
+        app = _build_app()
+        app._enter_type_picker()
+        with patch.object(app._app.layout, "focus"):
+            app._on_type_picker_enter()
+        app._fld_name.text = "x"
+        app._fld_api_base_url.text = ""  # missing
+        with patch.object(app._app, "exit") as mock_exit:
+            app._submit_form()
+        mock_exit.assert_not_called()
+        assert "api_base_url" in (app._error_message or "")
+
+    def test_duplicate_name_rejected_on_add(self):
+        app = _build_app(dashboards={"superset": _dash_cfg()})
+        app._enter_type_picker()
+        with patch.object(app._app.layout, "focus"):
+            app._on_type_picker_enter()
+        app._fld_name.text = "superset"  # collides
+        app._fld_api_base_url.text = "http://x"
+        with patch.object(app._app, "exit") as mock_exit:
+            app._submit_form()
+        mock_exit.assert_not_called()
+        assert "already exists" in (app._error_message or "")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Edit / delete / test / set_default / set_project_default
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestEditExisting:
+    def test_e_loads_existing_and_masks_password(self):
+        app = _build_app(dashboards={"superset": _dash_cfg(password="real-secret")})
+        app._list_cursor = 0
+        with patch.object(app._app.layout, "focus"):
+            app._on_edit()
+        assert app._view == _View.FORM
+        assert app._form_is_edit is True
+        # Masked placeholder, not the raw password.
+        assert app._fld_password.text != "real-secret"
+
+    def test_submit_with_masked_password_keeps_existing(self):
+        from datus.cli.service_config_app import _MASKED_PLACEHOLDER
+
+        app = _build_app(dashboards={"superset": _dash_cfg(password="real-secret")})
+        app._list_cursor = 0
+        with patch.object(app._app.layout, "focus"):
+            app._on_edit()
+        # User did not touch the password field.
+        assert app._fld_password.text == _MASKED_PLACEHOLDER
+        with patch.object(app._app, "exit") as mock_exit:
+            app._submit_form()
+        result = mock_exit.call_args.kwargs["result"]
+        # ``password`` is omitted from payload because the user kept the existing value.
+        assert "password" not in result.payload
+
+
+class TestDeleteAndTest:
+    def test_x_emits_delete(self):
+        app = _build_app(dashboards={"superset": _dash_cfg()})
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_delete()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "delete"
+        assert result.name == "superset"
+
+    def test_delete_ignored_on_add_row(self):
+        app = _build_app()
+        app._list_cursor = 0  # only Add row
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_delete()
+        mock_exit.assert_not_called()
+
+    def test_t_emits_test(self):
+        app = _build_app(dashboards={"superset": _dash_cfg()})
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_test()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "test"
+
+
+class TestSetGlobalDefault:
+    def test_d_only_active_on_scheduler_tab(self):
+        app = _build_app(dashboards={"superset": _dash_cfg()})
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_set_default()
+        # Dashboard tab → no exit.
+        mock_exit.assert_not_called()
+
+    def test_d_emits_set_default_on_scheduler_tab(self):
+        app = _build_app(schedulers={"airflow_prod": {"type": "airflow"}, "airflow_dev": {"type": "airflow"}})
+        app._tab = _Tab.SCHEDULER
+        app._list_cursor = 0  # airflow_dev sorts before airflow_prod alphabetically
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_set_default()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "set_default"
+        assert result.section == "schedulers"
+
+
+class TestSetProjectDefault:
+    def test_p_pins_when_not_currently_default(self):
+        app = _build_app(
+            dashboards={"superset": _dash_cfg(), "grafana": _dash_cfg("grafana")},
+            active_dash=None,
+        )
+        app._list_cursor = 0  # grafana sorts first
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_set_project_default()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "set_project_default"
+        assert result.section == "bi_platforms"
+        assert result.name == "grafana"
+
+    def test_p_clears_when_already_pinned(self):
+        app = _build_app(dashboards={"superset": _dash_cfg()}, active_dash="superset")
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_set_project_default()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "set_project_default"
+        assert result.name == ""  # clear sentinel
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Type picker — adapter installed indicator
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestTypePickerInstalled:
+    def test_installed_marker_reflects_helper(self):
+        cfg = _stub_agent_config()
+
+        # Mark superset as installed, grafana as missing.
+        def fake_installed(self, section, type_name):  # noqa: ARG001
+            return type_name == "superset"
+
+        with patch(
+            "datus.cli.service_config_app.ServiceConfigApp._is_installed",
+            new=fake_installed,
+        ):
+            app = ServiceConfigApp(cfg, Console(file=io.StringIO()))
+            app._enter_type_picker()
+            rendered = app._render_type_picker()
+
+        flat = "".join(text for _, text in rendered)
+        assert "superset" in flat and "(installed)" in flat
+        assert "grafana" in flat and "(will pip install)" in flat
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Cursor safety
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestCursor:
+    def test_clamp_with_no_entries_keeps_cursor_on_add_row(self):
+        app = _build_app()
+        # Only the Add row exists → total = 1, cursor must be 0.
+        app._list_cursor = 99
+        rendered = app._render_list()  # triggers _clamp_cursor internally
+        assert app._list_cursor == 0
+        flat = "".join(text for _, text in rendered)
+        assert "Add new dashboard" in flat
+
+
+@pytest.mark.parametrize(
+    "section,type_name",
+    [
+        ("bi_platforms", "superset"),
+        ("bi_platforms", "grafana"),
+        ("schedulers", "airflow"),
+        ("semantic_layer", "metricflow"),
+    ],
+)
+def test_builtin_types_present(section, type_name):
+    from datus.cli.service_config_app import _BUILTIN_TYPES
+
+    assert type_name in _BUILTIN_TYPES[section]
+
+
+def test_schedulers_currently_only_airflow():
+    """Lock the scheduler picker to ``airflow`` until another adapter
+    package ships. Adding more here is fine; *removing* ``airflow`` would
+    silently break the only working scheduler entry."""
+    from datus.cli.service_config_app import _BUILTIN_TYPES
+
+    assert _BUILTIN_TYPES["schedulers"] == ("airflow",)
+
+
+def test_semantic_layer_currently_only_metricflow():
+    """Lock the semantic picker to ``metricflow`` until another adapter
+    package ships. Removing it would break the sole supported semantic
+    layer entry."""
+    from datus.cli.service_config_app import _BUILTIN_TYPES
+
+    assert _BUILTIN_TYPES["semantic_layer"] == ("metricflow",)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Semantic tab — list, type-picker, save, delete
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestSemanticTab:
+    def test_build_semantic_entries_from_configs(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
+        entries = app._entries_for(_Tab.SEMANTIC)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.name == "metricflow"
+        assert entry.adapter_type == "metricflow"
+        assert entry.is_default is True  # single entry → default
+        assert entry.is_project_default is False
+
+    def test_render_list_shows_add_new_semantic_row(self):
+        app = _build_app()
+        app._tab = _Tab.SEMANTIC
+        rendered = app._render_list()
+        flat = "".join(text for _, text in rendered)
+        assert "Add new semantic" in flat
+
+    def test_type_picker_for_semantic_lists_metricflow(self):
+        app = _build_app()
+        app._tab = _Tab.SEMANTIC
+        app._enter_type_picker()
+        assert app._type_choices == ["metricflow"]
+
+    def test_type_picker_enter_emits_save_without_form(self):
+        app = _build_app()
+        app._tab = _Tab.SEMANTIC
+        app._enter_type_picker()
+        app._type_cursor = 0  # metricflow
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_type_picker_enter()
+        # FORM view is skipped — selection is emitted straight from the picker.
+        assert app._view != _View.FORM
+        result = mock_exit.call_args.kwargs["result"]
+        assert isinstance(result, ServiceConfigSelection)
+        assert result.action == "save"
+        assert result.section == "semantic_layer"
+        assert result.name == "metricflow"
+        assert result.payload == {"type": "metricflow"}
+
+    def test_enter_on_existing_entry_is_noop(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
+        app._tab = _Tab.SEMANTIC
+        app._list_cursor = 0  # existing metricflow row
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_list_enter()
+        # No FORM, no exit — semantic entries have nothing editable yet.
+        assert app._view == _View.LIST
+        mock_exit.assert_not_called()
+
+    def test_e_key_ignored_on_semantic_tab(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
+        app._tab = _Tab.SEMANTIC
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_edit()
+        assert app._view == _View.LIST
+        mock_exit.assert_not_called()
+
+    def test_p_key_ignored_on_semantic_tab(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
+        app._tab = _Tab.SEMANTIC
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_set_project_default()
+        mock_exit.assert_not_called()
+
+    def test_x_emits_delete_for_semantic(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
+        app._tab = _Tab.SEMANTIC
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_delete()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "delete"
+        assert result.section == "semantic_layer"
+        assert result.name == "metricflow"
+
+    def test_t_emits_test_for_semantic(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
+        app._tab = _Tab.SEMANTIC
+        app._list_cursor = 0
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_test()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "test"
+        assert result.section == "semantic_layer"
+
+    def test_footer_hint_omits_edit_and_default_keys(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
+        app._tab = _Tab.SEMANTIC
+        rendered = app._render_footer_hint()
+        flat = "".join(text for _, text in rendered)
+        assert "edit" not in flat
+        assert "project default" not in flat
+        assert "global default" not in flat
+        # Allowed keys still present.
+        assert "delete" in flat
+        assert "test" in flat

--- a/tests/unit_tests/cli/test_service_config_app.py
+++ b/tests/unit_tests/cli/test_service_config_app.py
@@ -255,13 +255,17 @@ class TestDeleteAndTest:
 
 
 class TestSetGlobalDefault:
-    def test_d_only_active_on_scheduler_tab(self):
-        app = _build_app(dashboards={"superset": _dash_cfg()})
-        app._list_cursor = 0
+    def test_d_emits_set_default_on_dashboard_tab(self):
+        """``d`` is now active on every tab — Dashboard included."""
+        app = _build_app(dashboards={"superset": _dash_cfg(), "grafana": _dash_cfg("grafana")})
+        app._tab = _Tab.DASHBOARD
+        app._list_cursor = 0  # grafana sorts before superset alphabetically
         with patch.object(app._app, "exit") as mock_exit:
             app._on_set_default()
-        # Dashboard tab → no exit.
-        mock_exit.assert_not_called()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "set_default"
+        assert result.section == "bi_platforms"
+        assert result.name == "grafana"
 
     def test_d_emits_set_default_on_scheduler_tab(self):
         app = _build_app(schedulers={"airflow_prod": {"type": "airflow"}, "airflow_dev": {"type": "airflow"}})
@@ -272,6 +276,22 @@ class TestSetGlobalDefault:
         result = mock_exit.call_args.kwargs["result"]
         assert result.action == "set_default"
         assert result.section == "schedulers"
+
+    def test_d_emits_set_default_on_semantic_tab(self):
+        app = _build_app(
+            semantic={
+                "metricflow": {"type": "metricflow"},
+                "dbt": {"type": "dbt"},
+            }
+        )
+        app._tab = _Tab.SEMANTIC
+        app._list_cursor = 0  # dbt sorts before metricflow
+        with patch.object(app._app, "exit") as mock_exit:
+            app._on_set_default()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "set_default"
+        assert result.section == "semantic_layer"
+        assert result.name == "dbt"
 
 
 class TestSetProjectDefault:
@@ -380,14 +400,22 @@ def test_semantic_layer_currently_only_metricflow():
 
 class TestSemanticTab:
     def test_build_semantic_entries_from_configs(self):
+        """``is_default`` reflects only the explicit YAML ``default: true``
+        flag — the single-entry shortcut is an implicit fallback handled
+        by the resolver, not a label we display."""
         app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
         entries = app._entries_for(_Tab.SEMANTIC)
         assert len(entries) == 1
         entry = entries[0]
         assert entry.name == "metricflow"
         assert entry.adapter_type == "metricflow"
-        assert entry.is_default is True  # single entry → default
+        assert entry.is_default is False  # no ``default: true`` in YAML
         assert entry.is_project_default is False
+
+    def test_build_semantic_entries_marks_yaml_default_flag(self):
+        app = _build_app(semantic={"metricflow": {"type": "metricflow", "default": True}})
+        entry = app._entries_for(_Tab.SEMANTIC)[0]
+        assert entry.is_default is True
 
     def test_render_list_shows_add_new_semantic_row(self):
         app = _build_app()
@@ -437,13 +465,18 @@ class TestSemanticTab:
         assert app._view == _View.LIST
         mock_exit.assert_not_called()
 
-    def test_p_key_ignored_on_semantic_tab(self):
+    def test_p_emits_set_project_default_for_semantic(self):
+        """Semantic now supports project-level pinning (``set_active_semantic``)
+        on par with Dashboard / Scheduler."""
         app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
         app._tab = _Tab.SEMANTIC
         app._list_cursor = 0
         with patch.object(app._app, "exit") as mock_exit:
             app._on_set_project_default()
-        mock_exit.assert_not_called()
+        result = mock_exit.call_args.kwargs["result"]
+        assert result.action == "set_project_default"
+        assert result.section == "semantic_layer"
+        assert result.name == "metricflow"
 
     def test_x_emits_delete_for_semantic(self):
         app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
@@ -466,14 +499,16 @@ class TestSemanticTab:
         assert result.action == "test"
         assert result.section == "semantic_layer"
 
-    def test_footer_hint_omits_edit_and_default_keys(self):
+    def test_footer_hint_includes_default_keys_but_omits_edit(self):
+        """``e edit`` is hidden because metricflow has no editable fields,
+        but ``d global default`` and ``p project default`` are now shown
+        on every tab — Semantic included."""
         app = _build_app(semantic={"metricflow": {"type": "metricflow"}})
         app._tab = _Tab.SEMANTIC
         rendered = app._render_footer_hint()
         flat = "".join(text for _, text in rendered)
         assert "edit" not in flat
-        assert "project default" not in flat
-        assert "global default" not in flat
-        # Allowed keys still present.
+        assert "global default" in flat
+        assert "project default" in flat
         assert "delete" in flat
         assert "test" in flat

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -504,28 +504,29 @@ class TestAgentConfigServiceSelectors:
         )
         assert cfg.resolve_semantic_adapter() == "metricflow"
 
-    def test_resolve_semantic_adapter_defaults_to_metricflow_without_service_config(self, tmp_path):
+    def test_resolve_semantic_adapter_raises_when_no_service_configured(self, tmp_path):
+        """The implicit metricflow fallback was removed: callers must
+        explicitly configure at least one entry under
+        ``services.semantic_layer``. The error message points the user at
+        the YAML or the ``/services semantic`` TUI."""
         cfg = self._make(
             tmp_path,
             services={
                 "datasources": {},
             },
         )
-        assert cfg.resolve_semantic_adapter() == "metricflow"
+        with pytest.raises(DatusException, match="No semantic layer configured"):
+            cfg.resolve_semantic_adapter()
 
-    def test_build_semantic_adapter_config_defaults_to_metricflow_without_service_config(self, tmp_path):
+    def test_build_semantic_adapter_config_raises_when_no_service_configured(self, tmp_path):
         cfg = self._make(
             tmp_path,
             services={
                 "datasources": {},
             },
         )
-
-        config = cfg.build_semantic_adapter_config()
-
-        assert config["type"] == "metricflow"
-        assert config["agent_home"] == str(tmp_path / "h")
-        assert config["semantic_models_path"].endswith("subject/semantic_models")
+        with pytest.raises(DatusException, match="No semantic layer configured"):
+            cfg.build_semantic_adapter_config()
 
     def test_resolve_semantic_adapter_requires_explicit_choice_for_multiple_entries(self, tmp_path):
         cfg = self._make(
@@ -785,6 +786,147 @@ class TestAgentConfigServiceSelectors:
                     },
                 },
             )
+
+    # ── default_dashboard_service ─────────────────────────────────────
+
+    def test_default_dashboard_service_returns_none_for_empty_section(self, tmp_path):
+        cfg = self._make(tmp_path, services={"datasources": {}})
+        assert cfg.default_dashboard_service() is None
+
+    def test_default_dashboard_service_uses_unique_entry(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "bi_platforms": {
+                    "superset": {"type": "superset", "api_base_url": "http://x"},
+                },
+            },
+        )
+        assert cfg.default_dashboard_service() == "superset"
+
+    def test_default_dashboard_service_picks_default_flag(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "bi_platforms": {
+                    "superset": {"type": "superset", "api_base_url": "http://prod"},
+                    "grafana": {"type": "grafana", "api_base_url": "http://dev", "default": True},
+                },
+            },
+        )
+        assert cfg.default_dashboard_service() == "grafana"
+
+    def test_default_dashboard_service_rejects_multiple_defaults(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "bi_platforms": {
+                    "superset": {"type": "superset", "default": True, "api_base_url": "http://a"},
+                    "grafana": {"type": "grafana", "default": True, "api_base_url": "http://b"},
+                },
+            },
+        )
+        with pytest.raises(DatusException, match="Multiple BI services are marked"):
+            cfg.default_dashboard_service()
+
+    def test_default_dashboard_service_returns_none_when_multiple_no_default(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "bi_platforms": {
+                    "superset": {"type": "superset", "api_base_url": "http://a"},
+                    "grafana": {"type": "grafana", "api_base_url": "http://b"},
+                },
+            },
+        )
+        assert cfg.default_dashboard_service() is None
+
+    # ── default_semantic_adapter ───────────────────────────────────────
+
+    def test_default_semantic_adapter_returns_none_for_empty_section(self, tmp_path):
+        """Empty section now means "nothing configured" — callers must
+        explicitly add an entry. Returning ``None`` here lets the resolver
+        own the user-facing error."""
+        cfg = self._make(tmp_path, services={"datasources": {}})
+        assert cfg.default_semantic_adapter() is None
+
+    def test_default_semantic_adapter_uses_unique_entry(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "semantic_layer": {"metricflow": {}},
+            },
+        )
+        assert cfg.default_semantic_adapter() == "metricflow"
+
+    def test_default_semantic_adapter_picks_default_flag(self, tmp_path):
+        """When multiple semantic adapters are configured, ``default: true``
+        wins over the unique-entry shortcut (which doesn't apply here)."""
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "semantic_layer": {
+                    "metricflow": {"default": True},
+                    # Hypothetical second adapter — registry validation is
+                    # deferred so the test can exercise the selection
+                    # logic without registering a real adapter.
+                    "dbt": {},
+                },
+            },
+        )
+        assert cfg.default_semantic_adapter() == "metricflow"
+
+    def test_default_semantic_adapter_rejects_multiple_defaults(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "semantic_layer": {
+                    "metricflow": {"default": True},
+                    "dbt": {"default": True},
+                },
+            },
+        )
+        with pytest.raises(DatusException, match="Multiple semantic layers are marked"):
+            cfg.default_semantic_adapter()
+
+    # ── active_semantic / set_active_semantic / resolver pin ────────────
+
+    def test_active_semantic_pin_outranks_global_default(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "semantic_layer": {
+                    "metricflow": {"default": True},
+                    "dbt": {},
+                },
+            },
+        )
+        cfg.set_active_semantic("dbt", persist=False)
+        assert cfg.resolve_semantic_adapter() == "dbt"
+
+    def test_stale_active_semantic_falls_through_to_default(self, tmp_path, caplog):
+        """A pin pointing at a deleted adapter is ignored (with warning);
+        resolution falls through to the global default."""
+        import logging
+
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+                "semantic_layer": {"metricflow": {}},
+            },
+        )
+        cfg.set_active_semantic("never_configured", persist=False)
+        with caplog.at_level(logging.WARNING):
+            assert cfg.resolve_semantic_adapter() == "metricflow"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -554,6 +554,124 @@ class TestAgentConfigServiceSelectors:
         )
         assert cfg.default_scheduler_service() == "airflow_prod"
 
+    def test_active_scheduler_overrides_global_default(self, tmp_path):
+        """Project-level ``active_scheduler`` outranks ``default: true``."""
+        cfg = AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            project_root=str(tmp_path / "proj"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            services={
+                "datasources": {},
+                "schedulers": {
+                    "airflow_prod": {"type": "airflow", "default": True},
+                    "airflow_dev": {"type": "airflow"},
+                },
+            },
+            active_scheduler="airflow_dev",
+            skip_init_dirs=True,
+        )
+        # Explicit name still wins over project override.
+        assert cfg.get_scheduler_config("airflow_prod")["name"] == "airflow_prod"
+        # No explicit name → project override beats the global default flag.
+        chosen = cfg.get_scheduler_config()
+        assert chosen.get("name") == "airflow_dev"
+
+    def test_active_scheduler_stale_falls_back_to_global_default(self, tmp_path, caplog):
+        cfg = AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            project_root=str(tmp_path / "proj"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            services={
+                "datasources": {},
+                "schedulers": {
+                    "airflow_prod": {"type": "airflow", "default": True},
+                },
+            },
+            active_scheduler="never_configured",
+            skip_init_dirs=True,
+        )
+        with caplog.at_level("WARNING"):
+            chosen = cfg.get_scheduler_config()
+        assert chosen.get("name") == "airflow_prod"
+        joined = " ".join(r.message for r in caplog.records)
+        assert "never_configured" in joined
+
+    def test_set_active_dashboard_persists_to_project_override(self, tmp_path):
+        cfg = AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            project_root=str(tmp_path / "proj"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            services={"datasources": {}},
+            skip_init_dirs=True,
+        )
+        cfg.set_active_dashboard("superset")
+        assert cfg.active_dashboard() == "superset"
+
+        from datus.configuration.project_config import load_project_override
+
+        loaded = load_project_override(cwd=str(tmp_path / "proj"))
+        assert loaded is not None
+        assert loaded.dashboard == "superset"
+
+        cfg.set_active_dashboard(None)
+        assert cfg.active_dashboard() is None
+        loaded = load_project_override(cwd=str(tmp_path / "proj"))
+        # Cleared field is omitted on disk.
+        assert loaded is None or loaded.dashboard is None
+
+    def test_set_active_scheduler_persists_to_project_override(self, tmp_path):
+        cfg = AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            project_root=str(tmp_path / "proj"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            services={"datasources": {}},
+            skip_init_dirs=True,
+        )
+        cfg.set_active_scheduler("airflow")
+        assert cfg.active_scheduler() == "airflow"
+
+        from datus.configuration.project_config import load_project_override
+
+        loaded = load_project_override(cwd=str(tmp_path / "proj"))
+        assert loaded is not None
+        assert loaded.scheduler == "airflow"
+
     def test_file_datasource_uri_expands_env_vars(self, tmp_path, monkeypatch):
         db_dir = tmp_path / "db"
         db_dir.mkdir()

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -364,6 +364,39 @@ class TestApplyProjectOverride:
             with pytest.raises(DatusException):
                 _apply_project_override(agent_raw)
 
+    def test_dashboard_override_forwarded_as_active_dashboard(self):
+        """Project-level ``dashboard:`` reaches AgentConfig via the
+        ``active_dashboard`` kwarg so ``BIFuncTool._resolved_platform`` can
+        consult it between explicit and unique-entry resolution."""
+        agent_raw = self._base_raw()
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(dashboard="superset_prod"),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["active_dashboard"] == "superset_prod"
+        assert "active_scheduler" not in agent_raw
+
+    def test_scheduler_override_forwarded_as_active_scheduler(self):
+        agent_raw = self._base_raw()
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(scheduler="airflow_dev"),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["active_scheduler"] == "airflow_dev"
+        assert "active_dashboard" not in agent_raw
+
+    def test_no_service_overrides_leaves_agent_raw_clean(self):
+        agent_raw = self._base_raw()
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(),
+        ):
+            _apply_project_override(agent_raw)
+        assert "active_dashboard" not in agent_raw
+        assert "active_scheduler" not in agent_raw
+
 
 class TestLoadNodeConfig:
     def test_with_model(self):

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -208,7 +208,15 @@ class TestSaveProjectOverride:
 class TestAllowedKeys:
     def test_whitelist_contains_expected_keys(self):
         assert ALLOWED_KEYS == frozenset(
-            {"target", "default_datasource", "project_name", "language", "reasoning_effort"}
+            {
+                "target",
+                "default_datasource",
+                "dashboard",
+                "scheduler",
+                "project_name",
+                "language",
+                "reasoning_effort",
+            }
         )
 
 
@@ -221,6 +229,8 @@ class TestProjectOverrideDataclass:
         [
             ("target", "x"),
             ("default_datasource", "y"),
+            ("dashboard", "superset"),
+            ("scheduler", "airflow"),
             ("project_name", "z"),
             ("language", "zh"),
             ("reasoning_effort", "high"),
@@ -229,3 +239,48 @@ class TestProjectOverrideDataclass:
     def test_is_not_empty_when_any_set(self, field, value):
         override = ProjectOverride(**{field: value})
         assert not override.is_empty()
+
+
+class TestServiceDefaultFields:
+    """``dashboard`` / ``scheduler`` overrides — project-level pin for BI
+    + scheduler services. Loaded by ``_apply_project_override`` and
+    surfaced via ``AgentConfig.active_dashboard()`` / ``active_scheduler()``."""
+
+    def test_load_dashboard_and_scheduler(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"dashboard": "superset_prod", "scheduler": "airflow"}))
+        result = load_project_override(str(tmp_path))
+        assert result.dashboard == "superset_prod"
+        assert result.scheduler == "airflow"
+        assert not result.is_empty()
+
+    def test_blank_dashboard_collapses_to_none(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"dashboard": "   "}))
+        result = load_project_override(str(tmp_path))
+        assert result.dashboard is None
+
+    def test_non_string_scheduler_dropped(self, tmp_path, caplog):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"scheduler": 42}))
+        with caplog.at_level(logging.WARNING):
+            result = load_project_override(str(tmp_path))
+        assert result.scheduler is None
+        warning_text = " ".join(r.message for r in caplog.records)
+        assert "scheduler" in warning_text
+
+    def test_save_round_trip(self, tmp_path):
+        original = ProjectOverride(dashboard="superset", scheduler="airflow")
+        save_project_override(original, cwd=str(tmp_path))
+        loaded = load_project_override(str(tmp_path))
+        assert loaded == original
+
+    def test_save_omits_none_service_fields(self, tmp_path):
+        override = ProjectOverride(dashboard="only_dash")
+        written = save_project_override(override, cwd=str(tmp_path))
+        loaded = yaml.safe_load(written.read_text())
+        assert "dashboard" in loaded
+        assert "scheduler" not in loaded

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -213,6 +213,7 @@ class TestAllowedKeys:
                 "default_datasource",
                 "dashboard",
                 "scheduler",
+                "semantic",
                 "project_name",
                 "language",
                 "reasoning_effort",
@@ -231,6 +232,7 @@ class TestProjectOverrideDataclass:
             ("default_datasource", "y"),
             ("dashboard", "superset"),
             ("scheduler", "airflow"),
+            ("semantic", "metricflow"),
             ("project_name", "z"),
             ("language", "zh"),
             ("reasoning_effort", "high"),
@@ -242,9 +244,23 @@ class TestProjectOverrideDataclass:
 
 
 class TestServiceDefaultFields:
-    """``dashboard`` / ``scheduler`` overrides — project-level pin for BI
-    + scheduler services. Loaded by ``_apply_project_override`` and
-    surfaced via ``AgentConfig.active_dashboard()`` / ``active_scheduler()``."""
+    """``dashboard`` / ``scheduler`` / ``semantic`` overrides — project-level
+    pins for the three service sections. Loaded by
+    ``_apply_project_override`` and surfaced via
+    ``AgentConfig.active_dashboard()`` / ``active_scheduler()`` /
+    ``active_semantic()``."""
+
+    def test_load_all_three_service_pins(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            yaml.safe_dump({"dashboard": "superset_prod", "scheduler": "airflow", "semantic": "metricflow"})
+        )
+        result = load_project_override(str(tmp_path))
+        assert result.dashboard == "superset_prod"
+        assert result.scheduler == "airflow"
+        assert result.semantic == "metricflow"
+        assert not result.is_empty()
 
     def test_load_dashboard_and_scheduler(self, tmp_path):
         path = tmp_path / PROJECT_CONFIG_REL
@@ -253,7 +269,31 @@ class TestServiceDefaultFields:
         result = load_project_override(str(tmp_path))
         assert result.dashboard == "superset_prod"
         assert result.scheduler == "airflow"
+        assert result.semantic is None
         assert not result.is_empty()
+
+    def test_blank_semantic_collapses_to_none(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"semantic": "   "}))
+        result = load_project_override(str(tmp_path))
+        assert result.semantic is None
+
+    def test_non_string_semantic_dropped(self, tmp_path, caplog):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"semantic": 42}))
+        with caplog.at_level(logging.WARNING):
+            result = load_project_override(str(tmp_path))
+        assert result.semantic is None
+        warning_text = " ".join(r.message for r in caplog.records)
+        assert "semantic" in warning_text
+
+    def test_save_round_trip_with_semantic(self, tmp_path):
+        original = ProjectOverride(dashboard="superset", scheduler="airflow", semantic="metricflow")
+        save_project_override(original, cwd=str(tmp_path))
+        loaded = load_project_override(str(tmp_path))
+        assert loaded == original
 
     def test_blank_dashboard_collapses_to_none(self, tmp_path):
         path = tmp_path / PROJECT_CONFIG_REL

--- a/tests/unit_tests/tools/func_tool/test_bi_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_bi_tools.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ---- Minimal stubs for datus_bi_core (so tests run without the package) ----
 
 
@@ -874,3 +876,63 @@ class TestGetBiServingTarget:
         result = tool.get_bi_serving_target()
         assert result.success == 0
         assert "dataset_db" in result.error
+
+
+class TestBIFuncToolResolvePlatform:
+    """``_resolved_platform`` resolution order — explicit > project default
+    > unique > error. The project-default branch was added to support the
+    ``/services`` TUI's project-level pin."""
+
+    def _agent_cfg(self, *, dashboards, active=None):
+        cfg = MagicMock()
+        cfg.dashboard_config = dashboards
+        cfg.active_dashboard = MagicMock(return_value=active)
+        return cfg
+
+    def test_explicit_bi_service_wins_over_active(self):
+        from datus.tools.func_tool.bi_tools import BIFuncTool
+
+        cfg = self._agent_cfg(
+            dashboards={"superset": MagicMock(), "grafana": MagicMock()},
+            active="grafana",
+        )
+        tool = BIFuncTool(cfg, bi_service="superset")
+        assert tool._resolved_platform() == "superset"
+
+    def test_active_dashboard_used_when_multiple_configured(self):
+        from datus.tools.func_tool.bi_tools import BIFuncTool
+
+        cfg = self._agent_cfg(
+            dashboards={"superset": MagicMock(), "grafana": MagicMock()},
+            active="grafana",
+        )
+        tool = BIFuncTool(cfg)
+        assert tool._resolved_platform() == "grafana"
+
+    def test_stale_active_falls_through_to_unique(self):
+        from datus.tools.func_tool.bi_tools import BIFuncTool
+
+        cfg = self._agent_cfg(
+            dashboards={"superset": MagicMock()},
+            active="never_configured",
+        )
+        tool = BIFuncTool(cfg)
+        assert tool._resolved_platform() == "superset"
+
+    def test_no_active_with_unique_falls_back(self):
+        from datus.tools.func_tool.bi_tools import BIFuncTool
+
+        cfg = self._agent_cfg(dashboards={"superset": MagicMock()})
+        tool = BIFuncTool(cfg)
+        assert tool._resolved_platform() == "superset"
+
+    def test_multiple_without_active_raises(self):
+        from datus.tools.func_tool.bi_tools import BIFuncTool
+        from datus.utils.exceptions import DatusException
+
+        cfg = self._agent_cfg(
+            dashboards={"superset": MagicMock(), "grafana": MagicMock()},
+        )
+        tool = BIFuncTool(cfg)
+        with pytest.raises(DatusException, match="Multiple BI platforms"):
+            tool._resolved_platform()

--- a/tests/unit_tests/tools/func_tool/test_bi_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_bi_tools.py
@@ -879,14 +879,33 @@ class TestGetBiServingTarget:
 
 
 class TestBIFuncToolResolvePlatform:
-    """``_resolved_platform`` resolution order — explicit > project default
-    > unique > error. The project-default branch was added to support the
-    ``/services`` TUI's project-level pin."""
+    """``_resolved_platform`` resolution order — explicit > project pin >
+    global ``default: true`` flag (or single-entry shortcut) > error.
+    Mirrors ``get_scheduler_config`` / ``resolve_semantic_adapter`` so all
+    three sections behave identically."""
 
-    def _agent_cfg(self, *, dashboards, active=None):
+    def _agent_cfg(self, *, dashboards, active=None, default=None):
+        """Build a minimal AgentConfig stub.
+
+        ``default`` lets a test pretend ``default_dashboard_service``
+        returned a specific value; ``None`` simulates "no default" so the
+        unique-shortcut / multi-without-default branches can be exercised.
+        Falling back to a key from ``dashboards`` when the test omits
+        ``default`` keeps the legacy single-entry tests passing without
+        forcing them to set up the resolver explicitly.
+        """
+
+        def _resolve_default():
+            if default is not None:
+                return default
+            if len(dashboards) == 1:
+                return next(iter(dashboards))
+            return None
+
         cfg = MagicMock()
         cfg.dashboard_config = dashboards
         cfg.active_dashboard = MagicMock(return_value=active)
+        cfg.default_dashboard_service = MagicMock(side_effect=_resolve_default)
         return cfg
 
     def test_explicit_bi_service_wins_over_active(self):
@@ -926,12 +945,34 @@ class TestBIFuncToolResolvePlatform:
         tool = BIFuncTool(cfg)
         assert tool._resolved_platform() == "superset"
 
+    def test_global_default_used_when_multiple_configured(self):
+        from datus.tools.func_tool.bi_tools import BIFuncTool
+
+        cfg = self._agent_cfg(
+            dashboards={"superset": MagicMock(), "grafana": MagicMock()},
+            default="grafana",
+        )
+        tool = BIFuncTool(cfg)
+        assert tool._resolved_platform() == "grafana"
+
+    def test_active_pin_outranks_global_default(self):
+        from datus.tools.func_tool.bi_tools import BIFuncTool
+
+        cfg = self._agent_cfg(
+            dashboards={"superset": MagicMock(), "grafana": MagicMock()},
+            active="superset",
+            default="grafana",
+        )
+        tool = BIFuncTool(cfg)
+        assert tool._resolved_platform() == "superset"
+
     def test_multiple_without_active_raises(self):
         from datus.tools.func_tool.bi_tools import BIFuncTool
         from datus.utils.exceptions import DatusException
 
         cfg = self._agent_cfg(
             dashboards={"superset": MagicMock(), "grafana": MagicMock()},
+            default=None,  # explicitly no default flag
         )
         tool = BIFuncTool(cfg)
         with pytest.raises(DatusException, match="Multiple BI platforms"):


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - `/services` command now features an interactive TUI for configuring BI dashboards, schedulers, and semantic adapters
  - Automatic on-demand installation of missing adapter packages with hot-reload
  - Global and per-project service defaults with clear selection precedence

* **Bug Fixes**
  - Semantic layer configuration now requires explicit setup; removed implicit MetricFlow fallback

* **Documentation**
  - Updated configuration guides for BI platforms, schedulers, and semantic layers
  - Improved quickstart setup instructions with simplified environment setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->