### PR TITLE
[Refactor] Add SQL prompt v1.2 and remove metricflow MCP shortcut

### DIFF
--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -22,7 +22,6 @@ from datus.schemas.chat_agentic_node_models import ChatNodeInput, ChatNodeResult
 from datus.tools.func_tool import ContextSearchTools, DBFuncTool, FilesystemFuncTool, PlatformDocSearchTool
 from datus.tools.func_tool.date_parsing_tools import DateParsingTools
 from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
-from datus.tools.mcp_tools import MCPServer
 from datus.tools.permission.permission_hooks import CompositeHooks, PermissionHooks
 from datus.tools.permission.permission_manager import PermissionManager
 from datus.tools.skill_tools.skill_func_tool import SkillFuncTool
@@ -347,15 +346,6 @@ class ChatAgenticNode(AgenticNode):
 
         for server_name in mcp_server_names:
             try:
-                if server_name == "metricflow_mcp":
-                    server = self._setup_metricflow_mcp()
-                    if server:
-                        mcp_servers["metricflow_mcp"] = server
-                        logger.info(
-                            f"Setup metricflow_mcp MCP server for database: {self.agent_config.current_datasource}"
-                        )
-                    continue
-
                 server = self._setup_mcp_server_from_config(server_name)
                 if server:
                     mcp_servers[server_name] = server
@@ -365,24 +355,6 @@ class ChatAgenticNode(AgenticNode):
 
         logger.debug(f"Setup {len(mcp_servers)} MCP servers: {list(mcp_servers.keys())}")
         return mcp_servers
-
-    def _setup_metricflow_mcp(self) -> Optional[Any]:
-        """Setup MetricFlow MCP server."""
-        try:
-            if not self.agent_config:
-                return None
-
-            db_config = self.agent_config.current_db_config()
-            if not db_config:
-                return None
-
-            metricflow_server = MCPServer.get_metricflow_mcp_server(datasource=self.agent_config.current_datasource)
-            if metricflow_server:
-                logger.info(f"Added metricflow_mcp MCP server for database: {db_config.database}")
-                return metricflow_server
-        except Exception as e:
-            logger.error(f"Failed to setup metricflow_mcp: {e}")
-        return None
 
     def _setup_mcp_server_from_config(self, server_name: str) -> Optional[Any]:
         """Setup MCP server from {agent.home}/conf/.mcp.json using mcp_manager."""
@@ -422,7 +394,7 @@ class ChatAgenticNode(AgenticNode):
             node_config=self.node_config,
             has_db_tools=bool(self.db_func_tool),
             has_filesystem_tools=bool(self.filesystem_func_tool),
-            has_mf_tools=any("metricflow" in k for k in self.mcp_servers.keys()),
+            has_mf_tools=False,
             has_context_search_tools=bool(self.context_search_tools),
             has_reference_template_tools=bool(
                 self.reference_template_tools and self.reference_template_tools.has_reference_templates

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -24,7 +24,6 @@ from datus.tools.func_tool import ContextSearchTools, DBFuncTool, FilesystemFunc
 from datus.tools.func_tool.date_parsing_tools import DateParsingTools
 from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
 from datus.tools.func_tool.semantic_tools import SemanticTools
-from datus.tools.mcp_tools import MCPServer
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_str
 from datus.utils.loggings import get_logger
@@ -494,29 +493,6 @@ class GenSQLAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup {tool_type}.{method_name}: {e}")
 
-    def _setup_metricflow_mcp(self) -> Optional[Any]:
-        """Setup MetricFlow MCP server."""
-        try:
-            if not self.agent_config:
-                logger.warning("Agent config not available for metricflow MCP setup")
-                return None
-
-            # Get current database config
-            db_config = self.agent_config.current_db_config()
-            if not db_config:
-                logger.warning("Database config not found")
-                return None
-
-            metricflow_server = MCPServer.get_metricflow_mcp_server(datasource=self.agent_config.current_datasource)
-            if metricflow_server:
-                logger.info(f"Added metricflow_mcp MCP server for database: {db_config.database}")
-                return metricflow_server
-            else:
-                logger.warning(f"Failed to create metricflow MCP server for db_config: {db_config}")
-        except Exception as e:
-            logger.error(f"Failed to setup metricflow_mcp: {e}")
-        return None
-
     def _setup_mcp_server_from_config(self, server_name: str) -> Optional[Any]:
         """Setup MCP server from {agent.home}/conf/.mcp.json using mcp_manager."""
         try:
@@ -557,16 +533,6 @@ class GenSQLAgenticNode(AgenticNode):
 
         for server_name in mcp_server_names:
             try:
-                # Handle metricflow_mcp
-                if server_name == "metricflow_mcp":
-                    server = self._setup_metricflow_mcp()
-                    if server:
-                        mcp_servers["metricflow_mcp"] = server
-                        logger.info(
-                            f"Setup metricflow_mcp MCP server for database: {self.agent_config.current_datasource}"
-                        )
-
-                # Handle MCP servers from {agent.home}/conf/.mcp.json using mcp_manager
                 server = self._setup_mcp_server_from_config(server_name)
                 if server:
                     mcp_servers[server_name] = server
@@ -601,7 +567,7 @@ class GenSQLAgenticNode(AgenticNode):
             node_config=self.node_config,
             has_db_tools=bool(self.db_func_tool),
             has_filesystem_tools=bool(self.filesystem_func_tool),
-            has_mf_tools=any("metricflow" in k for k in self.mcp_servers.keys()),
+            has_mf_tools=False,
             has_context_search_tools=bool(self.context_search_tools),
             has_reference_template_tools=bool(
                 self.reference_template_tools and self.reference_template_tools.has_reference_templates
@@ -612,8 +578,25 @@ class GenSQLAgenticNode(AgenticNode):
             workspace_root=self._resolve_workspace_root(),
         )
         context["conversation_summary"] = conversation_summary
-        context["has_ask_user_tool"] = self.ask_user_tool is not None
         context["has_task_tool"] = bool(self.sub_agent_task_tool)
+        available_tool_names = sorted(
+            {getattr(tool, "name", "") for tool in (self.tools or []) if getattr(tool, "name", "")}
+        )
+        context["available_tool_names"] = available_tool_names
+        context["has_read_query_tool"] = "read_query" in available_tool_names
+        context["has_describe_table_tool"] = "describe_table" in available_tool_names
+        context["has_list_metrics_tool"] = "list_metrics" in available_tool_names
+        context["has_query_metrics_tool"] = "query_metrics" in available_tool_names
+        context["has_ask_user_tool"] = "ask_user" in available_tool_names
+        context["has_reference_template_tools"] = any(
+            name in available_tool_names
+            for name in (
+                "search_reference_template",
+                "get_reference_template",
+                "render_reference_template",
+                "execute_reference_template",
+            )
+        )
         from datus.utils.time_utils import get_default_current_date
 
         ref = self.date_parsing_tools.reference_date if self.date_parsing_tools else None
@@ -1061,7 +1044,9 @@ class GenSQLAgenticNode(AgenticNode):
         Extract SQL content and formatted output from model response.
 
         Uses the existing llm_result2json utility for robust JSON parsing.
-        Handles the expected template format: {"sql": "...", "tables": [...], "explanation": "..."}
+        Handles the current template format: {"sql": "...", "output": "..."}.
+        Older {"sql": "...", "tables": [...], "explanation": "..."} responses are
+        still accepted as a compatibility fallback.
 
         Args:
             output: Output dictionary from model generation
@@ -1087,13 +1072,13 @@ class GenSQLAgenticNode(AgenticNode):
                 # Extract SQL
                 sql = parsed.get("sql")
 
-                # Build output from explanation and tables if available
-                output_text = None
+                # New sql_system protocol uses `output` as the single user-facing field.
+                output_text = parsed.get("output")
                 explanation = parsed.get("explanation", "")
                 tables = parsed.get("tables", [])
 
-                # If we have explanation or tables, format them as output
-                if explanation or tables:
+                # Backward compatibility for older prompts that returned explanation/tables.
+                if not output_text and (explanation or tables):
                     output_parts = []
                     if explanation:
                         output_parts.append(f"Explanation: {explanation}")
@@ -1101,10 +1086,6 @@ class GenSQLAgenticNode(AgenticNode):
                         tables_str = ", ".join(tables) if isinstance(tables, list) else str(tables)
                         output_parts.append(f"Tables used: {tables_str}")
                     output_text = "\n".join(output_parts)
-
-                # Fallback to direct output field if no explanation/tables
-                if not output_text:
-                    output_text = parsed.get("output")
 
                 # Unescape output content if present
                 if output_text and isinstance(output_text, str):
@@ -1179,7 +1160,7 @@ def prepare_template_context(
     node_config: Union[Dict[str, Any], SubAgentConfig],
     has_db_tools: bool = True,
     has_filesystem_tools: bool = True,
-    has_mf_tools: bool = True,
+    has_mf_tools: bool = False,
     has_context_search_tools: bool = True,
     has_reference_template_tools: bool = False,
     has_parsing_tools: bool = True,
@@ -1194,7 +1175,7 @@ def prepare_template_context(
         node_config: Node configuration
         has_db_tools: Whether database tools are available
         has_filesystem_tools: Whether filesystem tools are available
-        has_mf_tools: Whether MetricFlow MCP tools are available
+        has_mf_tools: Legacy MetricFlow prompt flag
         has_context_search_tools: Whether context search tools are available
         has_reference_template_tools: Whether reference template tools are available
         has_parsing_tools: Whether date parsing tools are available

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -548,6 +548,51 @@ class GenSQLAgenticNode(AgenticNode):
 
         return mcp_servers
 
+    def _get_available_tool_names(self) -> list[str]:
+        """Return native tool names plus discoverable MCP tool names."""
+        tool_names = {getattr(tool, "name", "") for tool in (self.tools or []) if getattr(tool, "name", "")}
+        tool_names.update(self._get_mcp_tool_names_for_prompt())
+        return sorted(tool_names)
+
+    def _get_mcp_tool_names_for_prompt(self) -> set[str]:
+        """Collect MCP tool names that can be known without starting new MCP connections."""
+        active_server_names = [name for name in (self.mcp_servers or {}).keys() if name]
+        if not active_server_names or not self.agent_config:
+            return set()
+
+        try:
+            from datus.tools.mcp_tools.mcp_manager import MCPManager
+
+            mcp_manager = MCPManager(agent_config=self.agent_config)
+        except Exception as e:
+            logger.debug(f"Unable to inspect MCP tool filters for prompt context: {e}")
+            return set()
+
+        tool_names: set[str] = set()
+        for server_name in active_server_names:
+            server_config = mcp_manager.get_server_config(server_name)
+            tool_filter = getattr(server_config, "tool_filter", None) if server_config else None
+
+            allowed_tool_names = getattr(tool_filter, "allowed_tool_names", None)
+            if allowed_tool_names:
+                tool_names.update(name for name in allowed_tool_names if tool_filter.is_tool_allowed(name))
+
+            cached_tool_names = self._get_cached_mcp_tool_names(self.mcp_servers[server_name])
+            if tool_filter:
+                cached_tool_names = {name for name in cached_tool_names if tool_filter.is_tool_allowed(name)}
+            tool_names.update(cached_tool_names)
+
+        return tool_names
+
+    @staticmethod
+    def _get_cached_mcp_tool_names(server: Any) -> set[str]:
+        """Read SDK-cached MCP tool names when the server already discovered them."""
+        cached_tools = getattr(server, "_tools_list", None)
+        if not isinstance(cached_tools, (list, tuple, set)):
+            return set()
+
+        return {getattr(tool, "name", "") for tool in cached_tools if getattr(tool, "name", "")}
+
     def _get_system_prompt(
         self,
         conversation_summary: Optional[str] = None,
@@ -579,9 +624,7 @@ class GenSQLAgenticNode(AgenticNode):
         )
         context["conversation_summary"] = conversation_summary
         context["has_task_tool"] = bool(self.sub_agent_task_tool)
-        available_tool_names = sorted(
-            {getattr(tool, "name", "") for tool in (self.tools or []) if getattr(tool, "name", "")}
-        )
+        available_tool_names = self._get_available_tool_names()
         context["available_tool_names"] = available_tool_names
         context["has_read_query_tool"] = "read_query" in available_tool_names
         context["has_describe_table_tool"] = "describe_table" in available_tool_names

--- a/datus/prompts/prompt_templates/sql_system_1.2.j2
+++ b/datus/prompts/prompt_templates/sql_system_1.2.j2
@@ -1,0 +1,178 @@
+{% set tools = available_tool_names | default([]) -%}
+{% set can_ask_user = has_ask_user_tool | default(false) -%}
+{% set can_read_query = has_read_query_tool | default(false) -%}
+{% set can_describe_table = has_describe_table_tool | default(false) -%}
+{% set can_list_metrics = has_list_metrics_tool | default(false) -%}
+{% set can_query_metrics = has_query_metrics_tool | default(false) -%}
+{% set can_search_reference_template = "search_reference_template" in tools -%}
+{% set can_execute_reference_template = "execute_reference_template" in tools -%}
+{% set can_render_reference_template = "render_reference_template" in tools -%}
+{% set can_search_metrics = "search_metrics" in tools -%}
+{% set can_get_metrics = "get_metrics" in tools -%}
+{% set can_search_reference_sql = "search_reference_sql" in tools -%}
+{% set can_get_reference_sql = "get_reference_sql" in tools -%}
+{% set can_search_semantic_objects = "search_semantic_objects" in tools -%}
+{% set can_list_subject_tree = "list_subject_tree" in tools -%}
+You are a SQL expert embedded in Datus-Agent. Generate correct, minimal SQL or use the best available SQL-producing tool for the user's request.
+
+{% if agent_description -%}
+## Role
+{{ agent_description }}
+{% endif -%}
+
+{% if rules|length > 0 %}
+## Rules From Configuration
+Follow these rules exactly:
+{% for rule in rules %}
+- {{ rule }}
+{% endfor %}
+{% endif %}
+
+## Source Priority
+- User constraints and configured rules are mandatory.
+- External Knowledge is authoritative for business definitions, formulas, filters, and metric semantics.
+- If External Knowledge conflicts with metrics, reference SQL, tool results, or general domain knowledge, External Knowledge wins.
+- Use database schemas, semantic context, reference SQL, and tool results to resolve remaining ambiguity.
+
+{% if can_ask_user %}
+## Clarification
+Use `ask_user` only when a missing table, metric, time range, business definition, or datasource would materially change the SQL. Do not ask for details that can be discovered from available tools or provided context.
+{% endif %}
+
+{% if can_search_reference_template %}
+## Reference Template First
+When the request appears to match a reusable, parameterized SQL pattern:
+1. Call `search_reference_template` before writing ad-hoc SQL.
+2. If a suitable template exists, use `execute_reference_template` when available.
+{% if not can_execute_reference_template and can_render_reference_template and can_read_query %}
+3. If only `render_reference_template` is available, render the SQL and validate it with `read_query`.
+{% endif %}
+4. Do not hand-write an equivalent query when a matching template can answer the request.
+{% endif %}
+
+{% if can_search_metrics or can_get_metrics or can_search_reference_sql or can_get_reference_sql or can_search_semantic_objects %}
+## Context Search
+Use context search when the request involves metrics, rates, business definitions, ambiguous fields, joins, or a likely domain/layer match.
+{% if can_list_subject_tree %}
+- Use `list_subject_tree` to browse available subject paths when the domain is unclear.
+{% endif %}
+{% if can_search_metrics %}
+- Use `search_metrics` to find relevant metric definitions.
+{% endif %}
+{% if can_get_metrics %}
+- Use `get_metrics` for exact metric details when you know the metric identity.
+{% endif %}
+{% if can_search_reference_sql %}
+- Use `search_reference_sql` to find reusable SQL examples.
+{% endif %}
+{% if can_get_reference_sql %}
+- Use `get_reference_sql` for exact reference SQL details.
+{% endif %}
+{% if can_search_semantic_objects %}
+- Use `search_semantic_objects` to discover relevant tables or columns when table context is missing.
+{% endif %}
+- Reuse matching reference SQL directly, or adapt it minimally, unless it conflicts with External Knowledge.
+{% endif %}
+
+{% if can_list_metrics or can_query_metrics %}
+## MetricFlow Path
+For KPI, metric, rate, percentage, trend, or dimensional aggregation requests:
+{% if can_list_metrics %}
+1. Call `list_metrics` first to identify standard metrics that match the user's intent.
+{% endif %}
+2. Use semantic judgment to decide whether a metric is suitable. Do not rely only on string similarity.
+{% if can_query_metrics %}
+3. If a suitable metric exists, use `query_metrics` instead of writing ad-hoc SQL.
+   - Use exact metric names from `list_metrics` or provided context.
+   - Use `dimensions` from available metric dimensions or the user request.
+   - Use `time_start` and `time_end` for date ranges.
+   - Use `time_granularity` for day/week/month/quarter/year grouping.
+   - Use `where` for filters.
+   - Use `dry_run=true` only when you need the generated SQL/plan without executing data retrieval.
+4. If `query_metrics` returns SQL in metadata, use that SQL in the final `sql` field. If it does not expose SQL, do not invent SQL; explain this in `output`.
+{% endif %}
+5. If no suitable metric exists, continue with ad-hoc SQL generation.
+{% endif %}
+
+{% if has_platform_doc_tools %}
+## Platform Documentation
+When platform-specific syntax, functions, data types, advanced features, or platform limitations matter, verify syntax with available platform documentation tools before finalizing SQL.
+{% if "list_document_nav" in tools %}
+- Prefer `list_document_nav` followed by `get_document` for known documentation topics.
+{% endif %}
+{% if "search_document" in tools %}
+- Use `search_document` when you know the feature but not the document title.
+{% endif %}
+{% if "web_search_document" in tools %}
+- Use `web_search_document` only as a fallback when local documentation is insufficient.
+{% endif %}
+{% endif %}
+
+## SQL Generation
+- Generate only the columns needed to answer the user.
+- Do not invent table names, column names, enum values, or business definitions.
+{% if can_describe_table %}
+- Use `describe_table` to verify schema before writing SQL when schemas are not already provided.
+{% endif %}
+{% if can_search_semantic_objects %}
+- Use semantic object search before broad table exploration when the likely table or column is unclear.
+{% endif %}
+- Prefer readable CTEs for complex logic.
+- Use the current datasource unless the user explicitly asks for another datasource.
+
+{% if can_read_query %}
+## SQL Validation
+- Validate every ad-hoc SQL query with `read_query` before final output.
+- If validation fails, analyze the error, fix the SQL, and retry.
+- For validation queries that may return many rows, add a safe preview limit when appropriate. Remove or adjust that limit in the final SQL according to the user's request.
+- For reference-template SQL, `execute_reference_template` counts as validation when it succeeds.
+- For MetricFlow, successful `query_metrics` execution counts as validation for the metric path.
+{% else %}
+## SQL Validation
+- No `read_query` tool is available. Do not claim ad-hoc SQL was executed.
+- If you cannot validate SQL with an available tool, state that clearly in `output`.
+{% endif %}
+
+{% if has_filesystem_tools and can_read_query %}
+## Long SQL File Storage
+When generated SQL is 50 lines or more:
+1. Save it with `write_file` to a whitespace-free path such as `sql/{task_slug}.sql`.
+2. Validate by calling `read_query` with the file path.
+3. Put the file path in the final `sql` field.
+For shorter SQL, return the SQL text inline.
+{% endif %}
+
+{% if datasource -%}
+{% if current_datasource_dialect -%}
+Current datasource: {{ datasource }} ({{ current_datasource_dialect }})
+{% else -%}
+Current datasource: {{ datasource }}
+{% endif -%}
+{% if available_datasources and available_datasources|length > 1 -%}
+Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
+
+Unless the user explicitly requests a different datasource, use ONLY the current datasource for all operations.
+{% endif -%}
+{% endif -%}
+{% if current_date -%}
+Current date: {{ current_date }}
+{% endif -%}
+
+{% if conversation_summary -%}
+## Previous Conversation Summary
+{{ conversation_summary }}
+{% endif -%}
+
+## Final Output Format
+Your final assistant response MUST be one valid JSON object, with no markdown fence and no extra text:
+
+{
+  "sql": "final SQL text, or .sql file path",
+  "output": "user-facing markdown summary"
+}
+
+Rules:
+- Include exactly the `sql` and `output` keys.
+- Put all user-facing explanation in `output`, including tables used, MetricFlow usage, reference-template usage, validation status, result preview, or reasons validation could not run.
+- Do not use `tables`, `explanation`, `mode`, or `validation` as final JSON fields.
+- Keep `sql` to the final SQL text or the SQL file path. Do not invent SQL when a tool path does not expose SQL.

--- a/datus/tools/mcp_tools/README.md
+++ b/datus/tools/mcp_tools/README.md
@@ -124,18 +124,16 @@ You can customize the root directory by configuring `agent.home` in `agent.yml`.
 ```json
 {
   "mcpServers": {
-    "metricflow": {
+    "filesystem": {
       "type": "stdio",
-      "command": "/usr/local/bin/uv",
+      "command": "npx",
       "args": [
-        "--directory", "/path/to/mcp-metricflow-server",
-        "run", "mcp-metricflow-server"
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/path/to/project"
       ],
-      "env": {
-        "MF_PROJECT_DIR": "/path/to/models"
-      },
       "tool_filter": {
-        "allowed_tool_names": ["get_dimensions", "get_metrics", "query_metrics"],
+        "allowed_tool_names": ["read_file", "list_directory"],
         "enabled": true
       }
     },

--- a/datus/tools/mcp_tools/__init__.py
+++ b/datus/tools/mcp_tools/__init__.py
@@ -20,7 +20,7 @@ from .mcp_config import (
     STDIOServerConfig,
 )
 from .mcp_manager import MCPManager
-from .mcp_server import MCPServer, MCPServerStdioParams, SilentMCPServerStdio, find_mcp_directory
+from .mcp_server import MCPServerStdioParams, SilentMCPServerStdio, find_mcp_directory
 from .mcp_tool import MCPTool, parse_command_string
 
 __all__ = [
@@ -34,7 +34,6 @@ __all__ = [
     "STDIOServerConfig",
     "parse_command_string",
     "SilentMCPServerStdio",
-    "MCPServer",
     "MCPServerStdioParams",
     "find_mcp_directory",
 ]

--- a/datus/tools/mcp_tools/mcp_server.py
+++ b/datus/tools/mcp_tools/mcp_server.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import os
-import threading
 from pathlib import Path
 
 from agents.mcp import MCPServerStdio, MCPServerStdioParams
@@ -105,58 +103,3 @@ def find_mcp_directory(mcp_name: str) -> str:
     raise FileNotFoundError(
         f"MCP directory '{mcp_name}' not found in development mcp directory or installed datus-mcp package"
     )
-
-
-class MCPServer:
-    _metricflow_mcp_server = None
-    _lock = threading.Lock()
-
-    @classmethod
-    def get_metricflow_mcp_server(cls, datasource: str):
-        if cls._metricflow_mcp_server is None:
-            with cls._lock:
-                if cls._metricflow_mcp_server is None:
-                    directory = os.getenv("METRICFLOW_MCP_DIR")
-                    if not directory:
-                        try:
-                            directory = find_mcp_directory("mcp-metricflow-server")
-                        except FileNotFoundError as e:
-                            logger.error(f"Could not find MetricFlow MCP directory: {e}")
-                            return None
-                    logger.info(f"Using MetricFlow MCP server with directory: {directory}")
-
-                    # Verify directory exists
-                    if not os.path.exists(directory):
-                        logger.error(f"MetricFlow MCP directory does not exist: {directory}")
-                        return None
-
-                    # Verify mcp-metricflow-server exists
-                    pyproject_path = os.path.join(directory, "pyproject.toml")
-                    if not os.path.exists(pyproject_path):
-                        logger.error(f"MetricFlow MCP pyproject.toml not found: {pyproject_path}")
-                        return None
-
-                    logger.info(f"MetricFlow MCP server directory verified: {directory}")
-
-                    # MetricFlow can now read Datus config directly via DatusConfigHandler
-                    # Pass the datasource via --datasource command line argument
-                    # Pass current working directory so mf can find ./conf/agent.yml
-                    env_dict = os.environ.copy()
-                    env_dict["DATUS_PROJECT_ROOT"] = os.getcwd()
-
-                    mcp_server_params = MCPServerStdioParams(
-                        command="uv",
-                        args=[
-                            "--directory",
-                            directory,
-                            "run",
-                            "mcp-metricflow-server",
-                            "--datasource",
-                            datasource,
-                        ],
-                        env=env_dict,
-                    )
-                    cls._metricflow_mcp_server = SilentMCPServerStdio(
-                        params=mcp_server_params, client_session_timeout_seconds=20
-                    )
-        return cls._metricflow_mcp_server

--- a/docs/cli/mcp_extensions.md
+++ b/docs/cli/mcp_extensions.md
@@ -125,15 +125,13 @@ Allows you to explicitly include or exclude specific tools exposed by a server.
 ```json
 {
   "mcpServers": {
-    "metricflow": {
-      "command": "/Users/me/miniconda3/bin/uv",
+    "filesystem": {
+      "command": "npx",
       "args": [
-        "--directory", "/Users/me/src/mcp-metricflow-server",
-        "run", "mcp-metricflow-server"
-      ],
-      "env": {
-        "MF_PROJECT_DIR": "/Users/me/.metricflow/sample_models"
-      }
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/me/project"
+      ]
     }
   }
 }

--- a/docs/cli/mcp_extensions.zh.md
+++ b/docs/cli/mcp_extensions.zh.md
@@ -125,15 +125,13 @@ MCP（Model Context Protocol）是 Datus-CLI 连接外部工具服务器的方�
 ```json
 {
   "mcpServers": {
-    "metricflow": {
-      "command": "/Users/me/miniconda3/bin/uv",
+    "filesystem": {
+      "command": "npx",
       "args": [
-        "--directory", "/Users/me/src/mcp-metricflow-server",
-        "run", "mcp-metricflow-server"
-      ],
-      "env": {
-        "MF_PROJECT_DIR": "/Users/me/.metricflow/sample_models"
-      }
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/me/project"
+      ]
     }
   }
 }
@@ -217,4 +215,3 @@ MCP 配置支持环境变量展开：
 /mcp call filesystem.list_directory /reports
 /mcp call filesystem.read_file /reports/summary.md
 ```
-

--- a/docs/integration/skills.md
+++ b/docs/integration/skills.md
@@ -192,7 +192,7 @@ Each subagent in `agentic_nodes` supports three types of tool extensions that ca
 | Field | Source | Description |
 |-------|--------|-------------|
 | `tools` | Built-in | Datus native tools (e.g. `db_tools.*`, `context_search_tools.*`, `date_parsing_tools.*`) |
-| `mcp` | Third-party | External MCP server tools, configured via `.mcp.json` (e.g. `metricflow_mcp`, `filesystem`) |
+| `mcp` | Third-party | External MCP server tools, configured via `.mcp.json` (e.g. `filesystem`) |
 | `skills` | User-defined | Skills discovered from `SKILL.md` files — can define workflows in Markdown and extend with custom scripts |
 
 To enable skills in a customized subagent, add the `skills` field under the subagent's config in `agentic_nodes` section of `agent.yml`:
@@ -203,7 +203,7 @@ agentic_nodes:
   school_report:
     node_class: gen_report
     tools: db_tools.*, context_search_tools.*
-    mcp: metricflow_mcp
+    mcp: filesystem
     skills: "report-*, data-*"
     model: deepseek
 

--- a/docs/integration/skills.zh.md
+++ b/docs/integration/skills.zh.md
@@ -192,7 +192,7 @@ agentic_nodes:
 | 字段 | 来源 | 描述 |
 |------|------|------|
 | `tools` | 内置 | Datus 原生工具（如 `db_tools.*`、`context_search_tools.*`、`date_parsing_tools.*`） |
-| `mcp` | 第三方 | 外部 MCP 服务器工具，通过 `.mcp.json` 配置（如 `metricflow_mcp`、`filesystem`） |
+| `mcp` | 第三方 | 外部 MCP 服务器工具，通过 `.mcp.json` 配置（如 `filesystem`） |
 | `skills` | 用户自定义 | 从 `SKILL.md` 文件发现的技能 — 可在 Markdown 中定义工作流，也可通过自定义脚本扩展能力 |
 
 要在自定义 Subagent 中启用技能，请在 `agent.yml` 的 `agentic_nodes` 部分中为对应 Subagent 添加 `skills` 字段：
@@ -203,7 +203,7 @@ agentic_nodes:
   school_report:
     node_class: gen_report
     tools: db_tools.*, context_search_tools.*
-    mcp: metricflow_mcp
+    mcp: filesystem
     skills: "report-*, data-*"
     model: deepseek
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,6 @@ exclude = ["benchmark*", "docs*"]
 "datus.prompts" = ["*.txt", "*.md", "*.j2"]
 "datus.prompts.prompt_templates" = ["*.j2"]
 
-[tool.setuptools.package-dir]
-"mcp.mcp-metricflow-server" = "mcp/mcp-metricflow-server"
-
 [tool.setuptools.data-files]
 "datus/conf" = ["conf/*.yml", "conf/*.yml.*"]
 
@@ -205,4 +202,3 @@ exclude_lines = [
 ]
 show_missing = true
 precision = 2
-

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -22,6 +22,8 @@ Tests verify:
 NO MOCK EXCEPT LLM: The only mock is LLMBaseModel.create_model -> MockLLMModel.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from datus.configuration.node_type import NodeType
@@ -496,25 +498,23 @@ class TestChatAgenticNodeMCPSetup:
         assert isinstance(node.mcp_servers, dict)
         assert len(node.mcp_servers) == 0
 
-    def test_setup_metricflow_mcp_returns_none_without_db_config(self, real_agent_config, mock_llm_create):
-        """_setup_metricflow_mcp returns None when agent_config is None."""
+    def test_mcp_setup_uses_configured_servers_only(self, real_agent_config, mock_llm_create):
+        """MCP server setup delegates configured names to MCPManager."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode
 
         node = ChatAgenticNode(
-            node_id="test_mf_none",
-            description="Test metricflow none",
+            node_id="test_mcp_configured",
+            description="Test configured MCP",
             node_type=NodeType.TYPE_CHAT,
             agent_config=real_agent_config,
         )
+        node.node_config = {"mcp": "custom_server"}
 
-        # Temporarily set agent_config to None
-        original_config = node.agent_config
-        node.agent_config = None
-
-        result = node._setup_metricflow_mcp()
-        assert result is None
-
-        node.agent_config = original_config
+        mock_server = MagicMock()
+        with patch.object(node, "_setup_mcp_server_from_config", return_value=mock_server) as mock_setup:
+            result = node._setup_mcp_servers()
+        mock_setup.assert_called_once_with("custom_server")
+        assert result == {"custom_server": mock_server}
 
     def test_setup_mcp_server_from_config_returns_none_for_unknown_server(self, real_agent_config, mock_llm_create):
         """_setup_mcp_server_from_config returns None for non-existent server name."""

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -15,6 +15,7 @@ real PathManager.
 """
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2931,3 +2932,71 @@ class TestGenSQLSystemPromptToolContext:
         assert call_kwargs["has_describe_table_tool"] is True
         assert call_kwargs["has_read_query_tool"] is False
         assert call_kwargs["has_ask_user_tool"] is True
+
+    def test_system_prompt_context_includes_configured_mcp_tool_names(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        real_agent_config.agentic_nodes["mcp_metrics"] = {
+            "system_prompt": "mcp_metrics",
+            "tools": "db_tools.describe_table",
+            "mcp": "metrics_server",
+            "max_turns": 5,
+        }
+        node = GenSQLAgenticNode(
+            node_id="mcp_metrics",
+            description="MCP metrics GenSQL",
+            node_type=NodeType.TYPE_GENSQL,
+            agent_config=real_agent_config,
+            node_name="mcp_metrics",
+        )
+        node.mcp_servers = {"metrics_server": MagicMock()}
+
+        tool_filter = MagicMock()
+        tool_filter.allowed_tool_names = ["list_metrics", "query_metrics", "blocked_metric"]
+        tool_filter.is_tool_allowed.side_effect = lambda name: name != "blocked_metric"
+        server_config = MagicMock()
+        server_config.tool_filter = tool_filter
+        mcp_manager = MagicMock()
+        mcp_manager.get_server_config.return_value = server_config
+
+        with (
+            patch("datus.tools.mcp_tools.mcp_manager.MCPManager", return_value=mcp_manager),
+            patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_get_prompt_manager,
+        ):
+            mock_prompt_manager = MagicMock()
+            mock_prompt_manager.render_template.return_value = "rendered prompt"
+            mock_get_prompt_manager.return_value = mock_prompt_manager
+
+            node._get_system_prompt()
+
+        mcp_manager.get_server_config.assert_called_once_with("metrics_server")
+        call_kwargs = mock_prompt_manager.render_template.call_args.kwargs
+        assert "list_metrics" in call_kwargs["available_tool_names"]
+        assert "query_metrics" in call_kwargs["available_tool_names"]
+        assert "blocked_metric" not in call_kwargs["available_tool_names"]
+        assert call_kwargs["has_list_metrics_tool"] is True
+        assert call_kwargs["has_query_metrics_tool"] is True
+
+    def test_available_tool_names_includes_cached_mcp_tool_names(self, real_agent_config, mock_llm_create):
+        node = _make_gensql_node(agent_config=real_agent_config)
+        node.tools = [SimpleNamespace(name="describe_table")]
+        node.mcp_servers = {
+            "templates_server": SimpleNamespace(
+                _tools_list=[
+                    SimpleNamespace(name="search_reference_template"),
+                    SimpleNamespace(name="blocked_template"),
+                ]
+            )
+        }
+        tool_filter = SimpleNamespace(
+            allowed_tool_names=None,
+            is_tool_allowed=lambda name: name != "blocked_template",
+        )
+        server_config = SimpleNamespace(tool_filter=tool_filter)
+        mcp_manager = MagicMock()
+        mcp_manager.get_server_config.return_value = server_config
+
+        with patch("datus.tools.mcp_tools.mcp_manager.MCPManager", return_value=mcp_manager):
+            tool_names = node._get_available_tool_names()
+
+        assert tool_names == ["describe_table", "search_reference_template"]

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -775,7 +775,7 @@ class TestPrepareTemplateContext:
         )
         assert context["has_db_tools"] is True
         assert context["has_filesystem_tools"] is True
-        assert context["has_mf_tools"] is True
+        assert context["has_mf_tools"] is False
         assert context["has_context_search_tools"] is True
         assert context["has_parsing_tools"] is True
 
@@ -2022,16 +2022,16 @@ class TestSetupMcpServers:
         result = node._setup_mcp_servers()
         assert result == {}
 
-    def test_metricflow_mcp_setup(self, real_agent_config, mock_llm_create):
+    def test_mcp_config_uses_manager_only(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
-        node.node_config = {"mcp": "metricflow_mcp"}
+        node.node_config = {"mcp": "custom_server"}
 
         mock_server = MagicMock()
-        with patch.object(node, "_setup_metricflow_mcp", return_value=mock_server):
-            with patch.object(node, "_setup_mcp_server_from_config", return_value=None):
-                result = node._setup_mcp_servers()
+        with patch.object(node, "_setup_mcp_server_from_config", return_value=mock_server) as mock_setup:
+            result = node._setup_mcp_servers()
 
-        assert "metricflow_mcp" in result
+        mock_setup.assert_called_once_with("custom_server")
+        assert result == {"custom_server": mock_server}
 
 
 # ---------------------------------------------------------------------------
@@ -2365,6 +2365,20 @@ class TestExtractSqlAndOutputFromResponse:
         sql, output = node._extract_sql_and_output_from_response({"content": content})
         assert sql == "SELECT 1"
         assert output == "Query result"
+
+    def test_output_field_wins_over_legacy_explanation_tables(self, real_agent_config, mock_llm_create):
+        node = _make_node_extra2(real_agent_config, mock_llm_create)
+        content = json.dumps(
+            {
+                "sql": "SELECT 1",
+                "output": "Use this final output",
+                "explanation": "legacy explanation",
+                "tables": ["legacy_table"],
+            }
+        )
+        sql, output = node._extract_sql_and_output_from_response({"content": content})
+        assert sql == "SELECT 1"
+        assert output == "Use this final output"
 
     def test_unescape_newlines_in_output(self, real_agent_config, mock_llm_create):
         node = _make_node_extra2(real_agent_config, mock_llm_create)
@@ -2883,3 +2897,37 @@ class TestGenSQLSystemPromptCurrentDate:
             prompt = node._get_system_prompt()
         mock_date.assert_called_once_with(None)
         assert "2025-06-15" in prompt
+
+
+class TestGenSQLSystemPromptToolContext:
+    """Verify prompt rendering receives the actual available tool surface."""
+
+    def test_system_prompt_context_uses_actual_tools(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        real_agent_config.agentic_nodes["describe_only"] = {
+            "system_prompt": "describe_only",
+            "tools": "db_tools.describe_table",
+            "max_turns": 5,
+        }
+        node = GenSQLAgenticNode(
+            node_id="describe_only",
+            description="Describe-only GenSQL",
+            node_type=NodeType.TYPE_GENSQL,
+            agent_config=real_agent_config,
+            node_name="describe_only",
+        )
+
+        with patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_get_prompt_manager:
+            mock_prompt_manager = MagicMock()
+            mock_prompt_manager.render_template.return_value = "rendered prompt"
+            mock_get_prompt_manager.return_value = mock_prompt_manager
+
+            node._get_system_prompt()
+
+        call_kwargs = mock_prompt_manager.render_template.call_args.kwargs
+        assert "describe_table" in call_kwargs["available_tool_names"]
+        assert "read_query" not in call_kwargs["available_tool_names"]
+        assert call_kwargs["has_describe_table_tool"] is True
+        assert call_kwargs["has_read_query_tool"] is False
+        assert call_kwargs["has_ask_user_tool"] is True

--- a/tests/unit_tests/prompts/test_prompt_utils.py
+++ b/tests/unit_tests/prompts/test_prompt_utils.py
@@ -9,6 +9,7 @@ CI-level: zero external deps, zero network, zero API keys.
 Mocks get_prompt_manager().render_template / get_raw_template to avoid template file I/O.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
@@ -363,3 +364,74 @@ class TestGenMetricsV12Template:
         latest = pm.get_latest_version("gen_metrics_system")
         latest_parts = tuple(int(p) for p in latest.split("."))
         assert latest_parts >= (1, 2), f"Expected latest version >= '1.2', got '{latest}'"
+
+
+class TestSqlSystemV12Template:
+    """Smoke tests for sql_system_1.2.j2 and GenSQL template aliasing."""
+
+    @staticmethod
+    def _builtin_versions(pm, template_name: str) -> list[str]:
+        versions = [
+            path.name.removeprefix(f"{template_name}_").removesuffix(".j2")
+            for path in pm.default_templates_dir.glob(f"{template_name}_*.j2")
+        ]
+        return sorted(versions, key=lambda v: tuple(int(part) for part in v.split(".")))
+
+    @staticmethod
+    def _read_builtin_template(pm, template_name: str, version: str) -> str:
+        return (pm.default_templates_dir / f"{template_name}_{version}.j2").read_text(encoding="utf-8")
+
+    def test_sql_system_v12_is_latest_version(self):
+        """Bundled sql_system latest version is 1.2 or newer."""
+        from datus.prompts.prompt_manager import PromptManager
+
+        pm = PromptManager()
+        latest = self._builtin_versions(pm, "sql_system")[-1]
+        latest_parts = tuple(int(p) for p in latest.split("."))
+        assert latest_parts >= (1, 2), f"Expected latest version >= '1.2', got '{latest}'"
+
+    def test_gen_sql_system_latest_remains_legacy_compatible(self):
+        """GenerateSQLNode still reads gen_sql_system as a raw legacy prompt."""
+        from datus.prompts.prompt_manager import PromptManager
+
+        pm = PromptManager()
+        latest = self._builtin_versions(pm, "gen_sql_system")[-1]
+
+        assert latest == "1.1"
+        content = self._read_builtin_template(pm, "gen_sql_system", latest)
+        assert "{% include" not in content
+        assert '"tables"' in content
+        assert '"explanation"' in content
+
+    def test_get_sql_prompt_uses_raw_legacy_gen_sql_system(self, tmp_path):
+        """get_sql_prompt should not receive a Jinja include as its raw system prompt."""
+        from datus.prompts.gen_sql import get_sql_prompt
+        from datus.utils.path_manager import DatusPathManager
+
+        agent_config = SimpleNamespace(path_manager=DatusPathManager(tmp_path / "datus_home"))
+        messages = get_sql_prompt(
+            database_type="sqlite",
+            table_schemas="",
+            data_details=[],
+            metrics=[],
+            question="count schools",
+            agent_config=agent_config,
+        )
+
+        system_content = messages[0]["content"]
+        assert "{% include" not in system_content
+        assert '"tables"' in system_content
+        assert '"explanation"' in system_content
+
+    def test_sql_system_v12_uses_current_output_protocol(self):
+        """sql_system 1.2 documents the compact sql/output final JSON protocol."""
+        from datus.prompts.prompt_manager import PromptManager
+
+        pm = PromptManager()
+        content = self._read_builtin_template(pm, "sql_system", "1.2")
+        assert "explain=true" not in content
+        assert "start_time" not in content
+        assert "end_time" not in content
+        assert '"sql"' in content
+        assert '"output"' in content
+        assert "Do not use `tables`, `explanation`, `mode`, or `validation` as final JSON fields." in content

--- a/tests/unit_tests/tools/mcp_tools/test_mcp_server_module.py
+++ b/tests/unit_tests/tools/mcp_tools/test_mcp_server_module.py
@@ -1,14 +1,14 @@
 # Copyright 2025-present DatusAI, Inc.
 # Licensed under the Apache License, Version 2.0.
 
-"""Unit tests for datus/tools/mcp_tools/mcp_server.py (SilentMCPServerStdio + find_mcp_directory + MCPServer)"""
+"""Unit tests for datus/tools/mcp_tools/mcp_server.py."""
 
 import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from datus.tools.mcp_tools.mcp_server import MCPServer, SilentMCPServerStdio, find_mcp_directory
+from datus.tools.mcp_tools.mcp_server import SilentMCPServerStdio, find_mcp_directory
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -127,61 +127,3 @@ class TestFindMcpDirectory:
         with patch("sys.path", []):
             with pytest.raises(FileNotFoundError, match="not found"):
                 find_mcp_directory("nonexistent-server-xyz")
-
-
-# ---------------------------------------------------------------------------
-# MCPServer singleton
-# ---------------------------------------------------------------------------
-
-
-class TestMCPServer:
-    def setup_method(self):
-        # Reset singleton before each test
-        MCPServer._metricflow_mcp_server = None
-
-    def test_returns_none_when_dir_env_not_set_and_not_found(self):
-        with patch.dict("os.environ", {}, clear=False):
-            # Remove METRICFLOW_MCP_DIR if set
-            import os
-
-            os.environ.pop("METRICFLOW_MCP_DIR", None)
-            with patch(
-                "datus.tools.mcp_tools.mcp_server.find_mcp_directory", side_effect=FileNotFoundError("not found")
-            ):
-                result = MCPServer.get_metricflow_mcp_server(datasource="test")
-        assert result is None
-
-    def test_returns_none_when_directory_does_not_exist(self, tmp_path):
-        nonexistent = str(tmp_path / "missing_dir")
-        with patch.dict("os.environ", {"METRICFLOW_MCP_DIR": nonexistent}):
-            result = MCPServer.get_metricflow_mcp_server(datasource="test")
-        assert result is None
-
-    def test_returns_none_when_pyproject_missing(self, tmp_path):
-        # Directory exists but no pyproject.toml
-        tmp_path.mkdir(parents=True, exist_ok=True)
-        with patch.dict("os.environ", {"METRICFLOW_MCP_DIR": str(tmp_path)}):
-            result = MCPServer.get_metricflow_mcp_server(datasource="test")
-        assert result is None
-
-    def test_creates_server_when_valid_directory(self, tmp_path):
-        # Create a valid directory structure
-        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'")
-        with patch.dict("os.environ", {"METRICFLOW_MCP_DIR": str(tmp_path)}):
-            with patch("datus.tools.mcp_tools.mcp_server.SilentMCPServerStdio") as mock_cls:
-                mock_instance = MagicMock()
-                mock_cls.return_value = mock_instance
-                result = MCPServer.get_metricflow_mcp_server(datasource="my_ns")
-        assert result is mock_instance
-
-    def test_singleton_returns_same_instance(self, tmp_path):
-        (tmp_path / "pyproject.toml").write_text("[project]")
-        with patch.dict("os.environ", {"METRICFLOW_MCP_DIR": str(tmp_path)}):
-            with patch("datus.tools.mcp_tools.mcp_server.SilentMCPServerStdio") as mock_cls:
-                mock_instance = MagicMock()
-                mock_cls.return_value = mock_instance
-                result1 = MCPServer.get_metricflow_mcp_server(datasource="ns1")
-                result2 = MCPServer.get_metricflow_mcp_server(datasource="ns2")
-        assert result1 is result2
-        # Constructor called only once
-        assert mock_cls.call_count == 1


### PR DESCRIPTION
## Why

The SQL agent prompt needs a newer compact output protocol without breaking the legacy GenerateSQLNode path that still reads gen_sql_system as a raw prompt.

The deprecated built-in metricflow_mcp shortcut also created stale prompt/runtime paths now that MetricFlow support goes through native semantic tools or generic MCP configuration.

## Solution

- Add bundled sql_system_1.2.j2 with the sql/output final JSON contract and tool-gated guidance.
- Keep gen_sql_system latest at 1.1 so GenerateSQLNode remains legacy-compatible.
- Update GenSQLAgenticNode to pass actual available tool names into prompt rendering and prefer the new output field while keeping explanation/tables fallback parsing.
- Remove the deprecated metricflow_mcp setup path, exports, packaging entry, and docs references.
- Add hermetic prompt compatibility tests and update node/MCP tests for the new behavior.

## Test Cases

- uv run pytest tests/unit_tests/prompts/test_prompt_utils.py tests/unit_tests/agent/node/test_gen_sql_agentic_node.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/tools/mcp_tools/test_mcp_server_module.py --import-mode=importlib
- git diff --check HEAD~1..HEAD
- rg -n "metricflow_mcp|METRICFLOW_MCP|mcp-metricflow-server|get_metricflow_mcp_server|_setup_metricflow_mcp" . -g '!benchmark/**' -g '!*.lock'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New SQL system prompting that produces minimal, validated SQL and requires final responses as JSON with "sql" and "output".

* **Bug Fixes**
  * SQL results now prefer the new "output" field for user-facing responses.

* **Documentation**
  * MCP configuration examples and integration docs switched to a filesystem-based server example.

* **Chores**
  * Removed bundled MetricFlow MCP server integration and related packaging/configuration. 

* **Tests**
  * Updated and added tests to cover new prompt versions, SQL extraction, and MCP configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->