### PR TITLE
[BugFix] Add json_repair fallback for malformed LLM tool call arguments

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -7,6 +7,7 @@ import inspect
 import json
 from typing import Any, Callable, Dict, List, Optional
 
+import json_repair
 from agents import FunctionTool, function_tool
 from pydantic import BaseModel, Field
 
@@ -127,18 +128,29 @@ def trans_to_function_tool(bound_method: Callable, *, strict_mode: bool = True) 
                 else:
                     args_dict = {}
             except (TypeError, json.JSONDecodeError) as e:
-                args_len = len(args_str) if isinstance(args_str, str) else 0
-                truncated_hint = ""
-                if isinstance(args_str, str) and args_len > 0:
-                    # Check if it looks like truncated output (no closing brace)
-                    stripped = args_str.rstrip()
-                    if not stripped.endswith("}") and not stripped.endswith("]"):
-                        truncated_hint = " Output appears truncated — likely hit model max_output_tokens limit."
-                return {
-                    "success": 0,
-                    "error": f"Invalid JSON arguments ({e}). Args length: {args_len} chars.{truncated_hint}",
-                    "result": None,
-                }
+                if isinstance(args_str, str) and args_str.strip():
+                    try:
+                        args_dict = json_repair.loads(args_str)
+                        if not isinstance(args_dict, dict):
+                            raise ValueError("Repaired result is not a dict")
+                        logger.warning(f"Repaired malformed JSON arguments for tool '{method_to_call.__name__}': {e}")
+                    except Exception:
+                        args_len = len(args_str)
+                        truncated_hint = ""
+                        stripped = args_str.rstrip()
+                        if not stripped.endswith("}") and not stripped.endswith("]"):
+                            truncated_hint = " Output appears truncated — likely hit model max_output_tokens limit."
+                        return {
+                            "success": 0,
+                            "error": f"Invalid JSON arguments ({e}). Args length: {args_len} chars.{truncated_hint}",
+                            "result": None,
+                        }
+                else:
+                    return {
+                        "success": 0,
+                        "error": f"Invalid JSON arguments ({e})",
+                        "result": None,
+                    }
 
             # Call sync or async bound methods transparently
             if inspect.ismethod(method_to_call):

--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -92,6 +92,75 @@ class FuncToolListResult(BaseModel):
     )
 
 
+def parse_tool_args(
+    args_str: Any,
+    required_fields: set[str] | None = None,
+    tool_name: str = "unknown",
+) -> tuple[dict, str | None]:
+    """Parse JSON tool arguments with json_repair fallback and required-field validation.
+
+    Returns (args_dict, error_message). error_message is None on success.
+    """
+    if not args_str:
+        if required_fields:
+            return {}, f"Empty arguments for tool '{tool_name}', missing required fields {required_fields}."
+        return {}, None
+    if not isinstance(args_str, str):
+        try:
+            result = dict(args_str)
+        except (TypeError, ValueError) as e:
+            return {}, f"Invalid arguments for tool '{tool_name}' ({e})"
+        else:
+            if required_fields:
+                missing = required_fields - set(result.keys())
+                if missing:
+                    return {}, f"Arguments for tool '{tool_name}' missing required fields {missing}."
+            return result, None
+
+    stripped = args_str.strip()
+    if not stripped:
+        if required_fields:
+            return {}, f"Empty arguments for tool '{tool_name}', missing required fields {required_fields}."
+        return {}, None
+
+    args_dict = None
+    original_error = None
+    try:
+        parsed = json.loads(stripped)
+        if isinstance(parsed, dict):
+            args_dict = parsed
+        else:
+            original_error = TypeError(f"Expected dict, got {type(parsed).__name__}")
+    except (json.JSONDecodeError, TypeError) as e:
+        original_error = e
+
+    if args_dict is None and original_error is not None:
+        try:
+            repaired = json_repair.loads(stripped)
+            if isinstance(repaired, dict):
+                args_dict = repaired
+                logger.warning(f"Repaired malformed JSON arguments for tool '{tool_name}': {original_error}")
+        except Exception:
+            pass
+
+    if args_dict is None or not isinstance(args_dict, dict):
+        args_len = len(args_str)
+        truncated_hint = ""
+        if not stripped.endswith("}") and not stripped.endswith("]"):
+            truncated_hint = " Output appears truncated — likely hit model max_output_tokens limit."
+        return {}, f"Invalid JSON arguments ({original_error}). Args length: {args_len} chars.{truncated_hint}"
+
+    if required_fields:
+        missing = required_fields - set(args_dict.keys())
+        if missing:
+            return {}, (
+                f"Repaired JSON for tool '{tool_name}' is missing required fields {missing}. "
+                f"Args length: {len(args_str)} chars."
+            )
+
+    return args_dict, None
+
+
 def trans_to_function_tool(bound_method: Callable, *, strict_mode: bool = True) -> FunctionTool:
     """
     Transfer a bound method to a function tool.
@@ -113,53 +182,28 @@ def trans_to_function_tool(bound_method: Callable, *, strict_mode: bool = True) 
     if "self" in corrected_schema.get("required", []):
         corrected_schema["required"].remove("self")
 
-    # The invoker MUST be an 'async' function.
-    # We define a closure to correctly capture the 'bound_method' for each iteration.
     def create_async_invoker(method_to_call: Callable) -> Callable:
-        async def final_invoker(tool_ctx, args_str) -> dict:
-            """
-            This is an async wrapper for tool methods.
-            The agent framework will 'await' this coroutine.
-            """
-            # The actual work (JSON parsing, method call)
-            try:
-                if args_str:
-                    args_dict = json.loads(args_str) if isinstance(args_str, str) else dict(args_str or {})
-                else:
-                    args_dict = {}
-            except (TypeError, json.JSONDecodeError) as e:
-                if isinstance(args_str, str) and args_str.strip():
-                    try:
-                        args_dict = json_repair.loads(args_str)
-                        if not isinstance(args_dict, dict):
-                            raise ValueError("Repaired result is not a dict")
-                        logger.warning(f"Repaired malformed JSON arguments for tool '{method_to_call.__name__}': {e}")
-                    except Exception:
-                        args_len = len(args_str)
-                        truncated_hint = ""
-                        stripped = args_str.rstrip()
-                        if not stripped.endswith("}") and not stripped.endswith("]"):
-                            truncated_hint = " Output appears truncated — likely hit model max_output_tokens limit."
-                        return {
-                            "success": 0,
-                            "error": f"Invalid JSON arguments ({e}). Args length: {args_len} chars.{truncated_hint}",
-                            "result": None,
-                        }
-                else:
-                    return {
-                        "success": 0,
-                        "error": f"Invalid JSON arguments ({e})",
-                        "result": None,
-                    }
+        sig = inspect.signature(method_to_call)
+        required_params = {
+            name
+            for name, p in sig.parameters.items()
+            if name != "self"
+            and p.default is inspect.Parameter.empty
+            and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        }
 
-            # Call sync or async bound methods transparently
+        async def final_invoker(tool_ctx, args_str) -> dict:
+            args_dict, error = parse_tool_args(
+                args_str, required_fields=required_params, tool_name=method_to_call.__name__
+            )
+            if error:
+                return {"success": 0, "error": error, "result": None}
+
             if inspect.ismethod(method_to_call):
                 tool = method_to_call.__self__
                 if hasattr(tool, "set_tool_context"):
                     tool.set_tool_context(tool_ctx)
 
-            # Filter out unexpected parameters that LLM may hallucinate
-            sig = inspect.signature(method_to_call)
             valid_params = set(sig.parameters.keys()) - {"self"}
             has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
             if not has_var_keyword:
@@ -187,7 +231,7 @@ def trans_to_function_tool(bound_method: Callable, *, strict_mode: bool = True) 
         name=tool_template.name,
         description=tool_template.description,
         params_json_schema=corrected_schema,
-        on_invoke_tool=async_invoker,  # <--- Assign the async function
+        on_invoke_tool=async_invoker,
         strict_json_schema=strict_mode,
     )
     return final_tool

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -13,13 +13,11 @@ tools, template rendering, and action history.
 
 from __future__ import annotations
 
-import json
 import uuid
 from contextlib import nullcontext
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
-import json_repair
 from agents import FunctionTool, Tool
 
 from datus.configuration.agent_config import AgentConfig
@@ -34,7 +32,7 @@ from datus.schemas.action_history import (
     ActionStatus,
 )
 from datus.schemas.agent_models import ScopedContext, SubAgentConfig
-from datus.tools.func_tool.base import FuncToolResult
+from datus.tools.func_tool.base import FuncToolResult, parse_tool_args
 from datus.utils.constants import SYS_SUB_AGENTS
 from datus.utils.loggings import get_logger
 from datus.utils.memory_loader import has_memory
@@ -294,21 +292,9 @@ class SubAgentTaskTool:
         }
 
         async def _invoke(_tool_ctx, args_str) -> dict:
-            try:
-                args = json.loads(args_str) if isinstance(args_str, str) else dict(args_str or {})
-            except (TypeError, json.JSONDecodeError) as e:
-                if isinstance(args_str, str) and args_str.strip():
-                    try:
-                        args = json_repair.loads(args_str)
-                        if not isinstance(args, dict):
-                            raise ValueError("Repaired result is not a dict")
-                        logger.warning(f"Repaired malformed JSON arguments for task tool: {e}")
-                    except Exception:
-                        return FuncToolResult(
-                            success=0, error=f"Invalid JSON arguments for task tool ({e})"
-                        ).model_dump()
-                else:
-                    return FuncToolResult(success=0, error=f"Invalid JSON arguments for task tool ({e})").model_dump()
+            args, error = parse_tool_args(args_str, required_fields={"type", "prompt", "description"}, tool_name="task")
+            if error:
+                return FuncToolResult(success=0, error=error).model_dump()
             # Resolve parent call_id from SDK ToolContext for action linking
             call_id = getattr(_tool_ctx, "tool_call_id", None) if _tool_ctx else None
             result = await self.task(call_id=call_id, **args)

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -19,6 +19,7 @@ from contextlib import nullcontext
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
+import json_repair
 from agents import FunctionTool, Tool
 
 from datus.configuration.agent_config import AgentConfig
@@ -295,8 +296,19 @@ class SubAgentTaskTool:
         async def _invoke(_tool_ctx, args_str) -> dict:
             try:
                 args = json.loads(args_str) if isinstance(args_str, str) else dict(args_str or {})
-            except (TypeError, json.JSONDecodeError):
-                return FuncToolResult(success=0, error="Invalid JSON arguments for task tool").model_dump()
+            except (TypeError, json.JSONDecodeError) as e:
+                if isinstance(args_str, str) and args_str.strip():
+                    try:
+                        args = json_repair.loads(args_str)
+                        if not isinstance(args, dict):
+                            raise ValueError("Repaired result is not a dict")
+                        logger.warning(f"Repaired malformed JSON arguments for task tool: {e}")
+                    except Exception:
+                        return FuncToolResult(
+                            success=0, error=f"Invalid JSON arguments for task tool ({e})"
+                        ).model_dump()
+                else:
+                    return FuncToolResult(success=0, error=f"Invalid JSON arguments for task tool ({e})").model_dump()
             # Resolve parent call_id from SDK ToolContext for action linking
             call_id = getattr(_tool_ctx, "tool_call_id", None) if _tool_ctx else None
             result = await self.task(call_id=call_id, **args)

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -5,6 +5,7 @@ Focuses on trans_to_function_tool parameter filtering for LLM-hallucinated argum
 
 import json
 import logging
+from unittest.mock import Mock
 
 import pytest
 
@@ -205,20 +206,17 @@ class TestParseToolArgs:
     def test_empty_args_with_required_fields(self):
         """Empty args_str with required_fields should return error."""
         result, error = parse_tool_args("", required_fields={"x"}, tool_name="test")
-        assert error is not None
         assert "missing required fields" in error
         assert result == {}
 
     def test_none_args_with_required_fields(self):
         """None args_str with required_fields should return error."""
         result, error = parse_tool_args(None, required_fields={"x"}, tool_name="test")
-        assert error is not None
         assert "missing required fields" in error
 
     def test_whitespace_only_args_with_required_fields(self):
         """Whitespace-only string with required_fields should return error."""
         result, error = parse_tool_args("   ", required_fields={"x"}, tool_name="test")
-        assert error is not None
         assert "missing required fields" in error
 
     def test_non_string_dict_input(self):
@@ -230,22 +228,19 @@ class TestParseToolArgs:
     def test_non_string_dict_input_missing_required(self):
         """Non-string dict input missing required fields should return error."""
         result, error = parse_tool_args({"a": 1}, required_fields={"b"}, tool_name="test")
-        assert error is not None
         assert "missing required fields" in error
 
     def test_non_string_invalid_input(self):
         """Non-string, non-dict input should return error."""
         result, error = parse_tool_args(12345, tool_name="test")
-        assert error is not None
         assert "Invalid arguments" in error
 
     def test_json_repair_exception_falls_through(self, monkeypatch):
         """When json_repair itself raises, should fall through to Invalid JSON error."""
         import json_repair as _jr
 
-        monkeypatch.setattr(_jr, "loads", lambda *a, **kw: (_ for _ in ()).throw(ValueError("boom")))
+        monkeypatch.setattr(_jr, "loads", Mock(side_effect=ValueError("boom")))
         result, error = parse_tool_args("{bad json}", tool_name="test")
-        assert error is not None
         assert "Invalid JSON" in error
 
     def test_truncated_json_hint(self, monkeypatch):
@@ -254,7 +249,6 @@ class TestParseToolArgs:
 
         monkeypatch.setattr(_jr, "loads", lambda *a, **kw: None)
         result, error = parse_tool_args('{"key": "val', tool_name="test")
-        assert error is not None
         assert "truncated" in error.lower()
 
     def test_repair_succeeds_no_truncation_hint(self):

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -100,6 +100,7 @@ class TestTransToFunctionTool:
         result = await tool.on_invoke_tool(None, malformed)
 
         assert result["success"] == 1
+        assert result["result"]["keywords"] == "PERCENTILE function"
         assert result["result"]["platform"] == "starrocks"
 
     @pytest.mark.asyncio
@@ -119,6 +120,66 @@ class TestTransToFunctionTool:
 
         assert result["success"] == 1
         assert any("Repaired malformed JSON" in msg for msg in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_repair_not_valid_json_brace(self):
+        """'not-valid-json{' repairs to {} but should fail on missing required params."""
+
+        class FakeTool:
+            def some_method(self, x: str) -> FuncToolResult:
+                return FuncToolResult(result=x)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.some_method)
+
+        result = await tool.on_invoke_tool(None, "not-valid-json{")
+        assert result["success"] == 0
+        assert "missing required fields" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_repair_truncated_key_value(self):
+        """'{"x":' repairs to {"x": ""} but should fail on missing required params."""
+
+        class FakeTool:
+            def some_method(self, name: str) -> FuncToolResult:
+                return FuncToolResult(result=name)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.some_method)
+
+        result = await tool.on_invoke_tool(None, '{"x":')
+        assert result["success"] == 0
+        assert "missing required fields" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_repair_empty_dict(self):
+        """'{}' is valid JSON but should fail when required params are missing."""
+
+        class FakeTool:
+            def some_method(self, x: str) -> FuncToolResult:
+                return FuncToolResult(result=x)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.some_method)
+
+        result = await tool.on_invoke_tool(None, "{}")
+        assert result["success"] == 0
+        assert "missing required fields" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_repair_array_not_dict(self):
+        """'[1,2,3]' is valid JSON but not a dict — should return error."""
+
+        class FakeTool:
+            def some_method(self, x: str) -> FuncToolResult:
+                return FuncToolResult(result=x)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.some_method)
+
+        result = await tool.on_invoke_tool(None, "[1,2,3]")
+        assert result["success"] == 0
+        assert "Invalid JSON" in result["error"]
 
     @pytest.mark.asyncio
     async def test_multiple_extra_params_all_filtered(self):

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -8,7 +8,7 @@ import logging
 
 import pytest
 
-from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
+from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, parse_tool_args, trans_to_function_tool
 
 
 class TestTransToFunctionTool:
@@ -197,6 +197,57 @@ class TestTransToFunctionTool:
 
         assert result["success"] == 1
         assert result["result"] == "test"
+
+
+class TestParseToolArgs:
+    """Direct tests for parse_tool_args covering branches not reachable via trans_to_function_tool."""
+
+    def test_empty_args_with_required_fields(self):
+        """Empty args_str with required_fields should return error."""
+        result, error = parse_tool_args("", required_fields={"x"}, tool_name="test")
+        assert error is not None
+        assert "missing required fields" in error
+        assert result == {}
+
+    def test_none_args_with_required_fields(self):
+        """None args_str with required_fields should return error."""
+        result, error = parse_tool_args(None, required_fields={"x"}, tool_name="test")
+        assert error is not None
+        assert "missing required fields" in error
+
+    def test_whitespace_only_args_with_required_fields(self):
+        """Whitespace-only string with required_fields should return error."""
+        result, error = parse_tool_args("   ", required_fields={"x"}, tool_name="test")
+        assert error is not None
+        assert "missing required fields" in error
+
+    def test_non_string_dict_input(self):
+        """Non-string dict-like input should be converted."""
+        result, error = parse_tool_args({"key": "val"}, tool_name="test")
+        assert error is None
+        assert result == {"key": "val"}
+
+    def test_non_string_dict_input_missing_required(self):
+        """Non-string dict input missing required fields should return error."""
+        result, error = parse_tool_args({"a": 1}, required_fields={"b"}, tool_name="test")
+        assert error is not None
+        assert "missing required fields" in error
+
+    def test_non_string_invalid_input(self):
+        """Non-string, non-dict input should return error."""
+        result, error = parse_tool_args(12345, tool_name="test")
+        assert error is not None
+        assert "Invalid arguments" in error
+
+    def test_json_repair_exception_falls_through(self):
+        """When json_repair itself raises, should fall through to error path."""
+        result, error = parse_tool_args("<<<>>>", required_fields={"x"}, tool_name="test")
+        assert error is not None
+
+    def test_truncated_json_hint(self):
+        """Truncated JSON not ending in } or ] should include truncation hint."""
+        result, error = parse_tool_args('{"key": "val', tool_name="test")
+        assert error is None or "truncated" in (error or "").lower()
 
 
 class TestFuncToolListResult:

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -4,6 +4,7 @@ Focuses on trans_to_function_tool parameter filtering for LLM-hallucinated argum
 """
 
 import json
+import logging
 
 import pytest
 
@@ -71,7 +72,7 @@ class TestTransToFunctionTool:
 
     @pytest.mark.asyncio
     async def test_invalid_json_returns_error(self):
-        """Invalid JSON should return an error result."""
+        """Truly unrepairable JSON should return an error result."""
 
         class FakeTool:
             def some_method(self, x: str) -> FuncToolResult:
@@ -80,9 +81,44 @@ class TestTransToFunctionTool:
         fake = FakeTool()
         tool = self._make_tool_from_method(fake.some_method)
 
-        result = await tool.on_invoke_tool(None, "not-valid-json{")
+        result = await tool.on_invoke_tool(None, "totally broken garbage @@!!")
         assert result["success"] == 0
         assert "Invalid JSON" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_repaired_by_json_repair(self):
+        """GLM-style malformed JSON (unquoted string values) should be repaired."""
+
+        class FakeTool:
+            def search_document(self, keywords: str, platform: str = "") -> FuncToolResult:
+                return FuncToolResult(result={"keywords": keywords, "platform": platform})
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.search_document)
+
+        malformed = '{"keywords": PERCENTILE function, "platform": "starrocks"}'
+        result = await tool.on_invoke_tool(None, malformed)
+
+        assert result["success"] == 1
+        assert result["result"]["platform"] == "starrocks"
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_repair_logs_warning(self, caplog):
+        """json_repair fallback should log a warning when repairing."""
+
+        class FakeTool:
+            def search_document(self, keywords: str, platform: str = "") -> FuncToolResult:
+                return FuncToolResult(result={"keywords": keywords, "platform": platform})
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.search_document)
+
+        malformed = '{"keywords": PERCENTILE function, "platform": "starrocks"}'
+        with caplog.at_level(logging.WARNING, logger="datus.tools.func_tool.base"):
+            result = await tool.on_invoke_tool(None, malformed)
+
+        assert result["success"] == 1
+        assert any("Repaired malformed JSON" in msg for msg in caplog.messages)
 
     @pytest.mark.asyncio
     async def test_multiple_extra_params_all_filtered(self):

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -239,15 +239,29 @@ class TestParseToolArgs:
         assert error is not None
         assert "Invalid arguments" in error
 
-    def test_json_repair_exception_falls_through(self):
-        """When json_repair itself raises, should fall through to error path."""
-        result, error = parse_tool_args("<<<>>>", required_fields={"x"}, tool_name="test")
-        assert error is not None
+    def test_json_repair_exception_falls_through(self, monkeypatch):
+        """When json_repair itself raises, should fall through to Invalid JSON error."""
+        import json_repair as _jr
 
-    def test_truncated_json_hint(self):
+        monkeypatch.setattr(_jr, "loads", lambda *a, **kw: (_ for _ in ()).throw(ValueError("boom")))
+        result, error = parse_tool_args("{bad json}", tool_name="test")
+        assert error is not None
+        assert "Invalid JSON" in error
+
+    def test_truncated_json_hint(self, monkeypatch):
         """Truncated JSON not ending in } or ] should include truncation hint."""
+        import json_repair as _jr
+
+        monkeypatch.setattr(_jr, "loads", lambda *a, **kw: None)
         result, error = parse_tool_args('{"key": "val', tool_name="test")
-        assert error is None or "truncated" in (error or "").lower()
+        assert error is not None
+        assert "truncated" in error.lower()
+
+    def test_repair_succeeds_no_truncation_hint(self):
+        """json_repair fixes truncated JSON — no error expected."""
+        result, error = parse_tool_args('{"key": "val', tool_name="test")
+        assert error is None
+        assert result == {"key": "val"}
 
 
 class TestFuncToolListResult:

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -12,6 +12,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.configuration.node_type import NodeType
 from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 from datus.schemas.agent_models import ScopedContext
+from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.sub_agent_task_tool import (
     BUILTIN_SUBAGENT_DESCRIPTIONS,
     NODE_CLASS_MAP,
@@ -2523,3 +2524,38 @@ class TestSessionPersistence:
         desc = schema["properties"]["session_id"]["description"]
         assert "continue" in desc.lower()
         assert "type" in desc.lower()  # callout that types must match
+
+
+@pytest.mark.ci
+class TestTaskToolJsonRepair:
+    """Tests for JSON argument repair in the task tool's _invoke handler."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_repaired(self, task_tool):
+        """Malformed JSON args should be repaired by json_repair and tool call should succeed."""
+        tools = task_tool.available_tools()
+        task_tool_fn = tools[0]
+
+        captured_args = {}
+
+        async def mock_task(**kwargs):
+            captured_args.update(kwargs)
+            return FuncToolResult(result={"response": "ok", "tokens_used": 0})
+
+        with patch.object(task_tool, "task", side_effect=mock_task):
+            args_str = '{"type": gen_sql, "prompt": "Show users", "description": "test"}'
+            result = await task_tool_fn.on_invoke_tool(None, args_str)
+
+        assert result["success"] == 1
+        assert captured_args.get("type") == "gen_sql"
+        assert captured_args.get("prompt") == "Show users"
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_still_returns_error(self, task_tool):
+        """Truly unrepairable JSON should still return error."""
+        tools = task_tool.available_tools()
+        task_tool_fn = tools[0]
+
+        result = await task_tool_fn.on_invoke_tool(None, "totally broken garbage @@!!")
+        assert result["success"] == 0
+        assert "Invalid JSON" in result["error"]

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -2549,6 +2549,7 @@ class TestTaskToolJsonRepair:
         assert result["success"] == 1
         assert captured_args.get("type") == "gen_sql"
         assert captured_args.get("prompt") == "Show users"
+        assert captured_args.get("description") == "test"
 
     @pytest.mark.asyncio
     async def test_invalid_json_still_returns_error(self, task_tool):
@@ -2559,3 +2560,14 @@ class TestTaskToolJsonRepair:
         result = await task_tool_fn.on_invoke_tool(None, "totally broken garbage @@!!")
         assert result["success"] == 0
         assert "Invalid JSON" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_repair_missing_required_fields(self, task_tool):
+        """Repaired JSON missing required fields (prompt, description) should return error."""
+        tools = task_tool.available_tools()
+        task_tool_fn = tools[0]
+
+        args_str = '{"type": gen_sql}'
+        result = await task_tool_fn.on_invoke_tool(None, args_str)
+        assert result["success"] == 0
+        assert "missing required fields" in result["error"]


### PR DESCRIPTION
## Why

Some LLM models (e.g. GLM) produce invalid JSON in tool call arguments, such as unquoted string values like `{"keywords": PERCENTILE function, "platform": "starrocks"}`. This causes tool calls to fail with a hard JSON parse error, breaking the agent workflow.

## Solution

Add a `json_repair` fallback in both `trans_to_function_tool` (base.py) and `SubAgentTaskTool._invoke` (sub_agent_task_tool.py). When `json.loads` fails, attempt repair via `json_repair.loads` before returning a hard error. A warning is logged when repair succeeds.

## Test Cases

- `test_malformed_json_repaired_by_json_repair` — verifies GLM-style malformed JSON is repaired and tool call succeeds
- `test_malformed_json_repair_logs_warning` — verifies warning is logged on repair
- `test_invalid_json_returns_error` — updated to use truly unrepairable input
- `TestTaskToolJsonRepair::test_malformed_json_repaired` — verifies repair in SubAgentTaskTool
- `TestTaskToolJsonRepair::test_invalid_json_still_returns_error` — verifies unrepairable JSON still errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized argument parsing with improved JSON handling: auto-repairs malformed JSON when possible (logs a warning), preserves prior "Invalid JSON" behavior, adds explicit "missing required fields" and truncation hints, and halts execution early on parse/validation failures. The task tool now enforces required arguments.

* **Tests**
  * Expanded unit tests covering repairable vs unrecoverable JSON, repair warnings, missing-required-fields, truncated inputs, and task-invocation outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->