### PR TITLE
[Enhancement] Cut redundant startup HTTPS calls and harden CLI shutdown

### DIFF
--- a/datus/__init__.py
+++ b/datus/__init__.py
@@ -4,4 +4,11 @@
 
 """Datus - Data engineering agent builds evolvable context for your data system"""
 
+import os
+
+# LiteLLM otherwise GETs https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
+# at import time. We don't rely on the freshest cost map, so default to the
+# bundled backup. User can opt back in by setting the env var to "false".
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+
 __version__ = "0.2.6"

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -470,6 +470,7 @@ class Application:
 
 def main():
     """Entry point for console scripts"""
+    import signal
     import sys
 
     # Intercept 'skill' subcommand and delegate to datus.main's skill handler
@@ -484,7 +485,19 @@ def main():
         sys.exit(run_skill_command(args))
 
     app = Application()
-    app.run()
+    try:
+        app.run()
+    finally:
+        # Ignore further SIGINT once the REPL has returned. Python's interpreter
+        # shutdown (threading._shutdown, atexit handlers) acquires locks while
+        # waiting for non-daemon threads from third-party libraries (agents SDK
+        # tracing worker, httpx pools, MCP clients). A user Ctrl+C during that
+        # wait raises KeyboardInterrupt mid-`lock.acquire()` and surfaces as
+        # noisy "Exception ignored in: <module 'threading'>" tracebacks.
+        try:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
 
 
 if __name__ == "__main__":

--- a/datus/cli/provider_model_catalog.py
+++ b/datus/cli/provider_model_catalog.py
@@ -5,8 +5,9 @@
 """Overlay provider model lists from OpenRouter's public catalog.
 
 Used by the `/model` command to present up-to-date model choices without shipping
-an ever-expanding local list. Failures silently fall back through:
+an ever-expanding local list. Resolution order:
 
+  L0 Fresh cache (mtime within FRESH_CACHE_TTL_SEC) — short-circuits remote
   L1 Remote GET https://openrouter.ai/api/v1/models  (8s timeout, no auth)
   L2 Cached file at ~/.datus/cache/openrouter_models.json
   L3 Local catalog from datus/conf/providers.yml
@@ -24,6 +25,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set
@@ -39,6 +41,10 @@ OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 OPENROUTER_TIMEOUT_SEC = 8.0
 CACHE_FILE_NAME = "openrouter_models.json"
 CACHE_SCHEMA_VERSION = 2
+# Skip the remote fetch if the on-disk cache was refreshed within this window.
+# Avoids two openrouter calls during a single CLI startup (Application credential
+# probe + AgentConfig.provider_catalog lazy load).
+FRESH_CACHE_TTL_SEC = 600.0
 # Cache versions that load_cached_models / load_cached_model_details accept.
 _SUPPORTED_CACHE_VERSIONS = frozenset({1, 2})
 
@@ -92,6 +98,15 @@ _MIN_CONTEXT_LENGTH = 4096
 
 def _cache_file_path() -> Path:
     return get_path_manager().datus_home / "cache" / CACHE_FILE_NAME
+
+
+def _cache_is_fresh(max_age_sec: float) -> bool:
+    """Return True iff the cache file exists and was modified within ``max_age_sec``."""
+    try:
+        mtime = _cache_file_path().stat().st_mtime
+    except OSError:
+        return False
+    return (time.time() - mtime) < max_age_sec
 
 
 def _extract_pricing(raw_pricing: Any) -> Optional[Dict[str, str]]:
@@ -368,7 +383,12 @@ def _resolve_models_from(catalog: dict) -> dict:
 
 
 def resolve_provider_models(local_catalog: dict) -> dict:
-    """Three-tier fallback: remote → cache → local. Never raises.
+    """Resolution order: fresh-cache → remote → stale-cache → local. Never raises.
+
+    A cache file refreshed within ``FRESH_CACHE_TTL_SEC`` is treated as
+    authoritative and short-circuits the remote fetch — this dedupes the two
+    openrouter requests that otherwise fire on every CLI startup (the
+    credential probe in ``main.py`` plus ``AgentConfig.provider_catalog``).
 
     Only overlays per-provider `models` lists; `model_overrides`, `model_specs`,
     `default_model`, `base_url`, `api_key_env`, `type`, `auth_type` are preserved.
@@ -380,16 +400,30 @@ def resolve_provider_models(local_catalog: dict) -> dict:
     providers_block = local_catalog.get("providers") if isinstance(local_catalog, dict) else None
     allowed_providers = set(providers_block.keys()) if isinstance(providers_block, dict) else None
 
+    if _cache_is_fresh(FRESH_CACHE_TTL_SEC):
+        cached_overlay = _overlay_from_cache(local_catalog, allowed_providers)
+        if cached_overlay is not None:
+            return cached_overlay
+
     remote_buckets = fetch_openrouter_models(allowed_providers=allowed_providers)
     if remote_buckets is not None:
         save_cached_models(remote_buckets)
         return _resolve_models_from(_overlay(local_catalog, remote_buckets))
 
-    cached_details = load_cached_model_details()
-    if cached_details is not None:
-        if allowed_providers is not None:
-            cached_details = {k: v for k, v in cached_details.items() if k in allowed_providers}
-        if cached_details:
-            return _resolve_models_from(_overlay(local_catalog, cached_details))
+    cached_overlay = _overlay_from_cache(local_catalog, allowed_providers)
+    if cached_overlay is not None:
+        return cached_overlay
 
     return _resolve_models_from(copy.deepcopy(local_catalog))
+
+
+def _overlay_from_cache(local_catalog: dict, allowed_providers: Optional[Set[str]]) -> Optional[dict]:
+    """Apply the on-disk cache as an overlay, filtered by ``allowed_providers``."""
+    cached_details = load_cached_model_details()
+    if cached_details is None:
+        return None
+    if allowed_providers is not None:
+        cached_details = {k: v for k, v in cached_details.items() if k in allowed_providers}
+    if not cached_details:
+        return None
+    return _resolve_models_from(_overlay(local_catalog, cached_details))

--- a/datus/utils/traceable_utils.py
+++ b/datus/utils/traceable_utils.py
@@ -72,11 +72,25 @@ def setup_tracing():
         return
     _tracing_initialized = True
 
+    def _disable_sdk_tracing(reason: str) -> None:
+        # The OpenAI Agents SDK's DefaultTraceProvider spawns a background worker
+        # whose atexit shutdown can deadlock under Ctrl+C. Disable it when we are
+        # not actively forwarding traces to LangSmith.
+        try:
+            from agents import set_tracing_disabled
+
+            set_tracing_disabled(True)
+            logger.debug(f"OpenAI Agents SDK tracing disabled: {reason}")
+        except ImportError:
+            pass
+
     if not HAS_LANGSMITH:
+        _disable_sdk_tracing("langsmith not installed")
         return
 
     if not _is_tracing_enabled():
         logger.debug("LangSmith tracing not enabled (set LANGSMITH_TRACING=true and LANGCHAIN_API_KEY to enable)")
+        _disable_sdk_tracing("LANGSMITH_TRACING/api key not set")
         return
 
     try:


### PR DESCRIPTION
- Dedupe duplicate openrouter /v1/models fetches: resolve_provider_models() now short-circuits to the on-disk cache when its mtime is younger than FRESH_CACHE_TTL_SEC (10 min). Falls through to remote → stale-cache → local on miss/corrupt cache, preserving the original three-tier behavior.
- Skip LiteLLM's GitHub model_prices_and_context_window.json fetch on import by defaulting LITELLM_LOCAL_MODEL_COST_MAP=true in datus/__init__.py. Users can opt back in by exporting LITELLM_LOCAL_MODEL_COST_MAP=false.
- Ignore SIGINT after the REPL returns so a Ctrl+C during interpreter shutdown (waiting on third-party non-daemon threads: agents SDK tracing worker, httpx pools, MCP clients) no longer surfaces noisy "Exception ignored in: <module 'threading'>" tracebacks.
- Disable the OpenAI Agents SDK default tracing worker when LangSmith is not active, eliminating the atexit deadlock window on Ctrl+C.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced model provider catalog caching for faster model resolution and fallback support.
  * Improved application shutdown behavior.
  * Better compatibility with tracing service configuration when services are unavailable.

* **Chores**
  * Optimized initialization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->