### PR TITLE
[Tool] Add PR trigger for merge queue gate

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,6 +1,11 @@
 name: "Merge Queue Gate"
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
   merge_group:
   workflow_dispatch:
 
@@ -14,6 +19,7 @@ permissions:
 jobs:
   merge-queue-gate:
     name: Merge Queue Gate
+    if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
     runs-on: self-hosted
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- add a pull_request trigger to the merge queue workflow so the required check context is visible on PRs
- keep the actual merge queue gate job limited to merge_group and manual workflow_dispatch events
- align the trigger split with the adapter CI pattern: PR events create the check, merge queue events run the heavy suites

## Validation
- uv run python workflow YAML assertion
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized merge queue validation workflow to run conditionally on merge group events or manual triggers, reducing unnecessary workflow executions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/744)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->