### PR TITLE
[BugFix] Stabilize nightly harness failures

### DIFF
--- a/ci/flaky-registry.yml
+++ b/ci/flaky-registry.yml
@@ -11,6 +11,39 @@ entries:
       - nightly
     action: rerun_only
 
+  - id: api-source-proxy-tool-call-llm-rerun
+    type: test
+    nodeid: tests/integration/api/test_api_chat.py::TestAPIChatN9::test_source_proxy_tool_result
+    owner: agent-runtime
+    layer: product_e2e
+    reason: Real LLM source-proxy filesystem tool-call flow reran once during nightly; rerun passed.
+    allowed_until: 2026-06-05
+    allowed_in:
+      - nightly
+    action: rerun_only
+
+  - id: deepseek-mcp-session-rerun
+    type: test
+    nodeid: tests/integration/models/test_deepseek_model.py::TestDeepSeekModel::test_generate_with_mcp_session
+    owner: agent-runtime
+    layer: provider_health
+    reason: DeepSeek MCP session call reran once during nightly; rerun passed.
+    allowed_until: 2026-06-05
+    allowed_in:
+      - nightly
+    action: rerun_only
+
+  - id: superset-bi-complete-workflow-provider-disconnect
+    type: test
+    nodeid: tests/integration/tools/test_bi_dashboard.py::TestE2EIntegration::test_complete_workflow
+    owner: bi-agent
+    layer: product_e2e
+    reason: DeepSeek provider disconnected during Superset BI metric generation; rerun passed.
+    allowed_until: 2026-06-05
+    allowed_in:
+      - nightly
+    action: rerun_only
+
   - id: litellm-async-pending-task-teardown
     type: log_pattern
     pattern: "Task was destroyed but it is pending"

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -367,8 +367,9 @@ if [ "${NIGHTLY_FORCE_ADAPTER_ENV:-1}" = "1" ]; then
   export TRINO_PASSWORD=
   export TRINO_HTTP_SCHEME=http
 
+  export GREENPLUM_HOST_PORT="${GREENPLUM_HOST_PORT:-15434}"
   export GREENPLUM_HOST=localhost
-  export GREENPLUM_PORT=15432
+  export GREENPLUM_PORT="$GREENPLUM_HOST_PORT"
   export GREENPLUM_USER=gpadmin
   export GREENPLUM_PASSWORD=pivotal
   export GREENPLUM_DATABASE=postgres
@@ -523,6 +524,7 @@ log "AIRFLOW_URL=$AIRFLOW_URL AIRFLOW_HOST_PORT=$AIRFLOW_HOST_PORT"
 log "CLICKHOUSE_HOST=${CLICKHOUSE_HOST:-} CLICKHOUSE_PORT=${CLICKHOUSE_PORT:-} CLICKHOUSE_NATIVE_HOST_PORT=${CLICKHOUSE_NATIVE_HOST_PORT:-}"
 log "STARROCKS_HOST=${STARROCKS_HOST:-} STARROCKS_PORT=${STARROCKS_PORT:-} STARROCKS_HTTP_HOST_PORT=${STARROCKS_HTTP_HOST_PORT:-}"
 log "TRINO_HOST=${TRINO_HOST:-} TRINO_PORT=${TRINO_PORT:-}"
+log "GREENPLUM_HOST=${GREENPLUM_HOST:-} GREENPLUM_PORT=${GREENPLUM_PORT:-} GREENPLUM_HOST_PORT=${GREENPLUM_HOST_PORT:-}"
 if [ -n "$NIGHTLY_GROUP_FILTER" ]; then
   log "NIGHTLY_GROUP_FILTER=$NIGHTLY_GROUP_FILTER"
 fi
@@ -540,7 +542,9 @@ run_logged "MCP Server Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJ
 
 run_logged "Gen Agent Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/agent/test_gen_semantic_model_agentic.py tests/integration/agent/test_gen_metrics_agentic.py tests/integration/agent/test_gen_ext_knowledge_agentic.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 
-run_logged "Main Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/ --deselect tests/integration/tools/test_mcp_server.py --deselect tests/integration/agent/test_gen_semantic_model_agentic.py --deselect tests/integration/agent/test_gen_metrics_agentic.py --deselect tests/integration/agent/test_gen_ext_knowledge_agentic.py --deselect tests/integration/agent/test_gen_dashboard_agentic.py --deselect tests/integration/agent/test_scheduler_agentic.py --deselect tests/integration/tools/test_bi_dashboard.py --deselect tests/integration/adapters/test_postgresql.py --deselect tests/integration/adapters/test_mysql.py --deselect tests/integration/adapters/test_clickhouse.py --deselect tests/integration/adapters/test_starrocks.py --deselect tests/integration/adapters/test_trino.py --deselect tests/integration/adapters/test_greenplum.py --deselect tests/integration/adapters/test_hive.py --deselect tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5 --dist=loadscope -n auto
+run_logged "Reference Template Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/tools/test_reference_template.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
+
+run_logged "Main Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/ --deselect tests/integration/tools/test_mcp_server.py --deselect tests/integration/agent/test_gen_semantic_model_agentic.py --deselect tests/integration/agent/test_gen_metrics_agentic.py --deselect tests/integration/agent/test_gen_ext_knowledge_agentic.py --deselect tests/integration/agent/test_gen_dashboard_agentic.py --deselect tests/integration/agent/test_scheduler_agentic.py --deselect tests/integration/tools/test_bi_dashboard.py --deselect tests/integration/tools/test_reference_template.py --deselect tests/integration/adapters/test_postgresql.py --deselect tests/integration/adapters/test_mysql.py --deselect tests/integration/adapters/test_clickhouse.py --deselect tests/integration/adapters/test_starrocks.py --deselect tests/integration/adapters/test_trino.py --deselect tests/integration/adapters/test_greenplum.py --deselect tests/integration/adapters/test_hive.py --deselect tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5 --dist=loadscope -n auto
 
 run_compose_suite "Superset Nightly Tests" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 

--- a/datus/tools/date_tools/date_parser.py
+++ b/datus/tools/date_tools/date_parser.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from datus.models.base import LLMBaseModel
@@ -116,6 +116,11 @@ class DateParserTool(BaseTool):
         date_type = expression.get("date_type", "relative")
         confidence = expression.get("confidence", 1.0)
 
+        deterministic_result = self._parse_deterministic_period(original_text, reference_date)
+        if deterministic_result:
+            start_date, end_date = deterministic_result
+            return self.create_extracted_date(original_text, date_type, confidence, start_date, end_date)
+
         logger.debug(f"Parsing '{original_text}' using LLM")
 
         result = self.parse_with_llm(original_text, reference_date, model)
@@ -124,6 +129,30 @@ class DateParserTool(BaseTool):
             return self.create_extracted_date(original_text, date_type, confidence, start_date, end_date)
 
         logger.warning(f"LLM parsing failed for: '{original_text}'")
+        return None
+
+    def _parse_deterministic_period(self, text: str, reference_date: datetime) -> Optional[Tuple[datetime, datetime]]:
+        """Resolve simple period expressions that have strict calendar rules."""
+        if self.language != "zh":
+            return None
+
+        current_week_start = reference_date - timedelta(days=reference_date.weekday())
+        previous_week_tokens = ("上周", "上星期", "上个星期", "上一周")
+        next_week_tokens = ("下周", "下星期", "下个星期", "下一周")
+        has_previous_period = any(token in text for token in previous_week_tokens)
+        has_next_period = any(token in text for token in next_week_tokens)
+
+        if has_previous_period and has_next_period:
+            return None
+
+        if has_previous_period:
+            start_date = current_week_start - timedelta(days=7)
+            return start_date, start_date + timedelta(days=6)
+
+        if has_next_period:
+            start_date = current_week_start + timedelta(days=7)
+            return start_date, start_date + timedelta(days=6)
+
         return None
 
     def parse_with_llm(

--- a/datus/tools/date_tools/date_parser.py
+++ b/datus/tools/date_tools/date_parser.py
@@ -142,6 +142,9 @@ class DateParserTool(BaseTool):
         has_previous_period = any(token in text for token in previous_week_tokens)
         has_next_period = any(token in text for token in next_week_tokens)
 
+        if self._has_weekday_specific_period(text, previous_week_tokens + next_week_tokens):
+            return None
+
         if has_previous_period and has_next_period:
             return None
 
@@ -154,6 +157,41 @@ class DateParserTool(BaseTool):
             return start_date, start_date + timedelta(days=6)
 
         return None
+
+    def _has_weekday_specific_period(self, text: str, period_tokens: Tuple[str, ...]) -> bool:
+        weekday_suffixes = ("一", "二", "三", "四", "五", "六", "日", "天")
+        weekday_prefixes = ("周", "星期")
+
+        for token in period_tokens:
+            search_start = 0
+            while True:
+                token_index = text.find(token, search_start)
+                if token_index == -1:
+                    break
+
+                remainder = text[token_index + len(token) :].lstrip()
+                if remainder.startswith(weekday_suffixes):
+                    return True
+
+                if any(
+                    remainder.startswith(f"{prefix}{suffix}")
+                    for prefix in weekday_prefixes
+                    for suffix in weekday_suffixes
+                ):
+                    return True
+
+                if remainder.startswith("的"):
+                    after_possessive = remainder[1:].lstrip()
+                    if any(
+                        after_possessive.startswith(f"{prefix}{suffix}")
+                        for prefix in weekday_prefixes
+                        for suffix in weekday_suffixes
+                    ):
+                        return True
+
+                search_start = token_index + len(token)
+
+        return False
 
     def parse_with_llm(
         self, text: str, reference_date: datetime, model: LLMBaseModel

--- a/tests/integration/agent/test_chat_agentic.py
+++ b/tests/integration/agent/test_chat_agentic.py
@@ -25,7 +25,7 @@ class TestChatAgentic:
                 patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal,
                 patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,
             ):
-                at_data.return_value = [], [], []
+                at_data.return_value = [], [], [], None
                 mock_internal.side_effect = ["n", "n"]
                 cli = DatusCLI(args=mock_args)
 
@@ -50,7 +50,7 @@ class TestChatAgentic:
                 patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal,
                 patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,
             ):
-                at_data.return_value = [], [], []
+                at_data.return_value = [], [], [], None
                 mock_internal.side_effect = ["n"]
                 cli = DatusCLI(args=mock_args)
 
@@ -77,7 +77,7 @@ class TestChatAgentic:
                 patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal,
                 patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,
             ):
-                at_data.return_value = [], [], []
+                at_data.return_value = [], [], [], None
                 mock_internal.side_effect = ["n"]
                 cli = DatusCLI(args=mock_args)
 
@@ -109,7 +109,7 @@ class TestChatAgentic:
                 patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal,
                 patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,
             ):
-                at_data.return_value = [], [], []
+                at_data.return_value = [], [], [], None
                 mock_internal.side_effect = ["n"]
                 cli = DatusCLI(args=mock_args)
 

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -185,7 +185,7 @@ def test_chat_command(mock_args, capsys, gen_sql_input: List[Dict[str, Any]]):
             patch("datus.cli.repl.DatusCLI.prompt_input") as mock_internal_prompt,
             patch("datus.cli.repl.AtReferenceCompleter.parse_at_context") as at_data,
         ):
-            at_data.return_value = table_schemas, [], []
+            at_data.return_value = table_schemas, [], [], None
             mock_internal_prompt.side_effect = ["n"]
             cli = DatusCLI(args=mock_args)
 

--- a/tests/integration/cli/test_web_chatbot.py
+++ b/tests/integration/cli/test_web_chatbot.py
@@ -98,7 +98,7 @@ class TestChatExecutorIntegration:
         ):
             mock_prompt.side_effect = [EOFError]
             mock_internal.side_effect = ["n"]
-            at_data.return_value = [], [], []
+            at_data.return_value = [], [], [], None
             cli = DatusCLI(args=mock_args)
             wait_for_agent(cli)
 

--- a/tests/integration/tools/test_mcp_server.py
+++ b/tests/integration/tools/test_mcp_server.py
@@ -553,18 +553,13 @@ class TestMCPClient:
             assert len(data["error"]) > 0, "Error message should not be empty"
 
     async def test_error_handling_nonexistent_table_describe(self):
-        """N10-07b: describe_table for nonexistent table returns empty columns."""
+        """N10-07b: describe_table for nonexistent table returns a clear failure."""
         async with mcp_http_session(self.url) as session:
             result = await session.call_tool("describe_table", {"table_name": "nonexistent_xyz_table"})
             data = parse_tool_result(result)
 
-            # SQLite returns success with 0 columns for nonexistent tables
-            assert data["success"] == 1, (
-                f"describe_table should return a valid response, got error: {data.get('error')}"
-            )
-            assert isinstance(data["result"], dict), f"Result should be a dict, got {type(data['result'])}"
-            columns = data["result"].get("columns", [])
-            assert len(columns) == 0, f"Nonexistent table should have 0 columns, got {len(columns)}"
+            assert data["success"] == 0, "describe_table with nonexistent table should return success=0"
+            assert "does not exist or has no columns" in data.get("error", "")
 
     async def test_large_result_set(self):
         """N10-08: Large query result is properly handled (compressed/truncated)."""

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3290,7 +3290,7 @@ def _make_console():
 
 class MinimalAtCompleterExtended:
     def parse_at_context(self, user_input):
-        return ([], [], [])
+        return ([], [], [], None)
 
 
 class MinimalCLIExtended:

--- a/tests/unit_tests/tools/date_tools/test_date_parser.py
+++ b/tests/unit_tests/tools/date_tools/test_date_parser.py
@@ -181,6 +181,24 @@ class TestParseTemporalExpression:
         assert result.end_date == "2025-02-23"
         assert result.date_type == "range"
 
+    def test_zh_weekday_specific_week_expression_falls_back_to_llm(self):
+        tool = _make_zh_tool()
+        mock_model = MagicMock()
+        reference_date = datetime(2025, 2, 15)
+        start = datetime(2025, 2, 17)
+        end = datetime(2025, 2, 17)
+
+        for original_text in ("下周一的会议", "上星期三的记录", "下周的周一计划"):
+            expression = {"original_text": original_text, "date_type": "relative", "confidence": 0.9}
+            with patch.object(tool, "parse_with_llm", return_value=(start, end)) as mock_parse:
+                result = tool.parse_temporal_expression(expression, reference_date, mock_model)
+
+            mock_parse.assert_called_once_with(original_text, reference_date, mock_model)
+            assert result is not None
+            assert result.parsed_date == "2025-02-17"
+            assert result.start_date is None
+            assert result.end_date is None
+
 
 # ---------------------------------------------------------------------------
 # TestParseWithLlm

--- a/tests/unit_tests/tools/date_tools/test_date_parser.py
+++ b/tests/unit_tests/tools/date_tools/test_date_parser.py
@@ -19,6 +19,10 @@ def _make_tool():
     return DateParserTool(language="en")
 
 
+def _make_zh_tool():
+    return DateParserTool(language="zh")
+
+
 # ---------------------------------------------------------------------------
 # TestExecute
 # ---------------------------------------------------------------------------
@@ -129,6 +133,53 @@ class TestParseTemporalExpression:
             result = tool.parse_temporal_expression(expression, reference_date, mock_model)
 
         assert result is None
+
+    def test_zh_previous_week_uses_calendar_rule_without_llm(self):
+        tool = _make_zh_tool()
+        mock_model = MagicMock()
+        reference_date = datetime(2025, 2, 15)
+        expression = {"original_text": "上周的会议记录", "date_type": "relative", "confidence": 0.9}
+
+        with patch.object(tool, "parse_with_llm") as mock_parse:
+            result = tool.parse_temporal_expression(expression, reference_date, mock_model)
+
+        mock_parse.assert_not_called()
+        assert result is not None
+        assert result.start_date == "2025-02-03"
+        assert result.end_date == "2025-02-09"
+        assert result.date_type == "range"
+
+    def test_zh_next_week_uses_calendar_rule_without_llm(self):
+        tool = _make_zh_tool()
+        mock_model = MagicMock()
+        reference_date = datetime(2025, 2, 15)
+        expression = {"original_text": "下周的计划", "date_type": "relative", "confidence": 0.9}
+
+        with patch.object(tool, "parse_with_llm") as mock_parse:
+            result = tool.parse_temporal_expression(expression, reference_date, mock_model)
+
+        mock_parse.assert_not_called()
+        assert result is not None
+        assert result.start_date == "2025-02-17"
+        assert result.end_date == "2025-02-23"
+        assert result.date_type == "range"
+
+    def test_zh_compound_week_expression_falls_back_to_llm(self):
+        tool = _make_zh_tool()
+        mock_model = MagicMock()
+        reference_date = datetime(2025, 2, 15)
+        expression = {"original_text": "从上周到下周", "date_type": "range", "confidence": 0.9}
+        start = datetime(2025, 2, 3)
+        end = datetime(2025, 2, 23)
+
+        with patch.object(tool, "parse_with_llm", return_value=(start, end)) as mock_parse:
+            result = tool.parse_temporal_expression(expression, reference_date, mock_model)
+
+        mock_parse.assert_called_once_with("从上周到下周", reference_date, mock_model)
+        assert result is not None
+        assert result.start_date == "2025-02-03"
+        assert result.end_date == "2025-02-23"
+        assert result.date_type == "range"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Nightly on upstream/main exposed several deterministic test drift issues plus a couple of harness-level stability gaps: outdated test mocks, changed describe_table fail-fast behavior, LLM date parsing drift, reference-template cleanup races, and Greenplum host port conflicts.

## Solution

- Update tests to match current parse_at_context and describe_table behavior.
- Add deterministic Chinese previous/next week parsing to avoid LLM drift for strict calendar expressions.
- Run reference-template nightly tests in a separate sequential group and keep them out of the parallel main nightly bucket.
- Make Greenplum host port configurable and default it away from the PostgreSQL port.
- Register observed real-provider rerun cases in the flaky registry with owner, layer, action, and expiry.

## Test Cases

- `git diff --check`
- `bash -n ci/run-nightly-tests.sh`
- `uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --strict`
- Local upstream/main-equivalent full nightly run passed end to end:
  - Full unit tests: 12416 passed, 1 skipped, 1 xfailed
  - MCP server tests: 46 passed
  - Gen agent tests: 13 passed
  - Reference template nightly: 9 passed, 3 deselected
  - Main nightly: 200 passed, 17 skipped
  - Superset nightly: 5 passed
  - Airflow nightly: 3 passed
  - PostgreSQL/MySQL/ClickHouse/StarRocks/Trino/Greenplum/Hive/Spark adapter tests: each 6 passed
  - Flaky log classification passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deterministic parsing for Chinese relative-week expressions ("previous week", "next week") to reduce reliance on LLMs and improve accuracy.
  * Clearer error handling for nonexistent table describe operations.

* **Tests**
  * Added unit tests for Chinese date parsing and adjusted integration/unit test mocks to match updated parser outputs.

* **Chores (CI)**
  * Whitelisted reruns for three flaky integration tests and split/added a dedicated nightly step for a reference template test; updated nightly DB host/port logging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/727)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->