### PR TITLE
[Refactor] Drop React CDN scripts from web chatbot page

### DIFF
--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -29,14 +29,11 @@ logger = get_logger(__name__)
 _TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
 
 # CDN URLs used when --chatbot-dist is NOT provided (production mode).
-_CDN_REACT_JS = "https://unpkg.com/react@18/umd/react.production.min.js"
-_CDN_REACT_DOM_JS = "https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+# React is bundled into datus-chatbot.umd.js, no separate React CDN needed.
 _CDN_CHATBOT_CSS = "https://unpkg.com/@datus/web-chatbot/dist/datus-chatbot.css"
 _CDN_CHATBOT_JS = "https://unpkg.com/@datus/web-chatbot/dist/datus-chatbot.umd.js"
 
 # Dev URLs used when --chatbot-dist IS provided (local development mode).
-_DEV_REACT_JS = "https://unpkg.com/react@18/umd/react.development.js"
-_DEV_REACT_DOM_JS = "https://unpkg.com/react-dom@18/umd/react-dom.development.js"
 _DEV_CHATBOT_CSS = "/chatbot-assets/datus-chatbot.css"
 _DEV_CHATBOT_JS = "/chatbot-assets/datus-chatbot.umd.js"
 
@@ -114,10 +111,8 @@ def create_web_app(args: argparse.Namespace) -> FastAPI:
 
     # ── Pick asset URLs based on mode ──────────────────────────────
     if use_local:
-        react_js, react_dom_js = _DEV_REACT_JS, _DEV_REACT_DOM_JS
         chatbot_css, chatbot_js = _DEV_CHATBOT_CSS, _DEV_CHATBOT_JS
     else:
-        react_js, react_dom_js = _CDN_REACT_JS, _CDN_REACT_DOM_JS
         chatbot_css, chatbot_js = _CDN_CHATBOT_CSS, _CDN_CHATBOT_JS
 
     # ── Render the HTML template ───────────────────────────────────
@@ -126,12 +121,7 @@ def create_web_app(args: argparse.Namespace) -> FastAPI:
 
     # Pre-render the static parts (asset URLs); dynamic parts (origin, user)
     # are rendered per-request so reverse proxies and alternate hostnames work.
-    static_html = (
-        html_template.replace("{{ react_js }}", react_js)
-        .replace("{{ react_dom_js }}", react_dom_js)
-        .replace("{{ chatbot_css }}", chatbot_css)
-        .replace("{{ chatbot_js }}", chatbot_js)
-    )
+    static_html = html_template.replace("{{ chatbot_css }}", chatbot_css).replace("{{ chatbot_js }}", chatbot_js)
 
     # Override the default JSON root endpoint with the chatbot page
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)

--- a/datus/cli/web/templates/index.html
+++ b/datus/cli/web/templates/index.html
@@ -6,17 +6,7 @@
     <link rel="icon" type="image/svg+xml" href="https://docs.datus.ai/assets/logo-light.png" />
     <title>Datus Chatbot</title>
 
-    <!-- React (externals) -->
-    <script
-      crossorigin
-      src="{{ react_js }}"
-    ></script>
-    <script
-      crossorigin
-      src="{{ react_dom_js }}"
-    ></script>
-
-    <!-- Datus Chatbot -->
+    <!-- Datus Chatbot (React is bundled) -->
     <link rel="stylesheet" href="{{ chatbot_css }}" />
     <script src="{{ chatbot_js }}"></script>
 

--- a/tests/unit_tests/cli/web/test_chatbot.py
+++ b/tests/unit_tests/cli/web/test_chatbot.py
@@ -75,7 +75,6 @@ class TestReadTemplate:
         assert "{{ user_name_json }}" in html
         assert "{{ chatbot_js }}" in html
         assert "{{ chatbot_css }}" in html
-        assert "{{ react_js }}" in html
 
     def test_returns_string(self):
         from datus.cli.web.chatbot import _read_template
@@ -154,7 +153,7 @@ class TestCreateWebApp:
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
 
-        from datus.cli.web.chatbot import _CDN_CHATBOT_JS, _CDN_REACT_JS, create_web_app
+        from datus.cli.web.chatbot import _CDN_CHATBOT_CSS, _CDN_CHATBOT_JS, create_web_app
 
         args = argparse.Namespace(
             datasource="test",
@@ -180,7 +179,7 @@ class TestCreateWebApp:
             resp = client.get("/")
             assert resp.status_code == 200
             assert _CDN_CHATBOT_JS in resp.text
-            assert _CDN_REACT_JS in resp.text
+            assert _CDN_CHATBOT_CSS in resp.text
 
     def test_warns_when_dist_missing(self):
         """Should warn and fall back to CDN when dist path doesn't exist."""
@@ -392,8 +391,6 @@ class TestTemplateFile:
         assert "chatbot-root" in content
         assert "{{ chatbot_js }}" in content
         assert "{{ chatbot_css }}" in content
-        assert "{{ react_js }}" in content
-        assert "{{ react_dom_js }}" in content
         assert "{{ request_origin_json }}" in content
         assert "{{ user_name_json }}" in content
 


### PR DESCRIPTION
## Why

`@datus/web-chatbot` now bundles `react` and `react-dom` directly into its UMD output (see Datus-saas PR #353). That makes the separate `unpkg` React script tags in the served chatbot page redundant — and worse, mixing a bundled React with a CDN React can produce duplicate-React runtime errors.

## Solution

- Remove `_CDN_REACT_JS`, `_CDN_REACT_DOM_JS`, `_DEV_REACT_JS`, `_DEV_REACT_DOM_JS` from `datus/cli/web/chatbot.py`, along with the `react_js` / `react_dom_js` template substitutions.
- Drop the matching `<script src="{{ react_js }}">` / `{{ react_dom_js }}` tags from `datus/cli/web/templates/index.html`. The template now only needs the chatbot CSS/JS placeholders.

## Test Cases

Updated `tests/unit_tests/cli/web/test_chatbot.py` to:
- No longer require `{{ react_js }}` / `{{ react_dom_js }}` placeholders in the rendered template.
- Replace `_CDN_REACT_JS in resp.text` with an assertion on `_CDN_CHATBOT_CSS in resp.text`, which still proves CDN URLs are wired through.

Verified: `pytest tests/unit_tests/cli/web/test_chatbot.py` — 14 passed; the 3 `TestRunWebInterface` cases fail on `main` already (unrelated mock-path issue with `datus.cli.web.config_manager`) and are out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored chatbot frontend asset delivery to use locally-served resources instead of external CDN, improving performance and reliability while reducing external dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/734)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->