### PR TITLE
[Tool] Add merge queue gate

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,169 @@
+name: "Merge Queue Gate"
+
+on:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: merge-queue-gate-${{ github.event.merge_group.head_sha || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  merge-queue-gate:
+    name: Merge Queue Gate
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-merge-queue-${{ hashFiles('requirements.txt', 'requirements-test.txt', 'pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-merge-queue-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+          pip install --upgrade --no-cache-dir datus-semantic-metricflow==0.2.2
+          pip install packaging==26.2
+
+      - name: Check release metadata
+        run: python3 ci/check_release_readiness.py
+
+      - name: Setup config file
+        run: |
+          cp /home/datus_ci/ci_template/agent.yml conf/agent.yml
+          cp /home/datus_ci/ci_template/ci.env .env
+
+      - name: Restore tracked test config
+        run: git restore --source=HEAD --worktree --staged tests/conf/agent.yml
+
+      - name: Isolate test data directory
+        run: |
+          DATUS_TEST_HOME="${GITHUB_WORKSPACE}/.datus_test_data"
+          echo "DATUS_TEST_HOME=$DATUS_TEST_HOME" >> "$GITHUB_ENV"
+          sed -i "s|home: .datus_test_data|home: $DATUS_TEST_HOME|g" tests/conf/agent.yml
+          sed -i "s|project_root: .datus_test_data/workspace|project_root: $DATUS_TEST_HOME/workspace|g" tests/conf/agent.yml
+
+      - name: Load environment variables
+        run: |
+          while IFS= read -r line || [ -n "$line" ]; do
+            if [[ ! -z "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+              var_value=$(echo "$line" | cut -d'=' -f2-)
+              echo "::add-mask::$var_value"
+              echo "$line" >> "$GITHUB_ENV"
+            fi
+          done < .env
+
+      - name: Run deterministic merge queue suites
+        run: python3 ci/run-merge-queue-tests.py
+
+      - name: Upload merge queue artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: merge-queue-results
+          path: |
+            ci/merge-queue-results.json
+            ci/test-results-merge-*.xml
+
+  notify-failure:
+    name: Notify Merge Queue Failure
+    needs:
+      - merge-queue-gate
+    if: ${{ always() && needs.merge-queue-gate.result == 'failure' }}
+    runs-on: self-hosted
+    steps:
+      - name: Send Feishu failure notification
+        uses: actions/github-script@v7
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_NOTIFY_CI_URL }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        with:
+          script: |
+            const https = require('https');
+            const webhook = process.env.FEISHU_WEBHOOK_URL;
+            if (!webhook) {
+              core.warning('FEISHU_WEBHOOK_URL is not set; skipping Feishu notification.');
+              return;
+            }
+
+            const needs = JSON.parse(process.env.NEEDS_JSON || '{}');
+            const failedJobs = Object.entries(needs)
+              .filter(([, job]) => job.result === 'failure')
+              .map(([name]) => name)
+              .join(', ') || 'unknown';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const messageBody = `## Merge Queue Failure
+
+            **Repository:** ${context.repo.owner}/${context.repo.repo}
+            **Workflow:** ${context.workflow}
+            **Event:** ${context.eventName}
+            **Ref:** ${context.ref}
+            **SHA:** ${context.sha}
+            **Failed jobs:** ${failedJobs}
+            **Run:** [#${context.runNumber}](${runUrl})
+
+            *Automated Feishu notification from GitHub Actions.*`;
+
+            const url = new URL(webhook);
+            const data = JSON.stringify({
+              msg_type: 'interactive',
+              card: {
+                type: 'template',
+                data: {
+                  template_id: 'AAqz7JC34dHlY',
+                  template_version_name: '1.0.0',
+                  template_variable: {
+                    report_result: messageBody,
+                  },
+                },
+              },
+            });
+
+            await new Promise((resolve) => {
+              const req = https.request(
+                {
+                  hostname: url.hostname,
+                  port: url.port || 443,
+                  path: url.pathname + url.search,
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': Buffer.byteLength(data),
+                  },
+                },
+                (res) => {
+                  res.resume();
+                  res.on('end', () => {
+                    if (res.statusCode >= 400) {
+                      core.warning(`Feishu notification returned HTTP ${res.statusCode}`);
+                    } else {
+                      console.log(`Feishu notification sent: ${res.statusCode}`);
+                    }
+                    resolve();
+                  });
+                },
+              );
+              req.on('error', (error) => {
+                core.warning(`Error sending Feishu notification: ${error.message}`);
+                resolve();
+              });
+              req.write(data);
+              req.end();
+            });

--- a/ci/run-merge-queue-tests.py
+++ b/ci/run-merge-queue-tests.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Run deterministic suites for GitHub merge queue."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = REPO_ROOT / "ci"
+DEFAULT_REPORT = OUT_DIR / "merge-queue-results.json"
+DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("MERGE_QUEUE_TEST_TIMEOUT", "1800"))
+
+FULL_UNIT_TARGETS = ("tests/unit_tests/",)
+FULL_UNIT_MARK_EXPR = "not nightly and not quarantine"
+ACCEPTANCE_MARK_EXPR = "acceptance"
+
+
+def log(message: str) -> None:
+    print(f"[merge-queue] {message}", flush=True)
+
+
+def load_pr_acceptance_targets() -> list[str]:
+    """Reuse the PR harness target list so PR and merge-queue coverage stay aligned."""
+    module_path = REPO_ROOT / "ci" / "run-pr-tests.py"
+    module_spec = importlib.util.spec_from_file_location("_run_pr_tests_for_merge_queue", module_path)
+    if module_spec is None or module_spec.loader is None:
+        raise RuntimeError(f"Unable to load PR harness targets from {module_path}")
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+
+    targets = getattr(module, "PR_ACCEPTANCE_TARGETS", None)
+    if not isinstance(targets, list) or not all(isinstance(target, str) for target in targets):
+        raise RuntimeError("ci/run-pr-tests.py PR_ACCEPTANCE_TARGETS must be a list of strings")
+    return targets
+
+
+def acceptance_integration_targets(targets: Sequence[str]) -> list[str]:
+    return [target for target in targets if target.startswith("tests/integration/")]
+
+
+def existing_paths(paths: Sequence[str]) -> list[str]:
+    existing: list[str] = []
+    for item in paths:
+        path = REPO_ROOT / item
+        if path.exists():
+            existing.append(item)
+        else:
+            log(f"Skipping missing path: {item}")
+    return existing
+
+
+def build_pytest_command(
+    targets: Sequence[str],
+    *,
+    mark_expr: str,
+    junit_xml: Path,
+    extra_args: Sequence[str] = (),
+) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "pytest",
+        *targets,
+        "-m",
+        mark_expr,
+        "--tb=short",
+        "--showlocals",
+        "--disable-warnings",
+        f"--junitxml={junit_xml}",
+        *extra_args,
+    ]
+
+
+def run_command(command: Sequence[str], *, suite_name: str, timeout: int) -> int:
+    log(f"Running {suite_name}: {' '.join(command)}")
+    try:
+        completed = subprocess.run(list(command), cwd=REPO_ROOT, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log(f"{suite_name} timed out after {timeout}s")
+        return 1
+    log(f"{suite_name} exited with code {completed.returncode}")
+    return completed.returncode
+
+
+def suite_definitions() -> dict[str, dict[str, Any]]:
+    acceptance_targets = acceptance_integration_targets(load_pr_acceptance_targets())
+    return {
+        "full-unit": {
+            "description": "Full deterministic unit suite excluding nightly and quarantined tests.",
+            "targets": list(FULL_UNIT_TARGETS),
+            "mark_expr": FULL_UNIT_MARK_EXPR,
+            "junit_xml": OUT_DIR / "test-results-merge-full-unit.xml",
+            "extra_args": ["--timeout=300", "--dist=loadscope", "-n", "auto"],
+        },
+        "acceptance-integration": {
+            "description": "Deterministic acceptance integration coverage reused from the PR harness.",
+            "targets": acceptance_targets,
+            "mark_expr": ACCEPTANCE_MARK_EXPR,
+            "junit_xml": OUT_DIR / "test-results-merge-acceptance.xml",
+            "extra_args": ["--timeout=300"],
+        },
+    }
+
+
+def run_suite(name: str, suite: dict[str, Any], *, timeout: int) -> dict[str, Any]:
+    targets = existing_paths(suite["targets"])
+    if not targets:
+        log(f"{name} has no existing targets")
+        return {"suite": name, "exit_code": 1, "targets": []}
+
+    command = build_pytest_command(
+        targets,
+        mark_expr=suite["mark_expr"],
+        junit_xml=suite["junit_xml"],
+        extra_args=suite["extra_args"],
+    )
+    exit_code = run_command(command, suite_name=name, timeout=timeout)
+    return {
+        "suite": name,
+        "exit_code": exit_code,
+        "targets": targets,
+        "junit_xml": str(suite["junit_xml"].relative_to(REPO_ROOT)),
+    }
+
+
+def write_report(results: Sequence[dict[str, Any]], path: Path | None = None) -> None:
+    report_path = path or DEFAULT_REPORT
+    payload = {
+        "status": "success" if all(result["exit_code"] == 0 for result in results) else "failure",
+        "results": list(results),
+    }
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    log(f"Wrote report to {report_path.relative_to(REPO_ROOT)}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run deterministic merge queue suites")
+    parser.add_argument(
+        "--suite",
+        action="append",
+        choices=("full-unit", "acceptance-integration"),
+        help="Run one suite. Defaults to all merge queue suites.",
+    )
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Per-suite timeout in seconds")
+    args = parser.parse_args(argv)
+
+    suites = suite_definitions()
+    selected_names = args.suite or list(suites)
+    results = [run_suite(name, suites[name], timeout=args.timeout) for name in selected_names]
+    write_report(results)
+    return 0 if all(result["exit_code"] == 0 for result in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_tests/ci/test_run_merge_queue_tests.py
+++ b/tests/unit_tests/ci/test_run_merge_queue_tests.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "run-merge-queue-tests.py"
+
+
+@pytest.fixture()
+def run_merge_queue_tests():
+    module_spec = importlib.util.spec_from_file_location("_test_run_merge_queue_tests", MODULE_PATH)
+    if module_spec is None or module_spec.loader is None:
+        raise AssertionError(f"Unable to load run-merge-queue-tests from {MODULE_PATH}")
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+    return module
+
+
+def test_acceptance_integration_targets_filters_unit_targets(run_merge_queue_tests):
+    targets = [
+        "tests/unit_tests/agent/node/test_chat_agentic_node.py",
+        "tests/integration/api/test_api.py",
+        "tests/integration/cli/test_cli_commands.py",
+    ]
+
+    assert run_merge_queue_tests.acceptance_integration_targets(targets) == [
+        "tests/integration/api/test_api.py",
+        "tests/integration/cli/test_cli_commands.py",
+    ]
+
+
+def test_build_pytest_command_includes_marker_junit_and_extra_args(tmp_path, run_merge_queue_tests):
+    junit_xml = tmp_path / "results.xml"
+
+    command = run_merge_queue_tests.build_pytest_command(
+        ["tests/unit_tests/"],
+        mark_expr="not nightly",
+        junit_xml=junit_xml,
+        extra_args=["--timeout=300", "-n", "auto"],
+    )
+
+    assert command[:4] == [run_merge_queue_tests.sys.executable, "-m", "pytest", "tests/unit_tests/"]
+    assert command[4:6] == ["-m", "not nightly"]
+    assert f"--junitxml={junit_xml}" in command
+    assert ["--timeout=300", "-n", "auto"] == command[-3:]
+
+
+def test_main_runs_selected_suite_and_writes_report(tmp_path, monkeypatch, run_merge_queue_tests):
+    repo_root = tmp_path
+    out_dir = repo_root / "ci"
+    tests_dir = repo_root / "tests" / "unit_tests"
+    out_dir.mkdir(parents=True)
+    tests_dir.mkdir(parents=True)
+    calls = []
+
+    class CompletedProcess:
+        returncode = 0
+
+    def fake_run(command, **kwargs):
+        calls.append({"command": command, "cwd": kwargs["cwd"], "timeout": kwargs["timeout"]})
+        return CompletedProcess()
+
+    monkeypatch.setattr(run_merge_queue_tests, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(run_merge_queue_tests, "OUT_DIR", out_dir)
+    monkeypatch.setattr(run_merge_queue_tests, "DEFAULT_REPORT", out_dir / "merge-queue-results.json")
+    monkeypatch.setattr(run_merge_queue_tests.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        run_merge_queue_tests,
+        "load_pr_acceptance_targets",
+        lambda: ["tests/integration/api/test_api.py"],
+    )
+
+    assert run_merge_queue_tests.main(["--suite", "full-unit", "--timeout", "10"]) == 0
+
+    assert calls == [
+        {
+            "command": run_merge_queue_tests.build_pytest_command(
+                ["tests/unit_tests/"],
+                mark_expr="not nightly and not quarantine",
+                junit_xml=out_dir / "test-results-merge-full-unit.xml",
+                extra_args=["--timeout=300", "--dist=loadscope", "-n", "auto"],
+            ),
+            "cwd": repo_root,
+            "timeout": 10,
+        }
+    ]
+    assert '"status": "success"' in (out_dir / "merge-queue-results.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Why

Datus-agent currently has PR checks, but no merge queue workflow. The repository cannot make merge queue checks required until a deterministic `merge_group` workflow exists.

## Solution

- add a dedicated `Merge Queue Gate` workflow triggered by `merge_group` and manual dispatch only
- run release metadata validation before the test suites
- add `ci/run-merge-queue-tests.py` for deterministic merge queue suites:
  - full unit suite excluding `nightly` and `quarantine`
  - deterministic acceptance integration targets reused from the PR harness
- upload merge queue JUnit/report artifacts
- reuse the existing Feishu CI webhook for merge queue failure notifications

## Test Cases

- `uv run ruff format --check ci/run-merge-queue-tests.py tests/unit_tests/ci/test_run_merge_queue_tests.py`
- `uv run ruff check ci/run-merge-queue-tests.py tests/unit_tests/ci/test_run_merge_queue_tests.py`
- `uv run pytest tests/unit_tests/ci/test_run_merge_queue_tests.py tests/unit_tests/ci/test_run_pr_tests.py tests/unit_tests/ci/test_check_release_readiness.py -q`
- `uv run python ci/run-merge-queue-tests.py --suite acceptance-integration --timeout 300` (`65 passed, 16 deselected`)
- `uv run python ci/run-merge-queue-tests.py --suite full-unit --timeout 1800` (`12591 passed, 6 skipped, 1 xfailed` after installing the same `datus-semantic-metricflow` dependency used by the workflow)
- `python3 ci/audit_tests.py --repo-root . --diff-only upstream/main --json /tmp/datus-agent-merge-queue-audit.json --github-output`
- YAML parse check for `.github/workflows/merge-queue.yml`
- `python3 ci/check_release_readiness.py`
- `git diff --check --cached`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new GitHub Actions workflow to run a merge-queue gate with automated merge readiness checks and failure notifications via webhook.
  * Added a CLI to run deterministic merge-queue test suites (unit and acceptance/integration) and produce consolidated test reports.
  * Added unit tests covering the merge-queue test runner and reporting behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/743)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/743)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->