### PR TITLE
[BugFix] Fix nightly knowledge base cache

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -49,7 +49,6 @@ jobs:
             {
               for file in \
                 build_scripts/build_test_data.sh \
-                tests/conf/agent.yml \
                 tests/data/SSB.db \
                 datus/cli/bootstrap_streams.py \
                 datus/main.py; do
@@ -243,7 +242,7 @@ jobs:
 
           if [ "${{ steps.kb-cache.outputs.cache-hit }}" = "true" ] \
             && [ -d "$KB_READY_DIR" ] \
-            && find "$KB_READY_DIR" -mindepth 1 -maxdepth 5 -print -quit | grep -q .; then
+            && find "$KB_READY_DIR" -mindepth 1 -maxdepth 5 -type f -size +0 -print -quit | grep -q .; then
             echo "Restored knowledge base cache from $KB_READY_DIR"
             echo "needs-build=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -41,6 +41,34 @@ jobs:
           find "$GITHUB_WORKSPACE" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
           echo "Disk usage: $(df -h /tmp | tail -1 | awk '{print $5, $4}')"
 
+      - name: Compute knowledge base cache key
+        id: kb-cache-key
+        run: |
+          set -euo pipefail
+          digest="$(
+            {
+              for file in \
+                build_scripts/build_test_data.sh \
+                tests/conf/agent.yml \
+                tests/data/SSB.db \
+                datus/cli/bootstrap_streams.py \
+                datus/main.py; do
+                if [ -f "$file" ]; then
+                  sha256sum "$file"
+                fi
+              done
+
+              for dir in datus/sample_data datus/storage; do
+                if [ -d "$dir" ]; then
+                  find "$dir" -type f -print0 | sort -z | while IFS= read -r -d '' file; do
+                    sha256sum "$file"
+                  done
+                fi
+              done
+            } | sha256sum | awk '{print $1}'
+          )"
+          echo "key=${RUNNER_OS}-kb-v3-datus_agent_nightly-${digest}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -131,9 +159,39 @@ jobs:
       - name: Isolate test data directory
         run: |
           DATUS_TEST_HOME="${GITHUB_WORKSPACE}/.datus_test_data"
+          DATUS_TEST_PROJECT_NAME="datus_agent_nightly"
           echo "DATUS_TEST_HOME=$DATUS_TEST_HOME" >> $GITHUB_ENV
-          sed -i "s|home: .datus_test_data|home: $DATUS_TEST_HOME|g" tests/conf/agent.yml
-          sed -i "s|project_root: .datus_test_data/workspace|project_root: $DATUS_TEST_HOME/workspace|g" tests/conf/agent.yml
+          echo "DATUS_TEST_PROJECT_NAME=$DATUS_TEST_PROJECT_NAME" >> $GITHUB_ENV
+          python3 - tests/conf/agent.yml "$DATUS_TEST_HOME" "$DATUS_TEST_HOME/workspace" "$DATUS_TEST_PROJECT_NAME" <<'PY'
+          import sys
+          from pathlib import Path
+
+          path = Path(sys.argv[1])
+          home = sys.argv[2]
+          project_root = sys.argv[3]
+          project_name = sys.argv[4]
+
+          updated = []
+          inserted_project_name = False
+          for line in path.read_text(encoding="utf-8").splitlines():
+              stripped = line.strip()
+              if line == "agent:":
+                  updated.append(line)
+                  updated.append(f"  project_name: {project_name}")
+                  inserted_project_name = True
+                  continue
+              if line.startswith("  project_name: ") and inserted_project_name:
+                  continue
+              if line.startswith("  home: ") and stripped.startswith("home:"):
+                  updated.append(f"  home: {home}")
+                  continue
+              if line.startswith("  project_root: ") and stripped.startswith("project_root:"):
+                  updated.append(f"  project_root: {project_root}")
+                  continue
+              updated.append(line)
+
+          path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+          PY
 
       - name: Load environment variables
         run: |
@@ -170,16 +228,34 @@ jobs:
         id: kb-cache
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ${{ github.workspace }}/.datus_test_data/data/datus_db_bird_school
-            ${{ github.workspace }}/.datus_test_data/data/datus_db_ssb_sqlite
-          key: ${{ runner.os }}-kb-${{ hashFiles('build_scripts/build_test_data.sh', 'sample_data/**', 'datus/storage/**/*.py') }}
-          restore-keys: |
-            ${{ runner.os }}-kb-
+          path: ${{ github.workspace }}/.datus_test_data/data
+          key: ${{ steps.kb-cache-key.outputs.key }}
+
+      - name: Validate knowledge base cache
+        id: kb-cache-state
+        run: |
+          set -euo pipefail
+          KB_DATA_DIR="${DATUS_TEST_HOME}/data"
+          KB_READY_DIR="$KB_DATA_DIR"
+          if [ -n "${DATUS_TEST_PROJECT_NAME:-}" ]; then
+            KB_READY_DIR="$KB_DATA_DIR/$DATUS_TEST_PROJECT_NAME/datus_db"
+          fi
+
+          if [ "${{ steps.kb-cache.outputs.cache-hit }}" = "true" ] \
+            && [ -d "$KB_READY_DIR" ] \
+            && find "$KB_READY_DIR" -mindepth 1 -maxdepth 5 -print -quit | grep -q .; then
+            echo "Restored knowledge base cache from $KB_READY_DIR"
+            echo "needs-build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Knowledge base cache is missing or empty; rebuilding test data"
+          rm -rf "$KB_DATA_DIR"
+          echo "needs-build=true" >> "$GITHUB_OUTPUT"
 
       - name: Build test data
         id: build-test-data
-        if: steps.kb-cache.outputs.cache-hit != 'true'
+        if: steps.kb-cache-state.outputs.needs-build == 'true'
         run: |
           echo "Building test data before running nightly tests..."
           chmod +x build_scripts/build_test_data.sh
@@ -187,13 +263,11 @@ jobs:
           echo "Test data build completed"
 
       - name: Save knowledge base cache
-        if: steps.build-test-data.outcome == 'success'
+        if: steps.kb-cache-state.outputs.needs-build == 'true' && steps.build-test-data.outcome == 'success'
         uses: actions/cache/save@v4
         with:
-          path: |
-            ${{ github.workspace }}/.datus_test_data/data/datus_db_bird_school
-            ${{ github.workspace }}/.datus_test_data/data/datus_db_ssb_sqlite
-          key: ${{ runner.os }}-kb-${{ hashFiles('build_scripts/build_test_data.sh', 'sample_data/**', 'datus/storage/**/*.py') }}
+          path: ${{ github.workspace }}/.datus_test_data/data
+          key: ${{ steps.kb-cache-key.outputs.key }}
 
       - name: Verify FEISHU_WEBHOOK_URL
         env:

--- a/build_scripts/build_test_data.sh
+++ b/build_scripts/build_test_data.sh
@@ -7,10 +7,10 @@ export DATUS_TEST_HOME
 validate_test_home() {
   local path="${DATUS_TEST_HOME%/}"
   local home="${HOME:-}"
-  local runner_temp="${RUNNER_TEMP:-}"
+  local github_workspace="${GITHUB_WORKSPACE:-}"
 
   case "$path" in
-    "" | "." | "/" | "~" | "$home" | "$PWD" | *"/.."* | *"/../"* | "../"* | *"/." | *"/./"*)
+    "" | "." | "/" | "~" | "$home" | "$PWD" | ".." | "../"* | *"/.." | *"/../"* | "./"* | *"/." | *"/./"*)
       echo "Refusing to remove unsafe DATUS_TEST_HOME: '$DATUS_TEST_HOME'" >&2
       exit 1
       ;;
@@ -24,13 +24,13 @@ validate_test_home() {
       ;;
   esac
 
-  if [ "$path" = "$home/.datus/tests" ] || [[ "$path" == */.datus_test_data ]]; then
+  if [ "$path" = "$home/.datus/tests" ] || [ "$path" = "$home/.datus_test_data" ]; then
     DATUS_TEST_HOME="$path"
     export DATUS_TEST_HOME
     return
   fi
 
-  if [ -n "$runner_temp" ] && [[ "$path" == "${runner_temp%/}"/* ]]; then
+  if [ -n "$github_workspace" ] && [ "$path" = "${github_workspace%/}/.datus_test_data" ]; then
     DATUS_TEST_HOME="$path"
     export DATUS_TEST_HOME
     return

--- a/build_scripts/build_test_data.sh
+++ b/build_scripts/build_test_data.sh
@@ -4,6 +4,42 @@ set -euo pipefail
 DATUS_TEST_HOME="${DATUS_TEST_HOME:-$HOME/.datus/tests}"
 export DATUS_TEST_HOME
 
+validate_test_home() {
+  local path="${DATUS_TEST_HOME%/}"
+  local home="${HOME:-}"
+  local runner_temp="${RUNNER_TEMP:-}"
+
+  case "$path" in
+    "" | "." | "/" | "~" | "$home" | "$PWD" | *"/.."* | *"/../"* | "../"* | *"/." | *"/./"*)
+      echo "Refusing to remove unsafe DATUS_TEST_HOME: '$DATUS_TEST_HOME'" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$path" in
+    /*) ;;
+    *)
+      echo "Refusing to remove non-absolute DATUS_TEST_HOME: '$DATUS_TEST_HOME'" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ "$path" = "$home/.datus/tests" ] || [[ "$path" == */.datus_test_data ]]; then
+    DATUS_TEST_HOME="$path"
+    export DATUS_TEST_HOME
+    return
+  fi
+
+  if [ -n "$runner_temp" ] && [[ "$path" == "${runner_temp%/}"/* ]]; then
+    DATUS_TEST_HOME="$path"
+    export DATUS_TEST_HOME
+    return
+  fi
+
+  echo "Refusing to remove DATUS_TEST_HOME outside expected test roots: '$DATUS_TEST_HOME'" >&2
+  exit 1
+}
+
 run_bootstrap_kb() {
   uv run python - "$@" <<'PY'
 from agents import set_tracing_disabled
@@ -17,6 +53,7 @@ PY
 }
 
 # Clean old data before creating a cacheable, deterministic fixture set.
+validate_test_home
 rm -rf "$DATUS_TEST_HOME"
 mkdir -p "$DATUS_TEST_HOME"
 
@@ -37,7 +74,7 @@ if [ -n "${DATUS_TEST_PROJECT_NAME:-}" ]; then
   CACHE_READY_DIR="$CACHE_READY_DIR/$DATUS_TEST_PROJECT_NAME/datus_db"
 fi
 
-if [ ! -d "$CACHE_READY_DIR" ] || ! find "$CACHE_READY_DIR" -mindepth 1 -maxdepth 5 -print -quit | grep -q .; then
+if [ ! -d "$CACHE_READY_DIR" ] || ! find "$CACHE_READY_DIR" -mindepth 1 -maxdepth 5 -type f -size +0 -print -quit | grep -q .; then
   echo "Expected test data under $CACHE_READY_DIR, but no cacheable data was produced" >&2
   exit 1
 fi

--- a/build_scripts/build_test_data.sh
+++ b/build_scripts/build_test_data.sh
@@ -1,25 +1,45 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
 DATUS_TEST_HOME="${DATUS_TEST_HOME:-$HOME/.datus/tests}"
-# clean old data
+export DATUS_TEST_HOME
+
+run_bootstrap_kb() {
+  uv run python - "$@" <<'PY'
+from agents import set_tracing_disabled
+
+set_tracing_disabled(True)
+
+from datus.main import main
+
+raise SystemExit(main())
+PY
+}
+
+# Clean old data before creating a cacheable, deterministic fixture set.
 rm -rf "$DATUS_TEST_HOME"
+mkdir -p "$DATUS_TEST_HOME"
 
-# Phase 1: Create datasource metadata in parallel (no LLM calls, fast)
-uv run python -m datus.main bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --kb_update_strategy overwrite --debug --yes &
-pid_bird=$!
-uv run python -m datus.main bootstrap-kb --config tests/conf/agent.yml --datasource ssb_sqlite --kb_update_strategy overwrite --debug --yes &
-pid_ssb=$!
-wait $pid_bird || exit 1
-wait $pid_ssb || exit 1
+# Phase 1: create datasource metadata. Keep this serial because the storage
+# backend writes shared tables and indexes under the same test home.
+run_bootstrap_kb bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --kb_update_strategy overwrite --debug --yes
+run_bootstrap_kb bootstrap-kb --config tests/conf/agent.yml --datasource ssb_sqlite --kb_update_strategy overwrite --debug --yes
 
-# Phase 2: Build reference_sql and metrics in parallel (different tables, safe)
-uv run python -m datus.main bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --components reference_sql --sql_dir datus/sample_data/california_schools/reference_sql --subject_tree "california_schools/Continuation/Free_Rate,california_schools/Charter/Education_Location,california_schools/Charter-Fund/Phone,california_schools/SAT_Score/Average,california_schools/SAT_Score/Excellence_Rate,california_schools/FRPM_Enrollment/Rate,california_schools/Enrollment/Total" --kb_update_strategy overwrite --yes &
-pid_ref=$!
-uv run python -m datus.main bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --kb_update_strategy overwrite --components metrics --success_story datus/sample_data/california_schools/success_story.csv --subject_tree "california_schools/Students_K-12/Free_Rate,california_schools/Education/Location" --yes &
-pid_met=$!
-wait $pid_ref || exit 1
-wait $pid_met || exit 1
+# Phase 2: build bird_school contextual stores. These target the same project
+# storage and subject tree, so serial execution is more important than speed.
+run_bootstrap_kb bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --components reference_sql --sql_dir datus/sample_data/california_schools/reference_sql --subject_tree "california_schools/Continuation/Free_Rate,california_schools/Charter/Education_Location,california_schools/Charter-Fund/Phone,california_schools/SAT_Score/Average,california_schools/SAT_Score/Excellence_Rate,california_schools/FRPM_Enrollment/Rate,california_schools/Enrollment/Total" --kb_update_strategy overwrite --yes
+run_bootstrap_kb bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --kb_update_strategy overwrite --components metrics --success_story datus/sample_data/california_schools/success_story.csv --subject_tree "california_schools/Students_K-12/Free_Rate,california_schools/Education/Location" --yes
+run_bootstrap_kb bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --kb_update_strategy overwrite --components ext_knowledge --success_story datus/sample_data/california_schools/success_story.csv --subject_tree "california_schools/Students_K-12/Free_Rate,california_schools/Education/Location" --yes
+run_bootstrap_kb bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --components reference_template --template_dir datus/sample_data/california_schools/reference_template --subject_tree "california_schools/Free_Rate/Query,california_schools/Charter/Zip,california_schools/SAT_Score/Phone,california_schools/Enrollment/Summary,california_schools/Stats/School_Count" --kb_update_strategy overwrite --yes
 
-# Phase 3: Build ext_knowledge, then reference_template (sequential — same datasource)
-uv run python -m datus.main bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --kb_update_strategy overwrite --components ext_knowledge --success_story datus/sample_data/california_schools/success_story.csv --subject_tree "california_schools/Students_K-12/Free_Rate,california_schools/Education/Location" --yes
-uv run python -m datus.main bootstrap-kb --config tests/conf/agent.yml --datasource bird_school --components reference_template --template_dir datus/sample_data/california_schools/reference_template --subject_tree "california_schools/Free_Rate/Query,california_schools/Charter/Zip,california_schools/SAT_Score/Phone,california_schools/Enrollment/Summary,california_schools/Stats/School_Count" --kb_update_strategy overwrite --yes
+CACHE_READY_DIR="$DATUS_TEST_HOME/data"
+if [ -n "${DATUS_TEST_PROJECT_NAME:-}" ]; then
+  CACHE_READY_DIR="$CACHE_READY_DIR/$DATUS_TEST_PROJECT_NAME/datus_db"
+fi
+
+if [ ! -d "$CACHE_READY_DIR" ] || ! find "$CACHE_READY_DIR" -mindepth 1 -maxdepth 5 -print -quit | grep -q .; then
+  echo "Expected test data under $CACHE_READY_DIR, but no cacheable data was produced" >&2
+  exit 1
+fi
+
+echo "Test data created under $CACHE_READY_DIR"


### PR DESCRIPTION
## Why

Nightly failed before running tests because the knowledge-base cache was never saved. The workflow cached stale child paths that no longer exist, so every run rebuilt test data and could hit bootstrap/tracing finalization instability.

## Solution

- Compute a stable KB cache key before rewriting `tests/conf/agent.yml`.
- Pin the nightly test project name to `datus_agent_nightly` so storage shards are stable across runners.
- Cache `${{ github.workspace }}/.datus_test_data/data` and validate the restored `data/datus_agent_nightly/datus_db` tree before skipping the build.
- Remove broad restore keys to avoid reusing stale KB layouts.
- Make cold-cache bootstrap serial and disable Agents SDK tracing before entering `datus.main`.

## Test Cases

- `bash -n build_scripts/build_test_data.sh`
- `git diff --check`
- Parsed `.github/workflows/run-nightly.yml` with Python/YAML and asserted cache wiring.
- Simulated the `tests/conf/agent.yml` isolation rewrite locally.

Full nightly was not run locally because the cold-cache build invokes real bootstrap/LLM paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly pipeline now uses a deterministic cache key and improved restore/save logic for more consistent caching.
  * Cache restore includes validation of test data; invalid or incomplete caches trigger rebuilds.
  * Test-data setup switched to a safer, programmatic configuration update and fully sequential bootstrap to ensure reliable artifacts.
  * Safer test-path validation prevents accidental deletions and enforces allowed test directories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/724)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->