### PR TITLE
[Enhancement] Align /agent detail response schema with saas backend

### DIFF
--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -6,8 +6,9 @@ from the BUILTIN_SUBAGENTS set; custom agents are persisted in agent.yml.
 """
 
 import os
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from datus.api.models.agent_models import CreateAgentInput, EditAgentInput
 from datus.api.models.base_models import Result
@@ -50,6 +51,53 @@ SUBAGENT_TOOL_REFERENCE: dict[str, list[str]] = {
     "gen_sql": list(VALID_TOOL_METHODS.keys()),
     "gen_report": list(VALID_TOOL_METHODS.keys()),
 }
+
+
+def _parse_tools(value: Any) -> list[str]:
+    """Normalize the yaml ``tools`` field to a list of pattern strings.
+
+    Accepts either a comma-separated string (legacy yaml form) or a list, and
+    trims surrounding whitespace from every entry. Empty entries are dropped.
+    """
+    if not value:
+        return []
+    if isinstance(value, str):
+        items = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        items = value
+    else:
+        return []
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _utc_now_iso() -> str:
+    """Current UTC time as ISO-8601 string with ``Z`` suffix."""
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _normalize_created_at(value: Any) -> Optional[str]:
+    """Coerce a yaml-loaded ``created_at`` value into ISO-8601 UTC with ``Z``.
+
+    yaml may parse the field as a ``datetime`` or pass it through as a string.
+    Returns ``None`` when the value is missing or unrecognized.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _file_mtime_iso(path: Path) -> Optional[str]:
+    """Return the file's mtime as ISO-8601 UTC with ``Z`` suffix, or None on error."""
+    try:
+        ts = path.stat().st_mtime
+    except OSError:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
 def _validate_tools(tools: list[str]) -> list[str]:
@@ -134,6 +182,12 @@ class AgentService:
                         "id": agent_id,
                         "name": agent_id,
                         "type": "builtin",
+                        "description": BUILTIN_SUBAGENT_DESCRIPTIONS.get(agent_id, ""),
+                        "created_at": None,
+                        "tools": [],
+                        "rules": [],
+                        "catalogs": [],
+                        "subjects": [],
                     }
                 },
             )
@@ -144,14 +198,10 @@ class AgentService:
         if not agent:
             return Result(success=False, errorCode="AGENT_NOT_FOUND", errorMessage=f"Agent '{agent_id}' not found")
 
-        # 3. Read prompt template content from project template file
         agent_type = agent.get("type", "gen_sql")
-        prompt_content = self._read_prompt_template(
-            agent_name=agent_id,
-            agent_type=agent_type,
-            version=agent.get("prompt_version"),
-            agent_config=agent_config,
-        )
+        created_at = _normalize_created_at(agent.get("created_at"))
+        if not created_at:
+            created_at = _file_mtime_iso(Path(agent_config.home) / "agent.yml")
 
         return Result(
             success=True,
@@ -161,11 +211,11 @@ class AgentService:
                     "name": agent_id,
                     "type": agent_type,
                     "description": agent.get("description", ""),
-                    "system_prompt": prompt_content or agent.get("prompt_template", ""),
-                    "tools": agent.get("tools", []),
-                    "rules": agent.get("rules", []),
-                    "catalogs": agent.get("catalogs", []),
-                    "subjects": agent.get("subjects", []),
+                    "created_at": created_at,
+                    "tools": _parse_tools(agent.get("tools")),
+                    "rules": agent.get("rules") or [],
+                    "catalogs": agent.get("catalogs") or [],
+                    "subjects": agent.get("subjects") or [],
                 }
             },
         )
@@ -241,6 +291,7 @@ class AgentService:
             "catalogs": request.catalogs or [],
             "subjects": request.subjects or [],
             "rules": request.rules or [],
+            "created_at": _utc_now_iso(),
         }
         if request.prompt_template:
             agent_entry["prompt_template"] = request.prompt_template
@@ -263,12 +314,6 @@ class AgentService:
             logger.warning(f"Failed to copy prompt template for agent '{request.name}' (non-fatal)", exc_info=True)
 
         return Result(success=True, data={"name": request.name, "id": request.name})
-
-    def _resolve_template_version(self, template_base: str, version: Optional[str] = None) -> Optional[str]:
-        """Resolve prompt template version via PromptManager; returns latest if version is None."""
-        if version:
-            return version
-        return self._prompt_manager.get_latest_version(template_base)
 
     @staticmethod
     def _sanitize_path_component(value: str) -> str:
@@ -306,38 +351,6 @@ class AgentService:
             content = source_path.read_text(encoding="utf-8")
             target_file.write_text(content, encoding="utf-8")
             logger.info(f"Copied prompt template: {source_path.name} -> {target_file}")
-
-    def _read_prompt_template(
-        self,
-        agent_name: str,
-        agent_type: str,
-        version: Optional[str],
-        agent_config: AgentConfig,
-    ) -> str:
-        """Read prompt template content. Checks workspace dir first, falls back to builtin."""
-        template_base = self._TYPE_TO_TEMPLATE.get(agent_type, "gen_sql_system")
-        safe_name = self._sanitize_path_component(agent_name)
-        resolved = self._resolve_template_version(template_base, version)
-
-        if resolved:
-            safe_resolved = self._sanitize_path_component(resolved)
-            # Try workspace template first
-            template_dir = Path(agent_config.home) / "template"
-            target_file = template_dir / f"{safe_name}_system_{safe_resolved}.j2"
-            try:
-                if target_file.exists():
-                    return target_file.read_text(encoding="utf-8")
-            except Exception:
-                logger.warning(f"Failed to read project template '{target_file}'", exc_info=True)
-
-            # Fallback: read builtin via PromptManager
-            try:
-                source_path = self._prompt_manager._get_template_path(template_base, resolved)
-                return source_path.read_text(encoding="utf-8")
-            except (FileNotFoundError, Exception):
-                logger.warning(f"Failed to read builtin template '{template_base}' v{resolved}", exc_info=True)
-
-        return ""
 
     def _save_prompt_template(
         self,

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -353,9 +353,7 @@ class TestGetAgent:
         result = await svc.get_agent("mtime_agent", real_agent_config)
         assert result.success is True
         created_at = result.data["agent"]["created_at"]
-        assert isinstance(created_at, str) and ISO_UTC_Z_RE.match(created_at), (
-            f"unexpected created_at: {created_at!r}"
-        )
+        assert isinstance(created_at, str) and ISO_UTC_Z_RE.match(created_at), f"unexpected created_at: {created_at!r}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -1,5 +1,7 @@
 """Tests for datus.api.services.agent_service — tool validation and agent constants."""
 
+import re
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -10,9 +12,14 @@ from datus.api.services.agent_service import (
     VALID_TOOL_CATEGORIES,
     VALID_TOOL_METHODS,
     AgentService,
+    _normalize_created_at,
+    _parse_tools,
+    _utc_now_iso,
     _validate_tools,
 )
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
+
+ISO_UTC_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$")
 
 
 class TestValidateTools:
@@ -166,17 +173,112 @@ class TestListAgents:
         assert len(agent_names) >= len(BUILTIN_SUBAGENTS)
 
 
+class TestParseTools:
+    """Tests for _parse_tools — normalize yaml tools field to list[str]."""
+
+    def test_comma_separated_string_is_split(self):
+        """Comma-separated string is split into trimmed entries."""
+        assert _parse_tools("db_tools.*, context_search_tools.*") == [
+            "db_tools.*",
+            "context_search_tools.*",
+        ]
+
+    def test_string_entries_are_trimmed(self):
+        """Surrounding whitespace is removed from each split entry."""
+        assert _parse_tools("  db_tools.*  ,\tcontext_search_tools.read_query \n") == [
+            "db_tools.*",
+            "context_search_tools.read_query",
+        ]
+
+    def test_list_input_is_trimmed_and_passed_through(self):
+        """List input is preserved with each entry trimmed."""
+        assert _parse_tools(["db_tools.*", "  ctx.*  "]) == ["db_tools.*", "ctx.*"]
+
+    def test_empty_string_returns_empty_list(self):
+        """Empty / whitespace-only string yields []."""
+        assert _parse_tools("") == []
+        assert _parse_tools("   ") == []
+        assert _parse_tools(",,, ,") == []
+
+    def test_none_returns_empty_list(self):
+        """None input yields []."""
+        assert _parse_tools(None) == []
+
+    def test_unsupported_type_returns_empty_list(self):
+        """Non-string non-list inputs (e.g. int, dict) yield [] safely."""
+        assert _parse_tools(42) == []
+        assert _parse_tools({"db_tools": "*"}) == []
+
+
+class TestUtcNowIso:
+    """Tests for _utc_now_iso — UTC ISO-8601 with Z suffix."""
+
+    def test_format_matches_iso_with_z_suffix(self):
+        """Returned string matches ISO-8601 microsecond format ending in Z."""
+        value = _utc_now_iso()
+        assert ISO_UTC_Z_RE.match(value), f"unexpected format: {value!r}"
+
+    def test_value_is_recent_utc_time(self):
+        """Returned timestamp is within a few seconds of now (UTC)."""
+        before = datetime.now(timezone.utc)
+        value = _utc_now_iso()
+        # Parse back: replace trailing Z so fromisoformat accepts it
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        delta = abs((parsed - before).total_seconds())
+        assert delta < 5, f"timestamp {value} not close to {before.isoformat()}"
+
+
+class TestNormalizeCreatedAt:
+    """Tests for _normalize_created_at — coerce yaml-loaded values to ISO Z string."""
+
+    def test_none_returns_none(self):
+        """Missing value returns None."""
+        assert _normalize_created_at(None) is None
+
+    def test_string_passes_through(self):
+        """String values pass through unchanged (assumed already ISO)."""
+        s = "2026-04-30T09:20:31.545000Z"
+        assert _normalize_created_at(s) == s
+
+    def test_aware_datetime_converted_to_z_suffix(self):
+        """Timezone-aware datetime converts to ISO Z."""
+        dt = datetime(2026, 4, 30, 9, 20, 31, 545000, tzinfo=timezone.utc)
+        assert _normalize_created_at(dt) == "2026-04-30T09:20:31.545000Z"
+
+    def test_naive_datetime_assumed_utc(self):
+        """Naive datetime is assumed UTC and gets Z suffix."""
+        dt = datetime(2026, 4, 30, 9, 20, 31, 545000)
+        assert _normalize_created_at(dt) == "2026-04-30T09:20:31.545000Z"
+
+    def test_unsupported_type_returns_none(self):
+        """Unsupported types (int, dict, etc.) yield None."""
+        assert _normalize_created_at(123) is None
+        assert _normalize_created_at({"foo": "bar"}) is None
+
+
 @pytest.mark.asyncio
 class TestGetAgent:
     """Tests for get_agent — retrieve single agent config."""
 
-    async def test_get_builtin_agent(self, real_agent_config):
-        """get_agent returns builtin agent info."""
+    EXPECTED_FIELDS = {"id", "name", "type", "description", "created_at", "tools", "rules", "catalogs", "subjects"}
+
+    async def test_get_builtin_agent_has_full_schema(self, real_agent_config):
+        """Builtin agent response carries the same field set as custom agents."""
         svc = AgentService()
         result = await svc.get_agent("gen_sql", real_agent_config)
         assert result.success is True
-        assert result.data["agent"]["name"] == "gen_sql"
-        assert result.data["agent"]["type"] == "builtin"
+        agent = result.data["agent"]
+        assert agent["name"] == "gen_sql"
+        assert agent["id"] == "gen_sql"
+        assert agent["type"] == "builtin"
+        assert set(agent.keys()) == self.EXPECTED_FIELDS
+        # All collection fields default to empty list, not None
+        assert agent["tools"] == []
+        assert agent["rules"] == []
+        assert agent["catalogs"] == []
+        assert agent["subjects"] == []
+        # system_prompt must NOT be present
+        assert "system_prompt" not in agent
 
     async def test_get_nonexistent_agent(self, real_agent_config):
         """get_agent returns error for unknown agent."""
@@ -185,17 +287,75 @@ class TestGetAgent:
         assert result.success is False
         assert result.errorCode == "AGENT_NOT_FOUND"
 
-    async def test_get_custom_agent_from_agentic_nodes(self, real_agent_config):
-        """get_agent returns custom agent info from agentic_nodes."""
+    async def test_get_custom_agent_schema_matches_contract(self, real_agent_config):
+        """Custom agent response matches the documented schema and omits system_prompt."""
         svc = AgentService()
-        # real_agent_config has agentic_nodes from conftest (e.g. 'gensql', 'chat', etc.)
         nodes = real_agent_config.agentic_nodes or {}
         assert nodes, "real_agent_config fixture must provide agentic_nodes"
         first_name = next(iter(nodes))
         result = await svc.get_agent(first_name, real_agent_config)
         assert result.success is True
-        assert result.data["agent"]["name"] == first_name
-        assert result.data["agent"]["id"] == first_name
+        agent = result.data["agent"]
+        assert agent["name"] == first_name
+        assert agent["id"] == first_name
+        assert set(agent.keys()) == self.EXPECTED_FIELDS
+        assert "system_prompt" not in agent
+        # tools is always a list — never a string
+        assert isinstance(agent["tools"], list)
+        # collection fields are always lists, never None
+        for field in ("rules", "catalogs", "subjects"):
+            assert isinstance(agent[field], list)
+
+    async def test_get_custom_agent_parses_tools_string(self, real_agent_config):
+        """yaml ``tools: "db_tools.*, ctx.*"`` is returned as a trimmed list."""
+        # Inject a custom node with a comma-separated tools string directly into the
+        # in-memory config — get_agent reads agent_config.agentic_nodes, not yaml.
+        real_agent_config.agentic_nodes["string_tools_agent"] = {
+            "type": "gen_sql",
+            "description": "agent with string tools",
+            "tools": "db_tools.*,  context_search_tools.read_query  ",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("string_tools_agent", real_agent_config)
+        assert result.success is True
+        assert result.data["agent"]["tools"] == [
+            "db_tools.*",
+            "context_search_tools.read_query",
+        ]
+
+    async def test_get_custom_agent_returns_explicit_created_at(self, real_agent_config):
+        """An explicit yaml ``created_at`` is surfaced verbatim in the response."""
+        real_agent_config.agentic_nodes["dated_agent"] = {
+            "type": "gen_sql",
+            "description": "agent with explicit created_at",
+            "tools": "db_tools.*",
+            "created_at": "2026-04-30T09:20:31.545000Z",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("dated_agent", real_agent_config)
+        assert result.success is True
+        assert result.data["agent"]["created_at"] == "2026-04-30T09:20:31.545000Z"
+
+    async def test_get_custom_agent_created_at_falls_back_to_file_mtime(self, real_agent_config):
+        """When yaml has no ``created_at``, fall back to agent.yml file mtime in ISO-Z."""
+        # Ensure agent.yml exists so the mtime fallback can resolve
+        config_path = Path(real_agent_config.home) / "agent.yml"
+        config_path.write_text("agentic_nodes: {}\n", encoding="utf-8")
+        real_agent_config.agentic_nodes["mtime_agent"] = {
+            "type": "gen_sql",
+            "description": "no explicit created_at",
+            "tools": "db_tools.*",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("mtime_agent", real_agent_config)
+        assert result.success is True
+        created_at = result.data["agent"]["created_at"]
+        assert isinstance(created_at, str) and ISO_UTC_Z_RE.match(created_at), (
+            f"unexpected created_at: {created_at!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -268,6 +428,35 @@ class TestCreateAgent:
         )
         assert result.success is False
         assert result.errorCode == "AGENT_ALREADY_EXISTS"
+
+    async def test_create_agent_persists_created_at(self, real_agent_config):
+        """create_agent writes a UTC ISO-Z created_at into agent.yml."""
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput
+
+        config_path = Path(real_agent_config.home) / "agent.yml"
+        if not config_path.exists():
+            with open(config_path, "w") as f:
+                yaml.dump({"agentic_nodes": {}}, f)
+
+        svc = AgentService()
+        result = await svc.create_agent(
+            CreateAgentInput(name="created_at_agent", type="gen_sql"),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(config_path) as f:
+            raw = yaml.safe_load(f)
+        entry = raw["agentic_nodes"]["created_at_agent"]
+        assert "created_at" in entry
+        # Round-trip through the public API: the value surfaces unchanged
+        get_result = await svc.get_agent("created_at_agent", real_agent_config)
+        assert get_result.success is True
+        created_at = get_result.data["agent"]["created_at"]
+        # Either yaml stored a string (Z-suffixed) or a datetime that gets normalized
+        assert created_at is not None and created_at.endswith("Z")
 
     async def test_create_agent_invalid_tools_fails(self, real_agent_config):
         """create_agent rejects invalid tool patterns."""


### PR DESCRIPTION
## Why

The `GET /api/v1/agent` endpoint returned a payload that diverged from the
Datus-backend (saas) contract in three ways, breaking frontend integration:

1. `tools` came back as the **raw yaml string** (`"db_tools.*, context_search_tools.*"`)
   because `agent.yml` stores the field as a comma-separated string, not a list.
   Clients had to split it themselves.
2. `system_prompt` was the **fully rendered template body** — multi-KB of
   Jinja2 source — even though clients only ever need the reference name. The
   field also overlapped with `EditAgentInput.system_prompt` (input/output
   semantic mismatch) and was decided to drop entirely on both Datus-agent
   and Datus-backend.
3. `created_at` was missing.

Builtin agents also returned a partial schema (only `id/name/type`), so any
frontend destructuring against the documented shape failed for them.

## Solution

- Add `_parse_tools(value)` (option B1: split + trim, no wildcard expansion).
  Tolerates legacy strings, lists, empty/None, and unsupported types.
- Drop `system_prompt` from the response. The matching change in Datus-backend
  is in https://github.com/Datus-ai/Datus-backend (companion PR).
- Add `created_at` as ISO-8601 UTC with `Z` suffix. New agents stamp the field
  on `create_agent`; legacy entries fall back to `agent.yml` mtime so no
  migration is required.
- Builtin agent branch fills the full schema with safe defaults
  (`description` from `BUILTIN_SUBAGENT_DESCRIPTIONS`, empty collections,
  `created_at: null`).
- Remove the now-dead `_read_prompt_template` and `_resolve_template_version`
  helpers — they only existed to populate the removed `system_prompt`.
- `id = name` (kept the existing convention; OSS Datus-agent has no separate
  agent id and `list_agents` already uses name as id).

The matching `agent_routes.py` was unchanged because routes only transmit
the service `Result` verbatim.

## Test Cases

Added to `tests/unit_tests/api/services/test_agent_service.py`:

- `TestParseTools` — 6 tests: comma split, whitespace trim, list passthrough,
  empty/None, unsupported types.
- `TestUtcNowIso` — format regex match + recency check.
- `TestNormalizeCreatedAt` — None / string passthrough / aware & naive
  datetime conversion / unsupported types.
- `TestGetAgent`:
  - builtin branch carries the full field set and omits `system_prompt`
  - custom branch matches the documented schema and omits `system_prompt`
  - `tools` always returns `list`, never `string`
  - explicit yaml `created_at` surfaces verbatim
  - missing `created_at` falls back to `agent.yml` mtime in ISO-Z format
- `TestCreateAgent.test_create_agent_persists_created_at` — `create_agent`
  writes `created_at` to yaml and the value round-trips through `get_agent`.

Gates:
- `ruff format` + `ruff check` pass
- `pytest tests/unit_tests/api/services/test_agent_service.py` — 50 passed
- Overall coverage 80.76% ≥ 80%
- Diff coverage **100%** on `datus/api/services/agent_service.py`
- `ci/audit_tests.py` on the changed test file: P0=0, P1=0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent retrieval returns richer metadata (creation timestamp and detailed agent specs: tools, rules, catalogs, subjects).
  * Agent creation now stamps new custom agents with a creation timestamp.

* **Bug Fixes**
  * Improved parsing and validation of tool specifications for more consistent agent data.
  * Added path-safety checks to prevent directory traversal when using prompt templates.

* **Refactor**
  * Agent response shape updated; system prompt removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->