### PR TITLE
[BugFix] Pass project explicitly to subject-aware embedding stores

### DIFF
--- a/datus/storage/registry.py
+++ b/datus/storage/registry.py
@@ -67,17 +67,20 @@ def get_storage_defaults() -> Dict[str, Any]:
 def _get_storage_cached(factory_name: str, embedding_model_conf_name: str, project: str) -> BaseEmbeddingStore:
     """LRU-cached storage creation, keyed by (factory, embedding model, project)."""
     from datus.storage.backend_holder import create_vector_connection
+    from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore
 
     with _registry_lock:
         factory = _factory_registry[factory_name]
     kwargs = dict(_storage_defaults)
     kwargs["db"] = create_vector_connection(project)
 
-    store = factory(get_embedding_model(embedding_model_conf_name), **kwargs)
-    from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore
+    # Subject-aware stores need ``project`` so their constructor can build the
+    # SubjectTreeStore without falling back to an empty ContextVar-scoped
+    # path_manager (which fails outside chat task threads).
+    if isinstance(factory, type) and issubclass(factory, BaseSubjectEmbeddingStore):
+        kwargs["project"] = project
 
-    if isinstance(store, BaseSubjectEmbeddingStore):
-        store.subject_tree = _get_subject_tree_cached(project)
+    store = factory(get_embedding_model(embedding_model_conf_name), **kwargs)
     return store
 
 

--- a/datus/storage/subject_tree/store.py
+++ b/datus/storage/subject_tree/store.py
@@ -674,6 +674,11 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         unique_columns: Optional[List[str]] = None,
         **kwargs,
     ):
+        # ``project`` is injected by the storage registry; pop it before forwarding
+        # so BaseEmbeddingStore (which has a strict signature) doesn't reject it.
+        # Falls back to the active path_manager for callers that bypass the registry.
+        project = kwargs.pop("project", None)
+
         super().__init__(
             table_name=table_name,
             embedding_model=embedding_model,
@@ -685,11 +690,14 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
             **kwargs,
         )
 
-        # Subject tree is project-scoped via the active path_manager.
         from datus.storage.registry import get_subject_tree_store
-        from datus.utils.path_manager import get_path_manager
 
-        self.subject_tree = get_subject_tree_store(project=get_path_manager().project_name)
+        if not project:
+            from datus.utils.path_manager import get_path_manager
+
+            project = get_path_manager().project_name
+
+        self.subject_tree = get_subject_tree_store(project=project)
 
     def batch_store(
         self,


### PR DESCRIPTION
## Summary
- Synchronous request paths (e.g. `POST /api/v1/subject/create` from datus-backend) never call `set_current_path_manager()`, so `BaseSubjectEmbeddingStore.__init__` falls back to `get_path_manager().project_name` which is empty, and the chain dies in `create_rdb_for_store("subject_tree", project="")` with `error_code=410000`.
- Storage registry now injects `project` into kwargs for `BaseSubjectEmbeddingStore` subclasses; the constructor pops it before forwarding to `BaseEmbeddingStore` (which has a strict signature) and uses it to build the `SubjectTreeStore`. Falls back to the path_manager for callers that bypass the registry (existing tests).
- Removes the redundant post-construction `store.subject_tree = ...` override since the constructor now sets the correct value at creation time.

## Repro
```
POST /api/v1/subject/create  → 500
DatusException: error_code=410000, error_message=create_rdb_for_store requires a non-empty project (store_db_name='subject_tree').
```
Triggered any time `ExplorerService` is lazily constructed by `DatusService.explorer` outside the chat task pool.

## Test plan
- [ ] Restart `datus-backend` and verify `POST /api/v1/subject/create` returns 200.
- [ ] Existing chat path (`chat_task_manager` sets `set_current_path_manager`) still works.
- [ ] `pytest tests/unit_tests/storage/` passes (direct constructor calls hit the path_manager fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal storage initialization architecture to better handle project-specific configurations at startup, enhancing how storage components are configured during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->