### PR TITLE
[BugFix] Allow grep tool to search a single file path

### DIFF
--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -607,9 +607,7 @@ class FilesystemFuncTool(BaseTool):
 
             target_path = seed.resolved
             if not target_path.exists():
-                return FuncToolResult(success=0, error=f"Directory not found: {seed.display}")
-            if not target_path.is_dir():
-                return FuncToolResult(success=0, error=f"Path is not a directory: {seed.display}")
+                return FuncToolResult(success=0, error=f"Path not found: {seed.display}")
 
             flags = 0 if case_sensitive else re.IGNORECASE
             try:
@@ -621,44 +619,53 @@ class FilesystemFuncTool(BaseTool):
             if seed.zone in (PathZone.INTERNAL, PathZone.WHITELIST):
                 report_relative_to = self._root_resolved
 
-            matches: List[dict] = []
-            for file_path in self._walk_files(seed, include_pattern=include):
+            def _search_file(file_path: Path, reported_file: str) -> List[dict]:
                 if not self._is_allowed_file(file_path):
-                    continue
-
+                    return []
                 try:
                     if file_path.stat().st_size > self.config.max_file_size:
-                        continue
+                        return []
                 except OSError:
-                    continue
-
+                    return []
                 try:
                     content = file_path.read_text(encoding="utf-8")
                 except (UnicodeDecodeError, PermissionError, OSError):
-                    continue
-
-                if report_relative_to is not None:
-                    try:
-                        reported_file = str(file_path.relative_to(report_relative_to))
-                    except ValueError:
-                        reported_file = str(file_path)
-                else:
-                    reported_file = str(file_path)
-
+                    return []
+                found = []
                 for line_num, line in enumerate(content.split("\n"), start=1):
                     if compiled.search(line):
-                        matches.append(
-                            {
-                                "file": reported_file,
-                                "line": line_num,
-                                "content": line.rstrip(),
-                            }
-                        )
+                        found.append({"file": reported_file, "line": line_num, "content": line.rstrip()})
+                return found
+
+            matches: List[dict] = []
+
+            if target_path.is_file():
+                if report_relative_to is not None:
+                    try:
+                        reported_file = str(target_path.relative_to(report_relative_to))
+                    except ValueError:
+                        reported_file = str(target_path)
+                else:
+                    reported_file = str(target_path)
+                matches = _search_file(target_path, reported_file)[:max_matches]
+            elif target_path.is_dir():
+                for file_path in self._walk_files(seed, include_pattern=include):
+                    if report_relative_to is not None:
+                        try:
+                            reported_file = str(file_path.relative_to(report_relative_to))
+                        except ValueError:
+                            reported_file = str(file_path)
+                    else:
+                        reported_file = str(file_path)
+
+                    for m in _search_file(file_path, reported_file):
+                        matches.append(m)
                         if len(matches) >= max_matches:
                             break
-
-                if len(matches) >= max_matches:
-                    break
+                    if len(matches) >= max_matches:
+                        break
+            else:
+                return FuncToolResult(success=0, error=f"Path is not a file or directory: {seed.display}")
 
             truncated = len(matches) >= max_matches
             result_data: dict = {

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -477,6 +477,32 @@ class TestGrep:
         assert result.result["truncated"] is True
         assert len(result.result["matches"]) == 100
 
+    def test_grep_single_file(self, tmp_path):
+        f = tmp_path / "target.py"
+        f.write_text("hello world\nno match\nhello again\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("hello", "target.py")
+        assert result.success == 1
+        assert len(result.result["matches"]) == 2
+        assert result.result["matches"][0]["line"] == 1
+        assert result.result["matches"][1]["line"] == 3
+
+    def test_grep_single_file_no_match(self, tmp_path):
+        f = tmp_path / "empty.py"
+        f.write_text("nothing here\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("missing", "empty.py")
+        assert result.success == 1
+        assert result.result["matches"] == []
+
+    def test_grep_file_not_dir_error_gone(self, tmp_path):
+        f = tmp_path / "code.sql"
+        f.write_text("SELECT 1\n")
+        tool = _make_tool(str(tmp_path))
+        result = tool.grep("SELECT", "code.sql")
+        assert result.success == 1
+        assert len(result.result["matches"]) == 1
+
 
 # ---------------------------------------------------------------------------
 # FilesystemFuncTool - available_tools


### PR DESCRIPTION
Previously grep rejected any non-directory path with "Path is not a directory". Now a file path is searched directly while directory paths continue to use the existing walk logic.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The grep tool now accepts both individual files and directories for searching.

* **Bug Fixes**
  * Improved error handling and messaging for invalid file paths.

* **Tests**
  * Added unit tests verifying grep functionality with single file searches, including line number accuracy and empty result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->