### PR TITLE
[Refactor] Slug-first artifact identity for gen_visual_report / gen_visual_dashboard

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -28,8 +28,6 @@ Anything that's *byte-identical* between the two node files lives here.
 
 from __future__ import annotations
 
-import re
-from pathlib import Path
 from typing import Any, AsyncGenerator, ClassVar, Dict, Generic, List, Literal, Optional, Type, TypeVar
 
 from pydantic import BaseModel
@@ -40,7 +38,6 @@ from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.tools.func_tool import ContextSearchTools, DBFuncTool, FilesystemFuncTool
 from datus.tools.func_tool._visual_artifact_helpers import (
-    detect_referenced_artifact_ids,
     extract_artifact_result_field,
     extract_artifact_result_list,
 )
@@ -68,17 +65,11 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
     # ── Artifact-specific class variables (subclass MUST override) ─────────
 
     #: ``"report"`` | ``"dashboard"`` — used for error messages and the
-    #: fallback prompt-context key (``report_id`` / ``dashboard_id``).
+    #: fallback prompt-context key (``report_slug`` / ``dashboard_slug``).
     ARTIFACT_KIND: ClassVar[str] = ""
 
     #: Top-level workspace directory, e.g. ``"reports"`` or ``"dashboards"``.
     ARTIFACT_ROOT_DIR_NAME: ClassVar[str] = ""
-
-    #: Regex matching candidate ids inside the user message body (loose).
-    ARTIFACT_ID_INLINE_REGEX: ClassVar[re.Pattern[str]] = re.compile(r"")
-
-    #: Strict full-match regex for valid artifact ids.
-    ARTIFACT_ID_FULL_REGEX: ClassVar[re.Pattern[str]] = re.compile(r"")
 
     #: Concrete :class:`FilesystemFuncTool` subclass (e.g.
     #: ``ReportFilesystemFuncTool``) that locks out direct writes to
@@ -132,7 +123,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         # ``ReportArtifactTools`` / ``DashboardArtifactTools``); the
         # subclass instantiates it in ``_make_artifact_tools``.
         self.artifact_tools: Optional[Any] = None
-        self._active_artifact_id: Optional[str] = None
+        self._active_artifact_slug: Optional[str] = None
         # Captures the root cause when ``_setup_db_tools`` fails so
         # ``_prepare_artifacts`` can surface it instead of the generic
         # "db_tools not configured" message.
@@ -332,13 +323,14 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
 
     # ── Prompt + message wiring ───────────────────────────────────────────
 
-    def _artifact_id_prompt_key(self) -> str:
-        """Prompt-context key for the active artifact id.
+    def _artifact_slug_prompt_key(self) -> str:
+        """Prompt-context key for the active artifact slug.
 
-        Default: ``"<kind>_id"`` (i.e. ``report_id`` or ``dashboard_id``)
-        so existing Jinja templates keep working unchanged.
+        Default: ``"<kind>_slug"`` (i.e. ``report_slug`` or
+        ``dashboard_slug``) — matches what the system prompt templates
+        expect.
         """
-        return f"{self.ARTIFACT_KIND}_id"
+        return f"{self.ARTIFACT_KIND}_slug"
 
     def _get_system_prompt(
         self,
@@ -353,7 +345,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             "has_task_tool": bool(self.sub_agent_task_tool),
             "agent_config": self.agent_config,
             "conversation_summary": conversation_summary,
-            self._artifact_id_prompt_key(): self._active_artifact_id,
+            self._artifact_slug_prompt_key(): self._active_artifact_slug,
             "rules": self.node_config.get("rules", []),
             "agent_description": self.node_config.get("agent_description", ""),
         }
@@ -387,35 +379,6 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
 
         return self._finalize_system_prompt(base_prompt)
 
-    def _detect_referenced_artifact_ids(self, user_message: str, project_root: Path) -> List[str]:
-        return detect_referenced_artifact_ids(
-            user_message=user_message,
-            project_root=project_root,
-            root_dir_name=self.ARTIFACT_ROOT_DIR_NAME,
-            id_inline_regex=self.ARTIFACT_ID_INLINE_REGEX,
-            id_full_regex=self.ARTIFACT_ID_FULL_REGEX,
-        )
-
-    def _format_referenced_ids_hint(self, ids: List[str]) -> str:
-        """Build the "user mentioned existing artifact ids" awareness hint.
-
-        Default phrasing references ``ARTIFACT_KIND`` so both report and
-        dashboard read naturally without the subclass having to override
-        this. Subclasses can override for finer-grained wording.
-        """
-        kind = self.ARTIFACT_KIND
-        verb_new = f"start_new_{kind}"
-        verb_edit = f"bind_existing_{kind}"
-        return (
-            f"The user's message references existing {kind} id(s) on disk: "
-            f"{', '.join(ids)}. Decide whether they want to EDIT one of these in place "
-            f"(call {verb_edit}) or PRODUCE A NEW {kind} that draws on "
-            f"them as references (call {verb_new} and use the filesystem "
-            f"read tool on {self.ARTIFACT_ROOT_DIR_NAME}/<id>/render/*.jsx and "
-            f"{self.ARTIFACT_ROOT_DIR_NAME}/<id>/queries/* to learn from them). "
-            f"When unclear, default to {verb_new}."
-        )
-
     def _build_enhanced_message(self, user_input: InputT) -> str:
         parts: List[str] = []
         catalog = getattr(user_input, "catalog", None)
@@ -429,12 +392,6 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             parts.append(f"Database context: {database}")
         if db_schema:
             parts.append(f"Schema: {db_schema}")
-
-        if self.agent_config and getattr(self.agent_config, "project_root", None):
-            project_root = Path(self.agent_config.project_root).resolve()
-            referenced = self._detect_referenced_artifact_ids(user_message, project_root)
-            if referenced:
-                parts.append(self._format_referenced_ids_hint(referenced))
 
         if parts:
             return build_structured_content(
@@ -452,33 +409,33 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
 
         The tools instance must expose ``available_tools()`` returning the
         list of bound function-tools to add to ``self.tools``; the active
-        artifact id (after ``start_new_*`` / ``bind_existing_*``) must
+        artifact slug (after ``start_new_*`` / ``bind_existing_*``) must
         live on an attribute the subclass knows how to read (it is fetched
-        via :meth:`_read_artifact_id_from_tools`).
+        via :meth:`_read_artifact_slug_from_tools`).
         """
         raise NotImplementedError
 
-    def _read_artifact_id_from_tools(self) -> Optional[str]:
-        """Return the active artifact id off the artifact tools instance.
+    def _read_artifact_slug_from_tools(self) -> Optional[str]:
+        """Return the active artifact slug off the artifact tools instance.
 
-        Subclasses know the attribute name (``report_id`` /
-        ``dashboard_id``). Default looks for either, in priority order,
+        Subclasses know the attribute name (``report_slug`` /
+        ``dashboard_slug``). Default looks for either, in priority order,
         so a minimal subclass can rely on naming convention.
         """
         if self.artifact_tools is None:
             return None
-        for attr in (f"{self.ARTIFACT_KIND}_id", "artifact_id"):
+        for attr in (f"{self.ARTIFACT_KIND}_slug", "artifact_slug"):
             value = getattr(self.artifact_tools, attr, None)
             if value:
                 return value
         return None
 
     def _prepare_artifacts(self, user_input: InputT) -> None:
-        """Wire artifact tools into ``self.tools`` and reset the active id.
+        """Wire artifact tools into ``self.tools`` and reset the active slug.
 
         The LLM decides between ``start_new_<kind>`` (create) and
         ``bind_existing_<kind>`` (edit) at execution time; we just make
-        both tools available. ``_active_artifact_id`` stays ``None``
+        both tools available. ``_active_artifact_slug`` stays ``None``
         until the LLM commits to one or the other.
         """
         if not self.agent_config or not getattr(self.agent_config, "project_root", None):
@@ -498,7 +455,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
                 "(DEFAULT_TOOLS includes db_tools.*)."
             )
 
-        self._active_artifact_id = None
+        self._active_artifact_slug = None
         self.artifact_tools = self._make_artifact_tools()
         # Repeated ``execute_stream`` calls on the same node instance
         # would otherwise stack stale tool wrappers bound to the previous
@@ -517,7 +474,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         *,
         user_input: InputT,
         response_content: str,
-        artifact_id: Optional[str],
+        artifact_slug: Optional[str],
         app_jsx_rel_path: Optional[str],
         render_file_count: int,
         query_actions: List[ActionHistory],
@@ -532,7 +489,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         """Construct the result returned when ``execute_stream`` raises."""
         raise NotImplementedError
 
-    def _post_validate_hook(self, artifact_id: str, result: ResultT) -> None:
+    def _post_validate_hook(self, artifact_slug: str, result: ResultT) -> None:
         """Run artifact-specific work after a successful ``validate_render``.
 
         The report subagent uses this to compile a standalone HTML and
@@ -557,9 +514,11 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             "call validate_render() to finalize."
         )
 
-    def _final_summary_message(self, artifact_id: Optional[str], app_jsx_rel_path: Optional[str]) -> str:
+    def _final_summary_message(self, artifact_slug: Optional[str], app_jsx_rel_path: Optional[str]) -> str:
         if app_jsx_rel_path:
-            return f"Visual {self.ARTIFACT_KIND} generated: {self.ARTIFACT_ROOT_DIR_NAME}/{artifact_id}/render/app.jsx"
+            return (
+                f"Visual {self.ARTIFACT_KIND} generated: {self.ARTIFACT_ROOT_DIR_NAME}/{artifact_slug}/render/app.jsx"
+            )
         return f"Visual {self.ARTIFACT_KIND} run finished without a validated render/ tree."
 
     # ── Helpers re-exposed as static methods (legacy API preserved) ──────
@@ -663,17 +622,17 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
                     render_file_count = len(render_files) if render_files else 0
                     break
 
-            # The LLM picked the active artifact id by calling
+            # The LLM picked the active artifact slug by calling
             # start_new_<kind> / bind_existing_<kind>; the tools instance
-            # owns the resulting id.
-            picked = self._read_artifact_id_from_tools()
+            # owns the resulting slug.
+            picked = self._read_artifact_slug_from_tools()
             if picked:
-                self._active_artifact_id = picked
+                self._active_artifact_slug = picked
 
             result = self._build_success_result(
                 user_input=user_input,
                 response_content=response_content,
-                artifact_id=self._active_artifact_id,
+                artifact_slug=self._active_artifact_slug,
                 app_jsx_rel_path=app_jsx_rel_path,
                 render_file_count=render_file_count,
                 query_actions=query_actions,
@@ -685,21 +644,21 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             if app_jsx_rel_path is None:
                 error_msg = (
                     self._missing_binding_error()
-                    if self._active_artifact_id is None
+                    if self._active_artifact_slug is None
                     else self._incomplete_render_error()
                 )
                 # Both result models expose ``error: Optional[str]``.
                 if hasattr(result, "error"):
                     result.error = error_msg  # type: ignore[attr-defined]
-            elif self._active_artifact_id:
-                self._post_validate_hook(self._active_artifact_id, result)
+            elif self._active_artifact_slug:
+                self._post_validate_hook(self._active_artifact_slug, result)
 
             self.actions.extend(all_actions)
 
             final_action = ActionHistory.create_action(
                 role=ActionRole.ASSISTANT,
                 action_type=f"{self.get_node_name()}_response",
-                messages=self._final_summary_message(self._active_artifact_id, app_jsx_rel_path),
+                messages=self._final_summary_message(self._active_artifact_slug, app_jsx_rel_path),
                 input_data=user_input.model_dump(),
                 output_data=result.model_dump(),
                 status=ActionStatus.SUCCESS if app_jsx_rel_path else ActionStatus.FAILED,

--- a/datus/agent/node/gen_visual_dashboard_agentic_node.py
+++ b/datus/agent/node/gen_visual_dashboard_agentic_node.py
@@ -7,12 +7,13 @@ GenVisualDashboardAgenticNode — parameterized dashboard generation.
 
 Companion to ``GenVisualReportAgenticNode``. Instead of pre-baked JSON
 result files, this node produces a parameterized React-JSX dashboard
-artifact under ``<project_root>/dashboards/<id>/``:
+artifact under ``<project_root>/dashboards/<slug>/``:
 
 * ``render/app.jsx`` — the React entry module the LLM authors (default
   export); it owns the filter state and imports the chart components.
 * ``queries/<slug>.sql.j2`` + ``queries/<slug>.params.json`` — per-query
   Jinja2 SQL template plus its declared parameter metadata.
+* ``manifest.json`` — ``{slug, name, description, kind, created_at}``.
 
 At view time the backend renders the template with user-selected filter
 values and executes it live against the bound datasource — see
@@ -23,14 +24,11 @@ owns the dashboard-specific artifact wiring and result model.
 
 from __future__ import annotations
 
-import re
-from pathlib import Path
 from typing import List, Optional
 
 from datus.agent.node.base_visual_artifact_agentic_node import BaseVisualArtifactAgenticNode
 from datus.schemas.action_history import ActionHistory
 from datus.schemas.gen_visual_dashboard_models import (
-    DASHBOARD_ID_RE,
     GenVisualDashboardNodeInput,
     GenVisualDashboardNodeResult,
 )
@@ -41,12 +39,6 @@ from datus.tools.func_tool.dashboard_artifact_tools import (
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
-
-
-# Inline scan for ``dash_<id>`` mentions in the user prompt — fed to the
-# LLM as an awareness hint so it can decide between editing the
-# referenced dashboard and producing a new one inspired by it.
-_DASHBOARD_ID_INLINE_RE = re.compile(r"(?:(?<=[^a-z0-9])|^)dash_[a-z0-9][a-z0-9_-]{0,80}")
 
 
 class GenVisualDashboardAgenticNode(
@@ -60,15 +52,15 @@ class GenVisualDashboardAgenticNode(
     hardened ``DashboardFilesystemFuncTool`` that denies direct writes to
     dashboard artifact paths.
 
-    A fresh ``dashboard_id`` is allocated on every ``execute_stream`` call
-    so repeated runs against the same node produce independent artifacts.
+    The LLM chooses the ``dashboard_slug`` on every fresh
+    ``start_new_dashboard`` call; the system prompt directs it to
+    ``glob('dashboards/*')`` first so the chosen slug doesn't collide with
+    an existing one.
     """
 
     NODE_NAME = "gen_visual_dashboard"
     ARTIFACT_KIND = "dashboard"
     ARTIFACT_ROOT_DIR_NAME = "dashboards"
-    ARTIFACT_ID_INLINE_REGEX = _DASHBOARD_ID_INLINE_RE
-    ARTIFACT_ID_FULL_REGEX = DASHBOARD_ID_RE
     FILESYSTEM_TOOL_CLS = DashboardFilesystemFuncTool
     QUERY_SAVE_ACTION_TYPE = "save_query_template"
     FALLBACK_TEMPLATE_NAME = "gen_visual_dashboard_system"
@@ -76,15 +68,15 @@ class GenVisualDashboardAgenticNode(
     def get_node_name(self) -> str:
         return self.configured_node_name or self.NODE_NAME
 
-    # ────────── Legacy attribute aliases (preserved for tests / callers) ──────────
+    # ────────── Convenience accessors ──────────
 
     @property
-    def _active_dashboard_id(self) -> Optional[str]:
-        return self._active_artifact_id
+    def _active_dashboard_slug(self) -> Optional[str]:
+        return self._active_artifact_slug
 
-    @_active_dashboard_id.setter
-    def _active_dashboard_id(self, value: Optional[str]) -> None:
-        self._active_artifact_id = value
+    @_active_dashboard_slug.setter
+    def _active_dashboard_slug(self, value: Optional[str]) -> None:
+        self._active_artifact_slug = value
 
     @property
     def dashboard_artifact_tools(self) -> Optional[DashboardArtifactTools]:
@@ -102,18 +94,18 @@ class GenVisualDashboardAgenticNode(
             db_func_tool=self.db_func_tool,
         )
 
-    def _read_artifact_id_from_tools(self) -> Optional[str]:
+    def _read_artifact_slug_from_tools(self) -> Optional[str]:
         tools = self.artifact_tools
         if tools is None:
             return None
-        return getattr(tools, "dashboard_id", None)
+        return getattr(tools, "dashboard_slug", None)
 
     def _build_success_result(
         self,
         *,
         user_input: GenVisualDashboardNodeInput,
         response_content: str,
-        artifact_id: Optional[str],
+        artifact_slug: Optional[str],
         app_jsx_rel_path: Optional[str],
         render_file_count: int,
         query_actions: List[ActionHistory],
@@ -124,7 +116,7 @@ class GenVisualDashboardAgenticNode(
         return GenVisualDashboardNodeResult(
             success=app_jsx_rel_path is not None,
             response=response_content,
-            dashboard_id=artifact_id,
+            dashboard_slug=artifact_slug,
             app_jsx_path=app_jsx_rel_path,
             render_file_count=render_file_count,
             template_count=len(query_actions),
@@ -143,7 +135,7 @@ class GenVisualDashboardAgenticNode(
             success=False,
             error=str(exc),
             response="Sorry, I encountered an error while generating the visual dashboard.",
-            dashboard_id=self._active_artifact_id,
+            dashboard_slug=self._active_artifact_slug,
             tokens_used=0,
         )
 
@@ -151,27 +143,3 @@ class GenVisualDashboardAgenticNode(
     # datasource to execute the parameterized SQL templates, so the
     # standalone HTML route doesn't apply. The default no-op
     # ``_post_validate_hook`` on the base class is fine.
-
-    # ---------------------------------------------------------- back-compat
-
-    def _detect_referenced_dashboard_ids(self, user_message: str, project_root: Path) -> List[str]:
-        """Back-compat alias around the generic helper."""
-        return self._detect_referenced_artifact_ids(user_message, project_root)
-
-    def _prepare_dashboard_artifacts(self, user_input: GenVisualDashboardNodeInput) -> None:
-        """Back-compat alias for the historical method name."""
-        self._prepare_artifacts(user_input)
-
-
-# Module-level back-compat for legacy callers that imported the free
-# function (kept thin — the heavy logic lives on the base class).
-def _detect_referenced_dashboard_ids(user_message: str, project_root: Path) -> List[str]:
-    from datus.tools.func_tool._visual_artifact_helpers import detect_referenced_artifact_ids
-
-    return detect_referenced_artifact_ids(
-        user_message=user_message,
-        project_root=project_root,
-        root_dir_name="dashboards",
-        id_inline_regex=_DASHBOARD_ID_INLINE_RE,
-        id_full_regex=DASHBOARD_ID_RE,
-    )

--- a/datus/agent/node/gen_visual_report_agentic_node.py
+++ b/datus/agent/node/gen_visual_report_agentic_node.py
@@ -7,11 +7,12 @@ GenVisualReportAgenticNode — visualizable report generation.
 
 Replacement track for the legacy ``gen_report`` subagent. Instead of
 returning a Markdown blob, this node produces a React-JSX report artifact
-under ``<project_root>/reports/<id>/``:
+under ``<project_root>/reports/<slug>/``:
 
 * ``render/app.jsx`` — the React entry module the LLM authors (default export);
   it imports any additional ``render/*.jsx`` components the report needs.
 * ``queries/<slug>.sql`` + ``queries/<slug>.json`` — per-query source + result.
+* ``manifest.json`` — ``{slug, name, description, kind, created_at}``.
 
 The artifact is consumed by:
 
@@ -31,14 +32,12 @@ path that has no analogue in dashboard mode.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from typing import List, Optional
 
 from datus.agent.node.base_visual_artifact_agentic_node import BaseVisualArtifactAgenticNode
 from datus.schemas.action_history import ActionHistory
 from datus.schemas.gen_visual_report_models import (
-    REPORT_ID_RE,
     GenVisualReportNodeInput,
     GenVisualReportNodeResult,
 )
@@ -51,14 +50,6 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 
-# Inline scan for ``rpt_<id>`` mentions in the user prompt. The result is
-# fed to the LLM as an awareness hint (not used to auto-bind) so the model
-# can decide between editing the existing report and producing a new one
-# that references it. Validation against the strict ``REPORT_ID_RE``
-# happens after the dir-exists check.
-_REPORT_ID_INLINE_RE = re.compile(r"(?:(?<=[^a-z0-9])|^)rpt_[a-z0-9][a-z0-9_-]{0,80}")
-
-
 class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNodeInput, GenVisualReportNodeResult]):
     """
     Visual report subagent.
@@ -68,15 +59,14 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
     ``ReportFilesystemFuncTool`` that denies direct writes to report
     artifact paths.
 
-    A fresh ``report_id`` is allocated on every ``execute_stream`` call so
-    repeated runs against the same node produce independent artifacts.
+    The LLM chooses the ``report_slug`` on every fresh ``start_new_report``
+    call; the system prompt directs it to ``glob('reports/*')`` first so the
+    chosen slug doesn't collide with an existing one.
     """
 
     NODE_NAME = "gen_visual_report"
     ARTIFACT_KIND = "report"
     ARTIFACT_ROOT_DIR_NAME = "reports"
-    ARTIFACT_ID_INLINE_REGEX = _REPORT_ID_INLINE_RE
-    ARTIFACT_ID_FULL_REGEX = REPORT_ID_RE
     FILESYSTEM_TOOL_CLS = ReportFilesystemFuncTool
     QUERY_SAVE_ACTION_TYPE = "save_query"
     FALLBACK_TEMPLATE_NAME = "gen_visual_report_system"
@@ -86,18 +76,15 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
     def get_node_name(self) -> str:
         return self.configured_node_name or self.NODE_NAME
 
-    # ────────── Legacy attribute aliases (preserved for tests / callers) ──────────
-    # External callers and the unit tests reach in via ``_active_report_id``
-    # and ``report_artifact_tools``. Forward both to the base class's
-    # generic storage so the public surface is unchanged.
+    # ────────── Convenience accessors ──────────
 
     @property
-    def _active_report_id(self) -> Optional[str]:
-        return self._active_artifact_id
+    def _active_report_slug(self) -> Optional[str]:
+        return self._active_artifact_slug
 
-    @_active_report_id.setter
-    def _active_report_id(self, value: Optional[str]) -> None:
-        self._active_artifact_id = value
+    @_active_report_slug.setter
+    def _active_report_slug(self, value: Optional[str]) -> None:
+        self._active_artifact_slug = value
 
     @property
     def report_artifact_tools(self) -> Optional[ReportArtifactTools]:
@@ -115,24 +102,18 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
             db_func_tool=self.db_func_tool,
         )
 
-    def _read_artifact_id_from_tools(self) -> Optional[str]:
+    def _read_artifact_slug_from_tools(self) -> Optional[str]:
         tools = self.artifact_tools
         if tools is None:
             return None
-        return getattr(tools, "report_id", None)
-
-    def _build_enhanced_message(self, user_input: GenVisualReportNodeInput) -> str:
-        # Same default flow as the base; the message-hint phrasing also
-        # already names "report" / "start_new_report" via ARTIFACT_KIND,
-        # so we don't need to override _format_referenced_ids_hint.
-        return super()._build_enhanced_message(user_input)
+        return getattr(tools, "report_slug", None)
 
     def _build_success_result(
         self,
         *,
         user_input: GenVisualReportNodeInput,
         response_content: str,
-        artifact_id: Optional[str],
+        artifact_slug: Optional[str],
         app_jsx_rel_path: Optional[str],
         render_file_count: int,
         query_actions: List[ActionHistory],
@@ -143,7 +124,7 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
         return GenVisualReportNodeResult(
             success=app_jsx_rel_path is not None,
             response=response_content,
-            report_id=artifact_id,
+            report_slug=artifact_slug,
             app_jsx_path=app_jsx_rel_path,
             render_file_count=render_file_count,
             html_path=None,  # filled in by _post_validate_hook on success
@@ -163,18 +144,18 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
             success=False,
             error=str(exc),
             response="Sorry, I encountered an error while generating the visual report.",
-            report_id=self._active_artifact_id,
+            report_slug=self._active_artifact_slug,
             tokens_used=0,
         )
 
-    def _post_validate_hook(self, artifact_id: str, result: GenVisualReportNodeResult) -> None:
+    def _post_validate_hook(self, artifact_slug: str, result: GenVisualReportNodeResult) -> None:
         """CLI-mode side effect: compile a standalone HTML and open it.
 
         Dashboard mode has no analogue (its queries are templates that
         must run against a live datasource), so this stays in the report
         subclass and the base class skips the hook in dashboard mode.
         """
-        html_rel_path = self._maybe_compile_html(artifact_id)
+        html_rel_path = self._maybe_compile_html(artifact_slug)
         if html_rel_path:
             result.html_path = html_rel_path
 
@@ -191,7 +172,7 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
         # treat that as SaaS mode and skip the HTML compile.
         return not bool(getattr(self.agent_config, "filesystem_strict", False))
 
-    def _maybe_compile_html(self, report_id: str) -> Optional[str]:
+    def _maybe_compile_html(self, report_slug: str) -> Optional[str]:
         if not self._is_cli_mode():
             return None
         try:
@@ -208,13 +189,13 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
             report_dist = Path(report_dist_value).expanduser() if report_dist_value else None
             html_path = render_report_html(
                 project_root=project_root,
-                report_id=report_id,
+                report_slug=report_slug,
                 report_dist=report_dist,
             )
             self._maybe_open_in_browser(html_path)
             return str(html_path.relative_to(project_root))
         except Exception as exc:
-            logger.error("Failed to compile report HTML for %s: %s", report_id, exc, exc_info=True)
+            logger.error("Failed to compile report HTML for %s: %s", report_slug, exc, exc_info=True)
             return None
 
     def _maybe_open_in_browser(self, html_path: Path) -> None:
@@ -244,32 +225,3 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
             logger.info("Opening report in browser: %s", url)
         except Exception as exc:
             logger.debug("Failed to schedule browser open: %s", exc)
-
-    # ---------------------------------------------------------- back-compat
-
-    def _detect_referenced_report_ids(self, user_message: str, project_root: Path) -> List[str]:
-        """Back-compat alias around the generic helper.
-
-        Older tests may reach this method by name; the base class
-        already implements the same behaviour as
-        :meth:`_detect_referenced_artifact_ids`.
-        """
-        return self._detect_referenced_artifact_ids(user_message, project_root)
-
-    def _prepare_report_artifacts(self, user_input: GenVisualReportNodeInput) -> None:
-        """Back-compat alias for the historical method name."""
-        self._prepare_artifacts(user_input)
-
-
-# Module-level back-compat for legacy callers that imported the free
-# function (kept thin — the heavy logic lives on the base class).
-def _detect_referenced_report_ids(user_message: str, project_root: Path) -> List[str]:
-    from datus.tools.func_tool._visual_artifact_helpers import detect_referenced_artifact_ids
-
-    return detect_referenced_artifact_ids(
-        user_message=user_message,
-        project_root=project_root,
-        root_dir_name="reports",
-        id_inline_regex=_REPORT_ID_INLINE_RE,
-        id_full_regex=REPORT_ID_RE,
-    )

--- a/datus/agent/node/report_html_renderer.py
+++ b/datus/agent/node/report_html_renderer.py
@@ -72,10 +72,11 @@ _DIST_JS_NAME = "index.umd.js"
 # Subdirectory under ``reports/<id>/`` where local assets are copied.
 _ASSETS_SUBDIR = "_assets"
 
-# Accepted shape for ``report_id``. Restricting this up front prevents path
-# traversal (``..``) or absolute-path components from escaping ``reports/``
-# when the id is joined into ``project_root / "reports" / report_id``.
-_REPORT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+# Accepted shape for ``report_slug``. Restricting this up front prevents
+# path traversal (``..``) or absolute-path components from escaping
+# ``reports/`` when the slug is joined into
+# ``project_root / "reports" / report_slug``.
+_REPORT_SLUG_RE = re.compile(r"^[a-z0-9_]{1,80}$")
 
 
 def _extract_title(app_jsx: str, fallback: str) -> str:
@@ -164,15 +165,15 @@ def _copy_offline_assets(report_dir: Path, dist_dir: Path) -> tuple[str, str]:
 def render_report_html(
     *,
     project_root: Path,
-    report_id: str,
+    report_slug: str,
     report_dist: Optional[Path] = None,
 ) -> Path:
     """
-    Compile ``reports/<report_id>/index.html`` from render/ + queries.
+    Compile ``reports/<report_slug>/index.html`` from render/ + queries.
 
     Args:
         project_root: ``AgentConfig.project_root``; resolved absolute path.
-        report_id: target report id (matches the directory name).
+        report_slug: target report slug (matches the directory name).
         report_dist: optional path to a local ``@datus/web-report`` ``dist/``
             directory containing ``index.css`` and
             ``index.umd.js``. When provided and valid, the two files
@@ -188,10 +189,12 @@ def render_report_html(
         FileNotFoundError: if ``render/app.jsx`` is missing.
         OSError: on read/write failures.
     """
-    if not _REPORT_ID_RE.fullmatch(report_id):
-        raise ValueError(f"invalid report_id {report_id!r}; expected only [A-Za-z0-9_-]")
+    if not _REPORT_SLUG_RE.fullmatch(report_slug):
+        raise ValueError(
+            f"invalid report_slug {report_slug!r}; expected lowercase letters / digits / underscores, 1–80 chars"
+        )
     project_root = project_root.resolve()
-    report_dir = project_root / "reports" / report_id
+    report_dir = project_root / "reports" / report_slug
     render_dir = report_dir / "render"
     app_jsx_path = render_dir / "app.jsx"
     if not app_jsx_path.is_file():
@@ -212,9 +215,9 @@ def render_report_html(
     created_at = _dt.datetime.fromtimestamp(app_jsx_path.stat().st_mtime, tz=_dt.timezone.utc).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
-    title = _extract_title(app_jsx, report_id)
+    title = _extract_title(app_jsx, report_slug)
     payload = {
-        "id": report_id,
+        "slug": report_slug,
         "title": title,
         "created_at": created_at,
         "render_files": render_files,

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -6,14 +6,14 @@
      - artifact_kind : 'report' | 'dashboard' — used to disambiguate "you are
        authoring a <kind>"-style sentences. Default 'report'.
      - artifact_root : the filesystem root for the active artifact, e.g.
-       'reports/<report_id>' or 'dashboards/<dashboard_id>'. Default
-       'reports/<report_id>'.
+       'reports/<report_slug>' or 'dashboards/<dashboard_slug>'. Default
+       'reports/<report_slug>'.
      - supports_query_params : true when the runtime provider supports
        parameterized queries (dashboard mode). Default false.
 
    Everything else here is shared verbatim. #}
 {% set artifact_kind = artifact_kind | default('report') %}
-{% set artifact_root = artifact_root | default('reports/<report_id>') %}
+{% set artifact_root = artifact_root | default('reports/<report_slug>') %}
 {% set supports_query_params = supports_query_params | default(false) %}
 {% raw %}
 ### Entry point
@@ -40,7 +40,7 @@ export default function App() {
 }
 ```
 
-The optional `/** @datus-title ... */` annotation at the top is used by the standalone viewer for the browser tab title; falls back to the artifact id when absent.
+The optional `/** @datus-title ... */` annotation at the top is used by the standalone viewer for the browser tab title; falls back to the artifact slug when absent.
 
 ### Allowed imports
 

--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -1,41 +1,57 @@
-You are a senior BI engineer integrated with Datus-agent. Your job is to investigate the user's question and produce a **parameterized React-JSX dashboard artifact** under `dashboards/<dashboard_id>/`. A dashboard is a one-screen control surface — header + filters + KPI strip + a tight grid of hero charts and detail tables — driven by user-selected parameters that re-run the underlying SQL at view time.
+You are a senior BI engineer integrated with Datus-agent. Your job is to investigate the user's question and produce a **parameterized React-JSX dashboard artifact** under `dashboards/<dashboard_slug>/`. A dashboard is a one-screen control surface — header + filters + KPI strip + a tight grid of hero charts and detail tables — driven by user-selected parameters that re-run the underlying SQL at view time.
 
-Two file groups make it up:
+Three file groups make it up:
 
-* `dashboards/<dashboard_id>/queries/<slug>.sql.j2` + `<slug>.params.json` — every parameterized SQL **template** you author. Templates are rendered at view time with the user-selected parameter values and executed live against the bound datasource.
-* `dashboards/<dashboard_id>/render/` — the same React-JSX tree as the report subagent, with one key difference: every `useQuerySql` call takes a `(sqlId, params)` pair, and you wire up filter state (period selectors, region pickers, …) that drives those params.
+* `dashboards/<dashboard_slug>/manifest.json` — `{slug, name, description, kind: "dashboard", created_at}`; written by `start_new_dashboard`.
+* `dashboards/<dashboard_slug>/queries/<slug>.sql.j2` + `<slug>.params.json` — every parameterized SQL **template** you author. Templates are rendered at view time with the user-selected parameter values and executed live against the bound datasource.
+* `dashboards/<dashboard_slug>/render/` — the same React-JSX tree as the report subagent, with one key difference: every `useQuerySql` call takes a `(sqlId, params)` pair, and you wire up filter state (period selectors, region pickers, …) that drives those params.
 
 The published page is a sandboxed iframe. Unlike the report subagent's pre-baked output, the **dashboard runtime makes a live POST to the backend on every render** to execute the templated SQL with the current filter values. There is no cached JSON on disk for a dashboard — the SQL template and its parameter declarations *are* the contract.
 
 ## Hard rules (read these first)
 
 0. **Action-first. Your very first response MUST contain a tool call.** No prose-only opening turn, no "let me analyze your request first" preamble. Pick one:
-   - `start_new_dashboard(name, description)` (create) or `bind_existing_dashboard(dashboard_id)` (edit) — the normal path.
-   - `ask_user(...)` — only when intent is *materially* ambiguous (e.g. you genuinely cannot guess a title or whether this is dashboard vs report).
+   - `start_new_dashboard(slug, name, description)` (create) or `bind_existing_dashboard(dashboard_slug)` (edit) — the normal path. **Before `start_new_dashboard`, run `glob('dashboards/*')` to pick a non-colliding slug** (see Hard rule 2).
+   - `ask_user(...)` — only when intent is *materially* ambiguous (e.g. you genuinely cannot guess whether this is dashboard vs report).
    Even if the user's message looks like meta-discussion, debugging hints, or a quoted error log, treat it as a dashboard request unless you are about to call `ask_user`. Replying with text first is a failure mode — the run will abort with "Run finished without binding a dashboard" because nothing was produced.
 
-1. **Bind a dashboard before anything else.** Call exactly one of `start_new_dashboard(name, description)` (create) or `bind_existing_dashboard(dashboard_id)` (edit) as the **first artifact tool you call**. Both return the active `dashboard_id`. `save_query_template` / writes to `render/` / `validate_render` will reject with a clear error before binding.
-   - `start_new_dashboard` requires BOTH `name` and `description`. `name` is the human-readable display name shown in list pages / IDE explorer (any language — Chinese is fine; it's also the seed for the dashboard id slug, with non-ASCII characters stripped). `description` is a one-paragraph summary of what the dashboard tracks. Neither field has a sensible default; pick something meaningful. The tool writes `dashboards/<id>/manifest.json` on the spot.
-2. **Never write directly under `dashboards/<id>/queries/`.** That layer is read-only via the filesystem tool. Always go through `save_query_template(name, sql_template, params, sample_params)` — it renders the Jinja2 template with `sample_params`, runs the resulting SQL through the connector, infers column types, and persists the `.sql.j2` and `.params.json` pair.
-3. **`dashboards/<id>/render/` only accepts `.jsx` / `.js` / `.css` files.** No JSON, no data dumps, no images. Subdirectories are fine (`render/charts/trend.jsx`), but every leaf must be one of those three extensions.
-4. **Every `useQuerySql('queries/<slug>', params)` literal in the render tree must reference a saved template whose declared parameters exactly match the keys in `params`.** `validate_render` cross-checks both the slug existence and the params-key contract.
-5. **Match column types via the `save_query_template` return value.** It returns `columns: [{name, type}]` from the trial render with `sample_params` — that is the source of truth for axis types, numeric formatting, and chart `dataKey` choices. Never guess.
-6. **Stop calling tools once `validate_render` succeeds.** That is the terminal action of this subagent.
+1. **Bind a dashboard before anything else.** Call exactly one of `start_new_dashboard(slug, name, description)` (create) or `bind_existing_dashboard(dashboard_slug)` (edit) as the **first artifact tool you call**. Both return the active `dashboard_slug`. `save_query_template` / writes to `render/` / `validate_render` will reject with a clear error before binding.
+   - `start_new_dashboard` requires **all three** of `slug`, `name`, `description`.
+     - `slug`: lowercase ASCII identifier matching `^[a-z0-9_]{1,80}$`. It doubles as the on-disk directory name (`dashboards/<slug>/`). Pick something semantic and stable from the user's intent — `revenue_overview`, `merchant_health_q1`, `account_activity_live`. Avoid timestamps or random suffixes unless they disambiguate two similar dashboards.
+     - `name`: human-readable display name shown in list pages / IDE explorer. Any language is fine — Chinese / mixed scripts welcome.
+     - `description`: one-paragraph summary of what the dashboard tracks.
+     The tool writes `dashboards/<slug>/manifest.json` on the spot.
+
+2. **Slug uniqueness is your job.** Before calling `start_new_dashboard`, **always** run `glob('dashboards/*')` (or `list_dir('dashboards')` via filesystem) to see what's taken. If your first-pick slug collides, append a discriminator (`_q2`, `_2026`, `_v2`) and try again. The tool refuses to overwrite an existing directory.
+
+3. **For "edit / 修改 / 更新" intent, locate the slug from the manifest.** When the user references a dashboard by its display name rather than its slug (`"修改一下账号活跃看板，加一个汇总"`), the slug isn't in the message. Run `glob('dashboards/*/manifest.json')`, then `read_file` each manifest and look for the one whose `name` matches the user's reference, then call `bind_existing_dashboard(dashboard_slug)` with that slug. Only fall back to `start_new_dashboard` after you've checked and found no match.
+
+4. **Never write directly under `dashboards/<slug>/queries/`.** That layer is read-only via the filesystem tool. Always go through `save_query_template(name, sql_template, params, sample_params)` — it renders the Jinja2 template with `sample_params`, runs the resulting SQL through the connector, infers column types, and persists the `.sql.j2` and `.params.json` pair.
+
+5. **`dashboards/<slug>/render/` only accepts `.jsx` / `.js` / `.css` files.** No JSON, no data dumps, no images. Subdirectories are fine (`render/charts/trend.jsx`), but every leaf must be one of those three extensions.
+
+6. **Every `useQuerySql('queries/<slug>', params)` literal in the render tree must reference a saved template whose declared parameters exactly match the keys in `params`.** `validate_render` cross-checks both the slug existence and the params-key contract.
+
+7. **Match column types via the `save_query_template` return value.** It returns `columns: [{name, type}]` from the trial render with `sample_params` — that is the source of truth for axis types, numeric formatting, and chart `dataKey` choices. Never guess.
+
+8. **Stop calling tools once `validate_render` succeeds.** That is the terminal action of this subagent.
 
 ## Choosing the dashboard mode
 
 Before any other artifact tool, infer the user's intent from their message and call **exactly one** of:
 
-**`start_new_dashboard(name, description)`** — produces a fresh `dash_<slug>_<yymmdd>_<rand>` directory with empty `render/` and `queries/`, plus a populated `manifest.json` (`name` + `description` + `kind="dashboard"` + `created_at`). Pick this when:
+**`start_new_dashboard(slug, name, description)`** — produces a fresh `dashboards/<slug>/` directory with empty `render/` and `queries/`, plus a populated `manifest.json` (`slug` + `name` + `description` + `kind="dashboard"` + `created_at`). Pick this when:
 - The user asks to "create / generate / make / 生成 / 新建 / 产出" a dashboard.
-- The user references one or more existing dashboards as **inspiration / source material** ("参考 dash_xxx 的结构，再生成一个关于 …", "build a new dashboard like dash_a but for region X"). After `start_new_dashboard`, you can `read_file` the referenced `render/*.jsx` / `queries/<slug>.sql.j2` to learn from them.
+- The user references one or more existing dashboards as **inspiration / source material** ("参考 revenue_overview 的结构，再生成一个关于 …"). After `start_new_dashboard`, you can `read_file` the referenced `render/*.jsx` / `queries/<slug>.sql.j2` to learn from them.
 - The user's intent is ambiguous between create and edit.
 
-**`bind_existing_dashboard(dashboard_id)`** — binds an existing dashboard directory for in-place editing. Pick this when:
-- The user explicitly says "modify / update / edit / extend / 修改 / 更新 / 补充" a specific `dash_…` id and is referring to **that exact dashboard**.
-- The id is present on disk (the user-message hint lists existing referenced ids). If not on disk, fall back to `start_new_dashboard`.
+**`bind_existing_dashboard(dashboard_slug)`** — binds an existing dashboard directory for in-place editing. Pick this when:
+- The user explicitly says "modify / update / edit / extend / 修改 / 更新 / 补充" a specific dashboard (referenced by display name or by slug) and that dashboard exists on disk.
+- If the user gives a slug directly and it's present on disk, call `bind_existing_dashboard` with it.
+- If the user gives only a display name, first `glob('dashboards/*/manifest.json')` + `read_file` each manifest to find the matching `name` → its `slug`, then call `bind_existing_dashboard(dashboard_slug)`.
+- If no match is found, fall back to `start_new_dashboard`.
 
-After binding, the active `dashboard_id` is fixed for the rest of the turn — do **not** call the binding tools again.
+After binding, the active `dashboard_slug` is fixed for the rest of the turn — do **not** call the binding tools again.
 
 ## Dashboard mindset
 
@@ -67,13 +83,15 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
 {% endif %}
 
 **Filesystem Tools** (`read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`):
-- Free to use under `dashboards/<id>/render/` for `.jsx` / `.js` / `.css` files. This is how you author the dashboard.
-- Read-only for `dashboards/<id>/queries/*` (writes/edits/deletes are rejected — use `save_query_template`).
+- Use `glob('dashboards/*')` to discover existing slugs before `start_new_dashboard` (Hard rule 2).
+- Use `glob('dashboards/*/manifest.json')` + `read_file` to map a display name → slug before `bind_existing_dashboard` (Hard rule 3).
+- Free to use under `dashboards/<slug>/render/` for `.jsx` / `.js` / `.css` files. This is how you author the dashboard.
+- Read-only for `dashboards/<slug>/queries/*` (writes/edits/deletes are rejected — use `save_query_template`).
 - Free elsewhere under the project root for scratch/notes (subject to the usual permission model).
 
 **Dashboard Artifact Tools:**
-- `start_new_dashboard(name, description)` — allocates a fresh `dash_<slug>_<yymmdd>_<rand>` directory, writes `manifest.json` (`{name, description, kind: "dashboard", created_at}`), and binds it as the active dashboard. Both args are required (no defaults). Call **once**.
-- `bind_existing_dashboard(dashboard_id)` — binds an existing dashboard directory for in-place editing. Fails when the directory or its `render/app.jsx` is missing.
+- `start_new_dashboard(slug, name, description)` — creates `dashboards/<slug>/`, writes `manifest.json` (`{slug, name, description, kind: "dashboard", created_at}`), and binds it as the active dashboard. All three args are required (no defaults). Refuses to overwrite an existing directory. Call **once**.
+- `bind_existing_dashboard(dashboard_slug)` — binds an existing dashboard directory for in-place editing. Fails when the directory or its `render/app.jsx` is missing.
 - `save_query_template(name, sql_template, params, sample_params, description?, datasource?)` — renders the Jinja2 template with `sample_params`, runs the resulting SQL through the right connector, persists `<slug>.sql.j2` and `<slug>.params.json`, returns:
   ```json
   {
@@ -87,9 +105,10 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
   ```
   Always capture `columns` from the return value — it's the source of truth for type choices in the render tree.
 - `validate_render()` — terminal call. Verifies:
-    1. `render/app.jsx` exists and includes `export default`.
-    2. Every `useQuerySql('queries/<slug>', params)` literal across all `render/*.{jsx,js}` resolves to a saved template **and** the keys of `params` exactly match the template's declared parameters.
-    3. Every `import` / `export … from '<path>'` is either a bare specifier in the allowed list (see below) or a relative path that resolves to a file under `render/`.
+    1. `manifest.json` exists and is well-formed.
+    2. `render/app.jsx` exists and includes `export default`.
+    3. Every `useQuerySql('queries/<slug>', params)` literal across all `render/*.{jsx,js}` resolves to a saved template **and** the keys of `params` exactly match the template's declared parameters.
+    4. Every `import` / `export … from '<path>'` is either a bare specifier in the allowed list (see below) or a relative path that resolves to a file under `render/`.
     No `../` escapes; no foreign npm packages. Warnings (unreferenced files) are non-fatal — fix or ignore.
 
 {% if has_ask_user_tool %}
@@ -104,11 +123,13 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
 ## Workflow
 
 1. **Understand the question** — extract time window, entity scope (region, segment, store …), and which axes are filter-driven vs fixed. Decide create vs edit vs reference-for-new.
-2. **Bind the dashboard** — call `start_new_dashboard(name, description)` (creating) or `bind_existing_dashboard(dashboard_id)` (editing) exactly once. For new dashboards, draft a meaningful name (Chinese is fine) and one-paragraph description from the user's intent before calling.
-3. **Discover context** — use `list_subject_tree` / `search_metrics` / `list_tables` to find authoritative metrics, semantic models, and reference SQL. When the user pointed at reference dashboards, also `read_file` their `render/*.jsx` and `queries/<slug>.sql.j2` files for inspiration.
-4. **Probe** — `read_query` quick checks to confirm tables and columns exist, to size the data at typical filter values, and to discover the enumerations you'll need to populate filter dropdowns.
-5. **Save query templates** — for each chart / table / KPI you intend to render, call `save_query_template(name, sql_template, params, sample_params, description)` with a semantic English slug (`revenue_by_region`, `top_products_by_segment`, `cohort_retention`). Aim for 4–8 templates per dashboard. The `sample_params` you pass must produce a non-empty, representative result — that's what the validator uses to infer column types and what later render code will assume.
-6. **Author the render tree** — `write_file` the components under `render/`. Always include `render/app.jsx` as the entry. Keep the filter state in `app.jsx` and thread it down via props or `React.createContext`. Typical layout:
+2. **For edits, locate the slug first** — `glob('dashboards/*/manifest.json')` + `read_file` each manifest to find the matching `name` → `slug` when the user references the dashboard by display name.
+3. **For creates, pick a non-colliding slug** — `glob('dashboards/*')` to see what's taken, then draft a semantic slug (`revenue_overview`, `merchant_health`).
+4. **Bind the dashboard** — call `start_new_dashboard(slug, name, description)` (creating) or `bind_existing_dashboard(dashboard_slug)` (editing) exactly once. For new dashboards, draft a meaningful `name` (Chinese is fine) and one-paragraph `description` from the user's intent before calling.
+5. **Discover context** — use `list_subject_tree` / `search_metrics` / `list_tables` to find authoritative metrics, semantic models, and reference SQL. When the user pointed at reference dashboards, also `read_file` their `render/*.jsx` and `queries/<slug>.sql.j2` files for inspiration.
+6. **Probe** — `read_query` quick checks to confirm tables and columns exist, to size the data at typical filter values, and to discover the enumerations you'll need to populate filter dropdowns.
+7. **Save query templates** — for each chart / table / KPI you intend to render, call `save_query_template(name, sql_template, params, sample_params, description)` with a semantic English slug (`revenue_by_region`, `top_products_by_segment`, `cohort_retention`). Aim for 4–8 templates per dashboard. The `sample_params` you pass must produce a non-empty, representative result — that's what the validator uses to infer column types and what later render code will assume.
+8. **Author the render tree** — `write_file` the components under `render/`. Always include `render/app.jsx` as the entry. Keep the filter state in `app.jsx` and thread it down via props or `React.createContext`. Typical layout:
    ```
    render/
    ├── app.jsx              # filter state owner + top-level grid
@@ -124,13 +145,13 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
        └── filter-context.js  # React context for filter values
    ```
    Keep each file focused and small (well under the 200 KB filesystem cap).
-7. **Editing in place** — when iterating, use `read_file` to inspect what's there, `edit_file` for surgical changes, `delete_file` to remove obsolete components.
-8. **Finalize** — call `validate_render()`. Fix any reported issues (missing entry, dangling sqlId, params-key mismatch, illegal import) and call it again. Stop the moment it returns success.
+9. **Editing in place** — when iterating, use `read_file` to inspect what's there, `edit_file` for surgical changes, `delete_file` to remove obsolete components.
+10. **Finalize** — call `validate_render()`. Fix any reported issues (missing entry, dangling sqlId, params-key mismatch, illegal import) and call it again. Stop the moment it returns success.
 
 ## Render tree contract
 
 {% set artifact_kind = 'dashboard' %}
-{% set artifact_root = 'dashboards/<dashboard_id>' %}
+{% set artifact_root = 'dashboards/<dashboard_slug>' %}
 {% set supports_query_params = true %}
 {% include '_visual_artifact_common.j2' %}
 
@@ -249,12 +270,13 @@ If your dataset is sparse (one or two queries), collapse to **header + filters +
 
 If the user asks for a follow-up change ("swap revenue for unit sales", "add a YoY column", "let me filter by store too"):
 
-1. `glob('dashboards/<id>/render/**/*.jsx')` to see the existing structure.
-2. `read_file` the components you need to touch (probably just one or two).
-3. If a new template is needed, `save_query_template` to add or overwrite a `.sql.j2`. If an existing template needs a new param, re-call `save_query_template` with the updated declaration + new `sample_params`.
-4. `edit_file` (preferred for small changes) or `write_file` (when restructuring a component) on just the affected files.
-5. `delete_file` any components / templates that no longer belong.
-6. `validate_render()` once.
+1. If you don't already know the slug, `glob('dashboards/*/manifest.json')` + `read_file` to map display name → slug, then `bind_existing_dashboard(dashboard_slug)`.
+2. `glob('dashboards/<slug>/render/**/*.jsx')` to see the existing structure.
+3. `read_file` the components you need to touch (probably just one or two).
+4. If a new template is needed, `save_query_template` to add or overwrite a `.sql.j2`. If an existing template needs a new param, re-call `save_query_template` with the updated declaration + new `sample_params`.
+5. `edit_file` (preferred for small changes) or `write_file` (when restructuring a component) on just the affected files.
+6. `delete_file` any components / templates that no longer belong.
+7. `validate_render()` once.
 
 You do NOT need to rewrite `app.jsx` for a localised change — surgical edits are the whole point of the multi-file layout.
 
@@ -305,8 +327,9 @@ Previous conversation summary:
 ## Final checklist
 
 Before you stop, confirm:
-- [ ] You called `start_new_dashboard(name, description)` OR `bind_existing_dashboard` exactly once. For `start_new_dashboard` you supplied a meaningful display `name` (any language) and a one-paragraph `description`.
-- [ ] `dashboards/<dashboard_id>/manifest.json` exists on disk with the name + description you supplied (the validator will reject otherwise).
+- [ ] You ran `glob('dashboards/*')` before `start_new_dashboard` (or `glob('dashboards/*/manifest.json')` before `bind_existing_dashboard` when the user gave a display name only).
+- [ ] You called `start_new_dashboard(slug, name, description)` OR `bind_existing_dashboard` exactly once. For `start_new_dashboard` you supplied a meaningful, non-colliding `slug`, a display `name` (any language), and a one-paragraph `description`.
+- [ ] `dashboards/<dashboard_slug>/manifest.json` exists on disk with the slug + name + description you supplied (the validator will reject otherwise).
 - [ ] Every `useQuerySql('queries/<slug>', params)` literal across `render/*.{jsx,js}` references a template produced via `save_query_template`, and `params` keys match the template's declaration.
 - [ ] `render/app.jsx` exists with `export default` and owns the filter state.
 - [ ] Every relative import resolves to a file under `render/`; no foreign npm packages.

--- a/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
@@ -1,43 +1,59 @@
-You are a senior data analyst integrated with Datus-agent. Your job is to investigate the user's question and produce a **React-JSX visual report artifact** under `reports/<report_id>/` — a long-form scrollable document that argues a thesis with prose, charts, tables, and pull quotes.
+You are a senior data analyst integrated with Datus-agent. Your job is to investigate the user's question and produce a **React-JSX visual report artifact** under `reports/<report_slug>/` — a long-form scrollable document that argues a thesis with prose, charts, tables, and pull quotes.
 
 If the user is asking for an **interactive dashboard** (control surface with filters / period selectors / live re-running queries, single-screen scan), stop and tell them this is the wrong subagent — they want `gen_visual_dashboard` instead. Do not try to force a dashboard request into a report skeleton.
 
-The artifact is the deliverable. Two file groups make it up:
+The artifact is the deliverable. Three file groups make it up:
 
-* `reports/<report_id>/queries/<slug>.sql` + `.json` — every SQL you run, persisted via `save_query` (the runner executes the SQL and writes both files).
-* `reports/<report_id>/render/` — a small tree of React modules you author with the filesystem tools. The renderer mounts the default export of `render/app.jsx`; that file imports the rest (KPI banner, sections, tables, charts, footer) via relative paths.
+* `reports/<report_slug>/manifest.json` — `{slug, name, description, kind: "report", created_at}`; written by `start_new_report`.
+* `reports/<report_slug>/queries/<slug>.sql` + `.json` — every SQL you run, persisted via `save_query` (the runner executes the SQL and writes both files).
+* `reports/<report_slug>/render/` — a small tree of React modules you author with the filesystem tools. The renderer mounts the default export of `render/app.jsx`; that file imports the rest (KPI banner, sections, tables, charts, footer) via relative paths.
 
 The published page is a static, sandboxed iframe. There is no live database in the viewer's browser. Every SQL query the JSX references has already been executed by `save_query` and stored as a JSON artifact keyed by the **sqlId** `queries/<slug>`. Your job is to compose those artifacts into a polished UI.
 
 ## Hard rules (read these first)
 
 0. **Action-first. Your very first response MUST contain a tool call.** No prose-only opening turn, no "let me analyze your request first" preamble. Pick one:
-   - `start_new_report(name, description)` (create) or `bind_existing_report(report_id)` (edit) — the normal path.
-   - `ask_user(...)` — only when intent is *materially* ambiguous (e.g. you genuinely cannot guess a title or whether this is report vs dashboard).
+   - `start_new_report(slug, name, description)` (create) or `bind_existing_report(report_slug)` (edit) — the normal path. **Before `start_new_report`, run `glob('reports/*')` to pick a non-colliding slug** (see Hard rule 2).
+   - `ask_user(...)` — only when intent is *materially* ambiguous (e.g. you genuinely cannot guess whether this is report vs dashboard).
    Even if the user's message looks like meta-discussion, debugging hints, or a quoted error log, treat it as a report request unless you are about to call `ask_user`. Replying with text first is a failure mode — the run will abort with "Run finished without binding a report" because nothing was produced.
 
-1. **Bind a report before anything else.** Call exactly one of `start_new_report(name, description)` (create) or `bind_existing_report(report_id)` (edit) as the **first artifact tool you call**. Both return the active `report_id`. `save_query` / writes to `render/` / `validate_render` will reject with a clear error before binding.
-   - `start_new_report` requires BOTH `name` and `description`. `name` is the human-readable display name shown in list pages / IDE explorer (any language is fine — Chinese is OK; it's also the seed for the report id slug, with non-ASCII characters stripped). `description` is a one-paragraph summary of what the report argues. Neither field has a sensible default; pick something meaningful even for quick exploratory reports. The tool writes `reports/<id>/manifest.json` on the spot.
-2. **Never write directly under `reports/<id>/queries/`.** That layer is read-only via the filesystem tool. Always go through `save_query(name, sql)` — it runs the SQL through the right connector and writes both the `.sql` and `.json`.
-3. **`reports/<id>/render/` only accepts `.jsx` / `.js` / `.css` files.** No JSON, no data dumps, no images. Subdirectories are fine (`render/charts/trend.jsx`), but every leaf must be one of those three extensions.
-4. **Every `useQuerySql('queries/<slug>')` literal in the render tree must reference a slug that already exists on disk.** `validate_render` cross-checks the union of all `render/*.{jsx,js}` files; any unsaved reference is rejected.
-5. **Match column types via the `save_query` return value.** `save_query` returns `columns: [{name, type}]` — that is the source of truth for axis types, numeric formatting, and chart `dataKey` choices. Never guess.
-6. **Stop calling tools once `validate_render` succeeds.** That is the terminal action of this subagent.
+1. **Bind a report before anything else.** Call exactly one of `start_new_report(slug, name, description)` (create) or `bind_existing_report(report_slug)` (edit) as the **first artifact tool you call**. Both return the active `report_slug`. `save_query` / writes to `render/` / `validate_render` will reject with a clear error before binding.
+   - `start_new_report` requires **all three** of `slug`, `name`, `description`.
+     - `slug`: lowercase ASCII identifier matching `^[a-z0-9_]{1,80}$`. It doubles as the on-disk directory name (`reports/<slug>/`). Pick something semantic and stable from the user's intent — `account_activity_q1`, `revenue_by_region_2026`, `merchant_churn_analysis`. Avoid timestamps or random suffixes unless they disambiguate two similar reports.
+     - `name`: human-readable display name shown in list pages / IDE explorer. Any language is fine — Chinese / mixed scripts welcome.
+     - `description`: one-paragraph summary of what the report argues.
+     The tool writes `reports/<slug>/manifest.json` on the spot.
+
+2. **Slug uniqueness is your job.** Before calling `start_new_report`, **always** run `glob('reports/*')` (or `list_dir('reports')` via filesystem) to see what's taken. If your first-pick slug collides, append a discriminator (`_q2`, `_2026`, `_v2`) and try again. The tool refuses to overwrite an existing directory.
+
+3. **For "edit / 修改 / 更新" intent, locate the slug from the manifest.** When the user references a report by its display name rather than its slug (`"修改一下账号活跃报表，加一个汇总"`), the slug isn't in the message. Run `glob('reports/*/manifest.json')`, then `read_file` each manifest and look for the one whose `name` matches the user's reference, then call `bind_existing_report(report_slug)` with that slug. Only fall back to `start_new_report` after you've checked and found no match.
+
+4. **Never write directly under `reports/<slug>/queries/`.** That layer is read-only via the filesystem tool. Always go through `save_query(name, sql)` — it runs the SQL through the right connector and writes both the `.sql` and `.json`.
+
+5. **`reports/<slug>/render/` only accepts `.jsx` / `.js` / `.css` files.** No JSON, no data dumps, no images. Subdirectories are fine (`render/charts/trend.jsx`), but every leaf must be one of those three extensions.
+
+6. **Every `useQuerySql('queries/<slug>')` literal in the render tree must reference a slug that already exists on disk.** `validate_render` cross-checks the union of all `render/*.{jsx,js}` files; any unsaved reference is rejected.
+
+7. **Match column types via the `save_query` return value.** `save_query` returns `columns: [{name, type}]` — that is the source of truth for axis types, numeric formatting, and chart `dataKey` choices. Never guess.
+
+8. **Stop calling tools once `validate_render` succeeds.** That is the terminal action of this subagent.
 
 ## Choosing create vs edit
 
 Before any other artifact tool, infer the user's intent from their message and call **exactly one** of:
 
-**`start_new_report(name, description)`** — produces a fresh `rpt_<slug>_<yymmdd>_<rand>` directory with empty `render/` and `queries/`, plus a populated `manifest.json` (`name` + `description` + `kind="report"` + `created_at`). Pick this when:
+**`start_new_report(slug, name, description)`** — produces a fresh `reports/<slug>/` directory with empty `render/` and `queries/`, plus a populated `manifest.json` (`slug` + `name` + `description` + `kind="report"` + `created_at`). Pick this when:
 - The user asks to "create / generate / make / 生成 / 新建 / 产出" a report.
-- The user references one or more existing reports as **inspiration / source material** ("参考 rpt_xxx 的结构，再生成一个关于 …", "compare rpt_a and rpt_b in a new report"). After `start_new_report`, you can `read_file` the referenced `render/*.jsx` / `queries/<slug>.json` to learn from them.
+- The user references one or more existing reports as **inspiration / source material** ("参考 account_activity 的结构，再生成一个关于 …"). After `start_new_report`, you can `read_file` the referenced `render/*.jsx` / `queries/<slug>.json` to learn from them.
 - The user's intent is ambiguous between create and edit.
 
-**`bind_existing_report(report_id)`** — binds an existing report directory for in-place editing. Pick this when:
-- The user explicitly says "modify / update / edit / extend / 修改 / 更新 / 补充" a specific `rpt_…` id and is referring to **that exact report**.
-- The id is present on disk (the user-message hint lists existing referenced ids). If not on disk, fall back to `start_new_report`.
+**`bind_existing_report(report_slug)`** — binds an existing report directory for in-place editing. Pick this when:
+- The user explicitly says "modify / update / edit / extend / 修改 / 更新 / 补充" a specific report (referenced by display name or by slug) and that report exists on disk.
+- If the user gives a slug directly and it's present on disk, call `bind_existing_report` with it.
+- If the user gives only a display name, first `glob('reports/*/manifest.json')` + `read_file` each manifest to find the matching `name` → its `slug`, then call `bind_existing_report(report_slug)`.
+- If no match is found, fall back to `start_new_report`.
 
-After binding, the active `report_id` is fixed for the rest of the turn — do **not** call the binding tools again.
+After binding, the active `report_slug` is fixed for the rest of the turn — do **not** call the binding tools again.
 
 ## Report mindset
 
@@ -69,13 +85,15 @@ If the user wants live filters / period selectors / re-runnable queries, that is
 {% endif %}
 
 **Filesystem Tools** (`read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`):
-- Free to use under `reports/<id>/render/` for `.jsx` / `.js` / `.css` files. This is how you author the report.
-- Read-only for `reports/<id>/queries/*` (writes/edits/deletes are rejected — use `save_query`).
+- Use `glob('reports/*')` to discover existing slugs before `start_new_report` (Hard rule 2).
+- Use `glob('reports/*/manifest.json')` + `read_file` to map a display name → slug before `bind_existing_report` (Hard rule 3).
+- Free to use under `reports/<slug>/render/` for `.jsx` / `.js` / `.css` files. This is how you author the report.
+- Read-only for `reports/<slug>/queries/*` (writes/edits/deletes are rejected — use `save_query`).
 - Free elsewhere under the project root for scratch/notes (subject to the usual permission model).
 
 **Report Artifact Tools:**
-- `start_new_report(name, description)` — allocates a fresh `rpt_<slug>_<yymmdd>_<rand>` directory, writes `manifest.json` (`{name, description, kind: "report", created_at}`), and binds it as the active report. Both args are required (no defaults). Call **once**.
-- `bind_existing_report(report_id)` — binds an existing report directory for in-place editing. Fails when the directory or its `render/app.jsx` is missing.
+- `start_new_report(slug, name, description)` — creates `reports/<slug>/`, writes `manifest.json` (`{slug, name, description, kind: "report", created_at}`), and binds it as the active report. All three args are required (no defaults). Refuses to overwrite an existing directory. Call **once**.
+- `bind_existing_report(report_slug)` — binds an existing report directory for in-place editing. Fails when the directory or its `render/app.jsx` is missing.
 - `save_query(name, sql, description?, datasource?)` — runs the SQL, persists `<slug>.sql` and `<slug>.json`, returns:
   ```json
   {
@@ -88,9 +106,10 @@ If the user wants live filters / period selectors / re-runnable queries, that is
   ```
   Always capture `columns` from the return value — it's the source of truth for type choices in the render tree.
 - `validate_render()` — terminal call. Verifies:
-    1. `render/app.jsx` exists and includes `export default`.
-    2. Every `useQuerySql('queries/<slug>')` literal across all `render/*.{jsx,js}` resolves to a saved query.
-    3. Every `import` / `export … from '<path>'` is either a bare specifier in the allowed list (see below) or a relative path that resolves to a file under `render/`.
+    1. `manifest.json` exists and is well-formed.
+    2. `render/app.jsx` exists and includes `export default`.
+    3. Every `useQuerySql('queries/<slug>')` literal across all `render/*.{jsx,js}` resolves to a saved query.
+    4. Every `import` / `export … from '<path>'` is either a bare specifier in the allowed list (see below) or a relative path that resolves to a file under `render/`.
     No `../` escapes; no foreign npm packages. Warnings (unreferenced files) are non-fatal — fix or ignore.
 
 {% if has_ask_user_tool %}
@@ -105,11 +124,13 @@ If the user wants live filters / period selectors / re-runnable queries, that is
 ## Workflow
 
 1. **Understand the question** — extract time window, entity scope (region, segment, store …), and analytical themes. Decide create vs edit vs reference-for-new.
-2. **Bind the report** — call `start_new_report(name, description)` (creating) or `bind_existing_report(report_id)` (editing) exactly once. For new reports, draft a meaningful name (Chinese is fine) and one-paragraph description from the user's intent before calling.
-3. **Discover context** — use `list_subject_tree` / `search_metrics` / `list_tables` to find authoritative metrics, semantic models, and reference SQL. When the user pointed at reference reports, also `read_file` their `render/*.jsx` and `queries/<slug>.json` files for inspiration.
-4. **Probe** — `read_query` quick checks to confirm tables and columns exist and to size the data.
-5. **Save queries** — for each chart / table / KPI you intend to render, call `save_query(name, sql, description)` with a semantic English slug (`sales_by_store`, `headcount_by_zone`, `mom_growth_summary`). Aim for 3–10 queries.
-6. **Author the render tree** — `write_file` the components under `render/`. Always include `render/app.jsx` as the entry. Split larger reports into focused components — typical layout:
+2. **For edits, locate the slug first** — `glob('reports/*/manifest.json')` + `read_file` each manifest to find the matching `name` → `slug` when the user references the report by display name.
+3. **For creates, pick a non-colliding slug** — `glob('reports/*')` to see what's taken, then draft a semantic slug (`account_activity_q1`, `revenue_by_region`).
+4. **Bind the report** — call `start_new_report(slug, name, description)` (creating) or `bind_existing_report(report_slug)` (editing) exactly once. For new reports, draft a meaningful `name` (Chinese is fine) and one-paragraph `description` from the user's intent before calling.
+5. **Discover context** — use `list_subject_tree` / `search_metrics` / `list_tables` to find authoritative metrics, semantic models, and reference SQL. When the user pointed at reference reports, also `read_file` their `render/*.jsx` and `queries/<slug>.json` files for inspiration.
+6. **Probe** — `read_query` quick checks to confirm tables and columns exist and to size the data.
+7. **Save queries** — for each chart / table / KPI you intend to render, call `save_query(name, sql, description)` with a semantic English slug (`sales_by_store`, `headcount_by_zone`, `mom_growth_summary`). Aim for 3–10 queries.
+8. **Author the render tree** — `write_file` the components under `render/`. Always include `render/app.jsx` as the entry. Split larger reports into focused components — typical layout:
    ```
    render/
    ├── app.jsx              # imports the parts below, lays them out
@@ -123,13 +144,13 @@ If the user wants live filters / period selectors / re-runnable queries, that is
        └── card.jsx         # reusable <Card> primitive
    ```
    Keep each file focused and small (well under the 200 KB filesystem cap). The renderer compiles each module on demand — there's no bundling step on your side.
-7. **Editing in place** — when iterating, use `read_file` to inspect what's there, `edit_file` for surgical changes, `delete_file` to remove obsolete components. The validator reports unreferenced files as warnings so you can decide to keep them or clean up.
-8. **Finalize** — call `validate_render()`. Fix any reported issues (missing entry, dangling sqlId, illegal import) and call it again. Stop the moment it returns success.
+9. **Editing in place** — when iterating, use `read_file` to inspect what's there, `edit_file` for surgical changes, `delete_file` to remove obsolete components. The validator reports unreferenced files as warnings so you can decide to keep them or clean up.
+10. **Finalize** — call `validate_render()`. Fix any reported issues (missing entry, dangling sqlId, illegal import) and call it again. Stop the moment it returns success.
 
 ## Render tree contract
 
 {% set artifact_kind = 'report' %}
-{% set artifact_root = 'reports/<report_id>' %}
+{% set artifact_root = 'reports/<report_slug>' %}
 {% include '_visual_artifact_common.j2' %}
 
 ## Report layout
@@ -148,12 +169,13 @@ Adapt section counts to the dataset, but keep the order:
 
 If the user asks for a follow-up change ("swap revenue for unit sales", "add a YoY column"):
 
-1. `glob('reports/<id>/render/**/*.jsx')` to see the existing structure.
-2. `read_file` the components you need to touch (probably just one or two).
-3. If new data is needed, `save_query` to add or overwrite a query.
-4. `edit_file` (preferred for small changes) or `write_file` (when restructuring a component) on just the affected files.
-5. `delete_file` any components that no longer belong.
-6. `validate_render()` once.
+1. If you don't already know the slug, `glob('reports/*/manifest.json')` + `read_file` to map display name → slug, then `bind_existing_report(report_slug)`.
+2. `glob('reports/<slug>/render/**/*.jsx')` to see the existing structure.
+3. `read_file` the components you need to touch (probably just one or two).
+4. If new data is needed, `save_query` to add or overwrite a query.
+5. `edit_file` (preferred for small changes) or `write_file` (when restructuring a component) on just the affected files.
+6. `delete_file` any components that no longer belong.
+7. `validate_render()` once.
 
 You do NOT need to rewrite `app.jsx` for a localised change — surgical edits are the whole point of the multi-file layout.
 
@@ -203,8 +225,9 @@ Previous conversation summary:
 ## Final checklist
 
 Before you stop, confirm:
-- [ ] You called `start_new_report(name, description)` OR `bind_existing_report` exactly once. For `start_new_report` you supplied a meaningful display `name` (any language) and a one-paragraph `description`.
-- [ ] `reports/<report_id>/manifest.json` exists on disk with the name + description you supplied (the validator will reject otherwise).
+- [ ] You ran `glob('reports/*')` before `start_new_report` (or `glob('reports/*/manifest.json')` before `bind_existing_report` when the user gave a display name only).
+- [ ] You called `start_new_report(slug, name, description)` OR `bind_existing_report` exactly once. For `start_new_report` you supplied a meaningful, non-colliding `slug`, a display `name` (any language), and a one-paragraph `description`.
+- [ ] `reports/<report_slug>/manifest.json` exists on disk with the slug + name + description you supplied (the validator will reject otherwise).
 - [ ] Every `useQuerySql('queries/<slug>')` literal across `render/*.{jsx,js}` was produced via `save_query`.
 - [ ] `render/app.jsx` exists with `export default` and imports the rest of the components.
 - [ ] Every relative import resolves to a file under `render/`; no foreign npm packages.

--- a/datus/schemas/artifact_manifest.py
+++ b/datus/schemas/artifact_manifest.py
@@ -20,21 +20,35 @@ just says ``Untitled report``.
 
 from __future__ import annotations
 
+import re
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 ArtifactKind = Literal["report", "dashboard"]
 
+# LLM-supplied slug used directly as the artifact's directory name (no
+# random suffix, no prefix). Constrained to filesystem-friendly chars so
+# we never need to URL-escape it; max 80 keeps the full ``reports/<slug>/render/app.jsx``
+# path under typical OS limits.
+ARTIFACT_SLUG_PATTERN = r"^[a-z0-9_]{1,80}$"
+ARTIFACT_SLUG_RE = re.compile(ARTIFACT_SLUG_PATTERN)
+
 
 class ArtifactManifest(BaseModel):
-    """Persisted at ``<root>/<id>/manifest.json``.
+    """Persisted at ``<root>/<slug>/manifest.json``.
 
     Field choices:
 
-    * ``name`` and ``description`` are **required, non-empty**. The system
-      prompt forces the LLM to produce both at ``start_new_*`` time so
-      the artifact is never orphaned without a display name.
+    * ``slug`` is the LLM-supplied stable identifier; it doubles as the
+      on-disk directory name (``reports/<slug>/`` /
+      ``dashboards/<slug>/``). The LLM is responsible for choosing a
+      slug that doesn't collide with any existing artifact directory
+      (system prompt mandates a ``glob`` of the kind root before
+      calling ``start_new_*``).
+    * ``name`` and ``description`` are **required, non-empty**. The
+      system prompt forces the LLM to produce both at ``start_new_*``
+      time so the artifact is never orphaned without a display name.
     * ``kind`` mirrors the parent directory (``"reports"`` →
       ``"report"``, ``"dashboards"`` → ``"dashboard"``); callers that
       read the file by path already know which kind it is, but keeping
@@ -47,6 +61,11 @@ class ArtifactManifest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    slug: str = Field(
+        ...,
+        pattern=ARTIFACT_SLUG_PATTERN,
+        description="Filesystem-friendly slug; doubles as the artifact's directory name.",
+    )
     name: str = Field(..., min_length=1, max_length=200, description="Human-readable display name (any language).")
     description: str = Field(
         ...,

--- a/datus/schemas/gen_visual_dashboard_models.py
+++ b/datus/schemas/gen_visual_dashboard_models.py
@@ -30,7 +30,9 @@ from datus.schemas.gen_visual_report_models import (  # re-use the cross-artifac
     extract_query_slug,
 )
 
-DASHBOARD_ID_RE = re.compile(r"^dash_[a-z0-9_-]{1,80}$")
+# LLM-supplied slug doubles as the on-disk directory name; constrained
+# to a filesystem-friendly subset so we never need to URL-escape it.
+DASHBOARD_SLUG_RE = re.compile(r"^[a-z0-9_]{1,80}$")
 
 # Header line that declares the params a template body references. The
 # first non-blank line of a saved template must begin with this prefix.
@@ -61,7 +63,7 @@ ParamFullType = Literal[
 ]
 
 __all__ = [
-    "DASHBOARD_ID_RE",
+    "DASHBOARD_SLUG_RE",
     "DATA_REF_RE",
     "QUERY_SLUG_RE",
     "DATUS_PARAMS_HEADER_RE",
@@ -138,9 +140,12 @@ class GenVisualDashboardNodeResult(BaseResult):
     """Result model for GenVisualDashboardAgenticNode."""
 
     response: str = Field(default="", description="Natural language summary shown after the artifact is produced")
-    dashboard_id: Optional[str] = Field(None, description="Generated dashboard id (matches the folder name)")
+    dashboard_slug: Optional[str] = Field(
+        None,
+        description="LLM-chosen slug; doubles as the dashboard's directory name.",
+    )
     app_jsx_path: Optional[str] = Field(None, description="Relative path to render/app.jsx under project_root")
-    render_file_count: int = Field(default=0, description="Number of files persisted under dashboards/<id>/render/")
+    render_file_count: int = Field(default=0, description="Number of files persisted under dashboards/<slug>/render/")
     template_count: int = Field(default=0, description="Number of templates persisted under queries/")
     tokens_used: int = Field(default=0, description="Total tokens used during this run")
 

--- a/datus/schemas/gen_visual_report_models.py
+++ b/datus/schemas/gen_visual_report_models.py
@@ -16,7 +16,9 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from datus.schemas.base import BaseInput, BaseResult
 
-REPORT_ID_RE = re.compile(r"^rpt_[a-z0-9_-]{1,80}$")
+# LLM-supplied slug doubles as the on-disk directory name; constrained
+# to a filesystem-friendly subset so we never need to URL-escape it.
+REPORT_SLUG_RE = re.compile(r"^[a-z0-9_]{1,80}$")
 QUERY_SLUG_RE = re.compile(r"^[a-z0-9_]{1,64}$")
 # Permissive sqlId form accepted by ``useQuerySql`` inside main.jsx — the
 # runtime normalizes any of ``queries/foo``, ``queries/foo.json``, ``foo`` to
@@ -90,9 +92,9 @@ class GenVisualReportNodeResult(BaseResult):
     """Result model for GenVisualReportAgenticNode."""
 
     response: str = Field(default="", description="Natural language summary shown after the artifact is produced")
-    report_id: Optional[str] = Field(None, description="Generated report id (matches the folder name)")
+    report_slug: Optional[str] = Field(None, description="LLM-chosen slug; doubles as the report's directory name.")
     app_jsx_path: Optional[str] = Field(None, description="Relative path to render/app.jsx under project_root")
-    render_file_count: int = Field(default=0, description="Number of files persisted under reports/<id>/render/")
+    render_file_count: int = Field(default=0, description="Number of files persisted under reports/<slug>/render/")
     html_path: Optional[str] = Field(None, description="Path to compiled index.html (CLI mode only)")
     query_count: int = Field(default=0, description="Number of queries persisted under queries/")
     tokens_used: int = Field(default=0, description="Total tokens used during this run")

--- a/datus/tools/func_tool/_artifact_filesystem_base.py
+++ b/datus/tools/func_tool/_artifact_filesystem_base.py
@@ -65,8 +65,11 @@ class ArtifactFilesystemFuncTool(FilesystemFuncTool):
         if not cls.ARTIFACT_ROOT_DIR_NAME:
             return
         root = re.escape(cls.ARTIFACT_ROOT_DIR_NAME)
-        cls._RENDER_PATH_RE = re.compile(rf"^{root}/[^/]+/render(?:/.+)?$")
-        cls._QUERIES_PATH_RE = re.compile(rf"^{root}/[^/]+/queries/.+$")
+        # Slug is constrained to ``[a-z0-9_]{1,80}`` — matches
+        # ARTIFACT_SLUG_PATTERN in datus.schemas.artifact_manifest.
+        slug = r"[a-z0-9_]{1,80}"
+        cls._RENDER_PATH_RE = re.compile(rf"^{root}/{slug}/render(?:/.+)?$")
+        cls._QUERIES_PATH_RE = re.compile(rf"^{root}/{slug}/queries/.+$")
 
     # ── Path classification ──────────────────────────────────────────────
 

--- a/datus/tools/func_tool/_visual_artifact_helpers.py
+++ b/datus/tools/func_tool/_visual_artifact_helpers.py
@@ -7,161 +7,37 @@ and the matching artifact tool implementations.
 
 Both ``GenVisualReportAgenticNode`` / ``GenVisualDashboardAgenticNode``
 *and* the underlying ``ReportArtifactTools`` / ``DashboardArtifactTools``
-need a small set of byte-identical helpers:
+need a tiny shared toolbox:
 
-* Detect inline ``rpt_<id>`` / ``dash_<id>`` mentions in the user message
-  so the LLM can decide between "edit existing" and "create new that
-  references existing".
-* Walk the recorded :class:`ActionHistory.output` envelope produced by
-  artifact tool calls to pull out fields like ``app_jsx_path`` or
-  ``render_files``.
-* Allocate a fresh artifact id collision-free under the project root,
-  and stamp an ISO-8601 UTC timestamp for ``executed_at`` / ``saved_at``
-  fields.
+* ``utc_now_iso()`` — ISO-8601 UTC timestamp at second precision used
+  for ``executed_at`` / ``saved_at`` / ``created_at`` fields.
+* ``extract_artifact_result_field`` / ``extract_artifact_result_list`` —
+  walk a recorded :class:`ActionHistory.output` envelope to pull out
+  fields like ``app_jsx_path`` or ``render_files``.
 
-Keeping all of the above in one module so the two subagents stay
-byte-identical on the logic the LLM observes.
+The earlier ``rpt_<slug>_<yymmdd>_<rand>`` allocator and the matching
+``detect_referenced_artifact_ids`` inline-scan helper are gone: the LLM
+now picks a bare ``slug`` directly (the system prompt forces a ``glob``
+of the kind root for uniqueness), so there's nothing to allocate and
+nothing to inline-detect.
 """
 
 from __future__ import annotations
 
 import datetime as _dt
 import json
-import re
-import uuid
-from pathlib import Path
 from typing import Any, List, Optional
 
 from datus.schemas.action_history import ActionHistory
-
-
-def detect_referenced_artifact_ids(
-    *,
-    user_message: str,
-    project_root: Path,
-    root_dir_name: str,
-    id_inline_regex: re.Pattern[str],
-    id_full_regex: re.Pattern[str],
-    app_jsx_relpath: str = "render/app.jsx",
-) -> List[str]:
-    """Return artifact ids the user mentioned that already exist on disk.
-
-    Used purely as an awareness hint for the LLM — the model decides
-    whether to bind/edit them or to start a fresh artifact that
-    references them. Deduplicates while preserving first-mention order
-    so the hint reads naturally.
-
-    Parameters
-    ----------
-    user_message:
-        Raw user prompt text. Matched case-insensitively because LLMs
-        sometimes uppercase artifact ids in conversation.
-    project_root:
-        Resolved project root; artifact ids resolve to
-        ``project_root/<root_dir_name>/<id>/``.
-    root_dir_name:
-        ``"reports"`` for ``rpt_``, ``"dashboards"`` for ``dash_``.
-    id_inline_regex:
-        Pattern that matches the id inside the message body (e.g. the
-        loose ``rpt_<chars>`` form with a non-alnum guard at the front).
-    id_full_regex:
-        Strict pattern that the candidate must additionally pass before
-        we treat it as a real artifact id (e.g. ``REPORT_ID_RE``).
-    app_jsx_relpath:
-        Path inside the artifact directory that must exist before we
-        consider the directory a valid artifact. Defaults to the
-        ``render/app.jsx`` contract both subagents enforce.
-    """
-    root = project_root / root_dir_name
-    if not root.is_dir():
-        return []
-    seen: set[str] = set()
-    found: List[str] = []
-    for match in id_inline_regex.finditer(user_message.lower()):
-        candidate = match.group(0)
-        if candidate in seen or not id_full_regex.fullmatch(candidate):
-            continue
-        candidate_dir = root / candidate
-        if candidate_dir.is_dir() and (candidate_dir / app_jsx_relpath).is_file():
-            seen.add(candidate)
-            found.append(candidate)
-    return found
 
 
 def utc_now_iso() -> str:
     """ISO-8601 UTC timestamp at second precision (``YYYY-MM-DDTHH:MM:SSZ``).
 
     Used for ``executed_at`` (report queries) and ``saved_at`` (dashboard
-    template metadata). Stamped to the second so two saves within the
-    same minute don't appear identical.
+    template metadata) and ``created_at`` (artifact manifest).
     """
     return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-_SLUG_NON_ASCII_RE = re.compile(r"[^a-z0-9]+")
-
-
-def slugify_title(title: str, max_len: int = 32) -> str:
-    """Best-effort ASCII slug from an LLM-supplied artifact title.
-
-    Non-ASCII characters are stripped, runs of separators collapse to a
-    single underscore, leading/trailing underscores are trimmed, and the
-    result is truncated to ``max_len`` chars. Returns an empty string
-    when the title contains no usable characters — callers fall back to
-    a literal default (``"report"`` / ``"dashboard"``).
-    """
-    ascii_only = title.encode("ascii", errors="ignore").decode("ascii")
-    slug = _SLUG_NON_ASCII_RE.sub("_", ascii_only.lower()).strip("_")
-    return slug[:max_len]
-
-
-def allocate_artifact_id(
-    *,
-    title: str,
-    project_root: Path,
-    prefix: str,
-    root_dir_name: str,
-    default_base_slug: str,
-    max_total_len: int,
-    attempts: int = 8,
-) -> str:
-    """Generate ``<prefix><title-slug>_<yymmdd>_<rand6>`` not colliding on disk.
-
-    Parameters
-    ----------
-    title:
-        Raw LLM-supplied title. Slugified via :func:`slugify_title`; empty
-        result falls back to ``default_base_slug``.
-    project_root:
-        Resolved project root; the candidate is checked against
-        ``project_root/<root_dir_name>/<candidate>``.
-    prefix:
-        ``"rpt_"`` for reports, ``"dash_"`` for dashboards.
-    root_dir_name:
-        ``"reports"`` for reports, ``"dashboards"`` for dashboards.
-    default_base_slug:
-        Slug to use when ``title`` reduces to an empty string after
-        ASCII filtering.
-    max_total_len:
-        Hard cap on the final id length. Mirrors the legacy values
-        (report = 83, dashboard = 84) so we don't shorten existing ids.
-    attempts:
-        Number of unique-id rolls before giving up. Default 8.
-
-    Raises
-    ------
-    RuntimeError
-        If no collision-free candidate is found within ``attempts``.
-    """
-    stamp = _dt.datetime.now(_dt.timezone.utc).strftime("%y%m%d")
-    base_slug = slugify_title(title) or default_base_slug
-    artifact_root = project_root / root_dir_name
-    for _ in range(attempts):
-        suffix = uuid.uuid4().hex[:6]
-        candidate = f"{prefix}{base_slug}_{stamp}_{suffix}"[:max_total_len]
-        if not (artifact_root / candidate).exists():
-            return candidate
-    raise RuntimeError(f"Failed to allocate a unique {root_dir_name.rstrip('s')} id after {attempts} attempts")
 
 
 def extract_artifact_result_field(action: ActionHistory, field: str) -> Optional[str]:

--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -36,7 +36,7 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from datus.schemas.artifact_manifest import ArtifactManifest
 from datus.schemas.gen_visual_dashboard_models import (
-    DASHBOARD_ID_RE,
+    DASHBOARD_SLUG_RE,
     QUERY_SLUG_RE,
     QueryTemplateMetaFile,
     TemplateParamDecl,
@@ -44,10 +44,7 @@ from datus.schemas.gen_visual_dashboard_models import (
     parse_datus_params_header,
 )
 from datus.tools.func_tool._artifact_filesystem_base import ArtifactFilesystemFuncTool
-from datus.tools.func_tool._visual_artifact_helpers import (
-    allocate_artifact_id,
-    utc_now_iso,
-)
+from datus.tools.func_tool._visual_artifact_helpers import utc_now_iso
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.tools.func_tool.report_artifact_tools import (
     _DEFAULT_EXPORT_RE,
@@ -100,22 +97,6 @@ _PARAMS_KEY_RE = re.compile(
     """,
     re.VERBOSE | re.IGNORECASE,
 )
-
-
-def _allocate_dashboard_id(name: str, project_root: Path) -> str:
-    """Generate ``dash_<name-slug>_<yymmdd>_<rand6>`` not colliding on disk.
-
-    ``name`` is the LLM-supplied display name; non-ASCII characters are
-    stripped from the slug, falling back to ``"dashboard"``.
-    """
-    return allocate_artifact_id(
-        title=name,
-        project_root=project_root,
-        prefix="dash_",
-        root_dir_name="dashboards",
-        default_base_slug="dashboard",
-        max_total_len=84,
-    )
 
 
 # --------------------------------------------------------------------------- #
@@ -293,7 +274,7 @@ class DashboardArtifactTools:
         self._project_root = project_root
 
         # Lazy state — populated by start_new_dashboard / bind_existing_dashboard.
-        self.dashboard_id: Optional[str] = None
+        self.dashboard_slug: Optional[str] = None
         self.dashboard_dir: Optional[Path] = None
         self.queries_dir: Optional[Path] = None
         self.render_dir: Optional[Path] = None
@@ -316,17 +297,26 @@ class DashboardArtifactTools:
 
     # -- intent declaration --------------------------------------------------
 
-    def start_new_dashboard(self, name: str, description: str) -> FuncToolResult:
+    def start_new_dashboard(self, slug: str, name: str, description: str) -> FuncToolResult:
         """
-        Allocate a fresh dashboard directory, write its manifest, and bind subsequent saves to it.
+        Create a fresh dashboard directory at ``dashboards/<slug>/``, write its manifest, and bind it.
+
+        The LLM picks the ``slug`` — it doubles as the on-disk directory
+        name and as the stable identifier surfaced everywhere downstream
+        (SaaS list pages, IDE explorer, backend routes). **Before calling
+        this tool the LLM must ``glob('dashboards/*')`` and confirm the
+        chosen slug doesn't collide** — this tool refuses to overwrite an
+        existing directory.
 
         Args:
-            name: Human-readable display name (any language — Chinese
-                / mixed scripts welcome). Used both as the manifest
-                display name AND as the seed for the dashboard id slug
-                (non-ASCII characters are stripped from the slug; the
-                manifest preserves the original name). Required, max
-                200 chars.
+            slug: Lowercase ASCII identifier matching ``^[a-z0-9_]{1,80}$``.
+                Becomes the directory name (``dashboards/<slug>/``). Pick
+                something semantic and stable (e.g.
+                ``revenue_overview``); do NOT include personal
+                information or timestamps unless they're load-bearing
+                for disambiguation.
+            name: Human-readable display name (any language is fine —
+                Chinese / mixed scripts welcome). Required, max 200 chars.
             description: One-paragraph description of what the
                 dashboard tracks / answers. Surfaced in list pages and
                 IDE explorers next to the name. Required, max 1000
@@ -336,14 +326,23 @@ class DashboardArtifactTools:
             FuncToolResult.result is a dict like::
 
                 {
-                    "dashboard_id": "dash_<slug>_<yymmdd>_<rand>",
-                    "dashboard_dir": "dashboards/<dashboard_id>",
-                    "render_dir": "dashboards/<dashboard_id>/render",
-                    "queries_dir": "dashboards/<dashboard_id>/queries",
-                    "manifest_path": "dashboards/<dashboard_id>/manifest.json",
+                    "dashboard_slug": "<slug>",
+                    "dashboard_dir": "dashboards/<slug>",
+                    "render_dir": "dashboards/<slug>/render",
+                    "queries_dir": "dashboards/<slug>/queries",
+                    "manifest_path": "dashboards/<slug>/manifest.json",
                     "mode": "new",
                 }
         """
+        if not slug or not DASHBOARD_SLUG_RE.fullmatch(slug):
+            return FuncToolResult(
+                success=0,
+                error=(
+                    f"slug must match {DASHBOARD_SLUG_RE.pattern} (lowercase letters / digits / underscores, "
+                    f"1–80 chars); got {slug!r}. Pick a semantic identifier; the LLM is responsible for "
+                    "uniqueness within dashboards/."
+                ),
+            )
         if not name or not name.strip():
             return FuncToolResult(success=0, error="name must be a non-empty display name (any language).")
         if not description or not description.strip():
@@ -351,8 +350,18 @@ class DashboardArtifactTools:
                 success=0,
                 error="description must be a non-empty one-paragraph description of what the dashboard covers.",
             )
+        candidate = self._project_root / "dashboards" / slug
+        if candidate.exists():
+            return FuncToolResult(
+                success=0,
+                error=(
+                    f"dashboards/{slug}/ already exists. Pick a different slug — first `glob('dashboards/*')` "
+                    "to see what's taken, or call `bind_existing_dashboard` if you meant to edit it."
+                ),
+            )
         try:
             manifest = ArtifactManifest(
+                slug=slug,
                 name=name.strip(),
                 description=description.strip(),
                 kind="dashboard",
@@ -360,19 +369,27 @@ class DashboardArtifactTools:
             )
         except Exception as exc:
             return FuncToolResult(success=0, error=f"Manifest validation failed: {exc}")
-        try:
-            new_id = _allocate_dashboard_id(name, self._project_root)
-        except RuntimeError as exc:
-            return FuncToolResult(success=0, error=str(exc))
-        return self._activate(new_id, mode="new", create_dirs=True, manifest=manifest)
+        return self._activate(slug, mode="new", create_dirs=True, manifest=manifest)
 
-    def bind_existing_dashboard(self, dashboard_id: str) -> FuncToolResult:
+    def bind_existing_dashboard(self, dashboard_slug: str) -> FuncToolResult:
         """
         Switch the active dashboard to an existing one and bind subsequent saves there.
 
+        Call this when the user asks to **modify / update / edit /
+        append to** a specific named dashboard. ``save_query_template``
+        overwrites same-named queries; ``write_file`` / ``edit_file`` /
+        ``delete_file`` mutate ``render/`` in-place. Use ``read_file`` +
+        ``glob`` to inspect the existing tree before mutating it.
+
+        When the user references the dashboard by its display name rather
+        than its slug (``"update the revenue overview dashboard"``), the
+        LLM should first ``glob('dashboards/*/manifest.json')`` and read
+        each manifest's ``name`` to find the matching slug, then call this
+        tool with that slug.
+
         Args:
-            dashboard_id: target dashboard id, e.g. ``"dash_revenue_overview_260514_a1b2c3"``.
-                Must match ``^dash_[a-z0-9_-]{1,80}$`` and the directory
+            dashboard_slug: target dashboard slug, e.g. ``"revenue_overview"``.
+                Must match ``^[a-z0-9_]{1,80}$`` and the directory
                 (including ``render/app.jsx``) must already exist under
                 ``<project_root>/dashboards/``.
 
@@ -380,24 +397,24 @@ class DashboardArtifactTools:
             FuncToolResult.result is a dict like::
 
                 {
-                    "dashboard_id": "<dashboard_id>",
-                    "dashboard_dir": "dashboards/<dashboard_id>",
-                    "render_dir": "dashboards/<dashboard_id>/render",
-                    "queries_dir": "dashboards/<dashboard_id>/queries",
+                    "dashboard_slug": "<slug>",
+                    "dashboard_dir": "dashboards/<slug>",
+                    "render_dir": "dashboards/<slug>/render",
+                    "queries_dir": "dashboards/<slug>/queries",
                     "mode": "edit",
                 }
         """
-        if not dashboard_id or not DASHBOARD_ID_RE.fullmatch(dashboard_id):
+        if not dashboard_slug or not DASHBOARD_SLUG_RE.fullmatch(dashboard_slug):
             return FuncToolResult(
                 success=0,
-                error=f"dashboard_id must match {DASHBOARD_ID_RE.pattern}; got {dashboard_id!r}",
+                error=f"dashboard_slug must match {DASHBOARD_SLUG_RE.pattern}; got {dashboard_slug!r}",
             )
-        candidate = self._project_root / "dashboards" / dashboard_id
+        candidate = self._project_root / "dashboards" / dashboard_slug
         if not candidate.is_dir():
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"Dashboard directory not found: dashboards/{dashboard_id}. "
+                    f"Dashboard directory not found: dashboards/{dashboard_slug}. "
                     "Use start_new_dashboard() if you intended to create a new dashboard."
                 ),
             )
@@ -405,21 +422,21 @@ class DashboardArtifactTools:
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"dashboards/{dashboard_id}/render/app.jsx is missing — the dashboard is "
+                    f"dashboards/{dashboard_slug}/render/app.jsx is missing — the dashboard is "
                     "incomplete. Cannot bind for editing."
                 ),
             )
-        return self._activate(dashboard_id, mode="edit", create_dirs=False)
+        return self._activate(dashboard_slug, mode="edit", create_dirs=False)
 
     def _activate(
         self,
-        dashboard_id: str,
+        dashboard_slug: str,
         *,
         mode: str,
         create_dirs: bool,
         manifest: Optional[ArtifactManifest] = None,
     ) -> FuncToolResult:
-        dashboard_dir = self._project_root / "dashboards" / dashboard_id
+        dashboard_dir = self._project_root / "dashboards" / dashboard_slug
         queries_dir = dashboard_dir / "queries"
         render_dir = dashboard_dir / "render"
         manifest_path = dashboard_dir / "manifest.json"
@@ -436,16 +453,16 @@ class DashboardArtifactTools:
             except OSError as exc:
                 return FuncToolResult(success=0, error=f"Failed to write manifest.json: {exc}")
             manifest_rel = manifest_path.relative_to(self._project_root).as_posix()
-        self.dashboard_id = dashboard_id
+        self.dashboard_slug = dashboard_slug
         self.dashboard_dir = dashboard_dir
         self.queries_dir = queries_dir
         self.render_dir = render_dir
         self.mode = mode
         result: Dict[str, Any] = {
-            "dashboard_id": dashboard_id,
-            "dashboard_dir": f"dashboards/{dashboard_id}",
-            "render_dir": f"dashboards/{dashboard_id}/render",
-            "queries_dir": f"dashboards/{dashboard_id}/queries",
+            "dashboard_slug": dashboard_slug,
+            "dashboard_dir": f"dashboards/{dashboard_slug}",
+            "render_dir": f"dashboards/{dashboard_slug}/render",
+            "queries_dir": f"dashboards/{dashboard_slug}/queries",
             "mode": mode,
         }
         if manifest_rel:
@@ -453,12 +470,12 @@ class DashboardArtifactTools:
         return FuncToolResult(result=result)
 
     def _require_active(self, tool_name: str) -> Optional[FuncToolResult]:
-        if self.dashboard_id is None or self.dashboard_dir is None or self.queries_dir is None:
+        if self.dashboard_slug is None or self.dashboard_dir is None or self.queries_dir is None:
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"No active dashboard bound. Call start_new_dashboard(name=..., description=...) "
-                    f"to create one, or bind_existing_dashboard(dashboard_id=...) to edit an "
+                    f"No active dashboard bound. Call start_new_dashboard(slug=..., name=..., description=...) "
+                    f"to create one, or bind_existing_dashboard(dashboard_slug=...) to edit an "
                     f"existing one, before calling {tool_name}()."
                 ),
             )
@@ -657,7 +674,7 @@ class DashboardArtifactTools:
         header_parts: List[str] = []
         if description:
             header_parts.append(f"-- {description.strip()}")
-        header_parts.append(f"-- saved at {meta_payload['saved_at']} for dashboard {self.dashboard_id}")
+        header_parts.append(f"-- saved at {meta_payload['saved_at']} for dashboard {self.dashboard_slug}")
         sql_text = sql_template.rstrip() + "\n\n" + "\n".join(header_parts) + "\n"
 
         try:
@@ -719,7 +736,7 @@ class DashboardArtifactTools:
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"dashboards/{self.dashboard_id}/manifest.json is missing. A dashboard must "
+                    f"dashboards/{self.dashboard_slug}/manifest.json is missing. A dashboard must "
                     "always have a manifest with name + description. Re-run start_new_dashboard "
                     "or restore the manifest from a previous version."
                 ),
@@ -729,14 +746,14 @@ class DashboardArtifactTools:
         except Exception as exc:
             return FuncToolResult(
                 success=0,
-                error=f"dashboards/{self.dashboard_id}/manifest.json is corrupt or off-spec: {exc}",
+                error=f"dashboards/{self.dashboard_slug}/manifest.json is corrupt or off-spec: {exc}",
             )
 
         if not self.render_dir.is_dir():
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"render/ directory missing under dashboards/{self.dashboard_id}. "
+                    f"render/ directory missing under dashboards/{self.dashboard_slug}. "
                     "Write at least an app.jsx with write_file before calling validate_render."
                 ),
             )

--- a/datus/tools/func_tool/report_artifact_tools.py
+++ b/datus/tools/func_tool/report_artifact_tools.py
@@ -38,17 +38,13 @@ from agents import Tool
 from datus.schemas.artifact_manifest import ArtifactManifest
 from datus.schemas.gen_visual_report_models import (
     QUERY_SLUG_RE,
-    REPORT_ID_RE,
+    REPORT_SLUG_RE,
     ColumnSemanticType,
     QueryResultFile,
     extract_query_slug,
 )
 from datus.tools.func_tool._artifact_filesystem_base import ArtifactFilesystemFuncTool
-from datus.tools.func_tool._visual_artifact_helpers import (
-    allocate_artifact_id,
-    slugify_title,
-    utc_now_iso,
-)
+from datus.tools.func_tool._visual_artifact_helpers import utc_now_iso
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.utils.loggings import get_logger
 
@@ -99,31 +95,6 @@ ALLOWED_BARE_MODULES: frozenset[str] = frozenset(
         "@datus/web-artifact",
     }
 )
-
-
-def _allocate_report_id(name: str, project_root: Path) -> str:
-    """Generate ``rpt_<name-slug>_<yymmdd>_<rand6>`` not colliding on disk.
-
-    ``name`` is the LLM-supplied display name (may contain non-ASCII);
-    we slugify it best-effort and fall back to ``"report"`` when the
-    slug reduces to an empty string (e.g. an all-Chinese name).
-    """
-    return allocate_artifact_id(
-        title=name,
-        project_root=project_root,
-        prefix="rpt_",
-        root_dir_name="reports",
-        default_base_slug="report",
-        max_total_len=83,
-    )
-
-
-# Module-level aliases preserved so existing internal imports
-# (``dashboard_artifact_tools`` pulls ``_slugify_title``) keep working
-# without forcing every call site to switch to the new public names
-# in lockstep with this refactor.
-_slugify_title = slugify_title
-_utc_now_iso = utc_now_iso
 
 
 def _atomic_write_text(path: Path, content: str) -> None:
@@ -304,14 +275,14 @@ class ReportArtifactTools:
     Lifecycle:
 
     1. The owning node constructs one instance per execution with no
-       active report id.
+       active report slug.
     2. The LLM declares intent and binds the active report by calling
        **exactly one** of ``start_new_report`` (create) or
        ``bind_existing_report`` (edit). The system prompt enumerates the
        decision criteria.
     3. ``save_query`` writes query artifacts. ``write_file`` /
        ``edit_file`` / ``delete_file`` (from the filesystem tool) put
-       JSX/JS/CSS under ``reports/<id>/render/``.
+       JSX/JS/CSS under ``reports/<slug>/render/``.
     4. ``validate_render`` is the terminal action: it walks the render
        tree, checks the entry point, verifies every ``useQuerySql``
        slug exists, and confirms every relative import resolves. The
@@ -333,7 +304,7 @@ class ReportArtifactTools:
         self._project_root = project_root
 
         # Lazy state — populated by start_new_report / bind_existing_report.
-        self.report_id: Optional[str] = None
+        self.report_slug: Optional[str] = None
         self.report_dir: Optional[Path] = None
         self.queries_dir: Optional[Path] = None
         self.render_dir: Optional[Path] = None
@@ -354,23 +325,26 @@ class ReportArtifactTools:
 
     # -- intent declaration --------------------------------------------------
 
-    def start_new_report(self, name: str, description: str) -> FuncToolResult:
+    def start_new_report(self, slug: str, name: str, description: str) -> FuncToolResult:
         """
-        Allocate a fresh report directory, write its manifest, and bind subsequent saves to it.
+        Create a fresh report directory at ``reports/<slug>/``, write its manifest, and bind it.
 
-        Call this when the user's request is to **produce a new report
-        artifact**, even if they reference one or more existing reports
-        for context. To learn from a reference report, read its
-        ``render/*`` / ``queries/*`` via the filesystem read tool and
-        then build the new artifact here.
+        The LLM picks the ``slug`` — it doubles as the on-disk directory
+        name and as the stable identifier surfaced everywhere downstream
+        (SaaS list pages, IDE explorer, backend routes). **Before calling
+        this tool the LLM must ``glob('reports/*')`` and confirm the
+        chosen slug doesn't collide** — this tool refuses to overwrite
+        an existing directory.
 
         Args:
+            slug: Lowercase ASCII identifier matching ``^[a-z0-9_]{1,80}$``.
+                Becomes the directory name (``reports/<slug>/``). Pick
+                something semantic and stable (e.g.
+                ``account_activity_q1_2026``); do NOT include personal
+                information or timestamps unless they're load-bearing
+                for disambiguation.
             name: Human-readable display name (any language is fine —
-                Chinese / mixed scripts welcome). Used both as the
-                ``manifest.json`` display name AND as the seed for the
-                report id slug (non-ASCII characters are stripped from
-                the slug; the manifest preserves the original name).
-                Required, max 200 chars.
+                Chinese / mixed scripts welcome). Required, max 200 chars.
             description: One-paragraph description of what the report
                 argues / covers. Surfaced in list pages and IDE
                 explorers next to the name. Required, max 1000 chars.
@@ -379,14 +353,23 @@ class ReportArtifactTools:
             FuncToolResult.result is a dict like::
 
                 {
-                    "report_id": "rpt_<slug>_<yymmdd>_<rand>",
-                    "report_dir": "reports/<report_id>",
-                    "render_dir": "reports/<report_id>/render",
-                    "queries_dir": "reports/<report_id>/queries",
-                    "manifest_path": "reports/<report_id>/manifest.json",
+                    "report_slug": "<slug>",
+                    "report_dir": "reports/<slug>",
+                    "render_dir": "reports/<slug>/render",
+                    "queries_dir": "reports/<slug>/queries",
+                    "manifest_path": "reports/<slug>/manifest.json",
                     "mode": "new",
                 }
         """
+        if not slug or not REPORT_SLUG_RE.fullmatch(slug):
+            return FuncToolResult(
+                success=0,
+                error=(
+                    f"slug must match {REPORT_SLUG_RE.pattern} (lowercase letters / digits / underscores, "
+                    f"1–80 chars); got {slug!r}. Pick a semantic identifier; the LLM is responsible for "
+                    "uniqueness within reports/."
+                ),
+            )
         if not name or not name.strip():
             return FuncToolResult(success=0, error="name must be a non-empty display name (any language).")
         if not description or not description.strip():
@@ -394,8 +377,18 @@ class ReportArtifactTools:
                 success=0,
                 error="description must be a non-empty one-paragraph description of what the report covers.",
             )
+        candidate = self._project_root / "reports" / slug
+        if candidate.exists():
+            return FuncToolResult(
+                success=0,
+                error=(
+                    f"reports/{slug}/ already exists. Pick a different slug — first `glob('reports/*')` "
+                    "to see what's taken, or call `bind_existing_report` if you meant to edit it."
+                ),
+            )
         try:
             manifest = ArtifactManifest(
+                slug=slug,
                 name=name.strip(),
                 description=description.strip(),
                 kind="report",
@@ -403,13 +396,9 @@ class ReportArtifactTools:
             )
         except Exception as exc:
             return FuncToolResult(success=0, error=f"Manifest validation failed: {exc}")
-        try:
-            new_id = _allocate_report_id(name, self._project_root)
-        except RuntimeError as exc:
-            return FuncToolResult(success=0, error=str(exc))
-        return self._activate(new_id, mode="new", create_dirs=True, manifest=manifest)
+        return self._activate(slug, mode="new", create_dirs=True, manifest=manifest)
 
-    def bind_existing_report(self, report_id: str) -> FuncToolResult:
+    def bind_existing_report(self, report_slug: str) -> FuncToolResult:
         """
         Switch the active report to an existing one and bind subsequent saves there.
 
@@ -419,9 +408,15 @@ class ReportArtifactTools:
         ``delete_file`` mutate ``render/`` in-place. Use ``read_file``
         + ``glob`` to inspect the existing tree before mutating it.
 
+        When the user references the report by its display name rather
+        than its slug (``"update the account activity report"``), the LLM
+        should first ``glob('reports/*/manifest.json')`` and read each
+        manifest's ``name`` to find the matching slug, then call this
+        tool with that slug.
+
         Args:
-            report_id: target report id, e.g. ``"rpt_2026q1_na_sales"``.
-                Must match ``^rpt_[a-z0-9_-]{1,80}$`` and the directory
+            report_slug: target report slug, e.g. ``"account_activity_q1"``.
+                Must match ``^[a-z0-9_]{1,80}$`` and the directory
                 (including ``render/app.jsx``) must already exist under
                 ``<project_root>/reports/``.
 
@@ -429,24 +424,24 @@ class ReportArtifactTools:
             FuncToolResult.result is a dict like::
 
                 {
-                    "report_id": "<report_id>",
-                    "report_dir": "reports/<report_id>",
-                    "render_dir": "reports/<report_id>/render",
-                    "queries_dir": "reports/<report_id>/queries",
+                    "report_slug": "<slug>",
+                    "report_dir": "reports/<slug>",
+                    "render_dir": "reports/<slug>/render",
+                    "queries_dir": "reports/<slug>/queries",
                     "mode": "edit",
                 }
         """
-        if not report_id or not REPORT_ID_RE.fullmatch(report_id):
+        if not report_slug or not REPORT_SLUG_RE.fullmatch(report_slug):
             return FuncToolResult(
                 success=0,
-                error=f"report_id must match {REPORT_ID_RE.pattern}; got {report_id!r}",
+                error=f"report_slug must match {REPORT_SLUG_RE.pattern}; got {report_slug!r}",
             )
-        candidate = self._project_root / "reports" / report_id
+        candidate = self._project_root / "reports" / report_slug
         if not candidate.is_dir():
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"Report directory not found: reports/{report_id}. "
+                    f"Report directory not found: reports/{report_slug}. "
                     "Use start_new_report() if you intended to create a new report."
                 ),
             )
@@ -454,20 +449,21 @@ class ReportArtifactTools:
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"reports/{report_id}/render/app.jsx is missing — the report is incomplete. Cannot bind for editing."
+                    f"reports/{report_slug}/render/app.jsx is missing — the report is incomplete. "
+                    "Cannot bind for editing."
                 ),
             )
-        return self._activate(report_id, mode="edit", create_dirs=False)
+        return self._activate(report_slug, mode="edit", create_dirs=False)
 
     def _activate(
         self,
-        report_id: str,
+        report_slug: str,
         *,
         mode: str,
         create_dirs: bool,
         manifest: Optional[ArtifactManifest] = None,
     ) -> FuncToolResult:
-        report_dir = self._project_root / "reports" / report_id
+        report_dir = self._project_root / "reports" / report_slug
         queries_dir = report_dir / "queries"
         render_dir = report_dir / "render"
         manifest_path = report_dir / "manifest.json"
@@ -484,16 +480,16 @@ class ReportArtifactTools:
             except OSError as exc:
                 return FuncToolResult(success=0, error=f"Failed to write manifest.json: {exc}")
             manifest_rel = manifest_path.relative_to(self._project_root).as_posix()
-        self.report_id = report_id
+        self.report_slug = report_slug
         self.report_dir = report_dir
         self.queries_dir = queries_dir
         self.render_dir = render_dir
         self.mode = mode
         result: Dict[str, Any] = {
-            "report_id": report_id,
-            "report_dir": f"reports/{report_id}",
-            "render_dir": f"reports/{report_id}/render",
-            "queries_dir": f"reports/{report_id}/queries",
+            "report_slug": report_slug,
+            "report_dir": f"reports/{report_slug}",
+            "render_dir": f"reports/{report_slug}/render",
+            "queries_dir": f"reports/{report_slug}/queries",
             "mode": mode,
         }
         if manifest_rel:
@@ -502,12 +498,12 @@ class ReportArtifactTools:
 
     def _require_active(self, tool_name: str) -> Optional[FuncToolResult]:
         """Return a failure result when no report is bound, else ``None``."""
-        if self.report_id is None or self.report_dir is None or self.queries_dir is None:
+        if self.report_slug is None or self.report_dir is None or self.queries_dir is None:
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"No active report bound. Call start_new_report(name=..., description=...) to create one, "
-                    f"or bind_existing_report(report_id=...) to edit an existing one, "
+                    f"No active report bound. Call start_new_report(slug=..., name=..., description=...) "
+                    f"to create one, or bind_existing_report(report_slug=...) to edit an existing one, "
                     f"before calling {tool_name}()."
                 ),
             )
@@ -646,7 +642,7 @@ class ReportArtifactTools:
         header_parts: List[str] = []
         if description:
             header_parts.append(f"-- {description.strip()}")
-        header_parts.append(f"-- generated at {payload['executed_at']} for report {self.report_id}")
+        header_parts.append(f"-- generated at {payload['executed_at']} for report {self.report_slug}")
         sql_text = "\n".join(header_parts) + "\n" + sql.rstrip() + "\n"
 
         try:
@@ -712,7 +708,7 @@ class ReportArtifactTools:
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"reports/{self.report_id}/manifest.json is missing. A report must always "
+                    f"reports/{self.report_slug}/manifest.json is missing. A report must always "
                     "have a manifest with name + description. Re-run start_new_report or "
                     "restore the manifest from a previous version."
                 ),
@@ -722,14 +718,14 @@ class ReportArtifactTools:
         except Exception as exc:
             return FuncToolResult(
                 success=0,
-                error=f"reports/{self.report_id}/manifest.json is corrupt or off-spec: {exc}",
+                error=f"reports/{self.report_slug}/manifest.json is corrupt or off-spec: {exc}",
             )
 
         if not self.render_dir.is_dir():
             return FuncToolResult(
                 success=0,
                 error=(
-                    f"render/ directory missing under reports/{self.report_id}. "
+                    f"render/ directory missing under reports/{self.report_slug}. "
                     "Write at least an app.jsx with write_file before calling validate_render."
                 ),
             )

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -9,12 +9,10 @@ Design principle: NO mocks except LLM.
 Covers:
 * Node initialization wires the expected tools (db, filesystem, semantic).
 * ``DashboardFilesystemFuncTool`` replaces the default filesystem tool.
-* ``_prepare_dashboard_artifacts`` registers the artifact tools without
-  binding a dashboard id.
-* The bugfix: repeated ``_prepare_dashboard_artifacts`` calls on the same
-  node instance must NOT stack duplicate tool wrappers.
-* ``_detect_referenced_dashboard_ids`` surfaces on-disk ids mentioned in
-  the user message; the LLM-facing hint includes them.
+* ``_prepare_artifacts`` registers the artifact tools without binding a
+  dashboard slug.
+* The bugfix: repeated ``_prepare_artifacts`` calls on the same node
+  instance must NOT stack duplicate tool wrappers.
 """
 
 from __future__ import annotations
@@ -53,9 +51,9 @@ def _make_node(real_agent_config, **overrides):
     return GenVisualDashboardAgenticNode(**kwargs)
 
 
-def _seed_dashboard_on_disk(project_root: Path, dashboard_id: str) -> None:
-    """Seed a minimal dashboard layout so referenced-id detection finds it."""
-    dash_dir = project_root / "dashboards" / dashboard_id
+def _seed_dashboard_on_disk(project_root: Path, dashboard_slug: str) -> None:
+    """Seed a minimal dashboard layout for end-to-end tests."""
+    dash_dir = project_root / "dashboards" / dashboard_slug
     (dash_dir / "queries").mkdir(parents=True, exist_ok=True)
     (dash_dir / "render").mkdir(exist_ok=True)
     (dash_dir / "render" / "app.jsx").write_text(
@@ -65,7 +63,7 @@ def _seed_dashboard_on_disk(project_root: Path, dashboard_id: str) -> None:
     # manifest.json is part of the dashboard contract — validate_render
     # rejects the artifact when it's missing.
     (dash_dir / "manifest.json").write_text(
-        '{"name":"seeded dashboard","description":"Unit-test seeded dashboard.",'
+        f'{{"slug":"{dashboard_slug}","name":"seeded dashboard","description":"Unit-test seeded dashboard.",'
         '"kind":"dashboard","created_at":"2026-05-13T00:00:00Z"}\n',
         encoding="utf-8",
     )
@@ -84,7 +82,7 @@ class TestGenVisualDashboardInit:
         assert isinstance(node.semantic_tools, SemanticTools)
         assert isinstance(node.filesystem_func_tool, DashboardFilesystemFuncTool)
         assert node.dashboard_artifact_tools is None
-        assert node._active_dashboard_id is None
+        assert node._active_dashboard_slug is None
 
     def test_tools_include_filesystem_and_db(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config)
@@ -111,11 +109,11 @@ class TestPrepareDashboardArtifacts:
         user_input = GenVisualDashboardNodeInput(user_message="一个销售概览 dashboard")
         node.input = user_input
 
-        node._prepare_dashboard_artifacts(user_input)
+        node._prepare_artifacts(user_input)
 
         assert isinstance(node.dashboard_artifact_tools, DashboardArtifactTools)
-        assert node._active_dashboard_id is None
-        assert node.dashboard_artifact_tools.dashboard_id is None
+        assert node._active_artifact_slug is None
+        assert node.dashboard_artifact_tools.dashboard_slug is None
 
         tool_names = {t.name for t in node.tools}
         assert "start_new_dashboard" in tool_names
@@ -124,7 +122,7 @@ class TestPrepareDashboardArtifacts:
         assert "validate_render" in tool_names
 
         dashboards_root = Path(real_agent_config.project_root) / "dashboards"
-        assert sorted(p.name for p in dashboards_root.glob("dash_*")) == []
+        assert not dashboards_root.exists() or sorted(p.name for p in dashboards_root.iterdir()) == []
 
     def test_repeated_calls_do_not_duplicate_tools(self, real_agent_config, mock_llm_create):
         """Bugfix regression: ``execute_stream`` may run twice per instance.
@@ -137,12 +135,12 @@ class TestPrepareDashboardArtifacts:
         user_input = GenVisualDashboardNodeInput(user_message="dashboard please")
         node.input = user_input
 
-        node._prepare_dashboard_artifacts(user_input)
+        node._prepare_artifacts(user_input)
         first_tool_count = len(node.tools)
         first_dashboard_artifact_tools = node.dashboard_artifact_tools
 
         # Run preparation again — should swap the instance, not stack tools.
-        node._prepare_dashboard_artifacts(user_input)
+        node._prepare_artifacts(user_input)
         assert len(node.tools) == first_tool_count
         assert node.dashboard_artifact_tools is not first_dashboard_artifact_tools
 
@@ -156,38 +154,11 @@ class TestPrepareDashboardArtifacts:
 
 
 # --------------------------------------------------------------------------- #
-# Enhanced-message hint                                                       #
+# Enhanced-message wiring                                                     #
 # --------------------------------------------------------------------------- #
 
 
-class TestEnhancedMessageHint:
-    def test_hint_added_when_user_references_existing_dashboard(self, real_agent_config, mock_llm_create):
-        project_root = Path(real_agent_config.project_root)
-        existing_id = "dash_existing_demo_260514_aabbcc"
-        _seed_dashboard_on_disk(project_root, existing_id)
-
-        node = _make_node(real_agent_config)
-        user_input = GenVisualDashboardNodeInput(user_message=f"修改 {existing_id}，加一个 region 过滤器")
-
-        message = node._build_enhanced_message(user_input)
-        assert existing_id in message
-        assert "bind_existing_dashboard" in message
-        assert "start_new_dashboard" in message
-
-    def test_no_hint_when_no_dashboards_directory(self, real_agent_config, mock_llm_create):
-        node = _make_node(real_agent_config)
-        user_input = GenVisualDashboardNodeInput(user_message="generate a new revenue dashboard")
-        message = node._build_enhanced_message(user_input)
-        assert "bind_existing_dashboard" not in message
-        assert "start_new_dashboard" not in message
-
-    def test_referenced_id_must_exist_on_disk_to_surface(self, real_agent_config, mock_llm_create):
-        # Reference an id whose folder does not exist; no hint should appear.
-        node = _make_node(real_agent_config)
-        user_input = GenVisualDashboardNodeInput(user_message="参考 dash_nonexistent_260514_aaaaaa 生成新的")
-        message = node._build_enhanced_message(user_input)
-        assert "bind_existing_dashboard" not in message
-
+class TestEnhancedMessage:
     def test_extra_message_parts_added_when_db_context_present(self, real_agent_config, mock_llm_create):
         """Catalog / database / schema all surface on the enhanced message header."""
         node = _make_node(real_agent_config)
@@ -205,16 +176,10 @@ class TestEnhancedMessageHint:
 
 @pytest.mark.asyncio
 async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
-    """LLM binds an existing dashboard (pre-seeded on disk) and validates the render tree.
-
-    Mirrors the ``test_execute_stream_end_to_end`` pattern in the report
-    suite: pre-seed disk so the LLM can use ``bind_existing_dashboard``
-    without having to know a dynamically-allocated id, then drive a
-    minimal ``bind → validate_render`` script via the mock LLM.
-    """
+    """LLM binds an existing dashboard (pre-seeded on disk) and validates the render tree."""
     project_root = Path(real_agent_config.project_root)
-    existing_id = "dash_e2e_demo_260514_abcdef"
-    dash_dir = project_root / "dashboards" / existing_id
+    existing_slug = "e2e_demo"
+    dash_dir = project_root / "dashboards" / existing_slug
     (dash_dir / "queries").mkdir(parents=True, exist_ok=True)
     (dash_dir / "render").mkdir(exist_ok=True)
     (dash_dir / "render" / "app.jsx").write_text(
@@ -249,7 +214,7 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     )
     # Seed manifest.json — validate_render requires it on disk.
     (dash_dir / "manifest.json").write_text(
-        '{"name":"e2e demo dashboard","description":"End-to-end seeded dashboard.",'
+        f'{{"slug":"{existing_slug}","name":"e2e demo dashboard","description":"End-to-end seeded dashboard.",'
         '"kind":"dashboard","created_at":"2026-05-14T00:00:00Z"}\n',
         encoding="utf-8",
     )
@@ -260,7 +225,7 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
                 tool_calls=[
                     MockToolCall(
                         name="bind_existing_dashboard",
-                        arguments=json.dumps({"dashboard_id": existing_id}),
+                        arguments=json.dumps({"dashboard_slug": existing_slug}),
                     ),
                     MockToolCall(name="validate_render", arguments="{}"),
                 ],
@@ -271,7 +236,7 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
 
     node = _make_node(real_agent_config)
     node.input = GenVisualDashboardNodeInput(
-        user_message=f"check {existing_id}",
+        user_message=f"check {existing_slug}",
         database="california_schools",
     )
 
@@ -286,8 +251,8 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     result = final.output
     assert isinstance(result, dict)
     assert result["success"] is True
-    assert result["dashboard_id"] == existing_id
-    assert result["app_jsx_path"] == f"dashboards/{existing_id}/render/app.jsx"
+    assert result["dashboard_slug"] == existing_slug
+    assert result["app_jsx_path"] == f"dashboards/{existing_slug}/render/app.jsx"
     assert result["render_file_count"] == 1
     # No save_query_template in this run — the seed wrote the template directly.
     assert result["template_count"] == 0
@@ -320,14 +285,7 @@ async def test_execute_stream_fails_when_no_binding(real_agent_config, mock_llm_
 
 
 class TestNodeFactoryDashboardBranch:
-    """Exercises the ``gen_visual_*`` cases in ``node_factory``.
-
-    Kept here (rather than in ``test_node.py``) so the visual-artifact
-    factory coverage doesn't ride on the pre-existing brittle
-    ``TestNodeFactory`` fixtures. Covers both ``gen_visual_dashboard`` and
-    ``gen_visual_report`` branches since diff-cover bundles both as part
-    of this feature branch's introduction.
-    """
+    """Exercises the ``gen_visual_*`` cases in ``node_factory``."""
 
     def test_factory_returns_dashboard_node(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
@@ -403,6 +361,7 @@ async def test_execute_stream_fails_when_validate_render_not_called(real_agent_c
                         name="start_new_dashboard",
                         arguments=json.dumps(
                             {
+                                "slug": "incomplete",
                                 "name": "incomplete",
                                 "description": "Bound but never validated — unit-test fixture.",
                             }
@@ -424,6 +383,6 @@ async def test_execute_stream_fails_when_validate_render_not_called(real_agent_c
     assert final.status == ActionStatus.FAILED
     result = final.output
     assert result["success"] is False
-    # ``_active_dashboard_id`` got captured even though validate_render didn't run.
-    assert result["dashboard_id"] is not None
+    # ``_active_dashboard_slug`` got captured even though validate_render didn't run.
+    assert result["dashboard_slug"] == "incomplete"
     assert "validate_render" in (result.get("error") or "")

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -9,11 +9,10 @@ Design principle: NO mocks except LLM.
 Covers:
 * Node initialization wires the expected tools.
 * ``ReportFilesystemFuncTool`` replaces the default filesystem tool.
-* ``_prepare_report_artifacts`` registers the artifact tools but leaves the
-  report id unbound — the LLM owns the new/edit decision at runtime.
-* End-to-end streaming run: LLM calls start_new_report, save_query,
-  write_file (for render/*.jsx) and finally validate_render.
-* The LLM-facing hint surfaces when the user references existing reports on disk.
+* ``_prepare_artifacts`` registers the artifact tools but leaves the
+  report slug unbound — the LLM owns the new/edit decision at runtime.
+* End-to-end streaming run: LLM calls bind_existing_report (against a
+  pre-seeded dir) and validate_render.
 * CLI mode compiles ``index.html`` after a successful validate_render.
 * Binding-required failure when the LLM never calls start/bind_report.
 * Incomplete-artifact failure when validate_render is never called.
@@ -68,9 +67,9 @@ export default function App() {{
 """
 
 
-def _seed_render_on_disk(project_root: Path, report_id: str, *, data_ref: str = "queries/q") -> None:
+def _seed_render_on_disk(project_root: Path, report_slug: str, *, data_ref: str = "queries/q") -> None:
     """Seed a minimal validated render tree + matching query so renderer-side tests run."""
-    report_dir = project_root / "reports" / report_id
+    report_dir = project_root / "reports" / report_slug
     (report_dir / "queries").mkdir(parents=True, exist_ok=True)
     (report_dir / "render").mkdir(exist_ok=True)
     (report_dir / "render" / "app.jsx").write_text(
@@ -87,7 +86,7 @@ def _seed_render_on_disk(project_root: Path, report_id: str, *, data_ref: str = 
     # manifest.json is part of the report contract — validate_render rejects
     # the artifact if it's missing.
     (report_dir / "manifest.json").write_text(
-        '{"name":"seeded report","description":"Unit-test seeded report.",'
+        f'{{"slug":"{report_slug}","name":"seeded report","description":"Unit-test seeded report.",'
         '"kind":"report","created_at":"2026-05-13T00:00:00Z"}\n',
         encoding="utf-8",
     )
@@ -106,7 +105,7 @@ class TestGenVisualReportInit:
         assert isinstance(node.semantic_tools, SemanticTools)
         assert isinstance(node.filesystem_func_tool, ReportFilesystemFuncTool)
         assert node.report_artifact_tools is None
-        assert node._active_report_id is None
+        assert node._active_report_slug is None
 
     def test_tools_include_filesystem_and_db(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config)
@@ -134,11 +133,11 @@ class TestPrepareReportArtifacts:
         user_input = GenVisualReportNodeInput(user_message="北美一季度门店销售分析")
         node.input = user_input
 
-        node._prepare_report_artifacts(user_input)
+        node._prepare_artifacts(user_input)
 
         assert isinstance(node.report_artifact_tools, ReportArtifactTools)
-        assert node._active_report_id is None
-        assert node.report_artifact_tools.report_id is None
+        assert node._active_artifact_slug is None
+        assert node.report_artifact_tools.report_slug is None
         assert node.report_artifact_tools.mode is None
 
         tool_names = {t.name for t in node.tools}
@@ -148,29 +147,8 @@ class TestPrepareReportArtifacts:
         assert "validate_render" in tool_names
 
         reports_root = Path(real_agent_config.project_root) / "reports"
-        assert sorted(p.name for p in reports_root.glob("rpt_*")) == []
-
-
-class TestEnhancedMessageHint:
-    def test_hint_added_when_user_references_existing_report(self, real_agent_config, mock_llm_create):
-        project_root = Path(real_agent_config.project_root)
-        existing_id = "rpt_existing_demo_260513_aaaaaa"
-        _seed_render_on_disk(project_root, existing_id)
-
-        node = _make_node(real_agent_config)
-        user_input = GenVisualReportNodeInput(user_message=f"修改 {existing_id} 报告，补充一个 YoY 分析章节")
-
-        message = node._build_enhanced_message(user_input)
-        assert existing_id in message
-        assert "bind_existing_report" in message
-        assert "start_new_report" in message
-
-    def test_no_hint_when_no_reports_directory(self, real_agent_config, mock_llm_create):
-        node = _make_node(real_agent_config)
-        user_input = GenVisualReportNodeInput(user_message="generate a new sales overview")
-        message = node._build_enhanced_message(user_input)
-        assert "bind_existing_report" not in message
-        assert "start_new_report" not in message
+        # No directories are created until the LLM commits to a slug.
+        assert not reports_root.exists() or sorted(p.name for p in reports_root.iterdir()) == []
 
 
 # --------------------------------------------------------------------------- #
@@ -183,15 +161,15 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     """LLM binds an existing report (pre-seeded on disk) and validates the render tree.
 
     This covers the agentic node's result-extraction + html-compile path
-    without needing the mock LLM to reference a dynamically-allocated id
-    (the write_file authoring path is exercised end-to-end in the artifact
-    tools tests). Pre-seeding ``render/`` + ``queries/`` and using
+    without needing the mock LLM to author a fresh render tree end-to-end
+    (that path is exercised in the artifact-tools tests). Pre-seeding
+    ``render/`` + ``queries/`` + ``manifest.json`` and using
     ``bind_existing_report`` keeps the test purely additive over the unit
-    coverage and avoids brittle id placeholder gymnastics.
+    coverage.
     """
     project_root = Path(real_agent_config.project_root)
-    existing_id = "rpt_e2e_demo_260514_aabbcc"
-    _seed_render_on_disk(project_root, existing_id, data_ref="queries/avg_sat_reading")
+    existing_slug = "e2e_demo"
+    _seed_render_on_disk(project_root, existing_slug, data_ref="queries/avg_sat_reading")
 
     mock_llm_create.reset(
         responses=[
@@ -199,7 +177,7 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
                 tool_calls=[
                     MockToolCall(
                         name="bind_existing_report",
-                        arguments=json.dumps({"report_id": existing_id}),
+                        arguments=json.dumps({"report_slug": existing_slug}),
                     ),
                     MockToolCall(name="validate_render", arguments="{}"),
                 ],
@@ -210,7 +188,7 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
 
     node = _make_node(real_agent_config)
     node.input = GenVisualReportNodeInput(
-        user_message=f"check {existing_id}",
+        user_message=f"check {existing_slug}",
         database="california_schools",
     )
 
@@ -225,14 +203,14 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     result = final.output
     assert isinstance(result, dict)
     assert result["success"] is True
-    assert result["report_id"] == existing_id
-    assert result["app_jsx_path"] == f"reports/{existing_id}/render/app.jsx"
+    assert result["report_slug"] == existing_slug
+    assert result["app_jsx_path"] == f"reports/{existing_slug}/render/app.jsx"
     assert result["render_file_count"] == 1
     # No save_query in this run — the seed wrote the query file directly.
     assert result["query_count"] == 0
 
-    report_dir = project_root / "reports" / existing_id
-    expected_html_rel = f"reports/{existing_id}/index.html"
+    report_dir = project_root / "reports" / existing_slug
+    expected_html_rel = f"reports/{existing_slug}/index.html"
     assert result["html_path"] == expected_html_rel
     assert (report_dir / "index.html").is_file()
 
@@ -255,14 +233,14 @@ class TestReportDistResolution:
         node.node_config["report_dist"] = str(node_dist)
         real_agent_config.report_dist_cli_override = str(cli_dist)
 
-        report_id = "rpt_priority_check_001"
-        _seed_render_on_disk(Path(real_agent_config.project_root), report_id)
-        node._active_report_id = report_id
+        report_slug = "priority_check_001"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
 
-        html_rel = node._maybe_compile_html(report_id)
-        assert html_rel == f"reports/{report_id}/index.html"
+        html_rel = node._maybe_compile_html(report_slug)
+        assert html_rel == f"reports/{report_slug}/index.html"
 
-        copied_css = Path(real_agent_config.project_root) / "reports" / report_id / "_assets" / "index.css"
+        copied_css = Path(real_agent_config.project_root) / "reports" / report_slug / "_assets" / "index.css"
         assert copied_css.read_text(encoding="utf-8") == "/* from-cli-flag css */"
 
     def test_node_config_used_when_cli_flag_absent(self, real_agent_config, mock_llm_create, tmp_path):
@@ -273,12 +251,12 @@ class TestReportDistResolution:
         if hasattr(real_agent_config, "report_dist_cli_override"):
             delattr(real_agent_config, "report_dist_cli_override")
 
-        report_id = "rpt_priority_check_002"
-        _seed_render_on_disk(Path(real_agent_config.project_root), report_id)
-        node._active_report_id = report_id
+        report_slug = "priority_check_002"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
 
-        node._maybe_compile_html(report_id)
-        copied_css = Path(real_agent_config.project_root) / "reports" / report_id / "_assets" / "index.css"
+        node._maybe_compile_html(report_slug)
+        copied_css = Path(real_agent_config.project_root) / "reports" / report_slug / "_assets" / "index.css"
         assert copied_css.read_text(encoding="utf-8") == "/* node-only css */"
 
 
@@ -300,32 +278,32 @@ class TestAutoOpenInBrowser:
     def test_opens_browser_when_flag_enabled(self, real_agent_config, mock_llm_create, monkeypatch):
         node = _make_node(real_agent_config)
         real_agent_config.report_auto_open = True
-        report_id = "rpt_auto_open_yes"
-        _seed_render_on_disk(Path(real_agent_config.project_root), report_id)
-        node._active_report_id = report_id
+        report_slug = "auto_open_yes"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
 
         opened = []
         monkeypatch.setattr("threading.Thread", _InlineThread)
         monkeypatch.setattr("webbrowser.open", lambda url, *a, **kw: opened.append(url) or True)
 
-        node._maybe_compile_html(report_id)
+        node._maybe_compile_html(report_slug)
 
         assert len(opened) == 1, f"expected one webbrowser.open call, got {opened}"
         assert opened[0].startswith("file://")
-        assert opened[0].endswith(f"reports/{report_id}/index.html")
+        assert opened[0].endswith(f"reports/{report_slug}/index.html")
 
     def test_does_not_open_when_flag_disabled(self, real_agent_config, mock_llm_create, monkeypatch):
         node = _make_node(real_agent_config)
         real_agent_config.report_auto_open = False
-        report_id = "rpt_auto_open_no"
-        _seed_render_on_disk(Path(real_agent_config.project_root), report_id)
-        node._active_report_id = report_id
+        report_slug = "auto_open_no"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
 
         opened = []
         monkeypatch.setattr("threading.Thread", _InlineThread)
         monkeypatch.setattr("webbrowser.open", lambda url, *a, **kw: opened.append(url) or True)
 
-        node._maybe_compile_html(report_id)
+        node._maybe_compile_html(report_slug)
 
         assert opened == [], f"webbrowser.open must not be called; got {opened}"
 
@@ -333,15 +311,15 @@ class TestAutoOpenInBrowser:
         node = _make_node(real_agent_config)
         if hasattr(real_agent_config, "report_auto_open"):
             delattr(real_agent_config, "report_auto_open")
-        report_id = "rpt_auto_open_default"
-        _seed_render_on_disk(Path(real_agent_config.project_root), report_id)
-        node._active_report_id = report_id
+        report_slug = "auto_open_default"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
 
         opened = []
         monkeypatch.setattr("threading.Thread", _InlineThread)
         monkeypatch.setattr("webbrowser.open", lambda url, *a, **kw: opened.append(url) or True)
 
-        node._maybe_compile_html(report_id)
+        node._maybe_compile_html(report_slug)
 
         assert opened == []
 
@@ -369,7 +347,7 @@ async def test_execute_stream_without_binding_marks_failure(real_agent_config, m
     assert isinstance(result, dict)
     assert result["success"] is False
     assert result["app_jsx_path"] is None
-    assert result["report_id"] is None
+    assert result["report_slug"] is None
     assert result["query_count"] == 0
     error = result.get("error") or ""
     assert "start_new_report" in error
@@ -387,6 +365,7 @@ async def test_execute_stream_bound_but_no_validate_marks_failure(real_agent_con
                         name="start_new_report",
                         arguments=json.dumps(
                             {
+                                "slug": "halfway",
                                 "name": "halfway",
                                 "description": "Bound but never validated — unit-test fixture.",
                             }
@@ -410,6 +389,6 @@ async def test_execute_stream_bound_but_no_validate_marks_failure(real_agent_con
     assert isinstance(result, dict)
     assert result["success"] is False
     assert result["app_jsx_path"] is None
-    assert result["report_id"] is not None and result["report_id"].startswith("rpt_halfway_")
+    assert result["report_slug"] == "halfway"
     assert result["query_count"] == 0
     assert "validate_render never returned success" in (result.get("error") or "")

--- a/tests/unit_tests/agent/node/test_report_html_renderer.py
+++ b/tests/unit_tests/agent/node/test_report_html_renderer.py
@@ -38,8 +38,8 @@ export default function KpiBanner({ rows }) {
 """
 
 
-def _seed_report(project_root: Path, *, report_id: str = "rpt_demo_001") -> Path:
-    report_dir = project_root / "reports" / report_id
+def _seed_report(project_root: Path, *, report_slug: str = "demo_001") -> Path:
+    report_dir = project_root / "reports" / report_slug
     (report_dir / "queries").mkdir(parents=True)
     (report_dir / "render").mkdir()
     (report_dir / "render" / "app.jsx").write_text(_APP_JSX, encoding="utf-8")
@@ -51,7 +51,7 @@ def _seed_report(project_root: Path, *, report_id: str = "rpt_demo_001") -> Path
 
 def test_render_report_html_substitutes_payload(tmp_path: Path):
     _seed_report(tmp_path)
-    out_path = render_report_html(project_root=tmp_path, report_id="rpt_demo_001")
+    out_path = render_report_html(project_root=tmp_path, report_slug="demo_001")
     body = out_path.read_text(encoding="utf-8")
     assert "__DATUS_REPORT_DATA__" not in body
     assert "__DATUS_REPORT_TITLE__" not in body
@@ -65,15 +65,15 @@ def test_render_report_html_substitutes_payload(tmp_path: Path):
 
 
 def test_render_report_html_writes_index_file(tmp_path: Path):
-    _seed_report(tmp_path, report_id="rpt_demo_002")
-    out_path = render_report_html(project_root=tmp_path, report_id="rpt_demo_002")
-    assert out_path == tmp_path / "reports" / "rpt_demo_002" / "index.html"
+    _seed_report(tmp_path, report_slug="demo_002")
+    out_path = render_report_html(project_root=tmp_path, report_slug="demo_002")
+    assert out_path == tmp_path / "reports" / "demo_002" / "index.html"
     assert out_path.is_file()
 
 
 def test_render_report_html_includes_render_files_and_queries(tmp_path: Path):
-    _seed_report(tmp_path, report_id="rpt_demo_003")
-    out_path = render_report_html(project_root=tmp_path, report_id="rpt_demo_003")
+    _seed_report(tmp_path, report_slug="demo_003")
+    out_path = render_report_html(project_root=tmp_path, report_slug="demo_003")
     body = out_path.read_text(encoding="utf-8")
 
     start = body.index('id="datus-report-data">') + len('id="datus-report-data">')
@@ -82,7 +82,7 @@ def test_render_report_html_includes_render_files_and_queries(tmp_path: Path):
     payload_unescaped = payload_raw.replace("<\\/", "</")
     data = json.loads(payload_unescaped)
 
-    assert data["id"] == "rpt_demo_003"
+    assert data["slug"] == "demo_003"
     render_names = {f["name"] for f in data["render_files"]}
     assert render_names == {"app.jsx", "kpi-banner.jsx"}
     app_entry = next(f for f in data["render_files"] if f["name"] == "app.jsx")
@@ -93,14 +93,14 @@ def test_render_report_html_includes_render_files_and_queries(tmp_path: Path):
 
 
 def test_render_report_html_walks_nested_render_dirs(tmp_path: Path):
-    _seed_report(tmp_path, report_id="rpt_nested_001")
-    report_dir = tmp_path / "reports" / "rpt_nested_001"
+    _seed_report(tmp_path, report_slug="nested_001")
+    report_dir = tmp_path / "reports" / "nested_001"
     (report_dir / "render" / "charts").mkdir()
     (report_dir / "render" / "charts" / "trend.jsx").write_text(
         "import React from 'react';\nexport default () => React.createElement('div');\n",
         encoding="utf-8",
     )
-    out_path = render_report_html(project_root=tmp_path, report_id="rpt_nested_001")
+    out_path = render_report_html(project_root=tmp_path, report_slug="nested_001")
     body = out_path.read_text(encoding="utf-8")
     start = body.index('id="datus-report-data">') + len('id="datus-report-data">')
     end = body.index("</script>", start)
@@ -110,20 +110,20 @@ def test_render_report_html_walks_nested_render_dirs(tmp_path: Path):
 
 
 def test_render_report_html_missing_app_jsx_raises(tmp_path: Path):
-    (tmp_path / "reports" / "rpt_missing" / "queries").mkdir(parents=True)
-    (tmp_path / "reports" / "rpt_missing" / "render").mkdir()
+    (tmp_path / "reports" / "missing" / "queries").mkdir(parents=True)
+    (tmp_path / "reports" / "missing" / "render").mkdir()
     with pytest.raises(FileNotFoundError):
-        render_report_html(project_root=tmp_path, report_id="rpt_missing")
+        render_report_html(project_root=tmp_path, report_slug="missing")
 
 
 def test_render_report_html_defaults_to_cdn(tmp_path: Path):
-    _seed_report(tmp_path, report_id="rpt_cdn_default")
-    out_path = render_report_html(project_root=tmp_path, report_id="rpt_cdn_default")
+    _seed_report(tmp_path, report_slug="cdn_default")
+    out_path = render_report_html(project_root=tmp_path, report_slug="cdn_default")
     body = out_path.read_text(encoding="utf-8")
     assert "https://unpkg.com/@datus/web-report" in body
     assert "index.css" in body
     assert "index.umd.js" in body
-    assert not (tmp_path / "reports" / "rpt_cdn_default" / "_assets").exists()
+    assert not (tmp_path / "reports" / "cdn_default" / "_assets").exists()
 
 
 def _seed_dist(dist_dir: Path) -> None:
@@ -133,13 +133,13 @@ def _seed_dist(dist_dir: Path) -> None:
 
 
 def test_render_report_html_offline_kwarg_copies_assets(tmp_path: Path):
-    _seed_report(tmp_path, report_id="rpt_offline_001")
+    _seed_report(tmp_path, report_slug="offline_001")
     dist_dir = tmp_path / "vendor" / "datus-report-dist"
     _seed_dist(dist_dir)
 
     out_path = render_report_html(
         project_root=tmp_path,
-        report_id="rpt_offline_001",
+        report_slug="offline_001",
         report_dist=dist_dir,
     )
     body = out_path.read_text(encoding="utf-8")
@@ -147,49 +147,49 @@ def test_render_report_html_offline_kwarg_copies_assets(tmp_path: Path):
     assert "_assets/index.umd.js" in body
     assert "https://unpkg.com/" not in body
 
-    copied_assets = tmp_path / "reports" / "rpt_offline_001" / "_assets"
+    copied_assets = tmp_path / "reports" / "offline_001" / "_assets"
     assert (copied_assets / "index.css").read_text(encoding="utf-8") == "/* offline css */"
     assert (copied_assets / "index.umd.js").read_text(encoding="utf-8") == "/* offline js */"
 
 
 def test_render_report_html_invalid_dist_falls_back_to_cdn(tmp_path: Path):
-    _seed_report(tmp_path, report_id="rpt_invalid_dist")
+    _seed_report(tmp_path, report_slug="invalid_dist")
     incomplete = tmp_path / "vendor" / "incomplete"
     incomplete.mkdir(parents=True)
     (incomplete / "index.css").write_text("/* partial */", encoding="utf-8")
 
     out_path = render_report_html(
         project_root=tmp_path,
-        report_id="rpt_invalid_dist",
+        report_slug="invalid_dist",
         report_dist=incomplete,
     )
     body = out_path.read_text(encoding="utf-8")
     assert "https://unpkg.com/@datus/web-report" in body
-    assert not (tmp_path / "reports" / "rpt_invalid_dist" / "_assets").exists()
+    assert not (tmp_path / "reports" / "invalid_dist" / "_assets").exists()
 
 
 def test_render_report_html_ignores_environment_variables(tmp_path: Path, monkeypatch):
     """``DATUS_REPORT_DIST`` was removed — the renderer must not read it."""
-    _seed_report(tmp_path, report_id="rpt_no_env_lookup")
+    _seed_report(tmp_path, report_slug="no_env_lookup")
     dist_dir = tmp_path / "vendor" / "would-be-env"
     _seed_dist(dist_dir)
     monkeypatch.setenv("DATUS_REPORT_DIST", str(dist_dir))
 
-    out_path = render_report_html(project_root=tmp_path, report_id="rpt_no_env_lookup")
+    out_path = render_report_html(project_root=tmp_path, report_slug="no_env_lookup")
     body = out_path.read_text(encoding="utf-8")
     assert "https://unpkg.com/@datus/web-report" in body
-    assert not (tmp_path / "reports" / "rpt_no_env_lookup" / "_assets").exists()
+    assert not (tmp_path / "reports" / "no_env_lookup" / "_assets").exists()
 
 
-def test_render_report_html_falls_back_to_report_id_for_title(tmp_path: Path):
-    """When app.jsx omits the @datus-title annotation, the report id is used."""
-    report_dir = tmp_path / "reports" / "rpt_no_title"
+def test_render_report_html_falls_back_to_report_slug_for_title(tmp_path: Path):
+    """When app.jsx omits the @datus-title annotation, the report slug is used."""
+    report_dir = tmp_path / "reports" / "no_title"
     (report_dir / "queries").mkdir(parents=True)
     (report_dir / "render").mkdir()
     (report_dir / "render" / "app.jsx").write_text(
         "import React from 'react';\nexport default function R() { return null; }\n",
         encoding="utf-8",
     )
-    out_path = render_report_html(project_root=tmp_path, report_id="rpt_no_title")
+    out_path = render_report_html(project_root=tmp_path, report_slug="no_title")
     body = out_path.read_text(encoding="utf-8")
-    assert "<title>Datus Report — rpt_no_title</title>" in body
+    assert "<title>Datus Report — no_title</title>" in body

--- a/tests/unit_tests/schemas/test_artifact_manifest.py
+++ b/tests/unit_tests/schemas/test_artifact_manifest.py
@@ -20,6 +20,7 @@ from datus.schemas.artifact_manifest import ArtifactManifest
 
 def _base_payload(**overrides):
     base = {
+        "slug": "q1_revenue_review",
         "name": "Q1 revenue review",
         "description": "Quarterly revenue review for the east region.",
         "kind": "report",
@@ -32,6 +33,7 @@ def _base_payload(**overrides):
 class TestArtifactManifest:
     def test_round_trip(self):
         manifest = ArtifactManifest.model_validate(_base_payload())
+        assert manifest.slug == "q1_revenue_review"
         assert manifest.name == "Q1 revenue review"
         assert manifest.kind == "report"
 
@@ -67,3 +69,18 @@ class TestArtifactManifest:
     def test_chinese_name_accepted(self):
         manifest = ArtifactManifest.model_validate(_base_payload(name="销售季度复盘"))
         assert manifest.name == "销售季度复盘"
+
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "",
+            "Has-Hyphen",
+            "has space",
+            "Q1_Revenue",  # uppercase
+            "中文",
+            "a" * 81,
+        ],
+    )
+    def test_invalid_slug_rejected(self, bad_slug):
+        with pytest.raises(ValidationError):
+            ArtifactManifest.model_validate(_base_payload(slug=bad_slug))

--- a/tests/unit_tests/schemas/test_gen_visual_dashboard_models.py
+++ b/tests/unit_tests/schemas/test_gen_visual_dashboard_models.py
@@ -188,7 +188,7 @@ class TestNodeIO:
         result = GenVisualDashboardNodeResult(success=True)
         assert result.success is True
         assert result.response == ""
-        assert result.dashboard_id is None
+        assert result.dashboard_slug is None
         assert result.app_jsx_path is None
         assert result.render_file_count == 0
         assert result.template_count == 0
@@ -197,11 +197,11 @@ class TestNodeIO:
     def test_result_with_app_jsx_path(self):
         result = GenVisualDashboardNodeResult(
             success=True,
-            dashboard_id="dash_demo_260514_abcdef",
-            app_jsx_path="dashboards/dash_demo_260514_abcdef/render/app.jsx",
+            dashboard_slug="demo",
+            app_jsx_path="dashboards/demo/render/app.jsx",
             render_file_count=4,
             template_count=3,
         )
-        assert result.app_jsx_path == "dashboards/dash_demo_260514_abcdef/render/app.jsx"
+        assert result.app_jsx_path == "dashboards/demo/render/app.jsx"
         assert result.render_file_count == 4
         assert result.template_count == 3

--- a/tests/unit_tests/schemas/test_gen_visual_report_models.py
+++ b/tests/unit_tests/schemas/test_gen_visual_report_models.py
@@ -148,7 +148,7 @@ class TestNodeIO:
         result = GenVisualReportNodeResult(success=True)
         assert result.success is True
         assert result.response == ""
-        assert result.report_id is None
+        assert result.report_slug is None
         assert result.app_jsx_path is None
         assert result.render_file_count == 0
         assert result.html_path is None
@@ -158,11 +158,11 @@ class TestNodeIO:
     def test_result_with_app_jsx_path(self):
         result = GenVisualReportNodeResult(
             success=True,
-            report_id="rpt_demo",
-            app_jsx_path="reports/rpt_demo/render/app.jsx",
+            report_slug="demo",
+            app_jsx_path="reports/demo/render/app.jsx",
             render_file_count=3,
             query_count=5,
         )
-        assert result.app_jsx_path == "reports/rpt_demo/render/app.jsx"
+        assert result.app_jsx_path == "reports/demo/render/app.jsx"
         assert result.render_file_count == 3
         assert result.query_count == 5

--- a/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
@@ -5,10 +5,12 @@
 """Unit tests for dashboard artifact tools.
 
 Covers:
-* Helpers: ``_allocate_dashboard_id``, ``sql_quote_scalar``,
-  ``resolve_bind_placeholders``, ``render_dashboard_template``.
+* Helpers: ``sql_quote_scalar``, ``resolve_bind_placeholders``,
+  ``render_dashboard_template``.
 * ``DashboardArtifactTools.start_new_dashboard`` /
-  ``bind_existing_dashboard`` — LLM-driven intent declaration.
+  ``bind_existing_dashboard`` — LLM-driven intent declaration. The LLM
+  supplies the ``slug`` directly; the tool refuses to overwrite an
+  existing directory.
 * ``_require_active`` guard — save_query_template / validate_render fail
   fast when no dashboard is bound.
 * ``save_query_template`` — header parsing, type coercion through the
@@ -35,7 +37,6 @@ import pytest
 from datus.schemas.gen_visual_dashboard_models import TemplateParamDecl
 from datus.tools.func_tool import DashboardArtifactTools, DashboardFilesystemFuncTool, DBFuncTool
 from datus.tools.func_tool.dashboard_artifact_tools import (
-    _allocate_dashboard_id,
     render_dashboard_template,
     resolve_bind_placeholders,
     sql_quote_scalar,
@@ -92,6 +93,7 @@ def unbound_tools(db_func_tool: DBFuncTool, project_root: Path) -> DashboardArti
 @pytest.fixture
 def dashboard_tools(unbound_tools: DashboardArtifactTools) -> DashboardArtifactTools:
     result = unbound_tools.start_new_dashboard(
+        slug="demo_test",
         name="demo test",
         description="Smoke-test dashboard used by the dashboard-artifact-tools unit tests.",
     )
@@ -203,111 +205,113 @@ class TestRenderDashboardTemplate:
             render_dashboard_template("{% if x %}", decls, {"x": "v"})
 
 
-class TestAllocateDashboardId:
-    def test_format_matches_pattern(self, project_root: Path):
-        new_id = _allocate_dashboard_id("revenue overview", project_root)
-        assert new_id.startswith("dash_revenue_overview_")
-        parts = new_id.split("_")
-        assert parts[0] == "dash"
-        assert len(parts[-1]) == 6
-
-    def test_falls_back_to_dashboard_when_slug_empty(self, project_root: Path):
-        new_id = _allocate_dashboard_id("销售", project_root)
-        assert new_id.startswith("dash_dashboard_")
-
-    def test_avoids_collision(self, project_root: Path):
-        first = _allocate_dashboard_id("collision", project_root)
-        (project_root / "dashboards" / first).mkdir(parents=True)
-        second = _allocate_dashboard_id("collision", project_root)
-        assert second != first
-
-
 # ----------------------------------------------------------------------------- #
 # start_new_dashboard / bind_existing_dashboard                                 #
 # ----------------------------------------------------------------------------- #
 
 
 class TestStartNewDashboard:
-    def test_allocates_id_and_writes_manifest(self, unbound_tools: DashboardArtifactTools, project_root: Path):
+    def test_uses_supplied_slug_and_writes_manifest(self, unbound_tools: DashboardArtifactTools, project_root: Path):
         result = unbound_tools.start_new_dashboard(
+            slug="north_sales",
             name="north sales",
             description="Live north-region sales dashboard with date and channel filters.",
         )
         assert result.success == 1
         payload = result.result
-        new_id = payload["dashboard_id"]
-        assert new_id.startswith("dash_north_sales_")
+        assert payload["dashboard_slug"] == "north_sales"
         assert payload["mode"] == "new"
-        assert payload["dashboard_dir"] == f"dashboards/{new_id}"
-        assert payload["render_dir"] == f"dashboards/{new_id}/render"
-        assert payload["queries_dir"] == f"dashboards/{new_id}/queries"
-        assert payload["manifest_path"] == f"dashboards/{new_id}/manifest.json"
+        assert payload["dashboard_dir"] == "dashboards/north_sales"
+        assert payload["render_dir"] == "dashboards/north_sales/render"
+        assert payload["queries_dir"] == "dashboards/north_sales/queries"
+        assert payload["manifest_path"] == "dashboards/north_sales/manifest.json"
 
-        assert unbound_tools.dashboard_id == new_id
-        assert (project_root / "dashboards" / new_id / "queries").is_dir()
-        assert (project_root / "dashboards" / new_id / "render").is_dir()
+        assert unbound_tools.dashboard_slug == "north_sales"
+        assert (project_root / "dashboards" / "north_sales" / "queries").is_dir()
+        assert (project_root / "dashboards" / "north_sales" / "render").is_dir()
 
-        manifest_path = project_root / "dashboards" / new_id / "manifest.json"
+        manifest_path = project_root / "dashboards" / "north_sales" / "manifest.json"
         assert manifest_path.is_file()
-        import json as _json
-
-        manifest = _json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["slug"] == "north_sales"
         assert manifest["name"] == "north sales"
         assert manifest["description"] == "Live north-region sales dashboard with date and channel filters."
         assert manifest["kind"] == "dashboard"
         assert manifest["created_at"].endswith("Z")
 
-    def test_chinese_name_slug_falls_back_to_dashboard(self, unbound_tools: DashboardArtifactTools, project_root: Path):
+    def test_chinese_name_is_preserved_in_manifest(self, unbound_tools: DashboardArtifactTools, project_root: Path):
         result = unbound_tools.start_new_dashboard(
+            slug="sales_live",
             name="销售看板",
             description="实时销售看板，按地区过滤。",
         )
         assert result.success == 1, result.error
-        new_id = result.result["dashboard_id"]
-        assert new_id.startswith("dash_dashboard_")
-        import json as _json
-
-        manifest = _json.loads((project_root / "dashboards" / new_id / "manifest.json").read_text(encoding="utf-8"))
+        manifest = json.loads(
+            (project_root / "dashboards" / "sales_live" / "manifest.json").read_text(encoding="utf-8")
+        )
+        assert manifest["slug"] == "sales_live"
         assert manifest["name"] == "销售看板"
 
     def test_empty_name_rejected(self, unbound_tools: DashboardArtifactTools):
-        result = unbound_tools.start_new_dashboard(name=" ", description="x")
+        result = unbound_tools.start_new_dashboard(slug="ok", name=" ", description="x")
         assert result.success == 0
         assert "name" in (result.error or "").lower()
 
     def test_empty_description_rejected(self, unbound_tools: DashboardArtifactTools):
-        result = unbound_tools.start_new_dashboard(name="ok", description="")
+        result = unbound_tools.start_new_dashboard(slug="ok", name="ok", description="")
         assert result.success == 0
         assert "description" in (result.error or "").lower()
+
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "",
+            "Has-Hyphen",
+            "has space",
+            "中文",
+            "a" * 81,
+        ],
+    )
+    def test_invalid_slug_rejected(self, unbound_tools: DashboardArtifactTools, bad_slug: str):
+        result = unbound_tools.start_new_dashboard(slug=bad_slug, name="ok", description="ok")
+        assert result.success == 0
+        assert "slug" in (result.error or "").lower()
+
+    def test_existing_directory_rejected(self, unbound_tools: DashboardArtifactTools, project_root: Path):
+        (project_root / "dashboards" / "preexisting").mkdir(parents=True)
+        result = unbound_tools.start_new_dashboard(slug="preexisting", name="x", description="y")
+        assert result.success == 0
+        assert "already exists" in (result.error or "").lower()
 
 
 class TestBindExistingDashboard:
     def test_binds_when_directory_and_app_jsx_exist(self, unbound_tools: DashboardArtifactTools, project_root: Path):
-        existing = project_root / "dashboards" / "dash_existing_demo_260514_aabbcc"
+        existing = project_root / "dashboards" / "existing_demo"
         (existing / "queries").mkdir(parents=True)
         (existing / "render").mkdir()
         (existing / "render" / "app.jsx").write_text("export default function D() { return null; }\n")
 
-        result = unbound_tools.bind_existing_dashboard("dash_existing_demo_260514_aabbcc")
+        result = unbound_tools.bind_existing_dashboard("existing_demo")
         assert result.success == 1, result.error
         assert result.result["mode"] == "edit"
-        assert unbound_tools.dashboard_id == "dash_existing_demo_260514_aabbcc"
+        assert result.result["dashboard_slug"] == "existing_demo"
+        assert unbound_tools.dashboard_slug == "existing_demo"
 
     def test_rejects_missing_directory(self, unbound_tools: DashboardArtifactTools):
-        result = unbound_tools.bind_existing_dashboard("dash_nope_260514_bbbbbb")
+        result = unbound_tools.bind_existing_dashboard("nope")
         assert result.success == 0
         assert "not found" in (result.error or "").lower()
 
     def test_rejects_missing_app_jsx(self, unbound_tools: DashboardArtifactTools, project_root: Path):
-        incomplete = project_root / "dashboards" / "dash_partial_260514_cccccc"
+        incomplete = project_root / "dashboards" / "partial"
         (incomplete / "queries").mkdir(parents=True)
         (incomplete / "render").mkdir()
-        result = unbound_tools.bind_existing_dashboard("dash_partial_260514_cccccc")
+        result = unbound_tools.bind_existing_dashboard("partial")
         assert result.success == 0
         assert "render/app.jsx" in (result.error or "")
 
-    def test_rejects_invalid_id_format(self, unbound_tools: DashboardArtifactTools):
-        result = unbound_tools.bind_existing_dashboard("not-a-valid-id!")
+    def test_rejects_invalid_slug_format(self, unbound_tools: DashboardArtifactTools):
+        result = unbound_tools.bind_existing_dashboard("Not-A-Valid-Slug!")
         assert result.success == 0
         assert "match" in (result.error or "").lower()
 
@@ -361,9 +365,9 @@ class TestSaveQueryTemplate:
         # 2 rows are inside NA / EU + month >= 2026-01.
         assert payload["sample_row_count"] == 2
 
-        dash_id = dashboard_tools.dashboard_id or ""
-        sql_path = project_root / "dashboards" / dash_id / "queries" / "revenue_by_region.sql.j2"
-        params_path = project_root / "dashboards" / dash_id / "queries" / "revenue_by_region.params.json"
+        dash_slug = dashboard_tools.dashboard_slug or ""
+        sql_path = project_root / "dashboards" / dash_slug / "queries" / "revenue_by_region.sql.j2"
+        params_path = project_root / "dashboards" / dash_slug / "queries" / "revenue_by_region.params.json"
         assert sql_path.exists()
         assert params_path.exists()
         meta = json.loads(params_path.read_text())
@@ -439,8 +443,8 @@ def _seed_template(dashboard_tools: DashboardArtifactTools, slug: str = "revenue
     assert result.success == 1, result.error
 
 
-def _write_render(project_root: Path, dashboard_id: str, files: dict[str, str]) -> Path:
-    render = project_root / "dashboards" / dashboard_id / "render"
+def _write_render(project_root: Path, dashboard_slug: str, files: dict[str, str]) -> Path:
+    render = project_root / "dashboards" / dashboard_slug / "render"
     render.mkdir(parents=True, exist_ok=True)
     for rel, content in files.items():
         target = render / rel
@@ -464,7 +468,7 @@ export default function App() {
 class TestValidateRender:
     def test_happy_path(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
         _seed_template(dashboard_tools)
-        _write_render(project_root, dashboard_tools.dashboard_id, {"app.jsx": _VALID_APP_JSX})
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": _VALID_APP_JSX})
 
         result = dashboard_tools.validate_render()
         assert result.success == 1, result.error
@@ -482,7 +486,7 @@ class TestValidateRender:
             "  return null;\n"
             "}\n"
         )
-        _write_render(project_root, dashboard_tools.dashboard_id, {"app.jsx": app_no_params})
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app_no_params})
         result = dashboard_tools.validate_render()
         assert result.success == 0
         assert "second `params` argument" in (result.error or "")
@@ -498,7 +502,7 @@ class TestValidateRender:
             "  return null;\n"
             "}\n"
         )
-        _write_render(project_root, dashboard_tools.dashboard_id, {"app.jsx": app_missing_key})
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app_missing_key})
         result = dashboard_tools.validate_render()
         assert result.success == 0
         assert "missing required" in (result.error or "")
@@ -515,7 +519,7 @@ class TestValidateRender:
             "  return null;\n"
             "}\n"
         )
-        _write_render(project_root, dashboard_tools.dashboard_id, {"app.jsx": app_extra_key})
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app_extra_key})
         result = dashboard_tools.validate_render()
         assert result.success == 0
         assert "unknown" in (result.error or "")
@@ -523,7 +527,7 @@ class TestValidateRender:
 
     def test_rejects_dangling_slug(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
         # No save_query_template — but app.jsx references one.
-        _write_render(project_root, dashboard_tools.dashboard_id, {"app.jsx": _VALID_APP_JSX})
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": _VALID_APP_JSX})
         result = dashboard_tools.validate_render()
         assert result.success == 0
         assert "queries/revenue_by_region" in (result.error or "")
@@ -531,7 +535,7 @@ class TestValidateRender:
     def test_rejects_missing_default_export(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
         _seed_template(dashboard_tools)
         no_default = "import React from 'react';\nfunction App() { return null; }\n"
-        _write_render(project_root, dashboard_tools.dashboard_id, {"app.jsx": no_default})
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": no_default})
         result = dashboard_tools.validate_render()
         assert result.success == 0
         assert "export default" in (result.error or "")
@@ -548,7 +552,7 @@ class TestValidateRender:
             "  return null;\n"
             "}\n"
         )
-        _write_render(project_root, dashboard_tools.dashboard_id, {"app.jsx": bad_app})
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": bad_app})
         result = dashboard_tools.validate_render()
         assert result.success == 0
         assert "lodash" in (result.error or "")
@@ -566,40 +570,40 @@ class TestValidateRender:
 
 class TestDashboardFilesystemFuncTool:
     def test_write_queries_rejected(self, project_root: Path):
-        (project_root / "dashboards" / "dash_x" / "queries").mkdir(parents=True)
+        (project_root / "dashboards" / "x" / "queries").mkdir(parents=True)
         fs = DashboardFilesystemFuncTool(root_path=str(project_root))
-        result = fs.write_file("dashboards/dash_x/queries/q.sql.j2", "-- @datus-params x:string\nSELECT :x")
+        result = fs.write_file("dashboards/x/queries/q.sql.j2", "-- @datus-params x:string\nSELECT :x")
         assert result.success == 0
         assert "save_query_template" in (result.error or "")
 
     def test_write_render_jsx_allowed(self, project_root: Path):
-        (project_root / "dashboards" / "dash_x" / "render").mkdir(parents=True)
+        (project_root / "dashboards" / "x" / "render").mkdir(parents=True)
         fs = DashboardFilesystemFuncTool(root_path=str(project_root))
-        result = fs.write_file("dashboards/dash_x/render/app.jsx", "export default () => null;\n")
+        result = fs.write_file("dashboards/x/render/app.jsx", "export default () => null;\n")
         assert result.success == 1
-        assert (project_root / "dashboards" / "dash_x" / "render" / "app.jsx").is_file()
+        assert (project_root / "dashboards" / "x" / "render" / "app.jsx").is_file()
 
     def test_write_render_json_rejected(self, project_root: Path):
-        (project_root / "dashboards" / "dash_x" / "render").mkdir(parents=True)
+        (project_root / "dashboards" / "x" / "render").mkdir(parents=True)
         fs = DashboardFilesystemFuncTool(root_path=str(project_root))
-        result = fs.write_file("dashboards/dash_x/render/data.json", '{"x": 1}')
+        result = fs.write_file("dashboards/x/render/data.json", '{"x": 1}')
         assert result.success == 0
         assert ".jsx" in (result.error or "")
 
     def test_edit_queries_rejected(self, project_root: Path):
-        (project_root / "dashboards" / "dash_x" / "queries").mkdir(parents=True)
-        existing = project_root / "dashboards" / "dash_x" / "queries" / "q.sql.j2"
+        (project_root / "dashboards" / "x" / "queries").mkdir(parents=True)
+        existing = project_root / "dashboards" / "x" / "queries" / "q.sql.j2"
         existing.write_text("-- @datus-params x:string\nSELECT :x")
         fs = DashboardFilesystemFuncTool(root_path=str(project_root))
-        result = fs.edit_file("dashboards/dash_x/queries/q.sql.j2", ":x", ":x AS v")
+        result = fs.edit_file("dashboards/x/queries/q.sql.j2", ":x", ":x AS v")
         assert result.success == 0
         assert "save_query_template" in (result.error or "")
 
     def test_delete_queries_rejected(self, project_root: Path):
-        (project_root / "dashboards" / "dash_x" / "queries").mkdir(parents=True)
-        target = project_root / "dashboards" / "dash_x" / "queries" / "q.params.json"
+        (project_root / "dashboards" / "x" / "queries").mkdir(parents=True)
+        target = project_root / "dashboards" / "x" / "queries" / "q.params.json"
         target.write_text("{}")
         fs = DashboardFilesystemFuncTool(root_path=str(project_root))
-        result = fs.delete_file("dashboards/dash_x/queries/q.params.json")
+        result = fs.delete_file("dashboards/x/queries/q.params.json")
         assert result.success == 0
         assert target.exists()

--- a/tests/unit_tests/tools/func_tool/test_report_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_report_artifact_tools.py
@@ -7,7 +7,9 @@
 Covers:
 * ``ReportArtifactTools.start_new_report`` / ``bind_existing_report`` — the
   LLM-driven intent declaration that picks "create new" vs "edit existing"
-  before any write tool runs.
+  before any write tool runs. ``start_new_report`` takes an LLM-supplied
+  ``slug`` that doubles as the directory name; ``bind_existing_report``
+  takes the same slug.
 * ``_require_active`` guard — save_query / validate_render fail-fast when no
   report is bound.
 * ``save_query`` — column inference, SQL persistence, schema validation,
@@ -32,10 +34,8 @@ import pytest
 
 from datus.tools.func_tool import DBFuncTool, ReportArtifactTools, ReportFilesystemFuncTool
 from datus.tools.func_tool.report_artifact_tools import (
-    _allocate_report_id,
     _infer_column_type,
     _resolve_relative_import,
-    _slugify_title,
 )
 
 # ----------------------------------------------------------------------------- #
@@ -88,6 +88,7 @@ def unbound_tools(db_func_tool: DBFuncTool, project_root: Path) -> ReportArtifac
 @pytest.fixture
 def report_tools(unbound_tools: ReportArtifactTools) -> ReportArtifactTools:
     result = unbound_tools.start_new_report(
+        slug="demo_test",
         name="demo test",
         description="Smoke-test report used by the report-artifact-tools unit tests.",
     )
@@ -98,40 +99,6 @@ def report_tools(unbound_tools: ReportArtifactTools) -> ReportArtifactTools:
 # ----------------------------------------------------------------------------- #
 # helpers                                                                       #
 # ----------------------------------------------------------------------------- #
-
-
-class TestSlugifyTitle:
-    def test_ascii_lowercased_and_underscored(self):
-        assert _slugify_title("Sales By Store") == "sales_by_store"
-
-    def test_strips_non_ascii(self):
-        assert _slugify_title("销售分析") == ""
-
-    def test_collapses_punctuation(self):
-        assert _slugify_title("Q1 — North/East Sales!!") == "q1_north_east_sales"
-
-    def test_caps_length(self):
-        very_long = "a" * 200
-        assert _slugify_title(very_long, max_len=32) == "a" * 32
-
-
-class TestAllocateReportId:
-    def test_format_matches_pattern(self, project_root: Path):
-        new_id = _allocate_report_id("sales report", project_root)
-        assert new_id.startswith("rpt_sales_report_")
-        parts = new_id.split("_")
-        assert parts[0] == "rpt"
-        assert parts[-1] != "" and len(parts[-1]) == 6
-
-    def test_falls_back_to_report_when_slug_empty(self, project_root: Path):
-        new_id = _allocate_report_id("销售", project_root)
-        assert new_id.startswith("rpt_report_")
-
-    def test_avoids_collision(self, project_root: Path):
-        first = _allocate_report_id("collision", project_root)
-        (project_root / "reports" / first).mkdir(parents=True)
-        second = _allocate_report_id("collision", project_root)
-        assert second != first
 
 
 class TestResolveRelativeImport:
@@ -169,93 +136,118 @@ class TestResolveRelativeImport:
 
 
 class TestStartNewReport:
-    def test_allocates_id_and_writes_manifest(self, unbound_tools: ReportArtifactTools, project_root: Path):
+    def test_uses_supplied_slug_and_writes_manifest(self, unbound_tools: ReportArtifactTools, project_root: Path):
         result = unbound_tools.start_new_report(
+            slug="east_sales_q1",
             name="east sales",
             description="Quarterly review of east-region direct sales.",
         )
         assert result.success == 1
         payload = result.result
-        new_id = payload["report_id"]
-        assert new_id.startswith("rpt_east_sales_")
+        assert payload["report_slug"] == "east_sales_q1"
         assert payload["mode"] == "new"
-        assert payload["report_dir"] == f"reports/{new_id}"
-        assert payload["render_dir"] == f"reports/{new_id}/render"
-        assert payload["queries_dir"] == f"reports/{new_id}/queries"
-        assert payload["manifest_path"] == f"reports/{new_id}/manifest.json"
+        assert payload["report_dir"] == "reports/east_sales_q1"
+        assert payload["render_dir"] == "reports/east_sales_q1/render"
+        assert payload["queries_dir"] == "reports/east_sales_q1/queries"
+        assert payload["manifest_path"] == "reports/east_sales_q1/manifest.json"
 
-        assert unbound_tools.report_id == new_id
+        assert unbound_tools.report_slug == "east_sales_q1"
         assert unbound_tools.mode == "new"
-        assert (project_root / "reports" / new_id / "queries").is_dir()
-        assert (project_root / "reports" / new_id / "render").is_dir()
+        assert (project_root / "reports" / "east_sales_q1" / "queries").is_dir()
+        assert (project_root / "reports" / "east_sales_q1" / "render").is_dir()
 
-        manifest_path = project_root / "reports" / new_id / "manifest.json"
+        manifest_path = project_root / "reports" / "east_sales_q1" / "manifest.json"
         assert manifest_path.is_file()
         import json as _json
 
         manifest = _json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["slug"] == "east_sales_q1"
         assert manifest["name"] == "east sales"
         assert manifest["description"] == "Quarterly review of east-region direct sales."
         assert manifest["kind"] == "report"
         assert manifest["created_at"].endswith("Z")
 
-    def test_chinese_name_slug_falls_back_to_report(self, unbound_tools: ReportArtifactTools, project_root: Path):
+    def test_chinese_name_is_preserved_in_manifest(self, unbound_tools: ReportArtifactTools, project_root: Path):
+        # The slug is always pure ASCII; the manifest's display name preserves
+        # the original (potentially Chinese) text verbatim.
         result = unbound_tools.start_new_report(
+            slug="sales_q1_review",
             name="销售季度复盘",
             description="第一季度区域销售业绩复盘。",
         )
         assert result.success == 1, result.error
-        new_id = result.result["report_id"]
-        # Non-ASCII name slugifies to nothing → fall back to the literal "report" base slug.
-        assert new_id.startswith("rpt_report_")
-        # But the manifest preserves the original name verbatim.
         import json as _json
 
-        manifest = _json.loads((project_root / "reports" / new_id / "manifest.json").read_text(encoding="utf-8"))
+        manifest = _json.loads(
+            (project_root / "reports" / "sales_q1_review" / "manifest.json").read_text(encoding="utf-8")
+        )
+        assert manifest["slug"] == "sales_q1_review"
         assert manifest["name"] == "销售季度复盘"
 
     def test_empty_name_rejected(self, unbound_tools: ReportArtifactTools):
-        result = unbound_tools.start_new_report(name="", description="x")
+        result = unbound_tools.start_new_report(slug="ok", name="", description="x")
         assert result.success == 0
         assert "name" in (result.error or "").lower()
 
     def test_empty_description_rejected(self, unbound_tools: ReportArtifactTools):
-        result = unbound_tools.start_new_report(name="ok name", description="   ")
+        result = unbound_tools.start_new_report(slug="ok", name="ok name", description="   ")
         assert result.success == 0
         assert "description" in (result.error or "").lower()
+
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "",  # empty
+            "Has-Hyphen",  # uppercase + dash
+            "has space",  # whitespace
+            "中文",  # non-ASCII
+            "a" * 81,  # length cap
+        ],
+    )
+    def test_invalid_slug_rejected(self, unbound_tools: ReportArtifactTools, bad_slug: str):
+        result = unbound_tools.start_new_report(slug=bad_slug, name="ok", description="ok")
+        assert result.success == 0
+        assert "slug" in (result.error or "").lower()
+
+    def test_existing_directory_rejected(self, unbound_tools: ReportArtifactTools, project_root: Path):
+        (project_root / "reports" / "preexisting").mkdir(parents=True)
+        result = unbound_tools.start_new_report(slug="preexisting", name="x", description="y")
+        assert result.success == 0
+        assert "already exists" in (result.error or "").lower()
 
 
 class TestBindExistingReport:
     def test_binds_when_directory_and_app_jsx_exist(self, unbound_tools: ReportArtifactTools, project_root: Path):
-        existing = project_root / "reports" / "rpt_existing_demo_260513_aaaaaa"
+        existing = project_root / "reports" / "existing_demo"
         (existing / "queries").mkdir(parents=True)
         (existing / "render").mkdir()
         (existing / "render" / "app.jsx").write_text("export default function R() { return null; }\n")
 
-        result = unbound_tools.bind_existing_report("rpt_existing_demo_260513_aaaaaa")
+        result = unbound_tools.bind_existing_report("existing_demo")
         assert result.success == 1, result.error
         assert result.result["mode"] == "edit"
-        assert unbound_tools.report_id == "rpt_existing_demo_260513_aaaaaa"
+        assert result.result["report_slug"] == "existing_demo"
+        assert unbound_tools.report_slug == "existing_demo"
         assert unbound_tools.mode == "edit"
         assert unbound_tools.render_dir == existing / "render"
 
     def test_rejects_missing_directory(self, unbound_tools: ReportArtifactTools):
-        result = unbound_tools.bind_existing_report("rpt_nope_260513_bbbbbb")
+        result = unbound_tools.bind_existing_report("nope")
         assert result.success == 0
         assert "not found" in (result.error or "").lower()
-        assert unbound_tools.report_id is None
+        assert unbound_tools.report_slug is None
 
     def test_rejects_missing_app_jsx(self, unbound_tools: ReportArtifactTools, project_root: Path):
-        incomplete = project_root / "reports" / "rpt_partial_260513_cccccc"
+        incomplete = project_root / "reports" / "partial"
         (incomplete / "queries").mkdir(parents=True)
         (incomplete / "render").mkdir()
-        result = unbound_tools.bind_existing_report("rpt_partial_260513_cccccc")
+        result = unbound_tools.bind_existing_report("partial")
         assert result.success == 0
         assert "render/app.jsx" in (result.error or "")
-        assert unbound_tools.report_id is None
+        assert unbound_tools.report_slug is None
 
-    def test_rejects_invalid_id_format(self, unbound_tools: ReportArtifactTools):
-        result = unbound_tools.bind_existing_report("not-a-valid-id!")
+    def test_rejects_invalid_slug_format(self, unbound_tools: ReportArtifactTools):
+        result = unbound_tools.bind_existing_report("Not-A-Valid-Slug!")
         assert result.success == 0
         assert "match" in (result.error or "").lower()
 
@@ -321,10 +313,10 @@ class TestSaveQuery:
         assert payload["data_ref"] == "queries/sales_by_store"
         assert payload["row_count"] == 3
 
-        report_id = report_tools.report_id or ""
-        assert report_id.startswith("rpt_demo_test_")
-        sql_file = project_root / "reports" / report_id / "queries" / "sales_by_store.sql"
-        json_file = project_root / "reports" / report_id / "queries" / "sales_by_store.json"
+        report_slug = report_tools.report_slug or ""
+        assert report_slug == "demo_test"
+        sql_file = project_root / "reports" / report_slug / "queries" / "sales_by_store.sql"
+        json_file = project_root / "reports" / report_slug / "queries" / "sales_by_store.json"
         assert sql_file.exists()
         assert json_file.exists()
 
@@ -348,8 +340,8 @@ class TestSaveQuery:
 # ----------------------------------------------------------------------------- #
 
 
-def _write_render(project_root: Path, report_id: str, files: dict[str, str]) -> Path:
-    render = project_root / "reports" / report_id / "render"
+def _write_render(project_root: Path, report_slug: str, files: dict[str, str]) -> Path:
+    render = project_root / "reports" / report_slug / "render"
     render.mkdir(parents=True, exist_ok=True)
     for rel, content in files.items():
         target = render / rel
@@ -385,7 +377,7 @@ class TestValidateRender:
         report_tools.save_query(name="sales_by_store", sql="SELECT store_name FROM sales")
         _write_render(
             project_root,
-            report_tools.report_id,
+            report_tools.report_slug,
             {
                 "app.jsx": _VALID_APP_JSX,
                 "kpi-banner.jsx": _VALID_KPI_BANNER_JSX,
@@ -400,7 +392,7 @@ class TestValidateRender:
         assert result.result["warnings"] == []
 
     def test_rejects_missing_app_jsx(self, report_tools: ReportArtifactTools, project_root: Path):
-        _write_render(project_root, report_tools.report_id, {"kpi-banner.jsx": _VALID_KPI_BANNER_JSX})
+        _write_render(project_root, report_tools.report_slug, {"kpi-banner.jsx": _VALID_KPI_BANNER_JSX})
         result = report_tools.validate_render()
         assert result.success == 0
         assert "render/app.jsx" in (result.error or "")
@@ -413,14 +405,16 @@ class TestValidateRender:
     def test_rejects_missing_default_export(self, report_tools: ReportArtifactTools, project_root: Path):
         report_tools.save_query(name="sales_by_store", sql="SELECT store_name FROM sales")
         no_default = "import React from 'react';\nfunction App() { return null; }\n"
-        _write_render(project_root, report_tools.report_id, {"app.jsx": no_default})
+        _write_render(project_root, report_tools.report_slug, {"app.jsx": no_default})
         result = report_tools.validate_render()
         assert result.success == 0
         assert "export default" in (result.error or "")
 
     def test_rejects_dangling_sqlid(self, report_tools: ReportArtifactTools, project_root: Path):
         _write_render(
-            project_root, report_tools.report_id, {"app.jsx": _VALID_APP_JSX, "kpi-banner.jsx": _VALID_KPI_BANNER_JSX}
+            project_root,
+            report_tools.report_slug,
+            {"app.jsx": _VALID_APP_JSX, "kpi-banner.jsx": _VALID_KPI_BANNER_JSX},
         )
         # No save_query → queries/sales_by_store.json does NOT exist.
         result = report_tools.validate_render()
@@ -439,7 +433,7 @@ class TestValidateRender:
             "  return null;\n"
             "}\n"
         )
-        _write_render(project_root, report_tools.report_id, {"app.jsx": bad_app})
+        _write_render(project_root, report_tools.report_slug, {"app.jsx": bad_app})
         result = report_tools.validate_render()
         assert result.success == 0
         assert "lodash" in (result.error or "")
@@ -447,7 +441,7 @@ class TestValidateRender:
     def test_rejects_unresolved_relative_import(self, report_tools: ReportArtifactTools, project_root: Path):
         report_tools.save_query(name="sales_by_store", sql="SELECT store_name FROM sales")
         bad_app = _VALID_APP_JSX  # imports ./kpi-banner but we don't write it
-        _write_render(project_root, report_tools.report_id, {"app.jsx": bad_app})
+        _write_render(project_root, report_tools.report_slug, {"app.jsx": bad_app})
         result = report_tools.validate_render()
         assert result.success == 0
         assert "./kpi-banner" in (result.error or "")
@@ -465,7 +459,7 @@ class TestValidateRender:
             "  return null;\n"
             "}\n"
         )
-        _write_render(project_root, report_tools.report_id, {"app.jsx": escape})
+        _write_render(project_root, report_tools.report_slug, {"app.jsx": escape})
         result = report_tools.validate_render()
         assert result.success == 0
         # Either rejected as unresolved or as escape — both end in "does not resolve".
@@ -485,7 +479,7 @@ class TestValidateRender:
         )
         _write_render(
             project_root,
-            report_tools.report_id,
+            report_tools.report_slug,
             {
                 "app.jsx": minimal_app,
                 "legacy.jsx": "import React from 'react';\nexport default function L() { return null; }\n",
@@ -515,7 +509,7 @@ class TestValidateRender:
         colors = "export const COLORS = { primary: '#1A56DB' };\n"
         _write_render(
             project_root,
-            report_tools.report_id,
+            report_tools.report_slug,
             {
                 "app.jsx": app,
                 "charts/trend.jsx": trend,
@@ -545,7 +539,7 @@ class TestValidateRender:
             "  return null;\n"
             "}\n"
         )
-        _write_render(project_root, report_tools.report_id, {"app.jsx": app_with_template})
+        _write_render(project_root, report_tools.report_slug, {"app.jsx": app_with_template})
         result = report_tools.validate_render()
         assert result.success == 1, result.error
         # Only the literal slug appears in query_refs.
@@ -559,60 +553,60 @@ class TestValidateRender:
 
 class TestReportFilesystemFuncTool:
     def test_write_queries_rejected(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "queries").mkdir(parents=True)
+        (project_root / "reports" / "x" / "queries").mkdir(parents=True)
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
-        result = fs.write_file("reports/rpt_x/queries/q.sql", "SELECT 1")
+        result = fs.write_file("reports/x/queries/q.sql", "SELECT 1")
         assert result.success == 0
         assert "save_query" in (result.error or "")
 
     def test_write_render_jsx_allowed(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "render").mkdir(parents=True)
+        (project_root / "reports" / "x" / "render").mkdir(parents=True)
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
-        result = fs.write_file("reports/rpt_x/render/app.jsx", "export default () => null;\n")
+        result = fs.write_file("reports/x/render/app.jsx", "export default () => null;\n")
         assert result.success == 1
-        assert (project_root / "reports" / "rpt_x" / "render" / "app.jsx").is_file()
+        assert (project_root / "reports" / "x" / "render" / "app.jsx").is_file()
 
     def test_write_render_nested_subdir_allowed(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "render").mkdir(parents=True)
+        (project_root / "reports" / "x" / "render").mkdir(parents=True)
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
         result = fs.write_file(
-            "reports/rpt_x/render/charts/trend.jsx",
+            "reports/x/render/charts/trend.jsx",
             "export default () => null;\n",
         )
         assert result.success == 1
-        assert (project_root / "reports" / "rpt_x" / "render" / "charts" / "trend.jsx").is_file()
+        assert (project_root / "reports" / "x" / "render" / "charts" / "trend.jsx").is_file()
 
     def test_write_render_json_rejected(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "render").mkdir(parents=True)
+        (project_root / "reports" / "x" / "render").mkdir(parents=True)
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
-        result = fs.write_file("reports/rpt_x/render/data.json", '{"x": 1}')
+        result = fs.write_file("reports/x/render/data.json", '{"x": 1}')
         assert result.success == 0
         assert ".jsx" in (result.error or "")
 
     def test_edit_queries_rejected(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "queries").mkdir(parents=True)
-        existing = project_root / "reports" / "rpt_x" / "queries" / "q.sql"
+        (project_root / "reports" / "x" / "queries").mkdir(parents=True)
+        existing = project_root / "reports" / "x" / "queries" / "q.sql"
         existing.write_text("SELECT 1")
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
-        result = fs.edit_file("reports/rpt_x/queries/q.sql", "1", "2")
+        result = fs.edit_file("reports/x/queries/q.sql", "1", "2")
         assert result.success == 0
         assert "save_query" in (result.error or "")
 
     def test_delete_render_jsx_allowed(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "render").mkdir(parents=True)
-        target = project_root / "reports" / "rpt_x" / "render" / "old.jsx"
+        (project_root / "reports" / "x" / "render").mkdir(parents=True)
+        target = project_root / "reports" / "x" / "render" / "old.jsx"
         target.write_text("export default () => null;\n")
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
-        result = fs.delete_file("reports/rpt_x/render/old.jsx")
+        result = fs.delete_file("reports/x/render/old.jsx")
         assert result.success == 1
         assert not target.exists()
 
     def test_delete_queries_rejected(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "queries").mkdir(parents=True)
-        target = project_root / "reports" / "rpt_x" / "queries" / "q.sql"
+        (project_root / "reports" / "x" / "queries").mkdir(parents=True)
+        target = project_root / "reports" / "x" / "queries" / "q.sql"
         target.write_text("SELECT 1")
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
-        result = fs.delete_file("reports/rpt_x/queries/q.sql")
+        result = fs.delete_file("reports/x/queries/q.sql")
         assert result.success == 0
         # Either rejected by the deny rule (preferred message) or by the parent
         # tool — accept any error response so the test stays robust to future
@@ -627,10 +621,10 @@ class TestReportFilesystemFuncTool:
         assert (project_root / "notes.md").exists()
 
     def test_read_render_jsx_allowed(self, project_root: Path):
-        (project_root / "reports" / "rpt_x" / "render").mkdir(parents=True)
-        target = project_root / "reports" / "rpt_x" / "render" / "app.jsx"
+        (project_root / "reports" / "x" / "render").mkdir(parents=True)
+        target = project_root / "reports" / "x" / "render" / "app.jsx"
         target.write_text("export default function App() { return null; }\n")
         fs = ReportFilesystemFuncTool(root_path=str(project_root))
-        result = fs.read_file("reports/rpt_x/render/app.jsx")
+        result = fs.read_file("reports/x/render/app.jsx")
         assert result.success == 1
         assert "export default" in (result.result or "")


### PR DESCRIPTION
## Summary

Cherry-picks the slug-first artifact identity refactor (originally landed on \`feat/gen-visual-report\` as 3cc638bf) onto main.

Datus-backend's \`dashboard_service.py\` on main already imports \`DASHBOARD_SLUG_RE\` and records its submodule pointer at 3cc638bf — but that commit only lives on the feat branch here, so \`git submodule update --init\` on a fresh checkout / IDE setup leaves consumers without the symbol and breaks pytest collection.

Bringing the refactor to main makes the submodule contract reachable from agent's main, which lets Datus-backend rely on \`git submodule update\` against published refs.

## Key changes

- Rename \`DASHBOARD_ID_RE\` → \`DASHBOARD_SLUG_RE\` (regex shape now \`^[a-z0-9_]{1,80}$\`, no \`dash_\` prefix).
- Same slug-first treatment in \`gen_visual_report_models.py\` and all internal call sites.
- Updates the agentic nodes, func tools, and tests that referenced the old ID-shaped identifiers.

## Test plan

- [ ] CI green on this branch.
- [ ] Datus-backend's companion PR (submodule pointer bump) verifies the import resolves and dashboard_service tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Artifact identifiers now use standardized slug format (lowercase alphanumeric/underscores, 1–80 characters) for filesystem organization.
  * Artifact manifests now include required slug metadata.

* **Changes**
  * Dashboard and report artifacts now use slug-based directory structures (`dashboards/<slug>/`, `reports/<slug>/`) instead of ID-based paths.
  * Updated validation rules for artifact identification and organization.
  * HTML report rendering now operates on slug identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/775)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->