### PR TITLE
[BugFix] Emit SSE error event on stream_chat generator failure

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -434,6 +434,7 @@ async def _stream_with_post_hook(
     """
     last_end_event: Optional[SSEEvent] = None
     captured_error: Optional[BaseException] = None
+    was_cancelled: bool = False
     last_event_id: int = 0
 
     try:
@@ -446,7 +447,11 @@ async def _stream_with_post_hook(
     except asyncio.CancelledError:
         # Client disconnected or the server is shutting down. The HTTP
         # response is already gone — nothing to yield, nothing to log
-        # as error.
+        # as error. We also do NOT schedule the post-chat hook below,
+        # because the usage payload is incomplete (no ``end`` event) and
+        # would otherwise look like a free successful turn to callers
+        # such as billing.
+        was_cancelled = True
         raise
     except BaseException as exc:
         captured_error = exc
@@ -458,6 +463,12 @@ async def _stream_with_post_hook(
             exc,
             exc_info=True,
         )
+        # Emit a synthetic SSE error event so the client renders a real
+        # reason instead of an opaque "network error". Catch
+        # ``BaseException`` here — including ``CancelledError`` raised
+        # by ``yield`` when the peer has already disconnected — so the
+        # outer bare ``raise`` below still re-propagates the original
+        # ``exc`` instead of being masked.
         try:
             error_event = SSEEvent(
                 id=last_event_id + 1,
@@ -469,16 +480,24 @@ async def _stream_with_post_hook(
                 ),
                 timestamp=now_utc_iso(),
             )
-            yield (
-                f"id: {error_event.id}\n"
-                f"event: {error_event.event}\n"
-                f"data: {error_event.data.model_dump_json()}\n\n"
+            yield (f"id: {error_event.id}\nevent: {error_event.event}\ndata: {error_event.data.model_dump_json()}\n\n")
+        except BaseException:  # pragma: no cover — defensive
+            logger.warning(
+                "Failed to emit terminal SSE error event (client likely disconnected)",
+                exc_info=True,
             )
-        except Exception:  # pragma: no cover — defensive
-            logger.error("Failed to emit terminal SSE error event", exc_info=True)
         raise
     finally:
-        if hooks is not None:
+        # Only schedule the post-chat hook when we have a meaningful
+        # outcome to report: either the stream finished normally (an
+        # ``end`` event was observed) or it failed with a real error
+        # we can describe. Pure cancellation is skipped — the usage
+        # payload would be empty and billing/audit callers would treat
+        # the turn as a free success.
+        should_schedule_post_hook = (
+            hooks is not None and not was_cancelled and (last_end_event is not None or captured_error is not None)
+        )
+        if should_schedule_post_hook:
             usage_dict: dict = {}
             session_id_value: Optional[str] = request.session_id
             if last_end_event is not None:

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -425,17 +425,57 @@ async def _stream_with_post_hook(
 
     The post hook is dispatched as a background task in ``finally`` so the
     response stream is never blocked waiting for billing to acknowledge.
+
+    If the upstream generator raises before the stream completes, we log
+    the error and emit a synthetic ``event: error`` to the client so the
+    UI can surface a real reason instead of an opaque "network error".
+    ``asyncio.CancelledError`` (client disconnect / shutdown) is treated
+    as expected and skips the error event.
     """
     last_end_event: Optional[SSEEvent] = None
     captured_error: Optional[BaseException] = None
+    last_event_id: int = 0
 
     try:
         async for event in upstream:
             if event.event == "end":
                 last_end_event = event
+            if isinstance(event.id, int):
+                last_event_id = event.id
             yield f"id: {event.id}\nevent: {event.event}\ndata: {event.data.model_dump_json()}\n\n"
+    except asyncio.CancelledError:
+        # Client disconnected or the server is shutting down. The HTTP
+        # response is already gone — nothing to yield, nothing to log
+        # as error.
+        raise
     except BaseException as exc:
         captured_error = exc
+        logger.error(
+            "stream_chat generator failed for session=%s user=%s subagent=%s: %s",
+            request.session_id,
+            user_id,
+            request.subagent_id,
+            exc,
+            exc_info=True,
+        )
+        try:
+            error_event = SSEEvent(
+                id=last_event_id + 1,
+                event="error",
+                data=SSEErrorData(
+                    error=str(exc) or type(exc).__name__,
+                    error_type=type(exc).__name__,
+                    session_id=request.session_id,
+                ),
+                timestamp=now_utc_iso(),
+            )
+            yield (
+                f"id: {error_event.id}\n"
+                f"event: {error_event.event}\n"
+                f"data: {error_event.data.model_dump_json()}\n\n"
+            )
+        except Exception:  # pragma: no cover — defensive
+            logger.error("Failed to emit terminal SSE error event", exc_info=True)
         raise
     finally:
         if hooks is not None:

--- a/tests/unit_tests/api/hooks/test_chat_hooks.py
+++ b/tests/unit_tests/api/hooks/test_chat_hooks.py
@@ -205,3 +205,73 @@ class TestStreamChatPostHookSchedule:
         assert ctx_seen.usage.get("total_tokens") == 30
         assert ctx_seen.pre_check_extra == {"trace_id": "abc"}
         assert ctx_seen.error is None
+
+
+class TestStreamChatGeneratorError:
+    """If the upstream stream raises, the route must emit a terminal SSE
+    ``event: error`` instead of letting the connection die silently."""
+
+    @pytest.mark.asyncio
+    async def test_upstream_exception_emits_error_event(self):
+        from datus.api.models.cli_models import SSEMessageData, SSEEvent
+        from datus.api.models.cli_models import SSEDataType, SSEMessagePayload
+
+        first_event = SSEEvent(
+            id=7,
+            event="message",
+            data=SSEMessageData(
+                type=SSEDataType.CREATE_MESSAGE,
+                payload=SSEMessagePayload(message_id="m1", role="assistant", content=[]),
+            ),
+            timestamp="2026-01-01T00:00:00Z",
+        )
+
+        async def _upstream(*_args, **_kwargs):
+            yield first_event
+            raise RuntimeError("boom from tool runner")
+
+        svc = _mock_svc_with_nodes()
+        svc.chat.stream_chat = _upstream
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="hi", session_id="sess-err")
+
+        response = await chat_routes.stream_chat(request, svc, ctx, MagicMock())
+
+        body_chunks: list[str] = []
+        with pytest.raises(RuntimeError):
+            async for chunk in response.body_iterator:
+                body_chunks.append(chunk)
+
+        # First chunk was forwarded; second chunk is the synthetic error.
+        assert any("event: message" in c for c in body_chunks)
+        error_chunks = [c for c in body_chunks if "event: error" in c]
+        assert len(error_chunks) == 1
+        data_line = next(
+            line for line in error_chunks[0].splitlines() if line.startswith("data: ")
+        )
+        payload = json.loads(data_line[len("data: ") :])
+        assert payload["error_type"] == "RuntimeError"
+        assert "boom from tool runner" in payload["error"]
+        assert payload["session_id"] == "sess-err"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_is_not_swallowed(self):
+        async def _upstream(*_args, **_kwargs):
+            if False:  # pragma: no cover — make this an async generator
+                yield None
+            raise asyncio.CancelledError()
+
+        svc = _mock_svc_with_nodes()
+        svc.chat.stream_chat = _upstream
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="hi", session_id="sess-cancel")
+
+        response = await chat_routes.stream_chat(request, svc, ctx, MagicMock())
+
+        body_chunks: list[str] = []
+        with pytest.raises(asyncio.CancelledError):
+            async for chunk in response.body_iterator:
+                body_chunks.append(chunk)
+
+        # Cancellation must not produce a synthetic SSE error event.
+        assert all("event: error" not in c for c in body_chunks)

--- a/tests/unit_tests/api/hooks/test_chat_hooks.py
+++ b/tests/unit_tests/api/hooks/test_chat_hooks.py
@@ -246,9 +246,7 @@ class TestStreamChatGeneratorError:
         assert any("event: message" in c for c in body_chunks)
         error_chunks = [c for c in body_chunks if "event: error" in c]
         assert len(error_chunks) == 1
-        data_line = next(
-            line for line in error_chunks[0].splitlines() if line.startswith("data: ")
-        )
+        data_line = next(line for line in error_chunks[0].splitlines() if line.startswith("data: "))
         payload = json.loads(data_line[len("data: ") :])
         assert payload["error_type"] == "RuntimeError"
         assert "boom from tool runner" in payload["error"]

--- a/tests/unit_tests/api/hooks/test_chat_hooks.py
+++ b/tests/unit_tests/api/hooks/test_chat_hooks.py
@@ -213,8 +213,12 @@ class TestStreamChatGeneratorError:
 
     @pytest.mark.asyncio
     async def test_upstream_exception_emits_error_event(self):
-        from datus.api.models.cli_models import SSEMessageData, SSEEvent
-        from datus.api.models.cli_models import SSEDataType, SSEMessagePayload
+        from datus.api.models.cli_models import (
+            SSEDataType,
+            SSEEvent,
+            SSEMessageData,
+            SSEMessagePayload,
+        )
 
         first_event = SSEEvent(
             id=7,


### PR DESCRIPTION
## Summary

- Convert an opaque chunked-response abort into a real SSE ``event: error`` when ``svc.chat.stream_chat()`` raises mid-flight (LLM SDK errors, tool runner crashes, Pydantic serialization failures, …). Previously the browser only saw Chromium's ``TypeError: network error`` and had no way to know what actually broke.
- Log the underlying exception at ``error`` level with ``exc_info`` plus ``session_id`` / ``user_id`` / ``subagent_id`` so CloudWatch retains the traceback for postmortem.
- Treat ``asyncio.CancelledError`` (client disconnect / server shutdown) as expected — no synthetic event, no error log.

## Why now

A user reported frequent ``Error: network error`` bubbles in the chat UI on top of long-running streams. Investigation showed three layers:

1. ``ChatTaskManager._run_loop`` already converts in-loop exceptions into SSE error events. ✅
2. The route-level wrapper ``_stream_with_post_hook`` swallowed exceptions silently. ❌ — this PR.
3. Front-end shows ``Error: \${err.message}`` as-is — addressed in the parallel SaaS PR.

Heartbeats (``HEARTBEAT_INTERVAL = 10s`` in ``chat_task_manager.consume_events``) already cover proxy idle timeouts; this PR closes the remaining failure mode where the connection dies because the generator died.

## Test plan
- [x] ``pytest tests/unit_tests/api/hooks/test_chat_hooks.py -x`` — 10 passed (8 existing + 2 new).
- [x] New tests cover both branches:
  - ``test_upstream_exception_emits_error_event`` — upstream raises ``RuntimeError`` after one ``message`` event; response stream contains a synthetic ``event: error`` carrying the error type / message / session id before the exception propagates.
  - ``test_cancelled_error_is_not_swallowed`` — ``CancelledError`` is re-raised cleanly and produces **no** ``event: error``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More deterministic streaming error reporting: emits a single terminal error event with error type, message, and request id when upstream fails.
  * Does not emit synthetic error events for cancelled/disconnected streams; client disconnects are re-raised and handled gracefully.
  * Post-chat hooks now run only when a terminal success or error was observed, avoiding false usage captures.

* **Tests**
  * Added tests covering upstream exceptions and cancellation behavior for streaming.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/732)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->