### PR TITLE
[BugFix] Use uv pip install for service adapters when uv is on PATH

### DIFF
--- a/datus/cli/service_adapter_installer.py
+++ b/datus/cli/service_adapter_installer.py
@@ -11,26 +11,30 @@ installed yet. The TUI calls into this module to:
 
 1. Detect whether the adapter is already importable
    (:func:`is_adapter_installed`).
-2. Run ``pip install`` for the missing package
-   (:func:`ensure_adapter`) — the install runs through
-   ``sys.executable -m pip`` so it targets the same interpreter that
-   loaded ``datus-cli`` (works for venv / pipx / uv-installed CLIs).
+2. Install the missing package (:func:`ensure_adapter`). When ``uv`` is
+   on ``PATH`` we shell out to ``uv pip install --python <sys.executable>
+   <pkg>`` so it works inside ``uv tool install`` / bare ``uv venv``
+   environments where ``pip`` is not seeded. Otherwise we fall back to
+   ``sys.executable -m pip install <pkg>``. Either way the package
+   lands in the interpreter that loaded ``datus-cli`` (venv / pipx /
+   uv-installed CLIs).
 3. Import the adapter module and refresh the BI / scheduler registries
    without restarting the process (:func:`hot_reload_adapter`).
 
 Pure Python on purpose — the module has no prompt_toolkit dependency so
-it can be unit-tested by monkey-patching ``subprocess.run`` and
-``importlib.util.find_spec``.
+it can be unit-tested by monkey-patching ``subprocess.run``,
+``shutil.which`` and ``importlib.util.find_spec``.
 """
 
 from __future__ import annotations
 
 import importlib
 import importlib.util
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import Callable, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from datus.utils.loggings import get_logger
 
@@ -115,18 +119,37 @@ def is_adapter_installed(section: str, adapter_type: str) -> bool:
         return False
 
 
+def _install_command(pkg: str) -> Tuple[List[str], str]:
+    """Pick the install command, preferring ``uv pip`` when available.
+
+    Mirrors ``datus.cli.datasource_commands._install_plugin``: ``uv tool
+    install`` and bare ``uv venv`` environments do not seed ``pip``, so
+    a plain ``python -m pip install`` exits with code 1 there. Routing
+    through ``uv pip install --python <sys.executable>`` reuses the
+    active interpreter without requiring ``pip`` to be present.
+
+    Returns ``(argv, label)`` where ``label`` names the underlying tool
+    (``"uv pip install"`` / ``"pip install"``) so callers can build
+    error messages that match the command actually executed.
+    """
+    uv_path = shutil.which("uv")
+    if uv_path:
+        return [uv_path, "pip", "install", "--python", sys.executable, pkg], "uv pip install"
+    return [sys.executable, "-m", "pip", "install", pkg], "pip install"
+
+
 def ensure_adapter(
     section: str,
     adapter_type: str,
     *,
     line_callback: Optional[Callable[[str], None]] = None,
 ) -> InstallResult:
-    """Install the adapter package via ``sys.executable -m pip`` if missing.
+    """Install the adapter package (via ``uv pip`` or ``pip``) if missing.
 
-    ``line_callback`` (when provided) receives one line of pip
+    ``line_callback`` (when provided) receives one line of installer
     stdout/stderr at a time so the TUI can display a live tail. The
-    function blocks until pip exits — the caller is expected to run it
-    on a worker thread when the UI must stay responsive.
+    function blocks until the installer exits — the caller is expected
+    to run it on a worker thread when the UI must stay responsive.
     """
     try:
         pkg, import_name = package_for(section, adapter_type)
@@ -136,7 +159,7 @@ def ensure_adapter(
     if is_adapter_installed(section, adapter_type):
         return InstallResult(ok=True, package=pkg, import_name=import_name)
 
-    cmd = [sys.executable, "-m", "pip", "install", pkg]
+    cmd, label = _install_command(pkg)
     logger.info("Installing adapter package: %s", " ".join(cmd))
     try:
         proc = subprocess.run(
@@ -162,7 +185,7 @@ def ensure_adapter(
             import_name=import_name,
             stdout=stdout,
             stderr=stderr,
-            error=f"pip install exited with code {proc.returncode}",
+            error=f"{label} exited with code {proc.returncode}",
         )
 
     importlib.invalidate_caches()

--- a/tests/unit_tests/cli/test_service_adapter_installer.py
+++ b/tests/unit_tests/cli/test_service_adapter_installer.py
@@ -78,6 +78,7 @@ class TestEnsureAdapter:
 
     def test_runs_pip_when_missing_and_succeeds(self, monkeypatch):
         monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(sai.shutil, "which", lambda name: None)
         captured = {}
 
         def fake_run(cmd, capture_output, text, check):
@@ -93,8 +94,52 @@ class TestEnsureAdapter:
         assert captured["cmd"][:3] == [sai.sys.executable, "-m", "pip"]
         assert "datus-scheduler-airflow" in captured["cmd"]
 
+    def test_uses_uv_when_uv_on_path(self, monkeypatch):
+        """When ``uv`` is discoverable, we must shell out to
+        ``uv pip install --python <sys.executable> <pkg>`` instead of
+        ``python -m pip install``. ``uv tool install`` / bare
+        ``uv venv`` envs do not seed pip, so the legacy path exits 1
+        there — this branch is the whole reason the function exists."""
+        monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(sai.shutil, "which", lambda name: "/usr/local/bin/uv" if name == "uv" else None)
+        captured = {}
+
+        def fake_run(cmd, capture_output, text, check):
+            captured["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(sai.subprocess, "run", fake_run)
+        monkeypatch.setattr(sai.importlib, "invalidate_caches", lambda: None)
+
+        result = sai.ensure_adapter("bi_platforms", "superset")
+        assert result.ok is True
+        assert captured["cmd"] == [
+            "/usr/local/bin/uv",
+            "pip",
+            "install",
+            "--python",
+            sai.sys.executable,
+            "datus-bi-superset",
+        ]
+
+    def test_uv_failure_error_message_names_uv(self, monkeypatch):
+        """Failure messages must match the tool we actually invoked so
+        the user can copy-paste the equivalent command. With uv on PATH
+        the prefix is ``uv pip install`` — not ``pip install``."""
+        monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(sai.shutil, "which", lambda name: "/usr/local/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr(
+            sai.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="resolve failed"),
+        )
+        result = sai.ensure_adapter("bi_platforms", "ghost")
+        assert result.ok is False
+        assert result.error == "uv pip install exited with code 1"
+
     def test_pip_failure_surfaces_error(self, monkeypatch):
         monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(sai.shutil, "which", lambda name: None)
         monkeypatch.setattr(
             sai.subprocess,
             "run",
@@ -102,7 +147,7 @@ class TestEnsureAdapter:
         )
         result = sai.ensure_adapter("bi_platforms", "ghost")
         assert result.ok is False
-        assert "exited with code 1" in (result.error or "")
+        assert result.error == "pip install exited with code 1"
         assert "ERROR" in result.stderr
 
     def test_unknown_section_returns_error(self):
@@ -115,6 +160,7 @@ class TestEnsureAdapter:
         ``pip install datus-semantic-metricflow`` when the package isn't
         already importable — this is the entire point of the new tab."""
         monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(sai.shutil, "which", lambda name: None)
         captured = {}
 
         def fake_run(cmd, capture_output, text, check):
@@ -131,6 +177,7 @@ class TestEnsureAdapter:
 
     def test_line_callback_receives_pip_output(self, monkeypatch):
         monkeypatch.setattr(sai, "is_adapter_installed", lambda *_: False)
+        monkeypatch.setattr(sai.shutil, "which", lambda name: None)
         monkeypatch.setattr(
             sai.subprocess,
             "run",


### PR DESCRIPTION
`/services` background install of `datus-bi-<type>` / `datus-scheduler-<type>` / `datus-semantic-<type>` exited with code 1 under `uv tool install` / bare `uv venv` because those environments do not seed `pip`. Mirror `datasource_commands._install_plugin`: when `shutil.which("uv")` is present, route through
`uv pip install --python <sys.executable> <pkg>`; otherwise fall back to `python -m pip install`. Failure message names the actual tool used.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adapter installation now supports `uv` for faster package installation when available, with automatic fallback to standard pip.

* **Bug Fixes**
  * Improved error messages to clearly indicate which installation tool encountered a failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->