### PR TITLE
[Tool] Prepare datus-agent 0.3.0 version

### DIFF
--- a/datus/__init__.py
+++ b/datus/__init__.py
@@ -11,4 +11,4 @@ import os
 # bundled backup. User can opt back in by setting the env var to "false".
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Project basic information configuration, required.
 [project]
 name = "datus-agent"
-version = "0.2.6"
+version = "0.3.0"
 description = "AI-powered SQL Agent for data engineering (Compiled Version)"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Why

Prepare the source package metadata for the datus-agent 0.3.0 release line.

## Solution

- Update `pyproject.toml` project version from `0.2.6` to `0.3.0`.
- Update `datus.__version__` from `0.2.6` to `0.3.0`.

## Test Cases

- `python3 ci/check_release_readiness.py --expected-version 0.3.0 --check-tag-available`
- pre-commit hooks during commit: `ruff format`, `ruff`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.3.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/767)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->