### PR TITLE
[Enhancement] Built-in sub-agents inherit parent memory (read-only)

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -471,14 +471,16 @@ class AgenticNode(Node):
     def _inject_memory_context(self, base_prompt: str, override_node_name: Optional[str] = None) -> str:
         """Inject memory context into the system prompt.
 
-        Injection rules:
-        - When ``override_node_name`` is provided (feedback path): inject
-          unconditionally, targeting that node's memory directory. Feedback
-          uses this to attach the caller's memory even when the caller itself
-          would not have memory enabled by default.
-        - Otherwise: inject only if ``self.memory_enabled`` is True. Built-in
-          subagents (gen_sql, gen_report, etc.) default to disabled so their
-          prompts stay focused; ``chat`` and custom subagents default to enabled.
+        Injection rules (resolved in order):
+        1. ``override_node_name`` provided (feedback path) → unconditional
+           injection of that node's memory, writable.
+        2. ``self.memory_enabled`` True (chat / custom subagents) → own memory,
+           writable.
+        3. ``inherited_memory`` contextvar set by ``SubAgentTaskTool`` for this
+           node name → render the parent's memory in **read-only** mode. Built-in
+           subagents launched via ``task`` see their originating parent's memory
+           for context but cannot modify it.
+        4. None of the above → no memory section is appended.
 
         Args:
             base_prompt: The prompt to append memory context to.
@@ -486,19 +488,29 @@ class AgenticNode(Node):
                 ``self.get_node_name()``. Enables injecting another node's memory (e.g. the
                 feedback node injects its caller's memory).
         """
+        from datus.configuration.inherited_memory_overrides import get_inherited_memory
         from datus.utils.memory_loader import get_memory_dir, load_memory_context
 
+        read_only = False
         if override_node_name:
             node_name = override_node_name
-        else:
-            if not self.memory_enabled:
-                return base_prompt
+        elif self.memory_enabled:
             node_name = self.get_node_name()
+        else:
+            inherited = get_inherited_memory(self.get_node_name())
+            if not inherited:
+                return base_prompt
+            node_name = inherited
+            read_only = True
 
         try:
             workspace_root = self._resolve_workspace_root()
 
             memory_content = load_memory_context(workspace_root, node_name)
+            if read_only and not memory_content.strip():
+                # Parent has no memory worth inheriting; skip the read-only block
+                # entirely so we do not waste prompt budget on an empty notice.
+                return base_prompt
             memory_dir = get_memory_dir(workspace_root, node_name)
 
             memory_section = get_prompt_manager(agent_config=self.agent_config).render_template(
@@ -507,6 +519,8 @@ class AgenticNode(Node):
                 has_memory=True,
                 memory_content=memory_content,
                 memory_dir=memory_dir,
+                read_only=read_only,
+                originating_agent=node_name,
             )
 
             if memory_section.strip():
@@ -1526,6 +1540,7 @@ class AgenticNode(Node):
         ``agent_config.filesystem_strict`` so API / gateway can opt out of
         interactive EXTERNAL prompts.
         """
+        from datus.configuration.inherited_memory_overrides import get_inherited_memory
         from datus.tools.func_tool import FilesystemFuncTool
 
         root_path = kwargs.pop("root_path", None) or self._resolve_workspace_root()
@@ -1540,11 +1555,16 @@ class AgenticNode(Node):
         strict = kwargs.pop("strict", None)
         if strict is None:
             strict = self._resolve_filesystem_strict()
+        current_node = kwargs.pop("current_node", None) or self.get_node_name()
+        inherited_memory_node = kwargs.pop("inherited_memory_node", None)
+        if inherited_memory_node is None:
+            inherited_memory_node = get_inherited_memory(current_node)
         return FilesystemFuncTool(
             root_path=root_path,
-            current_node=kwargs.pop("current_node", None) or self.get_node_name(),
+            current_node=current_node,
             datus_home=datus_home,
             strict=strict,
+            inherited_memory_node=inherited_memory_node,
             **kwargs,
         )
 

--- a/datus/configuration/inherited_memory_overrides.py
+++ b/datus/configuration/inherited_memory_overrides.py
@@ -1,0 +1,43 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Runtime overrides that let a built-in sub-agent inherit its parent's memory.
+
+When ``SubAgentTaskTool`` launches a built-in sub-agent (gen_sql, gen_report,
+explore, ...), that child has ``memory_enabled=False`` by default and would
+otherwise see no MEMORY.md context. This module installs the parent's memory
+node name under the child's subagent name for the duration of the child's
+execution; ``AgenticNode._inject_memory_context`` consults the override and
+renders the parent's memory in read-only mode.
+
+Backed by ``contextvars.ContextVar`` so concurrent ``asyncio.Task`` siblings
+remain isolated (each Task copies the current context at creation).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Dict, Iterator, Optional
+
+_OVERRIDES: ContextVar[Optional[Dict[str, str]]] = ContextVar("datus_inherited_memory", default=None)
+
+
+def _current_map() -> Dict[str, str]:
+    return _OVERRIDES.get() or {}
+
+
+def get_inherited_memory(sub_agent_name: str) -> Optional[str]:
+    """Return the parent memory node name pushed for ``sub_agent_name``, if any."""
+    return _current_map().get(sub_agent_name)
+
+
+@contextmanager
+def inherited_memory(sub_agent_name: str, parent_memory_node_name: str) -> Iterator[None]:
+    new_map = {**_current_map(), sub_agent_name: parent_memory_node_name}
+    token = _OVERRIDES.set(new_map)
+    try:
+        yield
+    finally:
+        _OVERRIDES.reset(token)

--- a/datus/prompts/prompt_templates/memory_context_1.0.j2
+++ b/datus/prompts/prompt_templates/memory_context_1.0.j2
@@ -1,5 +1,24 @@
 {# Memory context injected into system prompts when memory is enabled #}
 {% if has_memory %}
+{% if read_only %}
+## Memory (read-only inheritance from {{ originating_agent }})
+
+{{ originating_agent }}'s persistent memory at `{{ memory_dir }}/MEMORY.md` is inlined below as read-only background about the user's preferences, project decisions, and external references gathered by the parent agent. The MEMORY.md index may reference sibling topic files in the same directory — you may use `Read`, `Glob`, or `Grep` against `{{ memory_dir }}/**` to inspect those topic files when an entry is relevant.
+
+**Read-only**: do NOT use `Write`, `Edit`, `str_replace`, or shell commands to modify any path under `{{ memory_dir }}/` (or any other `.datus/memory/` subtree). Write attempts there are rejected by the path policy. If you discover something the user would want remembered, mention it in your response so the parent agent can persist it.
+
+### Current memory
+
+<memory>
+{% if memory_content %}
+{{ memory_content }}
+{% else %}
+(empty)
+{% endif %}
+</memory>
+
+**Access**: apply these facts when they are relevant to the current task. Verify file/function/flag claims against current code before acting — trust what you observe now. If the user asks to ignore memory, treat it as empty.
+{% else %}
 ## Memory
 
 Persistent memory at `{{ memory_dir }}/MEMORY.md`. Build it over time so future sessions know the user's preferences, project context, and external references.
@@ -23,4 +42,5 @@ Persistent memory at `{{ memory_dir }}/MEMORY.md`. Build it over time so future 
 **Access**: when memories seem relevant or user references past work; must access when user asks to recall. Verify file/function/flag claims against current code before acting — trust what you observe now and update stale entries. For current repo state, prefer `git log`/code. If user says ignore memory, treat it as empty.
 
 Use **plans** for implementation alignment, **tasks** for current work tracking — not memory.
+{% endif %}
 {% endif %}

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -72,6 +72,7 @@ class FilesystemFuncTool(BaseTool):
         current_node: Optional[str] = None,
         datus_home: Optional[str] = None,
         strict: bool = False,
+        inherited_memory_node: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -84,6 +85,11 @@ class FilesystemFuncTool(BaseTool):
                 closed instead of ever touching the host filesystem.
                 ``False`` (the CLI default) lets ``PermissionHooks`` prompt
                 the user.
+            inherited_memory_node: When set, the path policy treats
+                ``.datus/memory/{inherited_memory_node}/**`` as a read-only
+                whitelisted subtree so the calling node can ``Read``/``Glob``
+                its parent's memory. Writes/edits to that subtree are rejected
+                at the tool layer with a clear error message.
         """
         super().__init__(**kwargs)
         self.root_path = root_path or os.getcwd()
@@ -92,6 +98,7 @@ class FilesystemFuncTool(BaseTool):
         self._datus_home = Path(datus_home).expanduser().resolve(strict=False) if datus_home else None
         self._root_resolved = Path(self.root_path).expanduser().resolve(strict=False)
         self._strict = strict
+        self._inherited_memory_node = inherited_memory_node
 
     @property
     def strict(self) -> bool:
@@ -122,6 +129,17 @@ class FilesystemFuncTool(BaseTool):
             root_path=self._root_resolved,
             current_node=self._current_node,
             datus_home=self._datus_home,
+            inherited_memory_node=self._inherited_memory_node,
+        )
+
+    def _read_only_reject(self, resolved: ResolvedPath) -> FuncToolResult:
+        """Reject writes to a read-only whitelist (inherited parent memory)."""
+        return FuncToolResult(
+            success=0,
+            error=(
+                f"Read-only path: {resolved.display} is inherited from the parent "
+                "agent's memory and cannot be modified by this sub-agent."
+            ),
         )
 
     def _not_found(self, resolved: ResolvedPath) -> FuncToolResult:
@@ -253,6 +271,8 @@ class FilesystemFuncTool(BaseTool):
                 return self._not_found(resolved)
             if self._strict and resolved.zone == PathZone.EXTERNAL:
                 return self._strict_reject(resolved)
+            if resolved.read_only:
+                return self._read_only_reject(resolved)
 
             target_path = resolved.resolved
             if not self._is_allowed_file(target_path):
@@ -293,6 +313,8 @@ class FilesystemFuncTool(BaseTool):
                 return self._not_found(resolved)
             if self._strict and resolved.zone == PathZone.EXTERNAL:
                 return self._strict_reject(resolved)
+            if resolved.read_only:
+                return self._read_only_reject(resolved)
 
             target_path = resolved.resolved
             if not target_path.exists():
@@ -413,6 +435,7 @@ class FilesystemFuncTool(BaseTool):
             root_path=self._root_resolved,
             current_node=self._current_node,
             datus_home=self._datus_home,
+            inherited_memory_node=self._inherited_memory_node,
         )
 
         def has_whitelisted_descendant(directory: Path) -> bool:
@@ -478,6 +501,7 @@ class FilesystemFuncTool(BaseTool):
                                 root_path=self._root_resolved,
                                 current_node=self._current_node,
                                 datus_home=self._datus_home,
+                                inherited_memory_node=self._inherited_memory_node,
                             ).zone
                             if item_zone == PathZone.EXTERNAL:
                                 # Symlink escape from project tree; skip.
@@ -686,6 +710,12 @@ def filesystem_function_tools(
     *,
     current_node: Optional[str] = None,
     strict: bool = False,
+    inherited_memory_node: Optional[str] = None,
 ) -> List[Tool]:
     """Get filesystem function tools"""
-    return FilesystemFuncTool(root_path=root_path, current_node=current_node, strict=strict).available_tools()
+    return FilesystemFuncTool(
+        root_path=root_path,
+        current_node=current_node,
+        strict=strict,
+        inherited_memory_node=inherited_memory_node,
+    ).available_tools()

--- a/datus/tools/func_tool/fs_path_policy.py
+++ b/datus/tools/func_tool/fs_path_policy.py
@@ -48,12 +48,16 @@ class ResolvedPath:
         display: Human/LLM-friendly rendering. Relative to ``root_path`` for
             ``INTERNAL``/``WHITELIST``-in-project, ``~``-prefixed for home
             whitelist, absolute for ``EXTERNAL``/``HIDDEN``.
+        read_only: True when the path is whitelisted only because the calling
+            node inherited a parent's memory directory. Reads are allowed but
+            writes/edits must be rejected at the tool layer.
     """
 
     raw: str
     resolved: Path
     zone: PathZone
     display: str
+    read_only: bool = False
 
 
 def _is_relative_to(candidate: Path, anchor: Path) -> bool:
@@ -81,6 +85,7 @@ def classify_path(
     root_path: Path,
     current_node: Optional[str],
     datus_home: Optional[Path] = None,
+    inherited_memory_node: Optional[str] = None,
 ) -> ResolvedPath:
     """Classify ``path`` into a ``PathZone`` relative to ``root_path``.
 
@@ -98,6 +103,11 @@ def classify_path(
             which demotes every ``.datus/memory/**`` path to ``HIDDEN``.
         datus_home: Override for ``~/.datus``. Primarily a test hook; when
             ``None`` the classifier uses the real home directory.
+        inherited_memory_node: When a built-in sub-agent inherits its parent's
+            memory (read-only), the parent's
+            ``{root_path}/.datus/memory/{inherited_memory_node}/**`` subtree
+            also qualifies as ``WHITELIST``, but the resulting ``ResolvedPath``
+            carries ``read_only=True`` so the tool layer can deny writes.
 
     Returns:
         A ``ResolvedPath`` with the computed zone and display form. Never
@@ -128,20 +138,32 @@ def classify_path(
         project_memory_node = (project_dot_datus / "memory" / current_node).resolve(strict=False)
     global_skills = (home_resolved / "skills").resolve(strict=False)
 
-    whitelist_anchors = [project_skills]
+    inherited_memory_dir: Optional[Path] = None
+    if inherited_memory_node and inherited_memory_node != current_node:
+        inherited_memory_dir = (project_dot_datus / "memory" / inherited_memory_node).resolve(strict=False)
+
+    # Owned (writable) anchors first; the inherited anchor is checked last and
+    # tagged ``read_only=True`` so the tool layer can deny writes there.
+    writable_whitelist = [project_skills]
     if project_memory_node is not None:
-        whitelist_anchors.append(project_memory_node)
-    whitelist_anchors.append(global_skills)
+        writable_whitelist.append(project_memory_node)
+    writable_whitelist.append(global_skills)
 
     zone: PathZone
     display: str
+    read_only = False
     # Relative displays use ``.as_posix()`` instead of ``str()`` so the forward-
     # slash-shaped scope globs used downstream (e.g. ``subject/**`` matched
     # with ``wcmatch.globmatch``) still work on Windows. ``str(Path)`` yields
     # backslashes on Windows, which ``wcmatch`` does not normalize — it would
     # silently reject valid writes.
-    if any(_is_relative_to(resolved, anchor) for anchor in whitelist_anchors):
+    matched_writable = any(_is_relative_to(resolved, anchor) for anchor in writable_whitelist)
+    matched_inherited = inherited_memory_dir is not None and _is_relative_to(resolved, inherited_memory_dir)
+    if matched_writable or matched_inherited:
         zone = PathZone.WHITELIST
+        # Owned matches always win; the read-only flag is only set when the
+        # path is exclusively reachable via the inherited anchor.
+        read_only = matched_inherited and not matched_writable
         if _is_relative_to(resolved, root_resolved):
             display = resolved.relative_to(root_resolved).as_posix()
         elif _is_relative_to(resolved, home_resolved):
@@ -165,7 +187,7 @@ def classify_path(
         zone = PathZone.EXTERNAL
         display = str(resolved)
 
-    return ResolvedPath(raw=raw, resolved=resolved, zone=zone, display=display)
+    return ResolvedPath(raw=raw, resolved=resolved, zone=zone, display=display, read_only=read_only)
 
 
 def whitelist_anchors(
@@ -173,13 +195,16 @@ def whitelist_anchors(
     root_path: Path,
     current_node: Optional[str],
     datus_home: Optional[Path] = None,
+    inherited_memory_node: Optional[str] = None,
 ) -> list[Path]:
     """Return the resolved whitelist anchor directories for a given node.
 
     Used by walkers that need to answer "is there a whitelisted subtree
     underneath this HIDDEN directory?" without re-running ``classify_path``
     for every descendant. The order mirrors ``classify_path`` (project-side
-    first) so longer prefixes win.
+    first) so longer prefixes win. ``inherited_memory_node`` adds the parent
+    sub-agent's memory dir so a built-in child can ``Read``/``Glob`` it; write
+    enforcement is the tool layer's job.
     """
     root_resolved = Path(root_path).expanduser().resolve(strict=False)
     home_resolved = _resolve_home(datus_home)
@@ -187,6 +212,8 @@ def whitelist_anchors(
     anchors = [(project_dot_datus / "skills").resolve(strict=False)]
     if current_node:
         anchors.append((project_dot_datus / "memory" / current_node).resolve(strict=False))
+    if inherited_memory_node and inherited_memory_node != current_node:
+        anchors.append((project_dot_datus / "memory" / inherited_memory_node).resolve(strict=False))
     anchors.append((home_resolved / "skills").resolve(strict=False))
     return anchors
 
@@ -195,6 +222,7 @@ def build_walk_patterns(
     *,
     root_path: Path,
     current_node: Optional[str],
+    inherited_memory_node: Optional[str] = None,
 ) -> tuple[list[str], list[str]]:
     """Build the (exclude, re-include) glob pattern pair used by the walker.
 
@@ -209,6 +237,9 @@ def build_walk_patterns(
             patterns don't need to change signature).
         current_node: Same semantics as ``classify_path``; ``None`` leaves
             the memory subtree excluded.
+        inherited_memory_node: When set and distinct from ``current_node``,
+            the parent's memory subtree is also re-included so ``Glob`` /
+            ``Grep`` can surface inherited topic files (read-only).
 
     Returns:
         ``(excludes, re_includes)`` — both are glob patterns rooted at
@@ -219,4 +250,6 @@ def build_walk_patterns(
     re_includes = [".datus/skills/**"]
     if current_node:
         re_includes.append(f".datus/memory/{current_node}/**")
+    if inherited_memory_node and inherited_memory_node != current_node:
+        re_includes.append(f".datus/memory/{inherited_memory_node}/**")
     return excludes, re_includes

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 
 import json
 import uuid
+from contextlib import nullcontext
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from agents import FunctionTool, Tool
 
 from datus.configuration.agent_config import AgentConfig
+from datus.configuration.inherited_memory_overrides import inherited_memory
 from datus.configuration.node_type import NodeType
 from datus.configuration.scoped_context_overrides import effective_subagent
 from datus.schemas.action_history import (
@@ -34,6 +36,7 @@ from datus.schemas.agent_models import ScopedContext, SubAgentConfig
 from datus.tools.func_tool.base import FuncToolResult
 from datus.utils.constants import SYS_SUB_AGENTS
 from datus.utils.loggings import get_logger
+from datus.utils.memory_loader import has_memory
 
 if TYPE_CHECKING:
     from datus.agent.node.agentic_node import AgenticNode
@@ -572,6 +575,8 @@ class SubAgentTaskTool:
             )
 
         effective_cfg = self._resolve_effective_sub_agent_config(subagent_type)
+        inherited_parent = self._resolve_inherited_memory_node(subagent_type)
+        inherited_cm = inherited_memory(subagent_type, inherited_parent) if inherited_parent else nullcontext()
 
         # Validate the session_id format up-front (path-injection defence) so
         # we fail fast before paying the node-construction cost.
@@ -583,7 +588,7 @@ class SubAgentTaskTool:
             except ValueError as e:
                 return FuncToolResult(success=0, error=f"Invalid session_id format: {e}")
 
-        with effective_subagent(subagent_type, effective_cfg):
+        with effective_subagent(subagent_type, effective_cfg), inherited_cm:
             node = self._create_node(subagent_type)
 
             # Nest this subagent's session under the launching main session so the
@@ -713,6 +718,29 @@ class SubAgentTaskTool:
                     logger.debug("Failed to release sub-agent session handle", exc_info=True)
 
         return self._convert_to_func_result(final_output, session_id=node.session_id)
+
+    def _resolve_inherited_memory_node(self, subagent_type: str) -> Optional[str]:
+        """Pick the parent memory node name that a built-in child should inherit (read-only).
+
+        Returns ``None`` (no inheritance) when:
+        - the child has its own memory (custom subagent or ``chat``);
+        - the child is ``feedback`` — already injects the caller's memory via
+          ``override_node_name`` and would double-render;
+        - no parent node is registered, or the parent itself has no memory.
+        """
+        if subagent_type == "feedback":
+            return None
+        if has_memory(subagent_type):
+            return None
+        if self._parent_node is None:
+            return None
+        try:
+            parent_name = self._parent_node.get_node_name()
+        except Exception:
+            return None
+        if not parent_name or not has_memory(parent_name):
+            return None
+        return parent_name
 
     def _resolve_effective_sub_agent_config(self, subagent_type: str) -> SubAgentConfig:
         """Build an effective SubAgentConfig that inherits parent scoped_context when child has none."""

--- a/tests/unit_tests/agent/node/test_agentic_node_inherited_memory.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_inherited_memory.py
@@ -1,0 +1,134 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for the read-only memory inheritance branch of ``_inject_memory_context``.
+
+Built-in subagents (``memory_enabled=False``) launched via SubAgentTaskTool now
+read their parent's MEMORY.md when ``inherited_memory(...)`` is active in the
+contextvar. The injected block is read-only and must not contain the writable
+"Save" instructions that the writable branch renders for ``chat`` / custom
+subagents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from datus.configuration.inherited_memory_overrides import inherited_memory
+
+
+def _write_chat_memory(real_agent_config, content: str) -> Path:
+    """Seed a parent (chat) MEMORY.md inside the fixture project root."""
+    workspace_root = Path(real_agent_config.project_root)
+    chat_dir = workspace_root / ".datus" / "memory" / "chat"
+    chat_dir.mkdir(parents=True, exist_ok=True)
+    memory_file = chat_dir / "MEMORY.md"
+    memory_file.write_text(content, encoding="utf-8")
+    return memory_file
+
+
+def _new_gen_sql_node(real_agent_config):
+    from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+    from datus.configuration.node_type import NodeType
+
+    return GenSQLAgenticNode(
+        node_id="test_gensql_inherit",
+        description="Test inherited memory for gen_sql",
+        node_type=NodeType.TYPE_GENSQL,
+        agent_config=real_agent_config,
+        node_name="gen_sql",
+        execution_mode="workflow",
+    )
+
+
+@pytest.mark.ci
+class TestInheritedMemoryInjection:
+    """Behavior of the new read-only inherited memory branch."""
+
+    def test_builtin_with_inherited_memory_renders_readonly_block(self, real_agent_config, mock_llm_create):
+        _write_chat_memory(
+            real_agent_config,
+            "## Profile\n- User prefers concise SQL comments.\n",
+        )
+        node = _new_gen_sql_node(real_agent_config)
+        assert node.memory_enabled is False
+
+        with inherited_memory("gen_sql", "chat"):
+            prompt = node._inject_memory_context("BASE PROMPT")
+
+        # Read-only header carries the originating agent name and the parent's
+        # memory dir is rendered (so the child knows where its read-only topic
+        # files live). The child's own dir must NOT appear.
+        assert "## Memory (read-only inheritance from chat)" in prompt
+        assert ".datus/memory/chat" in prompt
+        assert ".datus/memory/gen_sql" not in prompt
+        # The seeded chat memory content shows up.
+        assert "User prefers concise SQL comments." in prompt
+        # Read-only branch must NOT include the writable "Save" instructions.
+        assert "**Save**" not in prompt
+        # Explicit read-only enforcement clause is present.
+        assert "Read-only" in prompt
+
+    def test_builtin_without_inherited_returns_base_prompt(self, real_agent_config, mock_llm_create):
+        node = _new_gen_sql_node(real_agent_config)
+        assert node.memory_enabled is False
+
+        # No contextvar push — current behavior preserved.
+        prompt = node._inject_memory_context("BASE PROMPT")
+        assert prompt == "BASE PROMPT"
+        assert "## Memory" not in prompt
+
+    def test_inherited_does_not_affect_chat_node(self, real_agent_config, mock_llm_create):
+        """Pushing inherited override for gen_sql must not change chat's prompt."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+        from datus.configuration.node_type import NodeType
+
+        _write_chat_memory(real_agent_config, "## Profile\n- chat-only fact\n")
+
+        chat = ChatAgenticNode(
+            node_id="test_chat_unaffected",
+            description="chat",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+        assert chat.memory_enabled is True
+
+        with inherited_memory("gen_sql", "chat"):
+            prompt = chat._inject_memory_context("BASE PROMPT")
+
+        # Chat renders its OWN writable memory block (Save/Don't save), not the
+        # read-only branch.
+        assert "## Memory" in prompt
+        assert "**Save**" in prompt
+        assert "read-only inheritance" not in prompt
+
+    def test_empty_parent_memory_short_circuits(self, real_agent_config, mock_llm_create):
+        """If the parent has no MEMORY.md (or it is empty), do not render the read-only block."""
+        node = _new_gen_sql_node(real_agent_config)
+
+        # Do NOT seed chat memory.
+        with inherited_memory("gen_sql", "chat"):
+            prompt = node._inject_memory_context("BASE PROMPT")
+
+        assert prompt == "BASE PROMPT"
+        assert "read-only inheritance" not in prompt
+
+    def test_explicit_override_node_name_takes_precedence(self, real_agent_config, mock_llm_create):
+        """``override_node_name`` (feedback path) wins over inherited contextvar.
+
+        Feedback intentionally writes the caller's memory, so it must keep the
+        writable branch even when inherited_memory happens to be active.
+        """
+        _write_chat_memory(real_agent_config, "## Profile\n- shared fact\n")
+        node = _new_gen_sql_node(real_agent_config)
+
+        with inherited_memory("gen_sql", "chat"):
+            prompt = node._inject_memory_context("BASE PROMPT", override_node_name="chat")
+
+        # Writable branch path (Save instructions present, no read-only header).
+        assert "## Memory" in prompt
+        assert "**Save**" in prompt
+        assert "read-only inheritance" not in prompt

--- a/tests/unit_tests/configuration/test_inherited_memory_overrides.py
+++ b/tests/unit_tests/configuration/test_inherited_memory_overrides.py
@@ -1,0 +1,82 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.configuration.inherited_memory_overrides``."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from datus.configuration.inherited_memory_overrides import (
+    get_inherited_memory,
+    inherited_memory,
+)
+
+
+@pytest.mark.ci
+class TestInheritedMemoryOverrides:
+    def test_default_returns_none(self):
+        assert get_inherited_memory("missing") is None
+
+    def test_push_then_pop_via_context_manager(self):
+        with inherited_memory("gen_sql", "chat"):
+            assert get_inherited_memory("gen_sql") == "chat"
+        assert get_inherited_memory("gen_sql") is None
+
+    def test_nested_overrides_stack_and_unwind(self):
+        with inherited_memory("gen_sql", "chat"):
+            assert get_inherited_memory("gen_sql") == "chat"
+            with inherited_memory("gen_sql", "custom_agent"):
+                assert get_inherited_memory("gen_sql") == "custom_agent"
+            assert get_inherited_memory("gen_sql") == "chat"
+        assert get_inherited_memory("gen_sql") is None
+
+    def test_exception_inside_block_still_resets_token(self):
+        with pytest.raises(RuntimeError):
+            with inherited_memory("gen_sql", "chat"):
+                raise RuntimeError("boom")
+        assert get_inherited_memory("gen_sql") is None
+
+    def test_distinct_subagent_names_coexist(self):
+        with inherited_memory("gen_sql", "chat"):
+            with inherited_memory("gen_report", "custom_agent"):
+                assert get_inherited_memory("gen_sql") == "chat"
+                assert get_inherited_memory("gen_report") == "custom_agent"
+                assert get_inherited_memory("explore") is None
+
+    @pytest.mark.asyncio
+    async def test_isolated_across_asyncio_tasks(self):
+        """A sibling Task that captures context at creation must not see a later push."""
+        captured: dict[str, str | None] = {}
+
+        async def reader():
+            await asyncio.sleep(0.01)
+            captured["sibling"] = get_inherited_memory("gen_sql")
+
+        async def pusher():
+            with inherited_memory("gen_sql", "chat"):
+                await asyncio.sleep(0.02)
+                captured["inside"] = get_inherited_memory("gen_sql")
+
+        sibling = asyncio.create_task(reader())
+        pusher_task = asyncio.create_task(pusher())
+        await asyncio.gather(sibling, pusher_task)
+
+        assert captured["sibling"] is None
+        assert captured["inside"] == "chat"
+        assert get_inherited_memory("gen_sql") is None
+
+    @pytest.mark.asyncio
+    async def test_parallel_pushers_do_not_pollute_each_other(self):
+        observed: dict[str, str] = {}
+
+        async def run(label: str, parent: str):
+            with inherited_memory("gen_sql", parent):
+                await asyncio.sleep(0.01)
+                observed[label] = get_inherited_memory("gen_sql")
+
+        await asyncio.gather(run("p1", "chat"), run("p2", "custom_agent"))
+        assert observed == {"p1": "chat", "p2": "custom_agent"}

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -240,6 +240,67 @@ class TestWriteFile:
         assert f.read_text() == "new content"
 
 
+class TestInheritedMemoryReadOnly:
+    """When a built-in sub-agent inherits its parent's memory, it must be able
+    to ``read_file`` / ``glob`` topic files in the parent's directory but writes
+    and edits there must be rejected with a clear error."""
+
+    def _make_inheriting_tool(self, root: Path) -> FilesystemFuncTool:
+        # Pre-create both memory dirs so reads see real content.
+        (root / ".datus" / "memory" / "chat").mkdir(parents=True)
+        (root / ".datus" / "memory" / "chat" / "MEMORY.md").write_text(
+            "## Profile\n- inherited fact\n", encoding="utf-8"
+        )
+        (root / ".datus" / "memory" / "chat" / "user_role.md").write_text("user is a data engineer", encoding="utf-8")
+        return FilesystemFuncTool(
+            root_path=str(root),
+            current_node="gen_sql",
+            inherited_memory_node="chat",
+        )
+
+    def test_read_inherited_memory_file_succeeds(self, tmp_path):
+        tool = self._make_inheriting_tool(tmp_path)
+        result = tool.read_file(".datus/memory/chat/MEMORY.md")
+        assert result.success == 1
+        assert "inherited fact" in str(result.result)
+
+    def test_read_inherited_topic_file_succeeds(self, tmp_path):
+        tool = self._make_inheriting_tool(tmp_path)
+        result = tool.read_file(".datus/memory/chat/user_role.md")
+        assert result.success == 1
+        assert "data engineer" in str(result.result)
+
+    def test_write_to_inherited_memory_rejected(self, tmp_path):
+        tool = self._make_inheriting_tool(tmp_path)
+        result = tool.write_file(".datus/memory/chat/MEMORY.md", "tampered")
+        assert result.success == 0
+        assert "read-only" in result.error.lower()
+        # The original content survived the rejected write.
+        assert (tmp_path / ".datus" / "memory" / "chat" / "MEMORY.md").read_text().strip().startswith("## Profile")
+
+    def test_edit_inherited_memory_rejected(self, tmp_path):
+        tool = self._make_inheriting_tool(tmp_path)
+        result = tool.edit_file(".datus/memory/chat/MEMORY.md", "inherited fact", "tampered")
+        assert result.success == 0
+        assert "read-only" in result.error.lower()
+
+    def test_write_to_own_memory_still_allowed_when_inheriting(self, tmp_path):
+        """Inheriting chat's memory must NOT block writes to gen_sql's own dir."""
+        tool = self._make_inheriting_tool(tmp_path)
+        result = tool.write_file(".datus/memory/gen_sql/MEMORY.md", "## My memory\n- mine\n")
+        assert result.success == 1
+        assert (tmp_path / ".datus" / "memory" / "gen_sql" / "MEMORY.md").read_text().startswith("## My memory")
+
+    def test_other_unrelated_memory_dir_still_hidden(self, tmp_path):
+        """Inheriting chat does NOT open up an unrelated agent's dir."""
+        (tmp_path / ".datus" / "memory" / "feedback").mkdir(parents=True)
+        (tmp_path / ".datus" / "memory" / "feedback" / "MEMORY.md").write_text("secret", encoding="utf-8")
+        tool = self._make_inheriting_tool(tmp_path)
+        result = tool.read_file(".datus/memory/feedback/MEMORY.md")
+        assert result.success == 0
+        assert "not found" in result.error.lower()
+
+
 # ---------------------------------------------------------------------------
 # FilesystemFuncTool - edit_file
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
+++ b/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
@@ -84,6 +84,65 @@ class TestClassifyWhitelist:
         assert r.display.startswith("~/.datus/skills/")
 
 
+class TestClassifyInheritedMemory:
+    """A built-in sub-agent passing ``inherited_memory_node`` should be able to
+    READ the parent's memory tree (zone=WHITELIST, read_only=True) while its
+    OWN memory subtree remains writable."""
+
+    def test_inherited_dir_is_readonly_whitelist(self, project):
+        r = classify_path(
+            ".datus/memory/chat/MEMORY.md",
+            root_path=project,
+            current_node="gen_sql",
+            inherited_memory_node="chat",
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.read_only is True
+
+    def test_inherited_topic_file_is_readonly_whitelist(self, project):
+        r = classify_path(
+            ".datus/memory/chat/feedback_testing.md",
+            root_path=project,
+            current_node="gen_sql",
+            inherited_memory_node="chat",
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.read_only is True
+
+    def test_own_memory_remains_writable_when_inheriting(self, project):
+        """Owning a self memory dir AND inheriting another should leave self writable."""
+        r = classify_path(
+            ".datus/memory/gen_sql/MEMORY.md",
+            root_path=project,
+            current_node="gen_sql",
+            inherited_memory_node="chat",
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.read_only is False
+
+    def test_unrelated_memory_dir_still_hidden(self, project):
+        """Inheriting from chat does NOT open up some_other_node's memory."""
+        r = classify_path(
+            ".datus/memory/feedback/MEMORY.md",
+            root_path=project,
+            current_node="gen_sql",
+            inherited_memory_node="chat",
+        )
+        assert r.zone == PathZone.HIDDEN
+
+    def test_inherited_same_as_current_node_collapses_to_writable(self, project):
+        """Defensive: when the inherited name equals current_node, do not
+        spuriously demote that subtree to read-only."""
+        r = classify_path(
+            ".datus/memory/chat/MEMORY.md",
+            root_path=project,
+            current_node="chat",
+            inherited_memory_node="chat",
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.read_only is False
+
+
 class TestClassifyExternal:
     def test_relative_escape_goes_external(self, project):
         r = classify_path("../other/secret.txt", root_path=project, current_node="chat")
@@ -138,6 +197,16 @@ class TestWhitelistAnchors:
         seen = {(a.parent.name, a.name) for a in anchors}
         assert seen == expected_suffixes
 
+    def test_anchors_include_inherited_memory_dir(self, project, fake_home):
+        anchors = whitelist_anchors(
+            root_path=project,
+            current_node="gen_sql",
+            datus_home=fake_home,
+            inherited_memory_node="chat",
+        )
+        assert (project / ".datus" / "memory" / "gen_sql").resolve(strict=False) in anchors
+        assert (project / ".datus" / "memory" / "chat").resolve(strict=False) in anchors
+
 
 class TestBuildWalkPatterns:
     """The walker relies on these patterns to prune ``HIDDEN`` subtrees cheaply
@@ -164,6 +233,26 @@ class TestBuildWalkPatterns:
         # Skills stays first (longest-prefix-wins isn't used here, but the
         # downstream walker iterates in list order for determinism).
         assert re_includes == [".datus/skills/**", ".datus/memory/gen_sql/**"]
+
+    def test_re_includes_add_inherited_memory(self, project):
+        _, re_includes = build_walk_patterns(
+            root_path=project,
+            current_node="gen_sql",
+            inherited_memory_node="chat",
+        )
+        assert re_includes == [
+            ".datus/skills/**",
+            ".datus/memory/gen_sql/**",
+            ".datus/memory/chat/**",
+        ]
+
+    def test_inherited_same_as_current_does_not_duplicate(self, project):
+        _, re_includes = build_walk_patterns(
+            root_path=project,
+            current_node="chat",
+            inherited_memory_node="chat",
+        )
+        assert re_includes == [".datus/skills/**", ".datus/memory/chat/**"]
 
     def test_patterns_are_posix_for_wcmatch(self, project):
         """All generated patterns are POSIX slashes; wcmatch does not normalize

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -259,6 +259,54 @@ class TestResolveNodeType:
         # Whole-segment override: child wins
         assert effective.scoped_context.tables == "public.products"
 
+    def test_resolve_inherited_memory_returns_parent_for_chat(self, task_tool):
+        """Built-in child + chat parent → inherit chat's memory."""
+        parent = MagicMock()
+        parent.get_node_name.return_value = "chat"
+        task_tool._parent_node = parent
+        assert task_tool._resolve_inherited_memory_node("gen_sql") == "chat"
+
+    def test_resolve_inherited_memory_returns_parent_for_custom_subagent(self, task_tool):
+        """Built-in child + custom subagent parent → inherit custom's memory."""
+        parent = MagicMock()
+        parent.get_node_name.return_value = "sales_analyst"
+        task_tool._parent_node = parent
+        # 'sales_analyst' is a custom subagent → has_memory() is True → inherit
+        assert task_tool._resolve_inherited_memory_node("gen_sql") == "sales_analyst"
+
+    def test_resolve_inherited_memory_returns_none_for_feedback(self, task_tool):
+        """feedback has its own caller-memory mechanism; never inherit via this path."""
+        parent = MagicMock()
+        parent.get_node_name.return_value = "chat"
+        task_tool._parent_node = parent
+        assert task_tool._resolve_inherited_memory_node("feedback") is None
+
+    def test_resolve_inherited_memory_returns_none_for_custom_child(self, task_tool):
+        """Custom subagents already have their own memory and should not be overridden."""
+        parent = MagicMock()
+        parent.get_node_name.return_value = "chat"
+        task_tool._parent_node = parent
+        # 'sales_analyst' is a custom subagent (not in built-in set) → has_memory=True
+        assert task_tool._resolve_inherited_memory_node("sales_analyst") is None
+
+    def test_resolve_inherited_memory_returns_none_when_no_parent(self, task_tool):
+        task_tool._parent_node = None
+        assert task_tool._resolve_inherited_memory_node("gen_sql") is None
+
+    def test_resolve_inherited_memory_returns_none_when_parent_has_no_memory(self, task_tool):
+        """Defensive: if parent itself is a no-memory built-in, do not propagate."""
+        parent = MagicMock()
+        parent.get_node_name.return_value = "gen_report"  # built-in, no memory
+        task_tool._parent_node = parent
+        assert task_tool._resolve_inherited_memory_node("gen_sql") is None
+
+    def test_resolve_inherited_memory_swallows_parent_exceptions(self, task_tool):
+        """If the parent's get_node_name() raises, fall back to no inheritance."""
+        parent = MagicMock()
+        parent.get_node_name.side_effect = RuntimeError("parent broken")
+        task_tool._parent_node = parent
+        assert task_tool._resolve_inherited_memory_node("gen_sql") is None
+
     def test_node_class_map_coverage(self):
         """NODE_CLASS_MAP contains exactly the expected key→NodeType mappings."""
         expected_map = {


### PR DESCRIPTION
Built-in sub-agents launched via SubAgentTaskTool (gen_sql, gen_report, explore, etc.) now see the originating parent's MEMORY.md as read-only context in their system prompt and can Read/Glob/Grep the parent's memory directory for sibling topic files. Writes/edits to any .datus/memory/** path are rejected at the FS tool layer, so the parent's notes cannot be tampered with. feedback is excluded — it already injects the caller's memory via override_node_name.

Implementation mirrors the scoped_context override pattern (commit 1fc55ed1): a contextvars-backed inherited_memory_overrides map is pushed inside SubAgentTaskTool._execute_node for the duration of the child's run. _inject_memory_context gains a third resolution branch that picks up the override and renders the read_only template variant. fs_path_policy.classify_path / whitelist_anchors / build_walk_patterns take a new inherited_memory_node arg so the parent's dir joins the whitelist; ResolvedPath.read_only flags inherited matches so FilesystemFuncTool.write_file/edit_file return a clear "Read-only path" error. _make_filesystem_tool reads the contextvar and pipes it through.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sub-agents can inherit and view a parent agent’s memory as read-only, with prompts showing inherited vs. writable memory sections.
  * Filesystem operations now enforce read-only access to inherited memory and return clear errors on attempted writes.

* **Tests**
  * Added tests covering inherited-memory behavior, read-only enforcement, prompt rendering, path-policy inclusion, and async/context isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->