### PR TITLE
[Tool] Use code quality checks for merge queue

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,9 +6,10 @@ on:
       - opened
       - synchronize
       - reopened
+  merge_group:
 
 concurrency:
-  group: code-quality-${{ github.event.pull_request.number }}
+  group: code-quality-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -17,10 +18,10 @@ permissions:
 
 jobs:
   format-check:
-    if: ${{ !startsWith(github.event.pull_request.title, '[Doc]') && !startsWith(github.event.pull_request.title, '[doc]') }}
+    if: ${{ github.event_name == 'merge_group' || (!startsWith(github.event.pull_request.title, '[Doc]') && !startsWith(github.event.pull_request.title, '[doc]')) }}
     uses: ./.github/workflows/python-format-check.yml
 
   run-coverage:
     needs: format-check
-    if: ${{ !startsWith(github.event.pull_request.title, '[Doc]') && !startsWith(github.event.pull_request.title, '[doc]') }}
+    if: ${{ github.event_name == 'merge_group' || (!startsWith(github.event.pull_request.title, '[Doc]') && !startsWith(github.event.pull_request.title, '[doc]')) }}
     uses: ./.github/workflows/run-ut-and-coverage.yml

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,12 +1,6 @@
 name: "Merge Queue Gate"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/python-format-check.yml
+++ b/.github/workflows/python-format-check.yml
@@ -9,12 +9,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
 
       - name: Debug - Show current commit
         run: |
           echo "Current HEAD: $(git rev-parse HEAD)"
-          echo "Expected PR head: ${{ github.event.pull_request.head.sha }}"
+          echo "Expected head: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}"
 
       - name: Set up python
         uses: actions/setup-python@v5

--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -10,11 +10,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref || github.ref_name }}
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name }}"
+          BASE_REF="${BASE_REF#refs/heads/}"
+          git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -73,10 +76,13 @@ jobs:
 
       - name: Run tests and extract coverage
         id: metrics
-        run: python3 ci/run-pr-tests.py "${{ github.event.pull_request.base.ref || github.ref_name }}"
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name }}"
+          BASE_REF="${BASE_REF#refs/heads/}"
+          python3 ci/run-pr-tests.py "$BASE_REF"
 
       - name: Post coverage comment
-        if: always() && steps.metrics.outcome != 'cancelled'
+        if: ${{ always() && github.event_name == 'pull_request_target' && steps.metrics.outcome != 'cancelled' }}
         uses: actions/github-script@v7
         env:
           METRIC_OVERALL: ${{ steps.metrics.outputs.overall }}


### PR DESCRIPTION
## Why

The repository ruleset now uses the existing `format-check / format-check` and `run-coverage / coverage` checks as the merge queue gate. Those checks already run for PRs, but the Code Quality workflow did not report them for `merge_group` refs, so merge queue validation could not use the same required checks.

## Solution

- Add `merge_group` to the Code Quality workflow.
- Make reusable format and coverage workflows resolve the PR head, merge-group head, or current SHA as appropriate.
- Normalize the base ref before running the PR test harness for merge-group events.
- Skip posting PR coverage comments outside `pull_request_target`.
- Leave the old Merge Queue Gate as `workflow_dispatch` only so it does not duplicate automatic merge queue testing.

## Test Cases

- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check upstream/main...HEAD`
- `actionlint` not available locally (`command -v actionlint` returned empty)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to improve merge queue handling and CI/CD execution logic. Refined workflow triggers and execution conditions to better support the merge queue process while maintaining code quality checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/760)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->