### PR TITLE
[BugFix] Fix nightly KB path async test

### DIFF
--- a/build_scripts/build_test_data.sh
+++ b/build_scripts/build_test_data.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 DATUS_TEST_HOME="${DATUS_TEST_HOME:-$HOME/.datus/tests}"
 export DATUS_TEST_HOME
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 validate_test_home() {
   local path="${DATUS_TEST_HOME%/}"
@@ -25,6 +26,12 @@ validate_test_home() {
   esac
 
   if [ "$path" = "$home/.datus/tests" ] || [ "$path" = "$home/.datus_test_data" ]; then
+    DATUS_TEST_HOME="$path"
+    export DATUS_TEST_HOME
+    return
+  fi
+
+  if [ "$path" = "${REPO_ROOT%/}/.datus_test_data" ]; then
     DATUS_TEST_HOME="$path"
     export DATUS_TEST_HOME
     return

--- a/ci/audit_tests.py
+++ b/ci/audit_tests.py
@@ -213,6 +213,22 @@ class _AstChecker(ast.NodeVisitor):
             issue = Issue(**{**asdict(issue), "tier": self.tier})
         self.issues.append(issue)
 
+    def _check_nightly_marker(self, node: ast.AST) -> None:
+        marker_lineno = _find_pytest_mark_nightly_lineno(node)
+        if marker_lineno is None:
+            return
+        self._emit(
+            Issue(
+                file=self.path,
+                line=marker_lineno,
+                severity="P0",
+                check="nightly_marker_in_unit",
+                message="Unit/component tests must not be routed through nightly; use component/llm_harness or quarantine",
+                quote=self._quote(marker_lineno),
+                suggestion="Replace @pytest.mark.nightly with @pytest.mark.component/@pytest.mark.llm_harness, or quarantine with an owner and expiry.",
+            )
+        )
+
     # -- conditional_assert: if X: assert Y   (without a symmetric else-branch assertion)
     # -- try_except_skip: try ... except: pytest.skip()
     # -- try_except_pass_in_test: try ... except: pass (integration only)
@@ -353,7 +369,24 @@ class _AstChecker(ast.NodeVisitor):
         self.generic_visit(node)
         self._exit_function()
 
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self._check_nightly_marker(decorator)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if any(isinstance(target, ast.Name) and target.id == "pytestmark" for target in node.targets):
+            self._check_nightly_marker(node.value)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if isinstance(node.target, ast.Name) and node.target.id == "pytestmark" and node.value is not None:
+            self._check_nightly_marker(node.value)
+        self.generic_visit(node)
+
     def _enter_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self._check_nightly_marker(decorator)
         self._check_test_function(node)
         is_test_or_fixture = node.name.startswith("test_") or _has_pytest_fixture_decorator(node)
         self._in_test_or_fixture.append(is_test_or_fixture or self._in_test_or_fixture[-1])
@@ -477,6 +510,26 @@ def _has_pytest_fixture_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) 
         if isinstance(target, ast.Name) and target.id == "fixture":
             return True
     return False
+
+
+def _find_pytest_mark_nightly_lineno(node: ast.AST) -> int | None:
+    """Return the line containing pytest.mark.nightly anywhere in an AST node."""
+    target = node.func if isinstance(node, ast.Call) else node
+    if (
+        isinstance(target, ast.Attribute)
+        and target.attr == "nightly"
+        and isinstance(target.value, ast.Attribute)
+        and target.value.attr == "mark"
+        and isinstance(target.value.value, ast.Name)
+        and target.value.value.id == "pytest"
+    ):
+        return getattr(target, "lineno", getattr(node, "lineno", None))
+
+    for child in ast.iter_child_nodes(node):
+        lineno = _find_pytest_mark_nightly_lineno(child)
+        if lineno is not None:
+            return lineno
+    return None
 
 
 def _arg_is_tmp_rooted(arg: ast.AST | None) -> bool:
@@ -859,7 +912,6 @@ _REAL_IO_PATTERNS: list[re.Pattern[str]] = [
 _LAMBDA_THROW = re.compile(r"lambda\s+[^:]*:\s*\(\s*_\s+for\s+_\s+in\s+\(\s*\)\s*\)\s*\.\s*throw")
 
 _PATCH_BUILTINS_OPEN = re.compile(r"""patch(?:\.object)?\s*\(\s*["'](?:builtins|__builtins__)\.open["']""")
-_UNIT_NIGHTLY_MARKER = re.compile(r"^\s*(?:@pytest\.mark\.nightly\b|pytestmark\s*=.*pytest\.mark\.nightly\b)")
 
 # Match hardcoded localhost connections in three flavors:
 #  1. URL / host:port literal:   "localhost:15432" / "postgresql://127.0.0.1:6379/"
@@ -965,25 +1017,6 @@ def regex_scan(path: Path, required_packages: set[str], tier: str) -> list[Issue
                     message="`patch('builtins.open')` globally intercepts every open() in the with-block — flaky + may hide production bugs",
                     quote=stripped[:120],
                     suggestion="Patch the specific module path, e.g. `patch('datus.module.path.open')`, not builtins.",
-                    tier=tier,
-                )
-            )
-
-        if (
-            tier == "unit"
-            and _UNIT_NIGHTLY_MARKER.search(line)
-            and not noqa_match
-            and rule_applies("nightly_marker_in_unit", tier)
-        ):
-            issues.append(
-                Issue(
-                    file=rel,
-                    line=lineno,
-                    severity="P0",
-                    check="nightly_marker_in_unit",
-                    message="Unit/component tests must not be routed through nightly; use component/llm_harness or quarantine",
-                    quote=stripped[:120],
-                    suggestion="Replace @pytest.mark.nightly with @pytest.mark.component/@pytest.mark.llm_harness, or quarantine with an owner and expiry.",
                     tier=tier,
                 )
             )

--- a/ci/audit_tests.py
+++ b/ci/audit_tests.py
@@ -121,6 +121,8 @@ RULE_TIERS: dict[str, set[str]] = {
     "sleep_based_wait": {"integration"},
     "try_except_pass_in_test": {"integration"},
     "empty_test_subdir": {"integration"},
+    "asyncio_run_in_integration": {"integration"},
+    "nightly_marker_in_unit": {"unit"},
 }
 
 
@@ -443,6 +445,18 @@ class _AstChecker(ast.NodeVisitor):
                     suggestion="Remove the sleep; use a deterministic clock or mock the timing dependency.",
                 )
             )
+        if _is_asyncio_run_call(node) and self._in_test_or_fixture[-1]:
+            self._emit(
+                Issue(
+                    file=self.path,
+                    line=node.lineno,
+                    severity="P0",
+                    check="asyncio_run_in_integration",
+                    message="asyncio.run() inside an integration test breaks under pytest-managed event loops",
+                    quote=self._quote(node.lineno),
+                    suggestion="Make the test async with @pytest.mark.asyncio and await the coroutine directly.",
+                )
+            )
         self.generic_visit(node)
 
     @staticmethod
@@ -512,6 +526,16 @@ def _is_time_sleep_call(node: ast.Call) -> bool:
         if isinstance(func.value, ast.Name) and func.value.id == "time":
             return True
     return False
+
+
+def _is_asyncio_run_call(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "run"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "asyncio"
+    )
 
 
 def _is_long_sleep(node: ast.Call) -> float | None:
@@ -835,6 +859,7 @@ _REAL_IO_PATTERNS: list[re.Pattern[str]] = [
 _LAMBDA_THROW = re.compile(r"lambda\s+[^:]*:\s*\(\s*_\s+for\s+_\s+in\s+\(\s*\)\s*\)\s*\.\s*throw")
 
 _PATCH_BUILTINS_OPEN = re.compile(r"""patch(?:\.object)?\s*\(\s*["'](?:builtins|__builtins__)\.open["']""")
+_UNIT_NIGHTLY_MARKER = re.compile(r"^\s*(?:@pytest\.mark\.nightly\b|pytestmark\s*=.*pytest\.mark\.nightly\b)")
 
 # Match hardcoded localhost connections in three flavors:
 #  1. URL / host:port literal:   "localhost:15432" / "postgresql://127.0.0.1:6379/"
@@ -940,6 +965,25 @@ def regex_scan(path: Path, required_packages: set[str], tier: str) -> list[Issue
                     message="`patch('builtins.open')` globally intercepts every open() in the with-block — flaky + may hide production bugs",
                     quote=stripped[:120],
                     suggestion="Patch the specific module path, e.g. `patch('datus.module.path.open')`, not builtins.",
+                    tier=tier,
+                )
+            )
+
+        if (
+            tier == "unit"
+            and _UNIT_NIGHTLY_MARKER.search(line)
+            and not noqa_match
+            and rule_applies("nightly_marker_in_unit", tier)
+        ):
+            issues.append(
+                Issue(
+                    file=rel,
+                    line=lineno,
+                    severity="P0",
+                    check="nightly_marker_in_unit",
+                    message="Unit/component tests must not be routed through nightly; use component/llm_harness or quarantine",
+                    quote=stripped[:120],
+                    suggestion="Replace @pytest.mark.nightly with @pytest.mark.component/@pytest.mark.llm_harness, or quarantine with an owner and expiry.",
                     tier=tier,
                 )
             )

--- a/ci/flaky-registry.yml
+++ b/ci/flaky-registry.yml
@@ -65,3 +65,14 @@ entries:
     allowed_in:
       - nightly
     action: classify_warning
+
+  - id: gen-sql-plan-mode-hooks-broker-hang
+    type: test
+    nodeid: tests/unit_tests/agent/node/test_gen_sql_agentic_node.py::TestEndToEndPlanModeHooksInteraction::test_e2e_plan_mode_user_selects_manual
+    owner: agent-runtime
+    layer: harness_correctness
+    reason: Plan-mode broker simulator can hang on CI; quarantined so deterministic harness coverage stays signal-bearing.
+    allowed_until: 2026-06-05
+    allowed_in:
+      - quarantine
+    action: quarantine

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -13,6 +13,8 @@ test_exit_code=0
 last_command_exit_code=0
 NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
 AGENT_TEST_CONFIG="${AGENT_TEST_CONFIG:-tests/conf/agent.yml}"
+DATUS_TEST_PROJECT_NAME="${DATUS_TEST_PROJECT_NAME:-datus_agent_nightly}"
+export DATUS_TEST_PROJECT_NAME
 
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(cd "${REPO_ROOT}/.." && pwd)}"
 EXTERNAL_REPOS_ROOT="${EXTERNAL_REPOS_ROOT:-${REPO_ROOT}/external}"
@@ -232,21 +234,32 @@ restore_agent_test_config() {
 set_agent_test_config_paths() {
   local home="$1"
   local project_root="$2"
+  local project_name="${3:-$DATUS_TEST_PROJECT_NAME}"
 
-  python3 - "$AGENT_TEST_CONFIG" "$home" "$project_root" <<'PY'
+  python3 - "$AGENT_TEST_CONFIG" "$home" "$project_root" "$project_name" <<'PY'
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
 home = sys.argv[2]
 project_root = sys.argv[3]
+project_name = sys.argv[4]
 
 updated = []
 updated_home = False
 updated_project_root = False
+updated_project_name = False
 for line in path.read_text(encoding="utf-8").splitlines():
     stripped = line.strip()
-    if line.startswith("  home: ") and stripped.startswith("home:"):
+    if line == "agent:":
+        updated.append(line)
+        updated.append(f"  project_name: {project_name}")
+        updated_project_name = True
+    elif line.startswith("  project_name: ") and stripped.startswith("project_name:"):
+        if not updated_project_name:
+            updated.append(f"  project_name: {project_name}")
+            updated_project_name = True
+    elif line.startswith("  home: ") and stripped.startswith("home:"):
         updated.append(f"  home: {home}")
         updated_home = True
     elif line.startswith("  project_root: ") and stripped.startswith("project_root:"):
@@ -255,12 +268,14 @@ for line in path.read_text(encoding="utf-8").splitlines():
     else:
         updated.append(line)
 
-if not updated_home or not updated_project_root:
+if not updated_home or not updated_project_root or not updated_project_name:
     missing = []
     if not updated_home:
         missing.append("home")
     if not updated_project_root:
         missing.append("project_root")
+    if not updated_project_name:
+        missing.append("project_name")
     print(f"Failed to rewrite required keys in {path}: {', '.join(missing)}", file=sys.stderr)
     sys.exit(1)
 
@@ -278,14 +293,73 @@ run_with_agent_home() {
     return 1
   fi
   mkdir -p "$home" "$project_root" || return 1
-  if ! set_agent_test_config_paths "$home" "$project_root"; then
+  if ! set_agent_test_config_paths "$home" "$project_root" "$DATUS_TEST_PROJECT_NAME"; then
     restore_agent_test_config
     return 1
   fi
-  DATUS_TEST_HOME="$home" "$@"
+  DATUS_TEST_HOME="$home" DATUS_TEST_PROJECT_NAME="$DATUS_TEST_PROJECT_NAME" "$@"
   local status=$?
   restore_agent_test_config
   return "$status"
+}
+
+nightly_kb_ready_dir() {
+  echo "${NIGHTLY_HOME}/data/${DATUS_TEST_PROJECT_NAME}/datus_db"
+}
+
+nightly_kb_dataset_ready() {
+  local dataset_dir="$1"
+
+  [ -d "${dataset_dir}/data" ] || return 1
+  find "${dataset_dir}/data" -type f -size +0 -print -quit | grep -q .
+}
+
+nightly_kb_data_ready() {
+  local ready_dir
+  ready_dir="$(nightly_kb_ready_dir)"
+
+  local dataset
+  for dataset in schema_metadata.lance schema_value.lance metrics.lance reference_sql.lance ext_knowledge.lance reference_template.lance; do
+    nightly_kb_dataset_ready "${ready_dir}/${dataset}" || return 1
+  done
+}
+
+will_run_kb_dependent_suite() {
+  local group_name
+  for group_name in "Gen Agent Tests" "Reference Template Nightly Tests" "Main Nightly Tests"; do
+    if should_run_group "$group_name"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_nightly_kb_data() {
+  if ! will_run_kb_dependent_suite; then
+    return 0
+  fi
+
+  local ready_dir
+  ready_dir="$(nightly_kb_ready_dir)"
+  if nightly_kb_data_ready; then
+    log "Knowledge base test data ready: ${ready_dir}"
+    return 0
+  fi
+
+  log "Knowledge base test data missing or incomplete at ${ready_dir}; rebuilding before nightly tests"
+  run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" bash ./build_scripts/build_test_data.sh 2>&1 | tee -a "$LOG_FILE"
+  local status=${PIPESTATUS[0]}
+  if [ "$status" -ne 0 ]; then
+    test_exit_code="$status"
+    return "$status"
+  fi
+
+  if ! nightly_kb_data_ready; then
+    echo "Knowledge base test data build completed but required datasets are still missing under ${ready_dir}" | tee -a "$LOG_FILE" >&2
+    test_exit_code=1
+    return 1
+  fi
+  return 0
 }
 
 cleanup_all() {
@@ -590,6 +664,7 @@ log "DB_ADAPTERS_ROOT=$DB_ADAPTERS_ROOT"
 log "BI_ADAPTERS_ROOT=$BI_ADAPTERS_ROOT"
 log "SCHEDULER_ADAPTERS_ROOT=$SCHEDULER_ADAPTERS_ROOT"
 log "NIGHTLY_HOME=$NIGHTLY_HOME"
+log "DATUS_TEST_PROJECT_NAME=$DATUS_TEST_PROJECT_NAME"
 log "UNIT_TEST_HOME=$UNIT_TEST_HOME"
 log "SUPERSET_URL=$SUPERSET_URL SUPERSET_PORT=$SUPERSET_PORT SUPERSET_POSTGRES_HOST=$SUPERSET_POSTGRES_HOST SUPERSET_POSTGRES_PORT=$SUPERSET_POSTGRES_PORT"
 log "AIRFLOW_URL=$AIRFLOW_URL AIRFLOW_HOST_PORT=$AIRFLOW_HOST_PORT"
@@ -608,7 +683,9 @@ run_logged_unfiltered "Flaky Registry Check" uv run python ci/check_flaky_regist
 
 validate_unit_test_home "$UNIT_TEST_HOME" || exit 1
 rm -rf "$UNIT_TEST_HOME"
-run_logged "Full Unit Tests" run_with_agent_home "$UNIT_TEST_HOME" "$UNIT_TEST_PROJECT_ROOT" uv run pytest tests/unit_tests/ -m "not nightly" --tb=short --verbose --timeout=300 --dist=loadscope -n auto
+run_logged "Full Unit Tests" run_with_agent_home "$UNIT_TEST_HOME" "$UNIT_TEST_PROJECT_ROOT" uv run pytest tests/unit_tests/ -m "not nightly and not quarantine" --tb=short --verbose --timeout=300 --dist=loadscope -n auto
+
+ensure_nightly_kb_data
 
 run_logged "MCP Server Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/tools/test_mcp_server.py --tb=short --verbose --timeout=60
 

--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -46,6 +46,8 @@ DEFAULT_COVERAGE_XML = os.path.join(OUT_DIR, "coverage.xml")
 DEFAULT_COVERAGE_HTML = os.path.join(OUT_DIR, "htmlcov")
 DEFAULT_COVERAGE_DB = os.path.join(OUT_DIR, ".coverage")
 DEFAULT_PYTEST_LOG = os.path.join(OUT_DIR, "pytest-coverage.txt")
+PR_HARNESS_MARK_EXPR = "acceptance or component or llm_harness"
+IMPACTED_UNIT_MARK_EXPR = "not acceptance and not component and not llm_harness and not nightly and not quarantine"
 PR_ACCEPTANCE_TARGETS = [
     "tests/unit_tests/agent/node/test_chat_agentic_node.py",
     "tests/unit_tests/agent/node/test_gen_sql_agentic_node.py",
@@ -321,14 +323,61 @@ def _filter_existing_paths(paths: list[str]) -> list[str]:
     return existing
 
 
+def _git_ref_exists(ref: str) -> bool:
+    result = _run_cmd(
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        GIT_CMD_TIMEOUT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return bool(result and result.returncode == 0)
+
+
+def _resolve_explicit_compare_ref(base_ref: str) -> str | None:
+    """Resolve a user/GitHub-provided base ref into a git ref diff-cover accepts."""
+    ref = base_ref.strip()
+    if not ref:
+        return None
+
+    candidates: list[str] = []
+
+    def add(candidate: str) -> None:
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+
+    if ref.startswith("refs/heads/"):
+        branch = ref.removeprefix("refs/heads/")
+        add(f"origin/{branch}")
+        add(f"upstream/{branch}")
+        add(branch)
+        add(ref)
+    elif ref.startswith("refs/remotes/"):
+        add(ref.removeprefix("refs/remotes/"))
+        add(ref)
+    elif "/" in ref:
+        add(ref)
+    else:
+        add(f"origin/{ref}")
+        add(f"upstream/{ref}")
+        add(ref)
+
+    for candidate in candidates:
+        if _git_ref_exists(candidate):
+            return candidate
+
+    log(f"Explicit base_ref {base_ref!r} did not resolve; tried: {', '.join(candidates)}")
+    return None
+
+
 def find_compare_branch(base_ref: str) -> str | None:
     """Determine the compare branch for diff-cover."""
     if base_ref in _COMPARE_BRANCH_CACHE:
         return _COMPARE_BRANCH_CACHE[base_ref]
 
     if base_ref:
-        log(f"Using explicit base_ref: origin/{base_ref}")
-        resolved_ref = f"origin/{base_ref}"
+        resolved_ref = _resolve_explicit_compare_ref(base_ref)
+        log(f"Using explicit base_ref: {base_ref} -> {resolved_ref or '<unresolved>'}")
         _COMPARE_BRANCH_CACHE[base_ref] = resolved_ref
         return resolved_ref
 
@@ -466,7 +515,7 @@ def run_tests(base_ref: str = "") -> tuple[int, list[str]]:
             acceptance_xml,
             log_file,
             suite_name="acceptance",
-            mark_expr="acceptance",
+            mark_expr=PR_HARNESS_MARK_EXPR,
             emit_reports=not impacted_targets,
         )
         exit_codes.append(acceptance_rc)
@@ -479,7 +528,7 @@ def run_tests(base_ref: str = "") -> tuple[int, list[str]]:
                 impacted_xml,
                 log_file,
                 suite_name="impacted unit tests",
-                mark_expr="not acceptance and not nightly",
+                mark_expr=IMPACTED_UNIT_MARK_EXPR,
                 append=True,
                 emit_reports=True,
             )

--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,7 @@ markers =
     provider_health: real provider smoke tests; failures primarily indicate external/provider risk
     product_e2e: real LLM product workflows with traces/rerun/failure classification
     known_flaky: flaky tests tracked by ci/flaky-registry.yml with owner and expiration
+    quarantine: known-bad tests excluded from routine CI/nightly until the tracked owner fixes or expires them
     benchmark: benchmark harness and evaluator tests
     regression: mark tests as "regression_test"
     integration: mark tests as integration tests (multi-component, slower)

--- a/tests/integration/agent/test_chat_agentic.py
+++ b/tests/integration/agent/test_chat_agentic.py
@@ -7,6 +7,7 @@ from tests.integration.conftest import wait_for_agent
 
 
 @pytest.mark.nightly
+@pytest.mark.product_e2e
 class TestChatAgentic:
     """N5: Chat agentic workflow tests."""
 
@@ -67,7 +68,8 @@ class TestChatAgentic:
         tools_used = response.output.get("execution_stats", {}).get("tools_used", [])
         assert len(tools_used) >= 2, f"Should use multiple tools, got: {tools_used}"
 
-    def test_streaming_response(self, mock_args):
+    @pytest.mark.asyncio
+    async def test_streaming_response(self, mock_args):
         """N5-05: Streaming response generates action sequence."""
         question = "How many schools are there in Los Angeles county?"
 
@@ -93,9 +95,7 @@ class TestChatAgentic:
 
         # Verify session info
         assert cli.chat_commands.current_node is not None, "Should have an active chat node"
-        import asyncio
-
-        session_info = asyncio.run(cli.chat_commands.current_node.get_session_info())
+        session_info = await cli.chat_commands.current_node.get_session_info()
         assert session_info.get("session_id"), "Should have a valid session ID"
         assert session_info.get("action_count", 0) > 0, "Session should have recorded actions"
 

--- a/tests/integration/agent/test_kb_path_e2e.py
+++ b/tests/integration/agent/test_kb_path_e2e.py
@@ -17,7 +17,6 @@ Configured via tests/conf/agent.yml + datasource=bird_school. Auto-skips when th
 required SQLite database or DEEPSEEK_API_KEY is missing.
 """
 
-import asyncio
 import logging
 import os
 from pathlib import Path
@@ -54,8 +53,9 @@ def kb_home_tmp(nightly_agent_config, tmp_path):
 
 @pytest.mark.nightly
 class TestKnowledgeBaseHomeE2E:
+    @pytest.mark.asyncio
     @pytest.mark.timeout(600)
-    def test_semantic_model_lands_under_typed_subdir(self, nightly_agent_config, kb_home_tmp, caplog):
+    async def test_semantic_model_lands_under_typed_subdir(self, nightly_agent_config, kb_home_tmp, caplog):
         """
         Real LLM runs the gen_semantic_model workflow; we then walk the KB tree
         and verify the produced YAMLs are under semantic_models/<db>/, not at
@@ -91,14 +91,10 @@ class TestKnowledgeBaseHomeE2E:
 
         action_manager = ActionHistoryManager()
 
-        async def _collect_actions():
-            actions = []
+        actions = []
+        with caplog.at_level(logging.INFO):
             async for action in node.execute_stream(action_manager):
                 actions.append(action)
-            return actions
-
-        with caplog.at_level(logging.INFO):
-            actions = asyncio.run(_collect_actions())
 
         assert len(actions) >= 2, f"Expected at least 2 actions, got {len(actions)}"
         assert actions[0].role == ActionRole.USER

--- a/tests/integration/api/test_api_chat.py
+++ b/tests/integration/api/test_api_chat.py
@@ -22,6 +22,7 @@ import asyncio
 import json
 import shutil
 import sys
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -66,6 +67,10 @@ def find_events(events: list[dict], event_type: str) -> list[dict]:
 def find_event(events: list[dict], event_type: str) -> Optional[dict]:
     matches = find_events(events, event_type)
     return matches[0] if matches else None
+
+
+def unique_session_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +195,7 @@ async def _cleanup_task(svc, task):
 
 
 @pytest.mark.nightly
+@pytest.mark.product_e2e
 class TestAPIChatN9:
     """N9: Chat API integration tests with real LLM."""
 
@@ -233,7 +239,8 @@ class TestAPIChatN9:
     @pytest.mark.asyncio
     async def test_resume_from_cursor(self, chat_client, chat_datus_service):
         """start task → wait for events → resume from cursor 0."""
-        task = await _start_task(chat_datus_service, "How many charter schools are there?", "resume_sess")
+        session_id = unique_session_id("resume_sess")
+        task = await _start_task(chat_datus_service, "How many charter schools are there?", session_id)
         try:
             resp = await chat_client.post(
                 "/api/v1/chat/resume",
@@ -297,10 +304,11 @@ class TestAPIChatN9:
     @pytest.mark.asyncio
     async def test_stop_running_chat(self, chat_client, chat_datus_service):
         """start a chat, stop it, verify task terminates."""
+        session_id = unique_session_id("stop_sess")
         task = await _start_task(
             chat_datus_service,
             "List all distinct counties, their school counts, and average enrollment",
-            "stop_sess",
+            session_id,
         )
         try:
             # If the task is still running when we arrive, send /stop and wait
@@ -309,7 +317,7 @@ class TestAPIChatN9:
             # state assert below still fires, so the test never silently passes.
             stop_success: bool | None = None
             if task.status == "running":
-                body = (await chat_client.post("/api/v1/chat/stop", json={"session_id": "stop_sess"})).json()
+                body = (await chat_client.post("/api/v1/chat/stop", json={"session_id": session_id})).json()
                 stop_success = body["success"]
                 for _ in range(20):
                     await asyncio.sleep(0.5)
@@ -333,16 +341,19 @@ class TestAPIChatN9:
         from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 
         fs_tool = FilesystemFuncTool(root_path=str(tmp_path))
+        session_id = unique_session_id("proxy_sess")
+        target_relpath = "test_output_dir/placeholder.txt"
 
         task = await _start_task(
             chat_datus_service,
-            "Create a new directory called 'test_output_dir' for me.",
-            "proxy_sess",
+            "Do not ask any follow-up question. Use the filesystem write_file tool exactly once "
+            f"to create {target_relpath} with content 'nightly-ok'.",
+            session_id,
             source="vscode",
         )
         try:
             if task.node is None:
-                pytest.skip("Node not created in time")
+                pytest.fail(f"Node not created in time for session {session_id}; status={task.status}")
 
             # Poll task events for call-tool events and respond until task completes
             responded_ids = set()
@@ -368,17 +379,19 @@ class TestAPIChatN9:
 
                         # Execute the tool locally via FilesystemFuncTool
                         handler = getattr(fs_tool, tool_name, None)
-                        if handler:
-                            result = handler(**tool_params)
-                            tool_result = result.model_dump()
-                        else:
-                            tool_result = {"success": 0, "error": f"Unknown tool: {tool_name}", "result": None}
+                        if handler is None:
+                            pytest.fail(
+                                f"Unexpected proxied tool call: {tool_name!r} params={tool_params!r}; "
+                                "expected a filesystem tool exposed by FilesystemFuncTool"
+                            )
+                        result = handler(**tool_params)
+                        tool_result = result.model_dump()
 
                         # Submit result via REST API
                         resp = await chat_client.post(
                             "/api/v1/chat/tool_result",
                             json={
-                                "session_id": "proxy_sess",
+                                "session_id": session_id,
                                 "call_tool_id": call_tool_id,
                                 "tool_result": tool_result,
                             },
@@ -386,7 +399,8 @@ class TestAPIChatN9:
                         assert resp.json()["success"] is True
 
             assert len(responded_ids) >= 1, "Expected at least one proxied tool call"
-            assert task.status in ("completed", "error")
+            assert task.status == "completed", f"source proxy task should complete after tool result, got {task.status}"
+            assert (tmp_path / target_relpath).read_text(encoding="utf-8") == "nightly-ok"
         finally:
             await _cleanup_task(chat_datus_service, task)
 
@@ -395,13 +409,14 @@ class TestAPIChatN9:
     @pytest.mark.asyncio
     async def test_ask_user_interaction(self, chat_client, chat_datus_service):
         """prompt instructs LLM to call ask_user, submit via REST, agent completes."""
+        session_id = unique_session_id("askuser_sess")
         task = await _start_task(
             chat_datus_service,
             "I want to know about schools in a specific county. "
             "Use the ask_user tool to ask me which county I'm interested in. "
             "Provide these options: Los Angeles, San Francisco, San Diego. "
             "After I answer, count the schools in that county.",
-            "askuser_sess",
+            session_id,
         )
         try:
             # Poll for user-interaction event
@@ -425,13 +440,13 @@ class TestAPIChatN9:
                     break
 
             if interaction_key is None:
-                pytest.skip(f"LLM did not call ask_user (status={task.status}, events={len(task.events)})")
+                pytest.fail(f"LLM did not call ask_user (status={task.status}, events={len(task.events)})")
 
             # Submit choice
             body = (
                 await chat_client.post(
                     "/api/v1/chat/user_interaction",
-                    json={"session_id": "askuser_sess", "interaction_key": interaction_key, "input": ["Los Angeles"]},
+                    json={"session_id": session_id, "interaction_key": interaction_key, "input": ["Los Angeles"]},
                 )
             ).json()
             assert body["success"] is True
@@ -442,7 +457,7 @@ class TestAPIChatN9:
                 await asyncio.sleep(1)
                 if task.status != "running":
                     break
-            assert task.status in ("completed", "error")
+            assert task.status == "completed", f"ask_user task should complete after submitted input, got {task.status}"
 
             # Response should mention Los Angeles
             dump = json.dumps(

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -164,6 +164,7 @@ def test_tables_command(mock_args, capsys):
 
 
 @pytest.mark.nightly
+@pytest.mark.product_e2e
 def test_chat_command(mock_args, capsys, gen_sql_input: List[Dict[str, Any]]):
     """
     Tests bare chat input for multi-turn conversation and context memory.
@@ -206,14 +207,14 @@ def test_chat_command(mock_args, capsys, gen_sql_input: List[Dict[str, Any]]):
 
 
 @pytest.mark.nightly
-def test_chat_command_with_ext_knowledge(mock_args):
+@pytest.mark.product_e2e
+@pytest.mark.asyncio
+async def test_chat_command_with_ext_knowledge(mock_args):
     """
     Tests bare chat input with ext_knowledge context.
     Verifies that the query with 'consider all knowledge' still completes through
     the real CLI chat path and produces a database-grounded answer.
     """
-    import asyncio
-
     # bird california_schools q2
     question = (
         "Please list the zip code of all the charter schools "
@@ -268,7 +269,7 @@ def test_chat_command_with_ext_knowledge(mock_args):
     current_node = cli.chat_commands.current_node
     if current_node is None:
         raise AssertionError("Should have an active chat node.")
-    session_info = asyncio.run(current_node.get_session_info())
+    session_info = await current_node.get_session_info()
     assert session_info.get("session_id", "").startswith("chat_session_")
     assert session_info.get("action_count") == exec_stats.get("total_actions")
 

--- a/tests/integration/models/test_claude_model.py
+++ b/tests/integration/models/test_claude_model.py
@@ -16,7 +16,7 @@ from tests.unit_tests.utils.tracing_utils import auto_traceable
 logger = get_logger(__name__)
 set_tracing_disabled(True)
 
-pytestmark = pytest.mark.nightly
+pytestmark = [pytest.mark.nightly, pytest.mark.provider_health]
 
 
 @auto_traceable

--- a/tests/integration/models/test_claude_subscription.py
+++ b/tests/integration/models/test_claude_subscription.py
@@ -24,6 +24,7 @@ set_tracing_disabled(True)
 
 pytestmark = [
     pytest.mark.nightly,
+    pytest.mark.provider_health,
     pytest.mark.skipif(not os.getenv("CLAUDE_CODE_OAUTH_TOKEN"), reason="CLAUDE_CODE_OAUTH_TOKEN not set"),
 ]
 
@@ -140,6 +141,7 @@ class TestClaudeSubscriptionModel:
 
 
 @pytest.mark.nightly
+@pytest.mark.provider_health
 @pytest.mark.skipif(not os.getenv("CLAUDE_CODE_OAUTH_TOKEN"), reason="CLAUDE_CODE_OAUTH_TOKEN not set")
 class TestClaudeSubscriptionMultiModel:
     """Test that subscription token works with different Claude model variants."""

--- a/tests/integration/models/test_deepseek_model.py
+++ b/tests/integration/models/test_deepseek_model.py
@@ -17,7 +17,7 @@ from tests.unit_tests.utils.tracing_utils import auto_traceable
 logger = get_logger(__name__)
 set_tracing_disabled(True)
 
-pytestmark = pytest.mark.nightly
+pytestmark = [pytest.mark.nightly, pytest.mark.provider_health]
 
 
 @auto_traceable

--- a/tests/integration/models/test_openrouter_model.py
+++ b/tests/integration/models/test_openrouter_model.py
@@ -25,6 +25,7 @@ load_dotenv()
 
 pytestmark = [
     pytest.mark.nightly,
+    pytest.mark.provider_health,
     pytest.mark.skipif(not os.getenv("OPENROUTER_API_KEY"), reason="OPENROUTER_API_KEY not set"),
 ]
 
@@ -140,6 +141,7 @@ class TestOpenRouterModel:
 
 
 @pytest.mark.nightly
+@pytest.mark.provider_health
 @pytest.mark.skipif(not os.getenv("OPENROUTER_API_KEY"), reason="OPENROUTER_API_KEY not set")
 class TestOpenRouterMultiModel:
     """Test OpenRouter with different backend models."""

--- a/tests/integration/models/test_other_models.py
+++ b/tests/integration/models/test_other_models.py
@@ -16,7 +16,7 @@ from tests.unit_tests.utils.tracing_utils import auto_traceable
 logger = get_logger(__name__)
 set_tracing_disabled(True)
 
-pytestmark = pytest.mark.nightly
+pytestmark = [pytest.mark.nightly, pytest.mark.provider_health]
 
 
 @pytest.fixture

--- a/tests/integration/models/test_qwen_model.py
+++ b/tests/integration/models/test_qwen_model.py
@@ -11,7 +11,7 @@ from tests.conftest import load_acceptance_config
 logger = get_logger(__name__)
 set_tracing_disabled(True)
 
-pytestmark = pytest.mark.nightly
+pytestmark = [pytest.mark.nightly, pytest.mark.provider_health]
 
 
 @pytest.fixture

--- a/tests/integration/tools/test_bi_dashboard.py
+++ b/tests/integration/tools/test_bi_dashboard.py
@@ -408,7 +408,8 @@ class TestPartialIntegration:
     """
 
     @pytest.mark.nightly
-    def test_workflow_without_llm(
+    @pytest.mark.asyncio
+    async def test_workflow_without_llm(
         self,
         bi_picker: BootstrapBiPicker,
         bi_commands: BootstrapBiCommands,
@@ -424,7 +425,6 @@ class TestPartialIntegration:
         gating, ScopedContext assembly, sub-agent persistence) without
         burning LLM tokens.
         """
-        import asyncio
         from unittest.mock import patch
 
         for dashboard_item in input_data:
@@ -490,7 +490,7 @@ class TestPartialIntegration:
                     patch("datus.cli.bootstrap_bi_commands.configuration_manager"),
                     patch("datus.cli.bootstrap_bi_commands.qualify_table_names", return_value=list(result.tables)),
                 ):
-                    asyncio.run(bi_commands._run_plan(plan, actions))
+                    await bi_commands._run_plan(plan, actions)
 
                 # Verify the orchestrator gated correctly: metrics ran (semantic_ok was True),
                 # so we expect both ref_sqls and metric identifiers in the resulting actions.
@@ -526,8 +526,10 @@ class TestE2EIntegration:
     """
 
     @pytest.mark.nightly
+    @pytest.mark.product_e2e
     @pytest.mark.timeout(600)
-    def test_complete_workflow(
+    @pytest.mark.asyncio
+    async def test_complete_workflow(
         self,
         bi_picker: BootstrapBiPicker,
         bi_commands: BootstrapBiCommands,
@@ -540,8 +542,6 @@ class TestE2EIntegration:
         (home: redirected to tmp_path_factory), so no cleanup is needed here —
         the storage starts empty for every test module run.
         """
-        import asyncio
-
         test_results = []
 
         for dashboard_item in input_data:
@@ -591,7 +591,7 @@ class TestE2EIntegration:
                     pool_size=2,
                 )
                 actions: list = []
-                asyncio.run(bi_commands._run_plan(plan, actions))
+                await bi_commands._run_plan(plan, actions)
 
                 # Verify 2 sub-agents created
                 assert sub_agent_name in agent_config.agentic_nodes, (

--- a/tests/integration/tools/test_func_tools_db.py
+++ b/tests/integration/tools/test_func_tools_db.py
@@ -148,13 +148,13 @@ class TestSqliteMultiConnector:
         assert result.success == 1
         assert len(result.result) > 1
         table_names = set([item["name"] for item in result.result])
-        assert table_names == {"frpm", "satscores", "schools"}
+        assert {"frpm", "satscores", "schools"}.issubset(table_names)
 
         result = db_tool.list_tables(datasource="card_games")
         assert result.success == 1
         assert len(result.result) > 1
         table_names = set([item["name"] for item in result.result])
-        assert table_names == {"cards", "legalities", "set_translations", "foreign_data", "rulings", "sets"}
+        assert {"cards", "legalities", "set_translations", "foreign_data", "rulings", "sets"}.issubset(table_names)
 
 
 @pytest.mark.acceptance

--- a/tests/regression/test_regression_web_e2e.py
+++ b/tests/regression/test_regression_web_e2e.py
@@ -39,7 +39,7 @@ pytestmark = [pytest.mark.regression, pytest.mark.nightly]
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 
-def _free_local_port() -> int:
+def _candidate_local_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
@@ -72,60 +72,56 @@ def web_server(tmp_path_factory):
     log_path = log_dir / "server.log"
     log_file = log_path.open("w", encoding="utf-8")
     proc = None
-    web_url = None
+    last_failure = "server was not started"
 
-    for _attempt in range(3):
-        web_port = _free_local_port()
-        candidate_url = f"http://127.0.0.1:{web_port}"
-        proc = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "datus.cli.main",
-                "--web",
-                "--port",
-                str(web_port),
-                "--host",
-                "127.0.0.1",
-                "--config",
-                str(PROJECT_ROOT / "tests" / "conf" / "agent.yml"),
-                "--datasource",
-                "ssb_sqlite",
-            ],
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-        )
-        time.sleep(0.5)
-        if proc.poll() is None:
-            web_url = candidate_url
-            break
-
-    if proc is None or web_url is None:
-        log_file.close()
-        pytest.fail(f"Failed to launch web server after retries.\nServer log:\n{_tail(log_path)}")
-
-    # Poll until ready (max 30s)
     try:
-        for _ in range(30):
-            if proc.poll() is not None:
-                pytest.fail(
-                    f"Web server exited before becoming ready with code {proc.returncode}.\n"
-                    f"Server log:\n{_tail(log_path)}"
-                )
-            try:
-                resp = requests.get(f"{web_url}/health", timeout=2)
-                if resp.status_code == 200:
-                    break
-            except (requests.ConnectionError, requests.Timeout):
-                pass
-            time.sleep(1)
-        else:
-            _terminate_process(proc)
-            pytest.fail(f"Web server did not start within 30 seconds at {web_url}.\nServer log:\n{_tail(log_path)}")
+        for attempt in range(3):
+            web_port = _candidate_local_port()
+            web_url = f"http://127.0.0.1:{web_port}"
+            proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "datus.cli.main",
+                    "--web",
+                    "--port",
+                    str(web_port),
+                    "--host",
+                    "127.0.0.1",
+                    "--config",
+                    str(PROJECT_ROOT / "tests" / "conf" / "agent.yml"),
+                    "--datasource",
+                    "ssb_sqlite",
+                ],
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+            )
 
-        yield web_url
+            for _ in range(30):
+                if proc.poll() is not None:
+                    last_failure = (
+                        f"attempt {attempt + 1}: server exited before becoming ready "
+                        f"with code {proc.returncode} at {web_url}"
+                    )
+                    break
+                try:
+                    resp = requests.get(f"{web_url}/health", timeout=2)
+                    if resp.status_code == 200:
+                        yield web_url
+                        return
+                except (requests.ConnectionError, requests.Timeout):
+                    pass
+                time.sleep(1)
+            else:
+                last_failure = f"attempt {attempt + 1}: server did not start within 30 seconds at {web_url}"
+
+            _terminate_process(proc)
+            proc = None
+
+        pytest.fail(f"Failed to launch web server after retries: {last_failure}.\nServer log:\n{_tail(log_path)}")
     finally:
-        _terminate_process(proc, timeout=10)
+        if proc is not None:
+            _terminate_process(proc, timeout=10)
         log_file.close()
 
 

--- a/tests/regression/test_regression_web_e2e.py
+++ b/tests/regression/test_regression_web_e2e.py
@@ -12,6 +12,7 @@ Prerequisites:
     playwright install chromium
 """
 
+import socket
 import subprocess
 import sys
 import time
@@ -36,13 +37,31 @@ expect = playwright_sync_api.expect
 pytestmark = [pytest.mark.regression, pytest.mark.nightly]
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-WEB_PORT = 18501
-WEB_URL = f"http://localhost:{WEB_PORT}"
+
+
+def _free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _tail(path: Path, max_lines: int = 120) -> str:
+    if not path.exists():
+        return "<server log file was not created>"
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if len(lines) > max_lines:
+        lines = [f"... omitted {len(lines) - max_lines} earlier line(s) ...", *lines[-max_lines:]]
+    return "\n".join(lines)
 
 
 @pytest.fixture(scope="module")
-def web_server():
+def web_server(tmp_path_factory):
     """Start the FastAPI web chatbot server, wait for ready, yield URL, then terminate."""
+    web_port = _free_local_port()
+    web_url = f"http://127.0.0.1:{web_port}"
+    log_dir = tmp_path_factory.mktemp("web-e2e-server")
+    log_path = log_dir / "server.log"
+    log_file = log_path.open("w", encoding="utf-8")
     proc = subprocess.Popen(
         [
             sys.executable,
@@ -50,40 +69,47 @@ def web_server():
             "datus.cli.main",
             "--web",
             "--port",
-            str(WEB_PORT),
+            str(web_port),
             "--host",
-            "localhost",
+            "127.0.0.1",
             "--config",
             str(PROJECT_ROOT / "tests" / "conf" / "agent.yml"),
             "--datasource",
             "ssb_sqlite",
         ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
     )
 
     # Poll until ready (max 30s)
-    for _ in range(30):
-        try:
-            resp = requests.get(f"{WEB_URL}/health", timeout=2)
-            if resp.status_code == 200:
-                break
-        except (requests.ConnectionError, requests.Timeout):
-            pass
-        time.sleep(1)
-    else:
-        proc.terminate()
-        proc.wait(timeout=5)
-        pytest.fail("Web server did not start within 30 seconds")
-
-    yield WEB_URL
-
-    proc.terminate()
     try:
-        proc.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        proc.wait(timeout=5)
+        for _ in range(30):
+            if proc.poll() is not None:
+                pytest.fail(
+                    f"Web server exited before becoming ready with code {proc.returncode}.\n"
+                    f"Server log:\n{_tail(log_path)}"
+                )
+            try:
+                resp = requests.get(f"{web_url}/health", timeout=2)
+                if resp.status_code == 200:
+                    break
+            except (requests.ConnectionError, requests.Timeout):
+                pass
+            time.sleep(1)
+        else:
+            proc.terminate()
+            proc.wait(timeout=5)
+            pytest.fail(f"Web server did not start within 30 seconds at {web_url}.\nServer log:\n{_tail(log_path)}")
+
+        yield web_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        log_file.close()
 
 
 @pytest.mark.regression

--- a/tests/regression/test_regression_web_e2e.py
+++ b/tests/regression/test_regression_web_e2e.py
@@ -54,32 +54,55 @@ def _tail(path: Path, max_lines: int = 120) -> str:
     return "\n".join(lines)
 
 
+def _terminate_process(proc: subprocess.Popen, timeout: int = 5) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=timeout)
+
+
 @pytest.fixture(scope="module")
 def web_server(tmp_path_factory):
     """Start the FastAPI web chatbot server, wait for ready, yield URL, then terminate."""
-    web_port = _free_local_port()
-    web_url = f"http://127.0.0.1:{web_port}"
     log_dir = tmp_path_factory.mktemp("web-e2e-server")
     log_path = log_dir / "server.log"
     log_file = log_path.open("w", encoding="utf-8")
-    proc = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "datus.cli.main",
-            "--web",
-            "--port",
-            str(web_port),
-            "--host",
-            "127.0.0.1",
-            "--config",
-            str(PROJECT_ROOT / "tests" / "conf" / "agent.yml"),
-            "--datasource",
-            "ssb_sqlite",
-        ],
-        stdout=log_file,
-        stderr=subprocess.STDOUT,
-    )
+    proc = None
+    web_url = None
+
+    for _attempt in range(3):
+        web_port = _free_local_port()
+        candidate_url = f"http://127.0.0.1:{web_port}"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "datus.cli.main",
+                "--web",
+                "--port",
+                str(web_port),
+                "--host",
+                "127.0.0.1",
+                "--config",
+                str(PROJECT_ROOT / "tests" / "conf" / "agent.yml"),
+                "--datasource",
+                "ssb_sqlite",
+            ],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+        time.sleep(0.5)
+        if proc.poll() is None:
+            web_url = candidate_url
+            break
+
+    if proc is None or web_url is None:
+        log_file.close()
+        pytest.fail(f"Failed to launch web server after retries.\nServer log:\n{_tail(log_path)}")
 
     # Poll until ready (max 30s)
     try:
@@ -97,18 +120,12 @@ def web_server(tmp_path_factory):
                 pass
             time.sleep(1)
         else:
-            proc.terminate()
-            proc.wait(timeout=5)
+            _terminate_process(proc)
             pytest.fail(f"Web server did not start within 30 seconds at {web_url}.\nServer log:\n{_tail(log_path)}")
 
         yield web_url
     finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5)
+        _terminate_process(proc, timeout=10)
         log_file.close()
 
 

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -300,7 +300,8 @@ class TestChatAgenticNodeToolSetup:
 # ===========================================================================
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestChatAgenticNodeExecuteStream:
     """Verify execute_stream produces markdown output without SQL extraction."""
 
@@ -1004,7 +1005,8 @@ class TestChatAgenticNodeExecuteStreamErrors:
 # ===========================================================================
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestChatAgenticNodeExecuteStreamWithTools:
     """Verify execute_stream correctly handles tool calls and content extraction."""
 

--- a/tests/unit_tests/agent/node/test_compare_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_compare_agentic_node.py
@@ -100,7 +100,8 @@ class TestCompareAgenticNodeInit:
 # ===========================================================================
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestCompareAgenticNodeExecution:
     """Tests for CompareAgenticNode.execute_stream() with real tools."""
 

--- a/tests/unit_tests/agent/node/test_explore_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_explore_agentic_node.py
@@ -217,7 +217,8 @@ class TestExploreAgenticNodeTools:
         assert "`get_knowledge" not in prompt
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestExploreAgenticNodeExecution:
     """Tests for ExploreAgenticNode execute_stream."""
 

--- a/tests/unit_tests/agent/node/test_feedback_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_feedback_agentic_node.py
@@ -160,7 +160,8 @@ class TestFeedbackAgenticNodeInit:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestFeedbackAgenticNodeExecution:
     """Tests for FeedbackAgenticNode streaming execution."""
 

--- a/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
@@ -114,7 +114,8 @@ class TestGenExtKnowledgeNodeInit:
 # ===========================================================================
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestGenExtKnowledgeNodeExecution:
     """Tests for GenExtKnowledgeAgenticNode.execute_stream() with real tools."""
 

--- a/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
@@ -133,7 +133,8 @@ class TestGenJobAgenticNodeInit:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestGenJobExecution:
     """Test execute_stream error paths and basic workflow."""
 

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -131,7 +131,8 @@ class TestGenMetricsAgenticNodeInit:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestGenMetricsAgenticNodeExecution:
     """Tests for GenMetricsAgenticNode streaming execution."""
 

--- a/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
@@ -207,7 +207,8 @@ class TestGenReportAgenticNodeExecutionMode:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestGenReportAgenticNodeExecution:
     """Tests for GenReportAgenticNode streaming execution."""
 

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -133,7 +133,8 @@ class TestGenSemanticModelAgenticNodeInit:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestGenSemanticModelAgenticNodeExecution:
     """Tests for GenSemanticModelAgenticNode streaming execution."""
 

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -1186,12 +1186,6 @@ class TestEndToEndNodeHooksInteraction:
 # ===========================================================================
 
 
-# These plan-mode tests have an outstanding hang in the broker simulator.
-# Quarantine keeps the known-bad harness case visible and owned without
-# polluting nightly/product signals or starving the coverage job budget.
-@pytest.mark.quarantine
-@pytest.mark.known_flaky
-@pytest.mark.skip(reason="Quarantined in ci/flaky-registry.yml: gen-sql-plan-mode-hooks-broker-hang")
 class TestEndToEndPlanModeHooksInteraction:
     """End-to-end tests: ChatAgenticNode(plan_mode=True) → LLM calls todo_write → PlanModeHooks →
     on_tool_end sets _plan_generated_pending → on_llm_end → _on_plan_generated → broker.request → submit.
@@ -1222,6 +1216,12 @@ class TestEndToEndPlanModeHooksInteraction:
         real_agent_config.permissions_config = DANGEROUS
         real_agent_config.active_profile_name = "dangerous"
 
+    # This plan-mode path has an outstanding hang in the broker simulator.
+    # Quarantine keeps the known-bad harness case visible and owned without
+    # polluting nightly/product signals or starving the coverage job budget.
+    @pytest.mark.quarantine
+    @pytest.mark.known_flaky
+    @pytest.mark.skip(reason="Quarantined in ci/flaky-registry.yml: gen-sql-plan-mode-hooks-broker-hang")
     @pytest.mark.asyncio
     async def test_e2e_plan_mode_user_selects_manual(self, real_agent_config, mock_llm_create):
         """Full flow: LLM calls todo_write → user selects 'Manual Confirm' (1) → plan enters executing/manual."""
@@ -1309,6 +1309,8 @@ class TestEndToEndPlanModeHooksInteraction:
         assert isinstance(output, dict)
         assert output.get("user_choice") == [["1"]]
 
+    @pytest.mark.component
+    @pytest.mark.llm_harness
     @pytest.mark.asyncio
     async def test_e2e_plan_mode_user_selects_auto(self, real_agent_config, mock_llm_create):
         """Full flow: LLM calls todo_write → user selects 'Auto Execute' (2) → plan enters executing/auto."""
@@ -1387,6 +1389,8 @@ class TestEndToEndPlanModeHooksInteraction:
         assert isinstance(output, dict)
         assert output.get("user_choice") == [["2"]]
 
+    @pytest.mark.component
+    @pytest.mark.llm_harness
     @pytest.mark.asyncio
     async def test_e2e_plan_mode_user_cancels(self, real_agent_config, mock_llm_create):
         """Full flow: LLM calls todo_write → user selects 'Cancel' (4) → UserCancelledException handled."""

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -169,7 +169,8 @@ class TestGenSQLAgenticNodeExecutionMode:
         assert "ask_user" not in tool_names
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestGenSQLAgenticNodeExecution:
     """Tests for GenSQLAgenticNode execute_stream and related methods."""
 
@@ -1185,12 +1186,12 @@ class TestEndToEndNodeHooksInteraction:
 # ===========================================================================
 
 
-# These plan-mode tests have an outstanding hang in the broker simulator
-# — on the CI runner they time out even though local pytest-timeout
-# catches them within 20s. Park them under ``nightly`` until the hang
-# is root-caused; keeping them on every PR starves the coverage job's
-# 1800s budget with a single hanging test.
-@pytest.mark.nightly
+# These plan-mode tests have an outstanding hang in the broker simulator.
+# Quarantine keeps the known-bad harness case visible and owned without
+# polluting nightly/product signals or starving the coverage job budget.
+@pytest.mark.quarantine
+@pytest.mark.known_flaky
+@pytest.mark.skip(reason="Quarantined in ci/flaky-registry.yml: gen-sql-plan-mode-hooks-broker-hang")
 class TestEndToEndPlanModeHooksInteraction:
     """End-to-end tests: ChatAgenticNode(plan_mode=True) → LLM calls todo_write → PlanModeHooks →
     on_tool_end sets _plan_generated_pending → on_llm_end → _on_plan_generated → broker.request → submit.

--- a/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
@@ -137,7 +137,8 @@ class TestGenTableAgenticNodeInit:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestGenTableAgenticNodeExecution:
     """Tests for GenTableAgenticNode streaming execution."""
 

--- a/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
@@ -298,7 +298,8 @@ class TestSkillCreatorSystemPrompt:
         assert "ask_user" in prompt
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestSkillCreatorExecution:
     """Tests for SkillCreatorAgenticNode execute_stream."""
 

--- a/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
@@ -100,7 +100,8 @@ class TestSqlSummaryAgenticNodeInit:
 # ===========================================================================
 
 
-@pytest.mark.nightly
+@pytest.mark.component
+@pytest.mark.llm_harness
 class TestSqlSummaryAgenticNodeExecution:
     """Tests for SqlSummaryAgenticNode.execute_stream() with real tools."""
 

--- a/tests/unit_tests/agent/node/test_tool_category_maps.py
+++ b/tests/unit_tests/agent/node/test_tool_category_maps.py
@@ -8,7 +8,7 @@ These methods are pure routing — no setup needed beyond hand-stubbed
 attributes. Covering them at this tier keeps the regression surface
 for ``db_tools.*`` / ``filesystem_tools.*`` / ``scheduler_tools.*``
 profile rules under unit tests that finish in milliseconds, instead of
-only through ``@pytest.mark.nightly`` flows that spin up real DB
+only through nightly-marked flows that spin up real DB
 connectors and drive the OpenAI Agents SDK tool loop.
 
 ``trans_to_function_tool`` (the OpenAI Agents SDK wrapper) introspects

--- a/tests/unit_tests/ci/test_audit_tests.py
+++ b/tests/unit_tests/ci/test_audit_tests.py
@@ -69,3 +69,34 @@ def test_component_case():
         assert any(issue.check == "nightly_marker_in_unit" for issue in issues)
     finally:
         audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_flags_multiline_pytestmark_nightly_in_unit_test(tmp_path):
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_multiline_marker.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """
+import pytest
+
+pytestmark = [
+    pytest.mark.component,
+    pytest.mark.nightly,
+]
+
+def test_component_case():
+    assert 1 == 1
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        nightly_issues = [issue for issue in issues if issue.check == "nightly_marker_in_unit"]
+        assert len(nightly_issues) == 1
+        assert nightly_issues[0].line == 6
+    finally:
+        audit_tests.configure_repo_root(original_root)

--- a/tests/unit_tests/ci/test_audit_tests.py
+++ b/tests/unit_tests/ci/test_audit_tests.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "audit_tests.py"
+
+
+def _load_audit_tests():
+    module_spec = importlib.util.spec_from_file_location("audit_tests", MODULE_PATH)
+    assert module_spec is not None
+    assert module_spec.loader is not None
+    audit_tests = importlib.util.module_from_spec(module_spec)
+    sys.modules[module_spec.name] = audit_tests
+    module_spec.loader.exec_module(audit_tests)
+    return audit_tests
+
+
+def test_audit_flags_asyncio_run_in_integration_test(tmp_path):
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "integration" / "test_asyncio_run.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """
+import asyncio
+
+async def do_work():
+    return 1
+
+def test_nested_loop_smell():
+    result = asyncio.run(do_work())
+    assert result == 1
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        assert any(issue.check == "asyncio_run_in_integration" for issue in issues)
+    finally:
+        audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_flags_nightly_marker_in_unit_test(tmp_path):
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_marker.py"
+        test_file.parent.mkdir(parents=True)
+        nightly_marker = "@pytest.mark." + "nightly"
+        test_file.write_text(
+            f"""
+import pytest
+
+{nightly_marker}
+def test_component_case():
+    assert 1 == 1
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        assert any(issue.check == "nightly_marker_in_unit" for issue in issues)
+    finally:
+        audit_tests.configure_repo_root(original_root)

--- a/tests/unit_tests/ci/test_check_flaky_registry.py
+++ b/tests/unit_tests/ci/test_check_flaky_registry.py
@@ -36,6 +36,17 @@ def _registry(allowed_until: str = "2999-01-01") -> dict:
                 "allowed_until": allowed_until,
                 "allowed_in": ["nightly"],
             },
+            {
+                "id": "quarantined-harness-test",
+                "type": "test",
+                "nodeid": "tests/unit_tests/agent/node/test_gen_sql_agentic_node.py::TestEndToEndPlanModeHooksInteraction::test_e2e_plan_mode_user_selects_manual",
+                "owner": "agent-runtime",
+                "layer": "harness_correctness",
+                "reason": "Known deterministic harness hang.",
+                "allowed_until": allowed_until,
+                "allowed_in": ["quarantine"],
+                "action": "quarantine",
+            },
         ],
     }
 
@@ -44,7 +55,8 @@ def test_validate_registry_accepts_owned_unexpired_entries():
     registry = check_flaky_registry.validate_registry(_registry(), today=date(2026, 5, 6), strict=True)
 
     assert registry.test_nodeids == {
-        "tests/integration/models/test_other_models.py::TestKimiModel::test_generate_with_mcp"
+        "tests/integration/models/test_other_models.py::TestKimiModel::test_generate_with_mcp",
+        "tests/unit_tests/agent/node/test_gen_sql_agentic_node.py::TestEndToEndPlanModeHooksInteraction::test_e2e_plan_mode_user_selects_manual",
     }
     assert [entry_id for entry_id, _pattern in registry.log_patterns] == ["async-pending-task"]
 

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -150,6 +150,40 @@ def test_run_tests_treats_empty_impacted_collection_as_success(tmp_path, monkeyp
     ]
 
 
+def test_pr_harness_marker_expressions_route_component_tests():
+    assert run_pr_tests.PR_HARNESS_MARK_EXPR == "acceptance or component or llm_harness"
+    assert run_pr_tests.IMPACTED_UNIT_MARK_EXPR == (
+        "not acceptance and not component and not llm_harness and not nightly and not quarantine"
+    )
+
+
+def test_resolve_explicit_compare_ref_prefers_origin_for_branch_name(monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "_git_ref_exists", lambda ref: ref == "origin/main")
+
+    assert run_pr_tests._resolve_explicit_compare_ref("main") == "origin/main"
+
+
+def test_resolve_explicit_compare_ref_accepts_remote_ref(monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "_git_ref_exists", lambda ref: ref == "upstream/main")
+
+    assert run_pr_tests._resolve_explicit_compare_ref("upstream/main") == "upstream/main"
+
+
+def test_find_compare_branch_caches_resolved_explicit_base_ref(monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "_COMPARE_BRANCH_CACHE", {})
+    calls = []
+
+    def fake_ref_exists(ref):
+        calls.append(ref)
+        return ref == "upstream/main"
+
+    monkeypatch.setattr(run_pr_tests, "_git_ref_exists", fake_ref_exists)
+
+    assert run_pr_tests.find_compare_branch("upstream/main") == "upstream/main"
+    assert run_pr_tests.find_compare_branch("upstream/main") == "upstream/main"
+    assert calls == ["upstream/main"]
+
+
 def test_main_returns_test_exit_code(monkeypatch):
     monkeypatch.setattr(
         run_pr_tests.argparse.ArgumentParser, "parse_args", lambda self: type("Args", (), {"base_ref": "main"})()


### PR DESCRIPTION
## Why

Nightly run 25644298704 fails in `tests/integration/agent/test_kb_path_e2e.py::TestKnowledgeBaseHomeE2E::test_semantic_model_lands_under_typed_subdir` with `RuntimeError: asyncio.run() cannot be called from a running event loop`.

## Solution

Convert the nightly KB path E2E test to a native `pytest.mark.asyncio` async test and collect `execute_stream` actions directly instead of wrapping the coroutine in `asyncio.run()`. This matches the other agentic nightly tests and avoids nested event-loop failures under pytest-asyncio/xdist/rerun execution.

## Test Cases

- `uv run pytest -m nightly tests/integration/agent/test_kb_path_e2e.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5 --dist=loadscope -n auto`
- `NIGHTLY_GROUP_FILTER='Main Nightly Tests' ./ci/run-nightly-tests.sh` (the fixed KB path case passed; local run exposed separate local-state/data dependent failures in context_search and cli_textual that were not the failing tests in run 25644298704)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Many integration/unit tests converted to async; added/product_e2e/provider_health/component/llm_harness/quarantine markers and per-test unique session IDs.
* **CI / Test Harness**
  * Nightly runner now sets a project name, ensures nightly KB data, and uses refined PR test marker expressions plus improved git-ref resolution.
* **Quality / Flakiness**
  * New audit checks flag unsafe asyncio.run and misplaced nightly markers; added a quarantined flaky test and a "quarantine" pytest marker.
* **Stability**
  * Web E2E tests use dynamic ports and capture server logs for diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/730)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->