### PR TITLE
[Enhancement] Rename profile command to permission

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -77,7 +77,8 @@ agent:
 
   # ---------------------------------------------------------------------------
   # Permission profile — pick a base security posture, layer user-defined
-  # rules on top via ``rules``. Override at runtime with ``/profile``.
+  # rules on top via ``rules``. Override at runtime with ``/permission``.
+  # ``/profile`` remains as a deprecated CLI alias for compatibility.
   #
   # Profiles:
   #   normal    — Read-only allowed; all writes prompt; named destructive deny

--- a/datus/cli/profile_picker_app.py
+++ b/datus/cli/profile_picker_app.py
@@ -57,10 +57,11 @@ class ProfilePickerApp:
 
     _PROFILES = ("normal", "auto", "dangerous")
 
-    def __init__(self, console: Console, current: str = "normal"):
+    def __init__(self, console: Console, current: str = "normal", notice: Optional[str] = None):
         self._console = console
         self._current = current if current in self._PROFILES else "normal"
         self._idx = self._PROFILES.index(self._current)
+        self._notice = notice
         # Dual-mode finish hook (see ``EffortApp`` for the rationale).
         self._on_done: Optional[Callable[[Optional[str]], None]] = None
         self._app: Optional[Application] = None
@@ -161,9 +162,11 @@ class ProfilePickerApp:
             height=1,
         )
 
-        return HSplit(
+        children = [title_bar]
+        if self._notice:
+            children.append(Window(content=FormattedTextControl(self._render_notice), height=1))
+        children.extend(
             [
-                title_bar,
                 header_window,
                 Window(height=1, char="\u2500"),
                 self._list_window,
@@ -171,12 +174,16 @@ class ProfilePickerApp:
                 hint_window,
             ]
         )
+        return HSplit(children)
 
     def _render_header(self) -> List[Tuple[str, str]]:
         return [
             ("bold", "  Select permission profile"),
             ("", f"  [current: {self._current}]"),
         ]
+
+    def _render_notice(self) -> List[Tuple[str, str]]:
+        return [("ansiyellow", f"  {self._notice}")]
 
     def _render_list(self) -> List[Tuple[str, str]]:
         lines: List[Tuple[str, str]] = []

--- a/datus/cli/profile_picker_app.py
+++ b/datus/cli/profile_picker_app.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Self-contained ``/profile`` pickers rendered as prompt_toolkit ``Application``s.
+"""Self-contained ``/permission`` pickers rendered as prompt_toolkit ``Application``s.
 
 Mirrors the dual-mode pattern of the other migrated wizards
 (:mod:`datus.cli.effort_app` et al): :meth:`run` constructs a transient
@@ -85,7 +85,7 @@ class ProfilePickerApp:
             return None
         except Exception as exc:
             logger.error("ProfilePickerApp crashed: %s", exc)
-            print_error(self._console, f"/profile error: {exc}")
+            print_error(self._console, f"/permission error: {exc}")
             return None
         finally:
             self._on_done = None
@@ -234,7 +234,7 @@ class DangerousConfirmApp:
             return False
         except Exception as exc:
             logger.error("DangerousConfirmApp crashed: %s", exc)
-            print_error(self._console, f"/profile confirm error: {exc}")
+            print_error(self._console, f"/permission confirm error: {exc}")
             return False
         finally:
             self._on_done = None

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -1480,11 +1480,11 @@ class DatusCLI:
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("Failed to refresh in-memory agent config: %s", exc)
 
-    def _run_profile_picker(self, current: str) -> Optional[str]:
+    def _run_profile_picker(self, current: str, notice: Optional[str] = None) -> Optional[str]:
         """Run ProfilePickerApp embedded in TUI when available."""
         from datus.cli.profile_picker_app import ProfilePickerApp
 
-        app = ProfilePickerApp(console=self.console, current=current)
+        app = ProfilePickerApp(console=self.console, current=current, notice=notice)
         tui_app = getattr(self, "tui_app", None)
         if tui_app is not None and getattr(tui_app, "_loop", None) is not None:
             return tui_app.run_wizard(app.build_embedded_panel)
@@ -1933,10 +1933,9 @@ class DatusCLI:
     def _cmd_profile(self, args: str) -> None:
         """Deprecated alias for :meth:`_cmd_permission`."""
 
-        print_warning(self.console, "/profile is deprecated; use /permission instead.")
-        return DatusCLI._cmd_permission(self, args)
+        return DatusCLI._cmd_permission(self, args, notice="/profile is deprecated; use /permission instead.")
 
-    def _cmd_permission(self, args: str) -> None:
+    def _cmd_permission(self, args: str, notice: Optional[str] = None) -> None:
         """Open the permission profile picker and apply the choice.
 
         Delegates to ``_run_profile_picker`` / ``_run_dangerous_confirm``
@@ -1948,7 +1947,7 @@ class DatusCLI:
         from datus.tools.permission.profiles import PROFILE_NAMES, build_effective_config, get_profile
 
         current = getattr(self.agent_config, "active_profile_name", self.active_profile)
-        choice = self._run_profile_picker(current)
+        choice = self._run_profile_picker(current, notice=notice)
 
         if choice is None:
             return

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -174,7 +174,7 @@ class DatusCLI:
         self.configuration_manager = configuration_manager()
 
         # Active permission profile name. Initialized from agent_config;
-        # mutated by /profile. StatusBarProvider reads this for display.
+        # mutated by /permission. StatusBarProvider reads this for display.
         self.active_profile: str = getattr(self.agent_config, "active_profile_name", "normal")
 
         # Bind the process-wide path-manager ContextVar once so implicit callers
@@ -351,6 +351,7 @@ class DatusCLI:
             "effort": self.effort_commands.cmd_effort,
             "init": self.init_commands.cmd_init,
             "services": self.service_commands.cmd_services,
+            "permission": self._cmd_permission,
             "profile": self._cmd_profile,
         }
 
@@ -1930,7 +1931,13 @@ class DatusCLI:
         return EXIT_SENTINEL
 
     def _cmd_profile(self, args: str) -> None:
-        """Open the profile selection picker and apply the choice.
+        """Deprecated alias for :meth:`_cmd_permission`."""
+
+        print_warning(self.console, "/profile is deprecated; use /permission instead.")
+        return DatusCLI._cmd_permission(self, args)
+
+    def _cmd_permission(self, args: str) -> None:
+        """Open the permission profile picker and apply the choice.
 
         Delegates to ``_run_profile_picker`` / ``_run_dangerous_confirm``
         (inline prompt_toolkit pickers mirroring ``/agent``). Selecting

--- a/datus/cli/slash_registry.py
+++ b/datus/cli/slash_registry.py
@@ -86,9 +86,15 @@ SLASH_COMMANDS: tuple[SlashSpec, ...] = (
     SlashSpec("init", "Generate AGENTS.md for the current project", "system"),
     SlashSpec("services", "Configure dashboards/schedulers (TUI) or list read-only methods", "system"),
     SlashSpec(
-        "profile",
+        "permission",
         "Switch the permission profile (normal / auto / dangerous)",
         "system",
+    ),
+    SlashSpec(
+        "profile",
+        "Deprecated: use /permission",
+        "system",
+        hidden=True,
     ),
 )
 

--- a/datus/cli/status_bar.py
+++ b/datus/cli/status_bar.py
@@ -248,7 +248,7 @@ class StatusBarProvider:
         """Return the active profile name from the CLI, defaulting to ``normal``.
 
         The CLI owns the mutable ``active_profile`` string (initialized from
-        ``agent_config.active_profile_name`` and mutated by ``/profile``).
+        ``agent_config.active_profile_name`` and mutated by ``/permission``).
         If the attribute is not yet wired (tests, early init, non-REPL paths),
         fall back to ``normal`` rather than raising.
         """

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -53,4 +53,5 @@ All slash commands available in Datus-CLI, grouped by category.
 | `/skill` | | Manage skills and marketplace | [Skill Command](skill_command.md) |
 | `/bootstrap-bi` | | Extract BI dashboard assets for sub-agent context | |
 | `/services` | | List configured service platforms and their read-only methods | |
-| `/profile` | | Switch the active CLI / agent profile | |
+| `/permission` | | Switch the active CLI / agent permission profile | |
+| `/profile` | | Deprecated alias for `/permission` | |

--- a/docs/cli/reference.zh.md
+++ b/docs/cli/reference.zh.md
@@ -53,4 +53,5 @@ Datus-CLI 中所有可用的斜杠命令，按类别分组。
 | `/skill` | | 管理技能和市场 | [Skill 命令](skill_command.zh.md) |
 | `/bootstrap-bi` | | 为子 agent 上下文提取 BI 仪表盘资产 | |
 | `/services` | | 列出已配置的服务平台及其只读方法 | |
-| `/profile` | | 切换当前 CLI / agent profile | |
+| `/permission` | | 切换当前 CLI / agent 权限配置文件 | |
+| `/profile` | | 已废弃的 `/permission` 兼容别名 | |

--- a/tests/unit_tests/cli/test_profile_command.py
+++ b/tests/unit_tests/cli/test_profile_command.py
@@ -32,13 +32,15 @@ class _FakeCLI:
 
         self._profile_responses = list(profile_responses)
         self._confirm_responses = list(confirm_responses or [])
+        self.picker_notices = []
         self.picker_calls = 0
         self.confirm_calls = 0
 
     # Instance-level overrides that the command handler finds via normal
     # attribute lookup before hitting DatusCLI's class methods.
-    def _run_profile_picker(self, current):
+    def _run_profile_picker(self, current, notice=None):
         self.picker_calls += 1
+        self.picker_notices.append(notice)
         return self._profile_responses.pop(0)
 
     def _run_dangerous_confirm(self):
@@ -86,7 +88,7 @@ def test_permission_switch_to_auto():
     assert agent_config.active_profile_name == "auto"
 
 
-def test_profile_alias_warns_then_switches():
+def test_profile_alias_shows_warning_in_picker():
     from datus.cli.repl import DatusCLI
 
     manager = PermissionManager(active_profile="normal")
@@ -97,7 +99,24 @@ def test_profile_alias_warns_then_switches():
 
     assert cli.active_profile == "auto"
     assert manager.active_profile == "auto"
-    assert any("/profile is deprecated" in str(call.args[0]) for call in cli.console.print.call_args_list)
+    assert cli.picker_notices == ["/profile is deprecated; use /permission instead."]
+
+
+def test_profile_alias_passes_warning_before_picker_selection():
+    from datus.cli.repl import DatusCLI
+
+    class _OrderCLI(_FakeCLI):
+        def _run_profile_picker(self, current, notice=None):
+            assert notice == "/profile is deprecated; use /permission instead."
+            return super()._run_profile_picker(current, notice=notice)
+
+    manager = PermissionManager(active_profile="normal")
+    agent_config = _make_agent_config("normal")
+    cli = _OrderCLI(manager, agent_config, profile_responses=["auto"])
+
+    DatusCLI._cmd_profile(cli, "")
+
+    assert cli.picker_notices == ["/profile is deprecated; use /permission instead."]
 
 
 def test_profile_switch_dangerous_requires_confirmation():
@@ -202,6 +221,7 @@ def test_profile_no_current_node_still_works():
             self.chat_commands.current_node = None
             self._profile_responses = ["auto"]
             self._confirm_responses = []
+            self.picker_notices = []
             self.picker_calls = 0
             self.confirm_calls = 0
 
@@ -221,8 +241,9 @@ def test_run_profile_picker_delegates_to_picker_app(monkeypatch):
     calls = {"run": 0}
 
     class _FakePicker:
-        def __init__(self, console, current):
+        def __init__(self, console, current, notice=None):
             assert current == "normal"
+            assert notice is None
 
         def run(self):
             calls["run"] += 1
@@ -279,9 +300,10 @@ def test_run_profile_picker_embeds_in_tui_when_loop_active(monkeypatch):
             return "auto"
 
     class _FakePicker:
-        def __init__(self, console, current):
+        def __init__(self, console, current, notice=None):
             self.console = console
             self.current = current
+            self.notice = notice
 
         def build_embedded_panel(self, done_future):
             return None  # not invoked; ``run_wizard`` is stubbed above

--- a/tests/unit_tests/cli/test_profile_command.py
+++ b/tests/unit_tests/cli/test_profile_command.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Tests for the /profile slash command handler.
+"""Tests for the /permission slash command handler and legacy /profile alias.
 
 Injects stub picker callables onto the CLI stub so we exercise handler
 logic without spinning up prompt_toolkit.
@@ -14,9 +14,9 @@ from datus.tools.permission.permission_manager import PermissionManager
 
 
 class _FakeCLI:
-    """Minimal CLI surface for /profile handler tests.
+    """Minimal CLI surface for permission command handler tests.
 
-    Exposes picker callables as instance attributes; ``_cmd_profile``
+    Exposes picker callables as instance attributes; ``_cmd_permission``
     reads them via ``self._run_profile_picker(current)`` /
     ``self._run_dangerous_confirm()`` which finds them on the instance
     before falling through to the class method.
@@ -35,7 +35,7 @@ class _FakeCLI:
         self.picker_calls = 0
         self.confirm_calls = 0
 
-    # Instance-level overrides that _cmd_profile will find via normal
+    # Instance-level overrides that the command handler finds via normal
     # attribute lookup before hitting DatusCLI's class methods.
     def _run_profile_picker(self, current):
         self.picker_calls += 1
@@ -70,6 +70,34 @@ def test_profile_switch_to_auto():
     assert manager.active_profile == "auto"
     assert manager._session_approvals == {}
     assert agent_config.active_profile_name == "auto"
+
+
+def test_permission_switch_to_auto():
+    from datus.cli.repl import DatusCLI
+
+    manager = PermissionManager(active_profile="normal")
+    agent_config = _make_agent_config("normal")
+    cli = _FakeCLI(manager, agent_config, profile_responses=["auto"])
+
+    DatusCLI._cmd_permission(cli, "")
+
+    assert cli.active_profile == "auto"
+    assert manager.active_profile == "auto"
+    assert agent_config.active_profile_name == "auto"
+
+
+def test_profile_alias_warns_then_switches():
+    from datus.cli.repl import DatusCLI
+
+    manager = PermissionManager(active_profile="normal")
+    agent_config = _make_agent_config("normal")
+    cli = _FakeCLI(manager, agent_config, profile_responses=["auto"])
+
+    DatusCLI._cmd_profile(cli, "")
+
+    assert cli.active_profile == "auto"
+    assert manager.active_profile == "auto"
+    assert any("/profile is deprecated" in str(call.args[0]) for call in cli.console.print.call_args_list)
 
 
 def test_profile_switch_dangerous_requires_confirmation():
@@ -277,7 +305,7 @@ def test_run_profile_picker_embeds_in_tui_when_loop_active(monkeypatch):
 
 
 def test_profile_malformed_rules_fails_closed_to_normal():
-    """``/profile dangerous`` with a broken rules list must refuse to apply.
+    """``/permission dangerous`` with a broken rules list must refuse to apply.
 
     Mirrors startup's fail-closed: expanding permissions while silently
     dropping restrictive user overrides is the worst-case outcome.

--- a/tests/unit_tests/cli/test_slash_registry.py
+++ b/tests/unit_tests/cli/test_slash_registry.py
@@ -101,16 +101,25 @@ class TestHandlerMapAlignment:
             assert needle in source, f"Handler for '{spec.name}' missing in _build_slash_handler_map"
 
 
-def test_profile_command_registered():
+def test_permission_command_registered():
     from datus.cli.slash_registry import SLASH_COMMANDS
 
     names = {spec.name for spec in SLASH_COMMANDS}
-    assert "profile" in names
+    assert "permission" in names
 
 
-def test_profile_command_is_in_system_group():
+def test_permission_command_is_in_system_group():
+    from datus.cli.slash_registry import SLASH_COMMANDS
+
+    spec = next(s for s in SLASH_COMMANDS if s.name == "permission")
+    assert spec.group == "system"
+    assert "permission" in spec.summary.lower()  # non-empty and autocomplete-relevant
+
+
+def test_profile_command_is_hidden_deprecated_compatibility_entry():
     from datus.cli.slash_registry import SLASH_COMMANDS
 
     spec = next(s for s in SLASH_COMMANDS if s.name == "profile")
     assert spec.group == "system"
-    assert "profile" in spec.summary.lower()  # non-empty and autocomplete-relevant
+    assert spec.hidden is True
+    assert "deprecated" in spec.summary.lower()


### PR DESCRIPTION
## Why

The CLI permission-profile switcher is currently exposed as `/profile`, which is less clear now that the command specifically controls permission profiles. Users should have a clearer `/permission` command while existing shell history and docs references keep working during migration.

## Solution

- Add `/permission` as the primary slash command for switching permission profiles.
- Keep `/profile` as a hidden deprecated compatibility command that warns and delegates to `/permission`.
- Update CLI docs, example config comments, and tests for the new command surface.

## Test Cases

- `uv run pytest tests/unit_tests/cli/test_profile_command.py tests/unit_tests/cli/test_slash_registry.py tests/unit_tests/cli/test_autocomplete.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/permission` command to switch the active CLI/agent permission profile.
  * Profile picker UI can now display an optional deprecation notice when invoked.

* **Deprecations**
  * `/profile` is deprecated; remains as a compatibility alias, emits a deprecation warning and delegates to `/permission`.

* **Documentation**
  * CLI docs clarified `/permission` and marked `/profile` as deprecated; example config header updated.

* **Tests**
  * Tests updated to cover `/permission`, the `/profile` alias warning, and picker notice behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/769)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->