### PR TITLE
[Feature] Add chat-stream pre/post hooks for embedding hosts

### DIFF
--- a/datus/api/hooks/__init__.py
+++ b/datus/api/hooks/__init__.py
@@ -1,0 +1,28 @@
+"""Public extension points for hosts that embed datus-agent.
+
+Hosts (e.g. Datus-backend SaaS) register hook implementations during
+lifespan startup. The agent's HTTP routes call into these hooks at well
+defined points; if no hook is registered, behavior is unchanged.
+"""
+
+from datus.api.hooks.chat_hooks import (
+    ChatHooks,
+    ChatPostUsageContext,
+    ChatPreCheckOutcome,
+    PostUsageFn,
+    PreCheckFn,
+    get_chat_hooks,
+    make_chat_hooks,
+    set_chat_hooks,
+)
+
+__all__ = [
+    "ChatHooks",
+    "ChatPostUsageContext",
+    "ChatPreCheckOutcome",
+    "PostUsageFn",
+    "PreCheckFn",
+    "get_chat_hooks",
+    "make_chat_hooks",
+    "set_chat_hooks",
+]

--- a/datus/api/hooks/chat_hooks.py
+++ b/datus/api/hooks/chat_hooks.py
@@ -1,0 +1,161 @@
+"""Pre / post hooks around the streaming chat endpoint.
+
+The chat route invokes ``ChatHooks.pre_chat`` *before* spinning up the
+agentic loop, and ``ChatHooks.post_chat`` after the loop completes (or
+errors). The hook is optional — if no host has called ``set_chat_hooks``,
+the route runs in passthrough mode.
+
+Design notes:
+
+* The pre-hook returns a structured outcome (allow / deny + user-facing
+  message) instead of raising, so the route can convert a denial into a
+  well-formed SSE error payload that frontends already render.
+
+* The post-hook is **fire-and-forget**: the route schedules it as a
+  background task and never awaits it. Hosts must catch their own
+  exceptions; an unhandled error is logged but never propagates back to
+  the client. This keeps token-usage reporting off the response path.
+
+* Both hooks receive the original ``fastapi.Request`` so hosts can lift
+  headers like ``x-trace-id`` (or read the OTel trace id) without us
+  having to thread bespoke context through the agent layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Optional, Protocol, runtime_checkable
+
+from fastapi import Request
+
+from datus.api.models.cli_models import StreamChatInput
+
+
+@dataclass
+class ChatPreCheckOutcome:
+    """Result returned by :meth:`ChatHooks.pre_chat`."""
+
+    allow: bool
+    """When ``False`` the route emits an SSE ``error`` event and stops."""
+
+    error: Optional[str] = None
+    """User-facing message used as ``SSEErrorData.error`` on denial."""
+
+    error_type: Optional[str] = None
+    """Machine-readable code used as ``SSEErrorData.error_type`` on denial."""
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Free-form data the host may carry over to the post hook (logging etc.)."""
+
+
+@dataclass
+class ChatPostUsageContext:
+    """Payload passed to :meth:`ChatHooks.post_chat` after the stream ends.
+
+    ``usage`` mirrors the fields of ``SSEEndData`` (input_tokens,
+    output_tokens, total_tokens, cached_tokens, requests, ...). When the
+    agent fails before reaching the end event this dict is empty.
+    """
+
+    user_id: Optional[str]
+    session_id: Optional[str]
+    model: Optional[str]
+    usage: Dict[str, Any]
+    error: Optional[str] = None
+    pre_check_extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class ChatHooks(Protocol):
+    """Extension contract for chat-stream embedding hosts."""
+
+    async def pre_chat(
+        self,
+        http_request: Request,
+        stream_request: StreamChatInput,
+        user_id: Optional[str],
+    ) -> ChatPreCheckOutcome:
+        """Approve or veto a streaming chat request.
+
+        Implementations MUST be defensive: catch their own exceptions and
+        translate them into a denial outcome (or re-raise to surface a
+        generic server-error SSE event).
+        """
+        ...
+
+    async def post_chat(
+        self,
+        http_request: Request,
+        stream_request: StreamChatInput,
+        ctx: ChatPostUsageContext,
+    ) -> None:
+        """Report usage / billing after the agentic loop finishes.
+
+        Called as a fire-and-forget background task. Implementations must
+        handle their own retries and logging — exceptions raised here are
+        only logged, never surfaced to the client.
+        """
+        ...
+
+
+_chat_hooks: Optional[ChatHooks] = None
+
+
+def set_chat_hooks(hooks: Optional[ChatHooks]) -> None:
+    """Register (or clear) the active chat hooks.
+
+    Typically called once during application lifespan startup. Passing
+    ``None`` removes any previously registered hooks.
+    """
+    global _chat_hooks
+    _chat_hooks = hooks
+
+
+def get_chat_hooks() -> Optional[ChatHooks]:
+    """Return the active chat hooks, or ``None`` when unregistered."""
+    return _chat_hooks
+
+
+# Convenience factory for hosts that prefer plain callables over a class.
+PreCheckFn = Callable[[Request, StreamChatInput, Optional[str]], Awaitable[ChatPreCheckOutcome]]
+PostUsageFn = Callable[[Request, StreamChatInput, ChatPostUsageContext], Awaitable[None]]
+
+
+def make_chat_hooks(
+    *,
+    pre_chat: Optional[PreCheckFn] = None,
+    post_chat: Optional[PostUsageFn] = None,
+) -> ChatHooks:
+    """Build a :class:`ChatHooks` from optional callables.
+
+    Missing callbacks fall back to permissive defaults: pre allows by
+    default, post is a no-op.
+    """
+
+    async def _default_pre(_req: Request, _input: StreamChatInput, _uid: Optional[str]) -> ChatPreCheckOutcome:
+        return ChatPreCheckOutcome(allow=True)
+
+    async def _default_post(_req: Request, _input: StreamChatInput, _ctx: ChatPostUsageContext) -> None:
+        return None
+
+    pre = pre_chat or _default_pre
+    post = post_chat or _default_post
+
+    class _LambdaHooks:
+        async def pre_chat(
+            self,
+            http_request: Request,
+            stream_request: StreamChatInput,
+            user_id: Optional[str],
+        ) -> ChatPreCheckOutcome:
+            return await pre(http_request, stream_request, user_id)
+
+        async def post_chat(
+            self,
+            http_request: Request,
+            stream_request: StreamChatInput,
+            ctx: ChatPostUsageContext,
+        ) -> None:
+            await post(http_request, stream_request, ctx)
+
+    return _LambdaHooks()

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -10,13 +10,20 @@ DatusService.task_manager) to run the agentic loop in a background
 asyncio.Task so that client disconnects do not cancel the computation.
 """
 
-from typing import Annotated, Optional
+import asyncio
+from typing import Annotated, AsyncGenerator, Optional
 
-from fastapi import APIRouter, HTTPException, Path, Query
+from fastapi import APIRouter, HTTPException, Path, Query, Request
 from fastapi.responses import StreamingResponse
 
 from datus.api.constants import BUILTIN_SUBAGENTS
 from datus.api.deps import AppContextDep, ServiceDep
+from datus.api.hooks import (
+    ChatHooks,
+    ChatPostUsageContext,
+    ChatPreCheckOutcome,
+    get_chat_hooks,
+)
 from datus.api.models.base_models import Result
 from datus.api.models.chat_models import (
     ResumeChatInput,
@@ -30,10 +37,16 @@ from datus.api.models.cli_models import (
     CompactSessionData,
     CompactSessionInput,
     FeedbackChatInput,
+    SSEErrorData,
+    SSEEvent,
     StreamChatInput,
     UserInteractionInput,
 )
 from datus.utils.feedback_prompt import build_reaction_feedback_prompt
+from datus.utils.loggings import get_logger
+from datus.utils.time_utils import now_utc_iso
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/v1/chat", tags=["chat"])
 
@@ -74,6 +87,7 @@ async def stream_chat(
     request: StreamChatInput,
     svc: ServiceDep,
     ctx: AppContextDep,
+    http_request: Request,
 ):
     sub_agent_id = request.subagent_id
     if sub_agent_id and not _is_valid_subagent_id(svc, sub_agent_id):
@@ -82,9 +96,27 @@ async def stream_chat(
             detail=f"Subagent '{sub_agent_id}' not found",
         )
 
+    hooks = get_chat_hooks()
+    pre_outcome = await _run_pre_chat_hook(hooks, http_request, request, ctx.user_id)
+    if pre_outcome and not pre_outcome.allow:
+        return StreamingResponse(
+            _emit_pre_check_denial(request, pre_outcome),
+            media_type="text/event-stream",
+            headers=_sse_headers(),
+        )
+
+    pre_extra = pre_outcome.extra if pre_outcome else {}
+
     async def generate_sse():
-        async for event in svc.chat.stream_chat(request, sub_agent_id=sub_agent_id, user_id=ctx.user_id):
-            yield f"id: {event.id}\nevent: {event.event}\ndata: {event.data.model_dump_json()}\n\n"
+        async for chunk in _stream_with_post_hook(
+            svc.chat.stream_chat(request, sub_agent_id=sub_agent_id, user_id=ctx.user_id),
+            http_request=http_request,
+            request=request,
+            user_id=ctx.user_id,
+            hooks=hooks,
+            pre_extra=pre_extra,
+        ):
+            yield chunk
 
     return StreamingResponse(generate_sse(), media_type="text/event-stream", headers=_sse_headers())
 
@@ -331,3 +363,120 @@ def _sse_headers() -> dict:
         "Access-Control-Allow-Origin": "*",
         "Content-Type": "text/event-stream; charset=utf-8",
     }
+
+
+# --------------------------------------------------------------------
+# Hook integration helpers
+# --------------------------------------------------------------------
+
+
+async def _run_pre_chat_hook(
+    hooks: Optional[ChatHooks],
+    http_request: Request,
+    request: StreamChatInput,
+    user_id: Optional[str],
+) -> Optional[ChatPreCheckOutcome]:
+    """Invoke the pre-chat hook and translate exceptions into a denial.
+
+    A hook that raises is treated as a server-error denial; we never
+    fail-open here, because the host registered the hook precisely to
+    gate access (e.g. credit balance).
+    """
+    if hooks is None:
+        return None
+    try:
+        outcome = await hooks.pre_chat(http_request, request, user_id)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.error("pre_chat hook failed: %s", exc, exc_info=True)
+        return ChatPreCheckOutcome(
+            allow=False,
+            error="Server error, please try again later.",
+            error_type="PRE_CHAT_HOOK_ERROR",
+        )
+    if outcome is None:
+        return ChatPreCheckOutcome(allow=True)
+    return outcome
+
+
+async def _emit_pre_check_denial(
+    request: StreamChatInput,
+    outcome: ChatPreCheckOutcome,
+) -> AsyncGenerator[str, None]:
+    """Emit a single SSE error event reflecting a pre-check denial."""
+    error_payload = SSEErrorData(
+        error=outcome.error or "Request denied",
+        error_type=outcome.error_type or "PRE_CHAT_DENIED",
+        session_id=request.session_id,
+    )
+    event = SSEEvent(id=1, event="error", data=error_payload, timestamp=now_utc_iso())
+    yield f"id: {event.id}\nevent: {event.event}\ndata: {event.data.model_dump_json()}\n\n"
+
+
+async def _stream_with_post_hook(
+    upstream: AsyncGenerator[SSEEvent, None],
+    *,
+    http_request: Request,
+    request: StreamChatInput,
+    user_id: Optional[str],
+    hooks: Optional[ChatHooks],
+    pre_extra: dict,
+) -> AsyncGenerator[str, None]:
+    """Forward SSE events while capturing usage for the post-chat hook.
+
+    The post hook is dispatched as a background task in ``finally`` so the
+    response stream is never blocked waiting for billing to acknowledge.
+    """
+    last_end_event: Optional[SSEEvent] = None
+    captured_error: Optional[BaseException] = None
+
+    try:
+        async for event in upstream:
+            if event.event == "end":
+                last_end_event = event
+            yield f"id: {event.id}\nevent: {event.event}\ndata: {event.data.model_dump_json()}\n\n"
+    except BaseException as exc:
+        captured_error = exc
+        raise
+    finally:
+        if hooks is not None:
+            usage_dict: dict = {}
+            session_id_value: Optional[str] = request.session_id
+            if last_end_event is not None:
+                # SSEEndData fields cover requests / *_tokens / duration.
+                usage_dict = last_end_event.data.model_dump()
+                session_id_value = usage_dict.get("session_id") or session_id_value
+
+            ctx = ChatPostUsageContext(
+                user_id=user_id,
+                session_id=session_id_value,
+                model=request.model,
+                usage=usage_dict,
+                error=str(captured_error) if captured_error else None,
+                pre_check_extra=dict(pre_extra),
+            )
+
+            try:
+                asyncio.create_task(
+                    _safe_post_chat(hooks, http_request, request, ctx),
+                    name=f"chat-post-hook:{session_id_value or '-'}",
+                )
+            except Exception:  # pragma: no cover — defensive
+                logger.error("Failed to schedule post_chat hook", exc_info=True)
+
+
+async def _safe_post_chat(
+    hooks: ChatHooks,
+    http_request: Request,
+    request: StreamChatInput,
+    ctx: ChatPostUsageContext,
+) -> None:
+    """Run the post-chat hook and swallow exceptions.
+
+    The hook is owned by the host and is responsible for its own retry
+    policy; we only ensure that a misbehaving hook never crashes the
+    background task in a way that propagates uncaught.
+    """
+    try:
+        await hooks.post_chat(http_request, request, ctx)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.error("post_chat hook raised: %s", exc, exc_info=True)

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -603,8 +603,7 @@ class AgentConfig:
         # are picked up on the next service-cache miss.
         model_extras_raw = kwargs.get("model_extras") or {}
         self.model_extras = {
-            str(name): dict(extras) if isinstance(extras, dict) else {}
-            for name, extras in model_extras_raw.items()
+            str(name): dict(extras) if isinstance(extras, dict) else {} for name, extras in model_extras_raw.items()
         }
         # Provider-level credentials (new schema). Empty when the user has not
         # migrated to the ``agent.providers`` section; legacy ``agent.models``

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -567,6 +567,10 @@ class AgentConfig:
     services: ServicesConfig
     scheduler_services: Dict[str, Dict[str, Any]]
     semantic_layer_configs: Dict[str, Dict[str, Any]]
+    # Free-form sidecar metadata for ``agent.models`` entries, keyed by
+    # the same name used in ``models``. Lets hosts attach extra context
+    # to a model without extending the strongly-typed ``ModelConfig``.
+    model_extras: Dict[str, Dict[str, Any]]
 
     def __init__(self, nodes: Dict[str, NodeConfig], **kwargs):
         """
@@ -594,6 +598,14 @@ class AgentConfig:
         models_raw = kwargs.get("models", {}) or {}
         self.target = kwargs.get("target", "") or ""
         self.models = {name: load_model_config(cfg) for name, cfg in models_raw.items()}
+        # Normalize to plain ``dict`` so ``dataclasses.asdict`` serializes
+        # cleanly into the AgentConfig fingerprint — host-side mutations
+        # are picked up on the next service-cache miss.
+        model_extras_raw = kwargs.get("model_extras") or {}
+        self.model_extras = {
+            str(name): dict(extras) if isinstance(extras, dict) else {}
+            for name, extras in model_extras_raw.items()
+        }
         # Provider-level credentials (new schema). Empty when the user has not
         # migrated to the ``agent.providers`` section; legacy ``agent.models``
         # still works via :meth:`active_model` fallback.
@@ -1520,6 +1532,33 @@ class AgentConfig:
             code=ErrorCode.COMMON_UNSUPPORTED,
             message=f"Datasource '{db_name}' not found. Available: {list(datasources.keys())}",
         )
+
+    def get_model_extra(self, model: Optional[str]) -> Dict[str, Any]:
+        """Look up ``model_extras`` for the request's ``model`` string.
+
+        Accepts ``"custom/<name>"``, bare ``"<name>"``, or empty/``None``
+        (which falls back to ``self.target``). Non-custom providers
+        return an empty dict — only ``custom`` models can carry extras.
+        Always returns a dict so callers can ``.get()`` without guarding.
+        """
+        if not self.model_extras:
+            return {}
+
+        name: Optional[str] = None
+        if model:
+            if "/" in model:
+                provider, _, key = model.partition("/")
+                if provider != "custom":
+                    return {}
+                name = key
+            else:
+                name = model
+        if not name:
+            name = self.target or None
+        if not name:
+            return {}
+        extras = self.model_extras.get(name)
+        return dict(extras) if isinstance(extras, dict) else {}
 
     def active_model(self) -> ModelConfig:
         """Return the currently active :class:`ModelConfig`.

--- a/tests/unit_tests/api/hooks/test_chat_hooks.py
+++ b/tests/unit_tests/api/hooks/test_chat_hooks.py
@@ -1,0 +1,197 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for ``datus.api.hooks.chat_hooks`` registry + helpers and the
+hook integration in ``datus.api.routes.chat_routes.stream_chat``."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from datus.api.hooks import (
+    ChatHooks,
+    ChatPostUsageContext,
+    ChatPreCheckOutcome,
+    get_chat_hooks,
+    make_chat_hooks,
+    set_chat_hooks,
+)
+from datus.api.models.cli_models import StreamChatInput
+from datus.api.routes import chat_routes
+
+
+@pytest.fixture(autouse=True)
+def _clear_hooks_after_test():
+    yield
+    set_chat_hooks(None)
+
+
+def _mock_svc_with_nodes(nodes=None):
+    svc = MagicMock()
+    svc.agent_config.agentic_nodes = nodes or {}
+    return svc
+
+
+class TestRegistry:
+    def test_default_is_none(self):
+        assert get_chat_hooks() is None
+
+    def test_set_and_get_hook(self):
+        hooks = make_chat_hooks()
+        set_chat_hooks(hooks)
+        assert get_chat_hooks() is hooks
+
+    def test_clear_hooks(self):
+        set_chat_hooks(make_chat_hooks())
+        set_chat_hooks(None)
+        assert get_chat_hooks() is None
+
+    def test_make_chat_hooks_default_pre_allows(self):
+        hooks = make_chat_hooks()
+
+        async def _run():
+            return await hooks.pre_chat(MagicMock(), StreamChatInput(message="hi"), "u1")
+
+        outcome = asyncio.run(_run())
+        assert outcome.allow is True
+
+    def test_make_chat_hooks_default_post_is_noop(self):
+        hooks = make_chat_hooks()
+
+        async def _run():
+            await hooks.post_chat(
+                MagicMock(),
+                StreamChatInput(message="hi"),
+                ChatPostUsageContext(user_id="u1", session_id="s1", model=None, usage={}),
+            )
+
+        # Just confirm it does not raise.
+        asyncio.run(_run())
+
+
+class TestStreamChatPreHookDenial:
+    """When pre_chat denies, stream_chat returns a single SSE error event."""
+
+    @pytest.mark.asyncio
+    async def test_denial_short_circuits_chat_service(self):
+        svc = _mock_svc_with_nodes()
+        # If we ever reach the upstream stream this side-effects; the denial
+        # path must not call into ChatService at all.
+        svc.chat.stream_chat = MagicMock(side_effect=AssertionError("upstream invoked"))
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="hi")
+
+        async def _pre(_req, _input, _uid):
+            return ChatPreCheckOutcome(
+                allow=False,
+                error="Datus credits exhausted; switch model.",
+                error_type="DATUS_CREDITS_EXHAUSTED",
+            )
+
+        set_chat_hooks(make_chat_hooks(pre_chat=_pre))
+
+        response = await chat_routes.stream_chat(request, svc, ctx, MagicMock())
+
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        body = chunks[0]
+        assert "event: error" in body
+        # Extract the JSON payload to assert structured fields.
+        data_line = next(line for line in body.splitlines() if line.startswith("data: "))
+        payload = json.loads(data_line[len("data: ") :])
+        assert payload["error"] == "Datus credits exhausted; switch model."
+        assert payload["error_type"] == "DATUS_CREDITS_EXHAUSTED"
+
+    @pytest.mark.asyncio
+    async def test_pre_hook_exception_treated_as_server_error(self):
+        svc = _mock_svc_with_nodes()
+        svc.chat.stream_chat = MagicMock(side_effect=AssertionError("upstream invoked"))
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="hi")
+
+        async def _pre(_req, _input, _uid):
+            raise RuntimeError("saas unreachable")
+
+        set_chat_hooks(make_chat_hooks(pre_chat=_pre))
+
+        response = await chat_routes.stream_chat(request, svc, ctx, MagicMock())
+
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        data_line = next(line for line in chunks[0].splitlines() if line.startswith("data: "))
+        payload = json.loads(data_line[len("data: ") :])
+        assert payload["error_type"] == "PRE_CHAT_HOOK_ERROR"
+        assert "Server error" in payload["error"]
+
+
+class TestStreamChatPostHookSchedule:
+    """When pre_chat allows, the upstream stream is forwarded and post_chat is scheduled."""
+
+    @pytest.mark.asyncio
+    async def test_post_hook_scheduled_after_stream(self):
+        # Build a fake upstream that yields exactly one "end" event.
+        from datus.api.models.cli_models import SSEEndData, SSEEvent
+
+        end_event = SSEEvent(
+            id=1,
+            event="end",
+            data=SSEEndData(
+                session_id="sess-1",
+                llm_session_id=None,
+                total_events=1,
+                action_count=0,
+                duration=0.1,
+                input_tokens=10,
+                output_tokens=20,
+                total_tokens=30,
+                cached_tokens=0,
+                requests=1,
+            ),
+            timestamp="2026-01-01T00:00:00Z",
+        )
+
+        async def _upstream(*_args, **_kwargs):
+            yield end_event
+
+        svc = _mock_svc_with_nodes()
+        svc.chat.stream_chat = _upstream
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="hi")
+
+        post_seen: list[ChatPostUsageContext] = []
+        post_done = asyncio.Event()
+
+        async def _pre(_req, _input, _uid):
+            return ChatPreCheckOutcome(allow=True, extra={"trace_id": "abc"})
+
+        async def _post(_req, _input, post_ctx: ChatPostUsageContext):
+            post_seen.append(post_ctx)
+            post_done.set()
+
+        set_chat_hooks(make_chat_hooks(pre_chat=_pre, post_chat=_post))
+
+        response = await chat_routes.stream_chat(request, svc, ctx, MagicMock())
+
+        body_chunks = []
+        async for chunk in response.body_iterator:
+            body_chunks.append(chunk)
+
+        # Wait for the fire-and-forget post hook to run.
+        await asyncio.wait_for(post_done.wait(), timeout=1.0)
+
+        assert len(body_chunks) == 1
+        assert "event: end" in body_chunks[0]
+        assert len(post_seen) == 1
+        ctx_seen = post_seen[0]
+        assert ctx_seen.user_id == "u1"
+        assert ctx_seen.usage.get("total_tokens") == 30
+        assert ctx_seen.pre_check_extra == {"trace_id": "abc"}
+        assert ctx_seen.error is None

--- a/tests/unit_tests/api/hooks/test_chat_hooks.py
+++ b/tests/unit_tests/api/hooks/test_chat_hooks.py
@@ -6,12 +6,11 @@ hook integration in ``datus.api.routes.chat_routes.stream_chat``."""
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from datus.api.hooks import (
-    ChatHooks,
     ChatPostUsageContext,
     ChatPreCheckOutcome,
     get_chat_hooks,
@@ -58,17 +57,28 @@ class TestRegistry:
         assert outcome.allow is True
 
     def test_make_chat_hooks_default_post_is_noop(self):
+        """The default post hook returns ``None`` and never touches its inputs.
+
+        Sentinel asserts that the no-op default doesn't accidentally read from
+        or mutate the supplied request / payload — anything else here would
+        be a regression in ``make_chat_hooks``'s default branch.
+        """
         hooks = make_chat_hooks()
+        sentinel: list[str] = []
+        request = MagicMock()
+        # Mark the request as "untouched" — if the default branch ever
+        # decides to introspect headers / call methods, the assertion below
+        # against ``mock_calls`` would catch it.
+        ctx = ChatPostUsageContext(user_id="u1", session_id="s1", model=None, usage={})
 
         async def _run():
-            await hooks.post_chat(
-                MagicMock(),
-                StreamChatInput(message="hi"),
-                ChatPostUsageContext(user_id="u1", session_id="s1", model=None, usage={}),
-            )
+            return await hooks.post_chat(request, StreamChatInput(message="hi"), ctx)
 
-        # Just confirm it does not raise.
-        asyncio.run(_run())
+        result = asyncio.run(_run())
+
+        assert result is None
+        assert sentinel == []
+        assert request.mock_calls == []
 
 
 class TestStreamChatPreHookDenial:

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -176,7 +176,7 @@ class TestStreamChat404Gate:
         request = StreamChatInput(message="hi", subagent_id="nonexistent_xyz")
 
         with pytest.raises(HTTPException) as exc_info:
-            await stream_chat(request, svc, ctx)
+            await stream_chat(request, svc, ctx, MagicMock())
 
         assert exc_info.value.status_code == 404
         assert "nonexistent_xyz" in exc_info.value.detail
@@ -190,7 +190,7 @@ class TestStreamChat404Gate:
         request = StreamChatInput(message="hi", subagent_id=None)
 
         # Should not raise — returns a StreamingResponse.
-        response = await stream_chat(request, svc, ctx)
+        response = await stream_chat(request, svc, ctx, MagicMock())
         assert response is not None
 
     @pytest.mark.asyncio
@@ -200,5 +200,5 @@ class TestStreamChat404Gate:
         ctx = MagicMock(user_id="u1")
         request = StreamChatInput(message="hi", subagent_id="gen_sql")
 
-        response = await stream_chat(request, svc, ctx)
+        response = await stream_chat(request, svc, ctx, MagicMock())
         assert response is not None

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 
 from datus.api.models.cli_models import StreamChatInput, UserInteractionInput
 from datus.api.routes.chat_routes import (
@@ -189,9 +190,11 @@ class TestStreamChat404Gate:
         ctx = MagicMock(user_id="u1")
         request = StreamChatInput(message="hi", subagent_id=None)
 
-        # Should not raise — returns a StreamingResponse.
         response = await stream_chat(request, svc, ctx, MagicMock())
-        assert response is not None
+
+        assert isinstance(response, StreamingResponse)
+        assert response.status_code == 200
+        assert response.media_type == "text/event-stream"
 
     @pytest.mark.asyncio
     async def test_valid_builtin_passes_gate(self):
@@ -201,4 +204,7 @@ class TestStreamChat404Gate:
         request = StreamChatInput(message="hi", subagent_id="gen_sql")
 
         response = await stream_chat(request, svc, ctx, MagicMock())
-        assert response is not None
+
+        assert isinstance(response, StreamingResponse)
+        assert response.status_code == 200
+        assert response.media_type == "text/event-stream"

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1756,3 +1756,71 @@ class TestValidationConfigFromDict:
     def test_non_numeric_retries_falls_back_to_default(self):
         cfg = ValidationConfig.from_dict({"max_retries": "oops"})
         assert cfg.max_retries == 3
+
+
+class TestAgentConfigModelExtras:
+    """``AgentConfig.model_extras`` + ``get_model_extra`` resolution."""
+
+    def _make(self, tmp_path, *, model_extras=None, target="primary"):
+        return AgentConfig(
+            nodes={"chat": NodeConfig(model="primary", input=None)},
+            home=str(tmp_path / "h"),
+            target=target,
+            models={
+                "primary": {"type": "openai", "api_key": "k", "model": "m", "base_url": "http://x"},
+                "secondary": {"type": "openai", "api_key": "k2", "model": "m2", "base_url": "http://y"},
+            },
+            model_extras=model_extras,
+            services={"datasources": {}},
+            skip_init_dirs=True,
+        )
+
+    def test_default_extras_is_empty_dict(self, tmp_path):
+        cfg = self._make(tmp_path)
+        assert cfg.model_extras == {}
+
+    def test_extras_normalized_to_plain_dict(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            model_extras={"primary": {"foo": "bar", "n": 1}},
+        )
+        assert cfg.model_extras == {"primary": {"foo": "bar", "n": 1}}
+
+    def test_get_extra_for_custom_model_string(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            model_extras={"primary": {"foo": "bar"}},
+        )
+        assert cfg.get_model_extra("custom/primary") == {"foo": "bar"}
+
+    def test_get_extra_falls_back_to_target_when_model_blank(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            target="secondary",
+            model_extras={"secondary": {"foo": "baz"}},
+        )
+        assert cfg.get_model_extra(None) == {"foo": "baz"}
+        assert cfg.get_model_extra("") == {"foo": "baz"}
+
+    def test_get_extra_skips_non_custom_provider(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            model_extras={"primary": {"foo": "bar"}},
+        )
+        # Only ``custom/<name>`` carries sidecar extras; provider models
+        # come from providers.yml so we must return {} there.
+        assert cfg.get_model_extra("openai/gpt-4o-mini") == {}
+
+    def test_get_extra_returns_copy_not_alias(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            model_extras={"primary": {"foo": "bar"}},
+        )
+        out = cfg.get_model_extra("custom/primary")
+        out["mutated"] = True
+        # Mutating the returned dict must not leak into the cached state.
+        assert "mutated" not in cfg.model_extras["primary"]
+
+    def test_get_extra_unknown_name_returns_empty(self, tmp_path):
+        cfg = self._make(tmp_path, model_extras={"primary": {"foo": "bar"}})
+        assert cfg.get_model_extra("custom/unknown") == {}


### PR DESCRIPTION
## Summary

- Introduce `datus.api.hooks.chat_hooks`: a registry + protocol for hosts that embed datus-agent to gate `/api/v1/chat/stream` and report token usage post-stream.
- `pre_chat` runs before the agentic loop and returns a structured allow/deny outcome; denials are emitted as a single SSE `error` event so existing clients render them naturally.
- `post_chat` is fire-and-forget after the SSE `end` event is captured — hosts handle their own retries; the response path never waits on billing.
- Both hooks receive the `fastapi.Request` so hosts can read `x-trace-id` (or the OTel trace id) for transaction-id composition.
- Behavior is unchanged when no host registers hooks.

## Why

Datus-saas grants per-user LLM credits backed by a Postgres ledger and needs to gate chat on balance and report consumption afterwards. The agent is shared infrastructure used by other hosts (CLI, VSCode plugin, self-hosted), so the integration must be opt-in via a clean extension point — not coupled to SaaS internals.

## Test plan

- [x] `pytest tests/unit_tests/api/hooks/test_chat_hooks.py` — registry + denial path + hook-exception path + post-hook scheduling
- [x] `pytest tests/unit_tests/api/routes/test_chat_routes.py` — existing route tests updated for the new `http_request` parameter
- [x] `pytest tests/unit_tests/api/` — full API test suite (878 passed)

## Notes

The host integration (Datus-backend hooking into Datus-saas `/api/internal/credit/*`) ships in a follow-up PR and depends on this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-extensible chat hooks: pre-chat allow/deny with user-facing errors and async post-chat usage reporting.
  * Agent config: per-model free-form "model_extras" with a helper to fetch resolved extras.
* **Tests**
  * Unit tests covering hook registry, pre-check denial/exception handling, post-hook scheduling, streaming route assertions, and model_extras behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/726)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->