### PR TITLE
[Enhancement] Pin @datus/web-chatbot CDN version to 1.1.3

### DIFF
--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -30,8 +30,9 @@ _TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
 
 # CDN URLs used when --chatbot-dist is NOT provided (production mode).
 # React is bundled into datus-chatbot.umd.js, no separate React CDN needed.
-_CDN_CHATBOT_CSS = "https://unpkg.com/@datus/web-chatbot/dist/datus-chatbot.css"
-_CDN_CHATBOT_JS = "https://unpkg.com/@datus/web-chatbot/dist/datus-chatbot.umd.js"
+_CDN_CHATBOT_VERSION = "1.1.3"
+_CDN_CHATBOT_CSS = f"https://unpkg.com/@datus/web-chatbot@{_CDN_CHATBOT_VERSION}/dist/datus-chatbot.css"
+_CDN_CHATBOT_JS = f"https://unpkg.com/@datus/web-chatbot@{_CDN_CHATBOT_VERSION}/dist/datus-chatbot.umd.js"
 
 # Dev URLs used when --chatbot-dist IS provided (local development mode).
 _DEV_CHATBOT_CSS = "/chatbot-assets/datus-chatbot.css"


### PR DESCRIPTION
## Why

`datus web` loads the chatbot frontend from unpkg using an unversioned URL (`@datus/web-chatbot/dist/...`), which always resolves to the latest published tag. Any upstream npm release immediately ships to every running server, leaving no way to roll back or reproduce a specific frontend build alongside this backend.

## Solution

Pin the CDN URLs in `datus/cli/web/chatbot.py` to `@datus/web-chatbot@1.1.3` via a single `_CDN_CHATBOT_VERSION` constant, so production deployments load a deterministic bundle. Local-dev mode (`--chatbot-dist`) is unchanged.

## Test Cases

No new tests. This is a constant-only change to two hardcoded CDN URLs; existing template-rendering paths in `datus/cli/web/chatbot.py` already cover URL substitution and behavior is identical aside from the pinned version segment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chatbot frontend asset versioning to explicitly use version 1.1.3 in production, transitioning from unversioned package paths to explicitly versioned CDN asset URLs for improved deployment consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/755)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->