### PR TITLE
[Enhancement] Steer visual report/dashboard subagents to use metrics first

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -87,7 +87,14 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
     FALLBACK_TEMPLATE_NAME: ClassVar[str] = ""
 
     #: Default tools when ``agent.yml`` doesn't override ``tools:``.
-    DEFAULT_TOOLS: ClassVar[str] = "semantic_tools.*, db_tools.*, context_search_tools.list_subject_tree"
+    #: ``context_search_tools.*`` expands at setup-time into whichever search
+    #: helpers the active project actually supports — ``list_subject_tree`` is
+    #: always present, while ``search_metrics`` / ``get_metrics`` /
+    #: ``search_reference_sql`` / etc. only surface when the corresponding
+    #: store has indexed content. Without the wildcard, the prompt advertises
+    #: metric-discovery tools the LLM can't actually call, so the model
+    #: silently falls back to deriving SQL from raw table DDL.
+    DEFAULT_TOOLS: ClassVar[str] = "semantic_tools.*, db_tools.*, context_search_tools.*"
 
     # ── Construction ──────────────────────────────────────────────────────
 

--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -127,9 +127,16 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
 2. **For edits, locate the slug first** — `glob('dashboards/*/manifest.json')` + `read_file` each manifest to find the matching `name` → `slug` when the user references the dashboard by display name.
 3. **For creates, pick a non-colliding slug** — `glob('dashboards/*')` to see what's taken, then draft a semantic slug (`revenue_overview`, `merchant_health`).
 4. **Bind the dashboard** — call `start_new_dashboard(slug, name, description)` (creating) or `bind_existing_dashboard(dashboard_slug)` (editing) exactly once. For new dashboards, draft a meaningful `name` (Chinese is fine) and one-paragraph `description` from the user's intent before calling.
-5. **Discover context** — use `list_subject_tree` / `search_metrics` / `list_tables` to find authoritative metrics, semantic models, and reference SQL. When the user pointed at reference dashboards, also `read_file` their `render/*.jsx` and `queries/<slug>.sql.j2` files for inspiration.
+5. **Discover context — metrics FIRST.** Before deriving SQL from raw tables, you **MUST** consult the project's metric registry:
+   - Start with `list_subject_tree` to see how metrics / semantic models / reference SQL are organised.
+   - Call `search_metrics(query_text, subject_path)` and/or `list_metrics(path)` for every KPI / chart in the user's question. Use `get_metrics(subject_path, name)` to read full definitions.
+   - Also check `search_reference_sql` for pre-curated SQL templates that fit.
+   - Only fall back to `list_tables` + `describe_table` when no metric or reference SQL fits — and note it in the template `description`.
+   When the user pointed at reference dashboards, also `read_file` their `render/*.jsx` and `queries/<slug>.sql.j2` files for inspiration.
 6. **Probe** — `read_query` quick checks to confirm tables and columns exist, to size the data at typical filter values, and to discover the enumerations you'll need to populate filter dropdowns.
 7. **Save query templates** — for each chart / table / KPI you intend to render, call `save_query_template(name, sql_template, params, sample_params, description)` with a semantic English slug (`revenue_by_region`, `top_products_by_segment`, `cohort_retention`). Aim for 4–8 templates per dashboard. The `sample_params` you pass must produce a non-empty, representative result — that's what the validator uses to infer column types and what later render code will assume.
+   - **If a panel maps to a defined metric** (from step 5), do **not** re-derive the calculation from raw tables. Call `query_metrics(metrics=[...], dimensions=[...], time_*, dry_run=True)` to obtain the canonical SQL, then parameterise it into a Jinja template and pass that to `save_query_template`. Mention the metric name in `description` so future turns can trace provenance.
+   - Use ad-hoc raw SQL only when no metric matches.
 8. **Author the render tree** — `write_file` the components under `render/`. Always include `render/app.jsx` as the entry. Keep the filter state in `app.jsx` and thread it down via props or `React.createContext`. Typical layout:
    ```
    render/

--- a/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
@@ -128,9 +128,16 @@ If the user wants live filters / period selectors / re-runnable queries, that is
 2. **For edits, locate the slug first** — `glob('reports/*/manifest.json')` + `read_file` each manifest to find the matching `name` → `slug` when the user references the report by display name.
 3. **For creates, pick a non-colliding slug** — `glob('reports/*')` to see what's taken, then draft a semantic slug (`account_activity_q1`, `revenue_by_region`).
 4. **Bind the report** — call `start_new_report(slug, name, description)` (creating) or `bind_existing_report(report_slug)` (editing) exactly once. For new reports, draft a meaningful `name` (Chinese is fine) and one-paragraph `description` from the user's intent before calling.
-5. **Discover context** — use `list_subject_tree` / `search_metrics` / `list_tables` to find authoritative metrics, semantic models, and reference SQL. When the user pointed at reference reports, also `read_file` their `render/*.jsx` and `queries/<slug>.json` files for inspiration.
+5. **Discover context — metrics FIRST.** Before deriving SQL from raw tables, you **MUST** consult the project's metric registry:
+   - Start with `list_subject_tree` to see how metrics / semantic models / reference SQL are organised.
+   - Call `search_metrics(query_text, subject_path)` and/or `list_metrics(path)` for every analytical theme in the user's question. Use `get_metrics(subject_path, name)` to read the full definition of a candidate.
+   - Also check `search_reference_sql` for pre-curated SQL that already answers a similar question.
+   - Only fall back to `list_tables` + `describe_table` when no metric or reference SQL fits — and say so explicitly in your follow-up `save_query` description.
+   When the user pointed at reference reports, also `read_file` their `render/*.jsx` and `queries/<slug>.json` files for inspiration.
 6. **Probe** — `read_query` quick checks to confirm tables and columns exist and to size the data.
 7. **Save queries** — for each chart / table / KPI you intend to render, call `save_query(name, sql, description)` with a semantic English slug (`sales_by_store`, `headcount_by_zone`, `mom_growth_summary`). Aim for 3–10 queries.
+   - **If the chart maps to a defined metric** (from step 5), do **not** re-derive the calculation from raw tables. Call `query_metrics(metrics=[...], dimensions=[...], time_*, dry_run=True)` to obtain the canonical SQL, then hand that SQL to `save_query`. Mention the metric name in `description` so future turns can trace provenance.
+   - Use ad-hoc raw SQL only when no metric matches the intent.
 8. **Author the render tree** — `write_file` the components under `render/`. Always include `render/app.jsx` as the entry. Split larger reports into focused components — typical layout:
    ```
    render/

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -110,6 +110,22 @@ class TestGenVisualDashboardInit:
         assert "db_tools" in mapping
         assert "semantic_tools" in mapping
 
+    def test_metric_discovery_tools_exposed_when_metrics_present(self, real_agent_config, mock_llm_create, monkeypatch):
+        """Mirrors the report-node contract: with metrics indexed, the
+        dashboard node must expose ``search_metrics`` and ``get_metrics``
+        so the LLM can discover the metric registry instead of
+        re-deriving SQL from raw schema. Also exercises the
+        ``context_search_tools.*`` wildcard end-to-end.
+        """
+        from datus.tools.func_tool.context_search import ContextSearchTools
+
+        monkeypatch.setattr(ContextSearchTools, "_show_metrics", lambda self: True)
+
+        node = _make_node(real_agent_config)
+        assert isinstance(node.context_search_tools, ContextSearchTools)
+        tool_names = {t.name for t in node.tools}
+        assert {"search_metrics", "get_metrics", "list_subject_tree"}.issubset(tool_names)
+
     def test_apply_proxy_tools_keeps_filesystem_tools_unwrapped(self, real_agent_config, mock_llm_create):
         """End-to-end check mirroring the visual report case: web-source
         ``["write_file", "edit_file"]`` patterns must leave the dashboard

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -136,6 +136,29 @@ class TestGenVisualReportInit:
         assert "db_tools" in mapping
         assert "semantic_tools" in mapping
 
+    def test_metric_discovery_tools_exposed_when_metrics_present(self, real_agent_config, mock_llm_create, monkeypatch):
+        """When the project has indexed metrics, the visual report node must
+        expose ``search_metrics`` and ``get_metrics`` to the LLM —
+        otherwise the prompt advertises metric-first discovery while the
+        tools are silently missing, and the model falls back to deriving
+        SQL from raw table DDL. ``ContextSearchTools`` gates these tools
+        on ``has_metrics``; patching ``_show_metrics`` to ``True`` is the
+        minimal way to simulate a metric-rich project in a unit test and
+        also exercises the ``context_search_tools.*`` wildcard expansion
+        end-to-end.
+        """
+        from datus.tools.func_tool.context_search import ContextSearchTools
+
+        monkeypatch.setattr(ContextSearchTools, "_show_metrics", lambda self: True)
+
+        node = _make_node(real_agent_config)
+        assert isinstance(node.context_search_tools, ContextSearchTools)
+        tool_names = {t.name for t in node.tools}
+        # search_metrics + get_metrics prove the metric discovery branch fired.
+        # list_subject_tree is force-included whenever any context_search
+        # branch fires, so it's a canary for the wildcard wiring itself.
+        assert {"search_metrics", "get_metrics", "list_subject_tree"}.issubset(tool_names)
+
     def test_apply_proxy_tools_keeps_filesystem_tools_unwrapped(self, real_agent_config, mock_llm_create):
         """End-to-end check on a real node: ``apply_proxy_tools`` invoked
         with the web-source pattern ``["write_file", "edit_file"]`` must

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -259,12 +259,15 @@ def real_agent_config(tmp_path, reset_global_singletons):
             },
             "gen_visual_report": {
                 "system_prompt": "gen_visual_report",
-                "tools": "semantic_tools.*,db_tools.*,context_search_tools.list_subject_tree",
+                # Intentionally omit ``tools`` so the fixture exercises the
+                # ``BaseVisualArtifactAgenticNode.DEFAULT_TOOLS`` fallback —
+                # matches the real-world deployment where users rarely
+                # override the runtime tool list for built-in subagents.
                 "max_turns": 5,
             },
             "gen_visual_dashboard": {
                 "system_prompt": "gen_visual_dashboard",
-                "tools": "semantic_tools.*,db_tools.*,context_search_tools.list_subject_tree",
+                # See the comment above on gen_visual_report.
                 "max_turns": 5,
             },
             "explore": {


### PR DESCRIPTION
## Why

When a user asks ``gen_visual_report`` / ``gen_visual_dashboard`` to
build a report on top of a metric they've already defined (e.g.
``Commerce/Orders/Average_Order_Value`` declared as a MetricFlow
ratio), the subagent skips the metric registry entirely. Observed
workflow on a question like *"create a report showing AOV trend"*:

* ``start_new_report`` → a series of ``describe_table`` →
  LLM-derived SQL → ``read_query`` → ``save_query`` with the
  hand-written calculation → ``write_file render/*.jsx`` →
  ``validate_render``.
* The exact same question asked of the chat subagent goes through
  ``search_metrics`` → ``get_metrics`` → ``query_metrics`` and reuses
  the canonical metric SQL.

Result: the report's KPI math drifts from the metric definition (no
``CAST``, no ``NULLIF``, different unit conversions, etc.), and there's
no machine-readable link back to the metric. Two compounding causes
behind the divergence:

1. **Tool-menu hole.** ``BaseVisualArtifactAgenticNode.DEFAULT_TOOLS``
   listed only ``context_search_tools.list_subject_tree``. The prompt
   advertised ``search_metrics`` / ``get_metrics`` as available —
   but they were never injected into ``node.tools``. The LLM saw the
   tools in the system prompt, got ``unknown function`` on call, and
   silently fell back to schema-linking.

2. **Prompt was loose on ordering.** Step 5 (Discover context) listed
   metric tools among many options without requiring them; step 7
   (Save queries) jumped straight to "write SQL" without a "if a
   metric matches, reuse it" branch.

## Solution

Phase 1 — plumbing + guidance only, no new tools and no rewrite of the
save flow:

1. ``DEFAULT_TOOLS`` in ``base_visual_artifact_agentic_node.py`` widens
   ``context_search_tools.list_subject_tree`` → ``context_search_tools.*``.
   The wildcard expands at setup-time via
   ``ContextSearchTools.available_tools``, which already gates
   ``search_metrics`` / ``get_metrics`` / ``search_reference_sql`` /
   etc. on ``has_metrics`` / ``has_reference_sql`` / … — so the
   change is context-aware and zero-cost for projects without metrics
   indexed.
2. ``gen_visual_report_system_1.0.j2`` and
   ``gen_visual_dashboard_system_1.0.j2``:
   * Step 5 now **requires** metric discovery before raw-schema
     fallback: ``list_subject_tree`` → ``search_metrics`` /
     ``list_metrics`` → ``get_metrics`` for every analytical theme,
     plus a check against ``search_reference_sql``.
   * Step 7 / 7 (templates) adds an explicit metric-first branch:
     ``If the chart maps to a defined metric, call
     query_metrics(metrics=..., dimensions=..., dry_run=True) to
     obtain the canonical SQL, then hand that SQL to
     save_query/save_query_template. Mention the metric name in
     description for provenance.``
3. ``tests/unit_tests/conftest.py``: drop the hardcoded ``tools``
   string from the visual-node fixture entries so they exercise the
   ``DEFAULT_TOOLS`` fallback — matches the real-world case where
   users don't override the runtime tool list for built-in subagents
   and keeps the fixture honest as ``DEFAULT_TOOLS`` evolves.

Phase 2 (separate PR, not in this change): add a dedicated
``save_metric_query`` tool that takes ``(metric, dimensions, time_*)``
and routes through the MetricFlow adapter end-to-end. That gives
report ``queries/<name>.json`` files the same engine as the chat
node's ``query_metrics`` call and records ``metric_ref`` in
``manifest.json``. Phase 1 just makes Phase 2 worth doing — it gets
the LLM into the metric registry in the first place.

## Test Cases

* ``tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py``
  adds ``test_metric_discovery_tools_exposed_when_metrics_present``:
  patches ``ContextSearchTools._show_metrics`` to ``True`` (simulating
  a project with indexed metrics), constructs a real
  ``GenVisualReportAgenticNode``, and asserts
  ``{search_metrics, get_metrics, list_subject_tree}`` is a subset of
  ``node.tools``. Also asserts
  ``isinstance(node.context_search_tools, ContextSearchTools)`` for
  end-to-end wildcard wiring.
* Same test added to
  ``test_gen_visual_dashboard_agentic_node.py``.
* No new mocks — both tests construct real nodes via the existing
  ``real_agent_config`` fixture and the ``mock_llm_create`` indirection.
* ``ci/audit_tests.py --diff-only upstream/main`` → ``P0=0, P1=0``
  on the touched test files.
* Manual verification path (after merge): with a project that has
  defined ``Average_Order_Value`` as a metric, ask the visual report
  subagent *"create a report showing AOV trend"*. Expected:
  ``search_metrics`` / ``get_metrics`` appear in the trace, and the
  ``save_query`` description references the metric name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard and report generation now automatically expose all metric discovery tools for improved semantic layer integration.
  * Metrics-first workflow: system prioritizes discovering pre-defined metrics and reference SQL before falling back to raw table inspection.

* **Tests**
  * Added test coverage verifying metric discovery tools are properly exposed during visual artifact generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/780)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->