### PR TITLE
[Enhancement] Improve dashboard generation context

### DIFF
--- a/datus/cli/bi_dashboard.py
+++ b/datus/cli/bi_dashboard.py
@@ -178,6 +178,7 @@ class BiDashboardCommands:
 
             with self.console.status("Loading datasets..."):
                 datasets = self._items_from_adapter_result(adapter.list_datasets(dashboard_id))
+            datasets = self._hydrate_datasets(assembler, datasets, dashboard_id)
 
             result = assembler.assemble(dashboard, chart_selections_ref, chart_selections_metrics, datasets)
 

--- a/datus/prompts/prompt_templates/gen_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_dashboard_system_1.0.j2
@@ -60,6 +60,23 @@ You MUST follow the workflow described by the active skills for dashboard creati
 | big_number | Single KPI metrics |
 | scatter | Correlation between metrics |
 
+## Dashboard Composition Guide
+
+For dashboard creation requests, plan the chart set before calling write tools.
+Default to a readable executive-to-detail flow:
+
+1. KPI overview: 3-5 `big_number` charts for headline totals, rates, or averages.
+2. Time trend: 1-2 `line` or time-based `bar` charts when a temporal column exists.
+3. Breakdown / ranking: `bar` charts for top categories, statuses, regions, teams, or owners.
+4. Composition: `pie` only for part-to-whole views with fewer than 7 categories.
+5. Detail: one `table` chart only when row-level inspection is useful.
+
+Do not use a fixed chart count. Include as many charts as the business
+questions need, but avoid multiple charts that answer the same question with
+only a different title. Use concise business-facing titles, include units in
+the title or description when needed, and order creation calls in the same
+order users should read the dashboard.
+
 ## Rules
 - When listing dashboards, present results in a readable format.
 - For chart creation, choose appropriate chart types based on the data.

--- a/datus/resources/skills/grafana-dashboard/SKILL.md
+++ b/datus/resources/skills/grafana-dashboard/SKILL.md
@@ -40,7 +40,29 @@ configured `dataset_db.bi_database_name`; `create_chart` resolves the Grafana
 datasource automatically. If the datasource cannot be resolved, bail with a
 structured error. Do NOT try to auto-provision.
 
-### Step 2: Create Dashboard (`create_dashboard`)
+### Step 2: Plan Dashboard Layout Before Creating Panels
+
+Before calling `create_dashboard` or `create_chart`, make an internal layout
+plan. Do not expose a long plan to the user unless asked, but use it to decide
+the panel count, panel order, row grouping, and expected size before any
+dashboard or panel write calls.
+
+The layout plan must include:
+
+- Reading flow: KPI overview first, then trend, breakdown / ranking,
+  composition, and optional detail.
+- Row grouping: which panels should share a row and which panel should span a
+  full row.
+- Panel sizing intent: KPI cards are compact and share rows; trend and
+  breakdown panels usually share rows; detail tables usually span the full row.
+- Creation order: create panels in the same order users should read the
+  dashboard because Grafana appends panels in creation order.
+
+If the user provides a row-by-row layout, normalize it against these rules
+before creating resources. Avoid blindly creating one row per panel when panels
+can share a row.
+
+### Step 3: Create Dashboard (`create_dashboard`)
 
 Create the dashboard first — Grafana requires `dashboard_id` to add panels.
 
@@ -48,9 +70,9 @@ Create the dashboard first — Grafana requires `dashboard_id` to add panels.
 create_dashboard(title="Dashboard Title", description="Optional description")
 ```
 
-Returns `dashboard_id` — save it for Step 3.
+Returns `dashboard_id` — save it for Step 4.
 
-### Step 3: Create Charts (`create_chart`)
+### Step 4: Create Charts (`create_chart`)
 
 Create panels with SQL that queries the **existing table** in the
 Grafana-registered datasource.
@@ -77,11 +99,26 @@ create_chart(
 
 Repeat Step 3 for each chart. All panels use the same `dashboard_id`.
 
+Create panels in this visual order because Grafana appends panels to the
+dashboard in creation order:
+
+1. KPI overview: 3-5 `big_number` panels for headline totals, rates, averages, or sums.
+2. Time trends: 1-2 `line` panels over a real time column.
+3. Breakdowns / rankings: `bar` panels for top categories, statuses, teams, or owners.
+4. Composition: `pie` only for fewer than 7 categories and exactly one metric.
+5. Detail: one `table` panel only when users need row-level inspection.
+
+For high-cardinality categories, write SQL that ranks or limits the result to
+the top 10-15 values. Avoid one panel per column. Do not use a fixed panel
+count; include the panels needed to answer distinct business questions, then
+stop. Keep panel titles short and business-facing, and put units in aliases or
+descriptions when useful.
+
 If a chart needs a different data shape and the table isn't available, stop
 and return a structured error listing the missing table. The caller must
 prepare or refresh that data separately before retrying.
 
-### Step 4: Finish and Let Validation Run
+### Step 5: Finish and Let Validation Run
 
 After creating the dashboard and panels, finish the run and return the created
 IDs. `bi-validation` is a validator skill invoked automatically by

--- a/datus/resources/skills/superset-dashboard/SKILL.md
+++ b/datus/resources/skills/superset-dashboard/SKILL.md
@@ -56,7 +56,37 @@ create_dataset(name="view_name", database_id="<from step 1>", sql="SELECT ... FR
   `list_bi_databases()`. Source connector IDs and Superset BI database IDs are
   separate identifiers.
 
-### Step 3: Create Charts (`create_chart`)
+### Step 3: Plan Dashboard Layout Before Creating Charts
+
+Before calling `create_dashboard`, `create_chart`, or
+`add_chart_to_dashboard`, make an internal layout plan. Do not expose a long
+plan to the user unless asked, but use it to decide the chart count, chart
+order, and expected row grouping before any dashboard or chart write calls.
+
+The layout plan must include:
+
+- Reading flow: KPI overview first, then trend, breakdown / ranking,
+  composition, and optional detail.
+- Row grouping: which charts should share a row and which chart should span a
+  full row.
+- Chart sizing intent: KPI cards are compact and share rows; trend and
+  breakdown charts usually share rows; detail tables usually span the full row.
+- Creation order: create and add charts in the same order users should read
+  the dashboard.
+
+If the user provides a row-by-row layout, normalize it against these rules
+before creating resources. Avoid blindly creating one row per chart when charts
+can share a row.
+
+### Step 4: Create Dashboard (`create_dashboard`)
+
+```python
+create_dashboard(title="Dashboard Title", description="Optional description")
+```
+
+Returns `dashboard_id` — save it for chart creation and assembly.
+
+### Step 5: Create Charts (`create_chart`)
 
 Create visualization charts referencing the dataset.
 
@@ -65,6 +95,7 @@ create_chart(
     chart_type="bar",        # bar, line, pie, table, big_number, scatter
     title="Chart Title",
     dataset_id="<from step 2>",
+    dashboard_id="<from step 4>",
     metrics="revenue,COUNT(order_id)",
     x_axis="date_column",
     dimensions="category"
@@ -80,23 +111,30 @@ create_chart(
 - Use a single metric: `metrics="AVG(activity_count)"`
 - No `x_axis` or `dimensions` needed.
 
-### Step 4: Create Dashboard (`create_dashboard`)
+**Dashboard design defaults:**
+- Create charts in this visual order: KPI overview, time trends, category
+  breakdowns / rankings, composition, then optional detail table.
+- Use 3-5 `big_number` charts for headline metrics when the request includes
+  totals, counts, rates, averages, or sums.
+- Use `line` only when there is a real temporal column; otherwise use `bar`
+  for comparisons and rankings.
+- For high-cardinality categories, prefer a virtual dataset SQL that pre-filters
+  or ranks the top 10-15 values before creating the chart.
+- Use `pie` only for fewer than 7 categories and exactly one metric.
+- Avoid one chart per column. Do not use a fixed chart count; include the
+  charts needed to answer distinct business questions, then stop.
+- Keep chart titles short and business-facing, for example
+  "Open Requisitions by Team" instead of "count by team chart".
+
+### Step 6: Add Charts to Dashboard (`add_chart_to_dashboard`)
 
 ```python
-create_dashboard(title="Dashboard Title", description="Optional description")
-```
-
-Returns `dashboard_id` — save it for Step 5.
-
-### Step 5: Add Charts to Dashboard (`add_chart_to_dashboard`)
-
-```python
-add_chart_to_dashboard(chart_id="<from step 3>", dashboard_id="<from step 4>")
+add_chart_to_dashboard(chart_id="<from step 5>", dashboard_id="<from step 4>")
 ```
 
 Repeat for each chart.
 
-### Step 6: Finish and Let Validation Run
+### Step 7: Finish and Let Validation Run
 
 After assembling the dashboard, finish the run and return the created IDs.
 `bi-validation` is a validator skill invoked automatically by

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -45,6 +45,7 @@ _NORMAL_RULES = [
     _rule("db_tools", "read_query", PermissionLevel.ALLOW),
     _rule("db_tools", "verify_sql", PermissionLevel.ALLOW),
     _rule("db_tools", "list_*", PermissionLevel.ALLOW),
+    _rule("db_tools", "search_*", PermissionLevel.ALLOW),
     _rule("db_tools", "describe_*", PermissionLevel.ALLOW),
     _rule("db_tools", "get_*", PermissionLevel.ALLOW),
     # bi read + destructive deny

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -973,6 +973,23 @@ class TestGenDashboardPromptBoundary:
 
         assert "bi_database_name" in prompt
 
+    def test_system_prompt_guides_dashboard_composition(self, real_agent_config, mock_llm_create):
+        _add_dashboard_config(real_agent_config)
+        _bi_core_mock.adapter_registry.get.return_value = lambda **kwargs: FullMockAdapter()
+        with patch.dict(sys.modules, _BI_MODULES_PATCH):
+            from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
+
+            node = GenDashboardAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+            prompt = node._get_system_prompt(template_context=node._prepare_template_context())
+
+        assert "Dashboard Composition Guide" in prompt
+        assert "KPI overview" in prompt
+        assert "Time trend" in prompt
+        assert "Breakdown / ranking" in prompt
+        assert "Do not use a fixed chart count" in prompt
+        assert "as many charts as the business" in prompt
+        assert "same question" in prompt
+
 
 class TestPlatformSkillTrim:
     """The per-platform skills (superset-dashboard, grafana-dashboard) must no
@@ -992,6 +1009,28 @@ class TestPlatformSkillTrim:
     def test_grafana_dashboard_skill_has_no_write_query_step(self):
         body = self._skill_body("grafana-dashboard")
         assert "write_query" not in body
+
+    def test_superset_dashboard_skill_guides_chart_organization(self):
+        body = self._skill_body("superset-dashboard")
+        assert "Dashboard design defaults" in body
+        assert "Plan Dashboard Layout Before Creating Charts" in body
+        assert "Before calling `create_dashboard`, `create_chart`, or" in body
+        assert "Row grouping" in body
+        assert "Create charts in this visual order" in body
+        assert "top 10-15 values" in body
+        assert "Avoid one chart per column" in body
+        assert "Do not use a fixed chart count" in body
+
+    def test_grafana_dashboard_skill_guides_panel_organization(self):
+        body = self._skill_body("grafana-dashboard")
+        assert "Plan Dashboard Layout Before Creating Panels" in body
+        assert "Before calling `create_dashboard` or `create_chart`" in body
+        assert "Row grouping" in body
+        assert "creation order" in body
+        assert "KPI overview" in body
+        assert "top 10-15 values" in body
+        assert "Avoid one panel per column" in body
+        assert "Do not use a fixed panel" in body
 
 
 class TestGenDashboardSkillContext:

--- a/tests/unit_tests/tools/bi_tools/test_bi_dashboard_no_adapter.py
+++ b/tests/unit_tests/tools/bi_tools/test_bi_dashboard_no_adapter.py
@@ -4,6 +4,7 @@
 
 """Tests for BI dashboard behavior when no adapter packages are installed."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -61,3 +62,58 @@ class TestNoAdapterInstalled:
         items = [object(), object()]
 
         assert empty_registry_commands._items_from_adapter_result(items) == items
+
+    def test_cmd_hydrates_dataset_details_before_assemble(self, empty_registry_commands):
+        """bootstrap-bi should assemble against dataset details, not list summaries."""
+        from datus.cli.bi_dashboard import DashboardCliOptions
+
+        dashboard = SimpleNamespace(id="dash-1", name="Sales Dashboard", description="")
+        chart = SimpleNamespace(
+            id="chart-1",
+            name="Revenue",
+            description="",
+            chart_type="bar",
+            query=SimpleNamespace(sql=["SELECT SUM(amount) FROM sales"]),
+        )
+        dataset_summary = SimpleNamespace(id="dataset-1", name="sales")
+        dataset_detail = SimpleNamespace(id="dataset-1", name="sales", tables=["sales"])
+
+        adapter = MagicMock()
+        adapter.list_charts.return_value = [chart]
+        adapter.list_datasets.return_value = [dataset_summary]
+
+        assembler = MagicMock()
+        assembler.hydrate_datasets.return_value = [dataset_detail]
+        assembler.assemble.return_value = SimpleNamespace(
+            tables=["sales"],
+            reference_sqls=[],
+            metric_sqls=[],
+            charts=[chart],
+            datasets=[dataset_detail],
+            dashboard=dashboard,
+        )
+
+        options = DashboardCliOptions(
+            platform="superset",
+            dashboard_url="http://localhost:8088/superset/dashboard/1/",
+            api_base_url="http://localhost:8088",
+            auth_params=AuthParam(username="admin", password="admin"),
+        )
+
+        with (
+            patch("datus.cli.bi_dashboard.DashboardAssembler", return_value=assembler),
+            patch.object(empty_registry_commands, "_prompt_options", return_value=options),
+            patch.object(empty_registry_commands, "_create_adapter", return_value=adapter),
+            patch.object(empty_registry_commands, "_resolve_default_table_context", return_value=("", "", "")),
+            patch.object(empty_registry_commands, "_confirm_dashboard", return_value=(dashboard, "dash-1")),
+            patch.object(empty_registry_commands, "_hydrate_charts", return_value=[chart]),
+            patch.object(empty_registry_commands, "_render_chart_table"),
+            patch.object(empty_registry_commands, "_prompt_input", return_value="all"),
+            patch.object(empty_registry_commands, "_review_tables", return_value=["sales"]),
+            patch.object(empty_registry_commands, "_save_sub_agent"),
+        ):
+            empty_registry_commands.cmd()
+
+        assembler.hydrate_datasets.assert_called_once_with([dataset_summary], "dash-1")
+        assemble_args = assembler.assemble.call_args.args
+        assert assemble_args[3] == [dataset_detail]

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -42,6 +42,7 @@ class TestNormalProfile:
         assert _resolve(config, "context_search_tools", "search_metrics") == PermissionLevel.ALLOW
         assert _resolve(config, "db_tools", "read_query") == PermissionLevel.ALLOW
         assert _resolve(config, "db_tools", "list_tables") == PermissionLevel.ALLOW
+        assert _resolve(config, "db_tools", "search_table") == PermissionLevel.ALLOW
         assert _resolve(config, "bi_tools", "list_dashboards") == PermissionLevel.ALLOW
         assert _resolve(config, "filesystem_tools", "read_file") == PermissionLevel.ALLOW
         assert _resolve(config, "filesystem_tools", "glob") == PermissionLevel.ALLOW


### PR DESCRIPTION
## Why

Dashboard generation had weak business and layout context: bootstrap-bi assembled against dataset list summaries, gen_dashboard lacked explicit composition planning, and normal mode still asked for benign db search tools.

## Solution

- Hydrate dataset details before bootstrap-bi assembly.
- Add dashboard composition guidance and BI skill layout preflight for Superset and Grafana.
- Allow `db_tools.search_*` in the normal permission profile.
- Cover the behavior with focused unit tests.

## Test Cases

- `uv run pytest tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py tests/unit_tests/tools/bi_tools/test_bi_dashboard_no_adapter.py tests/unit_tests/tools/permission/test_profiles.py -q`
- `git diff --check` for changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced dashboard generation with intelligent chart composition guidance—KPI metrics appear first, followed by trends, breakdowns, and detail tables for improved readability.
  * Search tool functionality now enabled.

* **Documentation**
  * Updated dashboard creation guides with improved layout planning instructions and chart type recommendations for Grafana and Superset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->