### PR TITLE
[Enhancement] Align /agent/use_tools response with saas Datus-backend contract

### DIFF
--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -6,6 +6,7 @@ from the BUILTIN_SUBAGENTS set; custom agents are persisted in agent.yml.
 """
 
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -31,6 +32,12 @@ VALID_TOOL_METHODS: dict[str, set[str]] = {
     "db_tools": set(DBFuncTool.all_tools_name()),
     "context_search_tools": set(ContextSearchTools.all_tools_name()),
     "semantic_tools": set(SemanticTools.all_tools_name()),
+    "reference_template_tools": {
+        "search_reference_template",
+        "get_reference_template",
+        "render_reference_template",
+        "execute_reference_template",
+    },
     "date_parsing_tools": {"parse_temporal_expressions"},
     "filesystem_tools": {
         "read_file",
@@ -46,11 +53,64 @@ VALID_TOOL_CATEGORIES = set(VALID_TOOL_METHODS.keys())
 
 BUILTIN_SUBAGENTS = SYS_SUB_AGENTS - HIDDEN_SYS_SUB_AGENTS
 
-# Tool reference for each agent type
-SUBAGENT_TOOL_REFERENCE: dict[str, list[str]] = {
-    "gen_sql": list(VALID_TOOL_METHODS.keys()),
-    "gen_report": list(VALID_TOOL_METHODS.keys()),
+# Curated list of categories surfaced through GET /agent/use_tools' ``tool_types``
+# block. Mirrors the saas Datus-backend choice — ``platform_doc_tools`` is a
+# valid tool (and stays in VALID_TOOL_METHODS for write-side validation) but is
+# excluded from the editor picker.
+_USER_FACING_TOOL_CATEGORIES: tuple[str, ...] = (
+    "db_tools",
+    "context_search_tools",
+    "semantic_tools",
+    "reference_template_tools",
+    "date_parsing_tools",
+    "filesystem_tools",
+)
+
+_ALL_TOOL_TYPES: dict[str, dict[str, list[str]]] = {
+    category: {"tools": sorted(VALID_TOOL_METHODS[category])} for category in _USER_FACING_TOOL_CATEGORIES
 }
+
+# Per-agent-type tool reference. Mirrors the saas Datus-backend contract:
+# ``default_tools`` are wildcard / specific patterns preselected for the type,
+# ``tool_types`` is the full catalog of allowed categories with their methods.
+SUBAGENT_TOOL_REFERENCE: dict[str, dict[str, Any]] = {
+    "chat": {
+        "default_tools": [
+            "db_tools.*",
+            "context_search_tools.*",
+            "reference_template_tools.*",
+            "date_parsing_tools.*",
+            "filesystem_tools.*",
+            "platform_doc_tools.*",
+        ],
+        "tool_types": _ALL_TOOL_TYPES,
+    },
+    "gen_sql": {
+        "default_tools": [
+            "db_tools.*",
+            "semantic_tools.*",
+            "context_search_tools.*",
+        ],
+        "tool_types": _ALL_TOOL_TYPES,
+    },
+    "gen_report": {
+        "default_tools": [
+            "semantic_tools.*",
+            "context_search_tools.list_subject_tree",
+        ],
+        "tool_types": _ALL_TOOL_TYPES,
+    },
+}
+
+
+def sanitize_agentic_node_name(name: str) -> str:
+    """Sanitize a sub-agent name for agentic_nodes keys and template filenames.
+
+    Replaces every character outside ``[A-Za-z0-9_-]`` with ``_`` so the name is
+    safe to use as a yaml key, dict key, or filesystem path component. ``None``
+    or an empty string degrades to ``""``.
+    """
+    return re.sub(r"[^a-zA-Z0-9_\-]", "_", name or "")
 
 
 def _parse_tools(value: Any) -> list[str]:
@@ -157,14 +217,18 @@ class AgentService:
 
     @staticmethod
     def get_use_tools(agent_type: str) -> Result[dict]:
-        """Return available tools for a given agent type."""
+        """Return available tools for a given agent type.
+
+        Response payload follows the saas Datus-backend contract:
+        ``{"default_tools": [...], "tool_types": {category: {"tools": [...]}}}``.
+        """
         if agent_type not in SUBAGENT_TOOL_REFERENCE:
             return Result(
                 success=False,
                 errorCode="INVALID_AGENT_TYPE",
                 errorMessage=f"Unknown agent_type '{agent_type}'. Must be one of: {', '.join(SUBAGENT_TOOL_REFERENCE)}",
             )
-        return Result(success=True, data={"tools": SUBAGENT_TOOL_REFERENCE[agent_type]})
+        return Result(success=True, data=SUBAGENT_TOOL_REFERENCE[agent_type])
 
     async def get_agent(
         self,

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -18,6 +18,7 @@ from datus.prompts.prompt_manager import PromptManager
 from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.func_tool.platform_doc_search import PlatformDocSearchTool
+from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
 from datus.tools.func_tool.semantic_tools import SemanticTools
 from datus.tools.func_tool.sub_agent_task_tool import BUILTIN_SUBAGENT_DESCRIPTIONS
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
@@ -32,12 +33,7 @@ VALID_TOOL_METHODS: dict[str, set[str]] = {
     "db_tools": set(DBFuncTool.all_tools_name()),
     "context_search_tools": set(ContextSearchTools.all_tools_name()),
     "semantic_tools": set(SemanticTools.all_tools_name()),
-    "reference_template_tools": {
-        "search_reference_template",
-        "get_reference_template",
-        "render_reference_template",
-        "execute_reference_template",
-    },
+    "reference_template_tools": set(ReferenceTemplateTools.all_tools_name()),
     "date_parsing_tools": {"parse_temporal_expressions"},
     "filesystem_tools": {
         "read_file",

--- a/datus/tools/func_tool/reference_template_tools.py
+++ b/datus/tools/func_tool/reference_template_tools.py
@@ -64,6 +64,14 @@ class ReferenceTemplateTools:
         self.has_reference_templates = self.reference_template_store.get_reference_template_size() > 0
         self.db_func_tool = db_func_tool
 
+    @staticmethod
+    def all_tools_name() -> List[str]:
+        from datus.utils.class_utils import get_public_instance_methods
+
+        return [
+            name for name in get_public_instance_methods(ReferenceTemplateTools).keys() if name != "available_tools"
+        ]
+
     def available_tools(self) -> List[Tool]:
         tools = []
         if self.has_reference_templates:

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from datus.api.services.agent_service import (
+    _USER_FACING_TOOL_CATEGORIES,
     BUILTIN_SUBAGENTS,
     SUBAGENT_TOOL_REFERENCE,
     VALID_TOOL_CATEGORIES,
@@ -16,6 +17,7 @@ from datus.api.services.agent_service import (
     _parse_tools,
     _utc_now_iso,
     _validate_tools,
+    sanitize_agentic_node_name,
 )
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
 
@@ -89,10 +91,55 @@ class TestConstants:
         """VALID_TOOL_CATEGORIES is non-empty."""
         assert len(VALID_TOOL_CATEGORIES) >= 4
 
-    def test_tool_reference_gen_sql(self):
-        """gen_sql tool reference includes all tool categories."""
-        assert "gen_sql" in SUBAGENT_TOOL_REFERENCE
-        assert set(SUBAGENT_TOOL_REFERENCE["gen_sql"]) == set(VALID_TOOL_METHODS.keys())
+    def test_tool_reference_gen_sql_has_saas_shape(self):
+        """gen_sql tool reference has the saas {default_tools, tool_types} shape."""
+        entry = SUBAGENT_TOOL_REFERENCE["gen_sql"]
+        assert set(entry.keys()) == {"default_tools", "tool_types"}
+        # tool_types is the user-facing curated subset, not every VALID_TOOL_METHODS key
+        assert set(entry["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        for category, payload in entry["tool_types"].items():
+            assert payload == {"tools": sorted(VALID_TOOL_METHODS[category])}
+        # gen_sql defaults to db / semantic / context_search wildcards (matches saas)
+        assert entry["default_tools"] == [
+            "db_tools.*",
+            "semantic_tools.*",
+            "context_search_tools.*",
+        ]
+
+    def test_user_facing_categories_excludes_platform_doc_tools(self):
+        """platform_doc_tools is a valid tool but is intentionally hidden from the editor."""
+        assert "platform_doc_tools" in VALID_TOOL_METHODS
+        assert "platform_doc_tools" not in _USER_FACING_TOOL_CATEGORIES
+
+    def test_tool_reference_gen_report_has_saas_defaults(self):
+        """gen_report defaults to semantic.* + context_search.list_subject_tree."""
+        entry = SUBAGENT_TOOL_REFERENCE["gen_report"]
+        assert entry["default_tools"] == [
+            "semantic_tools.*",
+            "context_search_tools.list_subject_tree",
+        ]
+
+    def test_tool_reference_chat_has_full_default_set(self):
+        """chat default_tools enumerates every non-semantic category as wildcard."""
+        entry = SUBAGENT_TOOL_REFERENCE["chat"]
+        assert entry["default_tools"] == [
+            "db_tools.*",
+            "context_search_tools.*",
+            "reference_template_tools.*",
+            "date_parsing_tools.*",
+            "filesystem_tools.*",
+            "platform_doc_tools.*",
+        ]
+
+    def test_reference_template_tools_registered(self):
+        """reference_template_tools category exposes the 4 expected methods."""
+        assert "reference_template_tools" in VALID_TOOL_METHODS
+        assert VALID_TOOL_METHODS["reference_template_tools"] == {
+            "search_reference_template",
+            "get_reference_template",
+            "render_reference_template",
+            "execute_reference_template",
+        }
 
     def test_valid_tool_methods_db_tools_has_methods(self):
         """db_tools category exposes core query methods."""
@@ -120,14 +167,45 @@ class TestAgentServiceInit:
 
 
 class TestGetUseTools:
-    """Tests for get_use_tools — tool reference lookup."""
+    """Tests for get_use_tools — saas-shape tool reference lookup."""
 
-    def test_known_agent_type_returns_tools(self):
-        """get_use_tools returns tools for known agent type."""
+    def test_gen_sql_returns_default_tools_and_tool_types(self):
+        """gen_sql payload matches the saas {default_tools, tool_types} contract."""
         result = AgentService.get_use_tools("gen_sql")
         assert result.success is True
-        assert isinstance(result.data, dict)
-        assert set(result.data["tools"]) == set(SUBAGENT_TOOL_REFERENCE["gen_sql"])
+        assert set(result.data.keys()) == {"default_tools", "tool_types"}
+        assert result.data["default_tools"] == [
+            "db_tools.*",
+            "semantic_tools.*",
+            "context_search_tools.*",
+        ]
+        # tool_types covers exactly the user-facing curated categories, each as {"tools": [...]}
+        assert set(result.data["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        for category, payload in result.data["tool_types"].items():
+            assert list(payload.keys()) == ["tools"]
+            assert payload["tools"] == sorted(VALID_TOOL_METHODS[category])
+
+    def test_gen_report_returns_correct_defaults(self):
+        """gen_report's default_tools is a curated subset, not the full wildcard list."""
+        result = AgentService.get_use_tools("gen_report")
+        assert result.success is True
+        assert result.data["default_tools"] == [
+            "semantic_tools.*",
+            "context_search_tools.list_subject_tree",
+        ]
+        assert set(result.data["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+
+    def test_chat_includes_reference_template_tools_in_default(self):
+        """chat default_tools wires up reference_template_tools.* (saas parity)."""
+        result = AgentService.get_use_tools("chat")
+        assert result.success is True
+        assert "reference_template_tools.*" in result.data["default_tools"]
+        assert "reference_template_tools" in result.data["tool_types"]
+
+    def test_payload_no_longer_wraps_in_tools_key(self):
+        """Old shape {"tools": [...]} is gone — data is now {default_tools, tool_types}."""
+        result = AgentService.get_use_tools("gen_sql")
+        assert "tools" not in result.data, "legacy 'tools' key must not appear at top level"
 
     def test_unknown_agent_type_returns_error(self):
         """get_use_tools returns error for unknown agent type."""
@@ -136,11 +214,12 @@ class TestGetUseTools:
         assert result.errorCode == "INVALID_AGENT_TYPE"
         assert "nonexistent" in result.errorMessage
 
-    def test_gen_report_returns_tools(self):
-        """get_use_tools returns tools for gen_report."""
-        result = AgentService.get_use_tools("gen_report")
-        assert result.success is True
-        assert set(result.data["tools"]) == set(SUBAGENT_TOOL_REFERENCE["gen_report"])
+    def test_known_agent_types_match_subagent_reference(self):
+        """Every key in SUBAGENT_TOOL_REFERENCE returns success and has saas shape."""
+        for agent_type in SUBAGENT_TOOL_REFERENCE:
+            result = AgentService.get_use_tools(agent_type)
+            assert result.success is True, f"agent_type {agent_type} should resolve"
+            assert set(result.data.keys()) == {"default_tools", "tool_types"}
 
 
 @pytest.mark.asyncio
@@ -171,6 +250,23 @@ class TestListAgents:
         # real_agent_config has agentic_nodes from conftest
         agent_names = {a["name"] for a in result.data["agents"]}
         assert len(agent_names) >= len(BUILTIN_SUBAGENTS)
+
+
+class TestSanitizeAgenticNodeName:
+    """Tests for sanitize_agentic_node_name — make a name safe for yaml/path keys."""
+
+    def test_alphanumeric_passthrough(self):
+        """Letters / digits / underscore / hyphen pass through unchanged."""
+        assert sanitize_agentic_node_name("OrderAnalyst-2") == "OrderAnalyst-2"
+
+    def test_unicode_and_punct_replaced_with_underscore(self):
+        """Spaces, dots, slashes, unicode all collapse to underscore."""
+        assert sanitize_agentic_node_name("订单 分析/v.1") == "______v_1"
+
+    def test_empty_and_none_become_empty_string(self):
+        """Empty / None inputs degrade to '' rather than raising."""
+        assert sanitize_agentic_node_name("") == ""
+        assert sanitize_agentic_node_name(None) == ""  # type: ignore[arg-type]
 
 
 class TestParseTools:


### PR DESCRIPTION
## Why

`GET /agent/use_tools` returned a single flat list of category names
(`{"tools": ["db_tools", "context_search_tools", ...]}`), while the saas
Datus-backend serves a richer editor manifest:

```json
{
  "default_tools": ["db_tools.*", "semantic_tools.*", "context_search_tools.*"],
  "tool_types": {
    "db_tools": {"tools": ["list_tables", "describe_table", ...]},
    ...
  }
}
```

The frontend agent editor has been built against the saas shape. Two
implementations of the same contract diverged, so this PR ports the saas
data over and gets us ready for Datus-backend to delete its copy and import
from here in the follow-up.

## Solution

- Restructure `SUBAGENT_TOOL_REFERENCE` to `{agent_type: {default_tools, tool_types}}`,
  matching saas exactly. Adds a `chat` entry alongside `gen_sql`/`gen_report`
  with the same defaults saas uses.
- Register `reference_template_tools` (`search/get/render/execute_reference_template`)
  in `VALID_TOOL_METHODS`. The runtime already exposes these tools via
  `ReferenceTemplateTools` — only the validation/editor catalog was missing.
- Introduce `_USER_FACING_TOOL_CATEGORIES` to curate which categories show up
  in `tool_types`. `platform_doc_tools` stays in `VALID_TOOL_METHODS` for
  write-side validation but is hidden from the picker — same call saas made.
- Add a public `sanitize_agentic_node_name(name)` helper, ported from
  Datus-backend's `common/agent.py`, so the saas side can drop its local
  copy and import from this module in the follow-up PR.
- `get_use_tools` now returns `SUBAGENT_TOOL_REFERENCE[agent_type]` verbatim;
  no more `{"tools": ...}` wrapping. The route handler is unchanged because
  it transparently passes `Result` through.

## Test Cases

Updated `tests/unit_tests/api/services/test_agent_service.py`:

- `TestConstants` — assert the new saas shape on `gen_sql` / `gen_report`
  / `chat`; assert `reference_template_tools` is registered with the four
  expected methods; assert `platform_doc_tools` is in `VALID_TOOL_METHODS`
  but excluded from `_USER_FACING_TOOL_CATEGORIES`.
- `TestGetUseTools` — full rewrite for the new payload: keys are
  `{default_tools, tool_types}`, each `tool_types` entry is `{"tools": [...]}`,
  and the legacy top-level `tools` key is gone.
- New `TestSanitizeAgenticNodeName` — alphanumeric/hyphen/underscore pass
  through; spaces / dots / slashes / unicode collapse to `_`; `None` and
  `""` degrade to `""`.

Gates: `ruff format` / `ruff check` clean · 60/60 unit tests pass · audit
P0=0, P1=0 · diff coverage 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tool categorization with a frontend-friendly exposed set and dynamic discovery of available tools.
  * Agent-type tool references now return a structured payload including default tools and available tool types.
  * Added agent name sanitization to ensure safe configuration keys.

* **Tests**
  * Expanded unit tests covering tool reference shapes, category alignment, and agent-name sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->