### PR TITLE
[BugFix] Guard query_metrics empty metrics

### DIFF
--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -53,6 +53,29 @@ def _normalize_dimension_rows(raw) -> list:
     return normalized
 
 
+def _normalize_name_list(value) -> List[str]:
+    """Normalize LLM-provided string/list arguments into a clean list of names."""
+    value = normalize_null(value)
+    if value is None:
+        return []
+    if isinstance(value, str):
+        candidates = [value]
+    elif isinstance(value, (list, tuple, set)):
+        candidates = list(value)
+    else:
+        candidates = [value]
+
+    names = []
+    for candidate in candidates:
+        candidate = normalize_null(candidate)
+        if candidate is None:
+            continue
+        text = str(candidate).strip()
+        if text:
+            names.append(text)
+    return names
+
+
 def _run_async(coro):
     """
     Run async coroutine safely, handling both sync and async contexts.
@@ -468,6 +491,20 @@ class SemanticTools:
         Returns:
             FuncToolResult with query results or explain plan
         """
+        metrics = _normalize_name_list(metrics)
+        dimensions = _normalize_name_list(dimensions)
+        path = _normalize_name_list(path)
+        order_by = _normalize_name_list(order_by)
+
+        if not metrics:
+            return FuncToolResult(
+                success=0,
+                error=(
+                    "query_metrics requires at least one metric name. "
+                    "Call list_metrics first and pass one or more metric names exactly as returned."
+                ),
+            )
+
         if not self.adapter:
             return FuncToolResult(
                 success=0,
@@ -477,6 +514,8 @@ class SemanticTools:
         # Sanitize time parameters: LLM may pass string "null"/"None" instead of omitting
         time_start = normalize_null(time_start)
         time_end = normalize_null(time_end)
+        time_granularity = normalize_null(time_granularity)
+        where = normalize_null(where)
         logger.info(
             f"query_metrics called: metrics={metrics}, dimensions={dimensions}, path={path}, "
             f"time=[{time_start},{time_end}], granularity={time_granularity}, where={where}, "
@@ -488,14 +527,14 @@ class SemanticTools:
             result = _run_async(
                 self.adapter.query_metrics(
                     metrics=metrics,
-                    dimensions=dimensions or [],
-                    path=path,
+                    dimensions=dimensions,
+                    path=path or None,
                     time_start=time_start,
                     time_end=time_end,
                     time_granularity=time_granularity,
                     where=where,
                     limit=limit,
-                    order_by=order_by,
+                    order_by=order_by or None,
                     dry_run=dry_run,
                 )
             )

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -211,6 +211,41 @@ class TestQueryMetricsCompression:
         assert result.success == 0
         assert "adapter" in result.error.lower()
 
+    @pytest.mark.parametrize("metrics", [[], ["null", "", None], ""])
+    def test_query_metrics_rejects_empty_metrics_before_adapter_call(self, semantic_tools, mock_adapter, metrics):
+        """MetricFlow otherwise raises a cryptic ComputeMetricsNode assertion."""
+        result = semantic_tools.query_metrics(metrics=metrics)
+
+        assert result.success == 0
+        assert "at least one metric name" in result.error
+        mock_adapter.query_metrics.assert_not_called()
+
+    def test_query_metrics_normalizes_string_arguments(self, semantic_tools, mock_adapter):
+        """LLM tool calls may send a single string even when the schema says list."""
+        query_result = QueryResult(columns=["revenue"], data=[{"revenue": 10}], metadata={})
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=query_result):
+            result = semantic_tools.query_metrics(
+                metrics="revenue",
+                dimensions="metric_time__day",
+                path="Finance",
+                order_by="-revenue",
+            )
+
+        assert result.success == 1
+        mock_adapter.query_metrics.assert_called_once_with(
+            metrics=["revenue"],
+            dimensions=["metric_time__day"],
+            path=["Finance"],
+            time_start=None,
+            time_end=None,
+            time_granularity=None,
+            where=None,
+            limit=None,
+            order_by=["-revenue"],
+            dry_run=False,
+        )
+
     def test_query_metrics_adapter_exception(self, semantic_tools):
         """Test query_metrics handles adapter exceptions gracefully."""
         with patch(


### PR DESCRIPTION
## Why

`query_metrics` could pass an empty metric list through to MetricFlow, which then failed with the internal assertion `ComputeMetricsNode was not properly constructed` instead of a user-actionable tool error.

## Solution

- Normalize list-like tool arguments from LLM calls, including single strings and `null`-like values.
- Reject empty `metrics` before invoking the semantic adapter and tell the caller to use `list_metrics` first.
- Keep adapter calls using normalized `metrics`, `dimensions`, `path`, and `order_by` values.

## Test Cases

- `uv run pytest tests/unit_tests/tools/func_tool/test_semantic_tools.py -q`
- `ruff check datus/tools/func_tool/semantic_tools.py tests/unit_tests/tools/func_tool/test_semantic_tools.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented stricter input validation for metric queries with improved error messages when required parameters are missing.
  * Enhanced normalization of scalar and list inputs to ensure consistent handling across parameters.

* **Tests**
  * Added comprehensive test coverage for input validation and parameter normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->