### PR TITLE
[BugFix] Resolve agent_config.home through path_manager so tilde expands

### DIFF
--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -193,7 +193,7 @@ def _save_agentic_nodes(agent_config: AgentConfig, nodes: dict) -> None:
     """Save agentic_nodes back to agent.yml."""
     import yaml
 
-    config_path = Path(agent_config.home) / "agent.yml"
+    config_path = agent_config.path_manager.datus_home / "agent.yml"
     with open(config_path) as f:
         raw = yaml.safe_load(f)
     raw["agentic_nodes"] = nodes
@@ -261,7 +261,7 @@ class AgentService:
         agent_type = agent.get("type", "gen_sql")
         created_at = _normalize_created_at(agent.get("created_at"))
         if not created_at:
-            created_at = _file_mtime_iso(Path(agent_config.home) / "agent.yml")
+            created_at = _file_mtime_iso(agent_config.path_manager.datus_home / "agent.yml")
 
         return Result(
             success=True,
@@ -402,7 +402,7 @@ class AgentService:
             return
 
         safe_version = self._sanitize_path_component(version) if version else version
-        template_dir = Path(agent_config.home) / "template"
+        template_dir = agent_config.path_manager.datus_home / "template"
         os.makedirs(template_dir, exist_ok=True)
         target_file = template_dir / f"{safe_name}_system_{safe_version}.j2"
         if not target_file.resolve().is_relative_to(template_dir.resolve()):
@@ -424,7 +424,7 @@ class AgentService:
             return
         safe_name = self._sanitize_path_component(agent_name)
         resolved = self._sanitize_path_component(version or "1.0")
-        template_dir = Path(agent_config.home) / "template"
+        template_dir = agent_config.path_manager.datus_home / "template"
         os.makedirs(template_dir, exist_ok=True)
         target_file = template_dir / f"{safe_name}_system_{resolved}.j2"
         if not target_file.resolve().is_relative_to(template_dir.resolve()):

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -451,6 +451,38 @@ class TestGetAgent:
         created_at = result.data["agent"]["created_at"]
         assert isinstance(created_at, str) and ISO_UTC_Z_RE.match(created_at), f"unexpected created_at: {created_at!r}"
 
+    async def test_get_agent_uses_path_manager_when_home_has_tilde(self, real_agent_config):
+        """``agent_config.home`` may contain a literal ``~`` (default ``~/.datus``).
+
+        The created_at file-mtime fallback must resolve through ``path_manager``
+        rather than naively constructing ``Path(home)``, otherwise the literal
+        tilde leaks into ``open()`` and raises FileNotFoundError. This regresses
+        the production bug where saving an agent under default config tried to
+        open ``'~/.datus/agent.yml'`` verbatim.
+        """
+        # Pre-create agent.yml under the tmp-path-resolved home so the fallback
+        # has something to stat.
+        resolved_home = real_agent_config.path_manager.datus_home
+        (resolved_home / "agent.yml").write_text("agentic_nodes: {}\n", encoding="utf-8")
+        # Now break agent_config.home — point it at a tilde path that does NOT
+        # exist on disk. If get_agent uses Path(agent_config.home) directly the
+        # mtime probe silently swallows OSError and returns None; if it routes
+        # through path_manager it succeeds.
+        real_agent_config.home = "~/datus-tilde-bug-regression-does-not-exist"
+        real_agent_config.agentic_nodes["tilde_agent"] = {
+            "type": "gen_sql",
+            "description": "agent under tilde-prefixed home",
+            "tools": "db_tools.*",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("tilde_agent", real_agent_config)
+        assert result.success is True
+        created_at = result.data["agent"]["created_at"]
+        assert isinstance(created_at, str) and ISO_UTC_Z_RE.match(created_at), (
+            f"created_at must resolve via path_manager, got {created_at!r}"
+        )
+
 
 @pytest.mark.asyncio
 class TestCreateAgent:
@@ -628,3 +660,43 @@ class TestEditAgent:
         get_result = await svc.get_agent("edit_me", real_agent_config)
         assert get_result.success is True
         assert get_result.data["agent"]["description"] == "updated description"
+
+    async def test_edit_existing_agent_when_home_has_tilde(self, real_agent_config):
+        """Regression: ``agent_config.home == "~/.datus"`` (the production default)
+        must not leak a literal tilde into ``open()``.
+
+        Before the fix, ``_save_agentic_nodes`` did ``Path(agent_config.home) / "agent.yml"``
+        which did NOT expand ``~``, raising ``FileNotFoundError: '~/.datus/agent.yml'``
+        on the live API. The fix routes the path through ``path_manager.datus_home``
+        which is already expanded and resolved.
+        """
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput, EditAgentInput
+
+        # Seed the resolved home with an empty agent.yml so create_agent has
+        # something to load.
+        resolved_home = real_agent_config.path_manager.datus_home
+        (resolved_home / "agent.yml").write_text(yaml.dump({"agentic_nodes": {}}), encoding="utf-8")
+        # Inject the production-shape default — a literal tilde path. If any
+        # write site uses Path(agent_config.home) directly, the next call
+        # raises FileNotFoundError and the test fails.
+        real_agent_config.home = "~/.datus-tilde-regression-does-not-exist"
+
+        svc = AgentService()
+        create_result = await svc.create_agent(
+            CreateAgentInput(name="tilde_edit", type="gen_sql", description="orig"),
+            real_agent_config,
+        )
+        assert create_result.success is True
+
+        edit_result = await svc.edit_agent(
+            EditAgentInput(id="tilde_edit", name="tilde_edit", description="updated under tilde"),
+            real_agent_config,
+        )
+        assert edit_result.success is True
+
+        # Confirm the change actually landed in the resolved home, not in
+        # whatever a literal ~ would expand to.
+        on_disk = yaml.safe_load((resolved_home / "agent.yml").read_text(encoding="utf-8"))
+        assert on_disk["agentic_nodes"]["tilde_edit"]["description"] == "updated under tilde"


### PR DESCRIPTION
## Why

`POST /api/v1/agent/edit` (and `create`) crashes with `FileNotFoundError`
when `agent_config.home` is the production default `'~/.datus'`:

```
File "/.../datus/api/services/agent_service.py", line 197, in _save_agentic_nodes
    with open(config_path) as f:
FileNotFoundError: [Errno 2] No such file or directory: '~/.datus/agent.yml'
```

`agent_config.home` is stored as a **raw string** (default `"~/.datus"`).
The four sites in `agent_service.py` that build filesystem paths via
`Path(agent_config.home)` never expand the tilde — `pathlib.Path()`
does not call `expanduser()` — so `open()` sees the literal `~` and
aborts.

The rest of the codebase already routes through
`agent_config.path_manager.datus_home`, which is the already-expanded
resolved `Path` (via `PathManager.resolve_home → Path(home).expanduser().resolve()`).
This PR makes the agent CRUD paths agree with that convention; no new
helper introduced.

## Solution

All four `Path(agent_config.home)` usages in `datus/api/services/agent_service.py`
swapped to `agent_config.path_manager.datus_home`:

- `_save_agentic_nodes` → `agent.yml` (the actual crash site)
- `get_agent`'s `created_at` file-mtime fallback
- `_copy_prompt_template` → `{home}/template`
- `_save_prompt_template` → `{home}/template`

The fix is a one-line swap per call site, no behavior change for
configs whose `home` was already absolute (the resolve step is a no-op
for absolute paths).

## Test Cases

Two regression tests added to `tests/unit_tests/api/services/test_agent_service.py`:

- **`test_edit_existing_agent_when_home_has_tilde`** — exercises
  `create_agent` + `edit_agent` end-to-end with `agent_config.home`
  forced to a literal `'~/...'` string that does not exist on disk.
  Pre-fix this raised `FileNotFoundError`; post-fix the operation
  succeeds and the change persists under `path_manager.datus_home`.
- **`test_get_agent_uses_path_manager_when_home_has_tilde`** — covers
  the `created_at` file-mtime fallback in `get_agent` for the same
  scenario.

Gates: ruff format/check clean · 62/62 unit tests pass · audit P0=0/P1=0
· diff coverage 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized agent configuration and template storage in the datus home directory for improved organization.
  * Enhanced timestamp handling for agent creation dates.

* **Tests**
  * Added test coverage for path handling with tilde expansion in agent home directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->