### PR TITLE
[BugFix] Stabilize nightly main failures

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -69,7 +69,39 @@ jobs:
             ./external/datus-bi-adapters/datus-bi-superset \
             ./external/datus-scheduler-adapters/datus-scheduler-core \
             ./external/datus-scheduler-adapters/datus-scheduler-airflow
-          uv run playwright install chromium
+          uv run playwright install --with-deps chromium
+
+      - name: Ensure Docker runtime
+        env:
+          DOCKER_COMPOSE_FALLBACK_VERSION: v2.29.7
+        run: |
+          set -euo pipefail
+          docker --version
+          docker info >/dev/null
+
+          if ! docker compose version >/dev/null 2>&1; then
+            os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+            arch="$(uname -m)"
+            case "$arch" in
+              x86_64 | amd64) arch="x86_64" ;;
+              arm64 | aarch64) arch="aarch64" ;;
+              *)
+                echo "::error::Unsupported Docker Compose architecture: $arch"
+                exit 1
+                ;;
+            esac
+            version="$(curl -fsSL https://api.github.com/repos/docker/compose/releases/latest \
+              | sed -n 's/.*"tag_name": "\(v[^"]*\)".*/\1/p' \
+              | head -1 || true)"
+            version="${version:-$DOCKER_COMPOSE_FALLBACK_VERSION}"
+            mkdir -p "$HOME/.docker/cli-plugins"
+            curl -fsSL \
+              "https://github.com/docker/compose/releases/download/${version}/docker-compose-${os}-${arch}" \
+              -o "$HOME/.docker/cli-plugins/docker-compose"
+            chmod +x "$HOME/.docker/cli-plugins/docker-compose"
+          fi
+
+          docker compose version
 
       - name: Setup config file
         run: |

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -73,6 +73,9 @@ jobs:
 
       - name: Ensure Docker runtime
         env:
+          # Keep this fallback pinned and refresh it periodically when Docker Compose
+          # releases a newer stable version. The workflow prefers the live latest
+          # release when the GitHub API is reachable.
           DOCKER_COMPOSE_FALLBACK_VERSION: v2.29.7
         run: |
           set -euo pipefail
@@ -90,15 +93,29 @@ jobs:
                 exit 1
                 ;;
             esac
-            version="$(curl -fsSL https://api.github.com/repos/docker/compose/releases/latest \
-              | sed -n 's/.*"tag_name": "\(v[^"]*\)".*/\1/p' \
-              | head -1 || true)"
+            version="$(curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 60 \
+              https://api.github.com/repos/docker/compose/releases/latest \
+              | python3 -c 'import json, sys; print(json.load(sys.stdin).get("tag_name", ""))' \
+              || true)"
             version="${version:-$DOCKER_COMPOSE_FALLBACK_VERSION}"
+            binary_name="docker-compose-${os}-${arch}"
+            compose_url="https://github.com/docker/compose/releases/download/${version}/${binary_name}"
+            plugin_path="$HOME/.docker/cli-plugins/docker-compose"
+            checksum_file="$(mktemp)"
             mkdir -p "$HOME/.docker/cli-plugins"
-            curl -fsSL \
-              "https://github.com/docker/compose/releases/download/${version}/docker-compose-${os}-${arch}" \
-              -o "$HOME/.docker/cli-plugins/docker-compose"
-            chmod +x "$HOME/.docker/cli-plugins/docker-compose"
+            curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 300 \
+              "$compose_url" \
+              -o "$plugin_path"
+            curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 60 \
+              "${compose_url}.sha256" \
+              -o "$checksum_file"
+            expected_sha="$(awk '{print $1}' "$checksum_file")"
+            actual_sha="$(sha256sum "$plugin_path" | awk '{print $1}')"
+            if [ -z "$expected_sha" ] || [ "$actual_sha" != "$expected_sha" ]; then
+              echo "::error::Docker Compose checksum verification failed for ${binary_name}"
+              exit 1
+            fi
+            chmod +x "$plugin_path"
           fi
 
           docker compose version

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -64,6 +64,19 @@ COMPOSE_FILES=(
   "$AIRFLOW_COMPOSE"
 )
 
+COMPOSE_GROUPS=(
+  "Superset Nightly Tests"
+  "Airflow Nightly Tests"
+  "PostgreSQL Adapter Tests"
+  "MySQL Adapter Tests"
+  "ClickHouse Adapter Tests"
+  "StarRocks Adapter Tests"
+  "Trino Adapter Tests"
+  "Greenplum Adapter Tests"
+  "Hive Adapter Tests"
+  "Spark Adapter Tests"
+)
+
 log() {
   echo "$@" | tee -a "$LOG_FILE"
 }
@@ -136,6 +149,40 @@ validate_unit_test_home() {
 
 has_docker_compose() {
   docker compose version >/dev/null 2>&1 || command -v docker-compose >/dev/null 2>&1
+}
+
+will_run_any_compose_suite() {
+  local group_name
+  for group_name in "${COMPOSE_GROUPS[@]}"; do
+    if should_run_group "$group_name"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+require_docker_runtime() {
+  if ! will_run_any_compose_suite; then
+    return 0
+  fi
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required for nightly compose-backed suites" | tee -a "$LOG_FILE" >&2
+    test_exit_code=127
+    return 1
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon is not available for nightly compose-backed suites" | tee -a "$LOG_FILE" >&2
+    test_exit_code=127
+    return 1
+  fi
+
+  if ! has_docker_compose; then
+    echo "Docker Compose is required for nightly compose-backed suites" | tee -a "$LOG_FILE" >&2
+    test_exit_code=127
+    return 1
+  fi
 }
 
 docker_compose() {
@@ -481,6 +528,7 @@ if [ -n "$NIGHTLY_GROUP_FILTER" ]; then
 fi
 
 validate_nightly_group_filter || exit 1
+require_docker_runtime || exit "$test_exit_code"
 
 run_logged_unfiltered "Flaky Registry Check" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --strict
 

--- a/datus/agent/node/gen_ext_knowledge_agentic_node.py
+++ b/datus/agent/node/gen_ext_knowledge_agentic_node.py
@@ -560,7 +560,11 @@ Do NOT give up. Continue iterating until verify_sql returns success=1.
 
         context = {}
 
-        context["native_tools"] = ", ".join([tool.name for tool in self.tools]) if self.tools else "None"
+        tool_names = [tool.name for tool in self.tools] if self.tools else []
+        context["native_tools"] = ", ".join(tool_names) if tool_names else "None"
+        context["tool_names"] = tool_names
+        context["has_search_knowledge_tool"] = "search_knowledge" in tool_names
+        context["has_get_knowledge_tool"] = "get_knowledge" in tool_names
         context["ext_knowledge_dir"] = self.ext_knowledge_dir
         context["knowledge_base_dir"] = self.knowledge_base_dir
         # Filesystem tool is rooted at project_root; full path required.

--- a/datus/prompts/prompt_templates/gen_ext_knowledge_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_ext_knowledge_system_1.0.j2
@@ -5,7 +5,12 @@ You are a business knowledge discovery expert.
 {% if has_gold_sql %}
 - **verify_sql(sql)**: Validate your SQL against hidden reference. Returns `success` (0 or 1) and `suggestions` if failed.
 {% endif %}
+{% if has_search_knowledge_tool %}
+- **search_knowledge(query_text, subject_path, top_n)**: Search existing business knowledge by semantic query.
+{% endif %}
+{% if has_get_knowledge_tool %}
 - **get_knowledge(paths)**: Get existing knowledge by paths. Each path is `[...subject_path, name]`
+{% endif %}
 - **write_file(path, content, file_type)**: Save files. Use `file_type="ext_knowledge"` for knowledge YAML, omit for SQL files. Always pass `path` as `{{ kind_subdir }}/<filename>` (relative to the knowledge base root).
 - **edit_file(filename, old_text, new_text)**: Apply targeted edits to an existing file (SQL or knowledge).
 - **read_file(filename)**: Read back file content (e.g., to pass SQL to `read_query` or `verify_sql`).
@@ -170,7 +175,13 @@ search_text: "GMV calculation amount aggregation time range"
 explanation: "When calculating GMV: (1) Use SUM(amount) to aggregate; (2) MUST filter by date field for time range; (3) Note: amount field may need type conversion."
 
 **Steps:**
-1. Check existing: If `get_knowledge` tool is available, call `get_knowledge(paths)` to find related knowledge
+{% if has_get_knowledge_tool %}
+1. Check existing: call `list_subject_tree()` and `get_knowledge(paths)` to find related knowledge when the subject path is known.
+{% elif has_search_knowledge_tool %}
+1. Check existing: call `search_knowledge(query_text, subject_path, top_n)` to find related knowledge.
+{% else %}
+1. Existing knowledge lookup is not available in this run; do not call unavailable knowledge retrieval tools.
+{% endif %}
 2. Decide action:
    - **New knowledge**: Create new entry with unique subject_path
    - **Update existing**: If found knowledge is incomplete or incorrect, use SAME subject_path to update it

--- a/tests/integration/agent/test_chat_agentic.py
+++ b/tests/integration/agent/test_chat_agentic.py
@@ -17,8 +17,8 @@ class TestChatAgentic:
 
         with patch("datus.cli.repl.PromptSession.prompt") as mock_prompt:
             mock_prompt.side_effect = [
-                f"/{question1}",
-                f"/{question2}",
+                question1,
+                question2,
                 EOFError,
             ]
             with (
@@ -45,7 +45,7 @@ class TestChatAgentic:
         question = "What is the average SAT reading score for schools in Fresno county?"
 
         with patch("datus.cli.repl.PromptSession.prompt") as mock_prompt:
-            mock_prompt.side_effect = [f"/{question}", EOFError]
+            mock_prompt.side_effect = [question, EOFError]
             with (
                 patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal,
                 patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,
@@ -72,7 +72,7 @@ class TestChatAgentic:
         question = "How many schools are there in Los Angeles county?"
 
         with patch("datus.cli.repl.PromptSession.prompt") as mock_prompt:
-            mock_prompt.side_effect = [f"/{question}", ".chat_info", EOFError]
+            mock_prompt.side_effect = [question, ".chat_info", EOFError]
             with (
                 patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal,
                 patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,
@@ -104,7 +104,7 @@ class TestChatAgentic:
         question = "List all schools in Fresno county"
 
         with patch("datus.cli.repl.PromptSession.prompt") as mock_prompt:
-            mock_prompt.side_effect = [f"/{question}", EOFError]
+            mock_prompt.side_effect = [question, EOFError]
             with (
                 patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal,
                 patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,

--- a/tests/integration/agent/test_kb_path_e2e.py
+++ b/tests/integration/agent/test_kb_path_e2e.py
@@ -98,7 +98,7 @@ class TestKnowledgeBaseHomeE2E:
         assert actions[-1].status == ActionStatus.SUCCESS, f"Run did not succeed: {actions[-1].output}"
 
         # --- Disk layout assertions ---
-        expected_dir = kb_home_tmp / "semantic_models"
+        expected_dir = kb_home_tmp / "semantic_models" / nightly_agent_config.current_datasource
         produced = list(expected_dir.glob("*.yml")) + list(expected_dir.glob("*.yaml"))
         assert produced, (
             f"No YAML produced under {expected_dir}. Tree contents: "

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -166,7 +166,7 @@ def test_tables_command(mock_args, capsys):
 @pytest.mark.nightly
 def test_chat_command(mock_args, capsys, gen_sql_input: List[Dict[str, Any]]):
     """
-    Tests the '/<chat>' command for multi-turn conversation and context memory.
+    Tests bare chat input for multi-turn conversation and context memory.
     """
     input_data = gen_sql_input[0]["input"]
     sql_task = input_data["sql_task"]
@@ -177,7 +177,7 @@ def test_chat_command(mock_args, capsys, gen_sql_input: List[Dict[str, Any]]):
 
     with patch("datus.cli.repl.PromptSession.prompt") as mock_prompt:
         mock_prompt.side_effect = [
-            f"/{sql_task['task']}",
+            sql_task["task"],
             "/chat_info",
             EOFError,
         ]
@@ -208,7 +208,7 @@ def test_chat_command(mock_args, capsys, gen_sql_input: List[Dict[str, Any]]):
 @pytest.mark.nightly
 def test_chat_command_with_ext_knowledge(mock_args):
     """
-    Tests the '/<chat>' command with ext_knowledge context.
+    Tests bare chat input with ext_knowledge context.
     Verifies that the query with 'consider all knowledge' triggers knowledge search
     and generates SQL correctly.
     """

--- a/tests/integration/cli/test_interactive_init.py
+++ b/tests/integration/cli/test_interactive_init.py
@@ -23,8 +23,7 @@ class TestInitKimiConnectivity:
         with tempfile.TemporaryDirectory() as tmpdir:
             init = InteractiveInit(user_home=tmpdir)
 
-            init.config["agent"]["target"] = "kimi"
-            init.config["agent"]["models"]["kimi"] = {
+            init._pending_probe = {
                 "type": "kimi",
                 "base_url": "https://api.moonshot.cn/v1",
                 "api_key": os.getenv("KIMI_API_KEY"),
@@ -47,8 +46,7 @@ class TestInitKimiConnectivity:
             init = InteractiveInit(user_home=tmpdir)
 
             # Deliberately omit temperature/top_p to trigger the 400 error
-            init.config["agent"]["target"] = "kimi"
-            init.config["agent"]["models"]["kimi"] = {
+            init._pending_probe = {
                 "type": "kimi",
                 "base_url": "https://api.moonshot.cn/v1",
                 "api_key": os.getenv("KIMI_API_KEY"),

--- a/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
@@ -562,6 +562,19 @@ class TestGenExtKnowledgeFilesystemRootPath:
 class TestGenExtKnowledgeTemplateContext:
     """has_gold_sql must flow into the rendered prompt to gate PHASE 2."""
 
+    @pytest.mark.acceptance
+    def test_prepare_template_context_exposes_registered_tool_flags(self, real_agent_config, mock_llm_create):
+        node = _create_node(real_agent_config)
+        user_input = ExtKnowledgeNodeInput(user_message="x", question="x")
+
+        ctx = node._prepare_template_context(user_input, gold_sql=None)
+
+        tool_names = [tool.name for tool in node.tools]
+        assert ctx["tool_names"] == tool_names
+        assert ctx["native_tools"] == ", ".join(tool_names)
+        assert ctx["has_search_knowledge_tool"] == ("search_knowledge" in tool_names)
+        assert ctx["has_get_knowledge_tool"] == ("get_knowledge" in tool_names)
+
     def test_prepare_template_context_has_gold_sql_true(self, real_agent_config, mock_llm_create):
         node = _create_node(real_agent_config)
         user_input = ExtKnowledgeNodeInput(user_message="x", question="x")

--- a/tests/unit_tests/agent/node/test_schema_linking.py
+++ b/tests/unit_tests/agent/node/test_schema_linking.py
@@ -59,10 +59,6 @@ def sqlite_connector(db_path):
     connector.close()
 
 
-def test_storage():
-    pass
-
-
 def test_store_and_search_schema(schema_lineage_tool, sqlite_connector):
     """Test storing and searching schema"""
     log.info("Creating test tables in SQLite")

--- a/tests/unit_tests/agent/node/test_schema_linking.py
+++ b/tests/unit_tests/agent/node/test_schema_linking.py
@@ -35,11 +35,11 @@ def vector_store_path():
 
 
 @pytest.fixture
-def agent_config():
+def agent_config(tmp_path):
     """Fixture to create a minimal AgentConfig for testing"""
     from tests.conftest import load_acceptance_config
 
-    config = load_acceptance_config(datasource="snowflake")
+    config = load_acceptance_config(datasource="snowflake", home=str(tmp_path / "datus_home"))
     return config
 
 

--- a/tests/unit_tests/agent/node/test_schema_linking.py
+++ b/tests/unit_tests/agent/node/test_schema_linking.py
@@ -3,7 +3,9 @@ import shutil
 import tempfile
 
 import pytest
+import yaml
 
+from datus.configuration.agent_config_loader import load_agent_config
 from datus.schemas.schema_linking_node_models import SchemaLinkingInput
 from datus.tools.db_tools.config import SQLiteConfig
 from datus.tools.db_tools.sqlite_connector import SQLiteConnector
@@ -37,10 +39,22 @@ def vector_store_path():
 @pytest.fixture
 def agent_config(tmp_path):
     """Fixture to create a minimal AgentConfig for testing"""
-    from tests.conftest import load_acceptance_config
+    from tests.conftest import TEST_CONF_DIR
 
-    config = load_acceptance_config(datasource="snowflake", home=str(tmp_path / "datus_home"))
-    return config
+    config_data = yaml.safe_load((TEST_CONF_DIR / "agent.yml").read_text(encoding="utf-8"))
+    config_data["agent"]["home"] = str(tmp_path / "datus_home")
+    config_data["agent"]["project_root"] = str(tmp_path / "workspace")
+
+    config_path = tmp_path / "agent.yml"
+    config_path.write_text(yaml.safe_dump(config_data, allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+    return load_agent_config(
+        config=str(config_path),
+        datasource="snowflake",
+        reload=True,
+        force=True,
+        yes=True,
+    )
 
 
 @pytest.fixture
@@ -126,12 +140,9 @@ def test_invalid_input(schema_lineage_tool):
     assert result["value_count"] == 0
 
 
-def test_schema_linking_no_exist():
+def test_schema_linking_no_exist(agent_config):
     """Test schema linking with non-existent database"""
-    from tests.conftest import load_acceptance_config
-
-    test_config = load_acceptance_config(datasource="snowflake")
-    tool = SchemaLineageTool(agent_config=test_config)
+    tool = SchemaLineageTool(agent_config=agent_config)
     res = tool.execute(
         SchemaLinkingInput(
             input_text="test query",


### PR DESCRIPTION
## Why

Nightly run https://github.com/Datus-ai/Datus-agent/actions/runs/25602839035 failed after the main merge. The failures were a mix of stale nightly test contracts, a prompt/tool mismatch, missing Playwright system dependencies, and a missing Docker Compose runtime on the self-hosted runner.

## Solution

- Align chat nightly tests with current bare-text chat routing instead of slash-prefixed natural language.
- Align Kimi interactive-init connectivity tests with the current `_pending_probe` contract.
- Assert semantic model files under `subject/semantic_models/<datasource>/`, matching the typed layout.
- Render external-knowledge retrieval instructions only when `search_knowledge` / `get_knowledge` tools are actually registered.
- Install Playwright browser system deps and ensure Docker Compose is available before compose-backed nightly suites run.
- Add an early Docker runtime preflight in `ci/run-nightly-tests.sh` for full nightly runs.

## Test Cases

- `bash -n ci/run-nightly-tests.sh`
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/run-nightly.yml')); print('workflow yaml ok')"`
- `uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --strict`
- `uv run pytest tests/unit_tests/cli/test_interactive_init.py::TestInit::test_llm_config_probe_success tests/unit_tests/cli/test_interactive_init.py::TestInit::test_llm_config_probe_without_pending_probe_fails -q`
- `uv run pytest tests/integration/cli/test_interactive_init.py --collect-only -q`
- `uv run pytest tests/integration/agent/test_chat_agentic.py tests/integration/cli/test_cli_commands.py::test_chat_command tests/integration/agent/test_kb_path_e2e.py::TestKnowledgeBaseHomeE2E::test_semantic_model_lands_under_typed_subdir tests/integration/agent/test_gen_ext_knowledge_agentic.py::TestGenExtKnowledgeAgentic::test_execute_stream_generates_ext_knowledge --collect-only -q`
- `NIGHTLY_GROUP_FILTER='__never__' NIGHTLY_LOG_FILE=/tmp/datus-nightly-noop.log ci/run-nightly-tests.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly CI now ensures Docker runtime is available and installs Playwright’s Chromium with OS dependencies.
* **Tests**
  * Nightly test orchestration adds preflight checks and skips compose-backed suites when not applicable.
  * Integration/CLI tests now use bare chat input; connectivity/init tests use probe-based config.
  * E2E expectations updated for semantic-model output paths; unit fixture updated and a placeholder test removed; added acceptance test for template tool flags.
* **Refactor**
  * Prompt/template logic now conditionally exposes external knowledge tools and related template variables.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/723)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->