### PR TITLE
[Enhancement] Clarify chat routing and profile context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ evaluation_details.json
 conf/agent.yml.bak
 .gstack/
 /quickstart/data_engineering/airflow/dags/*.py
+/.playwright-mcp/
 /.datus_test_data
 /subject/
 build/

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -406,6 +406,7 @@ class ChatAgenticNode(AgenticNode):
         )
         context["conversation_summary"] = conversation_summary
         context["has_task_tool"] = bool(self.sub_agent_task_tool)
+        context["active_profile"] = getattr(self.agent_config, "active_profile_name", None) or "normal"
         from datus.utils.time_utils import get_default_current_date
 
         context["current_date"] = get_default_current_date(None)

--- a/datus/prompts/prompt_templates/chat_system_1.1.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.1.j2
@@ -54,6 +54,9 @@ Current context:
 {% if workspace_root -%}
 - Current sql files root directory: {{ workspace_root }}
 {% endif -%}
+{% if active_profile -%}
+- Current permission profile: {{ active_profile }} (authoritative for this turn; previous messages may mention an older profile)
+{% endif -%}
 {% if conversation_summary -%}
 
 Previous conversation summary:

--- a/datus/prompts/prompt_templates/chat_system_1.2.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.2.j2
@@ -36,12 +36,12 @@ You have access to:
 
 **Routing decision — do this first, before any tool call:**
 
-1. Classify the request. Read the user's full intent and ask: does this match the scope of any subagent listed above (see each subagent's description and "When to use" block)?
-2. If a subagent matches, delegate to it via `task(type=..., ...)`. Do NOT pre-explore with `list_tables` / `describe_table` / `read_query` — the subagent owns that exploration and pre-running it leaks source-DB context the subagent doesn't need and may not have access to.
-3. If the request is ambiguous (missing metric, table, time range, target system, etc.), call `ask_user` FIRST to clarify, then route.
-4. Only when no subagent matches does the default apply: handle the request yourself with direct tools (`list_tables`, `describe_table`, `read_query`, etc.).
+1. Classify the requested deliverable. Ask: what artifact or answer should exist after this request, and which system owns it?
+2. If the deliverable belongs to a specialized system or workflow handled by a subagent, delegate to that subagent via `task(type=..., ...)`. Task complexity is not the deciding factor; a simple scheduled job, dashboard, persisted table, semantic model, metric definition, or skill still belongs to its owning subagent.
+3. Use direct tools (`list_tables`, `describe_table`, `read_query`, file tools, etc.) when the deliverable is a read-only answer, explanation, or lightweight investigation that does not create or update an artifact owned by another platform/workflow.
+4. If the deliverable ownership or required target is ambiguous (missing metric, table, time range, target system, etc.), call `ask_user` FIRST to clarify, then route.
 
-The subagent descriptions and "When to use" blocks below are the authoritative routing rubric — match by intent, not keyword.
+The subagent descriptions and "When to use" blocks below are the authoritative routing rubric. Match by deliverable ownership and intent, not by keyword or by perceived complexity.
 
 **When to use `task(type="explore")` — use sparingly:**
 - ONLY when broad exploration is needed that would require 5+ direct tool calls across schema, metrics, knowledge, and files
@@ -143,6 +143,9 @@ Current context:
 {% endif -%}
 {% if workspace_root -%}
 - Current sql files root directory: {{ workspace_root }}
+{% endif -%}
+{% if active_profile -%}
+- Current permission profile: {{ active_profile }} (authoritative for this turn; previous messages may mention an older profile)
 {% endif -%}
 - If a `<project_context>` block follows, it contains the project's AGENTS.md — an overview of the project architecture, directory layout, configured services, and data assets. Use it to understand the project context, but always verify with tools (list_tables, describe_table, etc.) for current data details.
 {% if conversation_summary -%}

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -912,9 +912,13 @@ class SubAgentTaskTool:
         available = self._get_available_types()
 
         lines = [
-            "Delegate a complex task to a specialized subagent. "
-            "Only use this for questions that require deep exploration or multi-step SQL reasoning. "
-            "For simple/direct questions, use your own tools (list_tables, describe_table, read_query, etc.) instead.",
+            "Delegate work to a specialized subagent when the requested deliverable belongs to that "
+            "subagent's owning workflow or platform. Task complexity is not the deciding factor: "
+            "a simple scheduled job, dashboard, persisted table, semantic model, metric definition, "
+            "or skill should still be handled by its specialized subagent. Use your own tools "
+            "(list_tables, describe_table, read_query, etc.) for read-only answers, explanations, "
+            "or lightweight investigations that do not create or update an artifact owned by another "
+            "platform/workflow.",
             "",
             "Available types:",
         ]
@@ -935,7 +939,8 @@ class SubAgentTaskTool:
             [
                 "",
                 "Guidelines:",
-                "- For simple questions, handle directly with your own tools — no need to launch subagents",
+                "- First classify the deliverable and its owning workflow/platform; delegate when it matches a subagent",
+                "- For read-only answers, explanations, and lightweight investigations, handle directly with your own tools",
                 '- For complex questions requiring deep exploration, call multiple task(type="explore") '
                 "in PARALLEL, each with a direction-specific prompt (schema+sample, knowledge, file)",
                 '- For quick single-direction lookups, call one task(type="explore") with a focused prompt',

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -569,6 +569,23 @@ class TestChatAgenticNodeSystemPrompt:
         assert isinstance(prompt, str)
         assert len(prompt) > 0
 
+    def test_get_system_prompt_contains_active_permission_profile(self, real_agent_config, mock_llm_create):
+        """Runtime /profile changes must be visible to the next LLM turn."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        real_agent_config.active_profile_name = "dangerous"
+        node = ChatAgenticNode(
+            node_id="test_prompt_profile",
+            description="Test active permission profile in prompt",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+
+        prompt = node._get_system_prompt()
+
+        assert "Current permission profile: dangerous" in prompt
+        assert "authoritative for this turn" in prompt
+
     def test_get_system_prompt_fallback_on_missing_template(self, real_agent_config, mock_llm_create):
         """_get_system_prompt falls back to chat_system when configured template is missing."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode

--- a/tests/unit_tests/cli/test_cli_styles.py
+++ b/tests/unit_tests/cli/test_cli_styles.py
@@ -128,7 +128,7 @@ class TestColorMarkup:
 
     def _capture_with_color(self, fn, *args, **kwargs) -> str:
         buf = StringIO()
-        console = Console(file=buf, force_terminal=True, color_system="truecolor")
+        console = Console(file=buf, force_terminal=True, color_system="truecolor", no_color=False)
         fn(console, *args, **kwargs)
         return buf.getvalue()
 

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -258,6 +258,13 @@ class TestBuildTaskDescription:
         desc = task_tool._build_task_description()
         assert "Guidelines" in desc
 
+    def test_description_routes_by_deliverable_ownership(self, task_tool):
+        desc = task_tool._build_task_description()
+        assert "requested deliverable" in desc
+        assert "owning workflow" in desc
+        assert "Task complexity is not the deciding factor" in desc
+        assert "For simple questions, handle directly" not in desc
+
     def test_contains_custom_description(self, task_tool):
         desc = task_tool._build_task_description()
         assert "Sales data specialist" in desc


### PR DESCRIPTION
## Why

This separates chat prompt/profile and subagent routing cleanup from the DuckDB Iceberg lakehouse quickstart PR, so the lakehouse PR can stay focused on data engineering changes.

## Solution

- Add the active permission profile to chat system prompt context so runtime `/profile` changes are visible to the next LLM turn.
- Reword chat/subagent routing guidance to route by deliverable ownership instead of task complexity alone.
- Keep generated Playwright MCP output out of git.
- Keep CLI color-style tests deterministic when color output is forced.

## Test Cases

- `uv run pytest tests/unit_tests/agent/node/test_chat_agentic_node.py::TestChatAgenticNodeSystemPrompt::test_get_system_prompt_contains_active_permission_profile tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py::TestBuildTaskDescription::test_description_routes_by_deliverable_ownership tests/unit_tests/cli/test_cli_styles.py -q`
- `uv run ruff check datus/agent/node/chat_agentic_node.py datus/tools/func_tool/sub_agent_task_tool.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/cli/test_cli_styles.py tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py`
- `uv run ruff format --check datus/agent/node/chat_agentic_node.py datus/tools/func_tool/sub_agent_task_tool.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/cli/test_cli_styles.py tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The system now displays the current active permission profile during interactions, marked authoritative for the current turn.

* **Improvements**
  * Clarified routing guidance so delegation decisions favor deliverable ownership rather than task complexity.
  * CLI/status output tests updated to reflect and preserve colored/markup rendering for clearer terminal feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->