### PR TITLE
[Feature] Support DuckDB Iceberg quickstart lakehouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ test.py
 evaluation_details.json
 conf/agent.yml.bak
 .gstack/
+/quickstart/data_engineering/airflow/dags/*.py
 /.datus_test_data
 /subject/
 build/

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -130,7 +130,7 @@ class DbConfig:
                 # Store unknown fields in extra for adapter-specific config
                 # Skip internal fields that are handled separately
                 if v is not None and v != "" and k not in internal_fields:
-                    extra_params[k] = resolve_env(v) if isinstance(v, str) else v
+                    extra_params[k] = _resolve_nested_value(v)
                 continue
             if not v:
                 params[k] = v
@@ -484,6 +484,12 @@ DEFAULT_REFLECTION_NODES = {
 
 def _parse_single_file_db(db_config: Dict[str, Any], dialect: str) -> DbConfig:
     uri = resolve_env(str(db_config["uri"]))
+    known_fields = {"uri", "name", "type", "schema", "default"}
+    extra = {
+        key: _resolve_nested_value(value)
+        for key, value in db_config.items()
+        if key not in known_fields and value is not None and value != ""
+    }
     if "name" in db_config:
         login_name = db_config["name"]
         db_name = file_stem_from_uri(uri)
@@ -492,7 +498,14 @@ def _parse_single_file_db(db_config: Dict[str, Any], dialect: str) -> DbConfig:
         db_name = login_name
     if not uri.startswith(dialect):
         uri = f"{dialect}:///{os.path.expanduser(uri)}"
-    return DbConfig(type=dialect, uri=uri, database=db_name, schema=db_config.get("schema", ""), logic_name=login_name)
+    return DbConfig(
+        type=dialect,
+        uri=uri,
+        database=db_name,
+        schema=db_config.get("schema", ""),
+        logic_name=login_name,
+        extra=extra or None,
+    )
 
 
 @dataclass
@@ -2041,6 +2054,8 @@ def _resolve_nested_value(value: Any) -> Any:
         return {k: _resolve_nested_value(v) for k, v in value.items()}
     if isinstance(value, list):
         return [_resolve_nested_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_resolve_nested_value(item) for item in value)
     return value
 
 

--- a/datus/resources/skills/data-migration/SKILL.md
+++ b/datus/resources/skills/data-migration/SKILL.md
@@ -63,7 +63,7 @@ Activate when you need to:
 ### Phase 4: Transfer Data
 
 - Use `transfer_query_result(source_sql, source_database, target_table, target_database, mode)` to move data
-- For fresh migration use `mode='replace'` (truncates target first)
+- For fresh migration use `mode='replace'` (creates the target table if missing; otherwise truncates it first)
 - For incremental load use `mode='append'`
 - Verify the transfer result (rows_transferred count)
 

--- a/datus/tools/db_tools/builtin_configs.py
+++ b/datus/tools/db_tools/builtin_configs.py
@@ -4,6 +4,8 @@
 
 """Configuration classes for built-in database adapters."""
 
+from typing import Any, Dict, Optional
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -32,3 +34,7 @@ class DuckDBConfig(BaseModel):
             "default_sample": "duckdb-demo.duckdb",
         },
     )
+    read_only: bool = Field(default=False, description="Whether to open the DuckDB database in read-only mode")
+    enable_external_access: bool = Field(default=True, description="Enable DuckDB external file access")
+    memory_limit: Optional[str] = Field(default=None, description="DuckDB memory limit, e.g. '2GB'")
+    iceberg: Optional[Dict[str, Any]] = Field(default=None, description="DuckDB Iceberg REST catalog configuration")

--- a/datus/tools/db_tools/config.py
+++ b/datus/tools/db_tools/config.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from datus_db_core import ConnectionConfig
 from pydantic import ConfigDict, Field
@@ -31,3 +31,4 @@ class DuckDBConfig(FileConnectionConfig):
     enable_external_access: bool = Field(default=True, description="Enable external file access")
     memory_limit: Optional[str] = Field(default=None, description="Memory limit (e.g., '2GB')")
     database_name: Optional[str] = Field(default=None, description="Optional database name override")
+    iceberg: Optional[Dict[str, Any]] = Field(default=None, description="DuckDB Iceberg REST catalog configuration")

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -294,6 +294,13 @@ class DBManager:
         db_type = _normalize_dialect_name(db_config.type)
         timeout_seconds = 30  # Default timeout
 
+        def _bool_extra(value, default: bool = False) -> bool:
+            if value is None:
+                return default
+            if isinstance(value, bool):
+                return value
+            return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
         if db_type == DBType.SQLITE:
             # SQLite uses file path - prioritize uri over database field
             db_path = db_config.uri or db_config.database
@@ -310,10 +317,15 @@ class DBManager:
             db_path = db_config.uri or db_config.database
             if db_path.startswith("duckdb:///"):
                 db_path = db_path.replace("duckdb:///", "")
+            extra = db_config.extra or {}
             return DuckDBConfig(
                 db_path=db_path,
                 timeout_seconds=timeout_seconds,
                 database_name=None,  # Let connector extract from file path
+                read_only=_bool_extra(extra.get("read_only"), False),
+                enable_external_access=_bool_extra(extra.get("enable_external_access"), True),
+                memory_limit=extra.get("memory_limit"),
+                iceberg=extra.get("iceberg"),
             )
 
         else:
@@ -350,13 +362,25 @@ class DBManager:
     def close(self):
         """Close all database connections."""
         for name, conn in list(self._conn_dict.items()):
-            if conn is not None:
-                try:
+            if conn is None:
+                continue
+            try:
+                if isinstance(conn, dict):
+                    for db_name, sub_conn in list(conn.items()):
+                        if sub_conn is None:
+                            continue
+                        try:
+                            sub_conn.close()
+                        except Exception as e:
+                            logger.warning(f"Error closing connection {name}.{db_name}: {str(e)}")
+                        finally:
+                            conn[db_name] = None
+                else:
                     conn.close()
-                except Exception as e:
-                    logger.warning(f"Error closing connection {name}: {str(e)}")
-                finally:
-                    self._conn_dict[name] = None
+            except Exception as e:
+                logger.warning(f"Error closing connection {name}: {str(e)}")
+            finally:
+                self._conn_dict[name] = None
 
     def __enter__(self):
         """Context manager entry point."""

--- a/datus/tools/db_tools/duckdb_connector.py
+++ b/datus/tools/db_tools/duckdb_connector.py
@@ -214,7 +214,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             if option:
                 secret_parts.append(option)
         if len(secret_parts) == 1:
-            return secret_name
+            return None
 
         self.connection.execute("CREATE OR REPLACE SECRET " + secret_name + " (" + ", ".join(secret_parts) + ")")
         return secret_name
@@ -460,7 +460,12 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
 
     @override
     def execute_ddl(self, sql: str) -> ExecuteSQLResult:
-        """Execute a DDL SQL statement."""
+        """Execute a DDL SQL statement.
+
+        DuckDB-Iceberg does not natively support CREATE OR REPLACE TABLE.
+        For that extension, the connector emulates it with DROP + CREATE
+        inside an explicit transaction.
+        """
         try:
             self.connect()
             try:
@@ -471,7 +476,22 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
                     rewritten_sql = self._rewrite_iceberg_create_or_replace_table(sql)
                 if rewritten_sql is None:
                     raise
-                self.connection.execute(rewritten_sql)
+                try:
+                    self.connection.execute("BEGIN")
+                    self.connection.execute(rewritten_sql)
+                    self.connection.execute("COMMIT")
+                except Exception as rewrite_error:
+                    try:
+                        self.connection.execute("ROLLBACK")
+                    except Exception as rollback_error:
+                        logger.warning(
+                            "Failed to rollback DuckDB-Iceberg CREATE OR REPLACE emulation: %s",
+                            rollback_error,
+                        )
+                    raise RuntimeError(
+                        "DuckDB-Iceberg CREATE OR REPLACE TABLE emulation failed; "
+                        f"original error: {e}; rewrite error: {rewrite_error}"
+                    ) from e
             return ExecuteSQLResult(
                 success=True,
                 sql_query=sql,

--- a/datus/tools/db_tools/duckdb_connector.py
+++ b/datus/tools/db_tools/duckdb_connector.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import re
 from typing import Any, Dict, List, Literal, Optional, Set, override
 
 import duckdb
@@ -54,6 +55,8 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         self.connection: Optional[duckdb.DuckDBPyConnection] = None
         self.enable_external_access = config.enable_external_access
         self.memory_limit = config.memory_limit
+        self.read_only = config.read_only
+        self.iceberg_config = config.iceberg or {}
 
         if config.database_name:
             self.database_name = config.database_name
@@ -78,9 +81,9 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
                 from duckdb_engine import __version__ as _de_ver
 
                 config = {"custom_user_agent": f"duckdb_engine/{_de_ver}(sqlalchemy/{_sa.__version__})"}
-                self.connection = duckdb.connect(self.db_path, config=config)
+                self.connection = duckdb.connect(self.db_path, read_only=self.read_only, config=config)
             except ImportError:
-                self.connection = duckdb.connect(self.db_path)
+                self.connection = duckdb.connect(self.db_path, read_only=self.read_only)
 
             # Per-session settings — kept as post-connect SET so they don't enter
             # DuckDB's instance-config equality check.
@@ -90,11 +93,227 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             if not self.enable_external_access:
                 self.connection.execute("SET enable_external_access=false")
 
+            if self.iceberg_config:
+                self._setup_iceberg()
+
         except Exception as e:
             raise DatusException(
                 ErrorCode.DB_CONNECTION_FAILED,
                 message_args={"error_message": str(e)},
             ) from e
+
+    @staticmethod
+    def _sql_literal(value: Any) -> str:
+        return "'" + str(value).replace("'", "''") + "'"
+
+    @staticmethod
+    def _safe_identifier(value: Any, field_name: str) -> str:
+        text = str(value)
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", text):
+            raise DatusException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                message_args={
+                    "field_name": field_name,
+                    "except_values": "SQL identifier matching [A-Za-z_][A-Za-z0-9_]*",
+                    "your_value": text,
+                },
+            )
+        return text
+
+    @staticmethod
+    def _bool_value(value: Any, default: bool = False) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+    @classmethod
+    def _s3_use_ssl(cls, cfg: Dict[str, Any], endpoint: Any) -> bool:
+        configured = cfg.get("s3_use_ssl")
+        if configured is not None and configured != "":
+            return cls._bool_value(configured)
+        if not endpoint:
+            return True
+        endpoint_text = str(endpoint).strip().lower()
+        return endpoint_text.startswith("https://")
+
+    def _load_extension(self, name: str) -> None:
+        try:
+            self.connection.execute(f"LOAD {name}")
+        except Exception as load_error:
+            try:
+                self.connection.execute(f"INSTALL {name}")
+                self.connection.execute(f"LOAD {name}")
+            except Exception as retry_error:
+                raise RuntimeError(
+                    f"Failed to load DuckDB extension {name}; "
+                    f"initial LOAD error: {load_error}; INSTALL/LOAD retry error: {retry_error}"
+                ) from retry_error
+
+    @classmethod
+    def _sql_option(cls, name: str, value: Any) -> Optional[str]:
+        if value is None or value == "":
+            return None
+        if isinstance(value, bool):
+            return f"{name} " + ("true" if value else "false")
+        return f"{name} {cls._sql_literal(value)}"
+
+    @staticmethod
+    def _rewrite_iceberg_create_or_replace_table(sql: str) -> Optional[str]:
+        quoted_identifier = r'"(?:[^"]|"")+"'
+        identifier = rf"(?:[A-Za-z_][A-Za-z0-9_]*|{quoted_identifier})"
+        match = re.match(
+            r"^\s*CREATE\s+OR\s+REPLACE\s+TABLE\s+"
+            rf"({identifier}(?:\s*\.\s*{identifier})*)\s+(.*)\Z",
+            sql,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        if not match:
+            return None
+        table_name = match.group(1)
+        remainder = match.group(2)
+        return f"DROP TABLE IF EXISTS {table_name};\nCREATE TABLE {table_name} {remainder}"
+
+    def _create_iceberg_secret_if_needed(self, cfg: Dict[str, Any]) -> Optional[str]:
+        """Create a DuckDB Iceberg catalog secret when auth credentials are supplied."""
+        if not self.connection:
+            return None
+
+        secret_name = cfg.get("iceberg_secret_name") or cfg.get("catalog_secret_name") or cfg.get("secret_name")
+        create_secret = self._bool_value(cfg.get("create_iceberg_secret"), default=True)
+        credential_keys = {
+            "client_id",
+            "client_secret",
+            "oauth2_server_uri",
+            "oauth2_scope",
+            "oauth2_grant_type",
+            "token",
+        }
+        has_credentials = any(cfg.get(key) for key in credential_keys)
+        if not secret_name and has_credentials and create_secret:
+            secret_name = "datus_iceberg"
+        if not secret_name:
+            return None
+
+        secret_name = self._safe_identifier(secret_name, "iceberg_secret_name")
+        if not create_secret:
+            return secret_name
+
+        secret_option_map = {
+            "client_id": "CLIENT_ID",
+            "client_secret": "CLIENT_SECRET",
+            "oauth2_server_uri": "OAUTH2_SERVER_URI",
+            "oauth2_scope": "OAUTH2_SCOPE",
+            "oauth2_grant_type": "OAUTH2_GRANT_TYPE",
+            "token": "TOKEN",
+        }
+        secret_parts = ["TYPE iceberg"]
+        for cfg_key, sql_name in secret_option_map.items():
+            option = self._sql_option(sql_name, cfg.get(cfg_key))
+            if option:
+                secret_parts.append(option)
+        if len(secret_parts) == 1:
+            return secret_name
+
+        self.connection.execute("CREATE OR REPLACE SECRET " + secret_name + " (" + ", ".join(secret_parts) + ")")
+        return secret_name
+
+    def _setup_iceberg(self) -> None:
+        """Attach an Iceberg REST catalog for DuckDB-as-query-engine mode."""
+        if not self.connection:
+            return
+
+        cfg = self.iceberg_config
+        catalog_alias = self._safe_identifier(cfg.get("catalog_alias") or "lake", "catalog_alias")
+        catalog_uri = cfg.get("catalog_uri") or cfg.get("iceberg_catalog_uri") or cfg.get("endpoint")
+        warehouse = cfg.get("warehouse")
+        if not catalog_uri:
+            raise DatusException(
+                ErrorCode.DB_CONNECTION_FAILED,
+                message_args={"error_message": "DuckDB iceberg config requires catalog_uri"},
+            )
+        if not warehouse:
+            raise DatusException(
+                ErrorCode.DB_CONNECTION_FAILED,
+                message_args={"error_message": "DuckDB iceberg config requires warehouse"},
+            )
+
+        self._load_extension("httpfs")
+        self._load_extension("iceberg")
+
+        iceberg_secret_name = self._create_iceberg_secret_if_needed(cfg)
+
+        key_id = cfg.get("s3_access_key_id") or cfg.get("aws_access_key_id")
+        secret = cfg.get("s3_secret_access_key") or cfg.get("aws_secret_access_key")
+        region = cfg.get("s3_region") or cfg.get("aws_region") or "us-east-1"
+        provider = str(cfg.get("s3_provider") or cfg.get("aws_provider") or "").strip().lower()
+        endpoint = cfg.get("s3_endpoint")
+        url_style = cfg.get("s3_url_style") or cfg.get("url_style")
+        use_ssl = self._s3_use_ssl(cfg, endpoint)
+
+        if provider:
+            provider = self._safe_identifier(provider, "s3_provider")
+            secret_parts = [
+                "TYPE s3",
+                f"PROVIDER {provider}",
+                f"REGION {self._sql_literal(region)}",
+            ]
+            if endpoint:
+                endpoint_value = str(endpoint).removeprefix("http://").removeprefix("https://")
+                secret_parts.append(f"ENDPOINT {self._sql_literal(endpoint_value)}")
+            if url_style:
+                secret_parts.append(f"URL_STYLE {self._sql_literal(url_style)}")
+            secret_parts.append("USE_SSL " + ("true" if use_ssl else "false"))
+            self.connection.execute("CREATE OR REPLACE SECRET datus_s3 (" + ", ".join(secret_parts) + ")")
+        elif key_id and secret:
+            secret_parts = [
+                "TYPE s3",
+                f"KEY_ID {self._sql_literal(key_id)}",
+                f"SECRET {self._sql_literal(secret)}",
+                f"REGION {self._sql_literal(region)}",
+            ]
+            if endpoint:
+                endpoint_value = str(endpoint).removeprefix("http://").removeprefix("https://")
+                secret_parts.append(f"ENDPOINT {self._sql_literal(endpoint_value)}")
+            if url_style:
+                secret_parts.append(f"URL_STYLE {self._sql_literal(url_style)}")
+            secret_parts.append("USE_SSL " + ("true" if use_ssl else "false"))
+            self.connection.execute("CREATE OR REPLACE SECRET datus_s3 (" + ", ".join(secret_parts) + ")")
+
+        attach_options = [
+            "TYPE iceberg",
+            f"ENDPOINT {self._sql_literal(catalog_uri)}",
+        ]
+        if iceberg_secret_name:
+            attach_options.append(f"SECRET {iceberg_secret_name}")
+
+        option_aliases = {
+            "endpoint_type": "ENDPOINT_TYPE",
+            "default_region": "DEFAULT_REGION",
+            "authorization_type": "AUTHORIZATION_TYPE",
+            "access_delegation_mode": "ACCESS_DELEGATION_MODE",
+            "support_nested_namespaces": "SUPPORT_NESTED_NAMESPACES",
+            "support_stage_create": "SUPPORT_STAGE_CREATE",
+            "max_table_staleness": "MAX_TABLE_STALENESS",
+            "purge_requested": "PURGE_REQUESTED",
+        }
+        has_catalog_auth = bool(iceberg_secret_name or cfg.get("authorization_type") or cfg.get("endpoint_type"))
+        if not has_catalog_auth:
+            if not cfg.get("authorization_type"):
+                attach_options.append("AUTHORIZATION_TYPE none")
+            if not cfg.get("access_delegation_mode"):
+                attach_options.append("ACCESS_DELEGATION_MODE none")
+        for cfg_key, sql_name in option_aliases.items():
+            option = self._sql_option(sql_name, cfg.get(cfg_key))
+            if option:
+                attach_options.append(option)
+        attach_options.append(
+            "READ_ONLY " + ("true" if self._bool_value(cfg.get("read_only"), default=False) else "false")
+        )
+        self.connection.execute(
+            f"ATTACH {self._sql_literal(warehouse)} AS {catalog_alias} (" + ", ".join(attach_options) + ")"
+        )
 
     @override
     def close(self):
@@ -244,7 +463,15 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         """Execute a DDL SQL statement."""
         try:
             self.connect()
-            self.connection.execute(sql)
+            try:
+                self.connection.execute(sql)
+            except Exception as e:
+                rewritten_sql = None
+                if self.iceberg_config and "create or replace not supported in duckdb-iceberg" in str(e).lower():
+                    rewritten_sql = self._rewrite_iceberg_create_or_replace_table(sql)
+                if rewritten_sql is None:
+                    raise
+                self.connection.execute(rewritten_sql)
             return ExecuteSQLResult(
                 success=True,
                 sql_query=sql,
@@ -278,12 +505,12 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
                     result_format=result_format,
                 )
             elif result_format == "arrow":
-                arrow_table = result.arrow()
+                arrow_table = result.fetch_arrow_table()
                 return ExecuteSQLResult(
                     success=True,
                     sql_query=sql,
                     sql_return=arrow_table,
-                    row_count=len(arrow_table),
+                    row_count=arrow_table.num_rows,
                     result_format=result_format,
                 )
             elif result_format == "pandas":

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1342,6 +1342,129 @@ class DBFuncTool:
     # Maximum rows allowed in a single transfer (v1 memory constraint)
     _TRANSFER_MAX_ROWS = 1_000_000
 
+    @staticmethod
+    def _identifier_quote_char(dialect: str) -> str:
+        backtick_dialects = ("mysql", "starrocks", "hive", "spark", "bigquery", "clickhouse")
+        return "`" if dialect in backtick_dialects else '"'
+
+    @classmethod
+    def _quote_column_identifier(cls, name: Any, dialect: str) -> str:
+        text = str(name)
+        if not text or "\x00" in text:
+            raise ValueError(f"Invalid column name: {text!r}")
+        quote_char = cls._identifier_quote_char(dialect)
+        escaped = text.replace(quote_char, quote_char * 2)
+        return f"{quote_char}{escaped}{quote_char}"
+
+    @staticmethod
+    def _is_missing_target_table_error(error: Any) -> bool:
+        text = str(error or "").lower()
+        missing_markers = (
+            "does not exist",
+            "doesn't exist",
+            "no such table",
+            "not found",
+            "undefinedtable",
+            "unknown table",
+            "table_not_exists",
+        )
+        object_markers = ("table", "relation", "object", "catalog", "schema")
+        return any(marker in text for marker in missing_markers) and any(marker in text for marker in object_markers)
+
+    @classmethod
+    def _infer_transfer_column_type(cls, series: Any, dialect: str) -> str:
+        from datetime import date, datetime, time
+        from decimal import Decimal
+
+        from pandas.api import types as pd_types
+
+        dialect = str(dialect or "").lower()
+
+        def choose(default: str, *, sqlite: str = "", postgres: str = "", duckdb: str = "") -> str:
+            if dialect == DBType.SQLITE:
+                return sqlite or default
+            if dialect in ("postgresql", "postgres"):
+                return postgres or default
+            if dialect == DBType.DUCKDB:
+                return duckdb or default
+            return default
+
+        if pd_types.is_bool_dtype(series):
+            return choose("BOOLEAN", sqlite="INTEGER")
+        if pd_types.is_integer_dtype(series):
+            return choose("BIGINT", sqlite="INTEGER")
+        if pd_types.is_float_dtype(series):
+            return choose("DOUBLE", sqlite="REAL", postgres="DOUBLE PRECISION")
+        if pd_types.is_datetime64_any_dtype(series):
+            return choose("TIMESTAMP", sqlite="TEXT")
+        if pd_types.is_timedelta64_dtype(series):
+            return choose("TEXT", duckdb="INTERVAL")
+
+        non_null = series.dropna()
+        if not non_null.empty:
+            value = non_null.iloc[0]
+            if isinstance(value, bool):
+                return choose("BOOLEAN", sqlite="INTEGER")
+            if isinstance(value, int):
+                return choose("BIGINT", sqlite="INTEGER")
+            if isinstance(value, float):
+                return choose("DOUBLE", sqlite="REAL", postgres="DOUBLE PRECISION")
+            if isinstance(value, Decimal):
+                return "NUMERIC"
+            if isinstance(value, datetime):
+                return choose("TIMESTAMP", sqlite="TEXT")
+            if isinstance(value, date):
+                return choose("DATE", sqlite="TEXT")
+            if isinstance(value, time):
+                return choose("TIME", sqlite="TEXT")
+            if isinstance(value, (bytes, bytearray, memoryview)):
+                return choose("TEXT", duckdb="VARCHAR")
+            if isinstance(value, (dict, list, tuple)):
+                return choose("TEXT", duckdb="VARCHAR")
+
+        return choose("TEXT", duckdb="VARCHAR")
+
+    def _create_transfer_target_table(self, target_conn: Any, target_table: str, df: Any) -> FuncToolResult:
+        if not hasattr(target_conn, "execute_ddl"):
+            return FuncToolResult(success=0, error="Target datasource connector does not support DDL operations")
+
+        columns = list(df.columns)
+        if not columns:
+            return FuncToolResult(
+                success=0, error="Cannot create target table because the source query returned no columns"
+            )
+
+        dialect = str(getattr(target_conn, "dialect", "") or "").lower()
+        seen_columns = set()
+        column_defs = []
+        try:
+            for column in columns:
+                column_key = str(column).casefold()
+                if column_key in seen_columns:
+                    return FuncToolResult(
+                        success=0,
+                        error=f"Cannot create target table because source query returned duplicate column '{column}'",
+                    )
+                seen_columns.add(column_key)
+                column_defs.append(
+                    f"  {self._quote_column_identifier(column, dialect)} "
+                    f"{self._infer_transfer_column_type(df[column], dialect)}"
+                )
+        except Exception as e:
+            return FuncToolResult(success=0, error=f"Failed to infer target table schema: {str(e)}")
+
+        create_sql = f"CREATE TABLE {target_table} (\n" + ",\n".join(column_defs) + "\n)"
+        try:
+            create_result = target_conn.execute_ddl(create_sql)
+            if not create_result.success:
+                return FuncToolResult(success=0, error=f"Failed to create target table: {create_result.error}")
+            if hasattr(target_conn, "connection") and hasattr(target_conn.connection, "commit"):
+                target_conn.connection.commit()
+        except Exception as e:
+            return FuncToolResult(success=0, error=f"Failed to create target table: {str(e)}")
+
+        return FuncToolResult(result={"sql": create_sql})
+
     def transfer_query_result(
         self,
         source_sql: str,
@@ -1362,7 +1485,8 @@ class DBFuncTool:
             source_datasource: Source datasource name. Uses default datasource if empty.
             target_table: Fully qualified target table name.
             target_datasource: Target datasource name. Uses default datasource if empty.
-            mode: Transfer mode - 'replace' (TRUNCATE + INSERT) or 'append' (INSERT only).
+            mode: Transfer mode - 'replace' (TRUNCATE + INSERT, creating the target table if missing)
+                  or 'append' (INSERT only).
             batch_size: Number of rows per INSERT batch.
 
         Returns:
@@ -1475,32 +1599,56 @@ class DBFuncTool:
                 "Please add WHERE conditions to transfer in smaller batches.",
             )
 
-        # TRUNCATE for replace mode BEFORE empty check — mode="replace" must clear old data
+        # TRUNCATE for replace mode BEFORE empty check - mode="replace" must clear old data.
+        # If the target table does not exist yet, create it from the source result schema so
+        # first-time transfers do not require a separate hand-written DDL step.
+        target_table_created = False
+        target_table_create_sql = None
         if mode == "replace":
             try:
                 truncate_result = target_conn.execute_ddl(f"TRUNCATE TABLE {target_table}")
                 if not truncate_result.success:
-                    return FuncToolResult(
-                        success=0,
-                        error=f"Failed to truncate target table: {truncate_result.error}",
-                    )
+                    if self._is_missing_target_table_error(truncate_result.error):
+                        create_result = self._create_transfer_target_table(target_conn, target_table, df)
+                        if not create_result.success:
+                            return create_result
+                        target_table_created = True
+                        target_table_create_sql = create_result.result["sql"]
+                    else:
+                        return FuncToolResult(
+                            success=0,
+                            error=f"Failed to truncate target table: {truncate_result.error}",
+                        )
             except Exception as e:
-                return FuncToolResult(success=0, error=f"Failed to truncate target table: {str(e)}")
+                if self._is_missing_target_table_error(e):
+                    create_result = self._create_transfer_target_table(target_conn, target_table, df)
+                    if not create_result.success:
+                        return create_result
+                    target_table_created = True
+                    target_table_create_sql = create_result.result["sql"]
+                else:
+                    return FuncToolResult(success=0, error=f"Failed to truncate target table: {str(e)}")
 
         # Handle empty result (after truncate so replace mode still clears old data)
         if row_count == 0:
             logger.info(f"Source query returned 0 rows, nothing to transfer to {target_table}")
+            if target_table_created:
+                message = "Transfer completed (empty result set - target table created)"
+            elif mode == "replace":
+                message = "Transfer completed (empty result set - target table truncated)"
+            else:
+                message = "Transfer completed (empty result set)"
             return FuncToolResult(
                 result={
-                    "message": "Transfer completed (empty result set — target table truncated)"
-                    if mode == "replace"
-                    else "Transfer completed (empty result set)",
+                    "message": message,
                     "source_sql": source_sql,
                     "source_datasource": source_datasource,
                     "target_table": target_table,
                     "target_datasource": target_datasource or self._default_datasource,
                     "mode": mode,
                     "rows_transferred": 0,
+                    "target_table_created": target_table_created,
+                    "target_table_create_sql": target_table_create_sql,
                     # Leave as None when the pre-count failed; 0 is a legitimate
                     # verified value (empty source). See _build_transfer_target.
                     "source_row_count": source_row_count,
@@ -1527,10 +1675,8 @@ class DBFuncTool:
         # Quote column names to handle reserved words (e.g., status, order, select).
         # Use dialect-appropriate quoting: backticks for MySQL/StarRocks, double quotes for others.
         columns = list(df.columns)
-        dialect = getattr(target_conn, "dialect", "")
-        backtick_dialects = ("mysql", "starrocks", "hive", "spark", "bigquery", "clickhouse")
-        quote_char = "`" if dialect in backtick_dialects else '"'
-        col_names = ", ".join(f"{quote_char}{c}{quote_char}" for c in columns)
+        dialect = str(getattr(target_conn, "dialect", "") or "").lower()
+        col_names = ", ".join(self._quote_column_identifier(c, dialect) for c in columns)
 
         rows_written = 0
         try:
@@ -1593,6 +1739,8 @@ class DBFuncTool:
                 "target_datasource": target_datasource or self._default_datasource,
                 "mode": mode,
                 "rows_transferred": rows_written,
+                "target_table_created": target_table_created,
+                "target_table_create_sql": target_table_create_sql,
                 "source_row_count": source_row_count,
                 "source_row_count_verified": source_row_count is not None,
                 "transferred_row_count": rows_written,

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -5,7 +5,7 @@
 """Scheduler tools for submitting and managing jobs via Datus scheduler adapters."""
 
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from agents import Tool
 from datus_scheduler_core.models import SchedulerJobPayload
@@ -15,7 +15,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.tools import BaseTool
 from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
 from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
-from datus.utils.exceptions import DatusException
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -103,6 +103,70 @@ class SchedulerTools(BaseTool):
     def _selected_scheduler_config(self) -> dict:
         return dict(self.agent_config.get_scheduler_config(self.scheduler_service))
 
+    @staticmethod
+    def _normalize_scheduler_connection(conn_id: str, raw: Any) -> Dict[str, Any]:
+        if isinstance(raw, dict):
+            raw_capabilities = raw.get("capabilities") or []
+            if isinstance(raw_capabilities, str):
+                capabilities = [raw_capabilities]
+            else:
+                try:
+                    capabilities = list(raw_capabilities)
+                except TypeError:
+                    capabilities = [raw_capabilities]
+            return {
+                "conn_id": conn_id,
+                "description": raw.get("description", ""),
+                "type": raw.get("type", ""),
+                "default": bool(raw.get("default", False)),
+                "capabilities": capabilities,
+            }
+        return {
+            "conn_id": conn_id,
+            "description": str(raw),
+            "type": "",
+            "default": False,
+            "capabilities": [],
+        }
+
+    def _scheduler_connections(self) -> List[Dict[str, Any]]:
+        try:
+            scheduler_config = self._selected_scheduler_config()
+        except DatusException:
+            raise
+        connections = scheduler_config.get("connections", {}) or {}
+        return [self._normalize_scheduler_connection(conn_id, raw) for conn_id, raw in connections.items()]
+
+    def _resolve_sql_conn_id(self, conn_id: Optional[str]) -> str:
+        if conn_id:
+            return conn_id
+
+        sql_connections = []
+        for conn in self._scheduler_connections():
+            capabilities = {str(item).lower() for item in conn.get("capabilities", [])}
+            if capabilities and "sql" not in capabilities:
+                continue
+            if conn.get("default"):
+                sql_connections.append(conn)
+
+        if len(sql_connections) == 1:
+            return str(sql_connections[0]["conn_id"])
+        if not sql_connections:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    "'conn_id' is required because no default SQL scheduler connection is configured. "
+                    "Set conn_id explicitly or mark one scheduler connection as default: true."
+                ),
+            )
+        raise DatusException(
+            ErrorCode.COMMON_CONFIG_ERROR,
+            message=(
+                "'conn_id' is required because multiple default SQL scheduler connections are configured: "
+                + ", ".join(str(conn["conn_id"]) for conn in sql_connections)
+            ),
+        )
+
     # ── Adapter factory ────────────────────────────────────────────────────
 
     def _get_adapter(self):
@@ -132,7 +196,7 @@ class SchedulerTools(BaseTool):
         self,
         job_name: str,
         sql_file_path: str,
-        conn_id: str,
+        conn_id: Optional[str] = None,
         schedule: Optional[str] = None,
         description: Optional[str] = None,
     ) -> FuncToolResult:
@@ -145,7 +209,8 @@ class SchedulerTools(BaseTool):
         Args:
             job_name:        Human-readable job name; used to derive the DAG/job ID.
             sql_file_path:   Local path to the .sql file.
-            conn_id:         Scheduler connection ID (e.g. Airflow Connection ID).
+            conn_id:         Scheduler connection ID (e.g. Airflow Connection ID). If omitted,
+                             the single default SQL-capable scheduler connection is used.
             schedule:        Cron expression, e.g. '0 8 * * *'.  None = manual trigger only.
             description:     Optional human-readable description for the DAG.
 
@@ -163,10 +228,11 @@ class SchedulerTools(BaseTool):
             return FuncToolResult(success=0, error=str(exc))
 
         try:
+            resolved_conn_id = self._resolve_sql_conn_id(conn_id)
             payload = SchedulerJobPayload(
                 job_name=job_name,
                 sql=sql_content,
-                db_connection={"conn_id": conn_id},
+                db_connection={"conn_id": resolved_conn_id},
                 schedule=schedule,
                 description=description,
             )
@@ -179,6 +245,7 @@ class SchedulerTools(BaseTool):
                     "status": job.status.value,
                     "scheduler": job.platform,
                     "platform": job.platform,
+                    "conn_id": resolved_conn_id,
                     "deliverable_target": self._build_scheduler_target(job),
                 },
             )
@@ -535,15 +602,17 @@ class SchedulerTools(BaseTool):
         Re-renders the job definition with updated content.  The scheduler reloads
         it automatically.  Supports both SQL and SparkSQL job types.
 
-        For SQL jobs, ``conn_id`` is required — it references the scheduler-managed
-        connection (e.g. Airflow Connection ID) resolved at runtime.
+        For SQL jobs, ``conn_id`` references the scheduler-managed connection
+        (e.g. Airflow Connection ID) resolved at runtime. If omitted, the single
+        default SQL-capable scheduler connection is used.
 
         Args:
             job_id:         The existing job/DAG identifier to update.
             sql_file_path:  Local path to the new .sql file.
             job_name:       Human-readable job name (used for rendering the job definition).
             job_type:       'sql' (default) or 'sparksql'.
-            conn_id:        Scheduler connection ID (e.g. Airflow Connection ID). Required for sql jobs.
+            conn_id:        Scheduler connection ID (e.g. Airflow Connection ID). Optional when one default
+                            SQL-capable scheduler connection is configured.
             spark_master:   Spark master URL, default 'local[*]' (sparksql only).
             schedule:       Cron expression, e.g. '0 8 * * *'.  None = manual trigger only.
             description:    Optional human-readable description.
@@ -558,12 +627,29 @@ class SchedulerTools(BaseTool):
         if err is not None:
             return err
 
-        # Validate conn_id for sql jobs
-        if job_type == "sql" and not conn_id:
-            return FuncToolResult(
-                success=0,
-                error="'conn_id' is required for sql job_type. "
-                "Set it to the Airflow Connection ID for the target database.",
+        resolved_conn_id = None
+        if job_type == "sparksql":
+            payload = SchedulerJobPayload(
+                job_name=job_name,
+                schedule=schedule,
+                description=description,
+                extra={
+                    "job_type": "sparksql",
+                    "sparksql": sql_content,
+                    "spark_master": spark_master or "local[*]",
+                },
+            )
+        else:
+            try:
+                resolved_conn_id = self._resolve_sql_conn_id(conn_id)
+            except (ValueError, DatusException) as exc:
+                return FuncToolResult(success=0, error=str(exc))
+            payload = SchedulerJobPayload(
+                job_name=job_name,
+                sql=sql_content,
+                db_connection={"conn_id": resolved_conn_id},
+                schedule=schedule,
+                description=description,
             )
 
         try:
@@ -572,25 +658,6 @@ class SchedulerTools(BaseTool):
             return FuncToolResult(success=0, error=str(exc))
 
         try:
-            if job_type == "sparksql":
-                payload = SchedulerJobPayload(
-                    job_name=job_name,
-                    schedule=schedule,
-                    description=description,
-                    extra={
-                        "job_type": "sparksql",
-                        "sparksql": sql_content,
-                        "spark_master": spark_master or "local[*]",
-                    },
-                )
-            else:
-                payload = SchedulerJobPayload(
-                    job_name=job_name,
-                    sql=sql_content,
-                    db_connection={"conn_id": conn_id},
-                    schedule=schedule,
-                    description=description,
-                )
             job = adapter.update_job(job_id, payload)
             return FuncToolResult(
                 success=1,
@@ -600,6 +667,7 @@ class SchedulerTools(BaseTool):
                     "status": job.status.value,
                     "scheduler": job.platform,
                     "platform": job.platform,
+                    "conn_id": resolved_conn_id,
                     "deliverable_target": self._build_scheduler_target(job),
                 },
             )
@@ -707,7 +775,7 @@ class SchedulerTools(BaseTool):
             scheduler_config = self._selected_scheduler_config()
         except DatusException as exc:
             return FuncToolResult(success=0, error=str(exc))
-        connections = scheduler_config.get("connections", {})
+        connections = scheduler_config.get("connections", {}) or {}
         if not connections:
             return FuncToolResult(
                 success=1,
@@ -718,7 +786,7 @@ class SchedulerTools(BaseTool):
                     "Check Airflow (Admin > Connections) for available connections.",
                 },
             )
-        conn_list = [{"conn_id": k, "description": v} for k, v in connections.items()]
+        conn_list = [self._normalize_scheduler_connection(k, v) for k, v in connections.items()]
         return FuncToolResult(
             success=1,
             result={
@@ -732,14 +800,25 @@ class SchedulerTools(BaseTool):
     def _connections_description(self) -> str:
         """Build a suffix describing available conn_ids from scheduler config."""
         try:
-            scheduler_config = self._selected_scheduler_config()
+            connections = self._scheduler_connections()
         except DatusException:
             return ""
-        connections = scheduler_config.get("connections", {})
         if not connections:
             return ""
-        items = ", ".join(f"'{k}' ({v})" for k, v in connections.items())
-        return f"\n\nAvailable conn_id values: {items}"
+        items = []
+        for conn in connections:
+            details = []
+            if conn.get("description"):
+                details.append(str(conn["description"]))
+            if conn.get("type"):
+                details.append(f"type={conn['type']}")
+            if conn.get("default"):
+                details.append("default")
+            if conn.get("capabilities"):
+                details.append("capabilities=" + ",".join(str(item) for item in conn["capabilities"]))
+            suffix = f" ({'; '.join(details)})" if details else ""
+            items.append(f"'{conn['conn_id']}'{suffix}")
+        return f"\n\nAvailable conn_id values: {', '.join(items)}"
 
     @staticmethod
     def _build_scheduler_target(job: Any) -> dict:

--- a/docs/getting_started/data_engineering_quickstart.md
+++ b/docs/getting_started/data_engineering_quickstart.md
@@ -15,23 +15,22 @@ mkdir -p ~/datus-quickstart-data
 cd ~/datus-quickstart-data
 ```
 
-Then run the bash block below — it downloads and unpacks the quickstart data
-and local Docker stack, exports `DACOMP_HOME` / `DATUS_QUICKSTART_STACK`,
-creates a writable DuckDB workbench, and finally prints the two `export`
-statements so you can paste them into another shell:
+Run the bash block below — it downloads and unpacks the quickstart data and
+local Docker stack, exports `DACOMP_HOME` / `DATUS_QUICKSTART_STACK`, and
+finally prints the two `export` statements so you can paste them into another
+shell:
 
 ```bash
-curl -L -o datus-de-lever-quickstart-v1.zip \
-  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-de-lever-quickstart-v1.zip
-curl -L -o datus-data-engineering-quickstart-stack-v1.zip \
-  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-data-engineering-quickstart-stack-v1.zip
+curl -L -o datus-de-lever-quickstart-v2.zip \
+  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v2/datus-de-lever-quickstart-v2.zip
+curl -L -o datus-data-engineering-quickstart-stack-v2.zip \
+  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v2/datus-data-engineering-quickstart-stack-v2.zip
 
-unzip -o datus-de-lever-quickstart-v1.zip
-unzip -o datus-data-engineering-quickstart-stack-v1.zip
+unzip -o datus-de-lever-quickstart-v2.zip
+unzip -o datus-data-engineering-quickstart-stack-v2.zip
 
 export DACOMP_HOME="$(pwd)/datus-de-lever-quickstart"
 export DATUS_QUICKSTART_STACK="$(pwd)/datus-data-engineering-quickstart-stack"
-cp "$DACOMP_HOME/lever_start.duckdb" "$DACOMP_HOME/lever_workbench.duckdb"
 cd "$DACOMP_HOME"
 
 echo "export DACOMP_HOME=$DACOMP_HOME"
@@ -63,7 +62,7 @@ Read those first so the prompts you give to the agent stay aligned with the inte
 
 ## Step 2: Start the Local Quickstart Stack
 
-The downloaded stack includes the two local demo environments used by this walkthrough.
+The downloaded stack includes the local demo services used by this walkthrough.
 
 Start Superset:
 
@@ -72,7 +71,21 @@ cd "$DATUS_QUICKSTART_STACK/superset"
 docker compose up -d
 ```
 
-Start Airflow:
+Start the local lakehouse stack used by both Datus and Airflow:
+
+```bash
+cd "$DATUS_QUICKSTART_STACK/lakehouse"
+docker compose up -d
+docker logs datus-quickstart-lakehouse-seed
+```
+
+The seed log should end with:
+
+```text
+Seeded lake.demo_raw tables: requisition, user, requisition_posting, requisition_offer
+```
+
+Start Airflow after the lakehouse network exists:
 
 ```bash
 cd "$DATUS_QUICKSTART_STACK/airflow"
@@ -83,13 +96,31 @@ Default local endpoints:
 
 - Superset: `http://127.0.0.1:8088`, username `admin`, password `admin`
 - Airflow: `http://127.0.0.1:8080`, username `admin`, password `admin`
+- MinIO Console: `http://127.0.0.1:9001`, username `admin`, password `password`
+- Iceberg REST catalog: `http://127.0.0.1:8181`
 
 For this quickstart, the Superset compose file uses local demo defaults for the
 metadata database and admin user.
 
-The Airflow compose file mounts `${DACOMP_HOME}` into the container and exposes
-an Airflow connection named `duckdb_dacomp_lever`, which points to
-`/workspace/lever_workbench.duckdb`.
+The lakehouse compose file seeds the required Lever source tables into the
+shared demo raw namespace `lake.demo_raw`. Airflow exposes a shared connection named
+`lakehouse_demo`; scheduled jobs use in-memory DuckDB attached to the same
+Iceberg REST catalog, so Datus and Airflow no longer compete for a local
+`.duckdb` file lock.
+
+In production or SaaS deployments, initialize `lake.demo_raw` with a system account
+that can write raw data, and run Datus/Airflow with a separate account that can
+read `lake.demo_raw` and write non-raw workspace namespaces such as
+`lake.ws_lever_demo`. Datus does not enforce namespace-specific rules itself;
+the Iceberg catalog and storage permissions are the boundary.
+
+If you need to reset the raw demo tables, rerun only the seed service:
+
+```bash
+cd "$DATUS_QUICKSTART_STACK/lakehouse"
+docker compose up -d --force-recreate seed-demo-raw
+docker logs datus-quickstart-lakehouse-seed
+```
 
 ## Step 3: Configure `agent.yml`
 
@@ -100,12 +131,25 @@ environment variables from Step 0.
 
 ```yaml
 agent:
+  project_name: lever_demo
+
   services:
     datasources:
-      lever_duckdb:
+      demo_lakehouse:
         type: duckdb
-        uri: "duckdb:///${DACOMP_HOME}/lever_workbench.duckdb"
+        uri: "duckdb:///:memory:"
         default: true
+        iceberg:
+          catalog_alias: lake
+          catalog_uri: http://127.0.0.1:8181
+          warehouse: s3://warehouse/
+          s3_region: us-east-1
+          s3_endpoint: http://127.0.0.1:9000
+          s3_access_key_id: admin
+          s3_secret_access_key: password
+          s3_url_style: path
+          authorization_type: none
+          access_delegation_mode: none
       superset_serving:
         type: postgresql
         host: 127.0.0.1
@@ -133,7 +177,13 @@ agent:
         password: admin
         dags_folder: "${DATUS_QUICKSTART_STACK}/airflow/dags"
         connections:
-          duckdb_dacomp_lever: DAComp Lever DuckDB
+          lakehouse_demo:
+            description: Shared DuckDB Iceberg demo lakehouse
+            type: duckdb_iceberg
+            default: true
+            capabilities:
+              - sql
+              - lakehouse
 
     semantic_layer:
       metricflow:
@@ -146,12 +196,25 @@ agent:
       scheduler_service: airflow_prod
 ```
 
-Then start Datus with the `lever_duckdb` datasource, which points at the
-workbench DuckDB file:
+The YAML above is for the local demo stack, whose Iceberg REST catalog does not
+authenticate. For a shared public catalog, use the runtime account credentials
+instead, for example `client_id`, `client_secret`, `oauth2_server_uri`, and
+`access_delegation_mode: vended_credentials`. Configure the Airflow connection
+with the same runtime account; reserve the system/admin account for raw-data
+initialization outside Datus.
+
+Then start Datus with the `demo_lakehouse` datasource:
 
 ```bash
 cd "$DACOMP_HOME"
-datus-cli --datasource lever_duckdb
+datus-cli --datasource demo_lakehouse
+```
+
+If this workspace was used with an older version of the quickstart, update
+`./.datus/config.yml` before starting Datus:
+
+```yaml
+default_datasource: demo_lakehouse
 ```
 
 If the CLI says no model is configured, configure one before continuing:
@@ -166,20 +229,33 @@ writes the active provider/model for this project to `./.datus/config.yml`.
 
 Here `dags_folder` is the host-side directory where Datus writes generated DAG files. The Airflow compose file mounts that directory into the Airflow container as `/opt/airflow/dags`, so newly generated DAGs are picked up automatically.
 
+Before continuing, verify that Datus can read the seeded lakehouse data:
+
+```sql
+SELECT COUNT(*) FROM lake.demo_raw.requisition;
+```
+
+The quickstart data should return `200` rows for `requisition`.
+
 ## Step 4: Create the Required Staging Tables
 
 For natural-language agent tasks, avoid starting the message with a raw SQL verb
 such as `CREATE` or `COPY`; the CLI uses those leading keywords to detect direct
 SQL.
 
-Ask the agent to create the target schemas:
+This quickstart uses:
+
+- shared demo source namespace: `lake.demo_raw`
+- current workspace output namespace: `lake.ws_lever_demo`
+
+Ask the agent to create the workspace output schema:
 
 ```text
-Please set up the target schemas staging, intermediate, and marts in the current DuckDB database. Keep the existing raw schema unchanged.
+Please set up the current workspace output schema lake.ws_lever_demo. Treat lake.demo_raw as read-only source data.
 ```
 
 This walkthrough builds a narrow but complete dependency chain for
-`marts.lever__requisition_enhanced`. Use `docs/data_contract.yaml` as the source
+`marts_lever__requisition_enhanced`. Use `docs/data_contract.yaml` as the source
 of truth for field selection, renames, and business logic.
 
 Ask the agent to create the staging tables required by the `source_models`
@@ -188,7 +264,7 @@ listed for `lever__requisition_enhanced` and
 the table-generation workflow:
 
 ```text
-Read ./docs/data_contract.yaml and create the staging tables needed for marts.lever__requisition_enhanced: staging.stg_lever__requisition from raw.requisition, staging.stg_lever__user from raw.user, staging.stg_lever__requisition_posting from raw.requisition_posting, and staging.stg_lever__requisition_offer from raw.requisition_offer. Use the field design and source-to-target mapping from the contract.
+Read ./docs/data_contract.yaml and create the staging tables needed for marts_lever__requisition_enhanced in lake.ws_lever_demo: stg_lever__requisition from lake.demo_raw.requisition, stg_lever__user from lake.demo_raw.user, stg_lever__requisition_posting from lake.demo_raw.requisition_posting, and stg_lever__requisition_offer from lake.demo_raw.requisition_offer. Use the field design and source-to-target mapping from the contract.
 ```
 
 These four staging tables are the minimum raw-to-staging inputs for the
@@ -203,21 +279,21 @@ user fields according to the `int_lever__requisition_users` entry in
 Create the intermediate table:
 
 ```text
-Read ./docs/data_contract.yaml and create intermediate.int_lever__requisition_users from staging.stg_lever__requisition and staging.stg_lever__user. Use the contract's field design, joins, and source-to-target mapping.
+Read ./docs/data_contract.yaml and create lake.ws_lever_demo.int_lever__requisition_users from lake.ws_lever_demo.stg_lever__requisition and lake.ws_lever_demo.stg_lever__user. Use the contract's field design, joins, and source-to-target mapping.
 ```
 
 Then create the marts table that is ready for downstream analytics. The contract
-defines `marts.lever__requisition_enhanced` as one row per `requisition_id`,
+defines `marts_lever__requisition_enhanced` as one row per `requisition_id`,
 using:
 
-- `intermediate.int_lever__requisition_users`
-- `staging.stg_lever__requisition_posting`
-- `staging.stg_lever__requisition_offer`
+- `lake.ws_lever_demo.int_lever__requisition_users`
+- `lake.ws_lever_demo.stg_lever__requisition_posting`
+- `lake.ws_lever_demo.stg_lever__requisition_offer`
 
 Create the marts table:
 
 ```text
-Read ./docs/data_contract.yaml and create marts.lever__requisition_enhanced from intermediate.int_lever__requisition_users, staging.stg_lever__requisition_posting, and staging.stg_lever__requisition_offer. Use the contract's business logic: keep all base requisition rows, count posting and offer links by requisition_id, fill missing counts with 0, and add has_posting and has_offer flags.
+Read ./docs/data_contract.yaml and create lake.ws_lever_demo.marts_lever__requisition_enhanced from lake.ws_lever_demo.int_lever__requisition_users, lake.ws_lever_demo.stg_lever__requisition_posting, and lake.ws_lever_demo.stg_lever__requisition_offer. Use the contract's business logic: keep all base requisition rows, count posting and offer links by requisition_id, fill missing counts with 0, and add has_posting and has_offer flags.
 ```
 
 The intended order is always:
@@ -229,17 +305,17 @@ staging -> intermediate -> marts
 After the marts table is built, validate it directly:
 
 ```sql
-SELECT COUNT(*) FROM marts.lever__requisition_enhanced;
+SELECT COUNT(*) FROM lake.ws_lever_demo.marts_lever__requisition_enhanced;
 ```
 
 ## Step 6: Submit a Daily Airflow Job
 
-Ask the agent to operationalize a daily marts refresh. The Airflow quickstart environment already exposes the `duckdb_dacomp_lever` connection.
+Ask the agent to operationalize a daily marts refresh. The Airflow quickstart environment already exposes the `lakehouse_demo` connection.
 
 Submit a daily SQL job at 8 AM that rebuilds the same contract-derived chain:
 
 ```text
-Submit a daily SQL job named daily_lever_requisition_enhanced that refreshes staging.stg_lever__requisition, staging.stg_lever__user, staging.stg_lever__requisition_posting, staging.stg_lever__requisition_offer, intermediate.int_lever__requisition_users, and marts.lever__requisition_enhanced at 8am every day using the duckdb_dacomp_lever connection. Use the SQL generated and validated from docs/data_contract.yaml in the previous steps.
+Submit a daily SQL job named daily_lever_requisition_enhanced that refreshes lake.ws_lever_demo.stg_lever__requisition, lake.ws_lever_demo.stg_lever__user, lake.ws_lever_demo.stg_lever__requisition_posting, lake.ws_lever_demo.stg_lever__requisition_offer, lake.ws_lever_demo.int_lever__requisition_users, and lake.ws_lever_demo.marts_lever__requisition_enhanced at 8am every day using the lakehouse_demo connection. Use the SQL generated and validated from docs/data_contract.yaml in the previous steps.
 ```
 
 Then trigger it once for validation:
@@ -257,15 +333,18 @@ What to expect:
 
 ## Step 7: Promote the Marts Table to the Superset Serving DB
 
-The marts table above was built through the `lever_duckdb` datasource. Before
+The marts table above was built through the `demo_lakehouse` datasource. Before
 dashboard generation can create Superset assets, copy that table into the
 BI-registered `superset_serving` Postgres datasource referenced by
 `dataset_db.datasource_ref`. These names are Datus datasource names from
 `agent.yml`, not physical database or catalog names inside DuckDB or Postgres.
 
 ```text
-Please copy the source table marts.lever__requisition_enhanced from the lever_duckdb datasource into the superset_serving datasource as public.lever__requisition_enhanced, replacing the target table if it already exists. Then verify the source and target row counts.
+Please copy the source table lake.ws_lever_demo.marts_lever__requisition_enhanced from the demo_lakehouse datasource into the superset_serving datasource as public.lever__requisition_enhanced, replacing the target table if it already exists. Then verify the source and target row counts.
 ```
+
+The transfer tool creates `public.lever__requisition_enhanced` from the source
+result columns if it does not already exist.
 
 After this step, the table exists in the same database Superset knows as
 `bi_database_name: examples`.
@@ -286,7 +365,7 @@ database.
 
 You should now have:
 
-- `staging`, `intermediate`, and `marts` schemas in `lever_workbench.duckdb`
-- `marts.lever__requisition_enhanced` built from raw data through staging and intermediate layers
+- `lake.demo_raw` seeded as the shared demo source namespace
+- `lake.ws_lever_demo.marts_lever__requisition_enhanced` built from raw data through staging and intermediate tables
 - a daily Airflow job visible in the scheduler UI
 - a Superset dashboard URL returned by the dashboard generation flow

--- a/docs/getting_started/data_engineering_quickstart.zh.md
+++ b/docs/getting_started/data_engineering_quickstart.zh.md
@@ -15,21 +15,19 @@ cd ~/datus-quickstart-data
 ```
 
 然后直接执行下面这段 bash，会下载并解压 quickstart 数据包和本地 Docker
-stack，导出 `DACOMP_HOME` / `DATUS_QUICKSTART_STACK`，复制一份可写的 DuckDB
-工作库，最后打印两个环境变量供后续步骤使用：
+stack，导出 `DACOMP_HOME` / `DATUS_QUICKSTART_STACK`，最后打印两个环境变量供后续步骤使用：
 
 ```bash
-curl -L -o datus-de-lever-quickstart-v1.zip \
-  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-de-lever-quickstart-v1.zip
-curl -L -o datus-data-engineering-quickstart-stack-v1.zip \
-  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v1/datus-data-engineering-quickstart-stack-v1.zip
+curl -L -o datus-de-lever-quickstart-v2.zip \
+  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v2/datus-de-lever-quickstart-v2.zip
+curl -L -o datus-data-engineering-quickstart-stack-v2.zip \
+  https://github.com/Datus-ai/datus-quickstart-data/releases/download/data-engineering-v2/datus-data-engineering-quickstart-stack-v2.zip
 
-unzip -o datus-de-lever-quickstart-v1.zip
-unzip -o datus-data-engineering-quickstart-stack-v1.zip
+unzip -o datus-de-lever-quickstart-v2.zip
+unzip -o datus-data-engineering-quickstart-stack-v2.zip
 
 export DACOMP_HOME="$(pwd)/datus-de-lever-quickstart"
 export DATUS_QUICKSTART_STACK="$(pwd)/datus-data-engineering-quickstart-stack"
-cp "$DACOMP_HOME/lever_start.duckdb" "$DACOMP_HOME/lever_workbench.duckdb"
 cd "$DACOMP_HOME"
 
 echo "export DACOMP_HOME=$DACOMP_HOME"
@@ -61,7 +59,7 @@ echo "export DATUS_QUICKSTART_STACK=$DATUS_QUICKSTART_STACK"
 
 ## 步骤 2：启动本地 quickstart 环境
 
-下载的 stack 中已经包含本文真正会用到的两套本地 demo 环境。
+下载的 stack 中已经包含本文会用到的本地 demo 服务。
 
 启动 Superset：
 
@@ -70,7 +68,21 @@ cd "$DATUS_QUICKSTART_STACK/superset"
 docker compose up -d
 ```
 
-启动 Airflow：
+启动本地 lakehouse stack。Datus 和 Airflow 都会访问这套共享存储：
+
+```bash
+cd "$DATUS_QUICKSTART_STACK/lakehouse"
+docker compose up -d
+docker logs datus-quickstart-lakehouse-seed
+```
+
+seed 日志最后应该看到：
+
+```text
+Seeded lake.demo_raw tables: requisition, user, requisition_posting, requisition_offer
+```
+
+lakehouse 网络创建完成后，再启动 Airflow：
 
 ```bash
 cd "$DATUS_QUICKSTART_STACK/airflow"
@@ -81,11 +93,28 @@ docker compose up -d
 
 - Superset：`http://127.0.0.1:8088`，用户名 `admin`，密码 `admin`
 - Airflow：`http://127.0.0.1:8080`，用户名 `admin`，密码 `admin`
+- MinIO Console：`http://127.0.0.1:9001`，用户名 `admin`，密码 `password`
+- Iceberg REST catalog：`http://127.0.0.1:8181`
 
 这套 quickstart 的 Superset compose 已经带了本地演示用的元数据库和管理员默认值。
 
-Airflow 的 compose 文件会挂载 `${DACOMP_HOME}`，并暴露一个名为
-`duckdb_dacomp_lever` 的连接，指向 `/workspace/lever_workbench.duckdb`。
+lakehouse compose 会把需要的 Lever 源表写入共享 demo raw namespace
+`lake.demo_raw`。Airflow 暴露一个名为 `lakehouse_demo` 的共享连接；调度任务会用
+in-memory DuckDB 连接同一个 Iceberg REST catalog，因此 Datus 和 Airflow 不再争抢本地
+`.duckdb` 文件锁。
+
+在生产或 SaaS 部署里，用能写 raw 数据的系统账号初始化 `lake.demo_raw`；Datus 和
+Airflow 运行时使用另一个账号，这个账号可以读 `lake.demo_raw`，并能写非 raw 的
+workspace namespace，比如 `lake.ws_lever_demo`。Datus 本身不做 namespace
+特判，真正的边界由 Iceberg catalog 和存储权限负责。
+
+如果需要重置原始 demo 表，只重跑 seed service：
+
+```bash
+cd "$DATUS_QUICKSTART_STACK/lakehouse"
+docker compose up -d --force-recreate seed-demo-raw
+docker logs datus-quickstart-lakehouse-seed
+```
 
 ## 步骤 3：配置 `agent.yml`
 
@@ -95,12 +124,25 @@ Airflow 的 compose 文件会挂载 `${DACOMP_HOME}`，并暴露一个名为
 
 ```yaml
 agent:
+  project_name: lever_demo
+
   services:
     datasources:
-      lever_duckdb:
+      demo_lakehouse:
         type: duckdb
-        uri: "duckdb:///${DACOMP_HOME}/lever_workbench.duckdb"
+        uri: "duckdb:///:memory:"
         default: true
+        iceberg:
+          catalog_alias: lake
+          catalog_uri: http://127.0.0.1:8181
+          warehouse: s3://warehouse/
+          s3_region: us-east-1
+          s3_endpoint: http://127.0.0.1:9000
+          s3_access_key_id: admin
+          s3_secret_access_key: password
+          s3_url_style: path
+          authorization_type: none
+          access_delegation_mode: none
       superset_serving:
         type: postgresql
         host: 127.0.0.1
@@ -128,7 +170,13 @@ agent:
         password: admin
         dags_folder: "${DATUS_QUICKSTART_STACK}/airflow/dags"
         connections:
-          duckdb_dacomp_lever: DAComp Lever DuckDB
+          lakehouse_demo:
+            description: Shared DuckDB Iceberg demo lakehouse
+            type: duckdb_iceberg
+            default: true
+            capabilities:
+              - sql
+              - lakehouse
 
     semantic_layer:
       metricflow:
@@ -141,11 +189,24 @@ agent:
       scheduler_service: airflow_prod
 ```
 
-然后使用 `lever_duckdb` datasource 启动 Datus；它指向上面的 DuckDB 工作库：
+上面的 YAML 是本地 demo stack 配置；本地 Iceberg REST catalog 不启用认证。
+如果连接共享公共 catalog，请换成运行账号凭据，例如 `client_id`、
+`client_secret`、`oauth2_server_uri` 和
+`access_delegation_mode: vended_credentials`。Airflow connection 也要配置同一个
+运行账号；系统/admin 账号只用于 Datus 之外的 raw 数据初始化。
+
+然后使用 `demo_lakehouse` datasource 启动 Datus：
 
 ```bash
 cd "$DACOMP_HOME"
-datus-cli --datasource lever_duckdb
+datus-cli --datasource demo_lakehouse
+```
+
+如果这个 workspace 之前跑过旧版 quickstart，启动前先把 `./.datus/config.yml`
+里的默认 datasource 改成：
+
+```yaml
+default_datasource: demo_lakehouse
 ```
 
 如果 CLI 提示还没有配置模型，继续之前先在 CLI 内运行：
@@ -160,18 +221,31 @@ provider/model 写入 `./.datus/config.yml`。
 
 这里的 `dags_folder` 是 Datus 在主机上写入 DAG 文件的目录。Airflow compose 会把这个目录挂载到 Airflow 容器内的 `/opt/airflow/dags`，所以 Datus 生成的新 DAG 会被 Airflow 自动发现。
 
+继续之前，先确认 Datus 能读到已经 seed 好的 lakehouse 数据：
+
+```sql
+SELECT COUNT(*) FROM lake.demo_raw.requisition;
+```
+
+quickstart 数据中，`requisition` 应该返回 `200` 行。
+
 ## 步骤 4：创建必要的 staging 表
 
 自然语言 agent 任务不要以 `CREATE`、`COPY` 这类 SQL 动词开头；CLI 会根据这些
 开头关键字判断是否直接执行 SQL。
 
-先要求 agent 创建目标 schema：
+这套 quickstart 使用：
+
+- 共享 demo 源 namespace：`lake.demo_raw`
+- 当前 workspace 输出 namespace：`lake.ws_lever_demo`
+
+先要求 agent 创建当前 workspace 的输出 schema：
 
 ```text
-Please set up the target schemas staging, intermediate, and marts in the current DuckDB database. Keep the existing raw schema unchanged.
+Please set up the current workspace output schema lake.ws_lever_demo. Treat lake.demo_raw as read-only source data.
 ```
 
-这条教程只构建一条窄但完整的依赖链：`marts.lever__requisition_enhanced`。
+这条教程只构建一条窄但完整的依赖链：`marts_lever__requisition_enhanced`。
 字段选择、字段重命名和业务逻辑以 `docs/data_contract.yaml` 为准。
 
 再要求 agent 根据 `lever__requisition_enhanced` 和
@@ -179,7 +253,7 @@ Please set up the target schemas staging, intermediate, and marts in the current
 staging 表。agent 会把任务分发到建表流程：
 
 ```text
-Read ./docs/data_contract.yaml and create the staging tables needed for marts.lever__requisition_enhanced: staging.stg_lever__requisition from raw.requisition, staging.stg_lever__user from raw.user, staging.stg_lever__requisition_posting from raw.requisition_posting, and staging.stg_lever__requisition_offer from raw.requisition_offer. Use the field design and source-to-target mapping from the contract.
+Read ./docs/data_contract.yaml and create the staging tables needed for marts_lever__requisition_enhanced in lake.ws_lever_demo: stg_lever__requisition from lake.demo_raw.requisition, stg_lever__user from lake.demo_raw.user, stg_lever__requisition_posting from lake.demo_raw.requisition_posting, and stg_lever__requisition_offer from lake.demo_raw.requisition_offer. Use the field design and source-to-target mapping from the contract.
 ```
 
 这四张 staging 表就是 requisition enhanced 示例需要的最小 raw-to-staging 输入。
@@ -192,20 +266,20 @@ Read ./docs/data_contract.yaml and create the staging tables needed for marts.le
 创建 intermediate 表：
 
 ```text
-Read ./docs/data_contract.yaml and create intermediate.int_lever__requisition_users from staging.stg_lever__requisition and staging.stg_lever__user. Use the contract's field design, joins, and source-to-target mapping.
+Read ./docs/data_contract.yaml and create lake.ws_lever_demo.int_lever__requisition_users from lake.ws_lever_demo.stg_lever__requisition and lake.ws_lever_demo.stg_lever__user. Use the contract's field design, joins, and source-to-target mapping.
 ```
 
-再生成面向分析的 marts 表。契约中定义 `marts.lever__requisition_enhanced`
+再生成面向分析的 marts 表。契约中定义 `marts_lever__requisition_enhanced`
 是一张按 `requisition_id` 一行的表，依赖：
 
-- `intermediate.int_lever__requisition_users`
-- `staging.stg_lever__requisition_posting`
-- `staging.stg_lever__requisition_offer`
+- `lake.ws_lever_demo.int_lever__requisition_users`
+- `lake.ws_lever_demo.stg_lever__requisition_posting`
+- `lake.ws_lever_demo.stg_lever__requisition_offer`
 
 创建 marts 表：
 
 ```text
-Read ./docs/data_contract.yaml and create marts.lever__requisition_enhanced from intermediate.int_lever__requisition_users, staging.stg_lever__requisition_posting, and staging.stg_lever__requisition_offer. Use the contract's business logic: keep all base requisition rows, count posting and offer links by requisition_id, fill missing counts with 0, and add has_posting and has_offer flags.
+Read ./docs/data_contract.yaml and create lake.ws_lever_demo.marts_lever__requisition_enhanced from lake.ws_lever_demo.int_lever__requisition_users, lake.ws_lever_demo.stg_lever__requisition_posting, and lake.ws_lever_demo.stg_lever__requisition_offer. Use the contract's business logic: keep all base requisition rows, count posting and offer links by requisition_id, fill missing counts with 0, and add has_posting and has_offer flags.
 ```
 
 这条链路的基本顺序始终是：
@@ -217,17 +291,17 @@ staging -> intermediate -> marts
 生成完成后，可以直接验证 marts 表：
 
 ```sql
-SELECT COUNT(*) FROM marts.lever__requisition_enhanced;
+SELECT COUNT(*) FROM lake.ws_lever_demo.marts_lever__requisition_enhanced;
 ```
 
 ## 步骤 6：提交天级 Airflow 任务
 
-现在可以要求 agent 把 marts 刷新过程提交给 scheduler。quickstart 自带的 Airflow 已经预置好了 `duckdb_dacomp_lever` 连接。
+现在可以要求 agent 把 marts 刷新过程提交给 scheduler。quickstart 自带的 Airflow 已经预置好了 `lakehouse_demo` 连接。
 
 提交一个每天早上 8 点运行的 SQL 任务，刷新同一条从契约生成的链路：
 
 ```text
-Submit a daily SQL job named daily_lever_requisition_enhanced that refreshes staging.stg_lever__requisition, staging.stg_lever__user, staging.stg_lever__requisition_posting, staging.stg_lever__requisition_offer, intermediate.int_lever__requisition_users, and marts.lever__requisition_enhanced at 8am every day using the duckdb_dacomp_lever connection. Use the SQL generated and validated from docs/data_contract.yaml in the previous steps.
+Submit a daily SQL job named daily_lever_requisition_enhanced that refreshes lake.ws_lever_demo.stg_lever__requisition, lake.ws_lever_demo.stg_lever__user, lake.ws_lever_demo.stg_lever__requisition_posting, lake.ws_lever_demo.stg_lever__requisition_offer, lake.ws_lever_demo.int_lever__requisition_users, and lake.ws_lever_demo.marts_lever__requisition_enhanced at 8am every day using the lakehouse_demo connection. Use the SQL generated and validated from docs/data_contract.yaml in the previous steps.
 ```
 
 再手动触发一次做验证：
@@ -245,14 +319,16 @@ Trigger daily_lever_requisition_enhanced once now and show me the latest run sta
 
 ## 步骤 7：把 marts 表同步到 Superset serving DB
 
-上面的 marts 表是通过 `lever_duckdb` datasource 生成的。创建仪表盘之前，需要先把它复制到
+上面的 marts 表是通过 `demo_lakehouse` datasource 生成的。创建仪表盘之前，需要先把它复制到
 `dataset_db.datasource_ref` 指向的 BI 注册数据库 `superset_serving`（Postgres）。
-这里的 `lever_duckdb` 和 `superset_serving` 都是 `agent.yml` 里的 Datus
+这里的 `demo_lakehouse` 和 `superset_serving` 都是 `agent.yml` 里的 Datus
 datasource 名称，不是 DuckDB 或 Postgres 内部真实的 database/catalog 名。
 
 ```text
-Please copy the source table marts.lever__requisition_enhanced from the lever_duckdb datasource into the superset_serving datasource as public.lever__requisition_enhanced, replacing the target table if it already exists. Then verify the source and target row counts.
+Please copy the source table lake.ws_lever_demo.marts_lever__requisition_enhanced from the demo_lakehouse datasource into the superset_serving datasource as public.lever__requisition_enhanced, replacing the target table if it already exists. Then verify the source and target row counts.
 ```
+
+如果 `public.lever__requisition_enhanced` 还不存在，传输工具会根据源查询结果列自动创建目标表。
 
 完成后，这张表就位于 Superset 通过 `bi_database_name: examples` 识别的数据库中。
 
@@ -271,7 +347,7 @@ SQL dataset 已经存在于 BI 已注册的数据库中。
 
 走完整条链路后，你应该能确认：
 
-- `lever_workbench.duckdb` 里已经有 `staging`、`intermediate`、`marts` 三层 schema
-- `marts.lever__requisition_enhanced` 是从 raw 数据经 staging 和 intermediate 逐层加工得到的
+- `lake.demo_raw` 已作为共享 demo 源 namespace 完成初始化
+- `lake.ws_lever_demo.marts_lever__requisition_enhanced` 是从 raw 数据经 staging 和 intermediate 表逐层加工得到的
 - Airflow 中能看到日常调度任务
 - 仪表盘生成流程返回了 Superset dashboard URL

--- a/docs/subagent/gen_job.md
+++ b/docs/subagent/gen_job.md
@@ -142,7 +142,7 @@ transfer_query_result(
     source_database="local_duckdb",
     target_table="public.users_copy",
     target_database="greenplum",
-    mode="replace"        # replace (TRUNCATE+INSERT) or append
+    mode="replace"        # replace (create if missing, otherwise TRUNCATE+INSERT) or append
 )
 ```
 

--- a/docs/subagent/gen_job.zh.md
+++ b/docs/subagent/gen_job.zh.md
@@ -140,7 +140,7 @@ transfer_query_result(
     source_database="local_duckdb",
     target_table="public.users_copy",
     target_database="greenplum",
-    mode="replace"        # replace（TRUNCATE+INSERT）或 append
+    mode="replace"        # replace（目标表不存在则创建，否则 TRUNCATE+INSERT）或 append
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "textual[syntax]==5.1.1",
     "anthropic==0.51.0",
     "duckdb-engine>=0.17.0",
-    "duckdb==1.3.0",
+    "duckdb>=1.5.2,<2.0.0",
     # MCP (Model Context Protocol) support
     "mcp>=1.11.0",
     "anyio>=4.9.0",

--- a/quickstart/data_engineering/airflow/docker-compose.yml
+++ b/quickstart/data_engineering/airflow/docker-compose.yml
@@ -34,24 +34,27 @@ services:
       _AIRFLOW_WWW_USER_LASTNAME: User
       _AIRFLOW_WWW_USER_EMAIL: admin@example.com
       _AIRFLOW_WWW_USER_ROLE: Admin
-      # Preload the DuckDB connection used in the quickstart scheduler walkthrough.
-      AIRFLOW_CONN_DUCKDB_DACOMP_LEVER: duckdb:////workspace/lever_workbench.duckdb
+      # Shared lakehouse connection used in the quickstart scheduler walkthrough.
+      # The Airflow adapter detects extra.datus_executor=duckdb_iceberg and runs
+      # SQL through an in-memory DuckDB engine attached to the Iceberg REST catalog.
+      AIRFLOW_CONN_LAKEHOUSE_DEMO: >-
+        {"conn_type":"generic","extra":{"datus_executor":"duckdb_iceberg","catalog_alias":"lake","iceberg_catalog_uri":"http://iceberg-rest:8181","warehouse":"s3://warehouse/","authorization_type":"none","access_delegation_mode":"none","s3_region":"us-east-1","s3_endpoint":"http://minio:9000","s3_access_key_id":"admin","s3_secret_access_key":"password","s3_url_style":"path"}}
 
     volumes:
       # DAG files written by the adapter land here
       - ./dags:/opt/airflow/dags
-      # Mount the local DAComp workspace so scheduled SQL jobs can reach the DuckDB file.
-      - ${DACOMP_HOME:?Set DACOMP_HOME to the DAComp workspace path}:/workspace
 
     ports:
       - "8080:8080"
+    networks:
+      - datus-data-engineering
 
     command:
       - bash
       - -lc
       - >
         python -m pip install --no-cache-dir
-        "duckdb>=1.2.0,<2.0.0"
+        "duckdb>=1.5.2,<2.0.0"
         "duckdb-engine>=0.17.0"
         &&
         exec airflow standalone
@@ -62,3 +65,8 @@ services:
       timeout: 10s
       retries: 30
       start_period: 60s
+
+networks:
+  datus-data-engineering:
+    name: datus-data-engineering
+    external: true

--- a/quickstart/data_engineering/lakehouse/docker-compose.yml
+++ b/quickstart/data_engineering/lakehouse/docker-compose.yml
@@ -1,0 +1,160 @@
+name: datus-data-engineering-lakehouse
+
+# Local S3-compatible object store plus Iceberg REST catalog for the Datus
+# data-engineering quickstart. This replaces sharing a writable DuckDB file
+# between Datus and Airflow at runtime.
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: datus-quickstart-iceberg-postgres
+    environment:
+      POSTGRES_DB: iceberg
+      POSTGRES_USER: iceberg
+      POSTGRES_PASSWORD: iceberg
+    volumes:
+      - iceberg_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U iceberg"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    networks:
+      - datus-data-engineering
+
+  minio:
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: datus-quickstart-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    networks:
+      - datus-data-engineering
+
+  minio-init:
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    container_name: datus-quickstart-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 admin password &&
+      mc mb -p local/warehouse || true
+      "
+    networks:
+      - datus-data-engineering
+
+  iceberg-rest:
+    image: tabulario/iceberg-rest:1.6.0
+    container_name: datus-quickstart-iceberg-rest
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: admin
+      AWS_SECRET_ACCESS_KEY: password
+      CATALOG_WAREHOUSE: s3://warehouse/
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://minio:9000
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"
+      CATALOG_URI: jdbc:postgresql://postgres:5432/iceberg
+      CATALOG_JDBC_USER: iceberg
+      CATALOG_JDBC_PASSWORD: iceberg
+    ports:
+      - "8181:8181"
+    networks:
+      - datus-data-engineering
+
+  seed-demo-raw:
+    image: python:3.12-slim
+    container_name: datus-quickstart-lakehouse-seed
+    depends_on:
+      iceberg-rest:
+        condition: service_started
+    volumes:
+      - ${DACOMP_HOME:?Set DACOMP_HOME to the DAComp workspace path}:/workspace:ro
+    command:
+      - bash
+      - -lc
+      - |
+        python -m pip install --no-cache-dir "duckdb>=1.5.2,<2.0.0" &&
+        python - <<'PY'
+        import time
+        import duckdb
+
+        tables = [
+            "requisition",
+            "user",
+            "requisition_posting",
+            "requisition_offer",
+        ]
+
+        con = duckdb.connect(":memory:")
+        for ext in ("httpfs", "iceberg"):
+            try:
+                con.execute(f"LOAD {ext}")
+            except Exception:
+                con.execute(f"INSTALL {ext}")
+                con.execute(f"LOAD {ext}")
+
+        con.execute("""
+            CREATE OR REPLACE SECRET datus_s3 (
+                TYPE s3,
+                KEY_ID 'admin',
+                SECRET 'password',
+                REGION 'us-east-1',
+                ENDPOINT 'minio:9000',
+                URL_STYLE 'path',
+                USE_SSL false
+            )
+        """)
+        for attempt in range(30):
+            try:
+                con.execute("""
+                    ATTACH 's3://warehouse/' AS lake (
+                        TYPE iceberg,
+                        ENDPOINT 'http://iceberg-rest:8181',
+                        AUTHORIZATION_TYPE none,
+                        ACCESS_DELEGATION_MODE none,
+                        READ_ONLY false
+                    )
+                """)
+                break
+            except Exception:
+                if attempt == 29:
+                    raise
+                time.sleep(2)
+        con.execute("ATTACH '/workspace/lever_start.duckdb' AS src (READ_ONLY)")
+        con.execute("CREATE SCHEMA IF NOT EXISTS lake.demo_raw")
+        for table in tables:
+            con.execute(f"DROP TABLE IF EXISTS lake.demo_raw.{table}")
+            con.execute(f"CREATE TABLE lake.demo_raw.{table} AS SELECT * FROM src.raw.{table}")
+        print("Seeded lake.demo_raw tables:", ", ".join(tables))
+        PY
+    networks:
+      - datus-data-engineering
+
+volumes:
+  minio_data:
+  iceberg_pg_data:
+
+networks:
+  datus-data-engineering:
+    name: datus-data-engineering

--- a/tests/unit_tests/cli/test_datasource_manager.py
+++ b/tests/unit_tests/cli/test_datasource_manager.py
@@ -111,6 +111,10 @@ class TestDatasourceManagerAdd:
             "test_duckdb",  # datasource name
             "duckdb",  # database type
             "/path/to/test.db",  # connection string
+            "False",  # read_only
+            "True",  # enable_external_access
+            "",  # memory_limit
+            "",  # iceberg
         ]
 
         nm = DatasourceManager(config_path)

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -27,6 +27,7 @@ from datus.configuration.agent_config import (
     NodeConfig,
     ServicesConfig,
     ValidationConfig,
+    _parse_single_file_db,
     file_stem_from_uri,
     load_model_config,
     resolve_env,
@@ -73,6 +74,29 @@ class TestResolveEnv:
 
     def test_no_placeholder_unchanged(self):
         assert resolve_env("plain/path/no/vars") == "plain/path/no/vars"
+
+    def test_file_db_extra_resolves_nested_env_values(self, monkeypatch):
+        monkeypatch.setenv("ICEBERG_URI", "http://iceberg-rest:8181")
+        monkeypatch.setenv("WAREHOUSE", "s3://warehouse/")
+        monkeypatch.setenv("REGION", "us-east-1")
+
+        cfg = _parse_single_file_db(
+            {
+                "uri": ":memory:",
+                "iceberg": {
+                    "catalog_uri": "${ICEBERG_URI}",
+                    "warehouse": "${WAREHOUSE}",
+                    "regions": ["${REGION}"],
+                    "tuple_value": ("${REGION}",),
+                },
+            },
+            "duckdb",
+        )
+
+        assert cfg.extra["iceberg"]["catalog_uri"] == "http://iceberg-rest:8181"
+        assert cfg.extra["iceberg"]["warehouse"] == "s3://warehouse/"
+        assert cfg.extra["iceberg"]["regions"] == ["us-east-1"]
+        assert cfg.extra["iceberg"]["tuple_value"] == ("us-east-1",)
 
 
 # ---------------------------------------------------------------------------
@@ -527,6 +551,34 @@ class TestAgentConfigServiceSelectors:
         )
         with pytest.raises(DatusException, match="No semantic layer configured"):
             cfg.build_semantic_adapter_config()
+
+    def test_file_datasource_preserves_adapter_specific_extra_fields(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {
+                    "demo_lakehouse": {
+                        "type": "duckdb",
+                        "uri": "duckdb:///:memory:",
+                        "default": True,
+                        "iceberg": {
+                            "catalog_alias": "lake",
+                            "catalog_uri": "http://127.0.0.1:8181",
+                            "warehouse": "s3://warehouse/",
+                        },
+                    }
+                }
+            },
+        )
+
+        datasource = cfg.services.datasources["demo_lakehouse"]
+        assert datasource.extra == {
+            "iceberg": {
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+            }
+        }
 
     def test_resolve_semantic_adapter_requires_explicit_choice_for_multiple_entries(self, tmp_path):
         cfg = self._make(

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -7,6 +7,7 @@ import pytest
 from datus_db_core import BaseSqlConnector, DatusDbException
 from datus_db_core import ErrorCode as DbErrorCode
 
+from datus.tools.db_tools.config import DuckDBConfig
 from datus.tools.db_tools.db_manager import (
     DBManager,
     _clean_str,
@@ -310,6 +311,44 @@ class TestDBManager:
         mgr = DBManager(configs)
         uris = mgr.get_db_uris("ns")
         assert uris["db1"] == "sqlite:///test.db"
+
+    def test_duckdb_config_includes_extra_runtime_options(self):
+        mgr = DBManager({})
+        cfg = _cfg(
+            type="duckdb",
+            uri="duckdb:///:memory:",
+            extra={
+                "read_only": "true",
+                "enable_external_access": "false",
+                "memory_limit": "2GB",
+                "iceberg": {
+                    "catalog_alias": "lake",
+                    "catalog_uri": "http://127.0.0.1:8181",
+                    "warehouse": "s3://warehouse/",
+                },
+            },
+        )
+
+        result = mgr._db_config_to_connection_config(cfg)
+
+        assert isinstance(result, DuckDBConfig)
+        assert result.db_path == ":memory:"
+        assert result.read_only is True
+        assert result.enable_external_access is False
+        assert result.memory_limit == "2GB"
+        assert result.iceberg == cfg.extra["iceberg"]
+
+    def test_close_closes_nested_multi_db_connections(self):
+        mgr = DBManager({})
+        first = MagicMock()
+        second = MagicMock()
+        mgr._conn_dict["analytics"] = {"raw": first, "mart": second}
+
+        mgr.close()
+
+        first.close.assert_called_once()
+        second.close.assert_called_once()
+        assert mgr._conn_dict["analytics"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
+++ b/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
@@ -228,7 +228,11 @@ def test_iceberg_execute_ddl_rewrites_create_or_replace_table(monkeypatch):
 
     try:
         assert result.success is True
-        assert executed[-1] == "DROP TABLE IF EXISTS lake.ws.table;\nCREATE TABLE lake.ws.table AS SELECT 1 AS x"
+        assert executed[-3:] == [
+            "BEGIN",
+            "DROP TABLE IF EXISTS lake.ws.table;\nCREATE TABLE lake.ws.table AS SELECT 1 AS x",
+            "COMMIT",
+        ]
     finally:
         connector.close()
 
@@ -264,9 +268,51 @@ def test_iceberg_execute_ddl_rewrites_quoted_create_or_replace_table(monkeypatch
 
     try:
         assert result.success is True
-        assert executed[-1] == (
-            'DROP TABLE IF EXISTS "lake"."raw"."my-table";\nCREATE TABLE "lake"."raw"."my-table" AS SELECT 1 AS x'
+        assert executed[-3:] == [
+            "BEGIN",
+            'DROP TABLE IF EXISTS "lake"."raw"."my-table";\nCREATE TABLE "lake"."raw"."my-table" AS SELECT 1 AS x',
+            "COMMIT",
+        ]
+    finally:
+        connector.close()
+
+
+def test_iceberg_execute_ddl_rewrite_rolls_back_on_create_failure(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            if sql.startswith("CREATE OR REPLACE TABLE"):
+                raise RuntimeError("CREATE OR REPLACE not supported in DuckDB-Iceberg")
+            if sql.startswith("DROP TABLE IF EXISTS"):
+                raise RuntimeError("create failed")
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+            },
         )
+    )
+
+    result = connector.execute_ddl("CREATE OR REPLACE TABLE lake.ws.table AS SELECT invalid")
+
+    try:
+        assert result.success is False
+        assert "original error: CREATE OR REPLACE not supported in DuckDB-Iceberg" in result.error
+        assert "rewrite error: create failed" in result.error
+        assert executed[-1] == "ROLLBACK"
     finally:
         connector.close()
 
@@ -465,6 +511,41 @@ def test_iceberg_create_secret_false_uses_explicit_existing_secret(monkeypatch):
         assert not any("CREATE OR REPLACE SECRET existing_iceberg_secret" in sql for sql in executed)
         attach_sql = next(sql for sql in executed if "ATTACH 'public_catalog' AS lake" in sql)
         assert "SECRET existing_iceberg_secret" in attach_sql
+    finally:
+        connector.close()
+
+
+def test_iceberg_explicit_secret_name_without_credentials_does_not_attach_uncreated_secret(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "https://catalog.example.com",
+                "warehouse": "public_catalog",
+                "secret_name": "uncreated_secret",
+            },
+        )
+    )
+    connector.connect()
+    try:
+        assert not any("CREATE OR REPLACE SECRET uncreated_secret" in sql for sql in executed)
+        attach_sql = next(sql for sql in executed if "ATTACH 'public_catalog' AS lake" in sql)
+        assert "SECRET uncreated_secret" not in attach_sql
+        assert "AUTHORIZATION_TYPE none" in attach_sql
     finally:
         connector.close()
 

--- a/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
+++ b/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
@@ -2,6 +2,7 @@
 alignment that lets datus and SQLAlchemy+duckdb_engine clients coexist."""
 
 import sys
+import types
 
 import duckdb
 import pytest
@@ -10,6 +11,13 @@ from sqlalchemy.pool import StaticPool
 
 from datus.tools.db_tools.config import DuckDBConfig
 from datus.tools.db_tools.duckdb_connector import DuckdbConnector
+from datus.utils.exceptions import DatusException
+
+
+def _fake_duckdb_engine(monkeypatch):
+    module = types.ModuleType("duckdb_engine")
+    module.__version__ = "test"
+    monkeypatch.setitem(sys.modules, "duckdb_engine", module)
 
 
 @pytest.fixture
@@ -71,3 +79,414 @@ def test_falls_back_when_duckdb_engine_missing(db_path, monkeypatch):
         assert "config" not in seen_kwargs
     finally:
         connector.close()
+
+
+def test_connect_passes_read_only(db_path, monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    seen_kwargs: dict = {}
+
+    class FakeConnection:
+        def execute(self, *_args, **_kwargs):
+            return self
+
+        def close(self):
+            pass
+
+    def spy_connect(path, **kwargs):
+        seen_kwargs["path"] = path
+        seen_kwargs.update(kwargs)
+        return FakeConnection()
+
+    monkeypatch.setattr(duckdb, "connect", spy_connect)
+
+    connector = DuckdbConnector(DuckDBConfig(db_path=db_path, read_only=True))
+    connector.connect()
+    try:
+        assert seen_kwargs["path"] == db_path
+        assert seen_kwargs["read_only"] is True
+    finally:
+        connector.close()
+
+
+def test_execute_query_arrow_counts_rows(db_path):
+    connector = DuckdbConnector(DuckDBConfig(db_path=db_path))
+    connector.execute_ddl("CREATE TABLE t AS SELECT 1 AS x UNION ALL SELECT 2 AS x")
+
+    result = connector.execute_query("SELECT * FROM t ORDER BY x", result_format="arrow")
+
+    try:
+        assert result.success is True
+        assert result.row_count == 2
+        assert result.sql_return.num_rows == 2
+    finally:
+        connector.close()
+
+
+def test_connect_sets_up_iceberg_catalog(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+                "s3_endpoint": "http://127.0.0.1:9000",
+                "s3_access_key_id": "admin",
+                "s3_secret_access_key": "password",
+                "s3_url_style": "path",
+            },
+        )
+    )
+    connector.connect()
+    try:
+        assert "LOAD httpfs" in executed
+        assert "LOAD iceberg" in executed
+        assert any("CREATE OR REPLACE SECRET datus_s3" in sql for sql in executed)
+        assert any("ATTACH 's3://warehouse/' AS lake" in sql for sql in executed)
+        assert any("READ_ONLY false" in sql for sql in executed)
+    finally:
+        connector.close()
+
+
+def test_connect_sets_up_iceberg_catalog_infers_ssl_from_https_endpoint(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+                "s3_endpoint": "https://s3.example.com",
+                "s3_access_key_id": "admin",
+                "s3_secret_access_key": "password",
+            },
+        )
+    )
+    connector.connect()
+    try:
+        secret_sql = next(sql for sql in executed if "CREATE OR REPLACE SECRET datus_s3" in sql)
+        assert "ENDPOINT 's3.example.com'" in secret_sql
+        assert "USE_SSL true" in secret_sql
+    finally:
+        connector.close()
+
+
+def test_iceberg_execute_ddl_rewrites_create_or_replace_table(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            if sql.startswith("CREATE OR REPLACE TABLE"):
+                raise RuntimeError("CREATE OR REPLACE not supported in DuckDB-Iceberg")
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+            },
+        )
+    )
+
+    result = connector.execute_ddl("CREATE OR REPLACE TABLE lake.ws.table AS SELECT 1 AS x")
+
+    try:
+        assert result.success is True
+        assert executed[-1] == "DROP TABLE IF EXISTS lake.ws.table;\nCREATE TABLE lake.ws.table AS SELECT 1 AS x"
+    finally:
+        connector.close()
+
+
+def test_iceberg_execute_ddl_rewrites_quoted_create_or_replace_table(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            if sql.startswith("CREATE OR REPLACE TABLE"):
+                raise RuntimeError("CREATE OR REPLACE not supported in DuckDB-Iceberg")
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+            },
+        )
+    )
+
+    result = connector.execute_ddl('CREATE OR REPLACE TABLE "lake"."raw"."my-table" AS SELECT 1 AS x')
+
+    try:
+        assert result.success is True
+        assert executed[-1] == (
+            'DROP TABLE IF EXISTS "lake"."raw"."my-table";\nCREATE TABLE "lake"."raw"."my-table" AS SELECT 1 AS x'
+        )
+    finally:
+        connector.close()
+
+
+def test_load_extension_reports_initial_load_error_when_retry_fails():
+    class FakeConnection:
+        def execute(self, sql):
+            if sql == "LOAD httpfs":
+                raise RuntimeError("read-only extension directory")
+            if sql == "INSTALL httpfs":
+                raise RuntimeError("install failed")
+            return self
+
+    connector = DuckdbConnector(DuckDBConfig(db_path=":memory:"))
+    connector.connection = FakeConnection()
+
+    with pytest.raises(RuntimeError, match="initial LOAD error: read-only extension directory"):
+        connector._load_extension("httpfs")
+
+
+def test_connect_sets_up_iceberg_catalog_with_credential_chain(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://example-datus-demo/warehouse/",
+                "s3_provider": "credential_chain",
+                "s3_region": "us-east-1",
+            },
+        )
+    )
+    connector.connect()
+    try:
+        secret_sql = next(sql for sql in executed if "CREATE OR REPLACE SECRET datus_s3" in sql)
+        assert "PROVIDER credential_chain" in secret_sql
+        assert "REGION 'us-east-1'" in secret_sql
+        assert "USE_SSL true" in secret_sql
+        assert "KEY_ID" not in secret_sql
+        assert "SECRET '" not in secret_sql
+        assert any("ATTACH 's3://example-datus-demo/warehouse/' AS lake" in sql for sql in executed)
+    finally:
+        connector.close()
+
+
+def test_iceberg_rejects_invalid_s3_provider(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+
+    class FakeConnection:
+        def execute(self, _sql):
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+                "s3_provider": "credential_chain; DROP SECRET datus_s3",
+            },
+        )
+    )
+
+    with pytest.raises(DatusException, match="s3_provider"):
+        connector.connect()
+
+
+def test_connect_sets_up_iceberg_catalog_with_oauth_secret(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "https://catalog.example.com",
+                "warehouse": "public_catalog",
+                "client_id": "lakehouse_user",
+                "client_secret": "user-secret",
+                "oauth2_server_uri": "https://catalog.example.com/oauth/tokens",
+                "access_delegation_mode": "vended_credentials",
+            },
+        )
+    )
+    connector.connect()
+    try:
+        secret_sql = next(sql for sql in executed if "CREATE OR REPLACE SECRET datus_iceberg" in sql)
+        assert "TYPE iceberg" in secret_sql
+        assert "CLIENT_ID 'lakehouse_user'" in secret_sql
+        assert "CLIENT_SECRET 'user-secret'" in secret_sql
+        assert "OAUTH2_SERVER_URI 'https://catalog.example.com/oauth/tokens'" in secret_sql
+        attach_sql = next(sql for sql in executed if "ATTACH 'public_catalog' AS lake" in sql)
+        assert "SECRET datus_iceberg" in attach_sql
+        assert "ACCESS_DELEGATION_MODE 'vended_credentials'" in attach_sql
+        assert "AUTHORIZATION_TYPE none" not in attach_sql
+    finally:
+        connector.close()
+
+
+def test_iceberg_create_secret_false_without_secret_name_does_not_attach_uncreated_secret(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "https://catalog.example.com",
+                "warehouse": "public_catalog",
+                "client_id": "lakehouse_user",
+                "client_secret": "user-secret",
+                "create_iceberg_secret": False,
+            },
+        )
+    )
+    connector.connect()
+    try:
+        assert not any("CREATE OR REPLACE SECRET datus_iceberg" in sql for sql in executed)
+        attach_sql = next(sql for sql in executed if "ATTACH 'public_catalog' AS lake" in sql)
+        assert "SECRET datus_iceberg" not in attach_sql
+        assert "AUTHORIZATION_TYPE none" in attach_sql
+    finally:
+        connector.close()
+
+
+def test_iceberg_create_secret_false_uses_explicit_existing_secret(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+    executed: list[str] = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            executed.append(sql)
+            return self
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "lake",
+                "catalog_uri": "https://catalog.example.com",
+                "warehouse": "public_catalog",
+                "secret_name": "existing_iceberg_secret",
+                "create_iceberg_secret": False,
+            },
+        )
+    )
+    connector.connect()
+    try:
+        assert not any("CREATE OR REPLACE SECRET existing_iceberg_secret" in sql for sql in executed)
+        attach_sql = next(sql for sql in executed if "ATTACH 'public_catalog' AS lake" in sql)
+        assert "SECRET existing_iceberg_secret" in attach_sql
+    finally:
+        connector.close()
+
+
+def test_iceberg_rejects_invalid_catalog_alias(monkeypatch):
+    _fake_duckdb_engine(monkeypatch)
+
+    class FakeConnection:
+        def execute(self, _sql):
+            return self
+
+    monkeypatch.setattr(duckdb, "connect", lambda *args, **kwargs: FakeConnection())
+
+    connector = DuckdbConnector(
+        DuckDBConfig(
+            db_path=":memory:",
+            iceberg={
+                "catalog_alias": "bad-name",
+                "catalog_uri": "http://127.0.0.1:8181",
+                "warehouse": "s3://warehouse/",
+            },
+        )
+    )
+    with pytest.raises(Exception, match="Failed to establish connection"):
+        connector.connect()

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -886,6 +886,119 @@ class TestTransferQueryResult:
         target.execute_ddl.assert_called_once()
         assert "TRUNCATE" in target.execute_ddl.call_args[0][0].upper()
 
+    def test_transfer_replace_creates_missing_target_table(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"], "is_open": [True, False]})
+        source = self._make_source_connector(df)
+        target, _ = self._make_target_connector()
+        target.execute_ddl.side_effect = [
+            Mock(success=False, error='relation "tgt.users" does not exist'),
+            Mock(success=True),
+        ]
+
+        tool = self._make_multi_tool(source, target)
+        result = tool.transfer_query_result(
+            source_sql="SELECT id, name, is_open FROM users",
+            source_datasource="source_db",
+            target_table="tgt.users",
+            target_datasource="target_db",
+            mode="replace",
+        )
+
+        assert result.success == 1
+        assert result.result["rows_transferred"] == 2
+        assert result.result["target_table_created"] is True
+        ddl_calls = [call.args[0] for call in target.execute_ddl.call_args_list]
+        assert ddl_calls[0] == "TRUNCATE TABLE tgt.users"
+        assert ddl_calls[1].startswith("CREATE TABLE tgt.users")
+        assert '"id" BIGINT' in ddl_calls[1]
+        assert '"name" TEXT' in ddl_calls[1]
+        assert '"is_open" BOOLEAN' in ddl_calls[1]
+        assert "INSERT INTO tgt.users" in target.execute_insert.call_args.args[0]
+
+    def test_transfer_replace_creates_missing_target_table_for_mysql_contraction(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"id": [1], "name": ["a"]})
+        source = self._make_source_connector(df)
+        target, _ = self._make_target_connector()
+        target.execute_ddl.side_effect = [
+            Mock(success=False, error="Table 'tgt.users' doesn't exist"),
+            Mock(success=True),
+        ]
+
+        tool = self._make_multi_tool(source, target)
+        result = tool.transfer_query_result(
+            source_sql="SELECT id, name FROM users",
+            source_datasource="source_db",
+            target_table="tgt.users",
+            target_datasource="target_db",
+            mode="replace",
+        )
+
+        assert result.success == 1
+        assert result.result["target_table_created"] is True
+        assert target.execute_ddl.call_args_list[1].args[0].startswith("CREATE TABLE tgt.users")
+
+    def test_transfer_create_target_keeps_complex_values_text_compatible(self):
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "payload": [{"a": 1}],
+                "raw_bytes": [b"abc"],
+            }
+        )
+        source = self._make_source_connector(df)
+        target, _ = self._make_target_connector()
+        target.execute_ddl.side_effect = [
+            Mock(success=False, error='relation "tgt.events" does not exist'),
+            Mock(success=True),
+        ]
+
+        tool = self._make_multi_tool(source, target)
+        result = tool.transfer_query_result(
+            source_sql="SELECT payload, raw_bytes FROM events",
+            source_datasource="source_db",
+            target_table="tgt.events",
+            target_datasource="target_db",
+            mode="replace",
+        )
+
+        assert result.success == 1
+        create_sql = target.execute_ddl.call_args_list[1].args[0]
+        assert '"payload" TEXT' in create_sql
+        assert '"raw_bytes" TEXT' in create_sql
+        assert "JSONB" not in create_sql
+        assert "BYTEA" not in create_sql
+
+    def test_transfer_replace_creates_missing_target_for_empty_result(self):
+        import pandas as pd
+
+        df = pd.DataFrame(columns=["id", "name"])
+        source = self._make_source_connector(df)
+        target, _ = self._make_target_connector()
+        target.execute_ddl.side_effect = [
+            Mock(success=False, error="no such table: tgt.users"),
+            Mock(success=True),
+        ]
+
+        tool = self._make_multi_tool(source, target)
+        result = tool.transfer_query_result(
+            source_sql="SELECT id, name FROM users WHERE 1 = 0",
+            source_datasource="source_db",
+            target_table="tgt.users",
+            target_datasource="target_db",
+            mode="replace",
+        )
+
+        assert result.success == 1
+        assert result.result["rows_transferred"] == 0
+        assert result.result["target_table_created"] is True
+        assert result.result["target_table_create_sql"].startswith("CREATE TABLE tgt.users")
+        target.execute_insert.assert_not_called()
+
     def test_transfer_append_mode_no_truncate(self):
         import pandas as pd
 

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -58,6 +58,7 @@ def _make_agent_config(scheduler_config=None, project_root="/tmp/datus_test_proj
     # ``FilesystemFuncTool``). MagicMock would otherwise return a child mock
     # that ``Path()`` cannot consume.
     cfg.project_root = project_root
+    cfg.project_name = "unit-test-workspace"
     # Match CLI default: ``filesystem_strict`` is False unless a test opts in.
     # Without this an auto-attribute MagicMock would be truthy, flipping
     # SchedulerTools into strict mode and breaking existing EXTERNAL-path tests.
@@ -623,6 +624,52 @@ class TestSubmitSqlJob:
         assert result.result["job_id"] == "sql_job_1"
         payload = mock_adapter.submit_job.call_args[0][0]
         assert payload.db_connection == {"conn_id": "starrocks_default"}
+        assert result.result["conn_id"] == "starrocks_default"
+
+    def test_submit_uses_default_sql_connection_when_conn_id_omitted(self, tmp_path):
+        sql_file = tmp_path / "query.sql"
+        sql_file.write_text("SELECT 1")
+
+        cfg = _make_agent_config()
+        cfg.scheduler_config["connections"] = {
+            "lakehouse_demo": {
+                "description": "Shared lakehouse",
+                "type": "duckdb_iceberg",
+                "default": True,
+                "capabilities": ["sql", "lakehouse"],
+            }
+        }
+        mock_job = _make_scheduled_job("sql_job_1")
+        mock_adapter = MagicMock()
+        mock_adapter.submit_job.return_value = mock_job
+        tools = SchedulerTools(cfg)
+
+        with patch.object(tools, "_get_adapter", return_value=mock_adapter):
+            result = tools.submit_sql_job(job_name="sql_job_1", sql_file_path=str(sql_file))
+
+        assert result.success == 1
+        assert result.result["conn_id"] == "lakehouse_demo"
+        payload = mock_adapter.submit_job.call_args[0][0]
+        assert payload.db_connection == {"conn_id": "lakehouse_demo"}
+
+    def test_submit_without_conn_id_errors_when_multiple_defaults(self, tmp_path):
+        sql_file = tmp_path / "query.sql"
+        sql_file.write_text("SELECT 1")
+
+        cfg = _make_agent_config()
+        cfg.scheduler_config["connections"] = {
+            "a": {"description": "A", "default": True, "capabilities": ["sql"]},
+            "b": {"description": "B", "default": True, "capabilities": ["sql"]},
+        }
+        mock_adapter = MagicMock()
+        tools = SchedulerTools(cfg)
+
+        with patch.object(tools, "_get_adapter", return_value=mock_adapter):
+            result = tools.submit_sql_job(job_name="sql_job_1", sql_file_path=str(sql_file))
+
+        assert result.success == 0
+        assert "multiple default" in (result.error or "")
+        mock_adapter.submit_job.assert_not_called()
 
     def test_missing_sql_file(self, tmp_path):
         tools = SchedulerTools(_make_agent_config())
@@ -853,6 +900,66 @@ class TestUpdateJob:
         payload = mock_adapter.update_job.call_args[0][1]
         assert payload.db_connection == {"conn_id": "starrocks_default"}
 
+    def test_update_uses_default_sql_connection_when_conn_id_omitted(self, tmp_path):
+        sql_file = tmp_path / "updated.sql"
+        sql_file.write_text("SELECT 2")
+
+        cfg = _make_agent_config()
+        cfg.scheduler_config["connections"] = {
+            "lakehouse_demo": {
+                "description": "Shared lakehouse",
+                "type": "duckdb_iceberg",
+                "default": True,
+                "capabilities": ["sql", "lakehouse"],
+            }
+        }
+        mock_job = _make_scheduled_job("dag_to_update")
+        mock_adapter = MagicMock()
+        mock_adapter.update_job.return_value = mock_job
+        tools = SchedulerTools(cfg)
+
+        with patch.object(tools, "_get_adapter", return_value=mock_adapter):
+            result = tools.update_job(
+                job_id="dag_to_update",
+                sql_file_path=str(sql_file),
+                job_name="DAG To Update",
+            )
+
+        assert result.success == 1
+        assert result.result["conn_id"] == "lakehouse_demo"
+        payload = mock_adapter.update_job.call_args[0][1]
+        assert payload.db_connection == {"conn_id": "lakehouse_demo"}
+
+    def test_update_uses_default_sql_connection_with_scalar_capability(self, tmp_path):
+        sql_file = tmp_path / "updated.sql"
+        sql_file.write_text("SELECT 2")
+
+        cfg = _make_agent_config()
+        cfg.scheduler_config["connections"] = {
+            "lakehouse_demo": {
+                "description": "Shared lakehouse",
+                "type": "duckdb_iceberg",
+                "default": True,
+                "capabilities": "sql",
+            }
+        }
+        mock_job = _make_scheduled_job("dag_to_update")
+        mock_adapter = MagicMock()
+        mock_adapter.update_job.return_value = mock_job
+        tools = SchedulerTools(cfg)
+
+        with patch.object(tools, "_get_adapter", return_value=mock_adapter):
+            result = tools.update_job(
+                job_id="dag_to_update",
+                sql_file_path=str(sql_file),
+                job_name="DAG To Update",
+            )
+
+        assert result.success == 1
+        assert result.result["conn_id"] == "lakehouse_demo"
+        payload = mock_adapter.update_job.call_args[0][1]
+        assert payload.db_connection == {"conn_id": "lakehouse_demo"}
+
     def test_update_missing_sql_file(self, tmp_path):
         tools = SchedulerTools(_make_agent_config())
         result = tools.update_job(
@@ -996,6 +1103,27 @@ class TestListSchedulerConnections:
         conn_ids = [c["conn_id"] for c in result.result["connections"]]
         assert "starrocks_default" in conn_ids
         assert "pg_conn" in conn_ids
+
+    def test_returns_structured_connection_metadata(self):
+        cfg = _make_agent_config()
+        cfg.scheduler_config["connections"] = {
+            "lakehouse_demo": {
+                "description": "Shared lakehouse",
+                "type": "duckdb_iceberg",
+                "default": True,
+                "capabilities": ["sql", "lakehouse"],
+            }
+        }
+        tools = SchedulerTools(cfg)
+        result = tools.list_scheduler_connections()
+
+        assert result.success == 1
+        conn = result.result["connections"][0]
+        assert conn["conn_id"] == "lakehouse_demo"
+        assert conn["description"] == "Shared lakehouse"
+        assert conn["type"] == "duckdb_iceberg"
+        assert conn["default"] is True
+        assert conn["capabilities"] == ["sql", "lakehouse"]
 
     def test_empty_connections(self):
         cfg = _make_agent_config()


### PR DESCRIPTION
## Why

The data-engineering quickstart used a local writable DuckDB file as the shared runtime between Datus and Airflow. That does not match the target demo flow where public raw data is exposed from an Iceberg lakehouse and downstream users write into their own working schema/database. The quickstart also required the Superset serving table to exist before `transfer_query_result(mode="replace")`, which prevented the full scenario from running cleanly end to end.

## Solution

- Add DuckDB Iceberg REST catalog support to datasource config and the DuckDB connector, including S3 settings, credential-chain support, OAuth catalog options, read-only mode, external access, memory limits, and a DuckDB-compatible fallback for unsupported Iceberg `CREATE OR REPLACE TABLE`.
- Add a local lakehouse compose stack and update the data-engineering quickstart docs to use `lake.demo_raw`, `lake.ws_lever_demo`, and the `lakehouse_demo` scheduler connection.
- Let `transfer_query_result(mode="replace")` create the target table when it is missing, then load the query result.
- Let scheduler SQL jobs resolve the single default SQL-capable connection when `conn_id` is omitted, and expose structured scheduler connection metadata.
- Include the active permission profile in chat prompts and update subagent routing guidance around deliverable ownership.
- Keep generated Airflow DAG files and `.playwright-mcp/` out of git.

## Test Cases

- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run pytest tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/cli/test_cli_styles.py tests/unit_tests/cli/test_datasource_manager.py tests/unit_tests/configuration/test_agent_config.py tests/unit_tests/tools/db_tools/test_db_manager.py tests/unit_tests/tools/db_tools/test_duckdb_connector.py tests/unit_tests/tools/func_tool/test_database.py tests/unit_tests/tools/func_tool/test_scheduler_tools.py tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py -q`
- `uv run pytest tests/unit_tests/ -m "not nightly" --cov=datus --cov-report=xml:coverage.xml --cov-fail-under=80`
- `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80`
- `uv run python ci/audit_tests.py --diff-only upstream/main` (`P0=0`; remaining findings are P1 test-size/weak-assert warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Iceberg REST catalog support for DuckDB with configurable authentication and S3 credentials
  * Automatic target table creation in data transfers when tables don't exist
  * Context manager support for database connections for improved resource cleanup

* **Improvements**
  * Enhanced DuckDB configuration with read-only mode, memory limits, and external access controls
  * Improved scheduler connection resolution with multi-datasource support
  * Better error handling and retry logic for data operations

* **Documentation**
  * Updated data engineering quickstart guide for lakehouse-centric workflow
  * Clarified data transfer replace mode behavior and target table creation

* **Dependencies**
  * Updated DuckDB version requirement to 1.5.2+
<!-- end of auto-generated comment: release notes by coderabbit.ai -->