### PR TITLE
[Enhancement] Batch metrics extraction with per-table semantic model isolation

### DIFF
--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -141,6 +141,13 @@ async def init_success_story_metrics_async(
             already contains entries.
         batch_size: Number of SQL queries per batch (default 1).
     """
+    if batch_size <= 0:
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        raise DatusException(
+            ErrorCode.STORAGE_INVALID_ARGUMENT, error_message=f"batch_size must be > 0, got {batch_size}"
+        )
+
     event_helper = BatchEventHelper(BIZ_NAME, emit)
 
     if build_mode == "overwrite":

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -34,6 +34,83 @@ def _action_status_value(action: Any) -> Optional[str]:
     return status.value if hasattr(status, "value") else str(status)
 
 
+DEFAULT_METRICS_BATCH_SIZE = 1
+
+
+async def _generate_metrics_batch(
+    batch_queries: list[str],
+    batch_idx: int,
+    agent_config: AgentConfig,
+    subject_tree: Optional[list],
+    extra_instructions: Optional[str],
+    event_helper: BatchEventHelper,
+    action_callback: Optional[Callable[["ActionHistory"], None]],
+) -> tuple[bool, str, Optional[dict[str, Any]]]:
+    """Process a single batch of SQL queries for metrics extraction."""
+    batch_message = "Analyze the following SQL queries and extract core metrics:\n\n" + "\n\n---\n\n".join(
+        batch_queries
+    )
+
+    if extra_instructions:
+        batch_message = f"{batch_message}\n\n## Additional Instructions\n{extra_instructions}"
+
+    current_db_config = agent_config.current_db_config()
+    latest_prompt_version = get_prompt_manager(agent_config=agent_config).get_latest_version("gen_metrics_system")
+
+    metrics_input = SemanticNodeInput(
+        user_message=batch_message,
+        catalog=current_db_config.catalog,
+        database=current_db_config.database,
+        db_schema=current_db_config.schema,
+        prompt_version=latest_prompt_version,
+    )
+
+    metrics_node = GenMetricsAgenticNode(
+        agent_config=agent_config,
+        execution_mode="workflow",
+        subject_tree=subject_tree,
+    )
+
+    action_history_manager = ActionHistoryManager()
+    metrics_node.input = metrics_input
+
+    batch_id = f"batch-{batch_idx}"
+
+    try:
+        final_result = None
+        terminal_error = None
+        async for action in metrics_node.execute_stream(action_history_manager):
+            if action_callback is not None:
+                try:
+                    action_callback(action)
+                except Exception as cb_exc:  # pragma: no cover - defensive
+                    logger.debug("metric action_callback raised: %s", cb_exc)
+            if event_helper:
+                event_helper.item_processing(
+                    item_id=batch_id,
+                    action_name="gen_metrics",
+                    status=_action_status_value(action),
+                    messages=action.messages,
+                    output=action.output,
+                )
+            action_type = getattr(action, "action_type", "")
+            if action.status == ActionStatus.FAILED and action_type == "error":
+                terminal_error = action.messages or "Metrics extraction failed"
+                logger.error(terminal_error)
+                continue
+            if action.status == ActionStatus.SUCCESS and action_type == "metrics_response" and action.output:
+                final_result = action.output
+                logger.debug(f"Metrics generation action (batch {batch_idx}): {action.messages}")
+        if terminal_error:
+            return False, terminal_error, None
+        if final_result is None:
+            return False, "Metrics extraction completed but produced no output", None
+        return True, "", final_result
+    except Exception as e:
+        logger.error(f"Error in metrics extraction (batch {batch_idx}): {e}")
+        return False, str(e), None
+
+
 async def init_success_story_metrics_async(
     agent_config: AgentConfig,
     success_story: str,
@@ -43,12 +120,15 @@ async def init_success_story_metrics_async(
     *,
     build_mode: str = "overwrite",
     action_callback: Optional[Callable[["ActionHistory"], None]] = None,
+    batch_size: int = DEFAULT_METRICS_BATCH_SIZE,
 ) -> tuple[bool, str, Optional[dict[str, Any]]]:
     """
     Async version: Initialize metrics from success story CSV by batch processing.
 
-    This reads all SQL queries from the CSV and processes them as a batch
+    This reads all SQL queries from the CSV and processes them in batches
     to extract core unique metrics (deduplicating aggregation patterns).
+    Each batch is processed independently so that one failure does not
+    block the rest.
 
     Args:
         agent_config: Agent configuration
@@ -59,6 +139,7 @@ async def init_success_story_metrics_async(
         build_mode: ``"overwrite"`` (default) regenerates unconditionally;
             ``"incremental"`` skips the LLM call when the metric store
             already contains entries.
+        batch_size: Number of SQL queries per batch (default 1).
     """
     event_helper = BatchEventHelper(BIZ_NAME, emit)
 
@@ -99,7 +180,7 @@ async def init_success_story_metrics_async(
     if all_tables:
         logger.info(f"Found {len(all_tables)} tables in success story SQL: {all_tables}")
 
-        # Check and create missing semantic models
+        # Check and create missing semantic models (per-table, partial failures tolerated)
         success, error, created_tables = await ensure_semantic_models_exist(all_tables, agent_config, emit=None)
 
         if not success:
@@ -110,91 +191,76 @@ async def init_success_story_metrics_async(
 
         if created_tables:
             logger.info(f"Created semantic models for tables: {created_tables}")
+        if error:
+            logger.warning(f"Semantic model generation had partial failures: {error}")
 
-    # Build batch message with all SQL queries
-    sql_queries = []
+    # Build query strings for all rows
+    all_query_strings = []
     for idx, row in df.iterrows():
         sql = row["sql"]
         question = row["question"]
-        sql_queries.append(f"Query {idx + 1}:\nQuestion: {question}\nSQL:\n{sql}")
+        all_query_strings.append(f"Query {idx + 1}:\nQuestion: {question}\nSQL:\n{sql}")
 
-    batch_message = "Analyze the following SQL queries and extract core metrics:\n\n" + "\n\n---\n\n".join(sql_queries)
+    # Split into batches
+    batches = [all_query_strings[i : i + batch_size] for i in range(0, len(all_query_strings), batch_size)]
+    total_batches = len(batches)
 
-    # Append extra instructions if provided
-    if extra_instructions:
-        batch_message = f"{batch_message}\n\n## Additional Instructions\n{extra_instructions}"
-
-    logger.info(f"Processing {len(df)} SQL queries as batch for core metrics extraction")
-
-    # Get database context
-    current_db_config = agent_config.current_db_config()
-    latest_prompt_version = get_prompt_manager(agent_config=agent_config).get_latest_version("gen_metrics_system")
-
-    metrics_input = SemanticNodeInput(
-        user_message=batch_message,
-        catalog=current_db_config.catalog,
-        database=current_db_config.database,
-        db_schema=current_db_config.schema,
-        prompt_version=latest_prompt_version,
+    logger.info(
+        f"Processing {len(df)} SQL queries in {total_batches} batch(es) (batch_size={batch_size}) for metrics extraction"
     )
 
-    metrics_node = GenMetricsAgenticNode(
-        agent_config=agent_config,
-        execution_mode="workflow",
-        subject_tree=subject_tree,
-    )
+    event_helper.task_processing(total_items=total_batches)
 
-    action_history_manager = ActionHistoryManager()
-    metrics_node.input = metrics_input
+    completed_batches = 0
+    failed_batches: list[tuple[int, str]] = []
+    merged_result: Optional[dict[str, Any]] = None
 
-    # Emit task processing
-    event_helper.task_processing(total_items=1)
+    for batch_idx, batch_queries in enumerate(batches):
+        logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
 
-    try:
-        final_result = None
-        terminal_error = None
-        async for action in metrics_node.execute_stream(action_history_manager):
-            if action_callback is not None:
-                try:
-                    action_callback(action)
-                except Exception as cb_exc:  # pragma: no cover - defensive
-                    logger.debug("metric action_callback raised: %s", cb_exc)
-            if event_helper:
-                event_helper.item_processing(
-                    item_id="batch",
-                    action_name="gen_metrics",
-                    status=_action_status_value(action),
-                    messages=action.messages,
-                    output=action.output,
-                )
-            action_type = getattr(action, "action_type", "")
-            if action.status == ActionStatus.FAILED and action_type == "error":
-                terminal_error = action.messages or "Metrics extraction failed"
-                logger.error(terminal_error)
-                continue
-            if action.status == ActionStatus.SUCCESS and action_type == "metrics_response" and action.output:
-                final_result = action.output
-                logger.debug(f"Metrics generation action: {action.messages}")
-        if terminal_error:
-            event_helper.task_failed(error=terminal_error)
-            return False, terminal_error, None
-        if final_result is None:
-            error_msg = "Metrics extraction completed but produced no output"
-            logger.warning(error_msg)
-            event_helper.task_failed(error=error_msg)
-            return False, error_msg, None
-        logger.info("Batch metrics extraction completed successfully")
-        event_helper.task_completed(
-            total_items=1,
-            completed_items=1,
-            failed_items=0,
+        success, error, batch_result = await _generate_metrics_batch(
+            batch_queries,
+            batch_idx,
+            agent_config,
+            subject_tree,
+            extra_instructions,
+            event_helper,
+            action_callback,
         )
-        return True, "", final_result
-    except Exception as e:
-        logger.error(f"Error in batch metrics extraction: {e}")
-        error = str(e)
-        event_helper.task_failed(error=error)
-        return False, error, None
+
+        if success and batch_result is not None:
+            completed_batches += 1
+            if merged_result is None:
+                merged_result = batch_result
+            elif isinstance(merged_result, dict) and isinstance(batch_result, dict):
+                for key, value in batch_result.items():
+                    if key in merged_result and isinstance(merged_result[key], list) and isinstance(value, list):
+                        merged_result[key].extend(value)
+                    elif key not in merged_result:
+                        merged_result[key] = value
+            logger.info(f"Batch {batch_idx + 1}/{total_batches} completed successfully")
+        else:
+            failed_batches.append((batch_idx, error))
+            logger.warning(f"Batch {batch_idx + 1}/{total_batches} failed: {error}, continuing with remaining batches")
+
+    if completed_batches == 0:
+        error_summary = "; ".join(f"batch {i + 1}: {e}" for i, e in failed_batches)
+        error_msg = f"All {total_batches} batch(es) failed: {error_summary}"
+        logger.error(error_msg)
+        event_helper.task_failed(error=error_msg)
+        return False, error_msg, None
+
+    if failed_batches:
+        failed_summary = "; ".join(f"batch {i + 1}: {e}" for i, e in failed_batches)
+        logger.warning(f"Metrics extraction partially succeeded: {failed_summary}")
+
+    logger.info(f"Metrics extraction completed: {completed_batches}/{total_batches} batch(es) succeeded")
+    event_helper.task_completed(
+        total_items=total_batches,
+        completed_items=completed_batches,
+        failed_items=len(failed_batches),
+    )
+    return True, "", merged_result
 
 
 def init_success_story_metrics(
@@ -205,6 +271,7 @@ def init_success_story_metrics(
     extra_instructions: Optional[str] = None,
     *,
     build_mode: str = "overwrite",
+    batch_size: int = DEFAULT_METRICS_BATCH_SIZE,
 ) -> tuple[bool, str, Optional[dict[str, Any]]]:
     """
     Sync wrapper: Initialize metrics from success story CSV by batch processing.
@@ -216,6 +283,7 @@ def init_success_story_metrics(
         emit: Optional callback to stream BatchEvent progress events
         extra_instructions: Optional extra instructions for the LLM
         build_mode: Forwarded to :func:`init_success_story_metrics_async`.
+        batch_size: Number of SQL queries per batch (default 1).
     """
     with suppress_keyboard_input():
         return asyncio.run(
@@ -226,6 +294,7 @@ def init_success_story_metrics(
                 emit,
                 extra_instructions,
                 build_mode=build_mode,
+                batch_size=batch_size,
             )
         )
 

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -250,9 +250,10 @@ async def init_success_story_metrics_async(
         event_helper.task_failed(error=error_msg)
         return False, error_msg, None
 
+    partial_error = ""
     if failed_batches:
-        failed_summary = "; ".join(f"batch {i + 1}: {e}" for i, e in failed_batches)
-        logger.warning(f"Metrics extraction partially succeeded: {failed_summary}")
+        partial_error = "; ".join(f"batch {i + 1}: {e}" for i, e in failed_batches)
+        logger.warning(f"Metrics extraction partially succeeded: {partial_error}")
 
     logger.info(f"Metrics extraction completed: {completed_batches}/{total_batches} batch(es) succeeded")
     event_helper.task_completed(
@@ -260,7 +261,7 @@ async def init_success_story_metrics_async(
         completed_items=completed_batches,
         failed_items=len(failed_batches),
     )
-    return True, "", merged_result
+    return True, partial_error, merged_result
 
 
 def init_success_story_metrics(

--- a/datus/storage/semantic_model/auto_create.py
+++ b/datus/storage/semantic_model/auto_create.py
@@ -92,18 +92,13 @@ def find_missing_semantic_models(
     return missing
 
 
-async def create_semantic_models_for_tables(
-    tables: List[str],
+async def create_semantic_model_for_table(
+    table: str,
     agent_config: AgentConfig,
     emit: Optional[Callable] = None,
 ) -> tuple[bool, str]:
     """
-    Create semantic models for the specified tables.
-
-    Args:
-        tables: List of table names to create semantic models for
-        agent_config: Agent configuration
-        emit: Optional progress callback
+    Create a semantic model for a single table.
 
     Returns:
         (success, error_message)
@@ -111,12 +106,7 @@ async def create_semantic_models_for_tables(
     from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
     from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
 
-    if not tables:
-        return True, ""
-
-    # Build user message
-    tables_str = ", ".join(tables)
-    user_message = f"Generate semantic models for the following tables: {tables_str}"
+    user_message = f"Generate semantic models for the following tables: {table}"
 
     current_db_config = agent_config.current_db_config()
     semantic_input = SemanticNodeInput(
@@ -126,7 +116,6 @@ async def create_semantic_models_for_tables(
         db_schema=current_db_config.schema,
     )
 
-    # Use workflow mode to auto-save to DB
     semantic_node = GenSemanticModelAgenticNode(
         agent_config=agent_config,
         execution_mode="workflow",
@@ -138,7 +127,6 @@ async def create_semantic_models_for_tables(
         terminal_error = None
         async for action in semantic_node.execute_stream(action_history_manager):
             if emit:
-                # Emit progress event
                 emit(action)
             action_type = getattr(action, "action_type", "")
             if action.status == ActionStatus.FAILED and action_type == "error":
@@ -149,17 +137,18 @@ async def create_semantic_models_for_tables(
             return False, terminal_error
         return True, ""
     except Exception as e:
-        logger.error(f"Error creating semantic models: {e}", exc_info=True)
+        logger.error(f"Error creating semantic model for table {table}: {e}", exc_info=True)
         return False, str(e)
 
 
-def create_semantic_models_for_tables_sync(
+async def create_semantic_models_for_tables(
     tables: List[str],
     agent_config: AgentConfig,
     emit: Optional[Callable] = None,
-) -> tuple[bool, str]:
+) -> tuple[List[str], List[tuple[str, str]]]:
     """
-    Synchronous wrapper for create_semantic_models_for_tables.
+    Create semantic models for the specified tables, processing each table
+    independently so that one failure does not block others.
 
     Args:
         tables: List of table names to create semantic models for
@@ -167,7 +156,40 @@ def create_semantic_models_for_tables_sync(
         emit: Optional progress callback
 
     Returns:
-        (success, error_message)
+        (succeeded_tables, failed_tables) where failed_tables is a list of
+        (table_name, error_message) tuples.
+    """
+    if not tables:
+        return [], []
+
+    succeeded: List[str] = []
+    failed: List[tuple[str, str]] = []
+
+    for table in tables:
+        logger.info(f"Creating semantic model for table: {table}")
+        success, error = await create_semantic_model_for_table(table, agent_config, emit)
+        if success:
+            succeeded.append(table)
+            logger.info(f"Successfully created semantic model for table: {table}")
+        else:
+            failed.append((table, error))
+            logger.warning(
+                f"Failed to create semantic model for table {table}: {error}, continuing with remaining tables"
+            )
+
+    return succeeded, failed
+
+
+def create_semantic_models_for_tables_sync(
+    tables: List[str],
+    agent_config: AgentConfig,
+    emit: Optional[Callable] = None,
+) -> tuple[List[str], List[tuple[str, str]]]:
+    """
+    Synchronous wrapper for create_semantic_models_for_tables.
+
+    Returns:
+        (succeeded_tables, failed_tables)
     """
     return asyncio.run(create_semantic_models_for_tables(tables, agent_config, emit))
 
@@ -178,7 +200,8 @@ async def ensure_semantic_models_exist(
     emit: Optional[Callable] = None,
 ) -> tuple[bool, str, List[str]]:
     """
-    Check and create missing semantic models.
+    Check and create missing semantic models. Processes each table independently
+    so that failures on individual tables do not block the rest.
 
     Args:
         tables: Set of table names to check
@@ -186,7 +209,9 @@ async def ensure_semantic_models_exist(
         emit: Optional progress callback
 
     Returns:
-        (success, error_message, created_tables)
+        (success, error_message, created_tables) — success is True when at
+        least one table was created or none were missing; error_message
+        summarises any per-table failures.
     """
     missing_tables = find_missing_semantic_models(tables, agent_config)
 
@@ -196,11 +221,20 @@ async def ensure_semantic_models_exist(
 
     logger.info(f"Found {len(missing_tables)} tables without semantic models: {missing_tables}")
 
-    success, error = await create_semantic_models_for_tables(missing_tables, agent_config, emit)
+    succeeded, failed = await create_semantic_models_for_tables(missing_tables, agent_config, emit)
 
-    if success:
-        logger.info(f"Successfully created semantic models for: {missing_tables}")
-    else:
-        logger.error(f"Failed to create semantic models: {error}")
+    if succeeded:
+        logger.info(f"Successfully created semantic models for: {succeeded}")
+    if failed:
+        failed_summary = "; ".join(f"{t}: {e}" for t, e in failed)
+        logger.warning(f"Failed to create semantic models for some tables: {failed_summary}")
 
-    return success, error, missing_tables
+    if not succeeded and failed:
+        error_msg = "; ".join(f"{t}: {e}" for t, e in failed)
+        return False, error_msg, []
+
+    error_msg = ""
+    if failed:
+        error_msg = "Partial failures: " + "; ".join(f"{t}: {e}" for t, e in failed)
+
+    return True, error_msg, succeeded

--- a/datus/storage/semantic_model/auto_create.py
+++ b/datus/storage/semantic_model/auto_create.py
@@ -96,9 +96,17 @@ async def create_semantic_model_for_table(
     table: str,
     agent_config: AgentConfig,
     emit: Optional[Callable] = None,
+    related_tables: Optional[List[str]] = None,
 ) -> tuple[bool, str]:
     """
     Create a semantic model for a single table.
+
+    Args:
+        table: Table to generate the semantic model for.
+        agent_config: Agent configuration.
+        emit: Optional progress callback.
+        related_tables: Other tables being processed in the same batch.
+            Passed as context so the LLM can infer join relationships.
 
     Returns:
         (success, error_message)
@@ -107,6 +115,10 @@ async def create_semantic_model_for_table(
     from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
 
     user_message = f"Generate semantic models for the following tables: {table}"
+    if related_tables:
+        others = [t for t in related_tables if t != table]
+        if others:
+            user_message += f"\n\nRelated tables (for join context): {', '.join(others)}"
 
     current_db_config = agent_config.current_db_config()
     semantic_input = SemanticNodeInput(
@@ -167,7 +179,7 @@ async def create_semantic_models_for_tables(
 
     for table in tables:
         logger.info(f"Creating semantic model for table: {table}")
-        success, error = await create_semantic_model_for_table(table, agent_config, emit)
+        success, error = await create_semantic_model_for_table(table, agent_config, emit, related_tables=tables)
         if success:
             succeeded.append(table)
             logger.info(f"Successfully created semantic model for table: {table}")

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -772,6 +772,7 @@ class TestBatchSplitting:
             )
 
         assert ok is True
+        assert "batch 2" in err
         assert result is not None
         assert len(result["metrics"]) == 2
         assert "m0" in result["metrics"]

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -9,7 +9,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from datus.storage.metric.metric_init import BIZ_NAME, _action_status_value, init_semantic_yaml_metrics
+from datus.storage.metric.metric_init import (
+    BIZ_NAME,
+    DEFAULT_METRICS_BATCH_SIZE,
+    _action_status_value,
+    _generate_metrics_batch,
+    init_semantic_yaml_metrics,
+)
 
 # ---------------------------------------------------------------------------
 # _action_status_value
@@ -509,3 +515,347 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
         assert success is True
         fake_rag_instance.truncate.assert_not_called()
         mock_exists.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_METRICS_BATCH_SIZE constant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestDefaultMetricsBatchSize:
+    def test_default_batch_size(self):
+        assert DEFAULT_METRICS_BATCH_SIZE == 1
+
+
+# ---------------------------------------------------------------------------
+# _generate_metrics_batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestGenerateMetricsBatch:
+    """Tests for the _generate_metrics_batch helper."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_result(self):
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.schemas.batch_events import BatchEventHelper
+
+        mock_node = MagicMock()
+
+        async def fake_stream(_ahm):
+            action = MagicMock()
+            action.status = ActionStatus.SUCCESS
+            action.action_type = "metrics_response"
+            action.output = {"metrics": ["revenue"]}
+            action.messages = "ok"
+            yield action
+
+        mock_node.execute_stream = fake_stream
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
+        ):
+            ok, err, result = await _generate_metrics_batch(
+                ["Query 1:\nQuestion: rev?\nSQL:\nSELECT 1"],
+                0,
+                mock_config,
+                None,
+                None,
+                BatchEventHelper("test", None),
+                None,
+            )
+
+        assert ok is True
+        assert err == ""
+        assert result == {"metrics": ["revenue"]}
+
+    @pytest.mark.asyncio
+    async def test_terminal_error_returns_failure(self):
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.schemas.batch_events import BatchEventHelper
+
+        mock_node = MagicMock()
+
+        async def fake_stream(_ahm):
+            action = MagicMock()
+            action.status = ActionStatus.FAILED
+            action.action_type = "error"
+            action.output = None
+            action.messages = "Max turns exceeded"
+            yield action
+
+        mock_node.execute_stream = fake_stream
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
+        ):
+            ok, err, result = await _generate_metrics_batch(
+                ["Query 1:\nQuestion: q?\nSQL:\nSELECT 1"],
+                0,
+                mock_config,
+                None,
+                None,
+                BatchEventHelper("test", None),
+                None,
+            )
+
+        assert ok is False
+        assert "Max turns" in err
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_failure(self):
+        from unittest.mock import patch
+
+        from datus.schemas.batch_events import BatchEventHelper
+
+        mock_node = MagicMock()
+
+        async def fake_stream(_ahm):
+            raise RuntimeError("connection lost")
+            yield  # noqa: F841 - async generator marker
+
+        mock_node.execute_stream = fake_stream
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
+        ):
+            ok, err, result = await _generate_metrics_batch(
+                ["Query 1:\nQuestion: q?\nSQL:\nSELECT 1"],
+                0,
+                mock_config,
+                None,
+                None,
+                BatchEventHelper("test", None),
+                None,
+            )
+
+        assert ok is False
+        assert "connection lost" in err
+
+
+# ---------------------------------------------------------------------------
+# init_success_story_metrics_async — batch splitting & partial failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestBatchSplitting:
+    """Tests for batch splitting and partial failure tolerance."""
+
+    def _make_node_factory(self, fail_on_batches=None):
+        """Return a mock GenMetricsAgenticNode factory.
+
+        Args:
+            fail_on_batches: set of batch indices (0-based) that should fail.
+        """
+        from datus.schemas.action_history import ActionStatus
+
+        fail_on_batches = fail_on_batches or set()
+        call_count = {"n": 0}
+
+        class MockNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+                self._batch_idx = call_count["n"]
+                call_count["n"] += 1
+
+            async def execute_stream(self, _ahm):
+                if self._batch_idx in fail_on_batches:
+                    action = MagicMock()
+                    action.status = ActionStatus.FAILED
+                    action.action_type = "error"
+                    action.output = None
+                    action.messages = f"Batch {self._batch_idx} failed"
+                    yield action
+                else:
+                    action = MagicMock()
+                    action.status = ActionStatus.SUCCESS
+                    action.action_type = "metrics_response"
+                    action.output = {"metrics": [f"m{self._batch_idx}"]}
+                    action.messages = "ok"
+                    yield action
+
+        return MockNode
+
+    @pytest.mark.asyncio
+    async def test_queries_split_into_batches(self):
+        """15 queries with batch_size=5 → 3 batches, 3 node instantiations."""
+        from unittest.mock import patch
+
+        import pandas as pd
+
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        MockNode = self._make_node_factory()
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        rows = [{"question": f"q{i}", "sql": f"SELECT {i}"} for i in range(15)]
+
+        with (
+            patch("datus.storage.metric.store.MetricRAG", MagicMock()),
+            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value=[]),
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", MockNode),
+            patch("datus.storage.metric.metric_init.pd.read_csv", return_value=pd.DataFrame(rows)),
+        ):
+            ok, err, result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="dummy.csv",
+                batch_size=5,
+            )
+
+        assert ok is True
+        assert err == ""
+        assert result is not None
+        assert len(result["metrics"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_partial_batch_failure_continues(self):
+        """3 batches, middle one fails → success=True, 2 batches of results merged."""
+        from unittest.mock import patch
+
+        import pandas as pd
+
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        MockNode = self._make_node_factory(fail_on_batches={1})
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        rows = [{"question": f"q{i}", "sql": f"SELECT {i}"} for i in range(15)]
+
+        with (
+            patch("datus.storage.metric.store.MetricRAG", MagicMock()),
+            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value=[]),
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", MockNode),
+            patch("datus.storage.metric.metric_init.pd.read_csv", return_value=pd.DataFrame(rows)),
+        ):
+            ok, err, result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="dummy.csv",
+                batch_size=5,
+            )
+
+        assert ok is True
+        assert result is not None
+        assert len(result["metrics"]) == 2
+        assert "m0" in result["metrics"]
+        assert "m2" in result["metrics"]
+
+    @pytest.mark.asyncio
+    async def test_all_batches_fail(self):
+        """All batches fail → success=False."""
+        from unittest.mock import patch
+
+        import pandas as pd
+
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        MockNode = self._make_node_factory(fail_on_batches={0, 1})
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        rows = [{"question": f"q{i}", "sql": f"SELECT {i}"} for i in range(10)]
+
+        with (
+            patch("datus.storage.metric.store.MetricRAG", MagicMock()),
+            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value=[]),
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", MockNode),
+            patch("datus.storage.metric.metric_init.pd.read_csv", return_value=pd.DataFrame(rows)),
+        ):
+            ok, err, result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="dummy.csv",
+                batch_size=5,
+            )
+
+        assert ok is False
+        assert "All" in err
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_single_row_single_batch(self):
+        """1 query → 1 batch, no splitting overhead."""
+        from unittest.mock import patch
+
+        import pandas as pd
+
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        MockNode = self._make_node_factory()
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.store.MetricRAG", MagicMock()),
+            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value=[]),
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", MockNode),
+            patch(
+                "datus.storage.metric.metric_init.pd.read_csv",
+                return_value=pd.DataFrame([{"question": "q1", "sql": "SELECT 1"}]),
+            ),
+        ):
+            ok, err, result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="dummy.csv",
+                batch_size=10,
+            )
+
+        assert ok is True
+        assert result == {"metrics": ["m0"]}
+
+    @pytest.mark.asyncio
+    async def test_batch_size_parameter_passed_through_sync(self):
+        """Sync wrapper forwards batch_size to async function."""
+        import inspect
+
+        from datus.storage.metric.metric_init import init_success_story_metrics
+
+        sig = inspect.signature(init_success_story_metrics)
+        assert "batch_size" in sig.parameters
+        assert sig.parameters["batch_size"].default == DEFAULT_METRICS_BATCH_SIZE

--- a/tests/unit_tests/storage/semantic_model/test_auto_create.py
+++ b/tests/unit_tests/storage/semantic_model/test_auto_create.py
@@ -195,22 +195,12 @@ class TestFindMissingSemanticModels:
 
 
 # ---------------------------------------------------------------------------
-# create_semantic_models_for_tables (async, lines 111-147)
+# create_semantic_model_for_table (single-table async)
 # ---------------------------------------------------------------------------
 
 
-class TestCreateSemanticModelsForTables:
-    """Tests for create_semantic_models_for_tables async function."""
-
-    @pytest.mark.asyncio
-    async def test_empty_tables_returns_true(self):
-        """Empty table list should return (True, '') immediately without calling node."""
-        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
-
-        config = MagicMock()
-        success, error = await create_semantic_models_for_tables([], config)
-        assert success is True
-        assert error == ""
+class TestCreateSemanticModelForTable:
+    """Tests for create_semantic_model_for_table async function."""
 
     @pytest.mark.asyncio
     async def test_success_path(self):
@@ -219,7 +209,7 @@ class TestCreateSemanticModelsForTables:
         from unittest.mock import patch
 
         from datus.schemas.action_history import ActionStatus
-        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
 
         mock_config = MagicMock()
         mock_db_config = MagicMock()
@@ -233,8 +223,7 @@ class TestCreateSemanticModelsForTables:
                 self.input = None
 
             async def execute_stream(self, ahm):
-                action = SimpleNamespace(status=ActionStatus.SUCCESS, messages="ok")
-                yield action
+                yield SimpleNamespace(status=ActionStatus.SUCCESS, messages="ok")
 
         with (
             patch(
@@ -246,7 +235,7 @@ class TestCreateSemanticModelsForTables:
                 MagicMock(return_value=MagicMock()),
             ),
         ):
-            success, error = await create_semantic_models_for_tables(["users", "orders"], mock_config)
+            success, error = await create_semantic_model_for_table("users", mock_config)
         assert success is True
         assert error == ""
 
@@ -257,7 +246,7 @@ class TestCreateSemanticModelsForTables:
         from unittest.mock import patch
 
         from datus.schemas.action_history import ActionStatus
-        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
 
         mock_config = MagicMock()
         mock_db_config = MagicMock()
@@ -271,8 +260,7 @@ class TestCreateSemanticModelsForTables:
                 self.input = None
 
             async def execute_stream(self, ahm):
-                action = SimpleNamespace(status=ActionStatus.FAILED, action_type="error", messages="Generation failed")
-                yield action
+                yield SimpleNamespace(status=ActionStatus.FAILED, action_type="error", messages="Generation failed")
 
         with (
             patch(
@@ -284,7 +272,7 @@ class TestCreateSemanticModelsForTables:
                 MagicMock(return_value=MagicMock()),
             ),
         ):
-            success, error = await create_semantic_models_for_tables(["users"], mock_config)
+            success, error = await create_semantic_model_for_table("users", mock_config)
         assert success is False
         assert "Generation failed" in error
 
@@ -295,7 +283,7 @@ class TestCreateSemanticModelsForTables:
         from unittest.mock import patch
 
         from datus.schemas.action_history import ActionStatus
-        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
 
         mock_config = MagicMock()
         mock_db_config = MagicMock()
@@ -309,8 +297,7 @@ class TestCreateSemanticModelsForTables:
                 self.input = None
 
             async def execute_stream(self, ahm):
-                action = SimpleNamespace(status=ActionStatus.FAILED, action_type="error", messages=None)
-                yield action
+                yield SimpleNamespace(status=ActionStatus.FAILED, action_type="error", messages=None)
 
         with (
             patch(
@@ -322,7 +309,7 @@ class TestCreateSemanticModelsForTables:
                 MagicMock(return_value=MagicMock()),
             ),
         ):
-            success, error = await create_semantic_models_for_tables(["users"], mock_config)
+            success, error = await create_semantic_model_for_table("users", mock_config)
         assert success is False
         assert error != ""
 
@@ -333,7 +320,7 @@ class TestCreateSemanticModelsForTables:
         from unittest.mock import patch
 
         from datus.schemas.action_history import ActionStatus
-        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
 
         mock_config = MagicMock()
         mock_db_config = MagicMock()
@@ -364,7 +351,7 @@ class TestCreateSemanticModelsForTables:
                 MagicMock(return_value=MagicMock()),
             ),
         ):
-            success, error = await create_semantic_models_for_tables(["users"], mock_config)
+            success, error = await create_semantic_model_for_table("users", mock_config)
         assert success is True
         assert error == ""
 
@@ -373,7 +360,7 @@ class TestCreateSemanticModelsForTables:
         """execute_stream raises → returns (False, error_str)."""
         from unittest.mock import patch
 
-        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
 
         mock_config = MagicMock()
         mock_db_config = MagicMock()
@@ -400,7 +387,7 @@ class TestCreateSemanticModelsForTables:
                 MagicMock(return_value=MagicMock()),
             ),
         ):
-            success, error = await create_semantic_models_for_tables(["users"], mock_config)
+            success, error = await create_semantic_model_for_table("users", mock_config)
         assert success is False
         assert "connection lost" in error
 
@@ -411,7 +398,7 @@ class TestCreateSemanticModelsForTables:
         from unittest.mock import patch
 
         from datus.schemas.action_history import ActionStatus
-        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
 
         mock_config = MagicMock()
         mock_db_config = MagicMock()
@@ -426,8 +413,7 @@ class TestCreateSemanticModelsForTables:
 
             async def execute_stream(self, ahm):
                 for _ in range(3):
-                    action = SimpleNamespace(status=ActionStatus.SUCCESS, messages="step")
-                    yield action
+                    yield SimpleNamespace(status=ActionStatus.SUCCESS, messages="step")
 
         emit_count = []
         with (
@@ -440,27 +426,95 @@ class TestCreateSemanticModelsForTables:
                 MagicMock(return_value=MagicMock()),
             ),
         ):
-            success, error = await create_semantic_models_for_tables(["users"], mock_config, emit=emit_count.append)
+            success, error = await create_semantic_model_for_table("users", mock_config, emit=emit_count.append)
         assert success is True
         assert len(emit_count) == 3
 
 
 # ---------------------------------------------------------------------------
-# create_semantic_models_for_tables_sync (line 166)
+# create_semantic_models_for_tables (batch with per-table isolation)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSemanticModelsForTables:
+    """Tests for create_semantic_models_for_tables async function."""
+
+    @pytest.mark.asyncio
+    async def test_empty_tables_returns_empty(self):
+        """Empty table list should return ([], []) immediately."""
+        from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables
+
+        config = MagicMock()
+        succeeded, failed = await create_semantic_models_for_tables([], config)
+        assert succeeded == []
+        assert failed == []
+
+    @pytest.mark.asyncio
+    async def test_all_succeed(self, monkeypatch):
+        """All tables succeed → succeeded=[all], failed=[]."""
+        from datus.storage.semantic_model import auto_create
+
+        async def mock_single(table, config, emit=None):
+            return True, ""
+
+        monkeypatch.setattr(auto_create, "create_semantic_model_for_table", mock_single)
+
+        succeeded, failed = await auto_create.create_semantic_models_for_tables(["users", "orders"], MagicMock())
+        assert succeeded == ["users", "orders"]
+        assert failed == []
+
+    @pytest.mark.asyncio
+    async def test_all_fail(self, monkeypatch):
+        """All tables fail → succeeded=[], failed=[all]."""
+        from datus.storage.semantic_model import auto_create
+
+        async def mock_single(table, config, emit=None):
+            return False, f"{table} error"
+
+        monkeypatch.setattr(auto_create, "create_semantic_model_for_table", mock_single)
+
+        succeeded, failed = await auto_create.create_semantic_models_for_tables(["t1", "t2"], MagicMock())
+        assert succeeded == []
+        assert len(failed) == 2
+        assert failed[0] == ("t1", "t1 error")
+        assert failed[1] == ("t2", "t2 error")
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_continues(self, monkeypatch):
+        """One table fails, others succeed — failure does not block the rest."""
+        from datus.storage.semantic_model import auto_create
+
+        async def mock_single(table, config, emit=None):
+            if table == "bad_table":
+                return False, "Max turns exceeded"
+            return True, ""
+
+        monkeypatch.setattr(auto_create, "create_semantic_model_for_table", mock_single)
+
+        succeeded, failed = await auto_create.create_semantic_models_for_tables(
+            ["good1", "bad_table", "good2"], MagicMock()
+        )
+        assert succeeded == ["good1", "good2"]
+        assert len(failed) == 1
+        assert failed[0] == ("bad_table", "Max turns exceeded")
+
+
+# ---------------------------------------------------------------------------
+# create_semantic_models_for_tables_sync
 # ---------------------------------------------------------------------------
 
 
 class TestCreateSemanticModelsForTablesSync:
     """Tests for create_semantic_models_for_tables_sync sync wrapper."""
 
-    def test_empty_tables_returns_true(self):
-        """Sync wrapper: empty list returns (True, '')."""
+    def test_empty_tables_returns_empty(self):
+        """Sync wrapper: empty list returns ([], [])."""
         from datus.storage.semantic_model.auto_create import create_semantic_models_for_tables_sync
 
         config = MagicMock()
-        success, error = create_semantic_models_for_tables_sync([], config)
-        assert success is True
-        assert error == ""
+        succeeded, failed = create_semantic_models_for_tables_sync([], config)
+        assert succeeded == []
+        assert failed == []
 
     def test_wraps_async_function(self, monkeypatch):
         """Sync wrapper delegates to async create_semantic_models_for_tables."""
@@ -470,17 +524,17 @@ class TestCreateSemanticModelsForTablesSync:
 
         async def mock_async(tables, config, emit=None):
             calls.append(tables)
-            return True, ""
+            return ["users"], []
 
         monkeypatch.setattr(auto_create, "create_semantic_models_for_tables", mock_async)
 
-        success, error = auto_create.create_semantic_models_for_tables_sync(["users"], MagicMock())
-        assert success is True
+        succeeded, failed = auto_create.create_semantic_models_for_tables_sync(["users"], MagicMock())
+        assert succeeded == ["users"]
         assert calls == [["users"]]
 
 
 # ---------------------------------------------------------------------------
-# ensure_semantic_models_exist (lines 185-200)
+# ensure_semantic_models_exist
 # ---------------------------------------------------------------------------
 
 
@@ -507,7 +561,7 @@ class TestEnsureSemanticModelsExist:
         monkeypatch.setattr(auto_create, "find_missing_semantic_models", lambda tables, config: ["orders"])
 
         async def mock_create(tables, config, emit=None):
-            return True, ""
+            return ["orders"], []
 
         monkeypatch.setattr(auto_create, "create_semantic_models_for_tables", mock_create)
 
@@ -517,21 +571,39 @@ class TestEnsureSemanticModelsExist:
         assert "orders" in created
 
     @pytest.mark.asyncio
-    async def test_creation_failure_propagated(self, monkeypatch):
-        """When creation fails, returns (False, error, missing_tables)."""
+    async def test_all_creation_fails(self, monkeypatch):
+        """When all tables fail, returns (False, error_summary, [])."""
         from datus.storage.semantic_model import auto_create
 
         monkeypatch.setattr(auto_create, "find_missing_semantic_models", lambda tables, config: ["bad_table"])
 
         async def mock_create(tables, config, emit=None):
-            return False, "Schema not found"
+            return [], [("bad_table", "Schema not found")]
 
         monkeypatch.setattr(auto_create, "create_semantic_models_for_tables", mock_create)
 
         success, error, created = await auto_create.ensure_semantic_models_exist({"bad_table"}, MagicMock())
         assert success is False
         assert "Schema not found" in error
-        assert "bad_table" in created
+        assert created == []
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_returns_success_with_warning(self, monkeypatch):
+        """Some tables succeed, some fail → success=True, error has partial info."""
+        from datus.storage.semantic_model import auto_create
+
+        monkeypatch.setattr(auto_create, "find_missing_semantic_models", lambda tables, config: ["good", "bad"])
+
+        async def mock_create(tables, config, emit=None):
+            return ["good"], [("bad", "Max turns exceeded")]
+
+        monkeypatch.setattr(auto_create, "create_semantic_models_for_tables", mock_create)
+
+        success, error, created = await auto_create.ensure_semantic_models_exist({"good", "bad"}, MagicMock())
+        assert success is True
+        assert "Partial failures" in error
+        assert "good" in created
+        assert "bad" not in created
 
     @pytest.mark.asyncio
     async def test_empty_tables_no_creation(self, monkeypatch):
@@ -544,7 +616,7 @@ class TestEnsureSemanticModelsExist:
 
         async def mock_create(tables, config, emit=None):
             create_calls.append(tables)
-            return True, ""
+            return tables, []
 
         monkeypatch.setattr(auto_create, "create_semantic_models_for_tables", mock_create)
 

--- a/tests/unit_tests/storage/semantic_model/test_auto_create.py
+++ b/tests/unit_tests/storage/semantic_model/test_auto_create.py
@@ -454,7 +454,7 @@ class TestCreateSemanticModelsForTables:
         """All tables succeed → succeeded=[all], failed=[]."""
         from datus.storage.semantic_model import auto_create
 
-        async def mock_single(table, config, emit=None):
+        async def mock_single(table, config, emit=None, related_tables=None):
             return True, ""
 
         monkeypatch.setattr(auto_create, "create_semantic_model_for_table", mock_single)
@@ -468,7 +468,7 @@ class TestCreateSemanticModelsForTables:
         """All tables fail → succeeded=[], failed=[all]."""
         from datus.storage.semantic_model import auto_create
 
-        async def mock_single(table, config, emit=None):
+        async def mock_single(table, config, emit=None, related_tables=None):
             return False, f"{table} error"
 
         monkeypatch.setattr(auto_create, "create_semantic_model_for_table", mock_single)
@@ -484,7 +484,7 @@ class TestCreateSemanticModelsForTables:
         """One table fails, others succeed — failure does not block the rest."""
         from datus.storage.semantic_model import auto_create
 
-        async def mock_single(table, config, emit=None):
+        async def mock_single(table, config, emit=None, related_tables=None):
             if table == "bad_table":
                 return False, "Max turns exceeded"
             return True, ""


### PR DESCRIPTION
## Why

When processing multiple SQL queries for metrics extraction, a single failure (e.g., LLM timeout on one table) would abort the entire pipeline. Similarly, semantic model creation for multiple tables was all-or-nothing — one bad table blocked all others.

## Solution

- **Metrics init (`metric_init.py`)**: Refactored to split SQL queries into configurable batches (`batch_size` param, default 1). Each batch is processed independently via `_generate_metrics_batch()`. Results are merged across successful batches; partial failures are logged but don't block the rest.
- **Semantic model creation (`auto_create.py`)**: Split `create_semantic_models_for_tables` into per-table `create_semantic_model_for_table` + a loop wrapper. Return type changed from `(bool, str)` to `(List[str], List[tuple[str, str]])` to report per-table success/failure. `ensure_semantic_models_exist` now returns success when at least one table succeeds.

## Test Cases

- `test_metric_init.py`: Added tests for `_generate_metrics_batch` (success, terminal error, exception), batch splitting (15 queries into 3 batches), partial batch failure (middle batch fails, others succeed), all batches fail, single row, and sync wrapper parameter forwarding.
- `test_auto_create.py`: Updated existing tests to match new single-table API. Added tests for `create_semantic_models_for_tables` batch wrapper (all succeed, all fail, partial failure). Added `test_partial_failure_returns_success_with_warning` for `ensure_semantic_models_exist`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics extraction now runs in configurable batches with per-batch progress, merged partial results, and aggregated partial-error summaries.
  * Semantic model creation is per-table so successful tables are preserved when others fail.
  * Synchronous APIs expose and forward the new batching/creation behavior.

* **Bug Fixes / Reliability**
  * Operations tolerate partial failures and report completed vs failed batches/tables.

* **Tests**
  * Expanded unit tests for batching, partial failures, progress and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->