### PR TITLE
[Tool] Slim merge queue test gate

### DIFF
--- a/ci/run-merge-queue-tests.py
+++ b/ci/run-merge-queue-tests.py
@@ -22,16 +22,15 @@ OUT_DIR = REPO_ROOT / "ci"
 DEFAULT_REPORT = OUT_DIR / "merge-queue-results.json"
 DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("MERGE_QUEUE_TEST_TIMEOUT", "1800"))
 
-FULL_UNIT_TARGETS = ("tests/unit_tests/",)
-FULL_UNIT_MARK_EXPR = "not nightly and not quarantine"
 ACCEPTANCE_MARK_EXPR = "acceptance"
+DEFAULT_PR_HARNESS_MARK_EXPR = "acceptance or component or llm_harness"
 
 
 def log(message: str) -> None:
     print(f"[merge-queue] {message}", flush=True)
 
 
-def load_pr_acceptance_targets() -> list[str]:
+def load_pr_harness_config() -> tuple[list[str], str]:
     """Reuse the PR harness target list so PR and merge-queue coverage stay aligned."""
     module_path = REPO_ROOT / "ci" / "run-pr-tests.py"
     module_spec = importlib.util.spec_from_file_location("_run_pr_tests_for_merge_queue", module_path)
@@ -43,7 +42,14 @@ def load_pr_acceptance_targets() -> list[str]:
     targets = getattr(module, "PR_ACCEPTANCE_TARGETS", None)
     if not isinstance(targets, list) or not all(isinstance(target, str) for target in targets):
         raise RuntimeError("ci/run-pr-tests.py PR_ACCEPTANCE_TARGETS must be a list of strings")
-    return targets
+    mark_expr = getattr(module, "PR_HARNESS_MARK_EXPR", DEFAULT_PR_HARNESS_MARK_EXPR)
+    if not isinstance(mark_expr, str) or not mark_expr:
+        raise RuntimeError("ci/run-pr-tests.py PR_HARNESS_MARK_EXPR must be a non-empty string")
+    return targets, mark_expr
+
+
+def acceptance_unit_targets(targets: Sequence[str]) -> list[str]:
+    return [target for target in targets if target.startswith("tests/unit_tests/")]
 
 
 def acceptance_integration_targets(targets: Sequence[str]) -> list[str]:
@@ -95,18 +101,20 @@ def run_command(command: Sequence[str], *, suite_name: str, timeout: int) -> int
 
 
 def suite_definitions() -> dict[str, dict[str, Any]]:
-    acceptance_targets = acceptance_integration_targets(load_pr_acceptance_targets())
+    pr_acceptance_targets, pr_harness_mark_expr = load_pr_harness_config()
+    unit_targets = acceptance_unit_targets(pr_acceptance_targets)
+    integration_targets = acceptance_integration_targets(pr_acceptance_targets)
     return {
-        "full-unit": {
-            "description": "Full deterministic unit suite excluding nightly and quarantined tests.",
-            "targets": list(FULL_UNIT_TARGETS),
-            "mark_expr": FULL_UNIT_MARK_EXPR,
-            "junit_xml": OUT_DIR / "test-results-merge-full-unit.xml",
+        "acceptance-unit": {
+            "description": "Deterministic unit harness targets reused from the PR acceptance list.",
+            "targets": unit_targets,
+            "mark_expr": pr_harness_mark_expr,
+            "junit_xml": OUT_DIR / "test-results-merge-acceptance-unit.xml",
             "extra_args": ["--timeout=300", "--dist=loadscope", "-n", "auto"],
         },
         "acceptance-integration": {
             "description": "Deterministic acceptance integration coverage reused from the PR harness.",
-            "targets": acceptance_targets,
+            "targets": integration_targets,
             "mark_expr": ACCEPTANCE_MARK_EXPR,
             "junit_xml": OUT_DIR / "test-results-merge-acceptance.xml",
             "extra_args": ["--timeout=300"],
@@ -150,7 +158,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--suite",
         action="append",
-        choices=("full-unit", "acceptance-integration"),
+        choices=("acceptance-unit", "acceptance-integration"),
         help="Run one suite. Defaults to all merge queue suites.",
     )
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Per-suite timeout in seconds")

--- a/tests/unit_tests/ci/test_run_merge_queue_tests.py
+++ b/tests/unit_tests/ci/test_run_merge_queue_tests.py
@@ -31,6 +31,18 @@ def test_acceptance_integration_targets_filters_unit_targets(run_merge_queue_tes
     ]
 
 
+def test_acceptance_unit_targets_filters_integration_targets(run_merge_queue_tests):
+    targets = [
+        "tests/unit_tests/agent/node/test_chat_agentic_node.py",
+        "tests/integration/api/test_api.py",
+        "tests/integration/cli/test_cli_commands.py",
+    ]
+
+    assert run_merge_queue_tests.acceptance_unit_targets(targets) == [
+        "tests/unit_tests/agent/node/test_chat_agentic_node.py",
+    ]
+
+
 def test_build_pytest_command_includes_marker_junit_and_extra_args(tmp_path, run_merge_queue_tests):
     junit_xml = tmp_path / "results.xml"
 
@@ -68,18 +80,18 @@ def test_main_runs_selected_suite_and_writes_report(tmp_path, monkeypatch, run_m
     monkeypatch.setattr(run_merge_queue_tests.subprocess, "run", fake_run)
     monkeypatch.setattr(
         run_merge_queue_tests,
-        "load_pr_acceptance_targets",
-        lambda: ["tests/integration/api/test_api.py"],
+        "load_pr_harness_config",
+        lambda: (["tests/unit_tests/"], "acceptance or component or llm_harness"),
     )
 
-    assert run_merge_queue_tests.main(["--suite", "full-unit", "--timeout", "10"]) == 0
+    assert run_merge_queue_tests.main(["--suite", "acceptance-unit", "--timeout", "10"]) == 0
 
     assert calls == [
         {
             "command": run_merge_queue_tests.build_pytest_command(
                 ["tests/unit_tests/"],
-                mark_expr="not nightly and not quarantine",
-                junit_xml=out_dir / "test-results-merge-full-unit.xml",
+                mark_expr="acceptance or component or llm_harness",
+                junit_xml=out_dir / "test-results-merge-acceptance-unit.xml",
                 extra_args=["--timeout=300", "--dist=loadscope", "-n", "auto"],
             ),
             "cwd": repo_root,


### PR DESCRIPTION
## Why

The merge queue gate currently reruns the full deterministic unit suite for each queued merge group. Full unit coverage is already handled by nightly, and running it per merge-group makes the merge queue unnecessarily slow.

Follow-up acceptance expansion is tracked in #770.

## Solution

- Remove the `full-unit` merge queue suite.
- Add an `acceptance-unit` suite that reuses unit targets from `ci/run-pr-tests.py` `PR_ACCEPTANCE_TARGETS`.
- Reuse the PR harness marker expression for those unit targets so the merge queue gate stays aligned with the PR acceptance harness.
- Keep the existing `acceptance-integration` suite for deterministic integration acceptance targets.

## Test Cases

- `python3 -m py_compile ci/run-merge-queue-tests.py`
- pre-commit hooks during commit: `ruff format`, `ruff`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for new unit-target filtering and added assertions for the new acceptance-unit test path.
* **Chores**
  * CI test runner now derives deterministic acceptance suites from PR harness configuration and restricts runnable suites to acceptance-unit and acceptance-integration, improving harness determinism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/771)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->