### PR TITLE
[Tool] Publish docs PR format check context

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,6 +21,14 @@ jobs:
     if: ${{ github.event_name == 'merge_group' || (github.event_name == 'pull_request_target' && !startsWith(github.event.pull_request.title, '[Doc]') && !startsWith(github.event.pull_request.title, '[doc]')) }}
     uses: ./.github/workflows/python-format-check.yml
 
+  format-check-doc-context:
+    name: format-check / format-check
+    if: ${{ github.event_name == 'pull_request_target' && (startsWith(github.event.pull_request.title, '[Doc]') || startsWith(github.event.pull_request.title, '[doc]')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish docs PR format context
+        run: echo "format-check is skipped for documentation PRs."
+
   run-coverage:
     needs: format-check
     if: ${{ github.event_name == 'pull_request_target' && !startsWith(github.event.pull_request.title, '[Doc]') && !startsWith(github.event.pull_request.title, '[doc]') }}


### PR DESCRIPTION
## Summary
- add a docs-PR placeholder job for the required `format-check / format-check` context
- keep real format checks skipped for `[Doc]` PRs

## Testing
- Not run; workflow-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Format checking is now skipped for documentation-only pull requests, streamlining the review process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/766)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->