### PR TITLE
[BugFix] Standardize API timestamps to ISO-8601 UTC with Z suffix

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -1,10 +1,11 @@
 """Pydantic models for CLI Command Type API endpoints."""
 
-from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from datus.utils.time_utils import now_utc_iso
 
 
 # SQL Execution models
@@ -514,7 +515,7 @@ class SSEEvent(BaseModel):
         description="Event type (start, thinking, action, message, response, error, ping, end)",
     )
     data: SSEEventData = Field(..., description="Event payload")
-    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat() + "Z")
+    timestamp: str = Field(default_factory=now_utc_iso)
 
 
 class ChatHistoryData(BaseModel):

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -6,7 +6,6 @@ chat-history retrieval can share the same conversion logic.
 """
 
 import json
-from datetime import datetime
 from typing import Any, List, Optional
 
 from datus.api.models.cli_models import (
@@ -19,6 +18,7 @@ from datus.api.models.cli_models import (
 from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 from datus.utils.json_utils import llm_result2json
 from datus.utils.loggings import get_logger
+from datus.utils.time_utils import now_utc_iso, to_utc_iso
 
 logger = get_logger(__name__)
 
@@ -424,7 +424,7 @@ def action_to_sse_event(
             id=event_id,
             event="message",
             data=sse_data,
-            timestamp=getattr(action, "start_time", datetime.now()).isoformat() + "Z",
+            timestamp=to_utc_iso(getattr(action, "start_time", None)) or now_utc_iso(),
         )
 
     except Exception as e:

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -7,7 +7,6 @@ read from disk each time (no in-memory state).
 """
 
 import uuid
-from datetime import datetime
 from typing import AsyncGenerator, List, Optional
 
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
@@ -36,6 +35,7 @@ from datus.models.session_manager import SessionManager, session_matches_agent
 from datus.schemas.action_history import ActionRole, ActionStatus
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
+from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
 
@@ -78,7 +78,7 @@ class ChatService:
                 id=1,
                 event="error",
                 data=SSEErrorData(error=str(e), error_type=error_code, session_id=request.session_id),
-                timestamp=datetime.now().isoformat() + "Z",
+                timestamp=now_utc_iso(),
             )
             return
         async for event in task_manager.consume_events(task):
@@ -117,8 +117,8 @@ class ChatService:
                     info = session_mgr.get_session_info(sid)
                     if not info.get("exists", False):
                         continue
-                    created_at = info.get("created_at", "")
-                    last_updated = info.get("updated_at", "") or info.get("file_modified_iso", "") or created_at
+                    created_at = info.get("created_at") or ""
+                    last_updated = info.get("updated_at") or info.get("file_modified_iso") or created_at
                     sessions.append(
                         ChatSessionItemInfo(
                             user_query=info.get("first_user_message"),
@@ -159,7 +159,7 @@ class ChatService:
                 data=ChatSessionData(
                     session_id=session_id,
                     created_at="",
-                    last_updated=datetime.now().isoformat() + "Z",
+                    last_updated=now_utc_iso(),
                     total_turns=0,
                     token_count=0,
                     last_sql_queries=[],

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -32,6 +32,7 @@ from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
 from datus.tools.proxy.proxy_tool import apply_proxy_tools
 from datus.utils.loggings import get_logger
 from datus.utils.path_manager import set_current_path_manager
+from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
 
@@ -377,7 +378,7 @@ class ChatTaskManager:
                                 id=-1,
                                 event="ping",
                                 data=SSEPingData(),
-                                timestamp=datetime.now().isoformat() + "Z",
+                                timestamp=now_utc_iso(),
                             )
                             break  # exit inner loop so ping can be yielded
                 new_events = task.events[cursor:]
@@ -474,7 +475,7 @@ class ChatTaskManager:
                         session_id=session_id,
                         llm_session_id=node.session_id,
                     ),
-                    timestamp=datetime.now().isoformat() + "Z",
+                    timestamp=now_utc_iso(),
                 ),
             )
             event_id += 1
@@ -591,7 +592,7 @@ class ChatTaskManager:
                         duration=(datetime.now() - start_time).total_seconds(),
                         **token_kwargs,
                     ),
-                    timestamp=datetime.now().isoformat() + "Z",
+                    timestamp=now_utc_iso(),
                 ),
             )
             event_id += 1
@@ -616,7 +617,7 @@ class ChatTaskManager:
                         session_id=session_id,
                         llm_session_id=task.node.session_id if task.node else None,
                     ),
-                    timestamp=datetime.now().isoformat() + "Z",
+                    timestamp=now_utc_iso(),
                 ),
             )
             event_id += 1

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -6,7 +6,6 @@ import asyncio
 import threading
 import time
 import uuid
-from datetime import datetime
 from typing import Dict, Optional
 
 from datus.api.models.base_models import Result
@@ -33,6 +32,7 @@ from datus.schemas.action_history import (
 )
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
+from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
 
@@ -204,7 +204,7 @@ class CLIService:
                     sql_return=sql_return,
                     result_format=request.result_format,
                     execution_time=exec_time,
-                    executed_at=datetime.now().isoformat() + "Z",
+                    executed_at=now_utc_iso(),
                     columns=columns,
                 )
 
@@ -405,7 +405,7 @@ class CLIService:
                     "current_catalog": getattr(self.cli_context, "current_catalog", None) if self.cli_context else None,
                     "current_schema": getattr(self.cli_context, "current_schema", None) if self.cli_context else None,
                     "database": db_info,
-                    "timestamp": datetime.now().isoformat() + "Z",
+                    "timestamp": now_utc_iso(),
                 }
 
             elif context_type == "catalog":

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -3,7 +3,6 @@ Service for handling Database Management operations.
 """
 
 import os
-from datetime import datetime
 from typing import List, Optional
 
 from datus_db_core import BaseSqlConnector
@@ -30,6 +29,7 @@ from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_table_name_parts
 from datus.utils.text_utils import redact_uri
+from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
 # Database types that do NOT support schema switching
@@ -115,7 +115,7 @@ class DatasourceService:
         dialect = getattr(connector, "dialect", "unknown")
         has_schema = connector_registry.support_schema(dialect)
         catalog_name = request.catalog_name or getattr(connector, "catalog_name", None)
-        now = datetime.now().isoformat() + "Z"
+        now = now_utc_iso()
 
         def _disconnected(db_name: str) -> DatabaseInfo:
             return DatabaseInfo(

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -3,7 +3,6 @@
 import asyncio
 import os
 import types
-from datetime import datetime
 from typing import AsyncGenerator, Optional
 
 from datus.api.models.kb_models import (
@@ -31,6 +30,7 @@ from datus.storage.semantic_model.semantic_model_init import (
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
+from datus.utils.time_utils import now_utc_iso, to_utc_iso
 
 logger = get_logger(__name__)
 
@@ -513,7 +513,7 @@ class KbService:
             error=error,
             progress=progress,
             payload=payload,
-            timestamp=datetime.now().isoformat(),
+            timestamp=now_utc_iso(),
         )
 
     @staticmethod
@@ -534,5 +534,5 @@ class KbService:
             error=event.error,
             progress=progress,
             payload=event.payload,
-            timestamp=event.timestamp.isoformat() if event.timestamp else datetime.now().isoformat(),
+            timestamp=to_utc_iso(event.timestamp) or now_utc_iso(),
         )

--- a/datus/api/services/success_story_service.py
+++ b/datus/api/services/success_story_service.py
@@ -8,7 +8,6 @@ consumers keep working.
 import csv
 import os
 import re
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -17,6 +16,7 @@ from datus.api.models.success_story_models import SuccessStoryData, SuccessStory
 from datus.configuration.agent_config import AgentConfig
 from datus.utils.csv_utils import sanitize_csv_field
 from datus.utils.loggings import get_logger
+from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
 
@@ -49,7 +49,7 @@ class SuccessStoryService:
         target_dir.mkdir(parents=True, exist_ok=True)
         csv_path = target_dir / "success_story.csv"
 
-        timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        timestamp = now_utc_iso()
         row = {
             "session_link": sanitize_csv_field(payload.session_link),
             "session_id": payload.session_id,

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -30,6 +30,7 @@ from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
 from datus.utils.loggings import get_logger
 from datus.utils.terminal_utils import EscapeGuard, interrupt_on_escape
+from datus.utils.time_utils import format_local_time
 
 
 @contextmanager
@@ -1356,7 +1357,7 @@ class ChatCommands:
                     first_msg = raw_first_msg.replace("\n", " ").replace("\r", " ")
                     if not first_msg:
                         first_msg = "(empty)"
-                    updated = (info.get("updated_at") or info.get("latest_message_at") or "N/A")[:19]
+                    updated = format_local_time(info.get("updated_at") or info.get("latest_message_at")) or "N/A"
                     msg_count = str(info.get("message_count", 0))
                     items.append(
                         ListItem(key=sid, primary=first_msg, secondary=f"{sid}  Updated: {updated}  Msgs: {msg_count}")
@@ -1502,7 +1503,7 @@ class ChatCommands:
                     content = (turn_msg.get("content", "") or "").replace("\n", " ").replace("\r", " ")
                     if not content:
                         content = "(empty)"
-                    timestamp = (turn_msg.get("created_at") or "")[:19]
+                    timestamp = format_local_time(turn_msg.get("created_at"))
                     items.append(ListItem(key=str(idx), primary=content, secondary=f"Turn: {idx}  {timestamp}"))
 
                 app = ListSelectorApp(title="Session Rewind", items=items)

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -22,6 +22,7 @@ from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import llm_result2json
 from datus.utils.loggings import get_logger
 from datus.utils.message_utils import extract_user_input
+from datus.utils.time_utils import to_utc_iso
 
 logger = get_logger(__name__)
 
@@ -593,6 +594,7 @@ class SessionManager:
                 file_info = {
                     "file_size": stat.st_size,
                     "file_modified": stat.st_mtime,
+                    "file_modified_iso": to_utc_iso(stat.st_mtime),
                 }
         except Exception as e:
             logger.debug(f"Could not get file info for {db_path}: {e}")
@@ -711,6 +713,17 @@ class SessionManager:
             # Return basic info even if database query fails
             session_metadata = {"total_tokens": 0, "message_count": 0, "item_count": 0}
 
+        # Normalize SQLite naive timestamps (UTC) to ISO-8601 with 'Z' suffix.
+        for key in (
+            "created_at",
+            "updated_at",
+            "latest_message_at",
+            "latest_user_message_at",
+            "first_user_message_at",
+        ):
+            if key in session_metadata and session_metadata[key]:
+                session_metadata[key] = to_utc_iso(session_metadata[key])
+
         return {
             "exists": True,
             "session_id": session_id,
@@ -782,7 +795,7 @@ class SessionManager:
                             "total_tokens": tot or 0,
                             "input_tokens_details": inp_detail_dict,
                             "output_tokens_details": out_detail_dict,
-                            "created_at": created_at,
+                            "created_at": to_utc_iso(created_at),
                         }
                     )
         except sqlite3.OperationalError:
@@ -891,6 +904,8 @@ class SessionManager:
                 current_actions = []  # Collect ActionHistory objects for detailed view
 
                 for message_data, created_at in cursor.fetchall():
+                    # Normalize SQLite naive UTC timestamp for outward-facing fields.
+                    created_at_iso = to_utc_iso(created_at)
                     try:
                         message_json = json.loads(message_data)
                         role = message_json.get("role", "")
@@ -918,7 +933,12 @@ class SessionManager:
                             # Add user message (extract original user input from structured content)
                             content = extract_user_input(message_json.get("content", ""))
                             messages.append(
-                                {"role": "user", "content": content, "timestamp": created_at, "created_at": created_at}
+                                {
+                                    "role": "user",
+                                    "content": content,
+                                    "timestamp": created_at_iso,
+                                    "created_at": created_at_iso,
+                                }
                             )
                             continue
 
@@ -932,8 +952,8 @@ class SessionManager:
                                 current_assistant_group = {
                                     "role": "assistant",
                                     "content": "",
-                                    "timestamp": created_at,
-                                    "created_at": created_at,
+                                    "timestamp": created_at_iso,
+                                    "created_at": created_at_iso,
                                 }
 
                             # Parse arguments
@@ -1030,8 +1050,8 @@ class SessionManager:
                                         current_assistant_group = {
                                             "role": "assistant",
                                             "content": "",
-                                            "timestamp": created_at,
-                                            "created_at": created_at,
+                                            "timestamp": created_at_iso,
+                                            "created_at": created_at_iso,
                                         }
 
                                     # Add to progress

--- a/datus/utils/time_utils.py
+++ b/datus/utils/time_utils.py
@@ -4,8 +4,10 @@
 
 """Time utility functions for the Datus Agent."""
 
-from datetime import datetime
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Optional, Union
+
+TimestampLike = Union[None, str, int, float, datetime]
 
 
 def get_default_current_date(current_date: Optional[str]) -> str:
@@ -41,3 +43,78 @@ def format_duration_human(seconds: float) -> str:
         parts.append(f"{seconds}s")
 
     return "".join(parts)
+
+
+def now_utc_iso() -> str:
+    """Return current UTC time as ISO-8601 with ``Z`` suffix, second precision.
+
+    Example: ``2026-04-30T12:34:56Z``.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_timestamp(value: TimestampLike) -> Optional[datetime]:
+    """Parse a heterogeneous timestamp value into an aware UTC ``datetime``.
+
+    Accepts:
+    - ``None`` or empty string → ``None``
+    - ``int`` / ``float`` (Unix epoch seconds, UTC) → aware datetime
+    - aware ``datetime`` → converted to UTC
+    - naive ``datetime`` → assumed UTC
+    - ``str`` in SQLite ``CURRENT_TIMESTAMP`` form ``YYYY-MM-DD HH:MM:SS`` (UTC)
+      or ISO-8601 (with optional ``Z`` / ``+HH:MM`` offset). Naive forms are
+      assumed UTC.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        # Normalize trailing 'Z' so fromisoformat can handle it.
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        # SQLite default uses a space separator between date and time.
+        if "T" not in text and " " in text:
+            text = text.replace(" ", "T", 1)
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed
+    return None
+
+
+def to_utc_iso(value: TimestampLike) -> Optional[str]:
+    """Normalize a timestamp value to ISO-8601 UTC string with ``Z`` suffix.
+
+    Returns ``None`` for empty inputs (``None``/empty string) and for inputs
+    that cannot be parsed. Output is always second precision regardless of
+    sub-second components in the input.
+    """
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return None
+    return parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def format_local_time(value: TimestampLike, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
+    """Format a UTC timestamp value in the local timezone for display.
+
+    Returns an empty string when the input cannot be parsed, so call sites
+    can use ``format_local_time(...) or "N/A"`` for fallback.
+    """
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return ""
+    return parsed.astimezone().strftime(fmt)

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -115,6 +115,62 @@ class TestChatServiceListSessions:
         session_ids = {s.session_id for s in result.data.sessions}
         assert {"chat_session_a", "gen_metrics_session_a"} <= session_ids
 
+    def test_list_sessions_timestamps_use_iso_z_format(self, chat_svc):
+        """created_at / last_updated must be ISO-8601 UTC with 'Z' suffix.
+
+        Regression guard: previously these fields were emitted as bare SQLite
+        ``YYYY-MM-DD HH:MM:SS`` strings (no timezone), so clients could not
+        convert them to local time correctly.
+        """
+        import os
+        import re
+        import sqlite3
+        from datetime import datetime
+
+        # Build a session DB with explicit naive UTC timestamps in agent_sessions
+        # and one user message, mirroring the schema OpenAI Agents SDK creates.
+        session_id = "ts-format-session"
+        db_path = os.path.join(chat_svc._session_dir, f"{session_id}.db")
+        os.makedirs(chat_svc._session_dir, exist_ok=True)
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE agent_sessions ("
+                "session_id TEXT PRIMARY KEY, "
+                "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+            )
+            conn.execute(
+                "CREATE TABLE agent_messages ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "session_id TEXT NOT NULL, "
+                "message_data TEXT NOT NULL, "
+                "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+            )
+            conn.execute(
+                "INSERT INTO agent_sessions (session_id, created_at, updated_at) "
+                "VALUES (?, '2026-04-30 12:34:56', '2026-04-30 12:35:10')",
+                (session_id,),
+            )
+            conn.execute(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) "
+                "VALUES (?, ?, '2026-04-30 12:34:56')",
+                (session_id, '{"role": "user", "content": "Hi"}'),
+            )
+
+        result = chat_svc.list_sessions()
+        target = next(s for s in result.data.sessions if s.session_id == session_id)
+
+        assert target.created_at == "2026-04-30T12:34:56Z"
+        assert target.last_updated == "2026-04-30T12:35:10Z"
+        iso_z_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+        assert iso_z_pattern.match(target.created_at), target.created_at
+        assert iso_z_pattern.match(target.last_updated), target.last_updated
+        # And they must round-trip through fromisoformat as aware UTC datetimes.
+        from datetime import timezone
+
+        parsed = datetime.fromisoformat(target.created_at.replace("Z", "+00:00"))
+        assert parsed == datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
+
 
 class TestChatServiceDeleteSession:
     """Tests for delete_session."""

--- a/tests/unit_tests/utils/test_time_utils.py
+++ b/tests/unit_tests/utils/test_time_utils.py
@@ -5,10 +5,18 @@
 """Unit tests for datus/utils/time_utils.py — CI tier, zero external deps."""
 
 import re
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
-from datus.utils.time_utils import format_duration_human, get_default_current_date
+from datus.utils.time_utils import (
+    format_duration_human,
+    format_local_time,
+    get_default_current_date,
+    now_utc_iso,
+    to_utc_iso,
+)
 
 
 class TestGetDefaultCurrentDate:
@@ -89,6 +97,113 @@ class TestFormatDurationHuman:
     )
     def test_parametrized_durations(self, seconds, expected):
         assert format_duration_human(seconds) == expected
+
+
+_ISO_Z_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+class TestNowUtcIso:
+    """Tests for now_utc_iso."""
+
+    def test_format_matches_iso8601_with_z_suffix(self):
+        result = now_utc_iso()
+        assert _ISO_Z_PATTERN.match(result), result
+
+    def test_returns_utc_time(self):
+        fixed = datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
+
+        class _FakeDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                assert tz is timezone.utc
+                return fixed
+
+        with patch("datus.utils.time_utils.datetime", _FakeDatetime):
+            assert now_utc_iso() == "2026-04-30T12:34:56Z"
+
+
+class TestToUtcIso:
+    """Tests for to_utc_iso normalization."""
+
+    def test_none_returns_none(self):
+        assert to_utc_iso(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert to_utc_iso("") is None
+        assert to_utc_iso("   ") is None
+
+    def test_unparseable_string_returns_none(self):
+        assert to_utc_iso("not-a-timestamp") is None
+
+    def test_sqlite_naive_string_treated_as_utc(self):
+        # SQLite CURRENT_TIMESTAMP form: space separator, no offset.
+        assert to_utc_iso("2026-04-30 12:34:56") == "2026-04-30T12:34:56Z"
+
+    def test_iso_t_form_naive_is_utc(self):
+        assert to_utc_iso("2026-04-30T12:34:56") == "2026-04-30T12:34:56Z"
+
+    def test_iso_with_z_suffix(self):
+        assert to_utc_iso("2026-04-30T12:34:56Z") == "2026-04-30T12:34:56Z"
+
+    def test_iso_with_explicit_offset(self):
+        assert to_utc_iso("2026-04-30T20:34:56+08:00") == "2026-04-30T12:34:56Z"
+
+    def test_microseconds_are_truncated_to_seconds(self):
+        assert to_utc_iso("2026-04-30T12:34:56.789012Z") == "2026-04-30T12:34:56Z"
+
+    def test_unix_float_timestamp(self):
+        # 1761835200.0 = 2025-10-30T14:40:00Z (verified via fromtimestamp(..., UTC))
+        assert to_utc_iso(1761835200.0) == "2025-10-30T14:40:00Z"
+
+    def test_unix_int_timestamp(self):
+        assert to_utc_iso(1761835200) == "2025-10-30T14:40:00Z"
+
+    def test_naive_datetime_treated_as_utc(self):
+        dt = datetime(2026, 4, 30, 12, 34, 56)
+        assert to_utc_iso(dt) == "2026-04-30T12:34:56Z"
+
+    def test_aware_datetime_converted_to_utc(self):
+        dt = datetime(2026, 4, 30, 20, 34, 56, tzinfo=timezone(timedelta(hours=8)))
+        assert to_utc_iso(dt) == "2026-04-30T12:34:56Z"
+
+    def test_already_utc_aware_datetime(self):
+        dt = datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
+        assert to_utc_iso(dt) == "2026-04-30T12:34:56Z"
+
+    def test_unsupported_type_returns_none(self):
+        assert to_utc_iso([1, 2, 3]) is None
+        assert to_utc_iso({"a": 1}) is None
+
+
+class TestFormatLocalTime:
+    """Tests for format_local_time (CLI display helper)."""
+
+    def test_none_returns_empty(self):
+        assert format_local_time(None) == ""
+
+    def test_empty_string_returns_empty(self):
+        assert format_local_time("") == ""
+
+    def test_unparseable_returns_empty(self):
+        assert format_local_time("not a date") == ""
+
+    def test_utc_zulu_converted_to_local(self):
+        # Force a known local timezone via patching astimezone result.
+        # Easier: pass an aware datetime and assert the pre-conversion math
+        # by comparing to manual astimezone() output.
+        utc = datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
+        expected = utc.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+        assert format_local_time("2026-04-30T12:34:56Z") == expected
+
+    def test_sqlite_naive_string_converted_to_local(self):
+        utc = datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
+        expected = utc.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+        assert format_local_time("2026-04-30 12:34:56") == expected
+
+    def test_custom_format(self):
+        utc = datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
+        expected = utc.astimezone().strftime("%H:%M")
+        assert format_local_time("2026-04-30T12:34:56Z", fmt="%H:%M") == expected
 
 
 class TestGetDefaultCurrentDateExtended:


### PR DESCRIPTION
Outbound timestamps were emitted in three inconsistent formats:
- SQLite naive strings ("YYYY-MM-DD HH:MM:SS", UTC but no marker) from agent_sessions / agent_messages / turn_usage.
- Local time disguised as UTC via `datetime.now().isoformat() + "Z"` in 9+ SSE / response builders.
- `datetime.utcnow().strftime(...)` UTC bare strings.

Clients had no way to convert to local time, and the CLI /resume and /rewind list views (which sliced the SQLite string with `[:19]`) showed times offset by the system tz from real wall-clock.

Add now_utc_iso / to_utc_iso / format_local_time helpers in datus/utils/time_utils.py. Normalize SessionManager outputs at the data boundary (get_session_info, get_session_messages, get_detailed_usage, plus a new file_modified_iso field). Replace every API-facing isoformat+Z and utcnow().strftime with now_utc_iso across chat, database, KB bootstrap, success story, action SSE converter, and cli_models default factories. Render /resume and /rewind through format_local_time so local-tz users see their own wall-clock.

Add 24 time_utils unit tests (round-trip, naive/aware/float/SQLite inputs, microsecond truncation, custom formats) and an ISO-Z regression guard in test_chat_service.list_sessions.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected timestamp formatting across API events, sessions, and CLI outputs to consistently use ISO-8601 UTC format with proper standardization.
  * Fixed session creation and update time values to display reliably across the system.

* **Tests**
  * Added comprehensive test coverage for timestamp utility functions and session timestamp normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->