### PR TITLE
[Enhancement] Add BigModel and Z.AI coding plans

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -26,7 +26,7 @@ agent:
   #   that provider without rewriting YAML. Supported providers (keys) are
   #   shipped in ``conf/providers.yml``: openai, claude, claude_subscription,
   #   codex, deepseek, kimi, qwen, gemini, glm, minimax, alibaba_coding,
-  #   glm_coding, minimax_coding, kimi_coding.
+  #   bigmodel_coding, zai_coding, minimax_coding, kimi_coding.
   #
   # - ``agent.models.<name>`` (legacy / custom)
   #   Retained for self-hosted or private-deployment models — hand-edit this

--- a/conf/providers.yml
+++ b/conf/providers.yml
@@ -80,14 +80,16 @@ providers:
   glm:
     type: glm
     base_url: https://open.bigmodel.cn/api/paas/v4
+    api_key_env: GLM_API_KEY
     default_model: glm-5
     models:
+      - glm-5.1
       - glm-5
       - glm-4.7
       - glm-4.5-air
       - glm-4.5-flash
 
-  # Coding Plan providers (Chinese vendor Anthropic-compatible endpoints)
+  # Coding Plan providers (vendor Anthropic-compatible endpoints)
   alibaba_coding:
     type: claude
     base_url: https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
@@ -100,12 +102,24 @@ providers:
       - kimi-k2.5
       - MiniMax-M2.5
 
-  glm_coding:
+  bigmodel_coding:
     type: claude
     base_url: https://open.bigmodel.cn/api/anthropic
-    default_model: glm-5
+    api_key_env: GLM_API_KEY
+    default_model: glm-5.1
     models_from: glm
     models:
+      - glm-5.1
+      - glm-5
+
+  zai_coding:
+    type: claude
+    base_url: https://api.z.ai/api/anthropic
+    api_key_env: ZAI_API_KEY
+    default_model: glm-5.1
+    models_from: glm
+    models:
+      - glm-5.1
       - glm-5
 
   minimax_coding:

--- a/datus/cli/model_app.py
+++ b/datus/cli/model_app.py
@@ -48,9 +48,9 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 
-_CODING_PLAN_PROVIDERS = frozenset({"alibaba_coding", "glm_coding", "minimax_coding", "kimi_coding"})
+_CODING_PLAN_PROVIDERS = frozenset({"alibaba_coding", "bigmodel_coding", "zai_coding", "minimax_coding", "kimi_coding"})
 # Providers that live on a separate "Plans" tab: everything that isn't a
-# straightforward api_key endpoint — Chinese coding plans (all use
+# straightforward api_key endpoint — coding plans (all use
 # Anthropic-compatible gateways), the Claude Code subscription path, and the
 # Codex OAuth path. Keeping them out of the main Providers tab reduces noise
 # and groups the "bring-your-own-plan" options together.
@@ -77,6 +77,18 @@ def _display_name(provider: str) -> str:
     if provider in _DISPLAY_NAME_OVERRIDES:
         return _DISPLAY_NAME_OVERRIDES[provider]
     return provider.replace("_", " ")
+
+
+def _validate_single_line_value(label: str, value: str, *, ascii_only: bool = False) -> Optional[str]:
+    """Return an error when a single-line form field received invalid text."""
+    if "\n" in value or "\r" in value:
+        return f"{label} must be a single line"
+    if ascii_only:
+        try:
+            value.encode("ascii")
+        except UnicodeEncodeError:
+            return f"{label} must contain only ASCII characters"
+    return None
 
 
 class _Tab(Enum):
@@ -792,6 +804,14 @@ class ModelApp:
     def _submit_cred_form(self) -> None:
         provider = self._active_provider or ""
         raw_key = self._cred_api_key.text.strip()
+        error = _validate_single_line_value("API key", raw_key, ascii_only=raw_key != _MASKED_KEY_PLACEHOLDER)
+        if error:
+            self._error_message = error
+            return
+        error = _validate_single_line_value("Base URL", self._cred_base_url.text, ascii_only=True)
+        if error:
+            self._error_message = error
+            return
         api_key: str | None = None if raw_key == _MASKED_KEY_PLACEHOLDER else raw_key
         base_url = self._cred_base_url.text.strip()
         try:
@@ -814,6 +834,10 @@ class ModelApp:
 
     def _submit_token_form(self) -> None:
         provider = self._active_provider or ""
+        error = _validate_single_line_value("Token", self._token_input.text, ascii_only=True)
+        if error:
+            self._error_message = error
+            return
         token = self._token_input.text.strip()
         if not token:
             self._error_message = "Token cannot be empty"
@@ -833,6 +857,20 @@ class ModelApp:
         self._enter_provider_models(provider)
 
     def _submit_add_model_form(self) -> None:
+        for label, area in (
+            ("name", self._add_name),
+            ("type", self._add_type),
+            ("model", self._add_model),
+        ):
+            error = _validate_single_line_value(label, area.text)
+            if error:
+                self._error_message = error
+                return
+        for label, area in (("base_url", self._add_base_url), ("api_key", self._add_api_key)):
+            error = _validate_single_line_value(label, area.text, ascii_only=True)
+            if error:
+                self._error_message = error
+                return
         name = self._add_name.text.strip()
         type_ = self._add_type.text.strip()
         model_name = self._add_model.text.strip()

--- a/datus/cli/provider_model_catalog.py
+++ b/datus/cli/provider_model_catalog.py
@@ -64,7 +64,8 @@ OPENROUTER_VENDOR_MAP: Dict[str, str] = {
 PROTECTED_PROVIDERS = frozenset(
     {
         "alibaba_coding",
-        "glm_coding",
+        "bigmodel_coding",
+        "zai_coding",
         "minimax_coding",
         "kimi_coding",
         "claude_subscription",

--- a/datus/conf/providers.yml
+++ b/datus/conf/providers.yml
@@ -80,14 +80,16 @@ providers:
   glm:
     type: glm
     base_url: https://open.bigmodel.cn/api/paas/v4
+    api_key_env: GLM_API_KEY
     default_model: glm-5
     models:
+      - glm-5.1
       - glm-5
       - glm-4.7
       - glm-4.5-air
       - glm-4.5-flash
 
-  # Coding Plan providers (Chinese vendor Anthropic-compatible endpoints)
+  # Coding Plan providers (vendor Anthropic-compatible endpoints)
   alibaba_coding:
     type: claude
     base_url: https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
@@ -100,12 +102,24 @@ providers:
       - kimi-k2.5
       - MiniMax-M2.5
 
-  glm_coding:
+  bigmodel_coding:
     type: claude
     base_url: https://open.bigmodel.cn/api/anthropic
-    default_model: glm-5
+    api_key_env: GLM_API_KEY
+    default_model: glm-5.1
     models_from: glm
     models:
+      - glm-5.1
+      - glm-5
+
+  zai_coding:
+    type: claude
+    base_url: https://api.z.ai/api/anthropic
+    api_key_env: ZAI_API_KEY
+    default_model: glm-5.1
+    models_from: glm
+    models:
+      - glm-5.1
       - glm-5
 
   minimax_coding:

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -158,7 +158,8 @@ These providers target coding/planning-oriented endpoints. Even though their nam
 | Provider | Default model | Interface Type | Notes |
 |----------|---------------|----------------|-------|
 | `alibaba_coding` | `qwen3-coder-plus` | `claude` | DashScope Anthropic-compatible coding endpoint |
-| `glm_coding` | `glm-5` | `claude` | GLM Anthropic-compatible coding endpoint |
+| `bigmodel_coding` | `glm-5.1` | `claude` | BigModel Anthropic-compatible coding endpoint |
+| `zai_coding` | `glm-5.1` | `claude` | Z.AI Anthropic-compatible coding endpoint |
 | `minimax_coding` | `MiniMax-M2.7` | `claude` | MiniMax Anthropic-compatible coding endpoint |
 | `kimi_coding` | `kimi-for-coding` | `claude` | Kimi coding endpoint |
 

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -91,7 +91,8 @@ agent:
 | 提供方 | 默认模型 | 接口类型 | 说明 |
 |---|---|---|---|
 | `alibaba_coding` | `qwen3-coder-plus` | `claude` | 阿里云 DashScope 的 Anthropic-compatible coding endpoint |
-| `glm_coding` | `glm-5` | `claude` | GLM 的 Anthropic-compatible coding endpoint |
+| `bigmodel_coding` | `glm-5.1` | `claude` | 智谱 BigModel 的 Anthropic-compatible coding endpoint |
+| `zai_coding` | `glm-5.1` | `claude` | Z.AI 国际版的 Anthropic-compatible coding endpoint |
 | `minimax_coding` | `MiniMax-M2.7` | `claude` | MiniMax 的 Anthropic-compatible coding endpoint |
 | `kimi_coding` | `kimi-for-coding` | `claude` | Kimi 的 coding endpoint |
 

--- a/tests/unit_tests/cli/test_model_app.py
+++ b/tests/unit_tests/cli/test_model_app.py
@@ -84,6 +84,29 @@ class TestProviderList:
         plans = app._providers_for_tab(_Tab.PLANS)
         assert set(plans) == {"claude_subscription", "codex"}
 
+    def test_plans_tab_contains_bigmodel_and_zai_coding_entries(self):
+        cfg = _stub_agent_config()
+        cfg.provider_catalog["providers"].update(
+            {
+                "bigmodel_coding": {
+                    "type": "claude",
+                    "base_url": "https://open.bigmodel.cn/api/anthropic",
+                    "default_model": "glm-5.1",
+                    "models": ["glm-5.1", "glm-5"],
+                },
+                "zai_coding": {
+                    "type": "claude",
+                    "base_url": "https://api.z.ai/api/anthropic",
+                    "default_model": "glm-5.1",
+                    "models": ["glm-5.1", "glm-5"],
+                },
+            }
+        )
+        app = ModelApp(cfg, Console(file=io.StringIO(), no_color=True))
+        plans = app._providers_for_tab(_Tab.PLANS)
+        assert "bigmodel_coding" in plans
+        assert "zai_coding" in plans
+
     def test_availability_is_cached(self):
         cfg = _stub_agent_config()
         ModelApp(cfg, Console(file=io.StringIO(), no_color=True))
@@ -385,6 +408,30 @@ class TestCredentialForm:
             auth_type="api_key",
         )
 
+    def test_multiline_api_key_is_rejected_before_save(self):
+        cfg = _stub_agent_config()
+        app = ModelApp(cfg, Console(file=io.StringIO(), no_color=True))
+        app._active_provider = "openai"
+        app._cred_api_key.text = "sk-test\nnext"
+        app._cred_base_url.text = "https://custom.example"
+
+        app._submit_cred_form()
+
+        cfg.set_provider_config.assert_not_called()
+        assert app._error_message == "API key must be a single line"
+
+    def test_non_ascii_api_key_is_rejected_before_save(self):
+        cfg = _stub_agent_config()
+        app = ModelApp(cfg, Console(file=io.StringIO(), no_color=True))
+        app._active_provider = "openai"
+        app._cred_api_key.text = "sk-test-\u7ffb\u8bd1"
+        app._cred_base_url.text = "https://custom.example"
+
+        app._submit_cred_form()
+
+        cfg.set_provider_config.assert_not_called()
+        assert app._error_message == "API key must contain only ASCII characters"
+
     def test_no_saved_key_leaves_field_empty(self):
         cfg = _stub_agent_config()
         cfg.providers = {}
@@ -413,6 +460,26 @@ class TestTokenForm:
         app._submit_token_form()
         assert app._view == _View.PROVIDER_MODELS
         app._cfg.set_provider_config.assert_called_once()
+
+    def test_multiline_token_is_rejected_before_save(self):
+        app = _build()
+        app._active_provider = "claude_subscription"
+        app._token_input.text = "sk-ant-oat01-xyz\nnext"
+
+        app._submit_token_form()
+
+        assert app._cfg.set_provider_config.call_count == 0
+        assert app._error_message == "Token must be a single line"
+
+    def test_non_ascii_token_is_rejected_before_save(self):
+        app = _build()
+        app._active_provider = "claude_subscription"
+        app._token_input.text = "sk-ant-oat01-\u7ffb\u8bd1"
+
+        app._submit_token_form()
+
+        assert app._cfg.set_provider_config.call_count == 0
+        assert app._error_message == "Token must contain only ASCII characters"
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -461,6 +528,20 @@ class TestAddModelForm:
         with patch.object(app._app, "exit") as mock_exit:
             app._submit_add_model_form()
         mock_exit.assert_not_called()
+
+    def test_multiline_custom_api_key_is_rejected(self):
+        app = self._prepare(name="x", type="openai", model="gpt-4o", api_key="sk\nnext")
+        with patch.object(app._app, "exit") as mock_exit:
+            app._submit_add_model_form()
+        mock_exit.assert_not_called()
+        assert app._error_message == "api_key must be a single line"
+
+    def test_non_ascii_custom_api_key_is_rejected(self):
+        app = self._prepare(name="x", type="openai", model="gpt-4o", api_key="sk-\u7ffb\u8bd1")
+        with patch.object(app._app, "exit") as mock_exit:
+            app._submit_add_model_form()
+        mock_exit.assert_not_called()
+        assert app._error_message == "api_key must contain only ASCII characters"
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/unit_tests/cli/test_provider_model_catalog.py
+++ b/tests/unit_tests/cli/test_provider_model_catalog.py
@@ -601,7 +601,7 @@ class TestResolveProviderModels:
         assert merged["model_specs"]["gpt-4.1"]["context_length"] == 400000
 
     def test_protected_providers_keep_local_models(self, fake_datus_home: Path) -> None:
-        """codex / claude_subscription must NOT be touched even if remote has matching vendor."""
+        """plan/auth providers must NOT be touched directly by remote overlay."""
 
         def handler(_req: httpx.Request) -> httpx.Response:
             # Remote returns a model under anthropic/, which would normally overlay `claude`.
@@ -610,11 +610,44 @@ class TestResolveProviderModels:
             return httpx.Response(200, json=_payload("anthropic/claude-opus-4-6"))
 
         local = _local_catalog()
+        local["providers"]["glm"] = {"type": "glm", "models": ["glm-local"], "default_model": "glm-local"}
+        local["providers"]["bigmodel_coding"] = {"models": ["bigmodel-local"], "models_from": "missing"}
+        local["providers"]["zai_coding"] = {"models": ["zai-local"], "models_from": "missing"}
         with _install_mock_transport(handler):
             merged = pmc.resolve_provider_models(local)
 
         assert merged["providers"]["codex"]["models"] == ["codex-mini-latest"]
         assert merged["providers"]["claude_subscription"]["models"] == ["claude-sonnet-4-6"]
+        assert merged["providers"]["bigmodel_coding"]["models"] == ["bigmodel-local"]
+        assert merged["providers"]["zai_coding"]["models"] == ["zai-local"]
+
+    def test_bigmodel_and_zai_coding_inherit_glm_models_after_overlay(self, fake_datus_home: Path) -> None:
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_payload("z-ai/glm-5.1", "z-ai/glm-5", "zhipuai/glm-4.7"))
+
+        local = {
+            "providers": {
+                "glm": {"type": "glm", "models": ["glm-local"], "default_model": "glm-5"},
+                "bigmodel_coding": {
+                    "type": "claude",
+                    "models_from": "glm",
+                    "default_model": "glm-5.1",
+                    "models": ["glm-5.1", "glm-5"],
+                },
+                "zai_coding": {
+                    "type": "claude",
+                    "models_from": "glm",
+                    "default_model": "glm-5.1",
+                    "models": ["glm-5.1", "glm-5"],
+                },
+            },
+        }
+        with _install_mock_transport(handler):
+            merged = pmc.resolve_provider_models(local)
+
+        assert merged["providers"]["glm"]["models"] == ["glm-5.1", "glm-5", "glm-4.7"]
+        assert merged["providers"]["bigmodel_coding"]["models"] == ["glm-5.1", "glm-5", "glm-4.7"]
+        assert merged["providers"]["zai_coding"]["models"] == ["glm-5.1", "glm-5", "glm-4.7"]
 
     def test_cache_written_is_v2_with_metadata(self, fake_datus_home: Path) -> None:
         """The freshly-written cache must carry pricing/context_length for billing."""


### PR DESCRIPTION
## Why

The coding-plan provider list still used `glm_coding`, which conflated the domestic BigModel endpoint with Z.AI's international endpoint. Pasted credentials could also accidentally include multiline or non-ASCII text and be saved before failing downstream.

## Solution

- Rename the domestic GLM coding-plan provider to `bigmodel_coding` and add `zai_coding` for the international Anthropic-compatible endpoint.
- Keep both providers on the Plans tab, protect them from direct OpenRouter overlays, and let them inherit the GLM model list through `models_from`.
- Add single-line and ASCII validation for `/model` credential fields that carry API keys, tokens, or base URLs.
- Update the provider configs, example config, and English/Chinese configuration docs.

## Test Cases

- `uv run pytest tests/unit_tests/cli/test_provider_model_catalog.py tests/unit_tests/cli/test_model_app.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new Anthropic-compatible coding plan providers and expanded supported model options for the GLM provider.
* **Improvements**
  * Stronger single-line and ASCII validation for API keys, tokens, and custom model inputs to prevent invalid submissions.
* **Documentation**
  * Updated configuration docs to list the new providers and updated default model info.
* **Tests**
  * Added unit tests covering new providers, validation behavior, and provider-model overlay/inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->