### PR TITLE
[BugFix] Clarify skill command boundaries

### DIFF
--- a/datus/prompts/prompt_templates/available_skills_context_1.0.j2
+++ b/datus/prompts/prompt_templates/available_skills_context_1.0.j2
@@ -14,7 +14,8 @@ Skills can be loaded on-demand to get detailed instructions for specific tasks.
 1. Review the available skills above to find one that matches your current task
 2. Call `load_skill(skill_name="<skill_name>")` to load the full skill content
 3. Follow the instructions in the loaded skill to complete the task
-4. Some skills may include script execution capabilities (allowed commands will be specified)
+4. Use `skill_execute_command` only for skill-owned scripts explicitly permitted by that skill's `allowed_commands`
+5. If loaded skill instructions mention a tool that is already available as a native tool, call the native tool directly instead of routing it through `skill_execute_command`
 
 ### When to Use Skills
 

--- a/datus/tools/skill_tools/skill_func_tool.py
+++ b/datus/tools/skill_tools/skill_func_tool.py
@@ -219,6 +219,8 @@ class SkillFuncTool:
         Commands are restricted to patterns defined in the skill's allowed_commands.
         For example, if a skill allows "python:scripts/*.py", only Python scripts
         in the scripts/ directory can be executed.
+        This tool is not a proxy for native tools named in skill instructions; call
+        available native tools directly.
 
         Args:
             skill_name: Name of the loaded skill (must have been loaded via load_skill)
@@ -243,7 +245,13 @@ class SkillFuncTool:
                 if not skill.has_scripts():
                     return FuncToolResult(
                         success=0,
-                        error=f"Skill '{skill_name}' does not have any allowed_commands defined",
+                        error=(
+                            f"Skill '{skill_name}' does not have any allowed_commands defined. "
+                            "This skill cannot execute shell commands through skill_execute_command. "
+                            "Use skill_execute_command only for skill-owned scripts explicitly permitted by "
+                            "allowed_commands; if the skill mentions an available native tool, call the native "
+                            "tool directly."
+                        ),
                     )
                 return FuncToolResult(
                     success=0,

--- a/datus/tools/skill_tools/skill_manager.py
+++ b/datus/tools/skill_tools/skill_manager.py
@@ -270,7 +270,12 @@ class SkillManager:
                 "are not in the list — not in ``ask_user`` prompts, not in plans, not "
                 "in explanations. If the needed skill is absent, delegate to a "
                 "subagent via ``sub_agent_tools.task(type=<subagent>, ...)`` and let "
-                "the subagent load its own skills."
+                "the subagent load its own skills.\n"
+                "  5. Use ``skill_execute_command`` only for skill-owned scripts "
+                "explicitly permitted by that skill's ``allowed_commands``.\n"
+                "  6. If loaded skill instructions mention a tool that is available "
+                "as a native tool in the current run, call that native tool directly "
+                "instead of routing it through ``skill_execute_command``."
             )
         else:
             lines.append(

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -182,6 +182,8 @@ class TestFinalizeSystemPrompt:
         assert result.startswith(base_prompt)
         assert "<available_skills>" in result
         assert "sql-analysis" in result
+        assert "skill-owned scripts" in result
+        assert "native tool directly" in result
 
     def test_with_skill_func_tool_empty_xml_appends_explicit_none_block(
         self, mock_agent_config, skill_manager, monkeypatch

--- a/tests/unit_tests/tools/skill_tools/test_skill_func_tool.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_func_tool.py
@@ -361,6 +361,8 @@ class TestSkillExecuteCommand:
 
         assert result.success == 0
         assert "allowed_commands" in result.error
+        assert "native tool" in result.error
+        assert "skill-owned scripts" in result.error
 
     def test_execute_command_after_load(self, skill_func_tool):
         """Test executing command after loading skill with scripts."""

--- a/tests/unit_tests/tools/skill_tools/test_skill_manager_unit.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_manager_unit.py
@@ -258,6 +258,8 @@ class TestGenerateSkillsXml:
         xml = manager.generate_available_skills_xml("node")
         assert "<available_skills>" in xml
         assert "test-skill" in xml
+        assert "skill-owned scripts" in xml
+        assert "native tool directly" in xml
 
     def test_generate_xml_empty_is_explicit(self):
         """With no visible skills, the XML must still be emitted and state the


### PR DESCRIPTION
## Why

Workflow skills can mention native tools in their instructions. The model could incorrectly route those tool names through `skill_execute_command`, which fails for instruction-only skills that do not declare `allowed_commands`.

## Solution

Clarify the skill guidance and command execution boundary without naming any semantic-specific tools:
- tell agents to use `skill_execute_command` only for skill-owned scripts explicitly permitted by `allowed_commands`
- tell agents to call available native tools directly when loaded skill instructions mention them
- improve the no-`allowed_commands` error with the same guidance
- cover the prompt XML and error path with unit tests

## Test Cases

- `uv run pytest tests/unit_tests/tools/skill_tools/test_skill_func_tool.py tests/unit_tests/tools/skill_tools/test_skill_manager_unit.py tests/unit_tests/agent/node/test_agentic_node_skills.py`
- `git diff --check`
- `uv run ruff check datus/tools/skill_tools/skill_func_tool.py datus/tools/skill_tools/skill_manager.py tests/unit_tests/tools/skill_tools/test_skill_func_tool.py tests/unit_tests/tools/skill_tools/test_skill_manager_unit.py tests/unit_tests/agent/node/test_agentic_node_skills.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified system prompt instructions for skill usage with explicit rules for command execution authorization and native tool prioritization
* **Improvements**  
  * Enhanced error messages when skill command execution is restricted, offering clearer guidance on permitted actions and proper tool usage

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/720)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->