### PR TITLE
[Enhancement] Sub-agents inherit parent scoped_context with override

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -736,11 +736,23 @@ class AgenticNode(Node):
             return {}
 
         nodes_config = agent_config.agentic_nodes
-        if node_name not in nodes_config:
+        from datus.configuration.scoped_context_overrides import get_override
+
+        override = get_override(node_name)
+        if node_name not in nodes_config and override is None:
             logger.debug(f"Node configuration '{node_name}' not found in agent.yml, using default configuration")
             return {}
 
-        node_config = nodes_config[node_name]
+        if override is not None:
+            # Layer the runtime override (with parent-merged scoped_context) on top
+            # of any yaml entry, so child node __init__ sees the effective context.
+            base = nodes_config.get(node_name) if node_name in nodes_config else {}
+            base_dict = (
+                dict(base) if isinstance(base, dict) else (base.model_dump() if hasattr(base, "model_dump") else {})
+            )
+            node_config = {**base_dict, **override.model_dump(exclude_unset=True)}
+        else:
+            node_config = nodes_config[node_name]
 
         # Extract configuration attributes
         config = {}

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -138,8 +138,9 @@ class ChatAgenticNode(AgenticNode):
 
     def setup_tools(self):
         """Initialize all tools with default database connection."""
-        self.db_func_tool = DBFuncTool(agent_config=self.agent_config)
-        self.context_search_tools = ContextSearchTools(self.agent_config)
+        node_name = self.get_node_name()
+        self.db_func_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=node_name)
+        self.context_search_tools = ContextSearchTools(self.agent_config, sub_agent_name=node_name)
         self.reference_template_tools = ReferenceTemplateTools(self.agent_config, db_func_tool=self.db_func_tool)
         self._setup_date_parsing_tools()
         self._setup_filesystem_tools()
@@ -288,7 +289,11 @@ class ChatAgenticNode(AgenticNode):
 
     def _update_database_connection(self, database_name: str):
         """Update database connection to a different database."""
-        self.db_func_tool = DBFuncTool(agent_config=self.agent_config, default_datasource=database_name)
+        self.db_func_tool = DBFuncTool(
+            agent_config=self.agent_config,
+            sub_agent_name=self.get_node_name(),
+            default_datasource=database_name,
+        )
         self._rebuild_tools()
 
     # ── Permission Helpers ──────────────────────────────────────────────

--- a/datus/agent/node/compare_agentic_node.py
+++ b/datus/agent/node/compare_agentic_node.py
@@ -86,7 +86,10 @@ class CompareAgenticNode(AgenticNode):
             return
 
         try:
-            self.db_func_tool = DBFuncTool(agent_config=self.agent_config)
+            self.db_func_tool = DBFuncTool(
+                agent_config=self.agent_config,
+                sub_agent_name=self.get_node_name(),
+            )
 
             self.tools = self.db_func_tool.available_tools()
             logger.debug(

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -143,7 +143,10 @@ class ExploreAgenticNode(AgenticNode):
     def _setup_context_search_tools(self):
         """Setup context search tools."""
         try:
-            self.context_search_tools = ContextSearchTools(self.agent_config)
+            self.context_search_tools = ContextSearchTools(
+                self.agent_config,
+                sub_agent_name=self.get_node_name(),
+            )
             self.tools.extend(self.context_search_tools.available_tools())
         except Exception as e:
             logger.warning(f"Failed to setup context search tools, continuing without: {e}")

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -159,8 +159,9 @@ class GenExtKnowledgeAgenticNode(AgenticNode):
         # Hardcoded tool configuration: specific methods from generation_tools and filesystem_tools
         # filesystem_tools: read_file, write_file, edit_file
         # Chat node uses all available tools by default
-        self.db_func_tool = DBFuncTool(agent_config=self.agent_config)
-        self.context_search_tools = ContextSearchTools(self.agent_config)
+        node_name = self.get_node_name()
+        self.db_func_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=node_name)
+        self.context_search_tools = ContextSearchTools(self.agent_config, sub_agent_name=node_name)
         if self.db_func_tool:
             self.tools.extend(self.db_func_tool.available_tools())
         if self.context_search_tools:

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -138,7 +138,10 @@ class GenSemanticModelAgenticNode(AgenticNode):
     def _setup_db_tools(self):
         """Setup database tools."""
         try:
-            self.db_func_tool = DBFuncTool(agent_config=self.agent_config)
+            self.db_func_tool = DBFuncTool(
+                agent_config=self.agent_config,
+                sub_agent_name=self.get_node_name(),
+            )
             # Add standard database tools
             self.tools.extend(self.db_func_tool.available_tools())
             logger.debug("Added database tools from DBFuncTool")

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -147,7 +147,10 @@ class SkillCreatorAgenticNode(AgenticNode):
     def _setup_db_tools(self):
         """Setup database tools (optional, for understanding schema when creating data-related skills)."""
         try:
-            self.db_func_tool = DBFuncTool(agent_config=self.agent_config)
+            self.db_func_tool = DBFuncTool(
+                agent_config=self.agent_config,
+                sub_agent_name=self.get_node_name(),
+            )
             self.tools.extend(self.db_func_tool.available_tools())
         except Exception as e:
             logger.warning(f"Failed to setup database tools, continuing without: {e}")

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -295,9 +295,7 @@ class GenSQLAgenticNode(AgenticNode):
     def _setup_context_search_tools(self):
         """Setup context search tools."""
         try:
-            self.context_search_tools = ContextSearchTools(
-                self.agent_config, sub_agent_name=self.get_node_name()
-            )
+            self.context_search_tools = ContextSearchTools(self.agent_config, sub_agent_name=self.get_node_name())
             self.tools.extend(self.context_search_tools.available_tools())
         except Exception as e:
             logger.error(f"Failed to setup context search tools: {e}")

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -252,11 +252,11 @@ class GenSQLAgenticNode(AgenticNode):
             return
 
         self.tools = []
-        config_value = self.node_config.get("tools")
-        if config_value is None:
-            config_value = self.DEFAULT_TOOLS
+        tools_str = self.node_config.get("tools")
+        if not tools_str:
+            tools_str = self.DEFAULT_TOOLS
 
-        tool_patterns = [p.strip() for p in config_value.split(",") if p.strip()]
+        tool_patterns = [p.strip() for p in tools_str.split(",") if p.strip()]
         for pattern in tool_patterns:
             self._setup_tool_pattern(pattern)
 
@@ -296,7 +296,7 @@ class GenSQLAgenticNode(AgenticNode):
         """Setup context search tools."""
         try:
             self.context_search_tools = ContextSearchTools(
-                self.agent_config, sub_agent_name=self.node_config["system_prompt"]
+                self.agent_config, sub_agent_name=self.get_node_name()
             )
             self.tools.extend(self.context_search_tools.available_tools())
         except Exception as e:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1891,10 +1891,14 @@ class AgentConfig:
     def sub_agent_config(self, sub_agent_name: str) -> Dict[str, Any]:
         from datus.configuration.scoped_context_overrides import get_override
 
+        base = self.agentic_nodes.get(sub_agent_name, {}) or {}
         override = get_override(sub_agent_name)
-        if override is not None:
-            return override.model_dump()
-        return self.agentic_nodes.get(sub_agent_name, {})
+        if override is None:
+            return base
+        # Layer override on top of YAML so non-SubAgentConfig keys
+        # (model, max_turns, permissions, hooks, ...) survive.
+        base_dict = dict(base) if isinstance(base, dict) else (base.model_dump() if hasattr(base, "model_dump") else {})
+        return {**base_dict, **override.model_dump(exclude_unset=True)}
 
     def benchmark_config(self, benchmark_platform) -> BenchmarkConfig:
         if benchmark_platform not in self.benchmark_configs:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1889,6 +1889,11 @@ class AgentConfig:
         )
 
     def sub_agent_config(self, sub_agent_name: str) -> Dict[str, Any]:
+        from datus.configuration.scoped_context_overrides import get_override
+
+        override = get_override(sub_agent_name)
+        if override is not None:
+            return override.model_dump()
         return self.agentic_nodes.get(sub_agent_name, {})
 
     def benchmark_config(self, benchmark_platform) -> BenchmarkConfig:

--- a/datus/configuration/scoped_context_overrides.py
+++ b/datus/configuration/scoped_context_overrides.py
@@ -1,0 +1,43 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Runtime overrides for sub-agent configuration.
+
+Allows ``SubAgentTaskTool`` to install an effective ``SubAgentConfig`` (with a
+parent-merged ``scoped_context``) for the duration of a child agent's
+execution. Consumers that already look up sub-agent config by name (e.g.
+``rag_scope._build_sub_agent_filter``) automatically observe the override
+without changes.
+
+Backed by ``contextvars.ContextVar`` so concurrent ``asyncio.Task`` siblings
+remain isolated (each Task copies the current context at creation).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Dict, Iterator, Optional
+
+from datus.schemas.agent_models import SubAgentConfig
+
+_OVERRIDES: ContextVar[Optional[Dict[str, SubAgentConfig]]] = ContextVar("datus_subagent_overrides", default=None)
+
+
+def _current_map() -> Dict[str, SubAgentConfig]:
+    return _OVERRIDES.get() or {}
+
+
+def get_override(sub_agent_name: str) -> Optional[SubAgentConfig]:
+    return _current_map().get(sub_agent_name)
+
+
+@contextmanager
+def effective_subagent(sub_agent_name: str, cfg: SubAgentConfig) -> Iterator[None]:
+    new_map = {**_current_map(), sub_agent_name: cfg}
+    token = _OVERRIDES.set(new_map)
+    try:
+        yield
+    finally:
+        _OVERRIDES.reset(token)

--- a/datus/schemas/agent_models.py
+++ b/datus/schemas/agent_models.py
@@ -50,6 +50,18 @@ class ScopedContext(BaseModel):
             ext_knowledge=_split(self.ext_knowledge),
         )
 
+    def merge_with(self, child: Optional["ScopedContext"]) -> "ScopedContext":
+        return merge_scoped_contexts(self, child)
+
+
+def merge_scoped_contexts(parent: Optional[ScopedContext], child: Optional[ScopedContext]) -> ScopedContext:
+    """Whole-segment override: child wins iff it declares any KB field; otherwise inherit parent."""
+    if child is not None and not child.is_empty:
+        return child.model_copy()
+    if parent is not None:
+        return parent.model_copy()
+    return ScopedContext()
+
 
 class SubAgentConfig(BaseModel):
     system_prompt: str = Field("", init=True, description="Name of sub agent")
@@ -116,6 +128,10 @@ class SubAgentConfig(BaseModel):
 
     def is_in_datasource(self, datasource: str) -> bool:
         return self.has_scoped_context() and datasource == self.scoped_context.datasource
+
+    def with_effective_scoped_context(self, parent_sc: Optional[ScopedContext]) -> "SubAgentConfig":
+        merged = merge_scoped_contexts(parent_sc, self.scoped_context)
+        return self.model_copy(update={"scoped_context": merged})
 
     def as_payload(self, datasource: Optional[str] = None) -> Dict[str, Any]:
         payload: Dict[str, Any] = {

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -30,7 +30,7 @@ class FilesystemConfig:
         self,
         root_path: str = None,
         allowed_extensions: List[str] = None,
-        max_file_size: int = 1024 * 1024,
+        max_file_size: int = 200 * 1024,
     ):
         self.root_path = root_path or os.getcwd()
         self.allowed_extensions = allowed_extensions or [

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -22,6 +22,7 @@ from agents import FunctionTool, Tool
 
 from datus.configuration.agent_config import AgentConfig
 from datus.configuration.node_type import NodeType
+from datus.configuration.scoped_context_overrides import effective_subagent
 from datus.schemas.action_history import (
     SUBAGENT_COMPLETE_ACTION_TYPE,
     ActionHistory,
@@ -29,7 +30,7 @@ from datus.schemas.action_history import (
     ActionRole,
     ActionStatus,
 )
-from datus.schemas.agent_models import SubAgentConfig
+from datus.schemas.agent_models import ScopedContext, SubAgentConfig
 from datus.tools.func_tool.base import FuncToolResult
 from datus.utils.constants import SYS_SUB_AGENTS
 from datus.utils.loggings import get_logger
@@ -544,91 +545,110 @@ class SubAgentTaskTool:
                 ),
             )
 
-        node = self._create_node(subagent_type)
-        node.ephemeral = True  # Use in-memory session — no SQLite persistence for sub-agents
+        effective_cfg = self._resolve_effective_sub_agent_config(subagent_type)
 
-        # Set input on the node
-        node.input = self._build_node_input(node, prompt)
+        with effective_subagent(subagent_type, effective_cfg):
+            node = self._create_node(subagent_type)
+            node.ephemeral = True  # Use in-memory session — no SQLite persistence for sub-agents
 
-        # Inject parent's InteractionBroker so that sub-agent INTERACTION
-        # actions are routed through the parent's broker queue.  When injected,
-        # we call execute_stream() (not execute_stream_with_interactions()) to
-        # avoid dual-consuming the same broker.fetch() stream.
-        if self._interaction_broker is not None:
-            self._inject_broker(node, self._interaction_broker)
+            # Set input on the node
+            node.input = self._build_node_input(node, prompt)
 
-        # Propagate proxy tool config from parent node so sub-agent tools are
-        # also proxied.  Uses the parent's tool_channel so stdin dispatch can
-        # resolve futures for both parent and sub-agent tools.
-        # Note: apply_proxy_tools internally detects fs-dependent nodes and
-        # excludes their filesystem_tools category from proxying.
-        if self._parent_node and self._parent_node.proxy_tool_patterns:
-            from datus.tools.proxy.proxy_tool import apply_proxy_tools
+            # Inject parent's InteractionBroker so that sub-agent INTERACTION
+            # actions are routed through the parent's broker queue.  When injected,
+            # we call execute_stream() (not execute_stream_with_interactions()) to
+            # avoid dual-consuming the same broker.fetch() stream.
+            if self._interaction_broker is not None:
+                self._inject_broker(node, self._interaction_broker)
 
-            apply_proxy_tools(node, self._parent_node.proxy_tool_patterns, channel=self._parent_node.tool_channel)
+            # Propagate proxy tool config from parent node so sub-agent tools are
+            # also proxied.  Uses the parent's tool_channel so stdin dispatch can
+            # resolve futures for both parent and sub-agent tools.
+            # Note: apply_proxy_tools internally detects fs-dependent nodes and
+            # excludes their filesystem_tools category from proxying.
+            if self._parent_node and self._parent_node.proxy_tool_patterns:
+                from datus.tools.proxy.proxy_tool import apply_proxy_tools
 
-        # Iterate the async generator directly (we're already in async context)
-        action_history_manager = ActionHistoryManager()
-        final_output = None
+                apply_proxy_tools(node, self._parent_node.proxy_tool_patterns, channel=self._parent_node.tool_channel)
 
-        # When parent broker is injected, INTERACTION actions flow through the
-        # parent's broker.fetch() → parent merge → CLI.  We only need
-        # execute_stream() here; otherwise fall back to the full merge.
-        if self._interaction_broker is not None:
-            stream = node.execute_stream(action_history_manager)
-        else:
-            stream = node.execute_stream_with_interactions(action_history_manager)
+            # Iterate the async generator directly (we're already in async context)
+            action_history_manager = ActionHistoryManager()
+            final_output = None
 
-        stream_start_time = datetime.now()
-        tool_count = 0
-        subagent_status = ActionStatus.SUCCESS
-        first_user_seen = False
+            # When parent broker is injected, INTERACTION actions flow through the
+            # parent's broker.fetch() → parent merge → CLI.  We only need
+            # execute_stream() here; otherwise fall back to the full merge.
+            if self._interaction_broker is not None:
+                stream = node.execute_stream(action_history_manager)
+            else:
+                stream = node.execute_stream_with_interactions(action_history_manager)
 
-        try:
-            async for action in stream:
-                # Inject _task_description into the first USER action for display
-                if not first_user_seen and action.role == ActionRole.USER:
-                    if description:
-                        if action.input is None:
-                            action.input = {}
-                        if isinstance(action.input, dict):
-                            action.input["_task_description"] = description
-                    first_user_seen = True
+            stream_start_time = datetime.now()
+            tool_count = 0
+            subagent_status = ActionStatus.SUCCESS
+            first_user_seen = False
 
-                # Forward sub-action to the ActionBus (real-time CoT streaming)
-                if self._action_bus is not None:
-                    action.depth = 1
-                    if call_id:
-                        action.parent_action_id = call_id
-                    logger.debug(
-                        "SubAgentTaskTool bus.put",
-                        action_type=action.action_type,
-                        role=str(action.role),
-                        status=str(action.status),
-                    )
-                    self._action_bus.put(action)
-
-                if action.role == ActionRole.TOOL:
-                    tool_count += 1
-
-                if action.status == ActionStatus.FAILED:
-                    subagent_status = ActionStatus.FAILED
-                    if action.output:
-                        final_output = action.output
-                elif action.status == ActionStatus.SUCCESS and action.output:
-                    final_output = action.output
-        except Exception:
-            subagent_status = ActionStatus.FAILED
-            raise
-        finally:
-            self._emit_complete_action(subagent_type, call_id, stream_start_time, tool_count, subagent_status)
-            # Cleanup node resources (MCP connections, sessions, file handles)
             try:
-                node.delete_session()
+                async for action in stream:
+                    # Inject _task_description into the first USER action for display
+                    if not first_user_seen and action.role == ActionRole.USER:
+                        if description:
+                            if action.input is None:
+                                action.input = {}
+                            if isinstance(action.input, dict):
+                                action.input["_task_description"] = description
+                        first_user_seen = True
+
+                    # Forward sub-action to the ActionBus (real-time CoT streaming)
+                    if self._action_bus is not None:
+                        action.depth = 1
+                        if call_id:
+                            action.parent_action_id = call_id
+                        logger.debug(
+                            "SubAgentTaskTool bus.put",
+                            action_type=action.action_type,
+                            role=str(action.role),
+                            status=str(action.status),
+                        )
+                        self._action_bus.put(action)
+
+                    if action.role == ActionRole.TOOL:
+                        tool_count += 1
+
+                    if action.status == ActionStatus.FAILED:
+                        subagent_status = ActionStatus.FAILED
+                        if action.output:
+                            final_output = action.output
+                    elif action.status == ActionStatus.SUCCESS and action.output:
+                        final_output = action.output
             except Exception:
-                logger.debug("Failed to cleanup sub-agent node session", exc_info=True)
+                subagent_status = ActionStatus.FAILED
+                raise
+            finally:
+                self._emit_complete_action(subagent_type, call_id, stream_start_time, tool_count, subagent_status)
+                # Cleanup node resources (MCP connections, sessions, file handles)
+                try:
+                    node.delete_session()
+                except Exception:
+                    logger.debug("Failed to cleanup sub-agent node session", exc_info=True)
 
         return self._convert_to_func_result(final_output)
+
+    def _resolve_effective_sub_agent_config(self, subagent_type: str) -> SubAgentConfig:
+        """Build an effective SubAgentConfig that inherits parent scoped_context when child has none."""
+        parent_sc: Optional[ScopedContext] = None
+        parent_cfg = getattr(self._parent_node, "node_config", None)
+        if isinstance(parent_cfg, dict):
+            raw = parent_cfg.get("scoped_context")
+            if isinstance(raw, ScopedContext):
+                parent_sc = raw
+            elif isinstance(raw, dict):
+                parent_sc = ScopedContext.model_validate(raw)
+
+        raw_child = self.agent_config.sub_agent_config(subagent_type)
+        child_dict = raw_child if isinstance(raw_child, dict) else {}
+        child_cfg = SubAgentConfig.model_validate(child_dict)
+        return child_cfg.with_effective_scoped_context(parent_sc)
 
     def _emit_complete_action(
         self,
@@ -944,17 +964,6 @@ class SubAgentTaskTool:
                 '- For complex questions requiring deep exploration, call multiple task(type="explore") '
                 "in PARALLEL, each with a direction-specific prompt (schema+sample, knowledge, file)",
                 '- For quick single-direction lookups, call one task(type="explore") with a focused prompt',
-                '- Use task(type="gen_sql") for SQL generation requiring multi-step reasoning, '
-                "complex joins, or domain-specific logic",
-                '- Use task(type="gen_report") for metric attribution, root cause analysis, '
-                "or analyzing why a metric/reference_sql result changed",
-                '- Use task(type="gen_skill") when the user wants to create a new skill or optimize an existing skill',
-                '- Use task(type="gen_dashboard") for creating/updating/inspecting BI dashboards, '
-                "charts, and datasets on Superset or Grafana",
-                '- Use task(type="scheduler") for submitting, monitoring, updating, '
-                "and troubleshooting scheduled jobs on Airflow",
-                "- In plan mode, use task() for each SQL sub-step",
-                "- Always provide a short 'description' summarizing the task goal",
             ]
         )
 

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -2754,6 +2754,50 @@ class TestGenSQLParseNodeConfig:
         result = node._parse_node_config(mock_config, "gensql")
         assert result == {}
 
+    def test_runtime_override_layered_on_yaml_entry(self):
+        """When effective_subagent pushes an override, _parse_node_config picks it up."""
+        from datus.configuration.scoped_context_overrides import effective_subagent
+        from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+        node = _make_gensql_node()
+        mock_config = MagicMock()
+        mock_config.agentic_nodes = {
+            "gensql": {
+                "system_prompt": "yaml_prompt",
+                "scoped_context": {"tables": "yaml_tables"},
+            }
+        }
+        override = SubAgentConfig(
+            system_prompt="effective",
+            scoped_context=ScopedContext(tables="override_tables"),
+        )
+        with effective_subagent("gensql", override):
+            result = node._parse_node_config(mock_config, "gensql")
+        sc = result.get("scoped_context")
+        if isinstance(sc, dict):
+            assert sc.get("tables") == "override_tables"
+        else:
+            assert sc.tables == "override_tables"
+
+    def test_runtime_override_creates_entry_when_yaml_missing(self):
+        """Builtin subagent (no yaml entry) still gets config when override is pushed."""
+        from datus.configuration.scoped_context_overrides import effective_subagent
+        from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+        node = _make_gensql_node()
+        mock_config = MagicMock()
+        mock_config.agentic_nodes = {}
+        override = SubAgentConfig(
+            system_prompt="builtin",
+            scoped_context=ScopedContext(tables="parent_tables"),
+        )
+        with effective_subagent("gen_metrics", override):
+            result = node._parse_node_config(mock_config, "gen_metrics")
+        assert result != {}
+        sc = result.get("scoped_context")
+        tables = sc.get("tables") if isinstance(sc, dict) else sc.tables
+        assert tables == "parent_tables"
+
 
 # ---------------------------------------------------------------------------
 # execute_stream with mocked model

--- a/tests/unit_tests/configuration/test_scoped_context_overrides.py
+++ b/tests/unit_tests/configuration/test_scoped_context_overrides.py
@@ -1,0 +1,98 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.configuration.scoped_context_overrides``."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from datus.configuration.scoped_context_overrides import effective_subagent, get_override
+from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+
+def _cfg(tables: str) -> SubAgentConfig:
+    return SubAgentConfig(system_prompt="x", scoped_context=ScopedContext(tables=tables))
+
+
+@pytest.mark.ci
+class TestScopedContextOverrides:
+    def test_no_override_returns_none(self):
+        assert get_override("missing") is None
+
+    def test_push_then_pop_via_context_manager(self):
+        cfg = _cfg("public.users")
+        with effective_subagent("agent_a", cfg):
+            got = get_override("agent_a")
+            assert got is not None
+            assert got.scoped_context.tables == "public.users"
+        # After exit, override is gone.
+        assert get_override("agent_a") is None
+
+    def test_nested_overrides_stack_and_unwind(self):
+        outer = _cfg("public.users")
+        inner = _cfg("public.orders")
+        with effective_subagent("agent_a", outer):
+            assert get_override("agent_a").scoped_context.tables == "public.users"
+            with effective_subagent("agent_a", inner):
+                assert get_override("agent_a").scoped_context.tables == "public.orders"
+            # Pop restores outer.
+            assert get_override("agent_a").scoped_context.tables == "public.users"
+        assert get_override("agent_a") is None
+
+    def test_exception_inside_block_still_resets(self):
+        cfg = _cfg("public.users")
+        with pytest.raises(RuntimeError):
+            with effective_subagent("agent_a", cfg):
+                raise RuntimeError("boom")
+        assert get_override("agent_a") is None
+
+    def test_multiple_distinct_names_coexist(self):
+        a = _cfg("t_a")
+        b = _cfg("t_b")
+        with effective_subagent("agent_a", a):
+            with effective_subagent("agent_b", b):
+                assert get_override("agent_a").scoped_context.tables == "t_a"
+                assert get_override("agent_b").scoped_context.tables == "t_b"
+
+    @pytest.mark.asyncio
+    async def test_override_isolated_across_asyncio_tasks(self):
+        """Sibling ``asyncio.Task`` that captures context at creation time must not see
+        an override pushed afterwards in the parent task."""
+        captured = {}
+
+        async def reader(name: str):
+            # No override pushed in this task → parent's later push must not leak in.
+            await asyncio.sleep(0.01)
+            captured[name] = get_override("agent_a")
+
+        async def pusher():
+            with effective_subagent("agent_a", _cfg("inside_task")):
+                await asyncio.sleep(0.02)
+                captured["inside_pusher"] = get_override("agent_a")
+
+        sibling = asyncio.create_task(reader("sibling"))
+        pusher_task = asyncio.create_task(pusher())
+        await asyncio.gather(sibling, pusher_task)
+
+        assert captured["sibling"] is None
+        assert captured["inside_pusher"].scoped_context.tables == "inside_task"
+        # Outer scope sees no override either.
+        assert get_override("agent_a") is None
+
+    @pytest.mark.asyncio
+    async def test_parallel_pushers_do_not_pollute_each_other(self):
+        """Two sibling tasks pushing the same name with different cfgs must each see only their own."""
+        observed: dict[str, str] = {}
+
+        async def run(label: str, tables: str):
+            with effective_subagent("agent_a", _cfg(tables)):
+                # Yield to scheduler so the other task runs concurrently.
+                await asyncio.sleep(0.01)
+                observed[label] = get_override("agent_a").scoped_context.tables
+
+        await asyncio.gather(run("p1", "table_one"), run("p2", "table_two"))
+        assert observed == {"p1": "table_one", "p2": "table_two"}

--- a/tests/unit_tests/schemas/test_agent_models.py
+++ b/tests/unit_tests/schemas/test_agent_models.py
@@ -9,7 +9,7 @@ Primary focus: the ``subagents`` field normalization validator.
 
 import pytest
 
-from datus.schemas.agent_models import SubAgentConfig
+from datus.schemas.agent_models import ScopedContext, SubAgentConfig, merge_scoped_contexts
 
 
 @pytest.mark.ci
@@ -79,3 +79,108 @@ class TestSubAgentsFieldNormalization:
         cfg = SubAgentConfig(system_prompt="x", subagents="gen_sql, explore")
         payload = cfg.as_payload()
         assert payload["subagents"] == "gen_sql,explore"
+
+
+@pytest.mark.ci
+class TestScopedContextMerge:
+    """Whole-segment override semantics for parent → child scoped_context inheritance."""
+
+    PARENT = ScopedContext(
+        datasource="db_p",
+        tables="public.users,public.orders",
+        metrics="rev",
+        sqls="q1",
+        ext_knowledge="kb1",
+    )
+
+    def test_child_none_inherits_parent(self):
+        merged = merge_scoped_contexts(self.PARENT, None)
+        assert merged.tables == "public.users,public.orders"
+        assert merged.metrics == "rev"
+        assert merged.sqls == "q1"
+        assert merged.ext_knowledge == "kb1"
+        assert merged.datasource == "db_p"
+
+    def test_child_empty_inherits_parent(self):
+        empty_child = ScopedContext()
+        merged = merge_scoped_contexts(self.PARENT, empty_child)
+        assert merged.tables == self.PARENT.tables
+        assert merged.metrics == self.PARENT.metrics
+        assert merged.datasource == "db_p"
+
+    def test_child_only_datasource_still_inherits_parent_kb(self):
+        # is_empty ignores datasource → child considered empty → inherit parent
+        ds_only = ScopedContext(datasource="db_c")
+        merged = merge_scoped_contexts(self.PARENT, ds_only)
+        assert merged.tables == self.PARENT.tables
+        assert merged.metrics == self.PARENT.metrics
+
+    def test_child_with_tables_replaces_whole_segment(self):
+        child = ScopedContext(tables="public.products")
+        merged = merge_scoped_contexts(self.PARENT, child)
+        assert merged.tables == "public.products"
+        # Whole-segment override: parent metrics/sqls/ext_knowledge dropped.
+        assert merged.metrics is None
+        assert merged.sqls is None
+        assert merged.ext_knowledge is None
+
+    def test_child_with_metrics_replaces_whole_segment(self):
+        child = ScopedContext(metrics="orders_per_day")
+        merged = merge_scoped_contexts(self.PARENT, child)
+        assert merged.metrics == "orders_per_day"
+        assert merged.tables is None
+
+    def test_both_none_returns_empty(self):
+        merged = merge_scoped_contexts(None, None)
+        assert merged.is_empty
+        assert merged.datasource == ""
+
+    def test_parent_none_yields_child_copy(self):
+        child = ScopedContext(tables="t1")
+        merged = merge_scoped_contexts(None, child)
+        assert merged.tables == "t1"
+        # Returned object is a copy, not the same instance.
+        assert merged is not child
+
+    def test_parent_returned_as_copy(self):
+        merged = merge_scoped_contexts(self.PARENT, None)
+        assert merged is not self.PARENT
+        # Mutating the merged copy doesn't touch the parent.
+        merged.tables = "xxx"
+        assert self.PARENT.tables == "public.users,public.orders"
+
+    def test_scoped_context_merge_with_method_delegates(self):
+        merged = self.PARENT.merge_with(None)
+        assert merged.tables == self.PARENT.tables
+        assert merged is not self.PARENT
+
+
+@pytest.mark.ci
+class TestSubAgentConfigEffectiveScopedContext:
+    """``SubAgentConfig.with_effective_scoped_context`` returns an immutable copy."""
+
+    def test_returns_new_instance_with_merged_scope(self):
+        parent = ScopedContext(tables="public.users")
+        child = SubAgentConfig(system_prompt="x")  # no scope → inherit parent
+        effective = child.with_effective_scoped_context(parent)
+        assert effective is not child
+        assert effective.scoped_context is not None
+        assert effective.scoped_context.tables == "public.users"
+        # Original child unchanged.
+        assert child.scoped_context is None
+
+    def test_child_scope_overrides_parent_segment(self):
+        parent = ScopedContext(tables="public.users", metrics="rev")
+        child = SubAgentConfig(
+            system_prompt="x",
+            scoped_context=ScopedContext(tables="public.orders"),
+        )
+        effective = child.with_effective_scoped_context(parent)
+        assert effective.scoped_context.tables == "public.orders"
+        assert effective.scoped_context.metrics is None  # whole-segment replacement
+
+    def test_no_parent_keeps_child_scope(self):
+        child_sc = ScopedContext(tables="public.users")
+        child = SubAgentConfig(system_prompt="x", scoped_context=child_sc)
+        effective = child.with_effective_scoped_context(None)
+        assert effective.scoped_context.tables == "public.users"

--- a/tests/unit_tests/storage/test_rag_scope.py
+++ b/tests/unit_tests/storage/test_rag_scope.py
@@ -170,3 +170,58 @@ class TestRuntimeOverrideIntegration:
         c1, c2 = await asyncio.gather(run("table_one"), run("table_two"))
         assert "table_one" in c1 and "table_two" not in c1
         assert "table_two" in c2 and "table_one" not in c2
+
+    def test_override_preserves_non_subagentconfig_yaml_keys(self):
+        """Override must layer on top of YAML so keys outside SubAgentConfig
+        (model, max_turns, permissions, ...) survive when scoped_context is overridden.
+        """
+        from datus.configuration.scoped_context_overrides import effective_subagent
+        from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+        config = self._real_config(
+            {
+                "team_a": {
+                    "model": "gpt-4.1",
+                    "max_turns": 7,
+                    "permissions": {"read": True},
+                    "scoped_context": {"tables": "public.users"},
+                }
+            }
+        )
+        override_cfg = SubAgentConfig(
+            system_prompt="x",
+            scoped_context=ScopedContext(tables="public.orders"),
+        )
+        with effective_subagent("team_a", override_cfg):
+            merged = config.sub_agent_config("team_a")
+        # Override fields win.
+        assert merged["scoped_context"]["tables"] == "public.orders"
+        # YAML-only fields preserved.
+        assert merged["model"] == "gpt-4.1"
+        assert merged["max_turns"] == 7
+        assert merged["permissions"] == {"read": True}
+
+    def test_override_only_overwrites_explicitly_set_fields(self):
+        """Fields not explicitly set on the override SubAgentConfig must not
+        clobber the YAML entry with their pydantic defaults.
+        """
+        from datus.configuration.scoped_context_overrides import effective_subagent
+        from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+        config = self._real_config(
+            {
+                "team_a": {
+                    "system_prompt": "yaml_prompt",
+                    "tools": "list_tables,describe_table",
+                    "scoped_context": {"tables": "public.users"},
+                }
+            }
+        )
+        # Only scoped_context is explicitly set on the override.
+        override_cfg = SubAgentConfig(scoped_context=ScopedContext(tables="public.orders"))
+        with effective_subagent("team_a", override_cfg):
+            merged = config.sub_agent_config("team_a")
+        assert merged["scoped_context"]["tables"] == "public.orders"
+        # YAML system_prompt and tools survive because override didn't set them.
+        assert merged["system_prompt"] == "yaml_prompt"
+        assert merged["tools"] == "list_tables,describe_table"

--- a/tests/unit_tests/storage/test_rag_scope.py
+++ b/tests/unit_tests/storage/test_rag_scope.py
@@ -97,3 +97,76 @@ class TestBuildSubAgentFilter:
         )
         result = _build_sub_agent_filter(config, "team_a", _mock_storage(), "tables")
         assert result is None
+
+
+class TestRuntimeOverrideIntegration:
+    """Verify ``AgentConfig.sub_agent_config`` consults the ContextVar override.
+
+    These tests exercise the real ``AgentConfig.sub_agent_config`` method (not the
+    test mock above) so the runtime override path is covered end-to-end.
+    """
+
+    def _real_config(self, agentic_nodes):
+        # Bypass __init__ to avoid loading agent.yml; only the method we test is needed.
+        from datus.configuration.agent_config import AgentConfig
+
+        config = AgentConfig.__new__(AgentConfig)
+        config.agentic_nodes = agentic_nodes
+        return config
+
+    def test_yaml_path_when_no_override(self):
+        config = self._real_config({"team_a": {"scoped_context": {"tables": "public.users"}}})
+        result = _build_sub_agent_filter(config, "team_a", _mock_storage(), "tables")
+        assert result is not None
+        assert "users" in build_where(result)
+
+    def test_runtime_override_takes_precedence_over_yaml(self):
+        from datus.configuration.scoped_context_overrides import effective_subagent
+        from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+        config = self._real_config({"team_a": {"scoped_context": {"tables": "public.users"}}})
+        override_cfg = SubAgentConfig(
+            system_prompt="x",
+            scoped_context=ScopedContext(tables="public.orders"),
+        )
+        with effective_subagent("team_a", override_cfg):
+            result = _build_sub_agent_filter(config, "team_a", _mock_storage(), "tables")
+        assert result is not None
+        clause = build_where(result)
+        assert "orders" in clause
+        assert "users" not in clause
+
+    def test_override_supplies_scope_when_yaml_has_none(self):
+        from datus.configuration.scoped_context_overrides import effective_subagent
+        from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+        # Builtin subagent: no yaml entry; parent inheritance should still produce a filter.
+        config = self._real_config({})
+        override_cfg = SubAgentConfig(
+            system_prompt="x",
+            scoped_context=ScopedContext(tables="public.users"),
+        )
+        with effective_subagent("gen_metrics", override_cfg):
+            result = _build_sub_agent_filter(config, "gen_metrics", _mock_storage(), "tables")
+        assert result is not None
+        assert "users" in build_where(result)
+
+    @pytest.mark.asyncio
+    async def test_override_isolated_per_asyncio_task(self):
+        import asyncio
+
+        from datus.configuration.scoped_context_overrides import effective_subagent
+        from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+
+        config = self._real_config({"team_a": {"scoped_context": {"tables": "public.users"}}})
+
+        async def run(table: str) -> str:
+            cfg = SubAgentConfig(system_prompt="x", scoped_context=ScopedContext(tables=table))
+            with effective_subagent("team_a", cfg):
+                await asyncio.sleep(0.01)
+                result = _build_sub_agent_filter(config, "team_a", _mock_storage(), "tables")
+            return build_where(result)
+
+        c1, c2 = await asyncio.gather(run("table_one"), run("table_two"))
+        assert "table_one" in c1 and "table_two" not in c1
+        assert "table_two" in c2 and "table_one" not in c2

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -221,6 +221,44 @@ class TestResolveNodeType:
         with pytest.raises(ValueError, match="Unknown subagent type"):
             task_tool._resolve_node_type("nonexistent")
 
+    def test_resolve_effective_inherits_parent_when_child_empty(self, task_tool):
+        parent = MagicMock()
+        parent.node_config = {"scoped_context": {"tables": "public.users"}}
+        task_tool._parent_node = parent
+        # 'sales_analyst' yaml has no scoped_context → child empty → inherit parent
+        effective = task_tool._resolve_effective_sub_agent_config("sales_analyst")
+        assert effective.scoped_context is not None
+        assert effective.scoped_context.tables == "public.users"
+
+    def test_resolve_effective_accepts_parent_scoped_context_instance(self, task_tool):
+        from datus.schemas.agent_models import ScopedContext
+
+        parent = MagicMock()
+        parent.node_config = {"scoped_context": ScopedContext(tables="public.orders")}
+        task_tool._parent_node = parent
+        effective = task_tool._resolve_effective_sub_agent_config("sales_analyst")
+        assert effective.scoped_context.tables == "public.orders"
+
+    def test_resolve_effective_no_parent_returns_child_only(self, task_tool):
+        # No parent → child config drives everything; sales_analyst has no scope → empty
+        task_tool._parent_node = None
+        effective = task_tool._resolve_effective_sub_agent_config("sales_analyst")
+        assert effective.scoped_context is None or effective.scoped_context.is_empty
+
+    def test_resolve_effective_child_overrides_parent(self, task_tool, mock_agent_config):
+        # Add a child with its own scoped_context to the agentic_nodes fixture
+        mock_agent_config.agentic_nodes["scoped_child"] = {
+            "model": "default",
+            "node_class": "gen_sql",
+            "scoped_context": {"tables": "public.products"},
+        }
+        parent = MagicMock()
+        parent.node_config = {"scoped_context": {"tables": "public.users"}}
+        task_tool._parent_node = parent
+        effective = task_tool._resolve_effective_sub_agent_config("scoped_child")
+        # Whole-segment override: child wins
+        assert effective.scoped_context.tables == "public.products"
+
     def test_node_class_map_coverage(self):
         """NODE_CLASS_MAP contains exactly the expected key→NodeType mappings."""
         expected_map = {


### PR DESCRIPTION
Sub-agents now inherit the parent's scoped_context at runtime; if the child declares its own scoped_context (any KB field non-empty) the whole segment replaces the parent. Builtin system sub-agents that have no yaml config fully inherit the parent.

Implemented via a contextvars-backed runtime override map. SubAgentTaskTool pushes an effective SubAgentConfig under the subagent name for the duration of the child's execution; AgentConfig.sub_agent_config consults the override first, so the six RAG stores observe the merged context with no changes. Multi-level A->B->C nesting works because each parent's node_config already holds its effective scope before the child is constructed.

Also wires sub_agent_name into DBFuncTool / ContextSearchTools constructors in the previously missing nodes (chat, compare, explore context tools, gen_skill, gen_ext_knowledge, gen_semantic_model db tools) so the override is actually consulted at tool init time.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime scoped sub-agent configuration overrides allowing temporary, context-scoped changes to sub-agent behavior
  * Sub-agents can inherit parent scoped context when not explicitly defined

* **Improvements**
  * More consistent sub-agent identification across tools for accurate scoping
  * Refined parent→child config merging semantics (whole-segment override)
  * Tighter filesystem tool defaults: reduced max file read size and stricter sandboxing/filters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->