### PR TITLE
[Enhancement] Install semantic adapter from source in nightly

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -40,6 +40,13 @@ jobs:
           ref: main
           path: external/datus-scheduler-adapters
 
+      - name: Checkout datus-semantic-adapter main
+        uses: actions/checkout@v4
+        with:
+          repository: Datus-ai/datus-semantic-adapter
+          ref: main
+          path: external/datus-semantic-adapter
+
       - name: Clean up stale temp files
         run: |
           echo "Cleaning stale pytest temp directories..."
@@ -89,8 +96,11 @@ jobs:
         run: |
           uv sync
           uv pip install --upgrade --no-cache-dir \
-            "datus-semantic-metricflow>=0.1.3" \
+            --reinstall-package datus-semantic-core \
+            --reinstall-package datus-semantic-metricflow \
             pytest-playwright \
+            ./external/datus-semantic-adapter/datus-semantic-core \
+            ./external/datus-semantic-adapter/datus-semantic-metricflow \
             ./external/datus-db-adapters/datus-db-core \
             ./external/datus-db-adapters/datus-sqlalchemy \
             ./external/datus-db-adapters/datus-postgresql \


### PR DESCRIPTION
## Why

Datus nightly currently installs `datus-semantic-metricflow` from PyPI while DB, BI, and scheduler adapters are checked out from their upstream source repos. This leaves semantic adapter main less directly covered by the Datus nightly harness.

## Solution

- Check out `Datus-ai/datus-semantic-adapter` at `main` into `external/datus-semantic-adapter`.
- Install `datus-semantic-core` and `datus-semantic-metricflow` from that checkout during the nightly dependency setup.
- Keep the existing nightly suite selection unchanged.

## Test Cases

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/run-nightly.yml")'`
- `git diff --check`

`actionlint` is not installed in the local environment, so it was not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated nightly testing workflow to use local semantic adapter builds, improving test consistency and enabling faster development iteration cycles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/736)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->