### PR TITLE
[BugFix] Cover all built-in & node_class custom agents in API _create_node

### DIFF
--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -11,7 +11,7 @@ SQL generation. It exposes only read-only tools and runs with a low max_turns
 budget for fast, focused exploration.
 """
 
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.workflow import Workflow
@@ -57,9 +57,14 @@ class ExploreAgenticNode(AgenticNode):
         agent_config: Optional[AgentConfig] = None,
         tools: Optional[list] = None,
         node_name: Optional[str] = None,
+        execution_mode: Literal["interactive", "workflow"] = "interactive",
         is_subagent: bool = False,
     ):
         self.configured_node_name = node_name
+        # Surface to permission-hook code paths so workflow callers (API /
+        # gateway) can short-circuit interactive ASK prompts that would
+        # otherwise block on a missing broker listener.
+        self.execution_mode = execution_mode
 
         # Default max_turns = 15, can be overridden by agent.yml
         self.max_turns = 15

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -59,6 +59,7 @@ class SkillCreatorAgenticNode(AgenticNode):
         tools: Optional[list] = None,
         node_name: Optional[str] = None,
         execution_mode: Literal["interactive", "workflow"] = "interactive",
+        scope: Optional[str] = None,
         is_subagent: bool = False,
     ):
         # Support custom node_name for alias subagents (e.g. my_skill_editor:
@@ -89,6 +90,7 @@ class SkillCreatorAgenticNode(AgenticNode):
             agent_config=agent_config,
             tools=tools or [],
             mcp_servers={},
+            scope=scope,
             is_subagent=is_subagent,
         )
 

--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -70,12 +70,13 @@ def create_interactive_node(
                 agent_config=agent_config,
                 execution_mode=execution_mode,
                 node_name=subagent_name if node_class_type == "gen_table" else None,
+                scope=scope,
             )
 
         elif subagent_name == "gen_job":
             from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
 
-            return GenJobAgenticNode(agent_config=agent_config, execution_mode=execution_mode)
+            return GenJobAgenticNode(agent_config=agent_config, execution_mode=execution_mode, scope=scope)
 
         elif subagent_name == "gen_report" or node_class_type == "gen_report":
             from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
@@ -110,6 +111,7 @@ def create_interactive_node(
                 agent_config=agent_config,
                 tools=None,
                 node_name=subagent_name,
+                execution_mode=execution_mode,
             )
 
         elif subagent_name == "gen_skill" or node_class_type == "gen_skill":
@@ -124,6 +126,7 @@ def create_interactive_node(
                 tools=None,
                 node_name=subagent_name if node_class_type == "gen_skill" else "gen_skill",
                 execution_mode=execution_mode,
+                scope=scope,
             )
 
         elif subagent_name == "gen_dashboard" or node_class_type == "gen_dashboard":

--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -8,7 +8,7 @@ Shared factory functions for creating interactive agentic nodes and their inputs
 Used by CLI print mode and interactive REPL to avoid duplicating node creation logic.
 """
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
@@ -19,6 +19,9 @@ def create_interactive_node(
     agent_config: "AgentConfig",
     node_id_suffix: str = "",
     scope: Optional[str] = None,
+    *,
+    execution_mode: Literal["interactive", "workflow"] = "interactive",
+    node_id: Optional[str] = None,
 ):
     """Create an interactive agentic node based on subagent_name.
 
@@ -27,6 +30,11 @@ def create_interactive_node(
         agent_config: Agent configuration.
         node_id_suffix: Suffix appended to node_id (e.g. "_cli", "_print").
         scope: Optional session scope for directory isolation.
+        execution_mode: Node execution mode. CLI defaults to ``interactive``;
+            API workflow runs pass ``workflow``.
+        node_id: Override the auto-generated ``f"{subagent_name}{node_id_suffix}"``
+            id. API path passes ``session_id`` here so the node's id matches the
+            HTTP session.
     """
     if subagent_name:
         node_class_type = _resolve_node_class_type(subagent_name, agent_config)
@@ -34,25 +42,25 @@ def create_interactive_node(
         if subagent_name == "gen_semantic_model":
             from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 
-            return GenSemanticModelAgenticNode(agent_config=agent_config, execution_mode="interactive", scope=scope)
+            return GenSemanticModelAgenticNode(agent_config=agent_config, execution_mode=execution_mode, scope=scope)
 
         elif subagent_name == "gen_metrics":
             from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
-            return GenMetricsAgenticNode(agent_config=agent_config, execution_mode="interactive", scope=scope)
+            return GenMetricsAgenticNode(agent_config=agent_config, execution_mode=execution_mode, scope=scope)
 
         elif subagent_name == "gen_sql_summary":
             from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
 
             return SqlSummaryAgenticNode(
-                node_name=subagent_name, agent_config=agent_config, execution_mode="interactive", scope=scope
+                node_name=subagent_name, agent_config=agent_config, execution_mode=execution_mode, scope=scope
             )
 
         elif subagent_name == "gen_ext_knowledge":
             from datus.agent.node.gen_ext_knowledge_agentic_node import GenExtKnowledgeAgenticNode
 
             return GenExtKnowledgeAgenticNode(
-                node_name=subagent_name, agent_config=agent_config, execution_mode="interactive", scope=scope
+                node_name=subagent_name, agent_config=agent_config, execution_mode=execution_mode, scope=scope
             )
 
         elif subagent_name == "gen_table" or node_class_type == "gen_table":
@@ -60,20 +68,20 @@ def create_interactive_node(
 
             return GenTableAgenticNode(
                 agent_config=agent_config,
-                execution_mode="interactive",
+                execution_mode=execution_mode,
                 node_name=subagent_name if node_class_type == "gen_table" else None,
             )
 
         elif subagent_name == "gen_job":
             from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
 
-            return GenJobAgenticNode(agent_config=agent_config, execution_mode="interactive")
+            return GenJobAgenticNode(agent_config=agent_config, execution_mode=execution_mode)
 
         elif subagent_name == "gen_report" or node_class_type == "gen_report":
             from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
 
             return GenReportAgenticNode(
-                node_id=f"{subagent_name}{node_id_suffix}",
+                node_id=node_id if node_id is not None else f"{subagent_name}{node_id_suffix}",
                 description=f"Report generation node for {subagent_name}",
                 node_type="gen_report",
                 input_data=None,
@@ -81,6 +89,7 @@ def create_interactive_node(
                 tools=None,
                 node_name=subagent_name,
                 scope=scope,
+                execution_mode=execution_mode,
             )
 
         elif subagent_name == "explore" or node_class_type == "explore":
@@ -94,7 +103,7 @@ def create_interactive_node(
             from datus.agent.node.explore_agentic_node import ExploreAgenticNode
 
             return ExploreAgenticNode(
-                node_id=f"{subagent_name}{node_id_suffix}",
+                node_id=node_id if node_id is not None else f"{subagent_name}{node_id_suffix}",
                 description=f"Explore node for {subagent_name}",
                 node_type="explore",
                 input_data=None,
@@ -107,13 +116,14 @@ def create_interactive_node(
             from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
 
             return SkillCreatorAgenticNode(
-                node_id=f"{subagent_name}{node_id_suffix}",
+                node_id=node_id if node_id is not None else f"{subagent_name}{node_id_suffix}",
                 description=f"Skill generation node for {subagent_name}",
                 node_type="gen_skill",
                 input_data=None,
                 agent_config=agent_config,
                 tools=None,
                 node_name=subagent_name if node_class_type == "gen_skill" else "gen_skill",
+                execution_mode=execution_mode,
             )
 
         elif subagent_name == "gen_dashboard" or node_class_type == "gen_dashboard":
@@ -121,8 +131,8 @@ def create_interactive_node(
 
             return GenDashboardAgenticNode(
                 agent_config=agent_config,
-                execution_mode="interactive",
-                node_id=f"{subagent_name}{node_id_suffix}",
+                execution_mode=execution_mode,
+                node_id=node_id if node_id is not None else f"{subagent_name}{node_id_suffix}",
                 node_name=subagent_name if node_class_type == "gen_dashboard" else None,
                 scope=scope,
             )
@@ -132,8 +142,8 @@ def create_interactive_node(
 
             return SchedulerAgenticNode(
                 agent_config=agent_config,
-                execution_mode="interactive",
-                node_id=f"{subagent_name}{node_id_suffix}",
+                execution_mode=execution_mode,
+                node_id=node_id if node_id is not None else f"{subagent_name}{node_id_suffix}",
                 node_name=subagent_name if node_class_type == "scheduler" else None,
                 scope=scope,
             )
@@ -143,7 +153,7 @@ def create_interactive_node(
 
             return FeedbackAgenticNode(
                 agent_config=agent_config,
-                execution_mode="interactive",
+                execution_mode=execution_mode,
                 scope=scope,
             )
 
@@ -151,7 +161,7 @@ def create_interactive_node(
             from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
 
             return GenSQLAgenticNode(
-                node_id=f"{subagent_name}{node_id_suffix}",
+                node_id=node_id if node_id is not None else f"{subagent_name}{node_id_suffix}",
                 description=f"SQL generation node for {subagent_name}",
                 node_type="gensql",
                 input_data=None,
@@ -159,18 +169,20 @@ def create_interactive_node(
                 tools=None,
                 node_name=subagent_name,
                 scope=scope,
+                execution_mode=execution_mode,
             )
     else:
         from datus.agent.node.chat_agentic_node import ChatAgenticNode
 
         return ChatAgenticNode(
-            node_id=f"chat{node_id_suffix}",
+            node_id=node_id if node_id is not None else f"chat{node_id_suffix}",
             description="Chat node for interactive mode",
             node_type="chat",
             input_data=None,
             agent_config=agent_config,
             tools=None,
             scope=scope,
+            execution_mode=execution_mode,
         )
 
 

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -14,8 +14,6 @@ from datetime import datetime
 from typing import AsyncGenerator, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
-from datus.agent.node.chat_agentic_node import ChatAgenticNode
-from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
 from datus.api.models.cli_models import (
     SSEDataType,
     SSEEndData,
@@ -661,90 +659,39 @@ class ChatTaskManager:
     ) -> AgenticNode:
         """Create a fresh AgenticNode based on subagent_id (builtin name or custom DB ID).
 
+        Delegates dispatch to :func:`datus.agent.node.node_factory.create_interactive_node`
+        so the API path matches the CLI exactly: every built-in sub_agent is wired to
+        its dedicated AgenticNode subclass, and custom sub_agents honour their
+        ``node_class`` field (``gen_report`` / ``gen_table`` / ``gen_dashboard`` /
+        ``scheduler`` / ``gen_skill`` / ``explore``) instead of always falling back
+        to ``GenSQLAgenticNode``.
+
         ``user_id`` is propagated as the node ``scope`` so that session files
         are isolated per user under ``{session_dir}/{user_id}/``.
         """
+        from datus.agent.node.node_factory import create_interactive_node
+
         execution_mode: Literal["interactive", "workflow"] = "interactive" if interactive else "workflow"
+
+        # ``agentic_nodes`` is keyed by sanitized node_name; the API receives the
+        # custom sub_agent's UUID under the "id" field. Translate UUID -> name so
+        # the factory's ``_resolve_node_class_type`` can look up node_class and
+        # downstream tools can resolve scoped_context via sub_agent_config().
+        node_name = subagent_id
         if subagent_id:
-            if subagent_id == "gen_semantic_model":
-                from datus.agent.node.gen_semantic_model_agentic_node import (
-                    GenSemanticModelAgenticNode,
-                )
+            for key, entry in (agent_config.agentic_nodes or {}).items():
+                entry_id = entry.get("id") if isinstance(entry, dict) else getattr(entry, "id", None)
+                if entry_id == subagent_id:
+                    node_name = key
+                    break
 
-                return GenSemanticModelAgenticNode(
-                    agent_config=agent_config,
-                    execution_mode=execution_mode,
-                    scope=user_id,
-                )
-            elif subagent_id == "gen_metrics":
-                from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-                return GenMetricsAgenticNode(
-                    agent_config=agent_config,
-                    execution_mode=execution_mode,
-                    scope=user_id,
-                )
-            elif subagent_id == "gen_sql_summary":
-                from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
-
-                return SqlSummaryAgenticNode(
-                    node_name=subagent_id,
-                    agent_config=agent_config,
-                    execution_mode=execution_mode,
-                    scope=user_id,
-                )
-            elif subagent_id == "gen_ext_knowledge":
-                from datus.agent.node.gen_ext_knowledge_agentic_node import (
-                    GenExtKnowledgeAgenticNode,
-                )
-
-                return GenExtKnowledgeAgenticNode(
-                    node_name=subagent_id,
-                    agent_config=agent_config,
-                    execution_mode=execution_mode,
-                    scope=user_id,
-                )
-            elif subagent_id == "feedback":
-                from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
-
-                return FeedbackAgenticNode(
-                    agent_config=agent_config,
-                    execution_mode=execution_mode,
-                    scope=user_id,
-                )
-            else:
-                # Custom sub_agent: agentic_nodes is keyed by sanitized node_name
-                # (not the UUID subagent_id). Each entry carries its original
-                # sub_agent id under the "id" field — use it to resolve the key
-                # so downstream tools can look up scoped_context via
-                # sub_agent_config().
-                node_name = subagent_id
-                for key, entry in (agent_config.agentic_nodes or {}).items():
-                    if isinstance(entry, dict) and entry.get("id") == subagent_id:
-                        node_name = key
-                        break
-                return GenSQLAgenticNode(
-                    node_id=session_id,
-                    description=f"SQL generation node for {node_name}",
-                    node_type="gensql",
-                    input_data=None,
-                    agent_config=agent_config,
-                    tools=None,
-                    node_name=node_name,
-                    scope=user_id,
-                    execution_mode=execution_mode,
-                )
-        else:
-            return ChatAgenticNode(
-                node_id=session_id,
-                description="Chat node for backend API",
-                node_type="chat",
-                input_data=None,
-                agent_config=agent_config,
-                tools=None,
-                scope=user_id,
-                execution_mode=execution_mode,
-            )
+        return create_interactive_node(
+            subagent_name=node_name,
+            agent_config=agent_config,
+            scope=user_id,
+            execution_mode=execution_mode,
+            node_id=session_id,
+        )
 
     # ------------------------------------------------------------------
     # Node input factory
@@ -763,77 +710,29 @@ class ChatTaskManager:
         plan_mode: bool = False,
         source_session_id: Optional[str] = None,
     ):
-        """Create node input based on node type."""
-        from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
-        from datus.agent.node.gen_ext_knowledge_agentic_node import GenExtKnowledgeAgenticNode
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
-        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
-        from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
+        """Create node input based on node type.
 
-        if isinstance(current_node, FeedbackAgenticNode):
-            from datus.schemas.feedback_agentic_node_models import FeedbackNodeInput
+        Delegates to :func:`datus.agent.node.node_factory.create_node_input` so
+        the API path covers every AgenticNode subclass the CLI knows about
+        (GenReport / Explore / SkillCreator / GenTable / GenJob in addition to
+        the legacy GenSQL / Semantic / SqlSummary / ExtKnowledge / Feedback /
+        Chat branches).
+        """
+        from datus.agent.node.node_factory import create_node_input
 
-            return FeedbackNodeInput(
-                user_message=user_message,
-                database=database,
-                source_session_id=source_session_id,
-            )
-
-        if isinstance(current_node, (GenSemanticModelAgenticNode, GenMetricsAgenticNode)):
-            from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
-
-            return SemanticNodeInput(
-                user_message=user_message,
-                catalog=catalog,
-                database=database,
-                db_schema=db_schema,
-                prompt_language="en",
-            )
-        elif isinstance(current_node, SqlSummaryAgenticNode):
-            from datus.schemas.sql_summary_agentic_node_models import SqlSummaryNodeInput
-
-            return SqlSummaryNodeInput(
-                user_message=user_message,
-                catalog=catalog,
-                database=database,
-                db_schema=db_schema,
-                prompt_language="en",
-            )
-        elif isinstance(current_node, GenExtKnowledgeAgenticNode):
-            from datus.schemas.ext_knowledge_agentic_node_models import ExtKnowledgeNodeInput
-
-            return ExtKnowledgeNodeInput(
-                user_message=user_message,
-                prompt_language="en",
-            )
-        elif isinstance(current_node, GenSQLAgenticNode):
-            from datus.schemas.gen_sql_agentic_node_models import GenSQLNodeInput
-
-            return GenSQLNodeInput(
-                user_message=user_message,
-                catalog=catalog,
-                database=database,
-                db_schema=db_schema,
-                schemas=at_tables,
-                metrics=at_metrics,
-                reference_sql=at_sqls,
-                prompt_language="en",
-                plan_mode=plan_mode,
-            )
-        else:
-            from datus.schemas.chat_agentic_node_models import ChatNodeInput
-
-            return ChatNodeInput(
-                user_message=user_message,
-                catalog=catalog,
-                database=database,
-                db_schema=db_schema,
-                schemas=at_tables,
-                metrics=at_metrics,
-                reference_sql=at_sqls,
-                plan_mode=plan_mode,
-            )
+        return create_node_input(
+            user_message=user_message,
+            node=current_node,
+            catalog=catalog,
+            database=database,
+            db_schema=db_schema,
+            at_tables=at_tables,
+            at_metrics=at_metrics,
+            at_sqls=at_sqls,
+            prompt_language="en",
+            plan_mode=plan_mode,
+            source_session_id=source_session_id,
+        )
 
     # ------------------------------------------------------------------
     # @ reference resolution

--- a/tests/unit_tests/agent/node/test_node_factory.py
+++ b/tests/unit_tests/agent/node/test_node_factory.py
@@ -112,7 +112,7 @@ class TestCreateInteractiveNode:
     def test_gen_table(self, mock_init):
         config = _mock_agent_config()
         create_interactive_node("gen_table", config)
-        mock_init.assert_called_once_with(agent_config=config, execution_mode="interactive", node_name=None)
+        mock_init.assert_called_once_with(agent_config=config, execution_mode="interactive", node_name=None, scope=None)
 
     @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
     def test_default_subagent_is_gensql(self, mock_init):
@@ -132,6 +132,7 @@ class TestCreateInteractiveNode:
             agent_config=config,
             execution_mode="interactive",
             node_name="wide_table_builder",
+            scope=None,
         )
 
     @patch("datus.agent.node.gen_skill_agentic_node.SkillCreatorAgenticNode.__init__", return_value=None)
@@ -204,6 +205,36 @@ class TestCreateInteractiveNode:
         config = _mock_agent_config()
         create_interactive_node(None, config, node_id="api-session-7")
         assert mock_init.call_args[1]["node_id"] == "api-session-7"
+
+    @patch("datus.agent.node.gen_table_agentic_node.GenTableAgenticNode.__init__", return_value=None)
+    def test_gen_table_scope_propagates(self, mock_init):
+        """API path passes user_id as scope; gen_table must isolate session by user."""
+        config = _mock_agent_config()
+        create_interactive_node("gen_table", config, scope="user-42")
+        assert mock_init.call_args[1]["scope"] == "user-42"
+
+    @patch("datus.agent.node.gen_job_agentic_node.GenJobAgenticNode.__init__", return_value=None)
+    def test_gen_job_scope_propagates(self, mock_init):
+        """gen_job session files must land under the per-user shard on the API path."""
+        config = _mock_agent_config()
+        create_interactive_node("gen_job", config, scope="user-42")
+        mock_init.assert_called_once_with(agent_config=config, execution_mode="interactive", scope="user-42")
+
+    @patch("datus.agent.node.gen_skill_agentic_node.SkillCreatorAgenticNode.__init__", return_value=None)
+    def test_gen_skill_scope_propagates(self, mock_init):
+        """gen_skill must accept and forward scope so user-scoped skill drafts are isolated."""
+        config = _mock_agent_config()
+        create_interactive_node("gen_skill", config, scope="user-42")
+        assert mock_init.call_args[1]["scope"] == "user-42"
+
+    @patch("datus.agent.node.explore_agentic_node.ExploreAgenticNode.__init__", return_value=None)
+    def test_explore_execution_mode_propagates(self, mock_init):
+        """explore must receive execution_mode so workflow callers don't trip the
+        interactive permission-hook ASK path (which would block on a missing
+        broker listener in API / gateway runs)."""
+        config = _mock_agent_config()
+        create_interactive_node("explore", config, execution_mode="workflow")
+        assert mock_init.call_args[1]["execution_mode"] == "workflow"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_node_factory.py
+++ b/tests/unit_tests/agent/node/test_node_factory.py
@@ -176,6 +176,35 @@ class TestCreateInteractiveNode:
         create_interactive_node("feedback", config)
         mock_init.assert_called_once_with(agent_config=config, execution_mode="interactive", scope=None)
 
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_execution_mode_workflow_propagates(self, mock_init):
+        """API workflow callers pass execution_mode="workflow"; factory must forward it."""
+        config = _mock_agent_config()
+        create_interactive_node("my_custom_sql", config, execution_mode="workflow")
+        mock_init.assert_called_once()
+        assert mock_init.call_args[1]["execution_mode"] == "workflow"
+
+    @patch("datus.agent.node.feedback_agentic_node.FeedbackAgenticNode.__init__", return_value=None)
+    def test_execution_mode_workflow_for_feedback(self, mock_init):
+        """Workflow flag also propagates to nodes that take agent_config-only signatures."""
+        config = _mock_agent_config()
+        create_interactive_node("feedback", config, execution_mode="workflow")
+        mock_init.assert_called_once_with(agent_config=config, execution_mode="workflow", scope=None)
+
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_node_id_override(self, mock_init):
+        """node_id kwarg must take precedence over the auto-generated suffix."""
+        config = _mock_agent_config()
+        create_interactive_node("my_custom_sql", config, node_id_suffix="_cli", node_id="api-session-42")
+        assert mock_init.call_args[1]["node_id"] == "api-session-42"
+
+    @patch("datus.agent.node.chat_agentic_node.ChatAgenticNode.__init__", return_value=None)
+    def test_node_id_override_for_chat(self, mock_init):
+        """Default chat node honours the node_id override (used by the API path)."""
+        config = _mock_agent_config()
+        create_interactive_node(None, config, node_id="api-session-7")
+        assert mock_init.call_args[1]["node_id"] == "api-session-7"
+
 
 # ---------------------------------------------------------------------------
 # Tests: create_node_input

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -695,6 +695,95 @@ class TestCreateNode:
         node = manager._create_node(real_agent_config, "gen_ext_knowledge", "test-session")
         assert isinstance(node, GenExtKnowledgeAgenticNode)
 
+    def test_create_gen_report_node(self, real_agent_config, mock_llm_create):
+        """gen_report must land on GenReportAgenticNode (regression: previously fell back to GenSQL)."""
+        from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "gen_report", "test-session")
+        assert isinstance(node, GenReportAgenticNode)
+        assert not isinstance(node, GenSQLAgenticNode)
+
+    def test_create_gen_table_node(self, real_agent_config, mock_llm_create):
+        """gen_table must land on GenTableAgenticNode (regression: previously fell back to GenSQL)."""
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+        from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "gen_table", "test-session")
+        assert isinstance(node, GenTableAgenticNode)
+        assert not isinstance(node, GenSQLAgenticNode)
+
+    def test_create_explore_node(self, real_agent_config, mock_llm_create):
+        """explore must land on ExploreAgenticNode (regression: previously fell back to GenSQL)."""
+        from datus.agent.node.explore_agentic_node import ExploreAgenticNode
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "explore", "test-session")
+        assert isinstance(node, ExploreAgenticNode)
+        assert not isinstance(node, GenSQLAgenticNode)
+
+    def test_create_feedback_node(self, real_agent_config, mock_llm_create):
+        """feedback continues to land on FeedbackAgenticNode through the shared factory."""
+        from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "feedback", "test-session")
+        assert isinstance(node, FeedbackAgenticNode)
+
+    def test_custom_agent_node_class_gen_report(self, real_agent_config, mock_llm_create):
+        """A custom sub_agent with node_class=gen_report must instantiate GenReportAgenticNode."""
+        from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        real_agent_config.agentic_nodes["my_report_agent"] = {
+            "system_prompt": "my_report_agent",
+            "node_class": "gen_report",
+            "tools": "db_tools.*",
+            "max_turns": 5,
+        }
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "my_report_agent", "test-session")
+        assert isinstance(node, GenReportAgenticNode)
+        assert not isinstance(node, GenSQLAgenticNode)
+
+    def test_custom_agent_no_node_class_falls_back_to_gen_sql(self, real_agent_config, mock_llm_create):
+        """A custom sub_agent without node_class must default to GenSQLAgenticNode."""
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        real_agent_config.agentic_nodes["plain_custom_agent"] = {
+            "system_prompt": "plain_custom_agent",
+            "tools": "db_tools.*",
+            "max_turns": 5,
+        }
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "plain_custom_agent", "test-session")
+        assert isinstance(node, GenSQLAgenticNode)
+
+    def test_custom_agent_uuid_resolved_to_node_class(self, real_agent_config, mock_llm_create):
+        """API passes the UUID under "id"; factory must look up the name and honour node_class."""
+        from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
+
+        real_agent_config.agentic_nodes["my_report_agent"] = {
+            "id": "11111111-2222-3333-4444-555555555555",
+            "system_prompt": "my_report_agent",
+            "node_class": "gen_report",
+            "tools": "db_tools.*",
+            "max_turns": 5,
+        }
+
+        manager = ChatTaskManager()
+        node = manager._create_node(
+            real_agent_config,
+            "11111111-2222-3333-4444-555555555555",
+            "test-session",
+        )
+        assert isinstance(node, GenReportAgenticNode)
+
 
 class TestCreateNodeInput:
     """Tests for _create_node_input — input model factory."""
@@ -1110,7 +1199,7 @@ class TestCreateNodeCustomSubAgent:
     def test_custom_subagent_resolves_sanitized_key(self, monkeypatch):
         """Custom sub_agent UUID resolves to sanitized node_name via agentic_nodes."""
         monkeypatch.setattr(
-            "datus.api.services.chat_task_manager.GenSQLAgenticNode",
+            "datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode",
             _StubGenSQLNode,
         )
         agent_config = MagicMock()
@@ -1124,7 +1213,7 @@ class TestCreateNodeCustomSubAgent:
     def test_custom_subagent_unknown_falls_back_to_id(self, monkeypatch):
         """Unknown subagent_id is used as-is when no matching entry exists."""
         monkeypatch.setattr(
-            "datus.api.services.chat_task_manager.GenSQLAgenticNode",
+            "datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode",
             _StubGenSQLNode,
         )
         agent_config = MagicMock()


### PR DESCRIPTION

Delegate `chat_task_manager._create_node` / `_create_node_input` to the shared `node_factory` instead of maintaining a parallel dispatch table. The API path now matches the CLI: every built-in sub_agent (gen_report, gen_table, gen_job, gen_skill, gen_dashboard, scheduler, explore, ...) lands on its dedicated AgenticNode subclass, and custom sub_agents honour their `node_class` field instead of always falling back to GenSQLAgenticNode. Extends `create_interactive_node` with `execution_mode` and `node_id` kwargs so the factory can serve both CLI and API call sites.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node creation now supports configurable execution modes (interactive and workflow).
  * Custom node IDs can be specified during node creation.
  * Node "scope" is now honored when creating several node types; workflow mode can bypass interactive prompt behavior where applicable.

* **Tests**
  * Added coverage for execution mode propagation, scope propagation, custom node ID overrides, and node dispatching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->