### PR TITLE
[Doc] Forbid inline hook calls inside JSX for gen_visual_report/dashboard

### DIFF
--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -116,6 +116,40 @@ Always read rows as `data?.rows ?? []` and columns as `data?.columns ?? []`. Coe
 
 - Render a skeleton placeholder when `isLoading`; an inline error block when `errorMessage`; the chart/table otherwise. Place those `return` statements after the full hook block, never between hooks.
 
+- **Never call hooks inline from JSX.** Writing `<div ref={useRef(null)}>` (or `<div style={useMemo(...)}>` etc.) is the *same* Rules-of-Hooks violation as a conditional hook: any early return above the JSX skips the hook call, so two consecutive renders see different hook counts and React crashes with #310. **Every `useRef` / `useMemo` / `useState` / `useCallback` / custom hook is declared as a `const` at the top of the component, before any early return, and then referenced from JSX by name.** Allocate one named ref per `<div ref={...}>` site — do not reuse `cardRef` across multiple wrappers, and do not invent fresh refs at the call site.
+
+  Correct (every hook above every early return; refs named):
+
+  ```jsx
+  function YoYSummary() {
+    const cardRef = useRef(null);                          // hook
+    const summaryRef = useRef(null);                       // hook — one per <div ref> site
+    const { data } = useQuerySql('queries/yoy_summary');   // hook
+    const rows = data?.rows ?? [];
+    if (rows.length === 0) return null;                    // early return AFTER all hooks
+
+    return (
+      <div ref={cardRef}>
+        <Card title="YoY Summary" titleRight={<ChartEntryMore sqlId="queries/yoy_summary" cardRef={cardRef} />}>
+          …
+          <div ref={summaryRef}>…</div>
+        </Card>
+      </div>
+    );
+  }
+  ```
+
+  Anti-pattern (the hook on the JSX `<div>` is reached only when `rows.length !== 0` — crashes the *next* render after the data arrives):
+
+  ```jsx
+  function YoYSummary() {
+    const { data } = useQuerySql('queries/yoy_summary');
+    const rows = data?.rows ?? [];
+    if (rows.length === 0) return null;
+    return <div ref={useRef(null)}>…</div>;  // ✗ #310: hook count differs from the empty-rows render
+  }
+  ```
+
 ### Visual design
 
 Treat each output as a polished deliverable — a small **branded analytics product** for dashboards, a **research-style document** for reports. Quality bar:

--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -336,4 +336,5 @@ Before you stop, confirm:
 - [ ] Numeric columns are coerced with `Number(...)` before arithmetic / Recharts.
 - [ ] Loading / error states are rendered for every `useQuerySql` call (filter changes re-trigger the loading state).
 - [ ] In every component, **all** `use*` hook calls precede every `if (...) return …` / early return — no hook is reachable only on some renders (would crash with React error #310).
+- [ ] **No hook call appears inside JSX.** `<div ref={useRef(null)}>` etc. is forbidden — every ref / memo / state is declared as a named `const` at the top of the component and referenced by name from JSX.
 - [ ] `validate_render()` returned `success: 1`.

--- a/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
@@ -234,4 +234,5 @@ Before you stop, confirm:
 - [ ] Numeric columns are coerced with `Number(...)` before arithmetic / Recharts.
 - [ ] Loading / error states are rendered for every `useQuerySql` call.
 - [ ] In every component, **all** `use*` hook calls precede every `if (...) return …` / early return — no hook is reachable only on some renders (would crash with React error #310).
+- [ ] **No hook call appears inside JSX.** `<div ref={useRef(null)}>` etc. is forbidden — every ref / memo / state is declared as a named `const` at the top of the component and referenced by name from JSX.
 - [ ] `validate_render()` returned `success: 1`.


### PR DESCRIPTION
## Why

Lower-tier models keep regenerating this exact shape — observed in production runs of `gen_visual_report`:

```jsx
function YoYSummary() {
  const { data } = useQuerySql('queries/yoy_summary');
  if (data?.rows.length === 0) return null;
  return <div ref={useRef(null)}>...</div>;   // ← hook inside JSX
}
```

The first render (empty rows) hits the early return. The second render (data arrived) reaches the JSX and calls `useRef`. React sees a different hook count between the two renders and crashes the whole artifact with the cryptic `Minified React error #310` ("Rendered more hooks than during the previous render").

Root cause is the **same** as a conditional hook, but the existing Rules-of-Hooks paragraph in `_visual_artifact_common.j2` only names the `if (...) return; useFoo()` shape — it doesn't call out the JSX-inline form, so the LLM keeps re-discovering it.

## Solution

Spell out the JSX-inline anti-pattern explicitly in the shared `_visual_artifact_common.j2` data-layer section, with a side-by-side correct vs anti-pattern code block:

- **Correct**: declare every `useRef` / `useMemo` / `useState` / `useCallback` as a named `const` at the top of the function, before any early return; reference from JSX by name.
- **Anti-pattern**: `<div ref={useRef(null)}>` (or `style={useMemo(...)}` etc.) inside the return.

Reinforced with a dedicated entry in the Final-checklist of both `gen_visual_report_system_1.0.j2` and `gen_visual_dashboard_system_1.0.j2`, parallel to the existing "all hooks precede early returns" check.

No tool / contract / schema changes; pure prompt hardening.

## Test Cases

No new integration / nightly tests: this PR only edits `.j2` prompt templates, no Python is exercised. Existing tests cover the agentic-node loop end-to-end (they render the prompts at setup, so template syntax errors would surface):

- `tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py` (33 tests)
- `tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py` (40 tests)
- `tests/unit_tests/prompts/` (smoke-renders the templates)

Ran locally — 73 passed in 1.51 s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced React code generation guidelines to prevent inline hook calls in JSX, reducing runtime errors in generated components. Added examples demonstrating correct hook declaration patterns as top-level constants rather than inline usage, improving code quality and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/777)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->