### PR TITLE
[BugFix] Harden semantic generation workflows

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -390,7 +390,7 @@ agent:
     gen_metrics:
       model: anthropic
       max_turns: 40
-      # Default: "gen-metrics"
+      # Default: "gen-metrics, gen-semantic-model"
 
     gen_sql_summary:
       model: deepseek_v3

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -43,7 +43,7 @@ class GenMetricsAgenticNode(AgenticNode):
     NODE_NAME = "gen_metrics"
 
     # Define-metric workflow scoped to ``gen_metrics`` via SKILL.md allowed_agents.
-    DEFAULT_SKILLS = "gen-metrics"
+    DEFAULT_SKILLS = "gen-metrics, gen-semantic-model"
 
     def __init__(
         self,
@@ -498,18 +498,21 @@ class GenMetricsAgenticNode(AgenticNode):
                 else:
                     response_content = str(last_successful_output)  # Fallback to string representation
 
-            # Extract semantic_model_file, metric_file and output from the final response_content
-            semantic_model_file, metric_file, extracted_output = self._extract_metric_and_output_from_response(
-                {"content": response_content}
-            )
+            # Extract semantic_model_file, metric_file, status and output from the final response_content
+            (
+                semantic_model_file,
+                metric_file,
+                status,
+                extracted_output,
+            ) = self._extract_metric_and_output_from_response({"content": response_content})
             if extracted_output:
                 response_content = extracted_output
 
-            if metric_file and not self.generation_evidence.metric_kb_sync_passed:
-                raise RuntimeError(
-                    "Metric generation did not publish to Knowledge Base. "
-                    "Call end_metric_generation after validate_semantic and query_metrics(dry_run=True) succeed."
-                )
+            self._finalize_metric_generation(
+                semantic_model_file=semantic_model_file,
+                metric_file=metric_file,
+                status=status,
+            )
 
             # Extract token usage (only in interactive mode with session)
             tokens_used = 0
@@ -585,20 +588,109 @@ class GenMetricsAgenticNode(AgenticNode):
             action_history_manager.add_action(error_action)
             yield error_action
 
+    @staticmethod
+    def _tool_succeeded(result: Any) -> bool:
+        if isinstance(result, dict):
+            return result.get("success", 1) in (1, True)
+        if hasattr(result, "success"):
+            return result.success in (1, True)
+        return False
+
+    @staticmethod
+    def _tool_error(result: Any) -> str:
+        if isinstance(result, dict):
+            return str(result.get("error") or result.get("result") or "unknown error")
+        return str(getattr(result, "error", None) or getattr(result, "result", None) or "unknown error")
+
+    def _resolve_metric_artifact_path(self, path: Optional[str], kind: str) -> str:
+        if not path:
+            return ""
+
+        from datus.cli.generation_hooks import resolve_kb_sandbox_path
+
+        resolved_path = resolve_kb_sandbox_path(path, kind, self.knowledge_base_dir)
+        if not resolved_path:
+            raise RuntimeError(f"Metric generation reported {kind}_file outside Knowledge Base sandbox: {path!r}")
+        return resolved_path
+
+    def _finalize_metric_generation(
+        self,
+        semantic_model_file: Optional[str],
+        metric_file: Optional[str],
+        status: Optional[str],
+    ) -> None:
+        """Ensure generated metric artifacts are published without relying on one LLM tool call."""
+        normalized_status = status.strip().lower() if isinstance(status, str) else status
+
+        if normalized_status == "skipped":
+            if metric_file:
+                raise RuntimeError(
+                    "Metric generation returned status='skipped' with a non-null metric_file. "
+                    "Skipped responses must set metric_file to null; generated metric files must be published."
+                )
+            return
+
+        if not metric_file or self.generation_evidence.metric_kb_sync_passed:
+            return
+
+        if not self.generation_tools:
+            raise RuntimeError("Metric generation produced a metric_file, but generation tools are unavailable.")
+
+        if not self.generation_evidence.validation_passed:
+            if not getattr(self, "semantic_tools", None):
+                raise RuntimeError("Metric generation produced a metric_file, but validate_semantic is unavailable.")
+            validation_result = self.semantic_tools.validate_semantic()
+            self.generation_evidence.record_validation_result(validation_result)
+            if not self._tool_succeeded(validation_result):
+                raise RuntimeError(
+                    f"validate_semantic failed before publishing metrics: {self._tool_error(validation_result)}"
+                )
+
+        abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
+        abs_semantic_model_file = (
+            self._resolve_metric_artifact_path(semantic_model_file, "semantic") if semantic_model_file else ""
+        )
+        preflight_error = self.generation_tools._validate_metric_file_has_blocks(abs_metric_file)
+        if preflight_error:
+            raise RuntimeError(preflight_error)
+
+        metric_names = self.generation_tools._extract_metric_names_from_file(abs_metric_file)
+        if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
+            if not getattr(self, "semantic_tools", None):
+                raise RuntimeError("Metric generation produced a metric_file, but query_metrics is unavailable.")
+            dry_run_result = self.semantic_tools.query_metrics(metrics=metric_names, dry_run=True)
+            self.generation_evidence.record_metric_dry_run(metric_names, dry_run_result)
+            if not self._tool_succeeded(dry_run_result):
+                raise RuntimeError(
+                    "query_metrics(dry_run=True) failed for generated metric(s) "
+                    f"{', '.join(metric_names)}: {self._tool_error(dry_run_result)}"
+                )
+
+        publish_result = self.generation_tools.end_metric_generation(
+            metric_file=abs_metric_file,
+            semantic_model_file=abs_semantic_model_file,
+        )
+        if not self._tool_succeeded(publish_result):
+            raise RuntimeError(f"Metric KB sync failed: {self._tool_error(publish_result)}")
+        self.generation_evidence.mark_kb_sync("metric")
+
     def _extract_metric_and_output_from_response(
         self, output: dict
-    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
         """
-        Extract semantic model file, metric file and formatted output from model response.
+        Extract semantic model file, metric file, status and formatted output from model response.
 
         Per prompt template requirements, LLM should return JSON format:
-        {"semantic_model_file": "path.yml", "metric_file": "path.yml", "output": "markdown text"}
+        {"semantic_model_file": "path.yml", "metric_file": "path.yml",
+         "status": "generated" | "skipped", "output": "markdown text"}
+
+        ``status`` is optional for backward compatibility; absent values are treated as ``"generated"``.
 
         Args:
             output: Output dictionary from model generation
 
         Returns:
-            Tuple of (semantic_model_file: Optional[str], metric_file: Optional[str], output_string: Optional[str])
+            Tuple of (semantic_model_file, metric_file, status, output_string), each Optional[str].
         """
         try:
             from datus.utils.json_utils import strip_json_str
@@ -611,12 +703,14 @@ class GenMetricsAgenticNode(AgenticNode):
                 output_text = content.get("output")
                 semantic_model_file = content.get("semantic_model_file")
                 metric_file = content.get("metric_file")
+                status = content.get("status")
 
-                if metric_file and isinstance(metric_file, str):
+                if (metric_file and isinstance(metric_file, str)) or status == "skipped":
                     logger.debug(
-                        f"Extracted from dict: semantic_model_file={semantic_model_file}, metric_file={metric_file}"
+                        f"Extracted from dict: semantic_model_file={semantic_model_file}, "
+                        f"metric_file={metric_file}, status={status}"
                     )
-                    return semantic_model_file, metric_file, output_text
+                    return semantic_model_file, metric_file, status, output_text
 
                 logger.warning(f"Dict format but missing expected keys or invalid format: {content.keys()}")
 
@@ -633,21 +727,23 @@ class GenMetricsAgenticNode(AgenticNode):
                             output_text = parsed.get("output")
                             semantic_model_file = parsed.get("semantic_model_file")
                             metric_file = parsed.get("metric_file")
+                            status = parsed.get("status")
 
-                            if metric_file and isinstance(metric_file, str):
+                            if (metric_file and isinstance(metric_file, str)) or status == "skipped":
                                 logger.debug(
                                     f"Extracted from JSON string: "
-                                    f"semantic_model_file={semantic_model_file}, metric_file={metric_file}"
+                                    f"semantic_model_file={semantic_model_file}, "
+                                    f"metric_file={metric_file}, status={status}"
                                 )
-                                return semantic_model_file, metric_file, output_text
+                                return semantic_model_file, metric_file, status, output_text
 
                             logger.warning(f"Parsed JSON but missing expected keys or invalid format: {parsed.keys()}")
                     except Exception as e:
                         logger.warning(f"Failed to parse cleaned JSON: {e}. Cleaned content: {cleaned_json[:200]}")
 
             logger.warning(f"Could not extract metric_file from response. Content type: {type(content)}")
-            return None, None, None
+            return None, None, None, None
 
         except Exception as e:
             logger.error(f"Unexpected error extracting metric_file: {e}", exc_info=True)
-            return None, None, None
+            return None, None, None, None

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -630,7 +630,16 @@ class GenMetricsAgenticNode(AgenticNode):
                 )
             return
 
-        if not metric_file or self.generation_evidence.metric_kb_sync_passed:
+        if self.generation_evidence.metric_kb_sync_passed:
+            return
+
+        if normalized_status == "generated" and not metric_file:
+            raise RuntimeError(
+                "Metric generation returned status='generated' without a metric_file. "
+                "Generated responses must include metric_file or call end_metric_generation."
+            )
+
+        if not metric_file:
             return
 
         if not self.generation_tools:
@@ -704,13 +713,14 @@ class GenMetricsAgenticNode(AgenticNode):
                 semantic_model_file = content.get("semantic_model_file")
                 metric_file = content.get("metric_file")
                 status = content.get("status")
+                normalized_status = status.strip().lower() if isinstance(status, str) else None
 
-                if (metric_file and isinstance(metric_file, str)) or status == "skipped":
+                if (metric_file and isinstance(metric_file, str)) or normalized_status in {"generated", "skipped"}:
                     logger.debug(
                         f"Extracted from dict: semantic_model_file={semantic_model_file}, "
-                        f"metric_file={metric_file}, status={status}"
+                        f"metric_file={metric_file}, status={normalized_status}"
                     )
-                    return semantic_model_file, metric_file, status, output_text
+                    return semantic_model_file, metric_file, normalized_status, output_text
 
                 logger.warning(f"Dict format but missing expected keys or invalid format: {content.keys()}")
 
@@ -728,14 +738,18 @@ class GenMetricsAgenticNode(AgenticNode):
                             semantic_model_file = parsed.get("semantic_model_file")
                             metric_file = parsed.get("metric_file")
                             status = parsed.get("status")
+                            normalized_status = status.strip().lower() if isinstance(status, str) else None
 
-                            if (metric_file and isinstance(metric_file, str)) or status == "skipped":
+                            if (metric_file and isinstance(metric_file, str)) or normalized_status in {
+                                "generated",
+                                "skipped",
+                            }:
                                 logger.debug(
                                     f"Extracted from JSON string: "
                                     f"semantic_model_file={semantic_model_file}, "
-                                    f"metric_file={metric_file}, status={status}"
+                                    f"metric_file={metric_file}, status={normalized_status}"
                                 )
-                                return semantic_model_file, metric_file, status, output_text
+                                return semantic_model_file, metric_file, normalized_status, output_text
 
                             logger.warning(f"Parsed JSON but missing expected keys or invalid format: {parsed.keys()}")
                     except Exception as e:

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -633,10 +633,10 @@ class GenMetricsAgenticNode(AgenticNode):
         if self.generation_evidence.metric_kb_sync_passed:
             return
 
-        if normalized_status == "generated" and not metric_file:
+        if normalized_status and not metric_file:
             raise RuntimeError(
-                "Metric generation returned status='generated' without a metric_file. "
-                "Generated responses must include metric_file or call end_metric_generation."
+                f"Metric generation returned status='{normalized_status}' without a metric_file. "
+                "Non-skipped metric responses must include metric_file or call end_metric_generation."
             )
 
         if not metric_file:
@@ -715,7 +715,7 @@ class GenMetricsAgenticNode(AgenticNode):
                 status = content.get("status")
                 normalized_status = status.strip().lower() if isinstance(status, str) else None
 
-                if (metric_file and isinstance(metric_file, str)) or normalized_status in {"generated", "skipped"}:
+                if (metric_file and isinstance(metric_file, str)) or normalized_status:
                     logger.debug(
                         f"Extracted from dict: semantic_model_file={semantic_model_file}, "
                         f"metric_file={metric_file}, status={normalized_status}"
@@ -740,10 +740,7 @@ class GenMetricsAgenticNode(AgenticNode):
                             status = parsed.get("status")
                             normalized_status = status.strip().lower() if isinstance(status, str) else None
 
-                            if (metric_file and isinstance(metric_file, str)) or normalized_status in {
-                                "generated",
-                                "skipped",
-                            }:
+                            if (metric_file and isinstance(metric_file, str)) or normalized_status:
                                 logger.debug(
                                     f"Extracted from JSON string: "
                                     f"semantic_model_file={semantic_model_file}, "

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -512,25 +512,12 @@ class GenSemanticModelAgenticNode(AgenticNode):
                                 else:
                                     logger.warning(f"no usage token found in this action {action.messages}")
 
-            # Auto-save to database in workflow mode (support multiple files)
-            if self.execution_mode == "workflow" and semantic_model_files:
-                try:
-                    for semantic_model_file in semantic_model_files:
-                        self._save_to_db(
-                            semantic_model_file,
-                            catalog=user_input.catalog,
-                            database=user_input.database,
-                            db_schema=user_input.db_schema,
-                        )
-                    logger.info(f"Auto-saved {len(semantic_model_files)} semantic models to database")
-                except Exception as e:
-                    logger.error(f"Failed to auto-save to database: {e}")
-
-            if semantic_model_files and not self.generation_evidence.semantic_kb_sync_passed:
-                raise RuntimeError(
-                    "Semantic model generation did not publish to Knowledge Base. "
-                    "Call end_semantic_model_generation after validate_semantic succeeds."
-                )
+            self._finalize_semantic_model_generation(
+                semantic_model_files=semantic_model_files,
+                catalog=user_input.catalog,
+                database=user_input.database,
+                db_schema=user_input.db_schema,
+            )
 
             # Create final result
             result = SemanticNodeResult(
@@ -587,6 +574,64 @@ class GenSemanticModelAgenticNode(AgenticNode):
             )
             action_history_manager.add_action(error_action)
             yield error_action
+
+    @staticmethod
+    def _tool_succeeded(result: Any) -> bool:
+        if isinstance(result, dict):
+            return result.get("success", 1) in (1, True)
+        if hasattr(result, "success"):
+            return result.success in (1, True)
+        return False
+
+    @staticmethod
+    def _tool_error(result: Any) -> str:
+        if isinstance(result, dict):
+            return str(result.get("error") or result.get("result") or "unknown error")
+        return str(getattr(result, "error", None) or getattr(result, "result", None) or "unknown error")
+
+    def _finalize_semantic_model_generation(
+        self,
+        semantic_model_files: list[str],
+        catalog=None,
+        database=None,
+        db_schema=None,
+    ) -> None:
+        """Validate and publish semantic model artifacts without relying on one LLM tool call."""
+        if not semantic_model_files or self.generation_evidence.semantic_kb_sync_passed:
+            return
+
+        if not self.generation_evidence.validation_passed:
+            if not getattr(self, "semantic_func_tool", None):
+                raise RuntimeError(
+                    "Semantic model generation produced semantic_model_files, but validate_semantic is unavailable."
+                )
+            validation_result = self.semantic_func_tool.validate_semantic()
+            self.generation_evidence.record_validation_result(validation_result)
+            if not self._tool_succeeded(validation_result):
+                raise RuntimeError(
+                    f"validate_semantic failed before publishing semantic models: {self._tool_error(validation_result)}"
+                )
+
+        synced_files = []
+        failed_files = []
+        for semantic_model_file in semantic_model_files:
+            if self._save_to_db(
+                semantic_model_file,
+                catalog=catalog,
+                database=database,
+                db_schema=db_schema,
+            ):
+                synced_files.append(semantic_model_file)
+            else:
+                failed_files.append(semantic_model_file)
+
+        if failed_files:
+            raise RuntimeError(
+                "Semantic model generation produced file(s), but failed to sync to Knowledge Base: "
+                f"{', '.join(failed_files)}"
+            )
+
+        logger.info(f"Auto-saved {len(synced_files)} semantic models to database")
 
     def _extract_semantic_model_and_output_from_response(self, output: dict) -> tuple[list[str], Optional[str]]:
         """
@@ -646,7 +691,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
             logger.error(f"Unexpected error extracting semantic_model_files: {e}", exc_info=True)
             return [], None
 
-    def _save_to_db(self, semantic_model_file: str, catalog=None, database=None, db_schema=None):
+    def _save_to_db(self, semantic_model_file: str, catalog=None, database=None, db_schema=None) -> bool:
         """
         Save generated semantic model to database (synchronous).
 
@@ -664,11 +709,11 @@ class GenSemanticModelAgenticNode(AgenticNode):
             full_path = resolve_kb_sandbox_path(semantic_model_file, "semantic", self.knowledge_base_dir)
             if not full_path:
                 logger.warning(f"Semantic model file rejected by sandbox check: {semantic_model_file!r}")
-                return
+                return False
 
             if not os.path.exists(full_path):
                 logger.warning(f"Semantic model file not found: {full_path}")
-                return
+                return False
 
             # Call static method to save to database
             # Deduplication is handled inside _sync_semantic_to_db
@@ -679,9 +724,11 @@ class GenSemanticModelAgenticNode(AgenticNode):
             if result.get("success"):
                 self.generation_evidence.mark_kb_sync("semantic")
                 logger.info(f"Successfully saved to database: {result.get('message')}")
+                return True
             else:
                 error = result.get("error", "Unknown error")
                 logger.error(f"Failed to save to database: {error}")
+                return False
 
         except Exception as e:
             logger.error(f"Error saving to database: {e}", exc_info=True)

--- a/datus/models/sdk_patches.py
+++ b/datus/models/sdk_patches.py
@@ -33,7 +33,8 @@ Kimi/Moonshot to DeepSeek models.
 
 import copy
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator, MutableMapping
+from contextvars import ContextVar
 from typing import Any
 
 from datus.utils.loggings import get_logger
@@ -180,10 +181,46 @@ _original_usage_model_dump_json = None
 _original_usage_init = None
 _original_showwarning = None
 
-# Cache reasoning_content from API responses, keyed by model name.
-# This provides a fallback when the SDK converter fails to extract
-# reasoning_content from items (e.g., when summary is empty).
-_reasoning_content_cache: dict[str, str] = {}
+# Cache reasoning_content from API responses, keyed by model name within the
+# current execution context. This avoids leaking one session's hidden reasoning
+# into another request while preserving the fallback inside a tool-calling run.
+_reasoning_content_cache_var: ContextVar[dict[str, str] | None] = ContextVar(
+    "datus_reasoning_content_cache",
+    default=None,
+)
+
+
+def _current_reasoning_content_cache() -> dict[str, str]:
+    cache = _reasoning_content_cache_var.get()
+    if cache is None:
+        cache = {}
+        _reasoning_content_cache_var.set(cache)
+    return cache
+
+
+class _ReasoningContentCache(MutableMapping[str, str]):
+    """Context-local mapping kept for tests and local cache helpers."""
+
+    def __getitem__(self, key: str) -> str:
+        return _current_reasoning_content_cache()[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        _current_reasoning_content_cache()[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del _current_reasoning_content_cache()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(_current_reasoning_content_cache())
+
+    def __len__(self) -> int:
+        return len(_current_reasoning_content_cache())
+
+    def clear(self) -> None:
+        _current_reasoning_content_cache().clear()
+
+
+_reasoning_content_cache: MutableMapping[str, str] = _ReasoningContentCache()
 
 
 _REASONING_CONTENT_FIELD_NAMES = (
@@ -477,17 +514,19 @@ def _postprocess_messages_for_reasoning(
     if is_deepseek and not last_reasoning_content:
         messages = _sanitize_deepseek_history_without_reasoning(messages)
 
-    # Ensure assistant messages preserve reasoning_content when the provider
-    # requires it. DeepSeek V4 Pro rejects follow-up requests if the final
-    # assistant message from a tool-using turn is missing reasoning_content,
-    # even though that final message has no tool_calls. Kimi/Moonshot keeps the
-    # narrower historical behavior and only patches assistant+tool_calls turns.
-    for msg in messages:
+    # Ensure assistant messages preserve reasoning_content on tool-calling turns.
+    # DeepSeek also requires the final assistant message immediately after a tool
+    # result to carry reasoning_content. Keep ordinary assistant history untouched.
+    for idx, msg in enumerate(messages):
         if not isinstance(msg, dict) or msg.get("role") != "assistant":
             continue
 
         has_tool_calls = bool(msg.get("tool_calls"))
-        should_patch_message = has_tool_calls or is_deepseek
+        previous_message = messages[idx - 1] if idx > 0 else None
+        follows_tool_result = (
+            is_deepseek and isinstance(previous_message, dict) and previous_message.get("role") == "tool"
+        )
+        should_patch_message = has_tool_calls or follows_tool_result
         if should_patch_message:
             current_rc = _coerce_reasoning_text(msg.get("reasoning_content"))
             if current_rc:

--- a/datus/models/sdk_patches.py
+++ b/datus/models/sdk_patches.py
@@ -186,6 +186,208 @@ _original_showwarning = None
 _reasoning_content_cache: dict[str, str] = {}
 
 
+_REASONING_CONTENT_FIELD_NAMES = (
+    "reasoning_content",
+    "reasoning",
+    "reasoning_text",
+    "thinking",
+)
+_REASONING_CONTENT_NESTED_FIELD_NAMES = (
+    "model_extra",
+    "additional_kwargs",
+    "provider_specific_fields",
+    "extra",
+    "extra_fields",
+    "__pydantic_extra__",
+)
+
+
+def _read_field(value: Any, name: str) -> Any:
+    """Safely read ``name`` from dict-like and object-like values."""
+    if isinstance(value, dict):
+        return value.get(name)
+    try:
+        return getattr(value, name)
+    except Exception:
+        return None
+
+
+def _coerce_reasoning_text(value: Any) -> str | None:
+    """Return a non-empty reasoning string from known reasoning-shaped values."""
+    if isinstance(value, str):
+        return value if value.strip() else None
+
+    if isinstance(value, dict):
+        for key in _REASONING_CONTENT_FIELD_NAMES + ("text", "content"):
+            text = _coerce_reasoning_text(value.get(key))
+            if text:
+                return text
+        return None
+
+    if isinstance(value, list):
+        parts = [_coerce_reasoning_text(item) for item in value]
+        text = "".join(part for part in parts if part)
+        return text if text.strip() else None
+
+    return None
+
+
+def _extract_reasoning_content(value: Any) -> str | None:
+    """Extract reasoning text from LiteLLM/OpenAI-style dicts or objects.
+
+    LiteLLM and provider adapters do not expose DeepSeek reasoning deltas in
+    one uniform shape. Some versions use ``delta.reasoning_content`` while
+    others put the same value inside dict deltas, ``model_extra`` or
+    ``provider_specific_fields``. Only inspect known reasoning fields so normal
+    assistant ``content`` is never mistaken for hidden reasoning.
+    """
+    seen: set[int] = set()
+    stack = [value]
+
+    while stack:
+        current = stack.pop()
+        if current is None:
+            continue
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+
+        for field_name in _REASONING_CONTENT_FIELD_NAMES:
+            text = _coerce_reasoning_text(_read_field(current, field_name))
+            if text:
+                return text
+
+        for nested_field_name in _REASONING_CONTENT_NESTED_FIELD_NAMES:
+            nested = _read_field(current, nested_field_name)
+            if nested is not None and nested is not current:
+                stack.append(nested)
+
+    return None
+
+
+def _reasoning_cache_keys(model: str | None) -> list[str]:
+    """Return equivalent cache keys for prefixed/unprefixed LiteLLM model names."""
+    if not model:
+        return []
+
+    raw_model = str(model).strip()
+    if not raw_model:
+        return []
+
+    keys: list[str] = []
+
+    def add(key: str | None) -> None:
+        if not key:
+            return
+        stripped = key.strip()
+        if stripped and stripped not in keys:
+            keys.append(stripped)
+        lowered = stripped.lower()
+        if lowered and lowered not in keys:
+            keys.append(lowered)
+
+    add(raw_model)
+
+    if "/" in raw_model:
+        _, suffix = raw_model.split("/", 1)
+        add(suffix)
+    elif _is_deepseek_model(raw_model):
+        add(f"deepseek/{raw_model}")
+    elif _is_kimi_model(raw_model):
+        add(f"moonshot/{raw_model}")
+
+    return keys
+
+
+def _cache_reasoning_content(model: str | None, reasoning_content: str) -> None:
+    """Cache reasoning_content under all equivalent model aliases."""
+    if not reasoning_content or not reasoning_content.strip():
+        return
+    for key in _reasoning_cache_keys(model):
+        _reasoning_content_cache[key] = reasoning_content
+
+
+def _get_cached_reasoning_content(model: str | None) -> str | None:
+    """Fetch cached reasoning_content across prefixed/unprefixed aliases."""
+    for key in _reasoning_cache_keys(model):
+        cached = _reasoning_content_cache.get(key)
+        if cached and cached.strip():
+            return cached
+    return None
+
+
+def _content_text(content: Any) -> str | None:
+    """Extract visible text from a chat-completion content value."""
+    if isinstance(content, str):
+        text = content.strip()
+        return text or None
+
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text")
+            else:
+                text = _read_field(item, "text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        joined = "\n".join(parts).strip()
+        return joined or None
+
+    return None
+
+
+def _sanitize_deepseek_history_without_reasoning(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop historical tool protocol messages that DeepSeek thinking cannot replay.
+
+    DeepSeek thinking mode requires every assistant message with ``tool_calls``
+    to carry the exact reasoning_content that DeepSeek produced. When a user
+    switches from another provider, old session history can contain tool-call
+    turns without any DeepSeek reasoning source. The current turn still has a
+    trailing user message, so only sanitize messages before the last user
+    message and leave in-flight DeepSeek tool calls untouched.
+    """
+    last_user_index = -1
+    for idx, msg in enumerate(messages):
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            last_user_index = idx
+
+    if last_user_index <= 0:
+        return messages
+
+    sanitized: list[dict[str, Any]] = []
+    dropped_count = 0
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict) or idx >= last_user_index:
+            sanitized.append(msg)
+            continue
+
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls") and not _extract_reasoning_content(msg):
+            text = _content_text(msg.get("content"))
+            if text:
+                clean_msg = {key: value for key, value in msg.items() if key not in ("tool_calls", "reasoning_content")}
+                clean_msg["content"] = text
+                sanitized.append(clean_msg)
+            dropped_count += 1
+            continue
+
+        if role == "tool":
+            dropped_count += 1
+            continue
+
+        sanitized.append(msg)
+
+    if dropped_count:
+        logger.info(
+            "[SDK Patch] Dropped %s historical tool-protocol message(s) before DeepSeek thinking call "
+            "because no replayable reasoning_content was available.",
+            dropped_count,
+        )
+    return sanitized
+
+
 class _ReasoningContentStreamWrapper:
     """
     Async iterator wrapper that intercepts streaming chunks to cache
@@ -212,11 +414,12 @@ class _ReasoningContentStreamWrapper:
             raise
 
         try:
-            for choice in getattr(chunk, "choices", []):
-                delta = getattr(choice, "delta", None)
+            choices = _read_field(chunk, "choices") or []
+            for choice in choices:
+                delta = _read_field(choice, "delta")
                 if delta:
-                    rc = getattr(delta, "reasoning_content", None)
-                    if rc and isinstance(rc, str):
+                    rc = _extract_reasoning_content(delta)
+                    if rc:
                         self._reasoning_chunks.append(rc)
         except Exception:
             pass
@@ -228,7 +431,7 @@ class _ReasoningContentStreamWrapper:
         if self._reasoning_chunks:
             full_rc = "".join(self._reasoning_chunks)
             if full_rc.strip():
-                _reasoning_content_cache[self._model] = full_rc
+                _cache_reasoning_content(self._model, full_rc)
                 logger.debug(
                     f"[SDK Patch] Cached reasoning_content from stream, model={self._model}, length={len(full_rc)}"
                 )
@@ -258,18 +461,21 @@ def _postprocess_messages_for_reasoning(
     # Find the last non-empty reasoning_content to reuse if needed
     last_reasoning_content = None
     for msg in messages:
-        if isinstance(msg, dict) and "reasoning_content" in msg:
-            rc = msg.get("reasoning_content", "")
-            if rc and rc.strip():
+        if isinstance(msg, dict):
+            rc = _extract_reasoning_content(msg)
+            if rc:
                 last_reasoning_content = rc
                 logger.debug(f"[SDK Patch] Found non-empty reasoning_content in messages, length={len(rc)}")
 
     # Fallback: use cached reasoning_content from a previous API response
     if not last_reasoning_content and model:
-        cached_rc = _reasoning_content_cache.get(model)
+        cached_rc = _get_cached_reasoning_content(model)
         if cached_rc:
             last_reasoning_content = cached_rc
             logger.debug(f"[SDK Patch] Using cached reasoning_content as fallback, length={len(cached_rc)}")
+
+    if is_deepseek and not last_reasoning_content:
+        messages = _sanitize_deepseek_history_without_reasoning(messages)
 
     # Ensure assistant messages preserve reasoning_content when the provider
     # requires it. DeepSeek V4 Pro rejects follow-up requests if the final
@@ -283,8 +489,10 @@ def _postprocess_messages_for_reasoning(
         has_tool_calls = bool(msg.get("tool_calls"))
         should_patch_message = has_tool_calls or is_deepseek
         if should_patch_message:
-            current_rc = msg.get("reasoning_content", "")
-            if (not current_rc or not current_rc.strip()) and last_reasoning_content:
+            current_rc = _coerce_reasoning_text(msg.get("reasoning_content"))
+            if current_rc:
+                msg["reasoning_content"] = current_rc
+            elif last_reasoning_content:
                 msg["reasoning_content"] = last_reasoning_content
                 logger.debug("[SDK Patch] Injected reasoning_content into assistant message")
             elif has_tool_calls and "reasoning_content" not in msg and is_kimi:
@@ -474,9 +682,9 @@ def apply_sdk_patches() -> None:
                         for choice in getattr(response, "choices", []):
                             msg = getattr(choice, "message", None)
                             if msg:
-                                rc = getattr(msg, "reasoning_content", None)
-                                if rc and isinstance(rc, str) and rc.strip():
-                                    _reasoning_content_cache[model] = rc
+                                rc = _extract_reasoning_content(msg)
+                                if rc:
+                                    _cache_reasoning_content(model, rc)
                                     logger.debug(
                                         f"[SDK Patch] Cached reasoning_content from response, "
                                         f"model={model}, length={len(rc)}"
@@ -513,9 +721,9 @@ def apply_sdk_patches() -> None:
                     for choice in getattr(response, "choices", []):
                         msg = getattr(choice, "message", None)
                         if msg:
-                            rc = getattr(msg, "reasoning_content", None)
-                            if rc and isinstance(rc, str) and rc.strip():
-                                _reasoning_content_cache[model] = rc
+                            rc = _extract_reasoning_content(msg)
+                            if rc:
+                                _cache_reasoning_content(model, rc)
                                 logger.debug(
                                     f"[SDK Patch] Cached reasoning_content from sync response, "
                                     f"model={model}, length={len(rc)}"

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
@@ -175,7 +175,7 @@ If `query_metrics(dry_run=True)` fails for any metric, fix the YAML and rerun
 
 ### Step 10: Complete Generation
 
-After validation succeeds and SQLs are collected, MUST call `end_metric_generation` tool with the metric SQLs as a JSON string. `metric_file` and `semantic_model_file` use the same `{{ kind_subdir }}/` prefix you wrote to:
+After validation succeeds and SQLs are collected, prefer calling `end_metric_generation` tool with the metric SQLs as a JSON string so publish errors are caught while you can still fix files. If you forget this tool, the host will still use the final JSON `metric_file` to validate, dry-run, and publish the generated metrics before reporting success. `metric_file` and `semantic_model_file` use the same `{{ kind_subdir }}/` prefix you wrote to:
 ```
 end_metric_generation(
     metric_file="{{ kind_subdir }}/metrics/users_metrics.yml",
@@ -196,13 +196,25 @@ end_metric_generation(
 {
   "semantic_model_file": "{{ kind_subdir }}/users.yml",
   "metric_file": "{{ kind_subdir }}/metrics/users_metrics.yml",
+  "status": "generated",
   "output": "markdown summary of extracted measures and generated metrics"
 }
 ```
 
 - `semantic_model_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/users.yml"`
 - `metric_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/metrics/users_metrics.yml"`
+- `status`: One of `"generated"` (at least one new metric was created and is ready to publish via `end_metric_generation` or the host fallback) or `"skipped"` (every requested metric already existed and was skipped — set `metric_file` to `null` in this case).
 - `output`: Brief summary message
+
+If every requested metric already exists, return:
+```json
+{
+  "semantic_model_file": null,
+  "metric_file": null,
+  "status": "skipped",
+  "output": "All requested metrics already exist; no new metric was generated."
+}
+```
 
 **DO NOT** return markdown, plain text, or any other format. Return **ONLY** the JSON object.
 
@@ -268,6 +280,6 @@ metric:
 4. **No redundancy**: If a measure already exists in semantic model, reuse it
 5. **Validate**: Always validate before completing
 6. **Generate SQL**: Use query_metrics(dry_run=True) to get SQL for each metric
-7. **Complete**: Always call end_metric_generation with metric_sqls_json (JSON string) at the end
+7. **Complete**: Prefer calling end_metric_generation with metric_sqls_json (JSON string) at the end; final JSON `metric_file` is the host fallback
 8. **YAML String Quoting**: ALWAYS wrap `description` values in double quotes (`"`). Escape special characters: `"` → `\"`, `\` → `\\`
 9. **The metric file MUST contain explicit `metric:` YAML blocks** (one per metric, separated by `---`). Documentation, markdown, comments, or empty content will be rejected by the sync step. Never rely on `create_metric: true` on semantic-model measures — that flag only emits metrics at MetricFlow runtime and they are NOT synced to the Knowledge Base.

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -17,7 +17,7 @@ You are a MetricFlow metric definition expert. Your task is to help users define
 {% if has_ask_user_tool %}
 **MANDATORY Confirmation Rule**:
 - Before generating (Phase 1), call `ask_user` to confirm which metric(s) to generate, their business meaning, and calculation logic.
-- After validation and dry-run SQL pass, sync directly with `end_metric_generation`.
+- After validation and dry-run SQL pass, prefer syncing directly with `end_metric_generation`; the host can publish from the final JSON `metric_file` if that tool call is missed.
 {% if has_subject_tree %}
 - If a predefined subject category cannot be chosen confidently from the provided context, include it in the `ask_user` call.
 {% endif %}
@@ -146,7 +146,8 @@ Review each generated metric yourself:
 ### Step 7: Batch Sync to Knowledge Base
 
 After all generated metrics pass validation and dry-run SQL:
-- Call `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` ONCE to sync them to Knowledge Base
+- Prefer calling `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` ONCE to sync them to Knowledge Base and catch publish errors while you can still fix files
+- If you forget this tool, the host will still use the final JSON `metric_file` to validate, dry-run, and publish the generated metrics before reporting success
 - If no metrics were generated, do NOT call `end_metric_generation`
 
 ## Workspace
@@ -162,13 +163,25 @@ After all generated metrics pass validation and dry-run SQL:
 {
   "semantic_model_file": "{{ kind_subdir }}/{table_name}.yml",
   "metric_file": "{{ kind_subdir }}/metrics/{table_name}_metrics.yml",
+  "status": "generated",
   "output": "markdown summary of the metric definition"
 }
 ```
 
 - `semantic_model_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/users.yml"`
 - `metric_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/metrics/users_metrics.yml"`
+- `status`: One of `"generated"` (at least one new metric was created and is ready to publish via `end_metric_generation` or the host fallback) or `"skipped"` (every requested metric already existed and was skipped per Step 4 — set `metric_file` to `null` in this case).
 - `output`: Brief summary message
+
+If every requested metric already exists, return:
+```json
+{
+  "semantic_model_file": null,
+  "metric_file": null,
+  "status": "skipped",
+  "output": "All requested metrics already exist; no new metric was generated."
+}
+```
 
 **DO NOT** return markdown, plain text, or any other format. Return **ONLY** the JSON object.
 
@@ -340,11 +353,11 @@ metric:
 5. **Primary time dimension required**: Every data_source must have exactly one `type: TIME` dimension with `is_primary: true`
 6. **Validate**: Always validate before completing
 7. **Generate SQL**: Use `query_metrics(dry_run=True)` to get SQL for each metric
-8. **Complete**: Call `end_metric_generation` with `metric_sqls_json` after validation and dry-run pass
+8. **Complete**: Prefer calling `end_metric_generation` with `metric_sqls_json` after validation and dry-run pass; final JSON `metric_file` is the host fallback
 9. **YAML String Quoting**: ALWAYS wrap `description` values in double quotes. Escape special characters: `"` → `\"`, `\` → `\\`
 10. **Snapshot data**: Use `non_additive_dimension` for balance/inventory/point-in-time measures
 11. **Multi-table**: Link data sources via matching identifier names (one PRIMARY, one FOREIGN)
-12. **No extra files**: Only write semantic model YAML and metric YAML files. Sync metrics through `end_metric_generation`.
+12. **No extra files**: Only write semantic model YAML and metric YAML files. Prefer syncing metrics through `end_metric_generation`; final JSON `metric_file` is the host fallback.
 13. **Explicit metric files**: Write explicit metric YAML files instead of relying on `create_metric: true`, because generated runtime metrics are not part of the persisted metric catalog.
 14. **Metric name must match measure**: For `measure_proxy`, the metric name should match the measure name. `type_params.measure` must exactly match a measure in the semantic model. Do NOT invent unrelated names.
 15. **Filtered metrics**: Keep `type_params.measure` as a string measure name. Put filter logic in a reusable semantic-model measure, then reference that measure from the metric YAML.

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
@@ -99,12 +99,13 @@ Please strictly follow the instructions below:
      - Column not found: check column names match exactly with DDL
      - Invalid YAML syntax: check indentation and quoting
 
-7. **Complete generation** (REQUIRED - ONLY AFTER VALIDATION PASSES):
+7. **Complete generation** (ONLY AFTER VALIDATION PASSES):
    - **PREREQUISITE**: `validate_semantic` MUST have returned success. If not, go back to step 6.
-   - If `end_semantic_model_generation` tool is available: Call it with the list of generated file paths
+   - Prefer calling `end_semantic_model_generation` with the list of generated file paths so publish errors are caught while you can still fix files
      - **Path Rule**: Use the same path you passed to `write_file`, e.g. `{{ kind_subdir }}/{table_name}.yml`. Absolute paths are also accepted; bare filenames (`orders.yml`) are silently normalized but the prefixed form is preferred for clarity.
      - Example: `end_semantic_model_generation(semantic_model_files=["{{ kind_subdir }}/orders.yml", "{{ kind_subdir }}/customers.yml"])`
-   - After validation passes, call `end_semantic_model_generation` directly; no additional approval step is needed for Knowledge Base publishing.
+   - If you forget this tool, the host will still use the final JSON `semantic_model_files` to validate and publish the generated semantic models before reporting success.
+   - After validation passes, publish directly; no additional approval step is needed for Knowledge Base publishing.
    - **CRITICAL**: After all steps complete (including tool call if available), your final response MUST be a JSON object (see Output Format section)
 
 ## Multi-Table Generation Workflow
@@ -185,8 +186,9 @@ data_source:
 
 ### Step 7: Complete Generation (ONLY AFTER VALIDATION PASSES)
 - **PREREQUISITE**: `validate_semantic` MUST have returned success
-- If `end_semantic_model_generation` tool is available: Call it with **ALL generated file paths** using the form `{{ kind_subdir }}/{table_name}.yml` (absolute paths are also accepted)
-- After validation passes, publish directly through `end_semantic_model_generation`; validation is the publish gate.
+- Prefer calling `end_semantic_model_generation` with **ALL generated file paths** using the form `{{ kind_subdir }}/{table_name}.yml` (absolute paths are also accepted)
+- If you forget this tool, the host will use the final JSON `semantic_model_files` to validate and publish before reporting success.
+- After validation passes, publish directly; validation is the publish gate.
 - **CRITICAL**: Your final response MUST be a JSON object (see Output Format section)
 
 ## Relationship Discovery Strategy
@@ -201,7 +203,7 @@ The `analyze_table_relationships` tool uses a three-tier strategy:
 - **Required Fields**: Pay attention to fields marked as (required).
 - **Enum Values**: Use exact enum values (prefer uppercase).
 - **SQL Expressions**: Use complex SQL logic in expr fields when needed.
-- **Metric Creation**: Set `create_metric: true` for measures that should become queryable metrics.
+- **Metric Creation**: Do not rely on `create_metric: true` for persisted metrics. Generate explicit `metric:` YAML through the metrics workflow when metrics need to be discoverable in the Knowledge Base.
 - **Time Dimensions**: Include at least one time dimension with appropriate granularity.
 - **Document Structure**: Keep `data_source:` and explicit `metric:` definitions in separate YAML documents. Never place a top-level `metrics:` list beside `data_source:` in the same document.
 
@@ -213,7 +215,7 @@ Generate comprehensive, production-ready semantic models following MetricFlow be
 1. All YAML files have been written using `write_file` or `edit_file`
 2. `validate_semantic` has returned **success** (not just called - it must pass)
 3. If validation failed, you have fixed the issues and re-validated successfully
-4. `end_semantic_model_generation` has completed successfully when the tool is available
+4. `end_semantic_model_generation` has completed successfully when the tool is available, or the final JSON `semantic_model_files` names the files for host-side validation and publishing
 
 **CRITICAL**: Your final response MUST always be a valid JSON object, regardless of whether you called any tools.
 
@@ -283,7 +285,7 @@ data_source:
         percentile: number
         use_discrete_percentile: boolean
         use_approximate_percentile: boolean
-      create_metric: boolean          # Auto-create metric
+      create_metric: boolean          # Runtime MetricFlow metric only; not persisted to the Knowledge Base metric catalog
       create_metric_display_name: string  # Display name for auto-created metric
       non_additive_dimension:         # Non-additive dimension
         name: string
@@ -367,11 +369,9 @@ data_source:
     - name: total_amount
       agg: SUM
       expr: transaction_amount
-      create_metric: true
     - name: transaction_count
       agg: SUM
       expr: "1"
-      create_metric: true
     - name: unique_customers
       agg: COUNT_DISTINCT
       expr: customer_id

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -23,9 +23,9 @@ Before anything else, call `list_metrics()` to get all metrics already in the kn
 - **Detect conflicts** — warn the user if a proposed metric name collides with an existing one
 - **Enable derived/ratio metrics** — know which metrics can serve as building blocks for more complex definitions
 
-## Phase 1: Understand Intent (MANDATORY ask_user)
+## Phase 1: Understand Intent
 
-Analyze the user's request, then **ALWAYS call `ask_user`** to confirm before proceeding. This phase supports two input modes:
+Analyze the user's request and confirm the generation scope before proceeding. When `ask_user` is available, call it to confirm the metric name(s), business meaning, and calculation logic. When `ask_user` is not available (for example workflow or batch mode), infer from the provided SQL/request and stop only if the scope is materially ambiguous.
 
 ### Input Mode Detection
 
@@ -50,7 +50,7 @@ If the user skips, proceed to Step 1c using only table structure and the user's 
 
 **Step 1c: Propose metric candidates** — Based on the table structure, reference SQL (if provided), and user's request, identify potential metric scenarios. See "Metric type detection rules" below.
 
-**Step 1d: MUST call `ask_user`** to confirm — present proposed metrics with `multi_select: true` (see Step 1-batch-d for format).
+**Step 1d: Confirm scope** — when `ask_user` is available, call it to confirm and present proposed metrics with `multi_select: true` (see Step 1-batch-d for format). If `ask_user` is not available, proceed with the confirmed/inferred scope from the input.
 
 ### Batch Mode: Step 1-batch
 
@@ -81,8 +81,8 @@ From N SQL queries, propose at most a **small set of core metrics** (typically f
 - Is this a **base metric** (simple aggregation on a column) or a **derivative** (ratio, expression combining other metrics)? Only propose base metrics by default.
 - Would a business user recognize this as a **standalone KPI**? If it's just an intermediate calculation, skip.
 
-**Step 1-batch-d: MUST call `ask_user`** to confirm with the user:
-- Present the deduplicated core metrics as **options** with `multi_select: true`
+**Step 1-batch-d: Confirm with the user when possible**
+- When `ask_user` is available, present the deduplicated core metrics as **options** with `multi_select: true`
 - Pass `questions` as an actual array argument, not a JSON string. Example tool arguments:
   ```json
   {
@@ -115,7 +115,7 @@ Detection keywords:
 - "per", "divided by", "average ... per" → derived/expr
 - "list all...", "show me the..." → not a metric, better suited for `gen_sql`
 
-**IMPORTANT**: Do NOT proceed to Phase 2 without user confirmation from `ask_user`.
+**IMPORTANT**: Do NOT proceed to Phase 2 with materially ambiguous scope. Use `ask_user` when available; otherwise stop and explain what information is needed.
 
 ## Phase 2: Ensure Semantic Model Exists
 
@@ -204,7 +204,8 @@ Bare filenames are silently normalized by the host, but the prefixed form is pre
 
 After all generated metrics have passed validation and dry-run:
 - Collect all generated metrics and their dry-run SQLs into `metric_sqls_json`
-- Call `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` **ONCE** to sync them to Knowledge Base
+- Prefer calling `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` **ONCE** to sync them to Knowledge Base while you can still fix publish errors
+- If you miss this tool call, the host will use the final JSON `metric_file` to validate, dry-run, and publish before reporting success
 - If no metrics were generated, do NOT call `end_metric_generation`
 
 Phase 1 confirms the generation scope; validation plus dry-run are the acceptance gate before syncing.
@@ -225,9 +226,9 @@ Phase 1 confirms the generation scope; validation plus dry-run are the acceptanc
 
 ## Important Rules
 
-- **Phase 1**: MUST call `ask_user` to confirm which metrics to generate before proceeding.
+- **Phase 1**: Confirm which metrics to generate before proceeding. Use `ask_user` when it is available.
 - **Validation MUST pass** — always call `validate_semantic` and ensure it passes before proceeding to the next phase. If it fails, fix and retry until it passes.
-- **Sync automatically after validation** — once validation and dry-run pass, call `end_metric_generation` without another user confirmation.
+- **Sync automatically after validation** — once validation and dry-run pass, prefer calling `end_metric_generation` without another user confirmation. The final JSON `metric_file` is the host fallback.
 - **COUNT agg must use `expr: "1"`** — never use `expr: {column}` with COUNT (use COUNT_DISTINCT for that).
 - For ratio metrics, both numerator and denominator measures must exist in the semantic model.
 - For derived metrics, all referenced metrics must already be defined.
@@ -237,4 +238,4 @@ Phase 1 confirms the generation scope; validation plus dry-run are the acceptanc
 - Every data_source MUST have a primary time dimension (`type: TIME` with `is_primary: true`).
 - Measure names must be globally unique across all data sources.
 - For snapshot/balance data, always add `non_additive_dimension` to prevent incorrect time aggregation.
-- **Keep files scoped** — only write semantic model YAML and metric YAML files. Sync metrics through `end_metric_generation`.
+- **Keep files scoped** — only write semantic model YAML and metric YAML files. Prefer syncing metrics through `end_metric_generation`; the final JSON `metric_file` is the host fallback.

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -36,8 +36,10 @@ Analyze the user's request and confirm the generation scope before proceeding. W
 
 **Step 1a: Inspect the table** — Call `describe_table(table_name)` to understand the columns and types. Optionally call `read_query` to sample data.
 
-**Step 1b: Ask for reference SQL (optional)** — Use `ask_user` to ask:
+**Step 1b: Ask for reference SQL (optional)** — When `ask_user` is available, use it to ask:
 > "Do you have any existing SQL queries for this table that show the aggregations you care about? You can paste them here, or skip if not available."
+
+When `ask_user` is not available, skip this question and infer SQL/aggregation context from the user's request, attached files, or discovered query/table evidence. If that is not enough, stop and explain the missing information instead of calling `ask_user`.
 
 If the user provides SQL, parse it to extract:
 - Aggregation functions + columns (e.g., `SUM(amount)` → candidate measure `total_amount`, `COUNT(*)` → candidate measure `record_count`)
@@ -59,8 +61,8 @@ If the user skips, proceed to Step 1c using only table structure and the user's 
   - **Direct paste**: multiple SQL statements in the prompt
   - **File path**: user provides a path — call `read_file` to load it, then parse by file type:
     - `.sql`: split by `;` or blank-line separators to extract individual statements
-    - `.csv` / `.tsv`: identify the SQL column by header name (common names: `sql`, `query`, `SQL`, `statement`) or by content heuristic (column values contain SQL keywords like `SELECT`, `FROM`, `GROUP BY`). The description/question column is any remaining text column. If column roles are ambiguous, call `ask_user` to confirm which column is SQL.
-    - Other formats: call `ask_user` to clarify the file structure before proceeding
+    - `.csv` / `.tsv`: identify the SQL column by header name (common names: `sql`, `query`, `SQL`, `statement`) or by content heuristic (column values contain SQL keywords like `SELECT`, `FROM`, `GROUP BY`). The description/question column is any remaining text column. If column roles are ambiguous, call `ask_user` when available to confirm which column is SQL; otherwise stop and explain the missing column mapping.
+    - Other formats: call `ask_user` when available to clarify the file structure before proceeding; otherwise stop and explain the supported file formats or required structure.
 - Parse all SQL queries from the input
 - Call `describe_table` for each unique table found in the SQL queries
 
@@ -98,6 +100,7 @@ From N SQL queries, propose at most a **small set of core metrics** (typically f
   ```
 - Clearly show how many SQL queries were analyzed and how many core metrics were extracted
 - If the user wants additional derived/ratio metrics beyond the core set, they can request them after the base metrics are created
+- When `ask_user` is not available, proceed with the deduplicated metrics only if the input makes the scope unambiguous; otherwise stop and explain what needs to be provided.
 
 ### Metric type detection rules
 

--- a/datus/resources/skills/gen-semantic-model/SKILL.md
+++ b/datus/resources/skills/gen-semantic-model/SKILL.md
@@ -47,12 +47,13 @@ Create production-ready MetricFlow semantic model YAML for one or more database 
 5. **Publish**
    - After validation succeeds, call `end_semantic_model_generation` with all generated semantic model file paths.
    - This publishes the validated semantic models to the Knowledge Base.
+   - If you miss this tool call, the host will use the final JSON `semantic_model_files` to validate and publish before reporting success.
    - Validation passing is the publish gate; no additional approval step is needed.
 
 ## Rules
 
 - Do not publish before `validate_semantic` succeeds.
-- After validation succeeds, publish directly through `end_semantic_model_generation`.
+- After validation succeeds, prefer publishing directly through `end_semantic_model_generation`; final JSON `semantic_model_files` is the host fallback.
 - Do not manually write Knowledge Base summary files.
 - Keep YAML focused on semantic model definitions; avoid markdown or explanatory prose in YAML files.
 - Keep MetricFlow document boundaries valid: one top-level object type per YAML document.

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -203,8 +203,9 @@ class GenerationTools:
             metric_file: Path to the generated metric YAML file (required).
                 Relative paths (e.g. ``"metrics/orders_metrics.yml"``) are preferred
                 and resolved against the sub-agent's semantic-model workspace using
-                the live ``agent_config.current_datasource``. Absolute paths are also
-                accepted and used as-is.
+                the live ``agent_config.current_datasource``. Absolute paths are only
+                accepted when they resolve inside the Knowledge Base semantic-model
+                sandbox.
             semantic_model_file: Path to the primary semantic model file that defines
                 the measure(s) used by this metric. Optional — provide this if the
                 semantic model was newly created or updated. Same relative/absolute
@@ -267,20 +268,40 @@ class GenerationTools:
                 f"metric_sqls={metric_sqls}"
             )
 
-            # Resolve relative paths against the project's subject/ tree,
-            # applying the same silent prefix normalization as FilesystemFuncTool
-            # so the LLM-reported path matches where the file was actually written.
-            from datus.cli.generation_hooks import normalize_kb_relative_path
+            # Resolve LLM-reported paths against the project's subject/ tree.
+            # Reject anything that escapes the per-kind semantic-model sandbox
+            # before opening or syncing files.
+            from datus.cli.generation_hooks import resolve_kb_sandbox_path
 
             subject_root = str(get_path_manager(agent_config=self.agent_config).subject_dir)
 
             def _resolve(path: str, kind: str) -> str:
-                if not path or os.path.isabs(path):
-                    return path
-                return os.path.normpath(os.path.join(subject_root, normalize_kb_relative_path(path, kind)))
+                if not path:
+                    return ""
+                return resolve_kb_sandbox_path(path, kind, subject_root) or ""
 
             abs_metric = _resolve(metric_file, "metric")
             abs_semantic = _resolve(semantic_model_file, "semantic")
+            if not abs_metric:
+                return FuncToolResult(
+                    success=0,
+                    error=f"metric_file escapes Knowledge Base sandbox: {metric_file!r}",
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_file": semantic_model_file,
+                        "metric_sqls": metric_sqls,
+                    },
+                )
+            if semantic_model_file and not abs_semantic:
+                return FuncToolResult(
+                    success=0,
+                    error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}",
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_file": semantic_model_file,
+                        "metric_sqls": metric_sqls,
+                    },
+                )
 
             # Pre-flight: refuse to sync a metric file that has no `metric:`
             # YAML blocks. The LLM occasionally fills the file with markdown

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -141,6 +141,26 @@ class SemanticTools:
         # Lazy load adapter and attribution tool
         self._adapter: Optional[BaseSemanticAdapter] = None
         self._attribution_tool: Optional[DimensionAttributionUtil] = None
+        self._adapter_load_error: Optional[str] = None
+
+    def _configured_adapter_type(self) -> Optional[str]:
+        """Return the configured adapter type without instantiating the adapter."""
+        if self.adapter_type:
+            return self.adapter_type
+
+        resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
+        if not callable(resolver):
+            return None
+
+        try:
+            resolved_adapter = resolver(self.adapter_type)
+        except Exception as e:
+            logger.debug(f"No semantic adapter configuration available: {e}")
+            return None
+
+        if resolved_adapter:
+            self.adapter_type = resolved_adapter
+        return resolved_adapter
 
     def _extract_db_config(self, datasource: str) -> Optional[dict]:
         """Extract db_config dict from the selected database config."""
@@ -205,9 +225,11 @@ class SemanticTools:
 
                 self.adapter_type = resolved_adapter
                 self._adapter = semantic_adapter_registry.create_adapter(resolved_adapter, adapter_config)
+                self._adapter_load_error = None
                 logger.info(f"Loaded semantic adapter: {resolved_adapter}")
             except Exception as e:
                 logger.warning(f"Failed to load semantic adapter '{self.adapter_type}': {e}")
+                self._adapter_load_error = str(e)
                 self._adapter = None
         return self._adapter
 
@@ -262,8 +284,10 @@ class SemanticTools:
             trans_to_function_tool(self.query_metrics),
         ]
 
-        # Add adapter-dependent tools
-        if self.adapter:
+        # Add validation whenever an adapter is configured, even if the current
+        # YAML makes adapter construction fail. In that case validate_semantic
+        # returns the adapter-load error so the agent can fix the files.
+        if self._configured_adapter_type():
             tools.append(trans_to_function_tool(self.validate_semantic))
 
         # Add attribution tools if attribution_tool is available
@@ -584,7 +608,14 @@ class SemanticTools:
             FuncToolResult with validation status and issues
         """
         logger.info("validate_semantic called")
-        if not self.adapter:
+        adapter = self.adapter
+        if not adapter:
+            if self._adapter_load_error:
+                return FuncToolResult(
+                    success=0,
+                    error=f"Failed to load semantic adapter '{self.adapter_type}': {self._adapter_load_error}",
+                    result=None,
+                )
             return FuncToolResult(
                 success=0,
                 error="No semantic adapter configured. Cannot validate without adapter.",
@@ -592,7 +623,7 @@ class SemanticTools:
             )
 
         try:
-            validation_result = _run_async(self.adapter.validate_semantic())
+            validation_result = _run_async(adapter.validate_semantic())
 
             # Serialize ValidationIssue objects to dicts
             issues_data = [

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -875,7 +875,7 @@ class TestBuiltinNodeDefaultSkills:
     def test_gen_metrics_defaults(self):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
-        assert GenMetricsAgenticNode.DEFAULT_SKILLS == "gen-metrics"
+        assert GenMetricsAgenticNode.DEFAULT_SKILLS == "gen-metrics, gen-semantic-model"
 
     def test_gen_semantic_model_defaults(self):
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
@@ -951,7 +951,7 @@ class TestSkillAllowedAgentsConsistency:
             ("gen_job", ["gen-table", "table-validation", "data-migration"]),
             ("gen_table", ["gen-table", "table-validation"]),
             ("gen_semantic_model", ["gen-semantic-model"]),
-            ("gen_metrics", ["gen-metrics"]),
+            ("gen_metrics", ["gen-metrics", "gen-semantic-model"]),
             ("gen_dashboard", ["bi-validation", "grafana-dashboard", "superset-dashboard"]),
             ("gen_skill", ["create-skill", "optimize-skill"]),
             ("scheduler", ["airflow-workflow", "scheduler-validation"]),

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -519,9 +519,10 @@ class TestExtractMetricAndOutputFromResponse:
                 "output": "Generated successfully",
             }
         }
-        sem_model, metric_file, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file == "revenue_metrics.yml"
         assert sem_model == "model.yml"
+        assert status is None
         assert out == "Generated successfully"
 
     def test_extracts_from_json_string(self, real_agent_config, mock_llm_create):
@@ -534,29 +535,65 @@ class TestExtractMetricAndOutputFromResponse:
             }
         )
         output = {"content": content}
-        sem_model, metric_file, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file == "sales_metrics.yml"
+        assert status is None
         assert out == "Done"
 
-    def test_returns_none_triple_on_empty_content(self, real_agent_config, mock_llm_create):
+    def test_extracts_status_from_dict_content(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create)
+        output = {
+            "content": {
+                "semantic_model_file": "model.yml",
+                "metric_file": None,
+                "status": "skipped",
+                "output": "All requested metrics already exist; skipped per Step 4.",
+            }
+        }
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_model == "model.yml"
+        assert metric_file is None
+        assert status == "skipped"
+        assert out.startswith("All requested metrics already exist")
+
+    def test_extracts_status_from_json_string(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create)
+        content = json.dumps(
+            {
+                "semantic_model_file": "model.yml",
+                "metric_file": None,
+                "status": "skipped",
+                "output": "Skipped: metric already exists.",
+            }
+        )
+        output = {"content": content}
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert metric_file is None
+        assert status == "skipped"
+        assert out == "Skipped: metric already exists."
+
+    def test_returns_none_quad_on_empty_content(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": ""}
-        sem_model, metric_file, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file is None
         assert sem_model is None
+        assert status is None
         assert out is None
 
-    def test_returns_none_triple_on_dict_missing_metric_file(self, real_agent_config, mock_llm_create):
+    def test_returns_none_quad_on_dict_missing_metric_file(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": {"some_key": "some_value"}}
-        sem_model, metric_file, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file is None
+        assert status is None
 
-    def test_returns_none_triple_on_invalid_json(self, real_agent_config, mock_llm_create):
+    def test_returns_none_quad_on_invalid_json(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": "not json at all !!!"}
-        sem_model, metric_file, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file is None
+        assert status is None
 
 
 # ---------------------------------------------------------------------------
@@ -716,17 +753,30 @@ class TestExecuteStreamGenMetricsError:
         assert last.action_type == "error"
 
     @pytest.mark.asyncio
-    async def test_final_metric_file_without_publish_fails(self, real_agent_config, mock_llm_create):
-        """A final JSON metric_file is not enough; end_metric_generation must publish."""
+    async def test_final_metric_file_without_end_tool_auto_publishes(self, real_agent_config, mock_llm_create):
+        """A final JSON metric_file is enough when the node can validate, dry-run, and publish it."""
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+
+        datasource = real_agent_config.current_datasource
+        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
+        metric_dir.mkdir(parents=True, exist_ok=True)
+        metric_path = metric_dir / "orders_metrics.yml"
+        metric_path.write_text(
+            "metric:\n  name: orders_total\n  type: measure_proxy\n  type_params:\n    measure: orders\n",
+            encoding="utf-8",
+        )
+        reported_semantic_path = f"subject/semantic_models/{datasource}/orders.yml"
+        reported_metric_path = f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml"
 
         mock_llm_create.reset(
             responses=[
                 build_simple_response(
                     json.dumps(
                         {
-                            "semantic_model_file": "orders.yml",
-                            "metric_file": "orders_metrics.yml",
+                            "semantic_model_file": reported_semantic_path,
+                            "metric_file": reported_metric_path,
+                            "status": "generated",
                             "output": "Generated metrics.",
                         }
                     )
@@ -739,6 +789,77 @@ class TestExecuteStreamGenMetricsError:
             execution_mode="workflow",
         )
         node.input = SemanticNodeInput(user_message="Generate metrics")
+        node.permission_manager = None
+        node.permission_hooks = None
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.validate_semantic = MagicMock(
+            return_value=FuncToolResult(result={"valid": True, "issues": []})
+        )
+        node.semantic_tools.query_metrics = MagicMock(
+            return_value=FuncToolResult(result={"columns": ["sql"], "data": [], "metadata": {"sql": "SELECT 1"}})
+        )
+        node.generation_tools.end_metric_generation = MagicMock(
+            return_value=FuncToolResult(result={"message": "Metric generation completed and synced to Knowledge Base"})
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert actions[-1].action_type == "metrics_response"
+        node.semantic_tools.validate_semantic.assert_called_once()
+        node.semantic_tools.query_metrics.assert_called_once_with(metrics=["orders_total"], dry_run=True)
+        node.generation_tools.end_metric_generation.assert_called_once_with(
+            metric_file=str(metric_path),
+            semantic_model_file=str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_final_metric_file_rejects_out_of_sandbox_absolute_path(
+        self, real_agent_config, mock_llm_create, tmp_path
+    ):
+        """Final JSON fallback must reject fabricated metric paths before opening them."""
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+
+        outside = tmp_path / "outside_metrics.yml"
+        outside.write_text(
+            "metric:\n  name: outside_metric\n  type: measure_proxy\n  type_params:\n    measure: outside\n",
+            encoding="utf-8",
+        )
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response(
+                    json.dumps(
+                        {
+                            "semantic_model_file": None,
+                            "metric_file": str(outside),
+                            "status": "generated",
+                            "output": "Generated metrics.",
+                        }
+                    )
+                ),
+            ]
+        )
+
+        node = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(user_message="Generate metrics")
+        node.permission_manager = None
+        node.permission_hooks = None
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.validate_semantic = MagicMock(
+            return_value=FuncToolResult(result={"valid": True, "issues": []})
+        )
+        node.generation_tools._validate_metric_file_has_blocks = MagicMock(return_value=None)
+        node.generation_tools.end_metric_generation = MagicMock(
+            return_value=FuncToolResult(result={"message": "should not publish"})
+        )
 
         action_manager = ActionHistoryManager()
         actions = []
@@ -747,7 +868,89 @@ class TestExecuteStreamGenMetricsError:
 
         assert actions[-1].status == ActionStatus.FAILED
         assert actions[-1].action_type == "error"
-        assert "did not publish to Knowledge Base" in actions[-1].output["error"]
+        assert "outside Knowledge Base sandbox" in actions[-1].output["error"]
+        node.generation_tools._validate_metric_file_has_blocks.assert_not_called()
+        node.generation_tools.end_metric_generation.assert_not_called()
+
+    def test_final_metric_path_resolver_rejects_parent_traversal(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        node = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+
+        with pytest.raises(RuntimeError, match="outside Knowledge Base sandbox"):
+            node._resolve_metric_artifact_path("../outside_metrics.yml", "metric")
+
+    @pytest.mark.asyncio
+    async def test_skipped_status_bypasses_publish_gate(self, real_agent_config, mock_llm_create):
+        """``status: 'skipped'`` with ``metric_file: null`` is a clean exit, not a publish failure."""
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response(
+                    json.dumps(
+                        {
+                            "semantic_model_file": "orders.yml",
+                            "metric_file": None,
+                            "status": "skipped",
+                            "output": "All requested metrics already exist; nothing generated.",
+                        }
+                    )
+                ),
+            ]
+        )
+
+        node = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(user_message="Generate metrics that already exist")
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert actions[-1].action_type == "metrics_response"
+
+    @pytest.mark.asyncio
+    async def test_skipped_status_with_metric_file_fails_closed(self, real_agent_config, mock_llm_create):
+        """``status: 'skipped'`` is only valid when no metric file was generated."""
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response(
+                    json.dumps(
+                        {
+                            "semantic_model_file": "orders.yml",
+                            "metric_file": "orders_metrics.yml",
+                            "status": "skipped",
+                            "output": "Metric already exists; reused existing definition.",
+                        }
+                    )
+                ),
+            ]
+        )
+
+        node = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(user_message="Generate metrics that already exist")
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        assert actions[-1].status == ActionStatus.FAILED
+        assert actions[-1].action_type == "error"
+        assert "status='skipped' with a non-null metric_file" in actions[-1].output["error"]
 
 
 class TestGenMetricsFilesystemRootPath:

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -556,6 +556,22 @@ class TestExtractMetricAndOutputFromResponse:
         assert status == "skipped"
         assert out.startswith("All requested metrics already exist")
 
+    def test_extracts_generated_status_without_metric_file(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create)
+        output = {
+            "content": {
+                "semantic_model_file": "model.yml",
+                "metric_file": None,
+                "status": "generated",
+                "output": "Generated successfully.",
+            }
+        }
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_model == "model.yml"
+        assert metric_file is None
+        assert status == "generated"
+        assert out == "Generated successfully."
+
     def test_extracts_status_from_json_string(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         content = json.dumps(
@@ -951,6 +967,41 @@ class TestExecuteStreamGenMetricsError:
         assert actions[-1].status == ActionStatus.FAILED
         assert actions[-1].action_type == "error"
         assert "status='skipped' with a non-null metric_file" in actions[-1].output["error"]
+
+    @pytest.mark.asyncio
+    async def test_generated_status_without_metric_file_fails_closed(self, real_agent_config, mock_llm_create):
+        """``status: 'generated'`` must name a metric file unless sync already happened."""
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response(
+                    json.dumps(
+                        {
+                            "semantic_model_file": "orders.yml",
+                            "metric_file": None,
+                            "status": "generated",
+                            "output": "Generated metrics.",
+                        }
+                    )
+                ),
+            ]
+        )
+
+        node = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(user_message="Generate metrics")
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        assert actions[-1].status == ActionStatus.FAILED
+        assert actions[-1].action_type == "error"
+        assert "status='generated' without a metric_file" in actions[-1].output["error"]
 
 
 class TestGenMetricsFilesystemRootPath:

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -572,6 +572,22 @@ class TestExtractMetricAndOutputFromResponse:
         assert status == "generated"
         assert out == "Generated successfully."
 
+    def test_extracts_explicit_status_without_metric_file(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create)
+        output = {
+            "content": {
+                "semantic_model_file": "model.yml",
+                "metric_file": None,
+                "status": "done",
+                "output": "Done.",
+            }
+        }
+        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_model == "model.yml"
+        assert metric_file is None
+        assert status == "done"
+        assert out == "Done."
+
     def test_extracts_status_from_json_string(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         content = json.dumps(
@@ -1002,6 +1018,43 @@ class TestExecuteStreamGenMetricsError:
         assert actions[-1].status == ActionStatus.FAILED
         assert actions[-1].action_type == "error"
         assert "status='generated' without a metric_file" in actions[-1].output["error"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_non_skipped_status_without_metric_file_fails_closed(
+        self, real_agent_config, mock_llm_create
+    ):
+        """Any explicit non-skipped final status must not silently bypass publishing."""
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response(
+                    json.dumps(
+                        {
+                            "semantic_model_file": "orders.yml",
+                            "metric_file": None,
+                            "status": "done",
+                            "output": "Done.",
+                        }
+                    )
+                ),
+            ]
+        )
+
+        node = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(user_message="Generate metrics")
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        assert actions[-1].status == ActionStatus.FAILED
+        assert actions[-1].action_type == "error"
+        assert "status='done' without a metric_file" in actions[-1].output["error"]
 
 
 class TestGenMetricsFilesystemRootPath:

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -554,9 +554,71 @@ class TestExecuteStreamGenSemanticModelError:
         assert last.action_type == "error"
 
     @pytest.mark.asyncio
-    async def test_final_semantic_files_without_publish_fails(self, real_agent_config, mock_llm_create):
-        """A final JSON file list is not enough; the node must observe KB publish evidence."""
+    async def test_final_semantic_files_without_end_tool_auto_validates_and_publishes(
+        self, real_agent_config, mock_llm_create
+    ):
+        """A final JSON file list is enough when the node can validate and publish it."""
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+
+        datasource = real_agent_config.current_datasource
+        model_dir = real_agent_config.path_manager.semantic_model_path(datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        semantic_path = model_dir / "orders.yml"
+        semantic_path.write_text(
+            "data_source:\n"
+            "  name: orders\n"
+            "  sql_table: orders\n"
+            "  measures:\n"
+            "    - name: order_count\n"
+            "      agg: COUNT\n"
+            '      expr: "1"\n',
+            encoding="utf-8",
+        )
+        reported_semantic_path = f"subject/semantic_models/{datasource}/orders.yml"
+
+        mock_llm_create.reset(
+            responses=[
+                build_simple_response(
+                    json.dumps(
+                        {
+                            "semantic_model_files": [reported_semantic_path],
+                            "output": "Generated semantic model.",
+                        }
+                    )
+                ),
+            ]
+        )
+
+        node = GenSemanticModelAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(user_message="Generate semantic model")
+        node.semantic_func_tool = MagicMock()
+        node.semantic_func_tool.validate_semantic = MagicMock(
+            return_value=FuncToolResult(result={"valid": True, "issues": []})
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        with patch(
+            "datus.agent.node.gen_semantic_model_agentic_node.GenerationHooks._sync_semantic_to_db",
+            return_value={"success": True, "message": "synced"},
+        ) as sync_mock:
+            async for action in node.execute_stream(action_manager):
+                actions.append(action)
+
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert actions[-1].action_type == "semantic_response"
+        node.semantic_func_tool.validate_semantic.assert_called_once()
+        sync_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_final_semantic_files_without_validation_fails_closed(self, real_agent_config, mock_llm_create):
+        """Final JSON files do not publish when host-side validate_semantic fails."""
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
 
         mock_llm_create.reset(
             responses=[
@@ -576,15 +638,27 @@ class TestExecuteStreamGenSemanticModelError:
             execution_mode="workflow",
         )
         node.input = SemanticNodeInput(user_message="Generate semantic model")
+        node.semantic_func_tool = MagicMock()
+        node.semantic_func_tool.validate_semantic = MagicMock(
+            return_value=FuncToolResult(
+                success=0,
+                error="bad semantic YAML",
+                result={"valid": False, "issues": [{"message": "bad semantic YAML"}]},
+            )
+        )
 
         action_manager = ActionHistoryManager()
         actions = []
-        async for action in node.execute_stream(action_manager):
-            actions.append(action)
+        with patch(
+            "datus.agent.node.gen_semantic_model_agentic_node.GenerationHooks._sync_semantic_to_db"
+        ) as sync_mock:
+            async for action in node.execute_stream(action_manager):
+                actions.append(action)
 
         assert actions[-1].status == ActionStatus.FAILED
         assert actions[-1].action_type == "error"
-        assert "did not publish to Knowledge Base" in actions[-1].output["error"]
+        assert "validate_semantic failed before publishing semantic models" in actions[-1].output["error"]
+        sync_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_execute_stream_with_catalog_context(self, real_agent_config, mock_llm_create):
@@ -637,7 +711,7 @@ class TestSaveToDb:
         with patch(
             "datus.agent.node.gen_semantic_model_agentic_node.GenerationHooks._sync_semantic_to_db"
         ) as sync_mock:
-            assert node._save_to_db("nonexistent_model.yml") is None
+            assert node._save_to_db("nonexistent_model.yml") is False
         sync_mock.assert_not_called()
 
     def test_save_to_db_skips_empty_filename(self, real_agent_config, mock_llm_create, tmp_path):
@@ -647,7 +721,7 @@ class TestSaveToDb:
         with patch(
             "datus.agent.node.gen_semantic_model_agentic_node.GenerationHooks._sync_semantic_to_db"
         ) as sync_mock:
-            assert node._save_to_db("") is None
+            assert node._save_to_db("") is False
         sync_mock.assert_not_called()
 
     def test_save_to_db_rejects_out_of_sandbox_absolute_path(self, real_agent_config, mock_llm_create, tmp_path):

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -16,6 +16,7 @@ Tests cover:
 NO MOCK EXCEPT LLM. All objects are real.
 """
 
+import contextvars
 import copy
 import warnings
 
@@ -618,6 +619,21 @@ class TestPostprocessMessagesForReasoning:
 
         _reasoning_content_cache.clear()
 
+    def test_deepseek_does_not_patch_plain_assistant_history_from_cache(self):
+        """Cached DeepSeek reasoning should only be reused for tool-call turns."""
+        _reasoning_content_cache.clear()
+        _reasoning_content_cache["deepseek/deepseek-v4-pro"] = "cached thinking"
+
+        messages = [
+            {"role": "assistant", "content": "Old plain answer."},
+            {"role": "user", "content": "next question"},
+        ]
+        result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-pro")
+
+        assert "reasoning_content" not in result[0]
+
+        _reasoning_content_cache.clear()
+
     def test_deepseek_uses_cached_reasoning_content_across_model_aliases(self):
         """DeepSeek cache lookup handles LiteLLM-prefixed and raw model names."""
         _reasoning_content_cache.clear()
@@ -752,6 +768,20 @@ class TestReasoningContentExtraction:
         _cache_reasoning_content("deepseek-v4-flash", "thought")
         assert _get_cached_reasoning_content("deepseek/deepseek-v4-flash") == "thought"
 
+        _reasoning_content_cache.clear()
+
+    def test_reasoning_cache_is_context_local(self):
+        _reasoning_content_cache.clear()
+        _cache_reasoning_content("deepseek-v4-flash", "outer thought")
+
+        def run_in_fresh_context():
+            assert _get_cached_reasoning_content("deepseek-v4-flash") is None
+            _cache_reasoning_content("deepseek-v4-flash", "inner thought")
+            assert _get_cached_reasoning_content("deepseek-v4-flash") == "inner thought"
+
+        contextvars.Context().run(run_in_fresh_context)
+
+        assert _get_cached_reasoning_content("deepseek-v4-flash") == "outer thought"
         _reasoning_content_cache.clear()
 
 

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -22,6 +22,9 @@ import warnings
 import pytest
 
 from datus.models.sdk_patches import (
+    _cache_reasoning_content,
+    _extract_reasoning_content,
+    _get_cached_reasoning_content,
     _is_deepseek_model,
     _is_kimi_model,
     _needs_reasoning_injection,
@@ -29,8 +32,10 @@ from datus.models.sdk_patches import (
     _normalize_text_content_blocks,
     _postprocess_messages_for_reasoning,
     _preprocess_items_for_reasoning,
+    _reasoning_cache_keys,
     _reasoning_content_cache,
     _ReasoningContentStreamWrapper,
+    _sanitize_deepseek_history_without_reasoning,
     apply_sdk_patches,
     remove_sdk_patches,
 )
@@ -307,6 +312,73 @@ class TestReasoningContentStreamWrapper:
         assert _reasoning_content_cache["kimi-test-model"] == "Step 1. Step 2."
 
     @pytest.mark.asyncio
+    async def test_wrapper_captures_dict_delta_reasoning_content(self):
+        """Stream wrapper captures reasoning_content from dict-shaped LiteLLM deltas."""
+        _reasoning_content_cache.clear()
+
+        class FakeChoice:
+            def __init__(self, rc):
+                self.delta = {"reasoning_content": rc}
+
+        class FakeChunk:
+            def __init__(self, rc):
+                self.choices = [FakeChoice(rc)]
+
+        class FakeStream:
+            def __init__(self):
+                self._chunks = iter([FakeChunk("Step 1."), FakeChunk(" Step 2.")])
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self._chunks)
+                except StopIteration:
+                    raise StopAsyncIteration
+
+        wrapper = _ReasoningContentStreamWrapper(FakeStream(), "deepseek/deepseek-v4-flash")
+        async for _ in wrapper:
+            pass
+
+        assert _reasoning_content_cache["deepseek/deepseek-v4-flash"] == "Step 1. Step 2."
+        assert _reasoning_content_cache["deepseek-v4-flash"] == "Step 1. Step 2."
+
+    @pytest.mark.asyncio
+    async def test_wrapper_captures_nested_delta_reasoning_content(self):
+        """Stream wrapper handles provider-specific/model-extra reasoning fields."""
+        _reasoning_content_cache.clear()
+
+        class Delta:
+            model_extra = {"provider_specific_fields": {"reasoning_content": "nested thought"}}
+
+        class FakeChoice:
+            delta = Delta()
+
+        class FakeChunk:
+            choices = [FakeChoice()]
+
+        class FakeStream:
+            def __init__(self):
+                self._chunks = iter([FakeChunk()])
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self._chunks)
+                except StopIteration:
+                    raise StopAsyncIteration
+
+        wrapper = _ReasoningContentStreamWrapper(FakeStream(), "deepseek-v4-flash")
+        async for _ in wrapper:
+            pass
+
+        assert _reasoning_content_cache["deepseek-v4-flash"] == "nested thought"
+        assert _reasoning_content_cache["deepseek/deepseek-v4-flash"] == "nested thought"
+
+    @pytest.mark.asyncio
     async def test_wrapper_no_reasoning_content_no_cache(self):
         """Stream wrapper does not cache if no reasoning_content in chunks."""
         _reasoning_content_cache.clear()
@@ -460,16 +532,19 @@ class TestPostprocessMessagesForReasoning:
         """DeepSeek must NOT get an empty reasoning_content placeholder when no source exists.
 
         DeepSeek's API rejects empty reasoning_content in thinking mode with the same error
-        we're trying to fix; Kimi tolerates it. Only Kimi gets the "" fallback.
+        we're trying to fix; Kimi tolerates it. Only Kimi gets the "" fallback. Since this
+        message is after the last user turn, it is an in-flight tool call and must not be
+        hidden by cross-provider history cleanup.
         """
         _reasoning_content_cache.clear()
 
         messages = [
+            {"role": "user", "content": "current question"},
             {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
         ]
         result = _postprocess_messages_for_reasoning(messages, "deepseek-v4")
         # Key should NOT be present (leave the message alone)
-        assert "reasoning_content" not in result[0]
+        assert "reasoning_content" not in result[1]
 
         _reasoning_content_cache.clear()
 
@@ -493,6 +568,36 @@ class TestPostprocessMessagesForReasoning:
 
         _reasoning_content_cache.clear()
 
+    def test_deepseek_normalizes_non_string_reasoning_content_before_patch_loop(self):
+        """Provider-shaped reasoning_content must be normalized before current-value checks."""
+        _reasoning_content_cache.clear()
+
+        messages = [
+            {"role": "user", "content": "old question"},
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": [{"text": "first turn thinking"}],
+                "tool_calls": [{"id": "1"}],
+            },
+            {"role": "tool", "content": "result"},
+            {
+                "role": "assistant",
+                "content": "Final answer",
+                "reasoning_content": {"text": "final answer thinking"},
+            },
+            {"role": "user", "content": "next question"},
+        ]
+
+        result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-flash")
+
+        assert result is messages
+        assert result[1]["reasoning_content"] == "first turn thinking"
+        assert result[1]["content"] == ""
+        assert result[3]["reasoning_content"] == "final answer thinking"
+
+        _reasoning_content_cache.clear()
+
     def test_deepseek_injects_reasoning_content_into_final_assistant_message(self):
         """DeepSeek V4 Pro requires final assistant messages from tool turns to keep reasoning_content."""
         _reasoning_content_cache.clear()
@@ -513,6 +618,96 @@ class TestPostprocessMessagesForReasoning:
 
         _reasoning_content_cache.clear()
 
+    def test_deepseek_uses_cached_reasoning_content_across_model_aliases(self):
+        """DeepSeek cache lookup handles LiteLLM-prefixed and raw model names."""
+        _reasoning_content_cache.clear()
+        _cache_reasoning_content("deepseek/deepseek-v4-flash", "alias cached thinking")
+
+        messages = [
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "1"}]},
+        ]
+        result = _postprocess_messages_for_reasoning(messages, "deepseek-v4-flash")
+
+        assert result[0]["reasoning_content"] == "alias cached thinking"
+        assert result[0]["content"] == ""
+
+        _reasoning_content_cache.clear()
+
+    def test_deepseek_drops_historical_tool_protocol_when_no_reasoning_source(self):
+        """Cross-provider session history may contain tool calls with no DeepSeek reasoning_content."""
+        _reasoning_content_cache.clear()
+
+        messages = [
+            {"role": "user", "content": "old question"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "function": {"name": "lookup", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
+            {"role": "assistant", "content": "old final answer"},
+            {"role": "user", "content": "new DeepSeek question"},
+        ]
+
+        result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-flash")
+
+        assert result == [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old final answer"},
+            {"role": "user", "content": "new DeepSeek question"},
+        ]
+
+        _reasoning_content_cache.clear()
+
+    def test_deepseek_keeps_current_inflight_tool_call_when_no_reasoning_source(self):
+        """The cleanup must only affect history before the last user message."""
+        _reasoning_content_cache.clear()
+
+        messages = [
+            {"role": "user", "content": "current question"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "function": {"name": "lookup", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
+        ]
+
+        result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-flash")
+
+        assert result is messages
+        assert result[1]["tool_calls"]
+        assert "reasoning_content" not in result[1]
+        assert result[2]["role"] == "tool"
+
+        _reasoning_content_cache.clear()
+
+    def test_deepseek_uses_cache_instead_of_dropping_historical_tool_protocol(self):
+        """When DeepSeek reasoning is available, preserve and patch tool-call history."""
+        _reasoning_content_cache.clear()
+        _cache_reasoning_content("deepseek/deepseek-v4-flash", "cached reasoning")
+
+        messages = [
+            {"role": "user", "content": "old question"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "function": {"name": "lookup", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
+            {"role": "assistant", "content": "old final answer"},
+            {"role": "user", "content": "new DeepSeek question"},
+        ]
+
+        result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-flash")
+
+        assert result is messages
+        assert result[1]["reasoning_content"] == "cached reasoning"
+        assert result[1]["content"] == ""
+        assert result[3]["reasoning_content"] == "cached reasoning"
+
+        _reasoning_content_cache.clear()
+
     def test_kimi_does_not_inject_reasoning_content_into_final_assistant_message(self):
         """Kimi keeps the historical narrower assistant+tool_calls patch scope."""
         _reasoning_content_cache.clear()
@@ -529,6 +724,57 @@ class TestPostprocessMessagesForReasoning:
         assert "reasoning_content" not in result[2]
 
         _reasoning_content_cache.clear()
+
+
+class TestReasoningContentExtraction:
+    """Tests for robust reasoning_content extraction and cache aliases."""
+
+    def test_extracts_from_dict_and_nested_provider_fields(self):
+        value = {"provider_specific_fields": {"reasoning_content": "nested thought"}}
+        assert _extract_reasoning_content(value) == "nested thought"
+
+    def test_extracts_from_object_model_extra(self):
+        class Value:
+            model_extra = {"reasoning": {"text": "model-extra thought"}}
+
+        assert _extract_reasoning_content(Value()) == "model-extra thought"
+
+    def test_does_not_treat_normal_content_as_reasoning(self):
+        value = {"content": "visible assistant text"}
+        assert _extract_reasoning_content(value) is None
+
+    def test_reasoning_cache_keys_include_prefixed_and_raw_deepseek_names(self):
+        keys = _reasoning_cache_keys("deepseek/deepseek-v4-flash")
+        assert "deepseek/deepseek-v4-flash" in keys
+        assert "deepseek-v4-flash" in keys
+
+        _reasoning_content_cache.clear()
+        _cache_reasoning_content("deepseek-v4-flash", "thought")
+        assert _get_cached_reasoning_content("deepseek/deepseek-v4-flash") == "thought"
+
+        _reasoning_content_cache.clear()
+
+
+class TestDeepSeekHistorySanitization:
+    """Tests for cross-provider DeepSeek history cleanup."""
+
+    def test_sanitize_keeps_visible_assistant_text_from_tool_call_message(self):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "content": "visible text", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
+            {"role": "user", "content": "new"},
+        ]
+
+        result = _sanitize_deepseek_history_without_reasoning(messages)
+
+        assert result == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "content": "visible text"},
+            {"role": "user", "content": "new"},
+        ]
 
 
 class TestApplyAndRemoveSdkPatches:

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -195,8 +195,10 @@ class TestEndMetricGeneration:
     def _patch_sync(self, generation_tools):
         """Patch get_path_manager, the pre-flight validator (so legacy tests
         can pass synthetic paths), and _sync_metric_to_db."""
+        mock_pm = Mock()
+        mock_pm.subject_dir = "/path"
         return (
-            patch("datus.tools.func_tool.generation_tools.get_path_manager"),
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
             patch.object(
                 type(generation_tools),
                 "_validate_metric_file_has_blocks",
@@ -206,13 +208,13 @@ class TestEndMetricGeneration:
         )
 
     def test_requires_validation(self, generation_tools):
-        result = generation_tools.end_metric_generation(metric_file="/path/metric.yaml")
+        result = generation_tools.end_metric_generation(metric_file="/path/semantic_models/metric.yaml")
         assert result.success == 0
         assert "validate_semantic must pass" in result.error
 
     def test_requires_dry_run(self, generation_tools):
         generation_tools.generation_evidence.validation_passed = True
-        result = generation_tools.end_metric_generation(metric_file="/path/metric.yaml")
+        result = generation_tools.end_metric_generation(metric_file="/path/semantic_models/metric.yaml")
         assert result.success == 0
         assert "query_metrics(dry_run=True) must pass" in result.error
 
@@ -220,9 +222,9 @@ class TestEndMetricGeneration:
         self._mark_ready_to_publish(generation_tools)
         p1, p2, p3 = self._patch_sync(generation_tools)
         with p1, p2, p3:
-            result = generation_tools.end_metric_generation(metric_file="/path/metric.yaml")
+            result = generation_tools.end_metric_generation(metric_file="/path/semantic_models/metric.yaml")
         assert result.success == 1
-        assert result.result["metric_file"] == "/path/metric.yaml"
+        assert result.result["metric_file"] == "/path/semantic_models/metric.yaml"
         assert result.result["semantic_model_file"] == ""
         assert result.result["metric_sqls"] == {}
         assert result.result["sync"]["success"] is True
@@ -232,10 +234,11 @@ class TestEndMetricGeneration:
         p1, p2, p3 = self._patch_sync(generation_tools)
         with p1, p2, p3:
             result = generation_tools.end_metric_generation(
-                metric_file="/path/metric.yaml", semantic_model_file="/path/model.yaml"
+                metric_file="/path/semantic_models/metric.yaml",
+                semantic_model_file="/path/semantic_models/model.yaml",
             )
         assert result.success == 1
-        assert result.result["semantic_model_file"] == "/path/model.yaml"
+        assert result.result["semantic_model_file"] == "/path/semantic_models/model.yaml"
 
     def test_success_with_metric_sqls_json(self, generation_tools):
         self._mark_ready_to_publish(generation_tools)
@@ -243,7 +246,7 @@ class TestEndMetricGeneration:
         p1, p2, p3 = self._patch_sync(generation_tools)
         with p1, p2, p3:
             result = generation_tools.end_metric_generation(
-                metric_file="/path/metric.yaml", metric_sqls_json=metric_sqls_json
+                metric_file="/path/semantic_models/metric.yaml", metric_sqls_json=metric_sqls_json
             )
         assert result.success == 1
         assert result.result["metric_sqls"] == {"revenue_total": "SELECT SUM(revenue) FROM orders"}
@@ -253,7 +256,7 @@ class TestEndMetricGeneration:
         p1, p2, p3 = self._patch_sync(generation_tools)
         with p1, p2, p3:
             result = generation_tools.end_metric_generation(
-                metric_file="/path/metric.yaml", metric_sqls_json="not valid json"
+                metric_file="/path/semantic_models/metric.yaml", metric_sqls_json="not valid json"
             )
         assert result.success == 1
         assert result.result["metric_sqls"] == {}
@@ -266,7 +269,7 @@ class TestEndMetricGenerationPreflight:
 
     @staticmethod
     def _patch_path_resolution(tools, kb_root):
-        """Make end_metric_generation treat absolute paths as-is."""
+        """Make end_metric_generation resolve paths under a synthetic KB root."""
         mock_pm = Mock()
         mock_pm.subject_dir = str(kb_root)
         return patch(
@@ -281,14 +284,16 @@ class TestEndMetricGenerationPreflight:
 
     def test_rejects_missing_metric_file(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
+        missing = tmp_path / "semantic_models" / "missing.yaml"
         with self._patch_path_resolution(generation_tools, tmp_path):
-            result = generation_tools.end_metric_generation(metric_file=str(tmp_path / "missing.yaml"))
+            result = generation_tools.end_metric_generation(metric_file=str(missing))
         assert result.success == 0
         assert "Metric file not found" in result.error
 
     def test_rejects_documentation_only_metric_file(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
-        bad = tmp_path / "frpm_metrics.yml"
+        bad = tmp_path / "semantic_models" / "frpm_metrics.yml"
+        bad.parent.mkdir(parents=True, exist_ok=True)
         bad.write_text(
             "# Generated metric documentation\n\n"
             "## Summary\n\n"
@@ -307,7 +312,8 @@ class TestEndMetricGenerationPreflight:
 
     def test_rejects_invalid_yaml(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
-        bad = tmp_path / "broken.yml"
+        bad = tmp_path / "semantic_models" / "broken.yml"
+        bad.parent.mkdir(parents=True, exist_ok=True)
         bad.write_text("name: x\n  bad-indent: : :\n")
         with (
             self._patch_path_resolution(generation_tools, tmp_path),
@@ -321,7 +327,8 @@ class TestEndMetricGenerationPreflight:
     def test_accepts_file_with_metric_block(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
         generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue_total")
-        good = tmp_path / "good_metric.yml"
+        good = tmp_path / "semantic_models" / "good_metric.yml"
+        good.parent.mkdir(parents=True, exist_ok=True)
         good.write_text("metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
         with (
             self._patch_path_resolution(generation_tools, tmp_path),
@@ -332,7 +339,8 @@ class TestEndMetricGenerationPreflight:
 
     def test_rejects_metric_not_covered_by_dry_run(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
-        good = tmp_path / "good_metric.yml"
+        good = tmp_path / "semantic_models" / "good_metric.yml"
+        good.parent.mkdir(parents=True, exist_ok=True)
         good.write_text("metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
         with (
             self._patch_path_resolution(generation_tools, tmp_path),
@@ -341,6 +349,21 @@ class TestEndMetricGenerationPreflight:
             result = generation_tools.end_metric_generation(metric_file=str(good))
         assert result.success == 0
         assert "revenue_total" in result.error
+        sync_mock.assert_not_called()
+
+    def test_rejects_out_of_sandbox_metric_path_before_reading(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        outside = tmp_path / "outside_metric.yml"
+        outside.write_text("metric:\n  name: outside_metric\n")
+        with (
+            self._patch_path_resolution(generation_tools, tmp_path),
+            patch.object(type(generation_tools), "_validate_metric_file_has_blocks") as validate_mock,
+            patch.object(generation_tools, "_sync_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(outside))
+        assert result.success == 0
+        assert "metric_file escapes Knowledge Base sandbox" in result.error
+        validate_mock.assert_not_called()
         sync_mock.assert_not_called()
 
 

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -471,6 +471,41 @@ class TestAvailableTools:
         # 3 base + validate_semantic + attribution_analyze (both enabled when adapter is set)
         assert len(tools) == 5
 
+    def test_configured_adapter_load_failure_still_exposes_validate(self):
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+            patch(
+                "datus.tools.func_tool.semantic_tools.semantic_adapter_registry.create_adapter",
+                side_effect=RuntimeError("bad yaml"),
+            ),
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: adapter_type
+            config.build_semantic_adapter_config.side_effect = lambda adapter_type=None: {"datasource": "ns1"}
+            tool = SemanticTools(agent_config=config, adapter_type="metricflow")
+
+            with patch("datus.tools.func_tool.semantic_tools.trans_to_function_tool") as mock_trans:
+
+                def _mock_tool(func):
+                    tool = Mock()
+                    tool.name = func.__name__
+                    return tool
+
+                mock_trans.side_effect = _mock_tool
+                tools = tool.available_tools()
+
+            names = [tool.name for tool in tools]
+            assert "validate_semantic" in names
+            assert "attribution_analyze" not in names
+
+            result = tool.validate_semantic()
+            assert result.success == 0
+            assert "bad yaml" in result.error
+
 
 class TestListMetrics:
     def test_success_from_storage(self, semantic_tools_ext):


### PR DESCRIPTION
## Why

Semantic model and metric generation could fail or leave generated artifacts unsynced when validation, publishing, or model-provider reasoning behavior did not follow the ideal happy path. DeepSeek/Kimi thinking-mode sessions also needed more robust `reasoning_content` handling across provider response shapes.

## Solution

- Harden semantic model and metric generation finalization so generated files can be validated and synced without relying tightly on the LLM calling a specific end tool.
- Add metric-path sandboxing and stricter final-response handling around skipped/generated metric outputs.
- Keep semantic validation usable when adapter-backed validation is unavailable, with clearer fallback behavior.
- Default generation skills for metrics to include both `gen-metrics` and `gen-semantic-model`.
- Normalize and cache DeepSeek/Kimi `reasoning_content` across string, dict, list, nested, and provider-specific shapes.
- Add focused unit coverage for generation fallback/finalization behavior and reasoning-content handling.

## Test Cases

- `uv run pytest tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/agent/node/test_agentic_node_skills.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/models/test_sdk_patches.py -q`
- `uv run ruff check datus/agent/node/gen_metrics_agentic_node.py datus/agent/node/gen_semantic_model_agentic_node.py datus/models/sdk_patches.py datus/tools/func_tool/generation_tools.py datus/tools/func_tool/semantic_tools.py tests/unit_tests/agent/node/test_agentic_node_skills.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/models/test_sdk_patches.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/tools/func_tool/test_semantic_tools.py`
- `uv run ruff format --check datus/agent/node/gen_metrics_agentic_node.py datus/agent/node/gen_semantic_model_agentic_node.py datus/models/sdk_patches.py datus/tools/func_tool/generation_tools.py datus/tools/func_tool/semantic_tools.py tests/unit_tests/agent/node/test_agentic_node_skills.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/models/test_sdk_patches.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/tools/func_tool/test_semantic_tools.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Final responses can include a "status" ("generated" or "skipped"); the host will prefer tool-based publish but will validate and publish from final JSON as a fallback.
* **Bug Fixes**
  * Stronger Knowledge Base sandbox enforcement to block out-of-sandbox paths and reject invalid artifact locations.
  * Validation now gates publishing and records dry-run/validation evidence.
  * More robust extraction and context-local caching of assistant reasoning; clearer validation/tool error messages.
* **Documentation**
  * Prompts and skill guides updated to prefer (not require) tool calls and to explain host-side fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->