### PR TITLE
[Enhancement] Persist subagent tools as CSV and nest catalogs/subjects under scoped_context

### DIFF
--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -123,8 +123,10 @@ def _read_description(node: dict) -> str:
 def _parse_tools(value: Any) -> list[str]:
     """Normalize the yaml ``tools`` field to a list of pattern strings.
 
-    Accepts either a comma-separated string (legacy yaml form) or a list, and
-    trims surrounding whitespace from every entry. Empty entries are dropped.
+    Accepts either a comma-separated string (the canonical yaml form, which
+    the runtime in ``GenSQLAgenticNode.setup_tools`` calls ``str.split`` on)
+    or a list, and trims surrounding whitespace from every entry. Empty
+    entries are dropped.
     """
     if not value:
         return []
@@ -135,6 +137,78 @@ def _parse_tools(value: Any) -> list[str]:
     else:
         return []
     return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _format_csv(value: Any) -> str:
+    """Render a list / tuple / string into the comma-separated yaml form.
+
+    The runtime expects ``tools``, ``mcp``, and the ``scoped_context`` path
+    fields (``catalogs``, ``subjects``, ``tables``, …) as comma-separated
+    strings — ``GenSQLAgenticNode.setup_tools`` and ``ScopedContext.as_lists``
+    both rely on ``str.split(",")`` to recover the entries. Persisting these
+    as yaml lists silently breaks both call sites, so the API normalizes on
+    write.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        items = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        items = value
+    else:
+        return ""
+    cleaned = [str(item).strip() for item in items if str(item) and str(item).strip()]
+    return ", ".join(cleaned)
+
+
+def _parse_csv(value: Any) -> list[str]:
+    """Inverse of :func:`_format_csv` — split the yaml form back into a list."""
+    return _parse_tools(value)
+
+
+def _strip_leading_slashes(value: Any) -> list[str]:
+    """Trim and drop leading ``/`` from each entry in a path list.
+
+    Catalog / subject entries arrive from the editor as absolute-style paths
+    (``/Commerce/Orders/Average_Gross_Order_Value``), but the runtime stores
+    them without the leading slash so ``ScopedContext.as_lists`` and the
+    downstream lookups don't treat the slash as a separator. Normalizing on
+    write keeps both the API contract and the on-disk shape consistent —
+    ``["/A/B", "C"]`` → ``["A/B", "C"]``.
+    """
+    return [token.lstrip("/") for token in _parse_csv(value) if token.lstrip("/")]
+
+
+def _build_scoped_context(
+    base: Optional[dict],
+    *,
+    catalogs: Any = None,
+    subjects: Any = None,
+) -> Optional[dict]:
+    """Merge API-level ``catalogs`` / ``subjects`` into a ``scoped_context`` dict.
+
+    ``base`` carries any existing scoped_context payload (yaml-loaded for
+    edits, an explicit ``request.scoped_context`` for inputs that send one);
+    ``catalogs`` and ``subjects`` are the API top-level fields that this
+    helper folds into the same dict using the comma-separated yaml form.
+    Path entries are normalized via :func:`_strip_leading_slashes` so the
+    on-disk shape never carries a leading ``/``. Returns ``None`` when the
+    result would be empty so ``scoped_context`` is omitted from the on-disk
+    entry rather than persisting a useless empty block.
+
+    Passing ``None`` for ``catalogs`` / ``subjects`` leaves the corresponding
+    key untouched on ``base``; passing an empty list explicitly clears it.
+    """
+    merged: dict = dict(base) if isinstance(base, dict) else {}
+    for key, value in (("catalogs", catalogs), ("subjects", subjects)):
+        if value is None:
+            continue
+        rendered = _format_csv(_strip_leading_slashes(value))
+        if rendered:
+            merged[key] = rendered
+        else:
+            merged.pop(key, None)
+    return merged or None
 
 
 def _utc_now_iso() -> str:
@@ -283,6 +357,17 @@ class AgentService:
 
             created_at = _file_mtime_iso(configuration_manager().config_path)
 
+        # ``catalogs`` / ``subjects`` are persisted under ``scoped_context``;
+        # the read path lifts them back to the top level so the editor sees
+        # the same shape it sent on save. Legacy entries that still carry the
+        # arrays at the top level keep working until the next edit migrates
+        # them into ``scoped_context``. Leading slashes are stripped on the
+        # way out so older entries written before this normalization land in
+        # the canonical form too.
+        scoped_ctx = agent.get("scoped_context") if isinstance(agent.get("scoped_context"), dict) else {}
+        catalogs = _strip_leading_slashes(scoped_ctx.get("catalogs")) or _strip_leading_slashes(agent.get("catalogs"))
+        subjects = _strip_leading_slashes(scoped_ctx.get("subjects")) or _strip_leading_slashes(agent.get("subjects"))
+
         return Result(
             success=True,
             data={
@@ -294,8 +379,8 @@ class AgentService:
                     "created_at": created_at,
                     "tools": _parse_tools(agent.get("tools")),
                     "rules": agent.get("rules") or [],
-                    "catalogs": agent.get("catalogs") or [],
-                    "subjects": agent.get("subjects") or [],
+                    "catalogs": catalogs,
+                    "subjects": subjects,
                 }
             },
         )
@@ -367,15 +452,24 @@ class AgentService:
         # API field ``description`` is persisted as ``agent_description`` to
         # match what the runtime reads (sub_agent_task_tool / agentic_node /
         # the wizard all look up ``agent_description`` from agentic_nodes).
+        # ``tools`` is rendered as the comma-separated yaml form expected by
+        # ``GenSQLAgenticNode.setup_tools``; ``catalogs`` / ``subjects`` are
+        # nested under ``scoped_context`` so a single block describes the
+        # subagent's full reference scope.
         agent_entry = {
             "type": request.type or "gen_sql",
             "agent_description": request.description or "",
-            "tools": request.tools or [],
-            "catalogs": request.catalogs or [],
-            "subjects": request.subjects or [],
+            "tools": _format_csv(request.tools),
             "rules": request.rules or [],
             "created_at": _utc_now_iso(),
         }
+        scoped_ctx = _build_scoped_context(
+            base=None,
+            catalogs=request.catalogs,
+            subjects=request.subjects,
+        )
+        if scoped_ctx:
+            agent_entry["scoped_context"] = scoped_ctx
         if request.prompt_template:
             agent_entry["prompt_template"] = request.prompt_template
         if request.prompt_version:
@@ -505,6 +599,40 @@ class AgentService:
         if "description" in update_data:
             update_data["agent_description"] = update_data.pop("description")
             agent.pop("description", None)
+
+        # ``tools`` is persisted as the comma-separated yaml form expected by
+        # ``GenSQLAgenticNode.setup_tools`` (which calls ``str.split(",")``).
+        if "tools" in update_data:
+            update_data["tools"] = _format_csv(update_data["tools"])
+
+        # ``catalogs`` / ``subjects`` are folded into ``scoped_context`` so the
+        # whole reference scope lives in a single nested block. The merge
+        # preserves yaml-loaded keys (``tables`` / ``metrics`` / ``sqls`` /
+        # ``ext_knowledge``) and any explicit ``scoped_context`` payload the
+        # caller sent. Top-level ``catalogs`` / ``subjects`` from older edits
+        # are also dropped so the read path doesn't see two competing copies.
+        catalogs_input = update_data.pop("catalogs", None)
+        subjects_input = update_data.pop("subjects", None)
+        if catalogs_input is not None or subjects_input is not None or "scoped_context" in update_data:
+            base_ctx: dict = {}
+            existing = agent.get("scoped_context")
+            if isinstance(existing, dict):
+                base_ctx.update(existing)
+            request_ctx = update_data.pop("scoped_context", None)
+            if isinstance(request_ctx, dict):
+                base_ctx.update(request_ctx)
+            merged = _build_scoped_context(
+                base=base_ctx,
+                catalogs=catalogs_input,
+                subjects=subjects_input,
+            )
+            if merged:
+                update_data["scoped_context"] = merged
+            else:
+                agent.pop("scoped_context", None)
+            agent.pop("catalogs", None)
+            agent.pop("subjects", None)
+
         if not update_data and prompt_content is None:
             return Result(success=True, data={"name": request.id, "id": request.id})
 

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -179,35 +179,186 @@ def _strip_leading_slashes(value: Any) -> list[str]:
     return [token.lstrip("/") for token in _parse_csv(value) if token.lstrip("/")]
 
 
+# Keys inside ``scoped_context`` that hold subject-tree path entries. ``subjects``
+# in the API payload is a flattened union of all three; the runtime stores them
+# split because each store (metrics, reference SQL, ext_knowledge) owns its own
+# scope filter.
+_SUBJECT_BUCKET_KEYS: tuple[str, ...] = ("metrics", "sqls", "ext_knowledge")
+
+
+def _path_to_slash_form(token: str) -> str:
+    """Render a stored subject token (``A.B.C`` or ``A/B/C``) as ``A/B/C``.
+
+    Existing subagent yaml may carry the wizard's dot-form
+    (``finance.revenue.daily_revenue``) or the API's slash-form
+    (``finance/revenue/daily_revenue``); the runtime accepts both via
+    ``ScopedFilterBuilder.build_subject_filter`` (which does
+    ``token.replace("/", ".")`` then ``split_reference_path``). The API
+    contract surfaces them as slash paths, so the read path normalizes
+    every stored token through here.
+    """
+    from datus.utils.reference_paths import split_reference_path
+
+    parts = split_reference_path(token.replace("/", "."))
+    return "/".join(parts)
+
+
+def _classify_subject_paths(
+    agent_config: AgentConfig,
+    subject_paths: list[str],
+    datasource_id: Optional[str] = None,
+) -> dict[str, list[str]]:
+    """Bucket subject paths into ``metrics`` / ``sqls`` / ``ext_knowledge``.
+
+    The API surfaces a single ``subjects`` array that's the merged union of
+    all entries the editor's subject-tree exposes (Metrics, Reference SQLs,
+    Knowledge — see ``ExplorerService.get_subject_list``). The runtime
+    expects them split: ``ScopedContext.metrics`` / ``.sqls`` /
+    ``.ext_knowledge`` each drive an independent scope filter.
+
+    For every input path:
+
+    1. Resolve the parent subject node via ``SubjectTreeStore.get_node_by_path``.
+    2. Probe the metric / reference-sql / ext-knowledge stores for an entry
+       named ``parts[-1]`` under that node.
+    3. Bucket on the first store that owns the name.
+
+    Paths that don't resolve land in ``metrics`` so the user's selection is
+    never silently dropped. If the storage layer can't be initialized at all
+    (no datasource bound, registry unavailable, etc.) every path falls back
+    to ``metrics`` and a warning is logged — the editor's input survives the
+    round-trip even when the project hasn't bootstrapped its KB yet.
+    """
+    buckets: dict[str, list[str]] = {key: [] for key in _SUBJECT_BUCKET_KEYS}
+    if not subject_paths:
+        return buckets
+
+    try:
+        from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
+        from datus.storage.metric.store import MetricRAG
+        from datus.storage.reference_sql.store import ReferenceSqlRAG
+        from datus.storage.registry import get_subject_tree_store
+        from datus.utils.reference_paths import split_reference_path
+    except ImportError:
+        logger.warning(
+            "Subject classification skipped — storage modules unavailable; routing all subjects to 'metrics'"
+        )
+        buckets["metrics"] = list(subject_paths)
+        return buckets
+
+    ds = datasource_id or getattr(agent_config, "current_datasource", None)
+    if not ds:
+        logger.warning(
+            "Subject classification skipped — no datasource bound on AgentConfig; routing all subjects to 'metrics'"
+        )
+        buckets["metrics"] = list(subject_paths)
+        return buckets
+
+    try:
+        subject_tree = get_subject_tree_store(project=agent_config.project_name)
+        metric_storage = MetricRAG(agent_config, datasource_id=ds).storage
+        sql_storage = ReferenceSqlRAG(agent_config, datasource_id=ds).reference_sql_storage
+        knowledge_storage = ExtKnowledgeRAG(agent_config, datasource_id=ds).store
+    except Exception:
+        logger.warning("Subject classification storage init failed — routing all subjects to 'metrics'", exc_info=True)
+        buckets["metrics"] = list(subject_paths)
+        return buckets
+
+    probes: tuple[tuple[str, Any], ...] = (
+        ("metrics", metric_storage),
+        ("sqls", sql_storage),
+        ("ext_knowledge", knowledge_storage),
+    )
+
+    for path in subject_paths:
+        normalized = path.replace("/", ".")
+        parts = split_reference_path(normalized)
+        if not parts:
+            continue
+        parent_path, name = parts[:-1], parts[-1]
+
+        parent_node = None
+        if parent_path:
+            try:
+                parent_node = subject_tree.get_node_by_path(parent_path)
+            except Exception:
+                parent_node = None
+        node_id = parent_node.get("node_id") if isinstance(parent_node, dict) else None
+
+        bucket: Optional[str] = None
+        if node_id is not None:
+            for candidate, storage in probes:
+                try:
+                    matched = storage.list_entries(node_id, name=name, limit=1)
+                except Exception:
+                    matched = None
+                if matched:
+                    bucket = candidate
+                    break
+
+        buckets[bucket or "metrics"].append(path)
+
+    return buckets
+
+
+def _merge_subjects_from_scoped_context(scoped_ctx: Optional[dict]) -> list[str]:
+    """Flatten ``metrics`` / ``sqls`` / ``ext_knowledge`` back into one list.
+
+    Mirrors the inverse of :func:`_classify_subject_paths` — every stored
+    bucket entry is normalized to slash-form (so wizard-written dot-form
+    entries like ``finance.revenue.daily_revenue`` come back as
+    ``finance/revenue/daily_revenue``) and entries are deduped while
+    preserving insertion order.
+    """
+    if not isinstance(scoped_ctx, dict):
+        return []
+    merged: list[str] = []
+    seen: set[str] = set()
+    for key in _SUBJECT_BUCKET_KEYS:
+        for token in _parse_csv(scoped_ctx.get(key)):
+            normalized = _path_to_slash_form(token)
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                merged.append(normalized)
+    return merged
+
+
 def _build_scoped_context(
     base: Optional[dict],
     *,
     catalogs: Any = None,
-    subjects: Any = None,
+    subject_buckets: Optional[dict[str, list[str]]] = None,
 ) -> Optional[dict]:
-    """Merge API-level ``catalogs`` / ``subjects`` into a ``scoped_context`` dict.
+    """Merge API-level ``catalogs`` / classified subject buckets into ``scoped_context``.
 
     ``base`` carries any existing scoped_context payload (yaml-loaded for
-    edits, an explicit ``request.scoped_context`` for inputs that send one);
-    ``catalogs`` and ``subjects`` are the API top-level fields that this
-    helper folds into the same dict using the comma-separated yaml form.
-    Path entries are normalized via :func:`_strip_leading_slashes` so the
-    on-disk shape never carries a leading ``/``. Returns ``None`` when the
-    result would be empty so ``scoped_context`` is omitted from the on-disk
-    entry rather than persisting a useless empty block.
+    edits, an explicit ``request.scoped_context`` for inputs that send one).
+    ``catalogs`` is folded in as a comma-separated string. ``subject_buckets``
+    — pre-classified by :func:`_classify_subject_paths` — are written to the
+    runtime-visible ``metrics`` / ``sqls`` / ``ext_knowledge`` keys; passing
+    a non-``None`` ``subject_buckets`` rewrites all three bucket keys (an
+    empty bucket clears its key), so the API contract is "the caller's
+    ``subjects`` list is the new full scope."
 
-    Passing ``None`` for ``catalogs`` / ``subjects`` leaves the corresponding
-    key untouched on ``base``; passing an empty list explicitly clears it.
+    Returns ``None`` when the merged dict would be empty.
     """
     merged: dict = dict(base) if isinstance(base, dict) else {}
-    for key, value in (("catalogs", catalogs), ("subjects", subjects)):
-        if value is None:
-            continue
-        rendered = _format_csv(_strip_leading_slashes(value))
+
+    if catalogs is not None:
+        rendered = _format_csv(_strip_leading_slashes(catalogs))
         if rendered:
-            merged[key] = rendered
+            merged["catalogs"] = rendered
         else:
-            merged.pop(key, None)
+            merged.pop("catalogs", None)
+
+    if subject_buckets is not None:
+        for key in _SUBJECT_BUCKET_KEYS:
+            rendered = _format_csv(_strip_leading_slashes(subject_buckets.get(key, [])))
+            if rendered:
+                merged[key] = rendered
+            else:
+                merged.pop(key, None)
+
     return merged or None
 
 
@@ -357,16 +508,21 @@ class AgentService:
 
             created_at = _file_mtime_iso(configuration_manager().config_path)
 
-        # ``catalogs`` / ``subjects`` are persisted under ``scoped_context``;
-        # the read path lifts them back to the top level so the editor sees
-        # the same shape it sent on save. Legacy entries that still carry the
-        # arrays at the top level keep working until the next edit migrates
-        # them into ``scoped_context``. Leading slashes are stripped on the
-        # way out so older entries written before this normalization land in
-        # the canonical form too.
+        # ``catalogs`` is persisted under ``scoped_context.catalogs``;
+        # ``subjects`` is recomposed from the three runtime buckets
+        # (``metrics`` / ``sqls`` / ``ext_knowledge``) — the inverse of the
+        # save-side classification. Legacy entries that still carry the
+        # arrays at the top level (older API writes) keep working until the
+        # next edit migrates them. Leading slashes are stripped so older
+        # entries written before this normalization land in the canonical
+        # form too, and stored dot-form (wizard convention) is converted to
+        # the API's slash-form on the way out.
         scoped_ctx = agent.get("scoped_context") if isinstance(agent.get("scoped_context"), dict) else {}
         catalogs = _strip_leading_slashes(scoped_ctx.get("catalogs")) or _strip_leading_slashes(agent.get("catalogs"))
-        subjects = _strip_leading_slashes(scoped_ctx.get("subjects")) or _strip_leading_slashes(agent.get("subjects"))
+        subjects = _merge_subjects_from_scoped_context(scoped_ctx)
+        if not subjects:
+            subjects = [_path_to_slash_form(t) for t in _strip_leading_slashes(agent.get("subjects"))]
+            subjects = [s for s in subjects if s]
 
         return Result(
             success=True,
@@ -463,10 +619,19 @@ class AgentService:
             "rules": request.rules or [],
             "created_at": _utc_now_iso(),
         }
+        subject_buckets = (
+            _classify_subject_paths(
+                agent_config,
+                _strip_leading_slashes(request.subjects),
+                datasource_id=request.datasource_id or None,
+            )
+            if request.subjects
+            else None
+        )
         scoped_ctx = _build_scoped_context(
             base=None,
             catalogs=request.catalogs,
-            subjects=request.subjects,
+            subject_buckets=subject_buckets,
         )
         if scoped_ctx:
             agent_entry["scoped_context"] = scoped_ctx
@@ -605,12 +770,15 @@ class AgentService:
         if "tools" in update_data:
             update_data["tools"] = _format_csv(update_data["tools"])
 
-        # ``catalogs`` / ``subjects`` are folded into ``scoped_context`` so the
-        # whole reference scope lives in a single nested block. The merge
-        # preserves yaml-loaded keys (``tables`` / ``metrics`` / ``sqls`` /
-        # ``ext_knowledge``) and any explicit ``scoped_context`` payload the
-        # caller sent. Top-level ``catalogs`` / ``subjects`` from older edits
-        # are also dropped so the read path doesn't see two competing copies.
+        # ``catalogs`` is folded in as a single ``scoped_context.catalogs`` key.
+        # ``subjects`` is *classified* (via the metric / reference-sql /
+        # ext-knowledge stores) and split across the runtime-visible
+        # ``metrics`` / ``sqls`` / ``ext_knowledge`` keys, since
+        # ``ScopedContext`` doesn't have a flat ``subjects`` field — each
+        # store owns its own scope filter. Pre-existing keys (``tables`` and
+        # any other yaml-loaded scoped_context payload) survive the merge.
+        # Top-level ``catalogs`` / ``subjects`` from older edits are dropped
+        # so the read path can't see two competing copies.
         catalogs_input = update_data.pop("catalogs", None)
         subjects_input = update_data.pop("subjects", None)
         if catalogs_input is not None or subjects_input is not None or "scoped_context" in update_data:
@@ -621,10 +789,16 @@ class AgentService:
             request_ctx = update_data.pop("scoped_context", None)
             if isinstance(request_ctx, dict):
                 base_ctx.update(request_ctx)
+            subject_buckets = None
+            if subjects_input is not None:
+                subject_buckets = _classify_subject_paths(
+                    agent_config,
+                    _strip_leading_slashes(subjects_input),
+                )
             merged = _build_scoped_context(
                 base=base_ctx,
                 catalogs=catalogs_input,
-                subjects=subjects_input,
+                subject_buckets=subject_buckets,
             )
             if merged:
                 update_data["scoped_context"] = merged

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -804,13 +804,22 @@ class AgentService:
             request_ctx = update_data.pop("scoped_context", None)
             if isinstance(request_ctx, dict):
                 base_ctx.update(request_ctx)
+            # Resolve the effective datasource *before* classification: if
+            # ``agent_config.current_datasource`` is unset but the agent
+            # already has a saved binding under ``scoped_context.datasource``,
+            # the classifier must use the saved DS to look up entries in the
+            # right metric / sql / ext_knowledge stores. Otherwise it would
+            # fall back to "no datasource → all metrics" and silently
+            # mis-bucket subjects against a binding that's about to be
+            # re-persisted by ``_build_scoped_context``.
+            datasource = getattr(agent_config, "current_datasource", "") or base_ctx.get("datasource") or ""
             subject_buckets = None
             if subjects_input is not None:
                 subject_buckets = _classify_subject_paths(
                     agent_config,
                     list(subjects_input),
+                    datasource_id=datasource or None,
                 )
-            datasource = getattr(agent_config, "current_datasource", "") or base_ctx.get("datasource") or ""
             merged = _build_scoped_context(
                 base=base_ctx,
                 datasource=datasource,

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -179,28 +179,11 @@ def _strip_leading_slashes(value: Any) -> list[str]:
     return [token.lstrip("/") for token in _parse_csv(value) if token.lstrip("/")]
 
 
-# Keys inside ``scoped_context`` that hold subject-tree path entries. ``subjects``
-# in the API payload is a flattened union of all three; the runtime stores them
+# Keys inside ``scoped_context`` that hold subject-tree path entries. The API's
+# flat ``subjects`` array is the union of all three; the runtime stores them
 # split because each store (metrics, reference SQL, ext_knowledge) owns its own
 # scope filter.
 _SUBJECT_BUCKET_KEYS: tuple[str, ...] = ("metrics", "sqls", "ext_knowledge")
-
-
-def _path_to_slash_form(token: str) -> str:
-    """Render a stored subject token (``A.B.C`` or ``A/B/C``) as ``A/B/C``.
-
-    Existing subagent yaml may carry the wizard's dot-form
-    (``finance.revenue.daily_revenue``) or the API's slash-form
-    (``finance/revenue/daily_revenue``); the runtime accepts both via
-    ``ScopedFilterBuilder.build_subject_filter`` (which does
-    ``token.replace("/", ".")`` then ``split_reference_path``). The API
-    contract surfaces them as slash paths, so the read path normalizes
-    every stored token through here.
-    """
-    from datus.utils.reference_paths import split_reference_path
-
-    parts = split_reference_path(token.replace("/", "."))
-    return "/".join(parts)
 
 
 def _classify_subject_paths(
@@ -210,18 +193,21 @@ def _classify_subject_paths(
 ) -> dict[str, list[str]]:
     """Bucket subject paths into ``metrics`` / ``sqls`` / ``ext_knowledge``.
 
-    The API surfaces a single ``subjects`` array that's the merged union of
-    all entries the editor's subject-tree exposes (Metrics, Reference SQLs,
-    Knowledge — see ``ExplorerService.get_subject_list``). The runtime
-    expects them split: ``ScopedContext.metrics`` / ``.sqls`` /
-    ``.ext_knowledge`` each drive an independent scope filter.
+    The API surfaces a single ``subjects`` array — dot-separated paths like
+    ``Commerce.Orders.Average_Order_Value.average_gross_order_value`` — that's
+    the merged union of all entries the editor's subject-tree exposes
+    (Metrics, Reference SQLs, Knowledge — see
+    ``ExplorerService.get_subject_list``). The runtime expects them split:
+    ``ScopedContext.metrics`` / ``.sqls`` / ``.ext_knowledge`` each drive an
+    independent scope filter.
 
     For every input path:
 
-    1. Resolve the parent subject node via ``SubjectTreeStore.get_node_by_path``.
-    2. Probe the metric / reference-sql / ext-knowledge stores for an entry
+    1. Split via ``split_reference_path`` (handles quoted segments).
+    2. Resolve the parent subject node via ``SubjectTreeStore.get_node_by_path``.
+    3. Probe the metric / reference-sql / ext-knowledge stores for an entry
        named ``parts[-1]`` under that node.
-    3. Bucket on the first store that owns the name.
+    4. Bucket on the first store that owns the name.
 
     Paths that don't resolve land in ``metrics`` so the user's selection is
     never silently dropped. If the storage layer can't be initialized at all
@@ -271,8 +257,7 @@ def _classify_subject_paths(
     )
 
     for path in subject_paths:
-        normalized = path.replace("/", ".")
-        parts = split_reference_path(normalized)
+        parts = split_reference_path(path)
         if not parts:
             continue
         parent_path, name = parts[:-1], parts[-1]
@@ -304,10 +289,8 @@ def _classify_subject_paths(
 def _merge_subjects_from_scoped_context(scoped_ctx: Optional[dict]) -> list[str]:
     """Flatten ``metrics`` / ``sqls`` / ``ext_knowledge`` back into one list.
 
-    Mirrors the inverse of :func:`_classify_subject_paths` — every stored
-    bucket entry is normalized to slash-form (so wizard-written dot-form
-    entries like ``finance.revenue.daily_revenue`` come back as
-    ``finance/revenue/daily_revenue``) and entries are deduped while
+    Inverse of :func:`_classify_subject_paths`. Stored entries are returned
+    verbatim (canonical dot-separated form), with duplicates dropped while
     preserving insertion order.
     """
     if not isinstance(scoped_ctx, dict):
@@ -316,10 +299,9 @@ def _merge_subjects_from_scoped_context(scoped_ctx: Optional[dict]) -> list[str]
     seen: set[str] = set()
     for key in _SUBJECT_BUCKET_KEYS:
         for token in _parse_csv(scoped_ctx.get(key)):
-            normalized = _path_to_slash_form(token)
-            if normalized and normalized not in seen:
-                seen.add(normalized)
-                merged.append(normalized)
+            if token and token not in seen:
+                seen.add(token)
+                merged.append(token)
     return merged
 
 
@@ -377,7 +359,7 @@ def _build_scoped_context(
 
     if subject_buckets is not None:
         for key in _SUBJECT_BUCKET_KEYS:
-            rendered = _format_csv(_strip_leading_slashes(subject_buckets.get(key, [])))
+            rendered = _format_csv(subject_buckets.get(key, []))
             if rendered:
                 merged[key] = rendered
             else:
@@ -645,7 +627,7 @@ class AgentService:
         subject_buckets = (
             _classify_subject_paths(
                 agent_config,
-                _strip_leading_slashes(request.subjects),
+                list(request.subjects),
                 datasource_id=datasource or None,
             )
             if request.subjects
@@ -820,7 +802,7 @@ class AgentService:
             if subjects_input is not None:
                 subject_buckets = _classify_subject_paths(
                     agent_config,
-                    _strip_leading_slashes(subjects_input),
+                    list(subjects_input),
                 )
             datasource = getattr(agent_config, "current_datasource", "") or base_ctx.get("datasource") or ""
             merged = _build_scoped_context(

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -790,6 +790,12 @@ class AgentService:
         catalogs_input = update_data.pop("catalogs", None)
         subjects_input = update_data.pop("subjects", None)
         scope_touched = catalogs_input is not None or subjects_input is not None or "scoped_context" in update_data
+        # Tracks deletions applied directly to ``agent`` (the live yaml dict)
+        # rather than through ``update_data``. ``agent.update(update_data)``
+        # below can't represent a key removal, so we have to bypass the
+        # ``not update_data`` short-circuit and force ``_save_agentic_nodes``
+        # to run when the only mutation was a pop.
+        agent_dict_mutated = False
         if scope_touched:
             base_ctx: dict = {}
             existing = agent.get("scoped_context")
@@ -813,12 +819,17 @@ class AgentService:
             )
             if merged:
                 update_data["scoped_context"] = merged
-            else:
-                agent.pop("scoped_context", None)
-            agent.pop("catalogs", None)
-            agent.pop("subjects", None)
+            elif agent.pop("scoped_context", None) is not None:
+                # Scope was fully cleared — record the deletion so the
+                # subsequent save persists it instead of leaving the old
+                # block on disk.
+                agent_dict_mutated = True
+            if agent.pop("catalogs", None) is not None:
+                agent_dict_mutated = True
+            if agent.pop("subjects", None) is not None:
+                agent_dict_mutated = True
 
-        if not update_data and prompt_content is None:
+        if not update_data and prompt_content is None and not agent_dict_mutated:
             return Result(success=True, data={"name": request.id, "id": request.id})
 
         # Merge update data into the agent entry

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -536,23 +536,11 @@ class AgentService:
         # runtime-honored key consumed by ``ScopedFilterBuilder.build_table_filter``).
         # ``subjects`` is recomposed from the three runtime buckets
         # (``metrics`` / ``sqls`` / ``ext_knowledge``) — the inverse of the
-        # save-side classification. Legacy entries that still carry the
-        # arrays at the top level (older API writes) or under a non-runtime
-        # ``scoped_context.catalogs`` key (intermediate API versions) keep
-        # working until the next edit migrates them. Leading slashes are
-        # stripped so older entries land in the canonical form too, and
-        # stored dot-form (wizard convention) is converted to the API's
-        # slash-form on the way out.
+        # save-side classification. Stored dot-form (wizard convention) is
+        # converted to the API's slash-form on the way out.
         scoped_ctx = agent.get("scoped_context") if isinstance(agent.get("scoped_context"), dict) else {}
-        catalogs = (
-            _strip_leading_slashes(scoped_ctx.get("tables"))
-            or _strip_leading_slashes(scoped_ctx.get("catalogs"))
-            or _strip_leading_slashes(agent.get("catalogs"))
-        )
+        catalogs = _strip_leading_slashes(scoped_ctx.get("tables"))
         subjects = _merge_subjects_from_scoped_context(scoped_ctx)
-        if not subjects:
-            subjects = [_path_to_slash_form(t) for t in _strip_leading_slashes(agent.get("subjects"))]
-            subjects = [s for s in subjects if s]
 
         return Result(
             success=True,

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -326,30 +326,54 @@ def _merge_subjects_from_scoped_context(scoped_ctx: Optional[dict]) -> list[str]
 def _build_scoped_context(
     base: Optional[dict],
     *,
+    datasource: Optional[str] = None,
     catalogs: Any = None,
     subject_buckets: Optional[dict[str, list[str]]] = None,
 ) -> Optional[dict]:
-    """Merge API-level ``catalogs`` / classified subject buckets into ``scoped_context``.
+    """Merge API-level fields into a runtime-shaped ``scoped_context`` dict.
 
     ``base`` carries any existing scoped_context payload (yaml-loaded for
     edits, an explicit ``request.scoped_context`` for inputs that send one).
-    ``catalogs`` is folded in as a comma-separated string. ``subject_buckets``
-    — pre-classified by :func:`_classify_subject_paths` — are written to the
-    runtime-visible ``metrics`` / ``sqls`` / ``ext_knowledge`` keys; passing
-    a non-``None`` ``subject_buckets`` rewrites all three bucket keys (an
-    empty bucket clears its key), so the API contract is "the caller's
-    ``subjects`` list is the new full scope."
+
+    ``ScopedContext`` (``datus/schemas/agent_models.py``) only defines
+    ``datasource`` / ``tables`` / ``metrics`` / ``sqls`` / ``ext_knowledge``;
+    the API's ``catalogs`` array is the editor's name for the same scope as
+    runtime ``tables`` (catalog/database/schema/table identifiers consumed by
+    ``ScopedFilterBuilder.build_table_filter``), so this helper writes
+    ``catalogs`` into ``scoped_context.tables`` and never persists a
+    non-runtime ``catalogs`` key. Stale ``catalogs`` keys from earlier
+    versions of this API are dropped on write.
+
+    ``datasource`` mirrors the wizard's behavior — saving a subagent always
+    binds it to the active datasource so ``SubAgentConfig.is_in_datasource``
+    can gate at runtime. Passing an empty string clears the binding;
+    ``None`` leaves the existing value intact.
+
+    ``subject_buckets`` (pre-classified by :func:`_classify_subject_paths`)
+    are written to the runtime-visible ``metrics`` / ``sqls`` /
+    ``ext_knowledge`` keys; passing a non-``None`` ``subject_buckets``
+    rewrites all three bucket keys (an empty bucket clears its key), so the
+    API contract is "the caller's ``subjects`` list is the new full scope."
 
     Returns ``None`` when the merged dict would be empty.
     """
     merged: dict = dict(base) if isinstance(base, dict) else {}
 
+    if datasource is not None:
+        if datasource:
+            merged["datasource"] = datasource
+        else:
+            merged.pop("datasource", None)
+
     if catalogs is not None:
+        # Drop any non-runtime ``catalogs`` key written by earlier API versions —
+        # only ``tables`` is honored by ``ScopedFilterBuilder.build_table_filter``.
+        merged.pop("catalogs", None)
         rendered = _format_csv(_strip_leading_slashes(catalogs))
         if rendered:
-            merged["catalogs"] = rendered
+            merged["tables"] = rendered
         else:
-            merged.pop("catalogs", None)
+            merged.pop("tables", None)
 
     if subject_buckets is not None:
         for key in _SUBJECT_BUCKET_KEYS:
@@ -508,17 +532,23 @@ class AgentService:
 
             created_at = _file_mtime_iso(configuration_manager().config_path)
 
-        # ``catalogs`` is persisted under ``scoped_context.catalogs``;
+        # The API ``catalogs`` field maps to ``scoped_context.tables`` (the
+        # runtime-honored key consumed by ``ScopedFilterBuilder.build_table_filter``).
         # ``subjects`` is recomposed from the three runtime buckets
         # (``metrics`` / ``sqls`` / ``ext_knowledge``) — the inverse of the
         # save-side classification. Legacy entries that still carry the
-        # arrays at the top level (older API writes) keep working until the
-        # next edit migrates them. Leading slashes are stripped so older
-        # entries written before this normalization land in the canonical
-        # form too, and stored dot-form (wizard convention) is converted to
-        # the API's slash-form on the way out.
+        # arrays at the top level (older API writes) or under a non-runtime
+        # ``scoped_context.catalogs`` key (intermediate API versions) keep
+        # working until the next edit migrates them. Leading slashes are
+        # stripped so older entries land in the canonical form too, and
+        # stored dot-form (wizard convention) is converted to the API's
+        # slash-form on the way out.
         scoped_ctx = agent.get("scoped_context") if isinstance(agent.get("scoped_context"), dict) else {}
-        catalogs = _strip_leading_slashes(scoped_ctx.get("catalogs")) or _strip_leading_slashes(agent.get("catalogs"))
+        catalogs = (
+            _strip_leading_slashes(scoped_ctx.get("tables"))
+            or _strip_leading_slashes(scoped_ctx.get("catalogs"))
+            or _strip_leading_slashes(agent.get("catalogs"))
+        )
         subjects = _merge_subjects_from_scoped_context(scoped_ctx)
         if not subjects:
             subjects = [_path_to_slash_form(t) for t in _strip_leading_slashes(agent.get("subjects"))]
@@ -619,17 +649,23 @@ class AgentService:
             "rules": request.rules or [],
             "created_at": _utc_now_iso(),
         }
+        # Bind the subagent to the active datasource (mirrors the wizard so
+        # ``SubAgentConfig.is_in_datasource`` can gate task delegation at runtime).
+        # ``request.datasource_id`` wins when set; otherwise fall back to the
+        # AgentConfig's current datasource.
+        datasource = request.datasource_id or getattr(agent_config, "current_datasource", "") or ""
         subject_buckets = (
             _classify_subject_paths(
                 agent_config,
                 _strip_leading_slashes(request.subjects),
-                datasource_id=request.datasource_id or None,
+                datasource_id=datasource or None,
             )
             if request.subjects
             else None
         )
         scoped_ctx = _build_scoped_context(
             base=None,
+            datasource=datasource,
             catalogs=request.catalogs,
             subject_buckets=subject_buckets,
         )
@@ -770,18 +806,21 @@ class AgentService:
         if "tools" in update_data:
             update_data["tools"] = _format_csv(update_data["tools"])
 
-        # ``catalogs`` is folded in as a single ``scoped_context.catalogs`` key.
-        # ``subjects`` is *classified* (via the metric / reference-sql /
-        # ext-knowledge stores) and split across the runtime-visible
-        # ``metrics`` / ``sqls`` / ``ext_knowledge`` keys, since
-        # ``ScopedContext`` doesn't have a flat ``subjects`` field — each
-        # store owns its own scope filter. Pre-existing keys (``tables`` and
-        # any other yaml-loaded scoped_context payload) survive the merge.
-        # Top-level ``catalogs`` / ``subjects`` from older edits are dropped
-        # so the read path can't see two competing copies.
+        # The API ``catalogs`` field maps to ``scoped_context.tables`` — that's
+        # the runtime-honored key consumed by
+        # ``ScopedFilterBuilder.build_table_filter``. ``subjects`` is *classified*
+        # (via the metric / reference-sql / ext-knowledge stores) and split
+        # across the runtime-visible ``metrics`` / ``sqls`` / ``ext_knowledge``
+        # keys, since ``ScopedContext`` has no flat ``subjects`` field. Editing
+        # any scope-related field also rewrites ``scoped_context.datasource`` to
+        # the active datasource so ``SubAgentConfig.is_in_datasource`` agrees
+        # with the saved binding. Pre-existing yaml-loaded scoped_context keys
+        # survive the merge; top-level ``catalogs`` / ``subjects`` from older
+        # edits are dropped so the read path can't see two competing copies.
         catalogs_input = update_data.pop("catalogs", None)
         subjects_input = update_data.pop("subjects", None)
-        if catalogs_input is not None or subjects_input is not None or "scoped_context" in update_data:
+        scope_touched = catalogs_input is not None or subjects_input is not None or "scoped_context" in update_data
+        if scope_touched:
             base_ctx: dict = {}
             existing = agent.get("scoped_context")
             if isinstance(existing, dict):
@@ -795,8 +834,10 @@ class AgentService:
                     agent_config,
                     _strip_leading_slashes(subjects_input),
                 )
+            datasource = getattr(agent_config, "current_datasource", "") or base_ctx.get("datasource") or ""
             merged = _build_scoped_context(
                 base=base_ctx,
+                datasource=datasource,
                 catalogs=catalogs_input,
                 subject_buckets=subject_buckets,
             )

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -13,10 +13,13 @@ from datus.api.services.agent_service import (
     VALID_TOOL_METHODS,
     AgentService,
     _build_scoped_context,
+    _classify_subject_paths,
     _format_csv,
+    _merge_subjects_from_scoped_context,
     _normalize_created_at,
     _parse_csv,
     _parse_tools,
+    _path_to_slash_form,
     _strip_leading_slashes,
     _utc_now_iso,
     _validate_tools,
@@ -941,40 +944,223 @@ class TestStripLeadingSlashes:
 
 
 class TestBuildScopedContext:
-    """Tests for _build_scoped_context — fold catalogs/subjects into scoped_context."""
+    """Tests for _build_scoped_context — fold catalogs/subject buckets into scoped_context."""
 
     def test_only_catalogs_returns_dict_with_csv_value(self):
         """Catalogs alone yields a single-key dict with a comma-separated string."""
         result = _build_scoped_context(None, catalogs=["/A", "/B"])
         assert result == {"catalogs": "A, B"}
 
-    def test_both_keys_are_merged_into_one_dict(self):
-        """Catalogs + subjects produce one scoped_context with both keys set."""
-        result = _build_scoped_context(None, catalogs=["/A"], subjects=["/X", "/Y"])
-        assert result == {"catalogs": "A", "subjects": "X, Y"}
+    def test_subject_buckets_write_runtime_keys(self):
+        """``subject_buckets`` writes to ``metrics`` / ``sqls`` / ``ext_knowledge``."""
+        result = _build_scoped_context(
+            None,
+            catalogs=["/A"],
+            subject_buckets={
+                "metrics": ["/M1", "/M2"],
+                "sqls": ["/S1"],
+                "ext_knowledge": [],
+            },
+        )
+        # ext_knowledge is empty, so its key is omitted; subjects key never appears.
+        assert result == {"catalogs": "A", "metrics": "M1, M2", "sqls": "S1"}
 
     def test_base_keys_are_preserved(self):
-        """Existing scoped_context keys (tables/metrics/sqls) survive the merge."""
+        """Existing scoped_context keys (tables) survive a catalogs-only update."""
         base = {"tables": "orders", "metrics": "revenue"}
         result = _build_scoped_context(base, catalogs=["/A"])
         assert result == {"tables": "orders", "metrics": "revenue", "catalogs": "A"}
 
-    def test_explicit_empty_list_clears_existing_value(self):
-        """Sending ``catalogs=[]`` removes the key from a base scoped_context."""
+    def test_subject_buckets_overwrite_existing_bucket_keys(self):
+        """Passing subject_buckets fully rewrites the three bucket keys.
+
+        Empty bucket entries clear their key (rule: the editor's subjects array
+        is the new full scope for the agent).
+        """
+        base = {"tables": "orders", "metrics": "old", "sqls": "stale", "ext_knowledge": "stale_kb"}
+        result = _build_scoped_context(
+            base,
+            subject_buckets={
+                "metrics": ["new_metric"],
+                "sqls": [],
+                "ext_knowledge": [],
+            },
+        )
+        # tables survives; the three subject keys are rewritten — empty buckets clear.
+        assert result == {"tables": "orders", "metrics": "new_metric"}
+
+    def test_explicit_empty_catalogs_clears_existing_value(self):
+        """Sending ``catalogs=[]`` removes the catalogs key from a base scoped_context."""
         base = {"catalogs": "old", "tables": "t1"}
         result = _build_scoped_context(base, catalogs=[])
         assert result == {"tables": "t1"}
 
-    def test_none_value_preserves_existing_key(self):
-        """``None`` for catalogs/subjects leaves the base value intact."""
-        base = {"catalogs": "keep"}
-        result = _build_scoped_context(base, catalogs=None, subjects=["/new"])
-        assert result == {"catalogs": "keep", "subjects": "new"}
+    def test_none_subject_buckets_preserves_existing_keys(self):
+        """``subject_buckets=None`` leaves any existing metrics/sqls/ext_knowledge intact."""
+        base = {"metrics": "keep_me", "sqls": "also_keep"}
+        result = _build_scoped_context(base, catalogs=["/A"], subject_buckets=None)
+        assert result == {"metrics": "keep_me", "sqls": "also_keep", "catalogs": "A"}
 
     def test_empty_result_returns_none(self):
         """When the merged dict ends up empty, return ``None`` so callers omit the block."""
         assert _build_scoped_context(None) is None
         assert _build_scoped_context({}, catalogs=[]) is None
+        assert _build_scoped_context(None, subject_buckets={"metrics": [], "sqls": [], "ext_knowledge": []}) is None
+
+
+class TestPathToSlashForm:
+    """Tests for _path_to_slash_form — normalize stored tokens to slash-form paths."""
+
+    def test_dot_form_is_converted_to_slash_form(self):
+        """Stored wizard-form (`a.b.c`) comes back as `a/b/c`."""
+        assert _path_to_slash_form("finance.revenue.daily_revenue") == "finance/revenue/daily_revenue"
+
+    def test_slash_form_passes_through(self):
+        """Stored slash-form is preserved."""
+        assert _path_to_slash_form("Commerce/Orders/Avg") == "Commerce/Orders/Avg"
+
+    def test_quoted_segments_are_unquoted(self):
+        """Quoted dot-form segments (`a."b.c".d`) round-trip through `split_reference_path`."""
+        assert _path_to_slash_form('domain."name with dots".item') == "domain/name with dots/item"
+
+    def test_empty_input_returns_empty(self):
+        """Empty token yields empty string, callers filter these out."""
+        assert _path_to_slash_form("") == ""
+
+
+class TestMergeSubjectsFromScopedContext:
+    """Tests for _merge_subjects_from_scoped_context — flatten the three buckets."""
+
+    def test_all_three_buckets_are_concatenated(self):
+        """metrics + sqls + ext_knowledge concatenate into a single subjects list."""
+        scoped = {
+            "metrics": "Commerce/Orders/Avg, Sales/Region",
+            "sqls": "finance/sql_a",
+            "ext_knowledge": "Docs/handbook",
+        }
+        assert _merge_subjects_from_scoped_context(scoped) == [
+            "Commerce/Orders/Avg",
+            "Sales/Region",
+            "finance/sql_a",
+            "Docs/handbook",
+        ]
+
+    def test_dot_form_entries_are_normalized_to_slash_form(self):
+        """Wizard-written entries (`a.b.c`) come back as slash paths."""
+        scoped = {"metrics": "finance.revenue.daily, sales.region"}
+        assert _merge_subjects_from_scoped_context(scoped) == [
+            "finance/revenue/daily",
+            "sales/region",
+        ]
+
+    def test_duplicates_across_buckets_are_dropped(self):
+        """A path that lands in multiple buckets only appears once in subjects."""
+        scoped = {"metrics": "shared", "sqls": "shared", "ext_knowledge": "unique"}
+        assert _merge_subjects_from_scoped_context(scoped) == ["shared", "unique"]
+
+    def test_missing_or_empty_buckets_yield_empty_list(self):
+        """Empty / non-dict inputs return an empty list."""
+        assert _merge_subjects_from_scoped_context(None) == []
+        assert _merge_subjects_from_scoped_context({}) == []
+        assert _merge_subjects_from_scoped_context({"tables": "t1"}) == []
+
+
+class TestClassifySubjectPaths:
+    """Tests for _classify_subject_paths — bucket subjects into metrics/sqls/ext_knowledge."""
+
+    def test_no_datasource_falls_back_to_metrics(self, real_agent_config):
+        """When the AgentConfig has no datasource bound, every subject defaults to metrics.
+
+        The fallback exists so the editor's input survives a save even when the
+        project hasn't bootstrapped its KB yet — losing the user's selection
+        silently would be the worse failure mode.
+        """
+        real_agent_config.current_datasource = ""
+        result = _classify_subject_paths(real_agent_config, ["Commerce/Orders/Avg", "Sales/Region"])
+        assert result == {
+            "metrics": ["Commerce/Orders/Avg", "Sales/Region"],
+            "sqls": [],
+            "ext_knowledge": [],
+        }
+
+    def test_empty_input_returns_empty_buckets(self, real_agent_config):
+        """An empty subjects list yields an empty bucket dict, not an error."""
+        result = _classify_subject_paths(real_agent_config, [])
+        assert result == {"metrics": [], "sqls": [], "ext_knowledge": []}
+
+    def test_storage_init_failure_falls_back_to_metrics(self, real_agent_config, monkeypatch):
+        """If the metric / sql / knowledge stores can't initialize, all subjects bucket as metrics.
+
+        Forcing a storage-init exception (here via a broken ``MetricRAG.__init__``)
+        exercises the defensive fallback so the API endpoint never raises a 500
+        on a save that the user can otherwise complete.
+        """
+        from datus.storage.metric.store import MetricRAG
+
+        def broken_init(self, *args, **kwargs):
+            raise RuntimeError("storage backend down")
+
+        monkeypatch.setattr(MetricRAG, "__init__", broken_init)
+        result = _classify_subject_paths(real_agent_config, ["Commerce/Orders/Avg"])
+        assert result["metrics"] == ["Commerce/Orders/Avg"]
+        assert result["sqls"] == []
+        assert result["ext_knowledge"] == []
+
+    def test_classifies_via_storage_lookup(self, real_agent_config, monkeypatch):
+        """Each path is bucketed by the first store whose ``list_entries`` matches the name.
+
+        Stubbing the three storages forces a deterministic classification that
+        doesn't depend on the test fixture pre-populating real KB data; the
+        probe order (metrics → sqls → ext_knowledge) is part of the contract.
+        """
+        from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
+        from datus.storage.metric.store import MetricRAG
+        from datus.storage.reference_sql.store import ReferenceSqlRAG
+
+        class _StubStore:
+            def __init__(self, owns: set[str]):
+                self._owns = owns
+
+            def list_entries(self, node_id, name=None, limit=None):
+                return [{"name": name}] if name in self._owns else []
+
+        class _StubTree:
+            def get_node_by_path(self, path):
+                # Return a stable node_id regardless of path so the storages
+                # decide ownership purely by name.
+                return {"node_id": 1}
+
+        def fake_metric_init(self, *args, **kwargs):
+            self.storage = _StubStore({"my_metric"})
+
+        def fake_sql_init(self, *args, **kwargs):
+            self.reference_sql_storage = _StubStore({"my_sql"})
+
+        def fake_knowledge_init(self, *args, **kwargs):
+            self.store = _StubStore({"my_doc"})
+
+        monkeypatch.setattr(MetricRAG, "__init__", fake_metric_init)
+        monkeypatch.setattr(ReferenceSqlRAG, "__init__", fake_sql_init)
+        monkeypatch.setattr(ExtKnowledgeRAG, "__init__", fake_knowledge_init)
+        monkeypatch.setattr(
+            "datus.storage.registry.get_subject_tree_store",
+            lambda project: _StubTree(),
+        )
+
+        result = _classify_subject_paths(
+            real_agent_config,
+            [
+                "Commerce/Orders/my_metric",
+                "Finance/my_sql",
+                "Docs/my_doc",
+                "Unknown/path",
+            ],
+        )
+        # Unknown paths fall back to metrics so the editor's input survives the
+        # round-trip — losing the user's selection silently would be worse.
+        assert result["metrics"] == ["Commerce/Orders/my_metric", "Unknown/path"]
+        assert result["sqls"] == ["Finance/my_sql"]
+        assert result["ext_knowledge"] == ["Docs/my_doc"]
 
 
 @pytest.mark.asyncio
@@ -1010,13 +1196,16 @@ class TestSubagentScopedContextRoundTrip:
         entry = raw["agent"]["agentic_nodes"]["csv_tools_agent"]
         assert entry["tools"] == "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree"
 
-    async def test_create_folds_catalogs_and_subjects_under_scoped_context(
+    async def test_create_folds_catalogs_into_scoped_context_and_classifies_subjects(
         self, real_agent_config, agent_yml_with_singleton
     ):
         """API top-level catalogs/subjects land inside ``scoped_context`` on save.
 
-        Leading slashes from the editor's path form are stripped so the
-        on-disk shape matches what the runtime stores natively.
+        Leading slashes from the editor's path form are stripped, and
+        ``subjects`` is *classified* into metrics / sqls / ext_knowledge —
+        no flat ``subjects`` key ever appears on disk because the runtime
+        ``ScopedContext`` doesn't have one (each store owns its own filter).
+        Without pre-populated KB stores the classifier falls back to metrics.
         """
         import yaml
 
@@ -1044,10 +1233,20 @@ class TestSubagentScopedContextRoundTrip:
         scoped = entry.get("scoped_context")
         assert isinstance(scoped, dict)
         assert scoped["catalogs"] == "Commerce/Orders/Average_Gross_Order_Value, Commerce/Sales"
-        assert scoped["subjects"] == "Finance/Revenue/Daily"
+        # Subjects route to ``metrics`` (the fallback bucket) because the
+        # KB stores have no entry named "Daily" under "Finance/Revenue".
+        # No flat ``subjects`` key is persisted.
+        assert "subjects" not in scoped
+        assert scoped["metrics"] == "Finance/Revenue/Daily"
 
     async def test_edit_migrates_tools_and_scoped_context(self, real_agent_config, agent_yml_with_singleton):
-        """An edit normalizes tools to CSV and moves catalogs/subjects into scoped_context."""
+        """An edit normalizes tools to CSV and rewrites scoped_context.
+
+        Legacy-shape entries (list-form tools, top-level catalogs/subjects)
+        get migrated: tools become a CSV string, catalogs lands in
+        ``scoped_context.catalogs``, and subjects are classified into the
+        runtime bucket keys (no flat ``subjects`` key persists).
+        """
         import yaml
 
         from datus.api.models.agent_models import EditAgentInput
@@ -1083,7 +1282,10 @@ class TestSubagentScopedContextRoundTrip:
         scoped = entry["scoped_context"]
         # Leading slashes are stripped so the on-disk form is canonical.
         assert scoped["catalogs"] == "Commerce/Orders/Avg"
-        assert scoped["subjects"] == "Sales/Region"
+        # No flat ``subjects`` key — subjects are classified into runtime buckets.
+        assert "subjects" not in scoped
+        # Without pre-populated KB stores the classifier defaults to metrics.
+        assert scoped["metrics"] == "Sales/Region"
 
     async def test_edit_preserves_existing_scoped_context_keys(self, real_agent_config, agent_yml_with_singleton):
         """Editing catalogs must not wipe pre-existing tables/metrics/sqls keys."""
@@ -1122,16 +1324,19 @@ class TestSubagentScopedContextRoundTrip:
     async def test_get_returns_tools_as_list_and_extracts_scoped_paths(self, real_agent_config):
         """The read path inverts the storage format the editor expects.
 
-        Catalog / subject entries are returned without the leading slash
-        regardless of whether they were stored with or without it — older
-        entries written before the normalization land in the canonical form.
+        Catalog entries are returned without the leading slash; subjects are
+        recomposed by merging the three runtime buckets (metrics / sqls /
+        ext_knowledge) into a single flat list. Stored dot-form entries
+        (wizard convention) are normalized to slash-form on the way out.
         """
         real_agent_config.agentic_nodes["roundtrip_get"] = {
             "type": "gen_sql",
             "tools": "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree",
             "scoped_context": {
                 "catalogs": "/Commerce/Orders/Avg, /Commerce/Sales",
-                "subjects": "/Finance/Revenue/Daily",
+                "metrics": "Finance/Revenue/Daily, finance.revenue.weekly",
+                "sqls": "Sales/region_query",
+                "ext_knowledge": "Docs/handbook",
                 "tables": "orders",
             },
             "created_at": "2026-04-30T09:20:31.545000Z",
@@ -1147,7 +1352,14 @@ class TestSubagentScopedContextRoundTrip:
             "context_search_tools.list_subject_tree",
         ]
         assert agent["catalogs"] == ["Commerce/Orders/Avg", "Commerce/Sales"]
-        assert agent["subjects"] == ["Finance/Revenue/Daily"]
+        # Subjects merge across all three buckets in probe order; the dot-form
+        # entry "finance.revenue.weekly" is normalized to slash-form.
+        assert agent["subjects"] == [
+            "Finance/Revenue/Daily",
+            "finance/revenue/weekly",
+            "Sales/region_query",
+            "Docs/handbook",
+        ]
 
     async def test_get_falls_back_to_top_level_catalogs_for_legacy_entries(self, real_agent_config):
         """Legacy entries written before the migration still surface catalogs/subjects.
@@ -1169,12 +1381,19 @@ class TestSubagentScopedContextRoundTrip:
         result = await svc.get_agent("legacy_top_level", real_agent_config)
         assert result.success is True
         agent = result.data["agent"]
-        # Even on the legacy fallback path, leading slashes are stripped.
+        # Even on the legacy fallback path, leading slashes are stripped and
+        # subjects are returned as slash-form paths.
         assert agent["catalogs"] == ["Legacy/Catalog"]
         assert agent["subjects"] == ["Legacy/Subject"]
 
     async def test_round_trip_create_then_get(self, real_agent_config, agent_yml_with_singleton):
-        """Saving and re-reading yields the canonical (slash-stripped) path form."""
+        """Saving and re-reading yields the canonical (slash-stripped) path form.
+
+        Even though the on-disk shape changes (subjects gets split into
+        ``metrics`` / ``sqls`` / ``ext_knowledge``), the API contract round-
+        trips: the editor sees ``subjects`` come back as the same flat list
+        it sent.
+        """
         from datus.api.models.agent_models import CreateAgentInput
 
         svc = AgentService()

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -12,8 +12,12 @@ from datus.api.services.agent_service import (
     VALID_TOOL_CATEGORIES,
     VALID_TOOL_METHODS,
     AgentService,
+    _build_scoped_context,
+    _format_csv,
     _normalize_created_at,
+    _parse_csv,
     _parse_tools,
+    _strip_leading_slashes,
     _utc_now_iso,
     _validate_tools,
     sanitize_agentic_node_name,
@@ -879,3 +883,315 @@ class TestEditAgent:
         # Legacy key must be cleared so downstream readers can't pick up
         # the old text.
         assert "description" not in entry
+
+
+class TestFormatAndParseCsv:
+    """Tests for _format_csv / _parse_csv — list ↔ comma-separated string."""
+
+    def test_list_renders_with_separator(self):
+        """A list is joined with ``", "`` so it matches the documented yaml form."""
+        rendered = _format_csv(["semantic_tools.*", "db_tools.*", "context_search_tools.list_subject_tree"])
+        assert rendered == "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree"
+
+    def test_string_input_is_normalized(self):
+        """A pre-formatted string is re-rendered with the canonical spacing."""
+        assert _format_csv("a,  b , c") == "a, b, c"
+
+    def test_empty_inputs_render_empty_string(self):
+        """``None`` / empty list / empty string all collapse to ``""``."""
+        assert _format_csv(None) == ""
+        assert _format_csv([]) == ""
+        assert _format_csv("") == ""
+
+    def test_blank_entries_are_dropped(self):
+        """Whitespace-only entries don't pollute the rendered string."""
+        assert _format_csv(["a", "", "  ", "b"]) == "a, b"
+
+    def test_round_trip_through_parse(self):
+        """``_parse_csv(_format_csv(items)) == items`` for trimmed entries."""
+        items = ["/Commerce/Orders/Average_Gross_Order_Value", "/Commerce/Sales"]
+        assert _parse_csv(_format_csv(items)) == items
+
+
+class TestStripLeadingSlashes:
+    """Tests for _strip_leading_slashes — normalize subject/catalog path entries."""
+
+    def test_each_entry_loses_leading_slash(self):
+        """A leading ``/`` is removed from every entry in the list."""
+        assert _strip_leading_slashes(["/Commerce/Orders/Avg", "/Commerce/Sales"]) == [
+            "Commerce/Orders/Avg",
+            "Commerce/Sales",
+        ]
+
+    def test_string_input_is_split_and_stripped(self):
+        """A pre-formatted comma-separated string is split before stripping."""
+        assert _strip_leading_slashes("/A/B, /C") == ["A/B", "C"]
+
+    def test_no_leading_slash_passes_through(self):
+        """Entries without a leading slash are preserved unchanged."""
+        assert _strip_leading_slashes(["A/B", "C/D"]) == ["A/B", "C/D"]
+
+    def test_inner_slashes_are_kept(self):
+        """Only the leading slash is trimmed — path separators are preserved."""
+        assert _strip_leading_slashes(["/Commerce/Orders/Avg"]) == ["Commerce/Orders/Avg"]
+
+    def test_slash_only_entry_is_dropped(self):
+        """A bare ``/`` collapses to nothing and is filtered out."""
+        assert _strip_leading_slashes(["/", "/A"]) == ["A"]
+
+
+class TestBuildScopedContext:
+    """Tests for _build_scoped_context — fold catalogs/subjects into scoped_context."""
+
+    def test_only_catalogs_returns_dict_with_csv_value(self):
+        """Catalogs alone yields a single-key dict with a comma-separated string."""
+        result = _build_scoped_context(None, catalogs=["/A", "/B"])
+        assert result == {"catalogs": "A, B"}
+
+    def test_both_keys_are_merged_into_one_dict(self):
+        """Catalogs + subjects produce one scoped_context with both keys set."""
+        result = _build_scoped_context(None, catalogs=["/A"], subjects=["/X", "/Y"])
+        assert result == {"catalogs": "A", "subjects": "X, Y"}
+
+    def test_base_keys_are_preserved(self):
+        """Existing scoped_context keys (tables/metrics/sqls) survive the merge."""
+        base = {"tables": "orders", "metrics": "revenue"}
+        result = _build_scoped_context(base, catalogs=["/A"])
+        assert result == {"tables": "orders", "metrics": "revenue", "catalogs": "A"}
+
+    def test_explicit_empty_list_clears_existing_value(self):
+        """Sending ``catalogs=[]`` removes the key from a base scoped_context."""
+        base = {"catalogs": "old", "tables": "t1"}
+        result = _build_scoped_context(base, catalogs=[])
+        assert result == {"tables": "t1"}
+
+    def test_none_value_preserves_existing_key(self):
+        """``None`` for catalogs/subjects leaves the base value intact."""
+        base = {"catalogs": "keep"}
+        result = _build_scoped_context(base, catalogs=None, subjects=["/new"])
+        assert result == {"catalogs": "keep", "subjects": "new"}
+
+    def test_empty_result_returns_none(self):
+        """When the merged dict ends up empty, return ``None`` so callers omit the block."""
+        assert _build_scoped_context(None) is None
+        assert _build_scoped_context({}, catalogs=[]) is None
+
+
+@pytest.mark.asyncio
+class TestSubagentScopedContextRoundTrip:
+    """End-to-end checks for the create/edit/get pipeline.
+
+    The contract documented in
+    ``docs/subagent/customized_subagent.zh.md``: ``tools`` is persisted as a
+    comma-separated string (the runtime calls ``str.split(",")``), and
+    ``catalogs`` / ``subjects`` live under ``scoped_context`` so a single
+    block describes the subagent's reference scope.
+    """
+
+    async def test_create_persists_tools_as_csv_string(self, real_agent_config, agent_yml_with_singleton):
+        """Tools list is rendered as the comma-separated yaml form on disk."""
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput
+
+        svc = AgentService()
+        result = await svc.create_agent(
+            CreateAgentInput(
+                name="csv_tools_agent",
+                type="gen_sql",
+                tools=["semantic_tools.*", "db_tools.*", "context_search_tools.list_subject_tree"],
+            ),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        entry = raw["agent"]["agentic_nodes"]["csv_tools_agent"]
+        assert entry["tools"] == "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree"
+
+    async def test_create_folds_catalogs_and_subjects_under_scoped_context(
+        self, real_agent_config, agent_yml_with_singleton
+    ):
+        """API top-level catalogs/subjects land inside ``scoped_context`` on save.
+
+        Leading slashes from the editor's path form are stripped so the
+        on-disk shape matches what the runtime stores natively.
+        """
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput
+
+        svc = AgentService()
+        result = await svc.create_agent(
+            CreateAgentInput(
+                name="scoped_create_agent",
+                type="gen_sql",
+                catalogs=["/Commerce/Orders/Average_Gross_Order_Value", "/Commerce/Sales"],
+                subjects=["/Finance/Revenue/Daily"],
+            ),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        entry = raw["agent"]["agentic_nodes"]["scoped_create_agent"]
+        # catalogs / subjects must NOT remain at the top level — that was the
+        # legacy shape before this change.
+        assert "catalogs" not in entry
+        assert "subjects" not in entry
+        scoped = entry.get("scoped_context")
+        assert isinstance(scoped, dict)
+        assert scoped["catalogs"] == "Commerce/Orders/Average_Gross_Order_Value, Commerce/Sales"
+        assert scoped["subjects"] == "Finance/Revenue/Daily"
+
+    async def test_edit_migrates_tools_and_scoped_context(self, real_agent_config, agent_yml_with_singleton):
+        """An edit normalizes tools to CSV and moves catalogs/subjects into scoped_context."""
+        import yaml
+
+        from datus.api.models.agent_models import EditAgentInput
+
+        # Seed a legacy-shape entry: list-form tools and top-level catalogs/subjects.
+        real_agent_config.agentic_nodes["legacy_scope"] = {
+            "type": "gen_sql",
+            "tools": ["db_tools.*"],
+            "catalogs": ["/Old/Catalog"],
+            "subjects": ["/Old/Subject"],
+        }
+
+        svc = AgentService()
+        result = await svc.edit_agent(
+            EditAgentInput(
+                id="legacy_scope",
+                name="legacy_scope",
+                tools=["semantic_tools.*", "db_tools.*"],
+                catalogs=["/Commerce/Orders/Avg"],
+                subjects=["/Sales/Region"],
+            ),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        entry = raw["agent"]["agentic_nodes"]["legacy_scope"]
+        assert entry["tools"] == "semantic_tools.*, db_tools.*"
+        # Top-level legacy keys must be cleared so the read path can't see two copies.
+        assert "catalogs" not in entry
+        assert "subjects" not in entry
+        scoped = entry["scoped_context"]
+        # Leading slashes are stripped so the on-disk form is canonical.
+        assert scoped["catalogs"] == "Commerce/Orders/Avg"
+        assert scoped["subjects"] == "Sales/Region"
+
+    async def test_edit_preserves_existing_scoped_context_keys(self, real_agent_config, agent_yml_with_singleton):
+        """Editing catalogs must not wipe pre-existing tables/metrics/sqls keys."""
+        import yaml
+
+        from datus.api.models.agent_models import EditAgentInput
+
+        real_agent_config.agentic_nodes["preserve_scope"] = {
+            "type": "gen_sql",
+            "scoped_context": {
+                "tables": "orders, customers",
+                "metrics": "revenue.daily",
+                "sqls": "finance.region_rollup",
+            },
+        }
+
+        svc = AgentService()
+        result = await svc.edit_agent(
+            EditAgentInput(
+                id="preserve_scope",
+                name="preserve_scope",
+                catalogs=["/Commerce/Orders"],
+            ),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        scoped = raw["agent"]["agentic_nodes"]["preserve_scope"]["scoped_context"]
+        assert scoped["tables"] == "orders, customers"
+        assert scoped["metrics"] == "revenue.daily"
+        assert scoped["sqls"] == "finance.region_rollup"
+        assert scoped["catalogs"] == "Commerce/Orders"
+
+    async def test_get_returns_tools_as_list_and_extracts_scoped_paths(self, real_agent_config):
+        """The read path inverts the storage format the editor expects.
+
+        Catalog / subject entries are returned without the leading slash
+        regardless of whether they were stored with or without it — older
+        entries written before the normalization land in the canonical form.
+        """
+        real_agent_config.agentic_nodes["roundtrip_get"] = {
+            "type": "gen_sql",
+            "tools": "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree",
+            "scoped_context": {
+                "catalogs": "/Commerce/Orders/Avg, /Commerce/Sales",
+                "subjects": "/Finance/Revenue/Daily",
+                "tables": "orders",
+            },
+            "created_at": "2026-04-30T09:20:31.545000Z",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("roundtrip_get", real_agent_config)
+        assert result.success is True
+        agent = result.data["agent"]
+        assert agent["tools"] == [
+            "semantic_tools.*",
+            "db_tools.*",
+            "context_search_tools.list_subject_tree",
+        ]
+        assert agent["catalogs"] == ["Commerce/Orders/Avg", "Commerce/Sales"]
+        assert agent["subjects"] == ["Finance/Revenue/Daily"]
+
+    async def test_get_falls_back_to_top_level_catalogs_for_legacy_entries(self, real_agent_config):
+        """Legacy entries written before the migration still surface catalogs/subjects.
+
+        Older yaml files persisted catalogs and subjects at the top level. The
+        read path must keep working for them until the next edit migrates the
+        keys into scoped_context — otherwise existing configs would lose the
+        scope information after an upgrade.
+        """
+        real_agent_config.agentic_nodes["legacy_top_level"] = {
+            "type": "gen_sql",
+            "tools": "db_tools.*",
+            "catalogs": ["/Legacy/Catalog"],
+            "subjects": ["/Legacy/Subject"],
+            "created_at": "2026-04-30T09:20:31.545000Z",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("legacy_top_level", real_agent_config)
+        assert result.success is True
+        agent = result.data["agent"]
+        # Even on the legacy fallback path, leading slashes are stripped.
+        assert agent["catalogs"] == ["Legacy/Catalog"]
+        assert agent["subjects"] == ["Legacy/Subject"]
+
+    async def test_round_trip_create_then_get(self, real_agent_config, agent_yml_with_singleton):
+        """Saving and re-reading yields the canonical (slash-stripped) path form."""
+        from datus.api.models.agent_models import CreateAgentInput
+
+        svc = AgentService()
+        await svc.create_agent(
+            CreateAgentInput(
+                name="full_round_trip",
+                type="gen_sql",
+                tools=["semantic_tools.*", "db_tools.*"],
+                catalogs=["/Commerce/Orders/Avg"],
+                subjects=["/Sales/Region"],
+            ),
+            real_agent_config,
+        )
+
+        result = await svc.get_agent("full_round_trip", real_agent_config)
+        assert result.success is True
+        agent = result.data["agent"]
+        assert agent["tools"] == ["semantic_tools.*", "db_tools.*"]
+        assert agent["catalogs"] == ["Commerce/Orders/Avg"]
+        assert agent["subjects"] == ["Sales/Region"]

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -1527,3 +1527,90 @@ class TestSubagentScopedContextRoundTrip:
         entry = raw["agent"]["agentic_nodes"]["clear_scope_agent"]
         # The whole scoped_context block is gone on disk, not just in memory.
         assert "scoped_context" not in entry
+
+    async def test_edit_classifies_subjects_under_saved_datasource(
+        self, real_agent_config, agent_yml_with_singleton, monkeypatch
+    ):
+        """Classification uses the saved DS binding when ``current_datasource`` is unset.
+
+        Without the fix, ``_classify_subject_paths`` ran with
+        ``datasource_id=None`` and fell back to ``agent_config.current_datasource``
+        — which is empty in this scenario — so every subject was bucketed to
+        ``metrics`` regardless of which store actually owned it. With the fix,
+        ``edit_agent`` resolves the effective datasource from the saved
+        ``scoped_context.datasource`` first, so the SQL/knowledge stores are
+        actually probed and ownership wins.
+        """
+        from datus.api.models.agent_models import EditAgentInput
+        from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
+        from datus.storage.metric.store import MetricRAG
+        from datus.storage.reference_sql.store import ReferenceSqlRAG
+
+        # Capture which datasource_id flows into the classifier so we can
+        # assert against the resolution rule directly.
+        captured: dict = {}
+
+        class _StubStore:
+            def __init__(self, owns: set[str]):
+                self._owns = owns
+
+            def list_entries(self, node_id, name=None, limit=None):
+                return [{"name": name}] if name in self._owns else []
+
+        class _StubTree:
+            def get_node_by_path(self, path):
+                return {"node_id": 1}
+
+        def fake_metric_init(self, agent_config, datasource_id=None):
+            captured["metric_ds"] = datasource_id
+            self.storage = _StubStore({"my_metric"})
+
+        def fake_sql_init(self, agent_config, datasource_id=None):
+            self.reference_sql_storage = _StubStore({"my_sql"})
+
+        def fake_knowledge_init(self, agent_config, datasource_id=None):
+            self.store = _StubStore({"my_doc"})
+
+        monkeypatch.setattr(MetricRAG, "__init__", fake_metric_init)
+        monkeypatch.setattr(ReferenceSqlRAG, "__init__", fake_sql_init)
+        monkeypatch.setattr(ExtKnowledgeRAG, "__init__", fake_knowledge_init)
+        monkeypatch.setattr(
+            "datus.storage.registry.get_subject_tree_store",
+            lambda project: _StubTree(),
+        )
+
+        # Seed an entry already bound to "finance" via scoped_context, then
+        # blank out the runtime's current_datasource so the only available
+        # binding is the saved one.
+        real_agent_config.agentic_nodes["edit_with_saved_ds"] = {
+            "type": "gen_sql",
+            "scoped_context": {
+                "datasource": "finance",
+                "tables": "default_catalog.mart.raw_orders",
+            },
+        }
+        real_agent_config.current_datasource = ""
+
+        svc = AgentService()
+        result = await svc.edit_agent(
+            EditAgentInput(
+                id="edit_with_saved_ds",
+                name="edit_with_saved_ds",
+                subjects=["Finance.SQL.my_sql", "Docs.handbook.my_doc", "Sales.unknown"],
+            ),
+            real_agent_config,
+        )
+        assert result.success is True
+        # The classifier must have been invoked with the saved datasource —
+        # without the fix it received None and fell back to the
+        # "no datasource → all metrics" branch.
+        assert captured.get("metric_ds") == "finance"
+
+        # SQL and knowledge entries land in their owning buckets; only the
+        # truly unmatched name falls back to metrics.
+        scoped = real_agent_config.agentic_nodes["edit_with_saved_ds"]["scoped_context"]
+        assert scoped["sqls"] == "Finance.SQL.my_sql"
+        assert scoped["ext_knowledge"] == "Docs.handbook.my_doc"
+        assert scoped["metrics"] == "Sales.unknown"
+        # Saved datasource binding survives the edit.
+        assert scoped["datasource"] == "finance"

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -946,10 +946,16 @@ class TestStripLeadingSlashes:
 class TestBuildScopedContext:
     """Tests for _build_scoped_context — fold catalogs/subject buckets into scoped_context."""
 
-    def test_only_catalogs_returns_dict_with_csv_value(self):
-        """Catalogs alone yields a single-key dict with a comma-separated string."""
+    def test_catalogs_writes_runtime_tables_key(self):
+        """API ``catalogs`` lands on the runtime-honored ``tables`` key.
+
+        ``ScopedContext`` has no ``catalogs`` field; the runtime's table-scope
+        filter (``ScopedFilterBuilder.build_table_filter``) reads ``tables``,
+        so the editor's ``catalogs`` array is the same scope under a
+        different surface name.
+        """
         result = _build_scoped_context(None, catalogs=["/A", "/B"])
-        assert result == {"catalogs": "A, B"}
+        assert result == {"tables": "A, B"}
 
     def test_subject_buckets_write_runtime_keys(self):
         """``subject_buckets`` writes to ``metrics`` / ``sqls`` / ``ext_knowledge``."""
@@ -963,13 +969,35 @@ class TestBuildScopedContext:
             },
         )
         # ext_knowledge is empty, so its key is omitted; subjects key never appears.
-        assert result == {"catalogs": "A", "metrics": "M1, M2", "sqls": "S1"}
+        assert result == {"tables": "A", "metrics": "M1, M2", "sqls": "S1"}
 
-    def test_base_keys_are_preserved(self):
-        """Existing scoped_context keys (tables) survive a catalogs-only update."""
-        base = {"tables": "orders", "metrics": "revenue"}
+    def test_datasource_is_written_when_provided(self):
+        """A non-empty datasource is recorded under ``scoped_context.datasource``."""
+        result = _build_scoped_context(None, datasource="finance", catalogs=["/A"])
+        assert result == {"datasource": "finance", "tables": "A"}
+
+    def test_empty_datasource_clears_existing_binding(self):
+        """An empty-string ``datasource`` removes a stale binding from ``base``."""
+        base = {"datasource": "old_ds", "tables": "orders"}
+        result = _build_scoped_context(base, datasource="")
+        assert result == {"tables": "orders"}
+
+    def test_none_datasource_preserves_existing_binding(self):
+        """``datasource=None`` leaves any existing binding intact."""
+        base = {"datasource": "keep_me"}
         result = _build_scoped_context(base, catalogs=["/A"])
-        assert result == {"tables": "orders", "metrics": "revenue", "catalogs": "A"}
+        assert result == {"datasource": "keep_me", "tables": "A"}
+
+    def test_catalogs_overwrites_tables_and_drops_legacy_catalogs_key(self):
+        """Catalogs fully rewrites ``tables`` and clears any non-runtime ``catalogs`` key.
+
+        Earlier API versions wrote ``scoped_context.catalogs`` directly. Once
+        the editor calls edit_agent again with catalogs the helper migrates
+        them under ``tables`` so the read path can't see two competing copies.
+        """
+        base = {"tables": "old_table", "catalogs": "stale_legacy", "metrics": "revenue"}
+        result = _build_scoped_context(base, catalogs=["/Commerce/Orders"])
+        assert result == {"tables": "Commerce/Orders", "metrics": "revenue"}
 
     def test_subject_buckets_overwrite_existing_bucket_keys(self):
         """Passing subject_buckets fully rewrites the three bucket keys.
@@ -989,17 +1017,17 @@ class TestBuildScopedContext:
         # tables survives; the three subject keys are rewritten — empty buckets clear.
         assert result == {"tables": "orders", "metrics": "new_metric"}
 
-    def test_explicit_empty_catalogs_clears_existing_value(self):
-        """Sending ``catalogs=[]`` removes the catalogs key from a base scoped_context."""
-        base = {"catalogs": "old", "tables": "t1"}
+    def test_explicit_empty_catalogs_clears_existing_tables(self):
+        """Sending ``catalogs=[]`` removes the ``tables`` key from a base scoped_context."""
+        base = {"tables": "old", "metrics": "m"}
         result = _build_scoped_context(base, catalogs=[])
-        assert result == {"tables": "t1"}
+        assert result == {"metrics": "m"}
 
     def test_none_subject_buckets_preserves_existing_keys(self):
         """``subject_buckets=None`` leaves any existing metrics/sqls/ext_knowledge intact."""
         base = {"metrics": "keep_me", "sqls": "also_keep"}
         result = _build_scoped_context(base, catalogs=["/A"], subject_buckets=None)
-        assert result == {"metrics": "keep_me", "sqls": "also_keep", "catalogs": "A"}
+        assert result == {"metrics": "keep_me", "sqls": "also_keep", "tables": "A"}
 
     def test_empty_result_returns_none(self):
         """When the merged dict ends up empty, return ``None`` so callers omit the block."""
@@ -1201,11 +1229,14 @@ class TestSubagentScopedContextRoundTrip:
     ):
         """API top-level catalogs/subjects land inside ``scoped_context`` on save.
 
-        Leading slashes from the editor's path form are stripped, and
-        ``subjects`` is *classified* into metrics / sqls / ext_knowledge —
-        no flat ``subjects`` key ever appears on disk because the runtime
-        ``ScopedContext`` doesn't have one (each store owns its own filter).
-        Without pre-populated KB stores the classifier falls back to metrics.
+        ``catalogs`` writes through to the runtime-honored ``tables`` key (no
+        ``catalogs`` key persists, since ``ScopedContext`` doesn't define one).
+        Leading slashes from the editor's path form are stripped. ``subjects``
+        is *classified* into metrics / sqls / ext_knowledge — no flat
+        ``subjects`` key ever appears on disk because each store owns its
+        own scope filter. Without pre-populated KB stores the classifier
+        falls back to metrics. ``scoped_context.datasource`` is bound to the
+        active datasource so ``SubAgentConfig.is_in_datasource`` agrees.
         """
         import yaml
 
@@ -1232,7 +1263,11 @@ class TestSubagentScopedContextRoundTrip:
         assert "subjects" not in entry
         scoped = entry.get("scoped_context")
         assert isinstance(scoped, dict)
-        assert scoped["catalogs"] == "Commerce/Orders/Average_Gross_Order_Value, Commerce/Sales"
+        # Active datasource binding is recorded.
+        assert scoped["datasource"] == real_agent_config.current_datasource
+        # No non-runtime ``catalogs`` key — catalogs write through to ``tables``.
+        assert "catalogs" not in scoped
+        assert scoped["tables"] == "Commerce/Orders/Average_Gross_Order_Value, Commerce/Sales"
         # Subjects route to ``metrics`` (the fallback bucket) because the
         # KB stores have no entry named "Daily" under "Finance/Revenue".
         # No flat ``subjects`` key is persisted.
@@ -1280,15 +1315,25 @@ class TestSubagentScopedContextRoundTrip:
         assert "catalogs" not in entry
         assert "subjects" not in entry
         scoped = entry["scoped_context"]
-        # Leading slashes are stripped so the on-disk form is canonical.
-        assert scoped["catalogs"] == "Commerce/Orders/Avg"
+        # Leading slashes are stripped, and catalogs lands on ``tables`` —
+        # no non-runtime ``catalogs`` key persists.
+        assert "catalogs" not in scoped
+        assert scoped["tables"] == "Commerce/Orders/Avg"
         # No flat ``subjects`` key — subjects are classified into runtime buckets.
         assert "subjects" not in scoped
         # Without pre-populated KB stores the classifier defaults to metrics.
         assert scoped["metrics"] == "Sales/Region"
+        # The active datasource is rebound on every scope-touching edit.
+        assert scoped["datasource"] == real_agent_config.current_datasource
 
     async def test_edit_preserves_existing_scoped_context_keys(self, real_agent_config, agent_yml_with_singleton):
-        """Editing catalogs must not wipe pre-existing tables/metrics/sqls keys."""
+        """Editing catalogs rewrites ``tables`` but leaves metrics/sqls intact.
+
+        Catalogs maps to the runtime ``tables`` key, so an edit that touches
+        catalogs is expected to overwrite that field. The other scope keys
+        (``metrics`` / ``sqls`` / ``ext_knowledge``) must survive when
+        ``subjects`` is not part of the request.
+        """
         import yaml
 
         from datus.api.models.agent_models import EditAgentInput
@@ -1316,16 +1361,17 @@ class TestSubagentScopedContextRoundTrip:
         with open(agent_yml_with_singleton) as f:
             raw = yaml.safe_load(f)
         scoped = raw["agent"]["agentic_nodes"]["preserve_scope"]["scoped_context"]
-        assert scoped["tables"] == "orders, customers"
+        # ``tables`` was rewritten by catalogs — there's no separate
+        # ``catalogs`` key in ``ScopedContext``. Other scope fields survive.
+        assert scoped["tables"] == "Commerce/Orders"
         assert scoped["metrics"] == "revenue.daily"
         assert scoped["sqls"] == "finance.region_rollup"
-        assert scoped["catalogs"] == "Commerce/Orders"
 
     async def test_get_returns_tools_as_list_and_extracts_scoped_paths(self, real_agent_config):
         """The read path inverts the storage format the editor expects.
 
-        Catalog entries are returned without the leading slash; subjects are
-        recomposed by merging the three runtime buckets (metrics / sqls /
+        Catalog entries are recovered from the runtime ``tables`` key; subjects
+        are recomposed by merging the three runtime buckets (metrics / sqls /
         ext_knowledge) into a single flat list. Stored dot-form entries
         (wizard convention) are normalized to slash-form on the way out.
         """
@@ -1333,11 +1379,11 @@ class TestSubagentScopedContextRoundTrip:
             "type": "gen_sql",
             "tools": "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree",
             "scoped_context": {
-                "catalogs": "/Commerce/Orders/Avg, /Commerce/Sales",
+                "datasource": "finance",
+                "tables": "/Commerce/Orders/Avg, /Commerce/Sales",
                 "metrics": "Finance/Revenue/Daily, finance.revenue.weekly",
                 "sqls": "Sales/region_query",
                 "ext_knowledge": "Docs/handbook",
-                "tables": "orders",
             },
             "created_at": "2026-04-30T09:20:31.545000Z",
         }
@@ -1351,6 +1397,8 @@ class TestSubagentScopedContextRoundTrip:
             "db_tools.*",
             "context_search_tools.list_subject_tree",
         ]
+        # Catalogs come back from ``scoped_context.tables`` (the runtime key);
+        # leading slashes are stripped on the way out.
         assert agent["catalogs"] == ["Commerce/Orders/Avg", "Commerce/Sales"]
         # Subjects merge across all three buckets in probe order; the dot-form
         # entry "finance.revenue.weekly" is normalized to slash-form.
@@ -1360,6 +1408,27 @@ class TestSubagentScopedContextRoundTrip:
             "Sales/region_query",
             "Docs/handbook",
         ]
+
+    async def test_get_falls_back_to_legacy_scoped_catalogs_key(self, real_agent_config):
+        """Older API versions wrote ``scoped_context.catalogs`` directly.
+
+        Until the next edit migrates that key into ``tables``, the read path
+        must surface those entries so the editor doesn't appear to lose the
+        scope after an upgrade.
+        """
+        real_agent_config.agentic_nodes["legacy_scoped_catalogs"] = {
+            "type": "gen_sql",
+            "tools": "db_tools.*",
+            "scoped_context": {
+                "catalogs": "/Legacy/Scoped/Catalog",
+            },
+            "created_at": "2026-04-30T09:20:31.545000Z",
+        }
+
+        svc = AgentService()
+        result = await svc.get_agent("legacy_scoped_catalogs", real_agent_config)
+        assert result.success is True
+        assert result.data["agent"]["catalogs"] == ["Legacy/Scoped/Catalog"]
 
     async def test_get_falls_back_to_top_level_catalogs_for_legacy_entries(self, real_agent_config):
         """Legacy entries written before the migration still surface catalogs/subjects.

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -19,7 +19,6 @@ from datus.api.services.agent_service import (
     _normalize_created_at,
     _parse_csv,
     _parse_tools,
-    _path_to_slash_form,
     _strip_leading_slashes,
     _utc_now_iso,
     _validate_tools,
@@ -958,18 +957,26 @@ class TestBuildScopedContext:
         assert result == {"tables": "A, B"}
 
     def test_subject_buckets_write_runtime_keys(self):
-        """``subject_buckets`` writes to ``metrics`` / ``sqls`` / ``ext_knowledge``."""
+        """``subject_buckets`` writes to ``metrics`` / ``sqls`` / ``ext_knowledge``.
+
+        Subject paths are stored verbatim in dot-form; no leading-slash
+        stripping happens since the API contract is dot-separated.
+        """
         result = _build_scoped_context(
             None,
             catalogs=["/A"],
             subject_buckets={
-                "metrics": ["/M1", "/M2"],
-                "sqls": ["/S1"],
+                "metrics": ["Finance.Revenue.M1", "Sales.M2"],
+                "sqls": ["Finance.SQL.s1"],
                 "ext_knowledge": [],
             },
         )
         # ext_knowledge is empty, so its key is omitted; subjects key never appears.
-        assert result == {"tables": "A", "metrics": "M1, M2", "sqls": "S1"}
+        assert result == {
+            "tables": "A",
+            "metrics": "Finance.Revenue.M1, Sales.M2",
+            "sqls": "Finance.SQL.s1",
+        }
 
     def test_datasource_is_written_when_provided(self):
         """A non-empty datasource is recorded under ``scoped_context.datasource``."""
@@ -1036,49 +1043,29 @@ class TestBuildScopedContext:
         assert _build_scoped_context(None, subject_buckets={"metrics": [], "sqls": [], "ext_knowledge": []}) is None
 
 
-class TestPathToSlashForm:
-    """Tests for _path_to_slash_form — normalize stored tokens to slash-form paths."""
-
-    def test_dot_form_is_converted_to_slash_form(self):
-        """Stored wizard-form (`a.b.c`) comes back as `a/b/c`."""
-        assert _path_to_slash_form("finance.revenue.daily_revenue") == "finance/revenue/daily_revenue"
-
-    def test_slash_form_passes_through(self):
-        """Stored slash-form is preserved."""
-        assert _path_to_slash_form("Commerce/Orders/Avg") == "Commerce/Orders/Avg"
-
-    def test_quoted_segments_are_unquoted(self):
-        """Quoted dot-form segments (`a."b.c".d`) round-trip through `split_reference_path`."""
-        assert _path_to_slash_form('domain."name with dots".item') == "domain/name with dots/item"
-
-    def test_empty_input_returns_empty(self):
-        """Empty token yields empty string, callers filter these out."""
-        assert _path_to_slash_form("") == ""
-
-
 class TestMergeSubjectsFromScopedContext:
     """Tests for _merge_subjects_from_scoped_context — flatten the three buckets."""
 
     def test_all_three_buckets_are_concatenated(self):
         """metrics + sqls + ext_knowledge concatenate into a single subjects list."""
         scoped = {
-            "metrics": "Commerce/Orders/Avg, Sales/Region",
-            "sqls": "finance/sql_a",
-            "ext_knowledge": "Docs/handbook",
+            "metrics": "Commerce.Orders.Avg, Sales.Region",
+            "sqls": "finance.sql_a",
+            "ext_knowledge": "Docs.handbook",
         }
         assert _merge_subjects_from_scoped_context(scoped) == [
-            "Commerce/Orders/Avg",
-            "Sales/Region",
-            "finance/sql_a",
-            "Docs/handbook",
+            "Commerce.Orders.Avg",
+            "Sales.Region",
+            "finance.sql_a",
+            "Docs.handbook",
         ]
 
-    def test_dot_form_entries_are_normalized_to_slash_form(self):
-        """Wizard-written entries (`a.b.c`) come back as slash paths."""
+    def test_stored_entries_are_returned_verbatim(self):
+        """Stored dot-form entries are surfaced unchanged — no path rewriting on read."""
         scoped = {"metrics": "finance.revenue.daily, sales.region"}
         assert _merge_subjects_from_scoped_context(scoped) == [
-            "finance/revenue/daily",
-            "sales/region",
+            "finance.revenue.daily",
+            "sales.region",
         ]
 
     def test_duplicates_across_buckets_are_dropped(self):
@@ -1104,9 +1091,9 @@ class TestClassifySubjectPaths:
         silently would be the worse failure mode.
         """
         real_agent_config.current_datasource = ""
-        result = _classify_subject_paths(real_agent_config, ["Commerce/Orders/Avg", "Sales/Region"])
+        result = _classify_subject_paths(real_agent_config, ["Commerce.Orders.Avg", "Sales.Region"])
         assert result == {
-            "metrics": ["Commerce/Orders/Avg", "Sales/Region"],
+            "metrics": ["Commerce.Orders.Avg", "Sales.Region"],
             "sqls": [],
             "ext_knowledge": [],
         }
@@ -1129,8 +1116,8 @@ class TestClassifySubjectPaths:
             raise RuntimeError("storage backend down")
 
         monkeypatch.setattr(MetricRAG, "__init__", broken_init)
-        result = _classify_subject_paths(real_agent_config, ["Commerce/Orders/Avg"])
-        assert result["metrics"] == ["Commerce/Orders/Avg"]
+        result = _classify_subject_paths(real_agent_config, ["Commerce.Orders.Avg"])
+        assert result["metrics"] == ["Commerce.Orders.Avg"]
         assert result["sqls"] == []
         assert result["ext_knowledge"] == []
 
@@ -1178,17 +1165,17 @@ class TestClassifySubjectPaths:
         result = _classify_subject_paths(
             real_agent_config,
             [
-                "Commerce/Orders/my_metric",
-                "Finance/my_sql",
-                "Docs/my_doc",
-                "Unknown/path",
+                "Commerce.Orders.my_metric",
+                "Finance.my_sql",
+                "Docs.my_doc",
+                "Unknown.path",
             ],
         )
         # Unknown paths fall back to metrics so the editor's input survives the
         # round-trip — losing the user's selection silently would be worse.
-        assert result["metrics"] == ["Commerce/Orders/my_metric", "Unknown/path"]
-        assert result["sqls"] == ["Finance/my_sql"]
-        assert result["ext_knowledge"] == ["Docs/my_doc"]
+        assert result["metrics"] == ["Commerce.Orders.my_metric", "Unknown.path"]
+        assert result["sqls"] == ["Finance.my_sql"]
+        assert result["ext_knowledge"] == ["Docs.my_doc"]
 
 
 @pytest.mark.asyncio
@@ -1248,7 +1235,7 @@ class TestSubagentScopedContextRoundTrip:
                 name="scoped_create_agent",
                 type="gen_sql",
                 catalogs=["/Commerce/Orders/Average_Gross_Order_Value", "/Commerce/Sales"],
-                subjects=["/Finance/Revenue/Daily"],
+                subjects=["Finance.Revenue.Daily"],
             ),
             real_agent_config,
         )
@@ -1269,10 +1256,10 @@ class TestSubagentScopedContextRoundTrip:
         assert "catalogs" not in scoped
         assert scoped["tables"] == "Commerce/Orders/Average_Gross_Order_Value, Commerce/Sales"
         # Subjects route to ``metrics`` (the fallback bucket) because the
-        # KB stores have no entry named "Daily" under "Finance/Revenue".
+        # KB stores have no entry named "Daily" under "Finance.Revenue".
         # No flat ``subjects`` key is persisted.
         assert "subjects" not in scoped
-        assert scoped["metrics"] == "Finance/Revenue/Daily"
+        assert scoped["metrics"] == "Finance.Revenue.Daily"
 
     async def test_edit_migrates_tools_and_scoped_context(self, real_agent_config, agent_yml_with_singleton):
         """An edit normalizes tools to CSV and rewrites scoped_context.
@@ -1301,7 +1288,7 @@ class TestSubagentScopedContextRoundTrip:
                 name="legacy_scope",
                 tools=["semantic_tools.*", "db_tools.*"],
                 catalogs=["/Commerce/Orders/Avg"],
-                subjects=["/Sales/Region"],
+                subjects=["Sales.Region"],
             ),
             real_agent_config,
         )
@@ -1315,14 +1302,14 @@ class TestSubagentScopedContextRoundTrip:
         assert "catalogs" not in entry
         assert "subjects" not in entry
         scoped = entry["scoped_context"]
-        # Leading slashes are stripped, and catalogs lands on ``tables`` —
-        # no non-runtime ``catalogs`` key persists.
+        # Leading slashes on catalogs are stripped, and catalogs lands on
+        # ``tables`` — no non-runtime ``catalogs`` key persists.
         assert "catalogs" not in scoped
         assert scoped["tables"] == "Commerce/Orders/Avg"
         # No flat ``subjects`` key — subjects are classified into runtime buckets.
         assert "subjects" not in scoped
         # Without pre-populated KB stores the classifier defaults to metrics.
-        assert scoped["metrics"] == "Sales/Region"
+        assert scoped["metrics"] == "Sales.Region"
         # The active datasource is rebound on every scope-touching edit.
         assert scoped["datasource"] == real_agent_config.current_datasource
 
@@ -1372,8 +1359,8 @@ class TestSubagentScopedContextRoundTrip:
 
         Catalog entries are recovered from the runtime ``tables`` key; subjects
         are recomposed by merging the three runtime buckets (metrics / sqls /
-        ext_knowledge) into a single flat list. Stored dot-form entries
-        (wizard convention) are normalized to slash-form on the way out.
+        ext_knowledge) into a single flat list. Stored entries surface in
+        their canonical dot-separated form unchanged.
         """
         real_agent_config.agentic_nodes["roundtrip_get"] = {
             "type": "gen_sql",
@@ -1381,9 +1368,9 @@ class TestSubagentScopedContextRoundTrip:
             "scoped_context": {
                 "datasource": "finance",
                 "tables": "/Commerce/Orders/Avg, /Commerce/Sales",
-                "metrics": "Finance/Revenue/Daily, finance.revenue.weekly",
-                "sqls": "Sales/region_query",
-                "ext_knowledge": "Docs/handbook",
+                "metrics": "Finance.Revenue.Daily, finance.revenue.weekly",
+                "sqls": "Sales.region_query",
+                "ext_knowledge": "Docs.handbook",
             },
             "created_at": "2026-04-30T09:20:31.545000Z",
         }
@@ -1400,13 +1387,13 @@ class TestSubagentScopedContextRoundTrip:
         # Catalogs come back from ``scoped_context.tables`` (the runtime key);
         # leading slashes are stripped on the way out.
         assert agent["catalogs"] == ["Commerce/Orders/Avg", "Commerce/Sales"]
-        # Subjects merge across all three buckets in probe order; the dot-form
-        # entry "finance.revenue.weekly" is normalized to slash-form.
+        # Subjects merge across all three buckets in probe order; entries
+        # surface verbatim in their stored dot-form.
         assert agent["subjects"] == [
-            "Finance/Revenue/Daily",
-            "finance/revenue/weekly",
-            "Sales/region_query",
-            "Docs/handbook",
+            "Finance.Revenue.Daily",
+            "finance.revenue.weekly",
+            "Sales.region_query",
+            "Docs.handbook",
         ]
 
     async def test_round_trip_create_then_get(self, real_agent_config, agent_yml_with_singleton):
@@ -1426,7 +1413,7 @@ class TestSubagentScopedContextRoundTrip:
                 type="gen_sql",
                 tools=["semantic_tools.*", "db_tools.*"],
                 catalogs=["/Commerce/Orders/Avg"],
-                subjects=["/Sales/Region"],
+                subjects=["Commerce.Orders.Average_Order_Value.average_gross_order_value"],
             ),
             real_agent_config,
         )
@@ -1436,4 +1423,4 @@ class TestSubagentScopedContextRoundTrip:
         agent = result.data["agent"]
         assert agent["tools"] == ["semantic_tools.*", "db_tools.*"]
         assert agent["catalogs"] == ["Commerce/Orders/Avg"]
-        assert agent["subjects"] == ["Sales/Region"]
+        assert agent["subjects"] == ["Commerce.Orders.Average_Order_Value.average_gross_order_value"]

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -911,35 +911,41 @@ class TestFormatAndParseCsv:
 
     def test_round_trip_through_parse(self):
         """``_parse_csv(_format_csv(items)) == items`` for trimmed entries."""
-        items = ["/Commerce/Orders/Average_Gross_Order_Value", "/Commerce/Sales"]
+        items = ["default_catalog.mart.mf_time_spine", "default_catalog.mart.raw_orders"]
         assert _parse_csv(_format_csv(items)) == items
 
 
 class TestStripLeadingSlashes:
-    """Tests for _strip_leading_slashes — normalize subject/catalog path entries."""
+    """Tests for _strip_leading_slashes — defensive normalizer for catalog inputs.
+
+    Catalogs in the API contract are dot-separated (e.g.
+    ``default_catalog.mart.raw_orders``), so the strip is normally a
+    no-op. The helper still runs for defensive normalization, and the
+    cases here pin down its mechanical behavior on path-style strings.
+    """
 
     def test_each_entry_loses_leading_slash(self):
         """A leading ``/`` is removed from every entry in the list."""
-        assert _strip_leading_slashes(["/Commerce/Orders/Avg", "/Commerce/Sales"]) == [
-            "Commerce/Orders/Avg",
-            "Commerce/Sales",
-        ]
+        assert _strip_leading_slashes(["/foo/bar", "/baz"]) == ["foo/bar", "baz"]
 
     def test_string_input_is_split_and_stripped(self):
         """A pre-formatted comma-separated string is split before stripping."""
-        assert _strip_leading_slashes("/A/B, /C") == ["A/B", "C"]
+        assert _strip_leading_slashes("/foo/bar, /baz") == ["foo/bar", "baz"]
 
     def test_no_leading_slash_passes_through(self):
-        """Entries without a leading slash are preserved unchanged."""
-        assert _strip_leading_slashes(["A/B", "C/D"]) == ["A/B", "C/D"]
+        """Dot-form catalog entries (no leading slash) survive unchanged."""
+        assert _strip_leading_slashes(["default_catalog.mart.mf_time_spine", "default_catalog.mart.raw_orders"]) == [
+            "default_catalog.mart.mf_time_spine",
+            "default_catalog.mart.raw_orders",
+        ]
 
     def test_inner_slashes_are_kept(self):
-        """Only the leading slash is trimmed — path separators are preserved."""
-        assert _strip_leading_slashes(["/Commerce/Orders/Avg"]) == ["Commerce/Orders/Avg"]
+        """Only the leading slash is trimmed — inner separators are preserved."""
+        assert _strip_leading_slashes(["/foo/bar"]) == ["foo/bar"]
 
     def test_slash_only_entry_is_dropped(self):
         """A bare ``/`` collapses to nothing and is filtered out."""
-        assert _strip_leading_slashes(["/", "/A"]) == ["A"]
+        assert _strip_leading_slashes(["/", "/foo"]) == ["foo"]
 
 
 class TestBuildScopedContext:
@@ -951,10 +957,15 @@ class TestBuildScopedContext:
         ``ScopedContext`` has no ``catalogs`` field; the runtime's table-scope
         filter (``ScopedFilterBuilder.build_table_filter``) reads ``tables``,
         so the editor's ``catalogs`` array is the same scope under a
-        different surface name.
+        different surface name. Catalog entries are dot-separated table
+        identifiers (``catalog.schema.table``) consumed by the right-aligned
+        token parser in ``ScopedFilterBuilder.build_table_filter``.
         """
-        result = _build_scoped_context(None, catalogs=["/A", "/B"])
-        assert result == {"tables": "A, B"}
+        result = _build_scoped_context(
+            None,
+            catalogs=["default_catalog.mart.mf_time_spine", "default_catalog.mart.raw_orders"],
+        )
+        assert result == {"tables": "default_catalog.mart.mf_time_spine, default_catalog.mart.raw_orders"}
 
     def test_subject_buckets_write_runtime_keys(self):
         """``subject_buckets`` writes to ``metrics`` / ``sqls`` / ``ext_knowledge``.
@@ -964,7 +975,7 @@ class TestBuildScopedContext:
         """
         result = _build_scoped_context(
             None,
-            catalogs=["/A"],
+            catalogs=["default_catalog.mart.mf_time_spine"],
             subject_buckets={
                 "metrics": ["Finance.Revenue.M1", "Sales.M2"],
                 "sqls": ["Finance.SQL.s1"],
@@ -973,27 +984,34 @@ class TestBuildScopedContext:
         )
         # ext_knowledge is empty, so its key is omitted; subjects key never appears.
         assert result == {
-            "tables": "A",
+            "tables": "default_catalog.mart.mf_time_spine",
             "metrics": "Finance.Revenue.M1, Sales.M2",
             "sqls": "Finance.SQL.s1",
         }
 
     def test_datasource_is_written_when_provided(self):
         """A non-empty datasource is recorded under ``scoped_context.datasource``."""
-        result = _build_scoped_context(None, datasource="finance", catalogs=["/A"])
-        assert result == {"datasource": "finance", "tables": "A"}
+        result = _build_scoped_context(
+            None,
+            datasource="finance",
+            catalogs=["default_catalog.mart.mf_time_spine"],
+        )
+        assert result == {
+            "datasource": "finance",
+            "tables": "default_catalog.mart.mf_time_spine",
+        }
 
     def test_empty_datasource_clears_existing_binding(self):
         """An empty-string ``datasource`` removes a stale binding from ``base``."""
-        base = {"datasource": "old_ds", "tables": "orders"}
+        base = {"datasource": "old_ds", "tables": "default_catalog.mart.raw_orders"}
         result = _build_scoped_context(base, datasource="")
-        assert result == {"tables": "orders"}
+        assert result == {"tables": "default_catalog.mart.raw_orders"}
 
     def test_none_datasource_preserves_existing_binding(self):
         """``datasource=None`` leaves any existing binding intact."""
         base = {"datasource": "keep_me"}
-        result = _build_scoped_context(base, catalogs=["/A"])
-        assert result == {"datasource": "keep_me", "tables": "A"}
+        result = _build_scoped_context(base, catalogs=["default_catalog.mart.mf_time_spine"])
+        assert result == {"datasource": "keep_me", "tables": "default_catalog.mart.mf_time_spine"}
 
     def test_catalogs_overwrites_tables_and_drops_legacy_catalogs_key(self):
         """Catalogs fully rewrites ``tables`` and clears any non-runtime ``catalogs`` key.
@@ -1002,9 +1020,16 @@ class TestBuildScopedContext:
         the editor calls edit_agent again with catalogs the helper migrates
         them under ``tables`` so the read path can't see two competing copies.
         """
-        base = {"tables": "old_table", "catalogs": "stale_legacy", "metrics": "revenue"}
-        result = _build_scoped_context(base, catalogs=["/Commerce/Orders"])
-        assert result == {"tables": "Commerce/Orders", "metrics": "revenue"}
+        base = {
+            "tables": "default_catalog.mart.legacy_table",
+            "catalogs": "stale_legacy_pattern.*",
+            "metrics": "Finance.Revenue.daily_revenue",
+        }
+        result = _build_scoped_context(base, catalogs=["default_catalog.mart.raw_orders"])
+        assert result == {
+            "tables": "default_catalog.mart.raw_orders",
+            "metrics": "Finance.Revenue.daily_revenue",
+        }
 
     def test_subject_buckets_overwrite_existing_bucket_keys(self):
         """Passing subject_buckets fully rewrites the three bucket keys.
@@ -1012,29 +1037,45 @@ class TestBuildScopedContext:
         Empty bucket entries clear their key (rule: the editor's subjects array
         is the new full scope for the agent).
         """
-        base = {"tables": "orders", "metrics": "old", "sqls": "stale", "ext_knowledge": "stale_kb"}
+        base = {
+            "tables": "default_catalog.mart.raw_orders",
+            "metrics": "Finance.Revenue.old_metric",
+            "sqls": "Sales.stale_query",
+            "ext_knowledge": "Docs.stale_kb",
+        }
         result = _build_scoped_context(
             base,
             subject_buckets={
-                "metrics": ["new_metric"],
+                "metrics": ["Finance.Revenue.daily_revenue"],
                 "sqls": [],
                 "ext_knowledge": [],
             },
         )
         # tables survives; the three subject keys are rewritten — empty buckets clear.
-        assert result == {"tables": "orders", "metrics": "new_metric"}
+        assert result == {
+            "tables": "default_catalog.mart.raw_orders",
+            "metrics": "Finance.Revenue.daily_revenue",
+        }
 
     def test_explicit_empty_catalogs_clears_existing_tables(self):
         """Sending ``catalogs=[]`` removes the ``tables`` key from a base scoped_context."""
-        base = {"tables": "old", "metrics": "m"}
+        base = {"tables": "default_catalog.mart.raw_orders", "metrics": "Finance.Revenue.daily_revenue"}
         result = _build_scoped_context(base, catalogs=[])
-        assert result == {"metrics": "m"}
+        assert result == {"metrics": "Finance.Revenue.daily_revenue"}
 
     def test_none_subject_buckets_preserves_existing_keys(self):
         """``subject_buckets=None`` leaves any existing metrics/sqls/ext_knowledge intact."""
-        base = {"metrics": "keep_me", "sqls": "also_keep"}
-        result = _build_scoped_context(base, catalogs=["/A"], subject_buckets=None)
-        assert result == {"metrics": "keep_me", "sqls": "also_keep", "tables": "A"}
+        base = {"metrics": "Finance.Revenue.daily_revenue", "sqls": "Sales.region_query"}
+        result = _build_scoped_context(
+            base,
+            catalogs=["default_catalog.mart.mf_time_spine"],
+            subject_buckets=None,
+        )
+        assert result == {
+            "metrics": "Finance.Revenue.daily_revenue",
+            "sqls": "Sales.region_query",
+            "tables": "default_catalog.mart.mf_time_spine",
+        }
 
     def test_empty_result_returns_none(self):
         """When the merged dict ends up empty, return ``None`` so callers omit the block."""
@@ -1218,10 +1259,9 @@ class TestSubagentScopedContextRoundTrip:
 
         ``catalogs`` writes through to the runtime-honored ``tables`` key (no
         ``catalogs`` key persists, since ``ScopedContext`` doesn't define one).
-        Leading slashes from the editor's path form are stripped. ``subjects``
-        is *classified* into metrics / sqls / ext_knowledge — no flat
-        ``subjects`` key ever appears on disk because each store owns its
-        own scope filter. Without pre-populated KB stores the classifier
+        ``subjects`` is *classified* into metrics / sqls / ext_knowledge — no
+        flat ``subjects`` key ever appears on disk because each store owns
+        its own scope filter. Without pre-populated KB stores the classifier
         falls back to metrics. ``scoped_context.datasource`` is bound to the
         active datasource so ``SubAgentConfig.is_in_datasource`` agrees.
         """
@@ -1234,7 +1274,7 @@ class TestSubagentScopedContextRoundTrip:
             CreateAgentInput(
                 name="scoped_create_agent",
                 type="gen_sql",
-                catalogs=["/Commerce/Orders/Average_Gross_Order_Value", "/Commerce/Sales"],
+                catalogs=["default_catalog.mart.mf_time_spine", "default_catalog.mart.raw_orders"],
                 subjects=["Finance.Revenue.Daily"],
             ),
             real_agent_config,
@@ -1254,7 +1294,7 @@ class TestSubagentScopedContextRoundTrip:
         assert scoped["datasource"] == real_agent_config.current_datasource
         # No non-runtime ``catalogs`` key — catalogs write through to ``tables``.
         assert "catalogs" not in scoped
-        assert scoped["tables"] == "Commerce/Orders/Average_Gross_Order_Value, Commerce/Sales"
+        assert scoped["tables"] == "default_catalog.mart.mf_time_spine, default_catalog.mart.raw_orders"
         # Subjects route to ``metrics`` (the fallback bucket) because the
         # KB stores have no entry named "Daily" under "Finance.Revenue".
         # No flat ``subjects`` key is persisted.
@@ -1277,8 +1317,8 @@ class TestSubagentScopedContextRoundTrip:
         real_agent_config.agentic_nodes["legacy_scope"] = {
             "type": "gen_sql",
             "tools": ["db_tools.*"],
-            "catalogs": ["/Old/Catalog"],
-            "subjects": ["/Old/Subject"],
+            "catalogs": ["default_catalog.mart.legacy_table"],
+            "subjects": ["Legacy.Subject"],
         }
 
         svc = AgentService()
@@ -1287,7 +1327,7 @@ class TestSubagentScopedContextRoundTrip:
                 id="legacy_scope",
                 name="legacy_scope",
                 tools=["semantic_tools.*", "db_tools.*"],
-                catalogs=["/Commerce/Orders/Avg"],
+                catalogs=["default_catalog.mart.raw_orders"],
                 subjects=["Sales.Region"],
             ),
             real_agent_config,
@@ -1302,10 +1342,9 @@ class TestSubagentScopedContextRoundTrip:
         assert "catalogs" not in entry
         assert "subjects" not in entry
         scoped = entry["scoped_context"]
-        # Leading slashes on catalogs are stripped, and catalogs lands on
-        # ``tables`` — no non-runtime ``catalogs`` key persists.
+        # Catalogs lands on ``tables`` — no non-runtime ``catalogs`` key persists.
         assert "catalogs" not in scoped
-        assert scoped["tables"] == "Commerce/Orders/Avg"
+        assert scoped["tables"] == "default_catalog.mart.raw_orders"
         # No flat ``subjects`` key — subjects are classified into runtime buckets.
         assert "subjects" not in scoped
         # Without pre-populated KB stores the classifier defaults to metrics.
@@ -1328,9 +1367,9 @@ class TestSubagentScopedContextRoundTrip:
         real_agent_config.agentic_nodes["preserve_scope"] = {
             "type": "gen_sql",
             "scoped_context": {
-                "tables": "orders, customers",
-                "metrics": "revenue.daily",
-                "sqls": "finance.region_rollup",
+                "tables": "default_catalog.mart.legacy_table",
+                "metrics": "Finance.Revenue.daily_revenue",
+                "sqls": "Finance.Revenue.region_rollup",
             },
         }
 
@@ -1339,7 +1378,7 @@ class TestSubagentScopedContextRoundTrip:
             EditAgentInput(
                 id="preserve_scope",
                 name="preserve_scope",
-                catalogs=["/Commerce/Orders"],
+                catalogs=["default_catalog.mart.raw_orders"],
             ),
             real_agent_config,
         )
@@ -1350,9 +1389,9 @@ class TestSubagentScopedContextRoundTrip:
         scoped = raw["agent"]["agentic_nodes"]["preserve_scope"]["scoped_context"]
         # ``tables`` was rewritten by catalogs — there's no separate
         # ``catalogs`` key in ``ScopedContext``. Other scope fields survive.
-        assert scoped["tables"] == "Commerce/Orders"
-        assert scoped["metrics"] == "revenue.daily"
-        assert scoped["sqls"] == "finance.region_rollup"
+        assert scoped["tables"] == "default_catalog.mart.raw_orders"
+        assert scoped["metrics"] == "Finance.Revenue.daily_revenue"
+        assert scoped["sqls"] == "Finance.Revenue.region_rollup"
 
     async def test_get_returns_tools_as_list_and_extracts_scoped_paths(self, real_agent_config):
         """The read path inverts the storage format the editor expects.
@@ -1367,7 +1406,7 @@ class TestSubagentScopedContextRoundTrip:
             "tools": "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree",
             "scoped_context": {
                 "datasource": "finance",
-                "tables": "/Commerce/Orders/Avg, /Commerce/Sales",
+                "tables": "default_catalog.mart.mf_time_spine, default_catalog.mart.raw_orders",
                 "metrics": "Finance.Revenue.Daily, finance.revenue.weekly",
                 "sqls": "Sales.region_query",
                 "ext_knowledge": "Docs.handbook",
@@ -1384,9 +1423,12 @@ class TestSubagentScopedContextRoundTrip:
             "db_tools.*",
             "context_search_tools.list_subject_tree",
         ]
-        # Catalogs come back from ``scoped_context.tables`` (the runtime key);
-        # leading slashes are stripped on the way out.
-        assert agent["catalogs"] == ["Commerce/Orders/Avg", "Commerce/Sales"]
+        # Catalogs come back from ``scoped_context.tables`` (the runtime key)
+        # in their canonical dot-separated form.
+        assert agent["catalogs"] == [
+            "default_catalog.mart.mf_time_spine",
+            "default_catalog.mart.raw_orders",
+        ]
         # Subjects merge across all three buckets in probe order; entries
         # surface verbatim in their stored dot-form.
         assert agent["subjects"] == [
@@ -1397,12 +1439,12 @@ class TestSubagentScopedContextRoundTrip:
         ]
 
     async def test_round_trip_create_then_get(self, real_agent_config, agent_yml_with_singleton):
-        """Saving and re-reading yields the canonical (slash-stripped) path form.
+        """Saving and re-reading yields the canonical dot-separated form.
 
         Even though the on-disk shape changes (subjects gets split into
         ``metrics`` / ``sqls`` / ``ext_knowledge``), the API contract round-
-        trips: the editor sees ``subjects`` come back as the same flat list
-        it sent.
+        trips: the editor sees ``subjects`` and ``catalogs`` come back as
+        the same flat lists it sent.
         """
         from datus.api.models.agent_models import CreateAgentInput
 
@@ -1412,7 +1454,7 @@ class TestSubagentScopedContextRoundTrip:
                 name="full_round_trip",
                 type="gen_sql",
                 tools=["semantic_tools.*", "db_tools.*"],
-                catalogs=["/Commerce/Orders/Avg"],
+                catalogs=["default_catalog.mart.raw_orders"],
                 subjects=["Commerce.Orders.Average_Order_Value.average_gross_order_value"],
             ),
             real_agent_config,
@@ -1422,7 +1464,7 @@ class TestSubagentScopedContextRoundTrip:
         assert result.success is True
         agent = result.data["agent"]
         assert agent["tools"] == ["semantic_tools.*", "db_tools.*"]
-        assert agent["catalogs"] == ["Commerce/Orders/Avg"]
+        assert agent["catalogs"] == ["default_catalog.mart.raw_orders"]
         assert agent["subjects"] == ["Commerce.Orders.Average_Order_Value.average_gross_order_value"]
 
     async def test_edit_clearing_scope_persists_to_yaml(self, real_agent_config, agent_yml_with_singleton):
@@ -1446,7 +1488,7 @@ class TestSubagentScopedContextRoundTrip:
         real_agent_config.agentic_nodes["clear_scope_agent"] = {
             "type": "gen_sql",
             "scoped_context": {
-                "tables": "orders",
+                "tables": "default_catalog.mart.raw_orders",
                 "metrics": "Finance.Revenue.Daily",
             },
         }

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -1424,3 +1424,64 @@ class TestSubagentScopedContextRoundTrip:
         assert agent["tools"] == ["semantic_tools.*", "db_tools.*"]
         assert agent["catalogs"] == ["Commerce/Orders/Avg"]
         assert agent["subjects"] == ["Commerce.Orders.Average_Order_Value.average_gross_order_value"]
+
+    async def test_edit_clearing_scope_persists_to_yaml(self, real_agent_config, agent_yml_with_singleton):
+        """Clearing the entire scope must reach disk, not just the in-memory dict.
+
+        When the only thing the user changes is to wipe their scope
+        (``catalogs=[]`` and ``subjects=[]``), ``_build_scoped_context``
+        returns ``None`` and ``edit_agent`` removes ``scoped_context`` from
+        the live agent dict. The subsequent ``not update_data`` short-circuit
+        used to skip ``_save_agentic_nodes``, so the deletion was lost on
+        the next config reload — this test pins the fix in place.
+        """
+        import yaml
+
+        from datus.api.models.agent_models import EditAgentInput
+
+        # Seed an entry that already has a scope on disk. ``datasource`` is
+        # intentionally omitted so clearing catalogs/subjects fully empties
+        # the scoped_context dict — that's the path where merged is ``None``
+        # and the early-return previously skipped the save.
+        real_agent_config.agentic_nodes["clear_scope_agent"] = {
+            "type": "gen_sql",
+            "scoped_context": {
+                "tables": "orders",
+                "metrics": "Finance.Revenue.Daily",
+            },
+        }
+        agent_yml_with_singleton.write_text(
+            yaml.safe_dump(
+                {
+                    "agent": {
+                        "agentic_nodes": {
+                            "clear_scope_agent": real_agent_config.agentic_nodes["clear_scope_agent"],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # Reset the active datasource so the helper doesn't re-bind a fresh
+        # datasource value into scoped_context — that would leave the dict
+        # non-empty and avoid the bug entirely.
+        real_agent_config.current_datasource = ""
+
+        svc = AgentService()
+        result = await svc.edit_agent(
+            EditAgentInput(
+                id="clear_scope_agent",
+                name="clear_scope_agent",
+                catalogs=[],
+                subjects=[],
+            ),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            raw = yaml.safe_load(f)
+        entry = raw["agent"]["agentic_nodes"]["clear_scope_agent"]
+        # The whole scoped_context block is gone on disk, not just in memory.
+        assert "scoped_context" not in entry

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -1409,52 +1409,6 @@ class TestSubagentScopedContextRoundTrip:
             "Docs/handbook",
         ]
 
-    async def test_get_falls_back_to_legacy_scoped_catalogs_key(self, real_agent_config):
-        """Older API versions wrote ``scoped_context.catalogs`` directly.
-
-        Until the next edit migrates that key into ``tables``, the read path
-        must surface those entries so the editor doesn't appear to lose the
-        scope after an upgrade.
-        """
-        real_agent_config.agentic_nodes["legacy_scoped_catalogs"] = {
-            "type": "gen_sql",
-            "tools": "db_tools.*",
-            "scoped_context": {
-                "catalogs": "/Legacy/Scoped/Catalog",
-            },
-            "created_at": "2026-04-30T09:20:31.545000Z",
-        }
-
-        svc = AgentService()
-        result = await svc.get_agent("legacy_scoped_catalogs", real_agent_config)
-        assert result.success is True
-        assert result.data["agent"]["catalogs"] == ["Legacy/Scoped/Catalog"]
-
-    async def test_get_falls_back_to_top_level_catalogs_for_legacy_entries(self, real_agent_config):
-        """Legacy entries written before the migration still surface catalogs/subjects.
-
-        Older yaml files persisted catalogs and subjects at the top level. The
-        read path must keep working for them until the next edit migrates the
-        keys into scoped_context — otherwise existing configs would lose the
-        scope information after an upgrade.
-        """
-        real_agent_config.agentic_nodes["legacy_top_level"] = {
-            "type": "gen_sql",
-            "tools": "db_tools.*",
-            "catalogs": ["/Legacy/Catalog"],
-            "subjects": ["/Legacy/Subject"],
-            "created_at": "2026-04-30T09:20:31.545000Z",
-        }
-
-        svc = AgentService()
-        result = await svc.get_agent("legacy_top_level", real_agent_config)
-        assert result.success is True
-        agent = result.data["agent"]
-        # Even on the legacy fallback path, leading slashes are stripped and
-        # subjects are returned as slash-form paths.
-        assert agent["catalogs"] == ["Legacy/Catalog"]
-        assert agent["subjects"] == ["Legacy/Subject"]
-
     async def test_round_trip_create_then_get(self, real_agent_config, agent_yml_with_singleton):
         """Saving and re-reading yields the canonical (slash-stripped) path form.
 


### PR DESCRIPTION
## Why

The web editor for subagents (`POST /api/v1/agent/create`, `POST /api/v1/agent/edit`) was persisting `tools` as a YAML list and `catalogs`/`subjects` as separate top-level lists. Three problems with that shape:

1. **Tools never reached the runtime.** `GenSQLAgenticNode.setup_tools` reads `node_config.get("tools")` and calls `str.split(",")` on it (`datus/agent/node/gen_sql_agentic_node.py:259`). When yaml stored a list, that call would crash or silently fall back to defaults — the editor's tool selection was effectively a no-op.
2. **Catalogs and subjects had nowhere to land in `ScopedContext`.** The runtime model (`datus/schemas/agent_models.py`) only defines `datasource` / `tables` / `metrics` / `sqls` / `ext_knowledge`; the editor's `catalogs` array is the same scope as runtime `tables` (consumed by `ScopedFilterBuilder.build_table_filter`), and `subjects` is a flat merge of Metrics + Reference SQLs + Knowledge entries (see `ExplorerService.get_subject_list`). Persisting either at the top level or under non-runtime keys meant the editor's selection never reached any filter.
3. **Datasource binding was missing.** The wizard always rebinds `scoped_context.datasource` on save so `SubAgentConfig.is_in_datasource` can gate task delegation; the API endpoints didn't.

The user-facing contract documented in `docs/subagent/customized_subagent.zh.md` already shows the canonical yaml form (`tools: semantic_tools.*, db_tools.*, ...` and `scoped_context: { datasource, tables, metrics, sqls }`) — this PR brings the API write/read paths in line with that contract.

## Solution

`datus/api/services/agent_service.py`:

- New helpers `_format_csv` / `_parse_csv` render and split the comma-separated yaml form. `_strip_leading_slashes` normalizes catalog/subject path entries (`/Commerce/Orders/Avg` → `Commerce/Orders/Avg`) so the on-disk form is canonical regardless of what the editor sends.
- `_classify_subject_paths` resolves each subject path through `SubjectTreeStore.get_node_by_path` and probes the metric → reference-sql → ext-knowledge stores for an entry named `parts[-1]` under that node. The first store that owns the name wins; unknown paths fall back to `metrics` so the editor's input survives the round-trip. Storage init failures (e.g., project hasn't bootstrapped its KB) also degrade to the metrics bucket rather than raising a 500.
- `_merge_subjects_from_scoped_context` is the inverse: flatten the three runtime buckets back into a single subjects list, normalizing stored dot-form (`finance.revenue.daily_revenue`) into slash-form (`finance/revenue/daily_revenue`) and deduping while preserving order.
- `_build_scoped_context` writes the editor's `catalogs` array into `scoped_context.tables`, drops any non-runtime `catalogs` key written by earlier API versions, records `scoped_context.datasource` from the active datasource, and routes pre-classified `subject_buckets` to the runtime `metrics` / `sqls` / `ext_knowledge` keys. Pre-existing scoped_context entries survive unless they're explicitly rewritten.
- `create_agent` / `edit_agent` write `tools` via `_format_csv(...)`, classify `subjects`, and route everything through `_build_scoped_context`. Every scope-touching save rebinds `scoped_context.datasource` to the active datasource so the runtime gate stays consistent. Legacy top-level `catalogs` / `subjects` keys are dropped on edit so the read path can't see two competing copies.
- `get_agent` returns `tools` as a list, recovers `catalogs` from `scoped_context.tables`, and recomposes `subjects` from the three runtime buckets — no fallback to legacy-shape keys; this PR introduces the new shape so nothing in production has the intermediate or top-level form yet.

No changes to `EditAgentInput` / `CreateAgentInput` schemas — the API contract surface is unchanged from the editor's perspective; only the on-disk shape moves to match the runtime's expectations.

## Test Cases

`tests/unit_tests/api/services/test_agent_service.py` (P0 audit clean, all 107 cases pass):

- `TestFormatAndParseCsv` — list ↔ comma-separated string round-trips, blank-entry filtering.
- `TestStripLeadingSlashes` — leading-`/` removal across list / string inputs, inner separators preserved, bare `/` dropped.
- `TestPathToSlashForm` — dot-form ↔ slash-form conversion, quoted segments, empty input.
- `TestMergeSubjectsFromScopedContext` — concatenation across buckets, dot-form normalization on read, dedup across buckets, missing/empty handling.
- `TestClassifySubjectPaths` — fallback path when no datasource is bound, fallback path when storage init raises, deterministic classification via stubbed stores, unknown-name fallback to `metrics`.
- `TestBuildScopedContext` — catalogs writes runtime `tables` key, datasource binding (set / clear / preserve), legacy `catalogs` key cleared on overwrite, subject_buckets fully rewriting the three keys, pre-existing key preservation, empty result returns `None`.
- `TestSubagentScopedContextRoundTrip` — end-to-end on a real `AgentConfig` + on-disk yaml:
  - `test_create_persists_tools_as_csv_string` — yaml `tools` is the documented `"semantic_tools.*, db_tools.*, ..."` form.
  - `test_create_folds_catalogs_into_scoped_context_and_classifies_subjects` — `catalogs` writes through to `tables`, datasource is bound, subjects route to bucket keys (no flat `subjects` / `catalogs` key persists).
  - `test_edit_migrates_tools_and_scoped_context` — edits convert legacy list-form tools and top-level catalogs/subjects to the new shape, including datasource rebind.
  - `test_edit_preserves_existing_scoped_context_keys` — editing `catalogs` rewrites `tables` but leaves `metrics` / `sqls` intact when subjects isn't sent.
  - `test_get_returns_tools_as_list_and_extracts_scoped_paths` — read path inverts the storage format and merges subjects across all three buckets; catalogs lifted from `tables`.
  - `test_round_trip_create_then_get` — end-to-end create → get yields the canonical (slash-stripped) form.

No nightly/integration test changes — this PR only moves serialization shape inside the existing CRUD endpoints; nightly regression for `/agent/edit` already covers the round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified how agent tools, catalogs and subjects are persisted and surfaced using a scoped-context model while preserving backward compatibility.
* **Bug Fixes**
  * Trimmed leading slashes and normalized separators in catalog/subject inputs; consistently persist and read tools to avoid conflicting representations.
  * Preserve unrelated scoped-context keys and correctly migrate legacy top-level catalogs/subjects during edits.
* **Tests**
  * Added comprehensive unit and end-to-end tests for CSV/tool normalization, subject classification, scoped-context merging and round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->