### PR TITLE
[BugFix] Include web template in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ exclude = ["benchmark*", "docs*"]
     "sample_data/california_schools/reference_template/*",
     "sample_data/superset/*",
 ]
+"datus.cli.web" = ["templates/*.html"]
 "datus.prompts" = ["*.txt", "*.md", "*.j2"]
 "datus.prompts.prompt_templates" = ["*.j2"]
 


### PR DESCRIPTION
## Why

The packaged `datus --web` command failed at startup because `datus/cli/web/templates/index.html` was present in the source tree but missing from the built wheel. The web entry point reads that template from the installed package path, so installed packages raised `FileNotFoundError`.

## Solution

Add `templates/*.html` to the `datus.cli.web` setuptools package data so `index.html` is included in both wheel and source distribution builds.

## Test Cases

- `uv build --out-dir /tmp/datus-web-template-package-pr-dist`
- Verified both wheel and sdist contain `datus/cli/web/templates/index.html`
- Installed `/tmp/datus-web-template-package-pr-dist/datus_agent-0.2.6-py3-none-any.whl` into `/tmp/datus-web-template-pr-wheel-install` with `pip --target`
- Verified `datus.cli.web.chatbot._read_template()` loads the installed template from the wheel install path
- Started packaged `datus --web --datasource njyh --host 127.0.0.1 --port <free-port>` with a temporary DuckDB datasource config and confirmed `GET /` returns 200 with chatbot HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to ensure HTML template files are properly included in the distribution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/721)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->