### PR TITLE
[BugFix] Exempt visual artifact nodes from filesystem proxy round-trip

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1619,6 +1619,32 @@ class AgenticNode(Node):
             mapping["skills"] = list(self.skill_func_tool.available_tools())
         return mapping
 
+    def _populate_tool_registry(self) -> None:
+        """Register every tool in :meth:`_tool_category_map` into
+        :attr:`tool_registry`.
+
+        Decoupled from :meth:`_ensure_permission_hooks` so callers that
+        need the category map filled *before* the first LLM turn — most
+        importantly :func:`apply_proxy_tools`, which inspects the
+        registry to honour the ``_FS_DEPENDENT_NODES`` exclusion — can
+        trigger it eagerly. Safe to call multiple times because
+        :meth:`ToolRegistry.register_tools` is overwrite-write.
+
+        Permission gating remains opt-in through
+        :meth:`_ensure_permission_hooks`; this helper does **not** require
+        a ``permission_manager`` and never builds ``PermissionHooks``.
+        """
+        try:
+            for category, tools in self._tool_category_map().items():
+                if tools:
+                    self.tool_registry.register_tools(category, tools)
+        except Exception:
+            logger.debug(
+                "Failed to populate tool_registry for %s; falling back to lazy registration.",
+                self.get_node_name(),
+                exc_info=True,
+            )
+
     def _ensure_permission_hooks(self) -> None:
         """Build ``self.permission_hooks`` once tools are in place.
 
@@ -1633,9 +1659,7 @@ class AgenticNode(Node):
         if not self.permission_manager:
             return
         try:
-            for category, tools in self._tool_category_map().items():
-                if tools:
-                    self.tool_registry.register_tools(category, tools)
+            self._populate_tool_registry()
             from datus.tools.permission.permission_hooks import PermissionHooks
 
             # ``execution_mode="workflow"`` flows have no human in the loop, so

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -281,6 +281,38 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         except Exception as exc:
             logger.error("Failed to setup filesystem tools: %s", exc)
 
+    def _tool_category_map(self) -> Dict[str, List[Any]]:
+        """Register tool buckets so category-scoped rules and the
+        ``_FS_DEPENDENT_NODES`` exclusion in ``apply_proxy_tools`` apply.
+
+        Without this mapping, every tool falls back to the catch-all
+        ``tools`` category. That breaks two things for the visual artifact
+        nodes:
+
+        * ``filesystem_tools.*`` rules (and the zone-based fs policy in
+          ``PermissionHooks._handle_filesystem_zone``) never match, so the
+          INTERNAL / EXTERNAL gating that every other fs-using node gets
+          would silently skip visual reports/dashboards.
+        * ``apply_proxy_tools`` cannot recognise their filesystem tools as
+          excluded — it looks up the tool's category in the registry — so
+          a parent agent's ``write_file`` / ``edit_file`` proxy patterns
+          end up wrapping the sub-agent's filesystem tools, round-tripping
+          every chunk to the browser instead of writing ``render/*.jsx``
+          server-side.
+        """
+        mapping = super()._tool_category_map()
+        if self.db_func_tool:
+            mapping["db_tools"] = list(self.db_func_tool.available_tools())
+        if self.semantic_tools:
+            mapping["semantic_tools"] = list(self.semantic_tools.available_tools())
+        if self.context_search_tools:
+            mapping["context_search_tools"] = list(self.context_search_tools.available_tools())
+        if self.filesystem_func_tool:
+            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
+        if self.ask_user_tool:
+            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
+        return mapping
+
     def _setup_specific_tool_method(self, tool_type: str, method_name: str) -> None:
         try:
             if tool_type == "semantic_tools":

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -500,22 +500,17 @@ class ChatTaskManager:
             )
             node.input = node_input
 
-            # 5. Replace filesystem tools with proxy if applicable
+            # 5. Replace filesystem tools with proxy if applicable.
+            # ``apply_proxy_tools`` consults ``_FS_DEPENDENT_NODES`` and the
+            # node's ``tool_registry`` to leave filesystem tools un-proxied
+            # for nodes that author server-side artifacts (e.g.
+            # ``gen_visual_report`` writing ``render/*.jsx``). No isinstance
+            # guard is needed here.
             effective_source = request.source or self._default_source
             if effective_source == "vscode":
                 apply_proxy_tools(node, ["filesystem_tools.*"])
             elif effective_source == "web":
-                # gen_visual_report / gen_visual_dashboard author their
-                # render/*.jsx tree server-side and surface it via
-                # ``/api/v1/(report|dashboard)/detail`` — proxying
-                # write_file / edit_file to the browser would round-trip
-                # every chunk for no benefit, so leave their filesystem
-                # tools directly bound to the server filesystem.
-                from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
-                from datus.agent.node.gen_visual_report_agentic_node import GenVisualReportAgenticNode
-
-                if not isinstance(node, (GenVisualReportAgenticNode, GenVisualDashboardAgenticNode)):
-                    apply_proxy_tools(node, ["write_file", "edit_file"])
+                apply_proxy_tools(node, ["write_file", "edit_file"])
             elif effective_source:
                 logger.warning("Unsupported source '%s'; skipping proxy shortcut", effective_source)
 

--- a/datus/tools/proxy/proxy_tool.py
+++ b/datus/tools/proxy/proxy_tool.py
@@ -76,6 +76,15 @@ def apply_proxy_tools(
     """
     node.proxy_tool_patterns = proxy_patterns
     target_channel = channel or node.tool_channel
+    # ``_FS_DEPENDENT_NODES`` exclusion below relies on ``tool_registry`` being
+    # populated. In production that population is normally driven by
+    # ``_ensure_permission_hooks``, which runs lazily on the first LLM turn —
+    # but ``apply_proxy_tools`` is called during node setup, well before any
+    # LLM call. Trigger registry population eagerly so the exclusion can fire.
+    # Guarded with ``hasattr`` so the SimpleNamespace-style mocks in tests
+    # still work without growing a no-op stub.
+    if hasattr(node, "_populate_tool_registry"):
+        node._populate_tool_registry()
     parsed = _parse_patterns(proxy_patterns)
     registry = node.tool_registry.to_dict()
 

--- a/datus/tools/proxy/proxy_tool.py
+++ b/datus/tools/proxy/proxy_tool.py
@@ -27,7 +27,18 @@ logger = get_logger(__name__)
 
 # Node types whose GenerationHooks depend on local filesystem tools (write_file, etc.)
 # Their filesystem_tools must NOT be proxied; other tools are still proxied.
-_FS_DEPENDENT_NODES: Set[str] = {"gen_semantic_model", "gen_metrics", "gen_sql_summary", "gen_ext_knowledge"}
+# gen_visual_report / gen_visual_dashboard author their render/*.jsx tree
+# server-side and surface it via ``/api/v1/(report|dashboard)/detail``; proxying
+# write_file / edit_file to the browser would round-trip every chunk for no
+# benefit, so the same exclusion applies to them.
+_FS_DEPENDENT_NODES: Set[str] = {
+    "gen_semantic_model",
+    "gen_metrics",
+    "gen_sql_summary",
+    "gen_ext_knowledge",
+    "gen_visual_report",
+    "gen_visual_dashboard",
+}
 
 
 def create_proxy_tool(original: FunctionTool, channel: ToolResultChannel) -> FunctionTool:

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -110,6 +110,28 @@ class TestGenVisualDashboardInit:
         assert "db_tools" in mapping
         assert "semantic_tools" in mapping
 
+    def test_apply_proxy_tools_keeps_filesystem_tools_unwrapped(self, real_agent_config, mock_llm_create):
+        """End-to-end check mirroring the visual report case: web-source
+        ``["write_file", "edit_file"]`` patterns must leave the dashboard
+        node's filesystem tools un-proxied because
+        ``gen_visual_dashboard`` is in ``_FS_DEPENDENT_NODES``.
+
+        Does not pre-fill ``tool_registry``; verifies that
+        ``apply_proxy_tools`` populates it eagerly so the exclusion
+        fires.
+        """
+        from datus.tools.proxy.proxy_tool import apply_proxy_tools
+
+        node = _make_node(real_agent_config)
+        before = {t.name: t.on_invoke_tool for t in node.tools if t.name in {"write_file", "edit_file"}}
+        assert before, "test setup: expected write_file/edit_file in node.tools"
+
+        apply_proxy_tools(node, ["write_file", "edit_file"])
+
+        after = {t.name: t.on_invoke_tool for t in node.tools if t.name in {"write_file", "edit_file"}}
+        for name, original in before.items():
+            assert after[name] is original, f"{name} was proxied despite gen_visual_dashboard fs-dependent exclusion"
+
 
 # --------------------------------------------------------------------------- #
 # Pre-execution artifact wiring                                               #

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -97,6 +97,19 @@ class TestGenVisualDashboardInit:
         assert "validate_render" not in tool_names
         assert "start_new_dashboard" not in tool_names
 
+    def test_tool_category_map_registers_filesystem_tools(self, real_agent_config, mock_llm_create):
+        """Same contract as the visual report node: filesystem tools must
+        be declared under ``filesystem_tools`` so permission gating and
+        ``_FS_DEPENDENT_NODES`` exclusion in ``apply_proxy_tools`` apply.
+        """
+        node = _make_node(real_agent_config)
+        mapping = node._tool_category_map()
+        assert "filesystem_tools" in mapping
+        fs_tool_names = {t.name for t in mapping["filesystem_tools"]}
+        assert {"read_file", "write_file", "edit_file", "delete_file"}.issubset(fs_tool_names)
+        assert "db_tools" in mapping
+        assert "semantic_tools" in mapping
+
 
 # --------------------------------------------------------------------------- #
 # Pre-execution artifact wiring                                               #

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -121,6 +121,21 @@ class TestGenVisualReportInit:
         assert "save_query" not in tool_names
         assert "validate_render" not in tool_names
 
+    def test_tool_category_map_registers_filesystem_tools(self, real_agent_config, mock_llm_create):
+        """Filesystem tools must be declared in the ``filesystem_tools``
+        category so ``PermissionHooks._handle_filesystem_zone`` engages and
+        ``apply_proxy_tools`` recognises them as excluded via
+        ``_FS_DEPENDENT_NODES``.
+        """
+        node = _make_node(real_agent_config)
+        mapping = node._tool_category_map()
+        assert "filesystem_tools" in mapping
+        fs_tool_names = {t.name for t in mapping["filesystem_tools"]}
+        assert {"read_file", "write_file", "edit_file", "delete_file"}.issubset(fs_tool_names)
+        # db_tools and semantic_tools also surface under their own categories.
+        assert "db_tools" in mapping
+        assert "semantic_tools" in mapping
+
 
 # --------------------------------------------------------------------------- #
 # Pre-execution artifact wiring                                               #

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -136,6 +136,32 @@ class TestGenVisualReportInit:
         assert "db_tools" in mapping
         assert "semantic_tools" in mapping
 
+    def test_apply_proxy_tools_keeps_filesystem_tools_unwrapped(self, real_agent_config, mock_llm_create):
+        """End-to-end check on a real node: ``apply_proxy_tools`` invoked
+        with the web-source pattern ``["write_file", "edit_file"]`` must
+        leave both filesystem tools un-proxied because
+        ``gen_visual_report`` is in ``_FS_DEPENDENT_NODES``.
+
+        Guards against a time-of-check regression: the exclusion only
+        fires when ``tool_registry`` is already populated, so this test
+        does NOT pre-fill the registry — it relies on
+        ``apply_proxy_tools`` triggering ``_populate_tool_registry``
+        eagerly.
+        """
+        from datus.tools.proxy.proxy_tool import apply_proxy_tools
+
+        node = _make_node(real_agent_config)
+        # Snapshot the original ``on_invoke_tool`` callable for each fs
+        # tool before applying the proxy wrapper.
+        before = {t.name: t.on_invoke_tool for t in node.tools if t.name in {"write_file", "edit_file"}}
+        assert before, "test setup: expected write_file/edit_file in node.tools"
+
+        apply_proxy_tools(node, ["write_file", "edit_file"])
+
+        after = {t.name: t.on_invoke_tool for t in node.tools if t.name in {"write_file", "edit_file"}}
+        for name, original in before.items():
+            assert after[name] is original, f"{name} was proxied despite gen_visual_report fs-dependent exclusion"
+
 
 # --------------------------------------------------------------------------- #
 # Pre-execution artifact wiring                                               #


### PR DESCRIPTION
## Why

When a chat agent runs under ``source=web`` and delegates to the
``gen_visual_report`` / ``gen_visual_dashboard`` sub-agent via
``task(...)``, every ``render/*.jsx`` write round-trips to the browser
for stdin-proxy confirmation instead of being written server-side as
designed. Symptom: the user is asked "approve this write?" for each file
the visual report authors, even though the artifact lives under the
project root and is fetched back by ``/api/v1/(report|dashboard)/detail``.

Root cause was two compounding bugs:

1. **Missing category registration on visual nodes.**
   ``apply_proxy_tools`` exempts ``_FS_DEPENDENT_NODES`` from proxying by
   looking up the tool's category in ``node.tool_registry``. Visual
   artifact nodes did not override ``_tool_category_map``, so their
   filesystem tools were never registered under ``filesystem_tools`` —
   the lookup always returned ``None`` and the exemption never fired.
2. **Time-of-check race on ``tool_registry``.**
   The registry is populated inside ``_ensure_permission_hooks``, which
   runs lazily from ``_compose_hooks`` at the start of an LLM turn. But
   ``apply_proxy_tools`` runs much earlier — during node setup in
   ``chat_task_manager._run_loop`` and again, on every sub-agent, in
   ``sub_agent_task_tool``. So even with (1) fixed, the lookup hit an
   empty registry and the exemption still failed. The existing mock
   tests in ``test_proxy_tool.py`` hid the bug by injecting a
   pre-populated ``ToolRegistry`` by hand.

## Solution

Three concentric fixes; together they make ``_FS_DEPENDENT_NODES`` the
single source of truth for "this node owns its filesystem tools":

1. **Register categories on visual nodes.**
   ``BaseVisualArtifactAgenticNode._tool_category_map`` (new override)
   declares ``db_tools``, ``semantic_tools``, ``context_search_tools``,
   ``filesystem_tools`` and the ask-user tool under ``tools``. Mirrors
   the pattern in ``gen_table`` / ``gen_metrics`` / ``gen_dashboard``.
   This is what lets ``PermissionHooks._handle_filesystem_zone`` engage
   (INTERNAL writes stay silent, EXTERNAL writes fall back to
   ``filesystem_strict``) and gives ``apply_proxy_tools`` a category to
   read.
2. **Extend ``_FS_DEPENDENT_NODES``.**
   ``proxy_tool.py`` now lists ``gen_visual_report`` /
   ``gen_visual_dashboard`` so the existing category-based exclusion
   skips their filesystem tools whether the node is top-level or a
   sub-agent inheriting a parent's proxy patterns.
3. **Close the time-of-check race.**
   Extract the registry-population loop from
   ``AgenticNode._ensure_permission_hooks`` into a standalone idempotent
   ``_populate_tool_registry`` (no permission_manager dependency, safe
   to call repeatedly). Call it eagerly at the top of
   ``apply_proxy_tools`` so the exclusion can read a filled registry
   before the first LLM turn. Permission-hooks construction stays lazy
   and unchanged; it just now finds a registry that may already be
   filled. ``hasattr`` guard keeps the existing ``SimpleNamespace``
   mocks in ``test_proxy_tool.py`` working.
4. **Drop the redundant ``isinstance`` guard.**
   ``chat_task_manager.py`` previously short-circuited
   ``apply_proxy_tools`` for visual nodes via ``isinstance``. With (1) +
   (2) + (3) the exclusion now happens correctly inside the helper, so
   the special-case branch collapses back into the common shape and
   ``_FS_DEPENDENT_NODES`` becomes the single source of truth.

Trade-off worth flagging for reviewers: user-defined
``filesystem_tools.*`` permission rules in ``agent.yml`` will now apply
to visual report / dashboard nodes as well. Previously such rules
silently no-oped because the tools fell through to the catch-all
``tools`` category. This is the same consistency gap already closed for
other artifact-producing nodes.

## Test Cases

* ``tests/unit_tests/tools/proxy/test_proxy_tool.py::TestFsDependentNodeExclusion``
  already parametrises over ``_FS_DEPENDENT_NODES`` — the two new node
  names are picked up automatically, asserting filesystem tools stay
  un-proxied while non-fs tools are still proxied. (These keep using
  pre-populated mock registries, which is fine for the unit-level
  contract.)
* ``tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py``
  and ``tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py``
  add two new cases each:
  * ``test_tool_category_map_registers_filesystem_tools`` — asserts the
    new mapping declares ``filesystem_tools`` with
    ``read_file`` / ``write_file`` / ``edit_file`` / ``delete_file``
    and the sibling ``db_tools`` / ``semantic_tools`` categories.
  * ``test_apply_proxy_tools_keeps_filesystem_tools_unwrapped`` —
    constructs a real node (no mocked ``tool_registry``), invokes
    ``apply_proxy_tools(["write_file","edit_file"])``, and asserts the
    filesystem tools keep their original ``on_invoke_tool`` reference.
    This is the integration-level regression test that catches the
    time-of-check race the parametrised mock test missed.
* ``tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py``'s
  existing ``test_apply_proxy_tools_fs_dependent_subagent`` documents
  the invariant the cleanup commit relies on (FS-dependent sub-agents
  still receive an ``apply_proxy_tools`` call; the exclusion is internal
  to the helper).
* ``uv run python ci/audit_tests.py --diff-only upstream/main`` →
  ``P0=0, P1=0``.
* Manual verification path: with ``source=web``, start a chat that asks
  "explore the database, then produce a credit-card report". When the
  delegation lands in ``gen_visual_report``, ``write_file`` /
  ``edit_file`` execute server-side (no browser confirmation prompt).
  Starting directly inside ``gen_visual_report`` behaves the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Visual report/dashboard generation now uses the correct database and filesystem tools (avoids fallback to a catch‑all tools bucket).

* **Changes**
  * Web-origin tasks consistently apply file-write/edit proxying for relevant visual tasks.
  * Tools are populated earlier so category-scoped proxying/exclusions behave correctly.

* **Tests**
  * Added unit tests verifying visual report/dashboard nodes register filesystem and database tools and preserve filesystem-tool proxy exclusions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/779)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->