### PR TITLE
[Enhancement] Default semantic layer to metricflow

### DIFF
--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1256,18 +1256,18 @@ class AgentConfig:
                 ),
             )
 
-        if not self.semantic_layer_configs:
-            return DEFAULT_SEMANTIC_ADAPTER
-
         active_override = self._active_semantic
         if active_override:
-            if active_override in self.semantic_layer_configs:
+            if not self.semantic_layer_configs or active_override in self.semantic_layer_configs:
                 return active_override
             logger.warning(
                 "Project override active_semantic=`%s` is not configured under "
                 "`agent.services.semantic_layer`; falling back to global default.",
                 active_override,
             )
+
+        if not self.semantic_layer_configs:
+            return DEFAULT_SEMANTIC_ADAPTER
 
         default_adapter = self.default_semantic_adapter()
         if default_adapter:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -40,6 +40,8 @@ _PROJECT_NAME_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 # We leave room for prefixes/extensions by truncating to 200 chars + md5 suffix.
 _PROJECT_NAME_MAX_LEN = 200
 
+DEFAULT_SEMANTIC_ADAPTER = "metricflow"
+
 
 def _normalize_project_name(cwd: str) -> str:
     """Sanitize a CWD path into a flat, filesystem-safe project name.
@@ -1238,14 +1240,13 @@ class AgentConfig:
 
         Order: explicit ``adapter_type`` argument -> project-level pin
         (``./.datus/config.yml`` ``semantic:``) -> global ``default: true``
-        flag / single-entry shortcut. Raises when no semantic layer is
-        configured at all, or when multiple are configured without a clear
-        default — this matches the Dashboard / Scheduler resolution
-        contract so all three sections behave identically.
+        flag / single-entry shortcut -> built-in ``metricflow`` fallback when
+        no semantic layer is configured. Raises when multiple semantic layers
+        are configured without a clear default.
         """
         normalized = str(adapter_type or "").lower().strip()
         if normalized:
-            if normalized in self.semantic_layer_configs:
+            if not self.semantic_layer_configs or normalized in self.semantic_layer_configs:
                 return normalized
             raise DatusException(
                 ErrorCode.COMMON_CONFIG_ERROR,
@@ -1256,13 +1257,7 @@ class AgentConfig:
             )
 
         if not self.semantic_layer_configs:
-            raise DatusException(
-                ErrorCode.COMMON_CONFIG_ERROR,
-                message=(
-                    "No semantic layer configured under `agent.services.semantic_layer`. "
-                    "Add an entry (e.g. `metricflow: {}`) or run `/services semantic` to configure one."
-                ),
-            )
+            return DEFAULT_SEMANTIC_ADAPTER
 
         active_override = self._active_semantic
         if active_override:

--- a/datus/tools/func_tool/context_search.py
+++ b/datus/tools/func_tool/context_search.py
@@ -204,9 +204,9 @@ class ContextSearchTools:
     @mcp_tool()
     def list_subject_tree(self) -> FuncToolResult:
         """
-        Get the domain-layer taxonomy from subject_tree store with metrics and SQL counts.
-        Use this as the first step to discover available metrics, reference SQL, and knowledge
-        before calling get_metrics, get_reference_sql, or get_knowledge.
+        Get the domain-layer taxonomy from subject_tree store.
+        Use this as the first step to discover available context entries before calling
+        enabled context retrieval tools.
 
         The response has the structure:
         {
@@ -214,7 +214,7 @@ class ContextSearchTools:
                 "<layer1>": {
                     "<layer2>": {
                         "metrics": <[name1, name2, ...], optional>,
-                        "reference_sql": <[name1, name2, ...], optional>
+                        "reference_sql": <[name1, name2, ...], optional>,
                         "knowledge": <[name1, name2, ...], optional>
                     },
                     ...

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -526,29 +526,40 @@ class TestAgentConfigServiceSelectors:
         )
         assert cfg.resolve_semantic_adapter() == "metricflow"
 
-    def test_resolve_semantic_adapter_raises_when_no_service_configured(self, tmp_path):
-        """The implicit metricflow fallback was removed: callers must
-        explicitly configure at least one entry under
-        ``services.semantic_layer``. The error message points the user at
-        the YAML or the ``/services semantic`` TUI."""
+    def test_resolve_semantic_adapter_defaults_to_metricflow_when_no_service_configured(self, tmp_path):
         cfg = self._make(
             tmp_path,
             services={
                 "datasources": {},
             },
         )
-        with pytest.raises(DatusException, match="No semantic layer configured"):
-            cfg.resolve_semantic_adapter()
+        assert cfg.resolve_semantic_adapter() == "metricflow"
 
-    def test_build_semantic_adapter_config_raises_when_no_service_configured(self, tmp_path):
+    def test_explicit_semantic_adapter_wins_when_no_service_configured(self, tmp_path):
         cfg = self._make(
             tmp_path,
             services={
                 "datasources": {},
             },
         )
-        with pytest.raises(DatusException, match="No semantic layer configured"):
-            cfg.build_semantic_adapter_config()
+        assert cfg.resolve_semantic_adapter("dbt") == "dbt"
+
+    def test_build_semantic_adapter_config_defaults_to_metricflow_when_no_service_configured(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {
+                    "demo": {
+                        "type": "duckdb",
+                        "uri": "duckdb:///:memory:",
+                        "default": True,
+                    }
+                },
+            },
+        )
+        config = cfg.build_semantic_adapter_config()
+        assert config["type"] == "metricflow"
+        assert config["datasource"] == "demo"
 
     def test_file_datasource_preserves_adapter_specific_extra_fields(self, tmp_path):
         cfg = self._make(

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -544,6 +544,16 @@ class TestAgentConfigServiceSelectors:
         )
         assert cfg.resolve_semantic_adapter("dbt") == "dbt"
 
+    def test_active_semantic_pin_wins_when_no_service_configured(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {},
+            },
+        )
+        cfg.set_active_semantic("dbt", persist=False)
+        assert cfg.resolve_semantic_adapter() == "dbt"
+
     def test_build_semantic_adapter_config_defaults_to_metricflow_when_no_service_configured(self, tmp_path):
         cfg = self._make(
             tmp_path,

--- a/tests/unit_tests/tools/func_tool/test_context_search_scope.py
+++ b/tests/unit_tests/tools/func_tool/test_context_search_scope.py
@@ -68,6 +68,25 @@ def test_list_subject_tree_scope_does_not_expose_query_tools():
     assert tool_names == {"list_subject_tree"}
 
 
+def test_list_subject_tree_description_does_not_name_disabled_context_tools():
+    tools = _build_tools(
+        {
+            "tools": (
+                "context_search_tools.search_metrics,context_search_tools.list_subject_tree,db_tools,date_parsing_tools"
+            )
+        }
+    )
+
+    available_tools = tools.available_tools()
+    tool_names = {tool.name for tool in available_tools}
+    subject_tree_tool = next(tool for tool in available_tools if tool.name == "list_subject_tree")
+
+    assert tool_names == {"list_subject_tree", "search_metrics", "get_metrics"}
+    assert "enabled context retrieval tools" in subject_tree_tool.description
+    assert "get_reference_sql" not in subject_tree_tool.description
+    assert "get_knowledge" not in subject_tree_tool.description
+
+
 def test_missing_sub_agent_config_uses_default_context_tools():
     tools = _build_tools({})
 

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -453,6 +453,36 @@ class TestAvailableTools:
             tools = semantic_tools_ext.available_tools()
         assert len(tools) == 3
 
+    def test_default_metricflow_adapter_exposes_validate_tool(self):
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+            patch(
+                "datus.tools.func_tool.semantic_tools.semantic_adapter_registry.create_adapter",
+                side_effect=RuntimeError("adapter unavailable"),
+            ),
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: adapter_type or "metricflow"
+            config.build_semantic_adapter_config.side_effect = lambda adapter_type=None: {"datasource": "ns1"}
+            tool = SemanticTools(agent_config=config)
+
+            with patch("datus.tools.func_tool.semantic_tools.trans_to_function_tool") as mock_trans:
+
+                def _mock_tool(func):
+                    tool = Mock()
+                    tool.name = func.__name__
+                    return tool
+
+                mock_trans.side_effect = _mock_tool
+                tools = tool.available_tools()
+
+        names = [tool.name for tool in tools]
+        assert "validate_semantic" in names
+
     def test_with_adapter_adds_validate_and_attribution_tools(self):
         with (
             patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),


### PR DESCRIPTION
## Why

`agent.services.semantic_layer` currently defaults to an empty section, so semantic model and metrics flows fail to expose `validate_semantic` unless users explicitly configure `metricflow: {}`. This breaks benchmark/bootstrap flows that expect MetricFlow to be the built-in semantic adapter.

`list_subject_tree` also used static guidance that named `get_knowledge` and `get_reference_sql` even when those tools were not enabled for the current sub-agent. In metrics-only benchmark agents this can steer the model into calling disabled tools and cause avoidable retries.

Closes #757.
Closes #759.

## Solution

Default semantic adapter resolution to `metricflow` when no semantic layer entries are configured, while preserving explicit node-level adapter selection and the existing single-entry/default-flag behavior for configured semantic layers.

Make `list_subject_tree` guidance neutral by referring to enabled context retrieval tools instead of naming tools that may be disabled by sub-agent scope. Add regression coverage for metrics-only scope so the description no longer exposes `get_knowledge` or `get_reference_sql`.

## Test Cases

- `uv run pytest tests/unit_tests/configuration/test_agent_config.py tests/unit_tests/tools/func_tool/test_semantic_tools.py -q`
- `uv run ruff check datus/configuration/agent_config.py tests/unit_tests/configuration/test_agent_config.py tests/unit_tests/tools/func_tool/test_semantic_tools.py`
- `uv run pytest tests/unit_tests/tools/func_tool/test_context_search_scope.py tests/unit_tests/tools/func_tool/test_context_search.py -q`
- `uv run ruff check datus/tools/func_tool/context_search.py tests/unit_tests/tools/func_tool/test_context_search_scope.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic adapter now defaults to "metricflow" when not explicitly configured.
  * Explicit adapter selection is honored even when no semantic-layer services are configured.

* **Documentation**
  * Clarified context search tool output format with explicit optional fields.

* **Tests**
  * Added and updated tests for adapter fallback behavior and tool availability/description scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/758)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
