### PR TITLE
[BugFix] Map /agent API description field to yaml agent_description key

### DIFF
--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -109,6 +109,17 @@ def sanitize_agentic_node_name(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_\-]", "_", name or "")
 
 
+def _read_description(node: dict) -> str:
+    """Read the description field from a yaml ``agentic_nodes`` entry.
+
+    The runtime (``sub_agent_task_tool``, ``agentic_node``, the wizard, etc.)
+    persists this field as ``agent_description``. Older yaml files written by
+    earlier versions of the API used ``description`` — fall back to that so
+    existing configs keep working until the next edit migrates them.
+    """
+    return node.get("agent_description") or node.get("description") or ""
+
+
 def _parse_tools(value: Any) -> list[str]:
     """Normalize the yaml ``tools`` field to a list of pattern strings.
 
@@ -279,7 +290,7 @@ class AgentService:
                     "id": agent_id,
                     "name": agent_id,
                     "type": agent_type,
-                    "description": agent.get("description", ""),
+                    "description": _read_description(agent),
                     "created_at": created_at,
                     "tools": _parse_tools(agent.get("tools")),
                     "rules": agent.get("rules") or [],
@@ -310,7 +321,7 @@ class AgentService:
                 "id": name,
                 "name": name,
                 "type": node.get("type", "gen_sql"),
-                "description": node.get("description", ""),
+                "description": _read_description(node),
             }
             for name, node in sorted(agentic_nodes.items())
         ]
@@ -352,10 +363,13 @@ class AgentService:
                 errorMessage=f"Agent '{request.name}' already exists",
             )
 
-        # Create new agent entry (dict keyed by name, which acts as the id)
+        # Create new agent entry (dict keyed by name, which acts as the id).
+        # API field ``description`` is persisted as ``agent_description`` to
+        # match what the runtime reads (sub_agent_task_tool / agentic_node /
+        # the wizard all look up ``agent_description`` from agentic_nodes).
         agent_entry = {
             "type": request.type or "gen_sql",
-            "description": request.description or "",
+            "agent_description": request.description or "",
             "tools": request.tools or [],
             "catalogs": request.catalogs or [],
             "subjects": request.subjects or [],
@@ -483,8 +497,14 @@ class AgentService:
             except Exception:
                 logger.warning(f"Failed to save prompt template for agent '{request.id}' (non-fatal)", exc_info=True)
 
-        # Update only provided fields (name is the dict key and acts as id, so exclude it)
+        # Update only provided fields (name is the dict key and acts as id, so exclude it).
+        # API ``description`` lands on the runtime-visible ``agent_description``
+        # key; drop any legacy flat ``description`` left over from older edits
+        # so the read path doesn't see two competing values.
         update_data = request.model_dump(exclude={"id", "name", "prompt_template"}, exclude_none=True)
+        if "description" in update_data:
+            update_data["agent_description"] = update_data.pop("description")
+            agent.pop("description", None)
         if not update_data and prompt_content is None:
             return Result(success=True, data={"name": request.id, "id": request.id})
 

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -455,6 +455,65 @@ class TestGetAgent:
         assert result.success is True
         assert result.data["agent"]["created_at"] == "2026-04-30T09:20:31.545000Z"
 
+    async def test_get_custom_agent_reads_description_from_agent_description_key(self, real_agent_config):
+        """yaml's ``agent_description`` key surfaces as the API ``description`` field.
+
+        The runtime stores descriptions under ``agent_description`` (read by
+        sub_agent_task_tool, agentic_node, the wizard, and Datus-backend's
+        config_loader). The /agent endpoint must surface the same key under
+        the API contract's ``description`` field so the editor reads what the
+        runtime sees.
+        """
+        real_agent_config.agentic_nodes["modern_agent"] = {
+            "type": "gen_sql",
+            "agent_description": "agent stored under the runtime-visible key",
+            "tools": "db_tools.*",
+            "created_at": "2026-04-30T09:20:31.545000Z",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("modern_agent", real_agent_config)
+        assert result.success is True
+        assert result.data["agent"]["description"] == "agent stored under the runtime-visible key"
+
+    async def test_get_custom_agent_falls_back_to_legacy_description_key(self, real_agent_config):
+        """Older yaml files stored the description under ``description``.
+
+        Until a save migrates the entry, the read path must fall back so
+        existing configs keep rendering the right text in the editor.
+        """
+        real_agent_config.agentic_nodes["legacy_agent"] = {
+            "type": "gen_sql",
+            "description": "stored under the legacy key only",
+            "tools": "db_tools.*",
+            "created_at": "2026-04-30T09:20:31.545000Z",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("legacy_agent", real_agent_config)
+        assert result.success is True
+        assert result.data["agent"]["description"] == "stored under the legacy key only"
+
+    async def test_get_custom_agent_prefers_agent_description_over_legacy(self, real_agent_config):
+        """When both keys are present, ``agent_description`` wins.
+
+        This matches the migration semantics: edit_agent writes the new key
+        and clears the legacy one, but during the transition both may briefly
+        coexist; the runtime sees ``agent_description`` so the API must too.
+        """
+        real_agent_config.agentic_nodes["mixed_agent"] = {
+            "type": "gen_sql",
+            "description": "stale legacy text",
+            "agent_description": "current text the runtime uses",
+            "tools": "db_tools.*",
+            "created_at": "2026-04-30T09:20:31.545000Z",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("mixed_agent", real_agent_config)
+        assert result.success is True
+        assert result.data["agent"]["description"] == "current text the runtime uses"
+
     async def test_get_custom_agent_created_at_falls_back_to_file_mtime(
         self, real_agent_config, agent_yml_with_singleton
     ):
@@ -546,6 +605,37 @@ class TestCreateAgent:
         created_at = get_result.data["agent"]["created_at"]
         # Either yaml stored a string (Z-suffixed) or a datetime that gets normalized
         assert created_at is not None and created_at.endswith("Z")
+
+    async def test_create_agent_persists_description_as_agent_description(
+        self, real_agent_config, agent_yml_with_singleton
+    ):
+        """API ``description`` lands on yaml's ``agent_description`` key.
+
+        The runtime (sub_agent_task_tool, agentic_node, the wizard, and the
+        saas config_loader) reads ``agent_description``. Persisting under
+        the API field name ``description`` would be invisible to the
+        runtime — this is the bug this PR fixes.
+        """
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput
+
+        svc = AgentService()
+        result = await svc.create_agent(
+            CreateAgentInput(name="desc_agent", type="gen_sql", description="hello"),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        # ConfigurationManager.save() round-trips the production ``agent:``
+        # wrapping, so the entry lives at agent.agentic_nodes.<name>.
+        entry = raw["agent"]["agentic_nodes"]["desc_agent"]
+        assert entry.get("agent_description") == "hello"
+        # The raw API field name must NOT be persisted — that would be invisible
+        # to the runtime.
+        assert "description" not in entry
 
     async def test_create_agent_invalid_tools_fails(self, real_agent_config, agent_yml_with_singleton):
         """create_agent rejects invalid tool patterns."""
@@ -727,3 +817,65 @@ class TestEditAgent:
             assert "cross_path_agent" not in (home_data.get("agent", {}).get("agentic_nodes") or {})
         finally:
             agent_config_loader.CONFIGURATION_MANAGER = None
+
+    async def test_edit_agent_persists_description_as_agent_description(
+        self, real_agent_config, agent_yml_with_singleton
+    ):
+        """edit_agent writes the API ``description`` field to ``agent_description``.
+
+        Without this mapping, the editor's update never reaches the runtime
+        (which only reads ``agent_description``).
+        """
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput, EditAgentInput
+
+        svc = AgentService()
+        await svc.create_agent(CreateAgentInput(name="edit_desc", type="gen_sql"), real_agent_config)
+        result = await svc.edit_agent(
+            EditAgentInput(id="edit_desc", name="edit_desc", description="brand new text"),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        entry = raw["agent"]["agentic_nodes"]["edit_desc"]
+        assert entry.get("agent_description") == "brand new text"
+        assert "description" not in entry
+
+    async def test_edit_agent_clears_legacy_description_key_on_write(self, real_agent_config, agent_yml_with_singleton):
+        """When yaml has both keys, edit_agent migrates by clearing the legacy one.
+
+        Older API versions wrote ``description``. The new API writes
+        ``agent_description``. If a user edits an entry that was created
+        under the old code, both keys can coexist briefly. Writing the new
+        key alone (and dropping the legacy one) prevents stale shadow data
+        from confusing future reads or downstream tools.
+        """
+        import yaml
+
+        from datus.api.models.agent_models import EditAgentInput
+
+        # Seed an entry with the legacy ``description`` key only. Inject
+        # directly into the in-memory dict so edit_agent finds it; the
+        # singleton fixture handles the on-disk yaml.
+        real_agent_config.agentic_nodes["legacy_edit"] = {
+            "type": "gen_sql",
+            "description": "old text from a previous version",
+        }
+
+        svc = AgentService()
+        result = await svc.edit_agent(
+            EditAgentInput(id="legacy_edit", name="legacy_edit", description="migrated text"),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        entry = raw["agent"]["agentic_nodes"]["legacy_edit"]
+        assert entry.get("agent_description") == "migrated text"
+        # Legacy key must be cleared so downstream readers can't pick up
+        # the old text.
+        assert "description" not in entry


### PR DESCRIPTION
## Why

Edits made through the `/agent` web editor never reached the runtime.
The runtime reads the description from yaml's `agent_description` key
in every consumer:

- `datus/tools/func_tool/sub_agent_task_tool.py` (line 929)
- `datus/agent/node/agentic_node.py` (line 757)
- `datus/agent/node/gen_sql_agentic_node.py` (line 1262)
- `datus/agent/node/gen_report_agentic_node.py` (line 323)
- `datus/cli/sub_agent_wizard.py` (multiple sites)
- `Datus-backend/datus_backend/config_loader.py` (line 743) — writes
  `\"agent_description\": sub_agent.description or \"\"` when building
  agentic_nodes for the runtime.

But the `/agent` service layer read and wrote `description`. Result:
descriptions saved through the editor lived under the wrong key and
were invisible to the agents they were meant to configure.

The API contract keeps `description` as the user-facing field (matches
the saas backend response shape); only the **persistence key** changes.

## Solution

- `get_agent` / `list_agents` read via a small `_read_description`
  helper that prefers `agent_description` and falls back to the legacy
  `description` key. Existing yaml configs continue to render correctly
  until the next edit migrates them.
- `create_agent` persists new entries under `agent_description`.
- `edit_agent` translates `EditAgentInput.description` →
  `agent_description` in `update_data`, and pops any stale flat
  `description` from the existing entry so two competing values can't
  coexist after a migration edit.

API request / response field name is unchanged (`description`).

## Test Cases

Added to `tests/unit_tests/api/services/test_agent_service.py`:

**Read side**
- `test_get_custom_agent_reads_description_from_agent_description_key` —
  modern yaml surfaces correctly.
- `test_get_custom_agent_falls_back_to_legacy_description_key` —
  pre-migration yaml still works.
- `test_get_custom_agent_prefers_agent_description_over_legacy` —
  when both keys are present (transient migration state), the
  runtime-visible one wins.

**Write side**
- `test_create_agent_persists_description_as_agent_description` —
  asserts the raw yaml has `agent_description` and no `description`.
- `test_edit_agent_persists_description_as_agent_description` — same
  guarantee for the edit path.
- `test_edit_agent_clears_legacy_description_key_on_write` — editing
  a legacy entry migrates it: new key written, old key removed.

Gates: `ruff format / check` clean · 66/66 unit tests pass · audit
P0=0/P1=0 · diff coverage 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt template operations during agent creation and editing are now more robust and non-fatal on copy errors.
  * Agent descriptions now reliably surface with fallback and migration from legacy fields; new descriptions take precedence when present.

* **Refactor**
  * Unified description handling so displayed agent descriptions are consistent across listing, reading, creating, and editing.

* **Tests**
  * Added coverage verifying description precedence, fallback, persistence, and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->