### PR TITLE
[Doc] Surface shared/table.jsx in gen_visual_report/dashboard workflow tree

### DIFF
--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -142,6 +142,7 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
        ├── colors.js        # COLORS, palettes
        ├── formatters.js    # d3-format / dayjs wrappers
        ├── card.jsx         # reusable <Card> primitive
+       ├── table.jsx        # paginated <DataTable> primitive (sticky headers, row striping, page-size selector)
        └── filter-context.js  # React context for filter values
    ```
    Keep each file focused and small (well under the 200 KB filesystem cap).

--- a/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
@@ -141,7 +141,8 @@ If the user wants live filters / period selectors / re-runnable queries, that is
    └── shared/
        ├── colors.js        # COLORS, palettes
        ├── formatters.js    # d3-format / dayjs wrappers
-       └── card.jsx         # reusable <Card> primitive
+       ├── card.jsx         # reusable <Card> primitive
+       └── table.jsx        # paginated <DataTable> primitive (sticky headers, row striping, page-size selector)
    ```
    Keep each file focused and small (well under the 200 KB filesystem cap). The renderer compiles each module on demand — there's no bundling step on your side.
 9. **Editing in place** — when iterating, use `read_file` to inspect what's there, `edit_file` for surgical changes, `delete_file` to remove obsolete components. The validator reports unreferenced files as warnings so you can decide to keep them or clean up.


### PR DESCRIPTION
## Why

Both `gen_visual_report` and `gen_visual_dashboard` system prompts include a "typical layout" sketch of the `render/` tree in their Workflow section. The `shared/` subtree already calls out `colors.js`, `formatters.js`, and `card.jsx` as expected reusable primitives — but data-table rendering (sticky headers, row striping, pagination, page-size selector) is currently re-implemented inline in every report / dashboard component that needs a table. The subagent has no signal that this is a candidate for extraction, so it keeps shipping ad-hoc inline `<table>` blocks.

## Solution

List `shared/table.jsx` next to the existing primitives so the LLM treats it as a first-class reusable file and authors a single paginated `<DataTable>` the rest of the tree imports.

```
└── shared/
    ├── colors.js
    ├── formatters.js
    ├── card.jsx
    └── table.jsx           # NEW — paginated <DataTable> primitive
                            #       (sticky headers, row striping, page-size selector)
```

No tool-contract changes, no schema changes — pure prompt nudge.

## Test Cases

No new integration / nightly tests: this PR only edits two `.j2` prompt templates, no Python is exercised. Existing tests cover the agentic-node loop end-to-end:

- `tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py` (33 tests)
- `tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py` (40 tests)
- `tests/unit_tests/prompts/` (0 tests assert on prompt body; the templates load and render OK as part of node initialisation in the agentic-node tests above)

Ran locally: 73 passed in 1.52s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated dashboard and report templates to document a new table component with pagination, sticky headers, row striping, and page-size selector capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/776)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->