### PR TITLE
[BugFix] read_file: treat max_file_size as per-read cap

### DIFF
--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -178,6 +178,10 @@ class FilesystemFuncTool(BaseTool):
             offset: Line number to start reading from (1-based). 0 means start from beginning.
             limit: Maximum number of lines to read. 0 means read all lines.
 
+        ``config.max_file_size`` bounds a single read: when neither ``offset``
+        nor ``limit`` is set it caps the whole-file size; otherwise it caps the
+        sliced output, so large files can still be read in chunks.
+
         Returns:
             dict: A dictionary with the execution result, containing these keys:
                   - 'success' (int): 1 for success, 0 for failure.
@@ -202,20 +206,41 @@ class FilesystemFuncTool(BaseTool):
             if not self._is_allowed_file(target_path):
                 return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
 
-            if target_path.stat().st_size > self.config.max_file_size:
-                return FuncToolResult(success=0, error=f"File too large: {resolved.display}")
+            max_bytes = self.config.max_file_size
+            use_slice = offset > 0 or limit > 0
 
             try:
-                content = target_path.read_text(encoding="utf-8")
-
-                if offset > 0 or limit > 0:
-                    lines = content.split("\n")
+                if use_slice:
                     start = max(0, offset - 1) if offset > 0 else 0
-                    end = start + limit if limit > 0 else len(lines)
-                    selected = lines[start:end]
+                    with target_path.open("r", encoding="utf-8") as fh:
+                        selected: List[str] = []
+                        for idx, line in enumerate(fh):
+                            if idx < start:
+                                continue
+                            if limit > 0 and len(selected) >= limit:
+                                break
+                            selected.append(line.rstrip("\n"))
                     numbered = [f"{start + i + 1}: {line}" for i, line in enumerate(selected)]
-                    return FuncToolResult(result="\n".join(numbered))
+                    result = "\n".join(numbered)
+                    if len(result.encode("utf-8")) > max_bytes:
+                        return FuncToolResult(
+                            success=0,
+                            error=(
+                                f"Read slice too large: {resolved.display} "
+                                f"(limit={max_bytes} bytes; reduce 'limit' to read a smaller range)"
+                            ),
+                        )
+                    return FuncToolResult(result=result)
 
+                if target_path.stat().st_size > max_bytes:
+                    return FuncToolResult(
+                        success=0,
+                        error=(
+                            f"File too large: {resolved.display} "
+                            f"(limit={max_bytes} bytes; use 'offset'/'limit' to read in chunks)"
+                        ),
+                    )
+                content = target_path.read_text(encoding="utf-8")
                 return FuncToolResult(result=content)
             except UnicodeDecodeError:
                 return FuncToolResult(success=0, error=f"Cannot read binary file: {resolved.display}")

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -698,9 +698,20 @@ class SubAgentTaskTool:
                             final_output = action.output
                     elif action.status == ActionStatus.SUCCESS and action.output:
                         final_output = action.output
-            except Exception:
+            except Exception as e:
+                # Surface the failure as an envelope (not a re-raise) so the
+                # parent agent can resume the partial subagent session via
+                # the returned session_id — e.g. when MaxTurnsExceeded
+                # interrupts a long workflow mid-task.
                 subagent_status = ActionStatus.FAILED
-                raise
+                logger.error(
+                    "Subagent stream error (type=%s, session_id=%s): %s",
+                    subagent_type,
+                    getattr(node, "session_id", None),
+                    e,
+                    exc_info=True,
+                )
+                final_output = {"success": False, "error": f"Subagent stream failed: {e}"}
             finally:
                 self._emit_complete_action(subagent_type, call_id, stream_start_time, tool_count, subagent_status)
                 # Release in-memory handles WITHOUT deleting the .db file — the parent
@@ -871,19 +882,26 @@ class SubAgentTaskTool:
         """Convert AgenticNode output to FuncToolResult.
 
         ``session_id`` is the subagent's session_id; when provided, it is
-        injected into every successful result dict so the parent LLM can
-        pass it back on a later task() call to resume the conversation.
-        Failure envelopes intentionally omit it.
+        injected into every result envelope — successful results carry it
+        inline alongside the payload, and failure envelopes carry it under
+        ``result`` so the parent LLM can resume the partial session
+        (e.g. after a MaxTurnsExceeded interruption) by passing it back
+        to a later task() call.
         """
+
+        def _failure(error_msg: str) -> FuncToolResult:
+            # Carry session_id under `result` so the parent can resume the
+            # partial subagent session. ``result`` is None when no session
+            # was created (e.g. errors raised before node construction).
+            result_payload = {"session_id": session_id} if session_id else None
+            return FuncToolResult(success=0, error=error_msg, result=result_payload)
+
         if not output or not isinstance(output, dict):
-            return FuncToolResult(success=0, error="No result from subagent")
+            return _failure("No result from subagent")
 
         # Check for explicit failure from subagent
         if output.get("success") is False:
-            return FuncToolResult(
-                success=0,
-                error=output.get("error") or output.get("response") or output.get("content", "Subagent failed"),
-            )
+            return _failure(output.get("error") or output.get("response") or output.get("content", "Subagent failed"))
 
         response = output.get("response", "")
         tokens = output.get("tokens_used", 0)
@@ -1055,11 +1073,14 @@ class SubAgentTaskTool:
                 '- For complex questions requiring deep exploration, call multiple task(type="explore") '
                 "in PARALLEL, each with a direction-specific prompt (schema+sample, knowledge, file)",
                 '- For quick single-direction lookups, call one task(type="explore") with a focused prompt',
-                "- Each successful task() result includes a 'session_id'. To CONTINUE refining a "
-                "prior subagent answer with full prior context (its previous SQL, schema "
-                "discoveries, reasoning), pass that session_id back as the task's 'session_id' "
-                "argument and put ONLY the diff/clarification in 'prompt' — do not re-state the "
-                "original problem. The session_id MUST be reused with the SAME 'type'.",
+                "- Each task() result — successful OR failed — includes a 'session_id' once the "
+                "subagent has started running. On success the id sits at top level of 'result'; "
+                "on failure (including MaxTurnsExceeded mid-run) it sits at 'result.session_id' "
+                "alongside the error. To CONTINUE refining a prior answer or to RESUME a "
+                "partial run with full prior context (its previous SQL, schema discoveries, "
+                "reasoning), pass that session_id back as the task's 'session_id' argument and "
+                "put ONLY the diff/clarification in 'prompt' — do not re-state the original "
+                "problem. The session_id MUST be reused with the SAME 'type'.",
                 "- Iterate-on-gen_sql example:",
                 '    Turn 1: task(type="gen_sql", prompt="Top 10 customers by revenue last quarter",',
                 '              description="customer revenue ranking")',

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -144,6 +144,24 @@ class TestReadFile:
         assert result.success == 0
         assert "too large" in result.error.lower()
 
+    def test_read_large_file_with_limit_succeeds(self, tmp_path):
+        f = tmp_path / "big.txt"
+        f.write_text("\n".join(f"line{i}" for i in range(1, 101)))
+        tool = _make_tool(str(tmp_path))
+        tool.config.max_file_size = 20
+        result = tool.read_file("big.txt", offset=1, limit=1)
+        assert result.success == 1
+        assert result.result == "1: line1"
+
+    def test_read_slice_too_large(self, tmp_path):
+        f = tmp_path / "big.txt"
+        f.write_text("\n".join(f"line{i}" for i in range(1, 101)))
+        tool = _make_tool(str(tmp_path))
+        tool.config.max_file_size = 20
+        result = tool.read_file("big.txt", offset=1, limit=50)
+        assert result.success == 0
+        assert "too large" in result.error.lower()
+
     def test_read_file_unicode_error(self, tmp_path):
         f = tmp_path / "data.txt"
         f.write_bytes(b"\xff\xfe\x00\x01")

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -2136,11 +2136,11 @@ class TestSessionPersistence:
         assert "not found on disk" in result.error
 
     @pytest.mark.asyncio
-    async def test_failure_envelope_omits_session_id(self, task_tool):
-        """Subagent failures return a clean error envelope without session_id —
-        callers know which id they sent and the failed run still leaves a (partial)
-        .db on disk should they wish to retry."""
+    async def test_failure_envelope_carries_session_id(self, task_tool):
+        """Subagent failures still expose session_id under `result` so the parent
+        can resume the partial subagent session (its .db is kept alive on disk)."""
         node = _build_persistent_mock_node(
+            session_id_to_assign="gen_sql_session_failed01",
             output={"success": False, "error": "broken"},
             status=ActionStatus.FAILED,
         )
@@ -2148,7 +2148,46 @@ class TestSessionPersistence:
             with patch.object(task_tool, "_build_node_input", return_value=Mock()):
                 result = await task_tool.task(type="gen_sql", prompt="x")
         assert result.success == 0
-        # Failure envelope: result is None, session_id never injected.
+        assert result.error  # subagent error surfaced
+        assert result.result == {"session_id": "gen_sql_session_failed01"}
+
+    @pytest.mark.asyncio
+    async def test_stream_exception_returns_session_id(self, task_tool):
+        """Mid-stream exceptions (e.g. MaxTurnsExceeded) must NOT propagate out
+        of the task tool. They are converted into a failure envelope that still
+        carries the subagent's session_id so the parent can resume the partial
+        run with `task(session_id=..., prompt=...)`."""
+        node = _build_persistent_mock_node(session_id_to_assign="gen_sql_session_maxturn1")
+
+        async def _exploding_stream(_ahm):
+            # Yield nothing — raise immediately, the way Runner propagates
+            # MaxTurnsExceeded wrapped as DatusException upward.
+            raise RuntimeError("Max turns exceeded: 30")
+            yield  # pragma: no cover — make this a generator function
+
+        node.execute_stream = _exploding_stream
+        node.execute_stream_with_interactions = _exploding_stream
+
+        with patch.object(task_tool, "_create_node", return_value=node):
+            with patch.object(task_tool, "_build_node_input", return_value=Mock()):
+                result = await task_tool.task(type="gen_sql", prompt="long task")
+
+        assert result.success == 0
+        assert "Subagent stream failed" in result.error
+        assert "Max turns exceeded" in result.error
+        assert result.result == {"session_id": "gen_sql_session_maxturn1"}
+        # Session handle release still ran in finally — partial .db survives on disk.
+        node._session_manager.close_all_sessions.assert_called_once()
+        node._session_manager.delete_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_node_creation_failure_omits_session_id(self, task_tool):
+        """When the node never gets created (e.g. _create_node raises), there is
+        no session_id to surface — the failure envelope's `result` stays None."""
+        with patch.object(task_tool, "_create_node", side_effect=RuntimeError("init boom")):
+            result = await task_tool.task(type="gen_sql", prompt="x")
+        assert result.success == 0
+        assert "Task execution failed" in result.error
         assert result.result is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File reading now supports chunked reads, allowing users to read large files in slices while respecting configured size limits.

* **Bug Fixes**
  * Improved error handling for subagent task execution with better recovery support through session persistence.
  * Enhanced error reporting to include session identifiers for easier debugging and recovery.

* **Tests**
  * Added unit tests for chunked file reading with size limit validation.
  * Added unit tests for subagent error handling and session recovery scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/735)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->