### PR TITLE
[BugFix] Improve nightly flaky diagnostics and MySQL readiness

### DIFF
--- a/ci/check_flaky_registry.py
+++ b/ci/check_flaky_registry.py
@@ -145,11 +145,21 @@ def classify_log(log_file: Path, registry: Registry) -> tuple[list[str], list[st
     return registered_reruns, unregistered_reruns, matched_patterns
 
 
+def warn(message: str) -> None:
+    print(f"WARNING: {message}", file=sys.stderr)
+    print(f"::warning::{message}", file=sys.stderr)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--registry", default=str(DEFAULT_REGISTRY), help="Path to ci/flaky-registry.yml")
     parser.add_argument("--log-file", help="Nightly log file to classify after tests finish")
     parser.add_argument("--strict", action="store_true", help="Validate test nodeid paths exist")
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Report registry/classification problems as warnings instead of failing",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -171,10 +181,17 @@ def main(argv: list[str] | None = None) -> int:
                 print("Unregistered reruns detected:")
                 for nodeid in sorted(set(unregistered)):
                     print(f"  - {nodeid}")
+                if args.warn_only:
+                    warn("Unregistered reruns detected; not failing because --warn-only is set")
+                    return 0
                 return 1
         return 0
     except Exception as exc:
-        print(f"Flaky registry check failed: {exc}", file=sys.stderr)
+        message = f"Flaky registry check failed: {exc}"
+        if args.warn_only:
+            warn(message)
+            return 0
+        print(message, file=sys.stderr)
         return 1
 
 

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -10,6 +10,7 @@ cd "$REPO_ROOT" || {
 
 LOG_FILE="${NIGHTLY_LOG_FILE:-test_output_nightly_$(date +%Y%m%d_%H%M%S).log}"
 test_exit_code=0
+last_command_exit_code=0
 NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
 AGENT_TEST_CONFIG="${AGENT_TEST_CONFIG:-tests/conf/agent.yml}"
 
@@ -397,6 +398,7 @@ run_logged_unfiltered() {
   log "=== ${group_name} ==="
   "$@" 2>&1 | tee -a "$LOG_FILE"
   local cmd_status=${PIPESTATUS[0]}
+  last_command_exit_code="$cmd_status"
   if [ "$cmd_status" -ne 0 ]; then
     test_exit_code="$cmd_status"
   fi
@@ -409,6 +411,7 @@ run_logged() {
   if ! should_run_group "$group_name"; then
     log ""
     log "=== Skipping ${group_name} (NIGHTLY_GROUP_FILTER=${NIGHTLY_GROUP_FILTER}) ==="
+    last_command_exit_code=0
     return 0
   fi
 
@@ -464,6 +467,64 @@ wait_for_service_health() {
   return 1
 }
 
+dump_compose_diagnostics() {
+  local compose_file="$1"
+  local group_name="$2"
+
+  log ""
+  log "=== ${group_name} Service Diagnostics ==="
+  docker_compose -f "$compose_file" ps 2>&1 | tee -a "$LOG_FILE" || true
+  docker_compose -f "$compose_file" logs --tail=200 2>&1 | tee -a "$LOG_FILE" || true
+}
+
+wait_for_mysql_client_readiness() {
+  local timeout_seconds="${1:-300}"
+  local deadline=$((SECONDS + timeout_seconds))
+  local probe_output="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-mysql-readiness-${GITHUB_RUN_ID:-$$}.log"
+
+  log "Waiting for MySQL client readiness at ${MYSQL_HOST:-localhost}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-test}"
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if uv run python - <<'PY' >"$probe_output" 2>&1; then
+import os
+
+import pymysql
+
+conn = pymysql.connect(
+    host=os.getenv("MYSQL_HOST", "localhost"),
+    port=int(os.getenv("MYSQL_PORT", "3306")),
+    user=os.getenv("MYSQL_USER", "test_user"),
+    password=os.getenv("MYSQL_PASSWORD", "test_password"),
+    database=os.getenv("MYSQL_DATABASE", "test"),
+    charset="utf8mb4",
+    autocommit=True,
+    connect_timeout=5,
+    read_timeout=5,
+    write_timeout=5,
+)
+try:
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT 1")
+        row = cursor.fetchone()
+        if not row or row[0] != 1:
+            raise RuntimeError(f"unexpected readiness result: {row!r}")
+finally:
+    conn.close()
+PY
+      log "MySQL client readiness probe succeeded"
+      return 0
+    fi
+    sleep 5
+  done
+
+  echo "Timed out waiting for MySQL client readiness" | tee -a "$LOG_FILE" >&2
+  if [ -s "$probe_output" ]; then
+    log "Last MySQL readiness probe output:"
+    sed 's/^/  /' "$probe_output" | tee -a "$LOG_FILE"
+  fi
+  test_exit_code=1
+  return 1
+}
+
 run_compose_suite() {
   local group_name="$1"
   local compose_file="$2"
@@ -505,7 +566,18 @@ run_compose_suite() {
     fi
   done
 
+  if [ "$group_name" = "MySQL Adapter Tests" ]; then
+    if ! wait_for_mysql_client_readiness 300; then
+      dump_compose_diagnostics "$compose_file" "$group_name"
+      compose_down "$compose_file"
+      return 0
+    fi
+  fi
+
   run_logged "$group_name" "$@"
+  if [ "$last_command_exit_code" -ne 0 ]; then
+    dump_compose_diagnostics "$compose_file" "$group_name"
+  fi
 
   log ""
   log "=== Stopping ${group_name} Services ==="
@@ -559,7 +631,7 @@ run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600"
 run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300
 run_compose_suite "Spark Adapter Tests" "$SPARK_COMPOSE" "spark-thrift:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300
 
-run_logged_unfiltered "Flaky Log Classification" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --log-file "$LOG_FILE"
+run_logged_unfiltered "Flaky Log Classification" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --log-file "$LOG_FILE" --warn-only
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "log_file=$LOG_FILE" >> "$GITHUB_OUTPUT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -15,6 +16,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 PROJECT_ROOT = Path(__file__).parent.parent
 TEST_DATA_DIR = Path(__file__).parent / "data"
 TEST_CONF_DIR = Path(__file__).parent / "conf"
+RERUN_LOG_MAX_LINES = int(os.getenv("DATUS_RERUN_LOG_MAX_LINES", "80"))
+RERUN_CAPTURE_LOG_MAX_LINES = int(os.getenv("DATUS_RERUN_CAPTURE_LOG_MAX_LINES", "40"))
+_DATUS_RERUN_REPORTS: list[dict[str, object]] = []
 
 
 @pytest.fixture
@@ -142,3 +146,67 @@ def load_acceptance_config(datasource: str = "snowflake", home: str = "") -> Age
     return load_agent_config(
         config=str(TEST_CONF_DIR / "agent.yml"), datasource=datasource, home=home, reload=True, force=True, yes=True
     )
+
+
+def _tail_lines(text: str, max_lines: int) -> list[str]:
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return lines
+    omitted = len(lines) - max_lines
+    return [f"... omitted {omitted} earlier line(s) ...", *lines[-max_lines:]]
+
+
+def _format_report_sections(sections: Iterable[tuple[str, str]]) -> list[str]:
+    formatted: list[str] = []
+    for name, content in sections:
+        if not content:
+            continue
+        formatted.append(f"-- {name} --")
+        formatted.extend(_tail_lines(content, RERUN_CAPTURE_LOG_MAX_LINES))
+    return formatted
+
+
+def pytest_configure(config) -> None:
+    _DATUS_RERUN_REPORTS.clear()
+
+
+def pytest_runtest_logreport(report) -> None:
+    if report.outcome != "rerun":
+        return
+
+    longrepr_text = getattr(report, "longreprtext", "") or str(report.longrepr or "")
+    _DATUS_RERUN_REPORTS.append(
+        {
+            "nodeid": report.nodeid,
+            "when": report.when,
+            "duration": report.duration,
+            "rerun": getattr(report, "rerun", "?"),
+            "worker": getattr(report, "worker_id", os.getenv("PYTEST_XDIST_WORKER", "main")),
+            "longrepr": _tail_lines(longrepr_text, RERUN_LOG_MAX_LINES),
+            "sections": _format_report_sections(getattr(report, "sections", [])),
+        }
+    )
+
+
+def pytest_terminal_summary(terminalreporter) -> None:
+    if not _DATUS_RERUN_REPORTS:
+        return
+
+    terminalreporter.section("Datus rerun diagnostics", sep="=")
+    for report in _DATUS_RERUN_REPORTS:
+        terminalreporter.write_line(
+            "RERUN "
+            f"{report['nodeid']} "
+            f"when={report['when']} "
+            f"attempt={report['rerun']} "
+            f"worker={report['worker']} "
+            f"duration={report['duration']:.2f}s"
+        )
+        if report["longrepr"]:
+            terminalreporter.write_line("First failure traceback summary:")
+            for line in report["longrepr"]:
+                terminalreporter.write_line(f"  {line}")
+        if report["sections"]:
+            terminalreporter.write_line("Captured output summary:")
+            for line in report["sections"]:
+                terminalreporter.write_line(f"  {line}")


### PR DESCRIPTION
## Why

Nightly reruns currently fail the workflow without preserving enough first-failure context, and MySQL adapter tests can start after Docker reports healthy before the host-level client path is actually ready.

## Solution

- Add rerun diagnostics to pytest terminal output, including nodeid, worker, attempt, duration, traceback summary, and captured output summary.
- Add a `--warn-only` mode for final flaky log classification so unregistered reruns are reported as warnings instead of failing nightly.
- Add a MySQL host-level PyMySQL readiness probe before running the MySQL adapter suite.
- Dump compose service diagnostics when a compose-backed suite fails.

## Test Cases

- `uv run python -m py_compile ci/check_flaky_registry.py tests/conftest.py`
- `bash -n ci/run-nightly-tests.sh`
- `uv run ruff check ci/check_flaky_registry.py tests/conftest.py`
- `NIGHTLY_GROUP_FILTER='MySQL Adapter Tests' NIGHTLY_FORCE_ADAPTER_ENV=0 DB_ADAPTERS_ROOT=/Users/kangxue/work/datus/datus-db-adapters-ci MYSQL_HOST_PORT=33306 MYSQL_HOST=127.0.0.1 MYSQL_PORT=33306 MYSQL_USER=test_user MYSQL_PASSWORD=test_password MYSQL_DATABASE=test NIGHTLY_LOG_FILE=/tmp/datus-mysql-nightly-local-clean-branch.log ci/run-nightly-tests.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive test rerun diagnostics, capturing rerun attempts, timing, and diagnostic details.
  * Added MySQL readiness verification before running MySQL adapter tests in nightly runs.

* **Improvements**
  * Enhanced nightly test runner with automatic diagnostics output for compose services when tests fail.
  * Flaky registry validation now runs in non-blocking warning mode during CI, preventing build failures while still reporting issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/729)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->