### PR TITLE
[BugFix] Clean up CI pytest temp dirs and reduce sqlite fixture copies

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -92,7 +92,18 @@ jobs:
 
       - name: Run deterministic merge queue suites
         if: ${{ github.event_name != 'pull_request_target' }}
+        env:
+          DATUS_CI_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-pytest-${{ github.run_id }}-${{ github.run_attempt }}
         run: python3 ci/run-merge-queue-tests.py
+
+      - name: Cleanup pytest temp
+        if: ${{ always() && github.event_name != 'pull_request_target' }}
+        env:
+          DATUS_CI_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-pytest-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          if [ -n "$DATUS_CI_PYTEST_BASETEMP" ]; then
+            rm -rf "$DATUS_CI_PYTEST_BASETEMP"
+          fi
 
       - name: Upload merge queue artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -100,10 +100,24 @@ jobs:
         if: ${{ always() && github.event_name != 'pull_request_target' }}
         env:
           DATUS_CI_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-pytest-${{ github.run_id }}-${{ github.run_attempt }}
+          RUNNER_TEMP_ROOT: ${{ runner.temp }}
         run: |
-          if [ -n "$DATUS_CI_PYTEST_BASETEMP" ]; then
-            rm -rf "$DATUS_CI_PYTEST_BASETEMP"
+          if [ -z "$DATUS_CI_PYTEST_BASETEMP" ]; then
+            exit 0
           fi
+          target="$(realpath -m "$DATUS_CI_PYTEST_BASETEMP")"
+          runner_temp="$(realpath -m "$RUNNER_TEMP_ROOT")"
+          home_dir="$(realpath -m "$HOME")"
+          workspace="$(realpath -m "$GITHUB_WORKSPACE")"
+          case "$target" in
+            "$runner_temp"/*) ;;
+            *) echo "Refusing to remove unsafe pytest temp: $target"; exit 0 ;;
+          esac
+          if [ "$target" = "/" ] || [ "$target" = "$runner_temp" ] || [ "$target" = "$home_dir" ] || [ "$target" = "$workspace" ]; then
+            echo "Refusing to remove unsafe pytest temp: $target"
+            exit 0
+          fi
+          rm -rf "$target"
 
       - name: Upload merge queue artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -367,6 +367,7 @@ jobs:
         timeout-minutes: 150
         env:
           EXTERNAL_REPOS_ROOT: ${{ github.workspace }}/external
+          NIGHTLY_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-nightly-pytest-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           ci/run-nightly-tests.sh
 
@@ -374,6 +375,7 @@ jobs:
         if: always()
         env:
           EXTERNAL_REPOS_ROOT: ${{ github.workspace }}/external
+          NIGHTLY_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-nightly-pytest-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           ci/run-nightly-tests.sh --cleanup-only
 

--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -87,10 +87,24 @@ jobs:
         if: always()
         env:
           DATUS_CI_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-pytest-${{ github.run_id }}-${{ github.run_attempt }}
+          RUNNER_TEMP_ROOT: ${{ runner.temp }}
         run: |
-          if [ -n "$DATUS_CI_PYTEST_BASETEMP" ]; then
-            rm -rf "$DATUS_CI_PYTEST_BASETEMP"
+          if [ -z "$DATUS_CI_PYTEST_BASETEMP" ]; then
+            exit 0
           fi
+          target="$(realpath -m "$DATUS_CI_PYTEST_BASETEMP")"
+          runner_temp="$(realpath -m "$RUNNER_TEMP_ROOT")"
+          home_dir="$(realpath -m "$HOME")"
+          workspace="$(realpath -m "$GITHUB_WORKSPACE")"
+          case "$target" in
+            "$runner_temp"/*) ;;
+            *) echo "Refusing to remove unsafe pytest temp: $target"; exit 0 ;;
+          esac
+          if [ "$target" = "/" ] || [ "$target" = "$runner_temp" ] || [ "$target" = "$home_dir" ] || [ "$target" = "$workspace" ]; then
+            echo "Refusing to remove unsafe pytest temp: $target"
+            exit 0
+          fi
+          rm -rf "$target"
 
       - name: Post coverage comment
         if: ${{ always() && github.event_name == 'pull_request_target' && steps.metrics.outcome != 'cancelled' }}

--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -76,10 +76,21 @@ jobs:
 
       - name: Run tests and extract coverage
         id: metrics
+        env:
+          DATUS_CI_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-pytest-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           BASE_REF="${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name }}"
           BASE_REF="${BASE_REF#refs/heads/}"
           python3 ci/run-pr-tests.py "$BASE_REF"
+
+      - name: Cleanup pytest temp
+        if: always()
+        env:
+          DATUS_CI_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-pytest-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          if [ -n "$DATUS_CI_PYTEST_BASETEMP" ]; then
+            rm -rf "$DATUS_CI_PYTEST_BASETEMP"
+          fi
 
       - name: Post coverage comment
         if: ${{ always() && github.event_name == 'pull_request_target' && steps.metrics.outcome != 'cancelled' }}

--- a/ci/run-merge-queue-tests.py
+++ b/ci/run-merge-queue-tests.py
@@ -12,8 +12,11 @@ import argparse
 import importlib.util
 import json
 import os
+import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -21,6 +24,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = REPO_ROOT / "ci"
 DEFAULT_REPORT = OUT_DIR / "merge-queue-results.json"
 DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("MERGE_QUEUE_TEST_TIMEOUT", "1800"))
+PYTEST_BASETEMP_ENV = "DATUS_CI_PYTEST_BASETEMP"
 
 ACCEPTANCE_MARK_EXPR = "acceptance"
 DEFAULT_PR_HARNESS_MARK_EXPR = "acceptance or component or llm_harness"
@@ -28,6 +32,79 @@ DEFAULT_PR_HARNESS_MARK_EXPR = "acceptance or component or llm_harness"
 
 def log(message: str) -> None:
     print(f"[merge-queue] {message}", flush=True)
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip(".-")
+    return slug or "default"
+
+
+def default_pytest_basetemp() -> Path:
+    configured = os.environ.get(PYTEST_BASETEMP_ENV)
+    if configured:
+        return Path(configured)
+
+    temp_root = Path(os.environ.get("RUNNER_TEMP") or tempfile.gettempdir())
+    run_id = slugify(os.environ.get("GITHUB_RUN_ID", "local"))
+    run_attempt = slugify(os.environ.get("GITHUB_RUN_ATTEMPT", "0"))
+    return temp_root / f"datus-agent-pytest-{run_id}-{run_attempt}-{os.getpid()}"
+
+
+PYTEST_BASETEMP = default_pytest_basetemp()
+
+
+def suite_pytest_basetemp(suite_name: str) -> Path:
+    return PYTEST_BASETEMP / slugify(suite_name)
+
+
+def path_is_under(path: Path, parent: Path) -> bool:
+    if not str(parent):
+        return False
+
+    path_abs = path.resolve(strict=False)
+    parent_abs = parent.resolve(strict=False)
+    if path_abs == parent_abs:
+        return False
+
+    try:
+        path_abs.relative_to(parent_abs)
+    except ValueError:
+        return False
+    return True
+
+
+def is_safe_pytest_basetemp(path: Path) -> bool:
+    if not str(path):
+        return False
+
+    path_abs = path.resolve(strict=False)
+    unsafe_roots = {
+        Path("/").resolve(strict=False),
+        REPO_ROOT.resolve(strict=False),
+        OUT_DIR.resolve(strict=False),
+        Path.home().resolve(strict=False),
+    }
+    if path_abs in unsafe_roots:
+        return False
+
+    allowed_roots = [
+        Path(os.environ["RUNNER_TEMP"]) if os.environ.get("RUNNER_TEMP") else None,
+        Path(tempfile.gettempdir()),
+        Path("/tmp"),
+    ]
+    return any(root is not None and path_is_under(path_abs, root) for root in allowed_roots)
+
+
+def cleanup_pytest_basetemp() -> None:
+    if not PYTEST_BASETEMP.exists():
+        return
+
+    if not is_safe_pytest_basetemp(PYTEST_BASETEMP):
+        log(f"Refusing to remove unsafe pytest basetemp: {PYTEST_BASETEMP}")
+        return
+
+    shutil.rmtree(PYTEST_BASETEMP, ignore_errors=True)
+    log(f"Cleaned pytest basetemp: {PYTEST_BASETEMP}")
 
 
 def load_pr_harness_config() -> tuple[list[str], str]:
@@ -73,20 +150,29 @@ def build_pytest_command(
     mark_expr: str,
     junit_xml: Path,
     extra_args: Sequence[str] = (),
+    basetemp: Path | None = None,
 ) -> list[str]:
-    return [
+    command = [
         sys.executable,
         "-m",
         "pytest",
         *targets,
-        "-m",
-        mark_expr,
-        "--tb=short",
-        "--showlocals",
-        "--disable-warnings",
-        f"--junitxml={junit_xml}",
-        *extra_args,
     ]
+    if basetemp is not None:
+        command.append(f"--basetemp={basetemp}")
+
+    command.extend(
+        [
+            "-m",
+            mark_expr,
+            "--tb=short",
+            "--showlocals",
+            "--disable-warnings",
+            f"--junitxml={junit_xml}",
+            *extra_args,
+        ]
+    )
+    return command
 
 
 def run_command(command: Sequence[str], *, suite_name: str, timeout: int) -> int:
@@ -128,12 +214,15 @@ def run_suite(name: str, suite: dict[str, Any], *, timeout: int) -> dict[str, An
         log(f"{name} has no existing targets")
         return {"suite": name, "exit_code": 1, "targets": []}
 
+    basetemp = suite_pytest_basetemp(name)
     command = build_pytest_command(
         targets,
         mark_expr=suite["mark_expr"],
         junit_xml=suite["junit_xml"],
         extra_args=suite["extra_args"],
+        basetemp=basetemp,
     )
+    log(f"{name} pytest basetemp: {basetemp}")
     exit_code = run_command(command, suite_name=name, timeout=timeout)
     return {
         "suite": name,
@@ -164,11 +253,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Per-suite timeout in seconds")
     args = parser.parse_args(argv)
 
-    suites = suite_definitions()
-    selected_names = args.suite or list(suites)
-    results = [run_suite(name, suites[name], timeout=args.timeout) for name in selected_names]
-    write_report(results)
-    return 0 if all(result["exit_code"] == 0 for result in results) else 1
+    try:
+        suites = suite_definitions()
+        selected_names = args.suite or list(suites)
+        results = [run_suite(name, suites[name], timeout=args.timeout) for name in selected_names]
+        write_report(results)
+        return 0 if all(result["exit_code"] == 0 for result in results) else 1
+    finally:
+        cleanup_pytest_basetemp()
 
 
 if __name__ == "__main__":

--- a/ci/run-merge-queue-tests.py
+++ b/ci/run-merge-queue-tests.py
@@ -57,6 +57,10 @@ def suite_pytest_basetemp(suite_name: str) -> Path:
     return PYTEST_BASETEMP / slugify(suite_name)
 
 
+def prepare_suite_pytest_basetemp(basetemp: Path) -> None:
+    basetemp.parent.mkdir(parents=True, exist_ok=True)
+
+
 def path_is_under(path: Path, parent: Path) -> bool:
     if not str(parent):
         return False
@@ -215,6 +219,7 @@ def run_suite(name: str, suite: dict[str, Any], *, timeout: int) -> dict[str, An
         return {"suite": name, "exit_code": 1, "targets": []}
 
     basetemp = suite_pytest_basetemp(name)
+    prepare_suite_pytest_basetemp(basetemp)
     command = build_pytest_command(
         targets,
         mark_expr=suite["mark_expr"],

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -23,6 +23,7 @@ NIGHTLY_HOME="${DATUS_TEST_HOME:-${REPO_ROOT}/.datus_test_data}"
 NIGHTLY_PROJECT_ROOT="${NIGHTLY_PROJECT_ROOT:-${NIGHTLY_HOME}/workspace}"
 UNIT_TEST_HOME="${NIGHTLY_UNIT_TEST_HOME:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-nightly-unit-${GITHUB_RUN_ID:-$$}}"
 UNIT_TEST_PROJECT_ROOT="${NIGHTLY_UNIT_TEST_PROJECT_ROOT:-${UNIT_TEST_HOME}/workspace}"
+NIGHTLY_PYTEST_BASETEMP="${NIGHTLY_PYTEST_BASETEMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-nightly-pytest-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}}"
 AGENT_TEST_CONFIG_BACKUP="${AGENT_TEST_CONFIG_BACKUP:-${TMPDIR:-/tmp}/datus-agent-nightly-config-${GITHUB_RUN_ID:-$$}.bak}"
 
 default_repo_root() {
@@ -148,6 +149,37 @@ validate_unit_test_home() {
   fi
 
   echo "Refusing to remove UNIT_TEST_HOME outside temp directories: $UNIT_TEST_HOME" | tee -a "$LOG_FILE" >&2
+  return 1
+}
+
+validate_pytest_basetemp() {
+  local path="${1%/}"
+  local user_home="${HOME:-}"
+  local tmp_root="${TMPDIR:-/tmp}"
+  tmp_root="${tmp_root%/}"
+  local runner_temp="${RUNNER_TEMP:-}"
+  runner_temp="${runner_temp%/}"
+
+  case "$path" in
+    "" | "." | "/" | "$user_home" | "$REPO_ROOT" | "$WORKSPACE_ROOT" | *"/.."* | *"/../"* | "../"* | *"/."* | *"/./"*)
+      echo "Refusing to remove unsafe NIGHTLY_PYTEST_BASETEMP: $NIGHTLY_PYTEST_BASETEMP" | tee -a "$LOG_FILE" >&2
+      return 1
+      ;;
+  esac
+
+  case "$path" in
+    /*) ;;
+    *)
+      echo "Refusing to remove non-absolute NIGHTLY_PYTEST_BASETEMP: $NIGHTLY_PYTEST_BASETEMP" | tee -a "$LOG_FILE" >&2
+      return 1
+      ;;
+  esac
+
+  if is_under_dir "$path" "$runner_temp" || is_under_dir "$path" "$tmp_root" || is_under_dir "$path" "/tmp"; then
+    return 0
+  fi
+
+  echo "Refusing to remove NIGHTLY_PYTEST_BASETEMP outside temp directories: $NIGHTLY_PYTEST_BASETEMP" | tee -a "$LOG_FILE" >&2
   return 1
 }
 
@@ -430,6 +462,9 @@ cleanup_all() {
   set +e
   restore_agent_test_config
   rm -f "$AGENT_TEST_CONFIG_BACKUP"
+  if validate_pytest_basetemp "$NIGHTLY_PYTEST_BASETEMP"; then
+    rm -rf "$NIGHTLY_PYTEST_BASETEMP"
+  fi
   cleanup_all_compose
 }
 
@@ -1082,6 +1117,7 @@ log "SCHEDULER_ADAPTERS_ROOT=$SCHEDULER_ADAPTERS_ROOT"
 log "NIGHTLY_HOME=$NIGHTLY_HOME"
 log "DATUS_TEST_PROJECT_NAME=$DATUS_TEST_PROJECT_NAME"
 log "UNIT_TEST_HOME=$UNIT_TEST_HOME"
+log "NIGHTLY_PYTEST_BASETEMP=$NIGHTLY_PYTEST_BASETEMP"
 log "NIGHTLY_COMPOSE_PROJECT_PREFIX=$NIGHTLY_COMPOSE_PROJECT_PREFIX"
 log "SUPERSET_URL=$SUPERSET_URL SUPERSET_PORT=$SUPERSET_PORT SUPERSET_POSTGRES_HOST=$SUPERSET_POSTGRES_HOST SUPERSET_POSTGRES_PORT=$SUPERSET_POSTGRES_PORT"
 log "AIRFLOW_URL=$AIRFLOW_URL AIRFLOW_HOST_PORT=$AIRFLOW_HOST_PORT"
@@ -1098,6 +1134,13 @@ if [ -n "$NIGHTLY_GROUP_FILTER" ]; then
 fi
 
 validate_nightly_group_filter || exit 1
+validate_pytest_basetemp "$NIGHTLY_PYTEST_BASETEMP" || exit 1
+rm -rf "$NIGHTLY_PYTEST_BASETEMP"
+if [ -n "${PYTEST_ADDOPTS:-}" ]; then
+  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --basetemp=$NIGHTLY_PYTEST_BASETEMP"
+else
+  export PYTEST_ADDOPTS="--basetemp=$NIGHTLY_PYTEST_BASETEMP"
+fi
 require_docker_runtime || exit "$test_exit_code"
 
 run_logged_unfiltered "Flaky Registry Check" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --strict

--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -30,10 +30,12 @@ import argparse
 import copy
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import xml.etree.ElementTree as XMLTree
 from typing import Any, TextIO
@@ -46,6 +48,7 @@ DEFAULT_COVERAGE_XML = os.path.join(OUT_DIR, "coverage.xml")
 DEFAULT_COVERAGE_HTML = os.path.join(OUT_DIR, "htmlcov")
 DEFAULT_COVERAGE_DB = os.path.join(OUT_DIR, ".coverage")
 DEFAULT_PYTEST_LOG = os.path.join(OUT_DIR, "pytest-coverage.txt")
+PYTEST_BASETEMP_ENV = "DATUS_CI_PYTEST_BASETEMP"
 PR_HARNESS_MARK_EXPR = "acceptance or component or llm_harness"
 IMPACTED_UNIT_MARK_EXPR = "not acceptance and not component and not llm_harness and not nightly and not quarantine"
 PR_ACCEPTANCE_TARGETS = [
@@ -97,6 +100,25 @@ _COMPARE_BRANCH_CACHE: dict[str, str | None] = {}
 READER_JOIN_TIMEOUT_SECONDS = 5
 
 
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip(".-")
+    return slug or "default"
+
+
+def _default_pytest_basetemp() -> str:
+    configured = os.environ.get(PYTEST_BASETEMP_ENV)
+    if configured:
+        return configured
+
+    temp_root = os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
+    run_id = _slugify(os.environ.get("GITHUB_RUN_ID", "local"))
+    run_attempt = _slugify(os.environ.get("GITHUB_RUN_ATTEMPT", "0"))
+    return os.path.join(temp_root, f"datus-agent-pytest-{run_id}-{run_attempt}-{os.getpid()}")
+
+
+DEFAULT_PYTEST_BASETEMP = _default_pytest_basetemp()
+
+
 def _run_cmd(
     cmd: list[str],
     timeout: int,
@@ -143,6 +165,55 @@ def _remove_output_path(path: str) -> None:
         os.remove(path)
 
 
+def _is_under_dir(path: str, parent: str) -> bool:
+    if not parent:
+        return False
+
+    path_abs = os.path.abspath(path)
+    parent_abs = os.path.abspath(parent)
+    if path_abs == parent_abs:
+        return False
+
+    try:
+        return os.path.commonpath([path_abs, parent_abs]) == parent_abs
+    except ValueError:
+        return False
+
+
+def _is_safe_pytest_basetemp(path: str) -> bool:
+    if not path:
+        return False
+
+    path_abs = os.path.abspath(path)
+    repo_root = os.path.abspath(os.path.join(OUT_DIR, os.pardir))
+    user_home = os.path.abspath(os.path.expanduser("~"))
+    if path_abs in {os.path.abspath(os.sep), repo_root, OUT_DIR, user_home}:
+        return False
+
+    allowed_roots = [
+        os.environ.get("RUNNER_TEMP", ""),
+        tempfile.gettempdir(),
+        "/tmp",
+    ]
+    return any(_is_under_dir(path_abs, root) for root in allowed_roots)
+
+
+def _cleanup_pytest_basetemp() -> None:
+    if not os.path.exists(DEFAULT_PYTEST_BASETEMP):
+        return
+
+    if not _is_safe_pytest_basetemp(DEFAULT_PYTEST_BASETEMP):
+        log(f"Refusing to remove unsafe pytest basetemp: {DEFAULT_PYTEST_BASETEMP}")
+        return
+
+    shutil.rmtree(DEFAULT_PYTEST_BASETEMP, ignore_errors=True)
+    log(f"Cleaned pytest basetemp: {DEFAULT_PYTEST_BASETEMP}")
+
+
+def _suite_pytest_basetemp(suite_name: str) -> str:
+    return os.path.join(DEFAULT_PYTEST_BASETEMP, _slugify(suite_name))
+
+
 def _reset_report_outputs() -> None:
     for path in [
         DEFAULT_COVERAGE_XML,
@@ -166,6 +237,7 @@ def _build_pytest_command(
     mark_expr: str | None = None,
     append: bool = False,
     emit_reports: bool = True,
+    basetemp: str | None = None,
 ) -> list[str]:
     cmd = [
         sys.executable,
@@ -173,6 +245,9 @@ def _build_pytest_command(
         "pytest",
         *targets,
     ]
+    if basetemp:
+        cmd.append(f"--basetemp={basetemp}")
+
     if mark_expr:
         cmd.extend(["-m", mark_expr])
 
@@ -215,14 +290,17 @@ def _run_pytest_suite(
     emit_reports: bool = True,
 ) -> int:
     """Run one pytest suite and stream logs to stdout and the CI log file."""
+    basetemp = _suite_pytest_basetemp(suite_name)
     cmd = _build_pytest_command(
         targets,
         junit_xml,
         mark_expr=mark_expr,
         append=append,
         emit_reports=emit_reports,
+        basetemp=basetemp,
     )
     log(f"Running {suite_name}: {' '.join(cmd)}")
+    log(f"{suite_name} pytest basetemp: {basetemp}")
 
     env = os.environ.copy()
     env["COVERAGE_FILE"] = DEFAULT_COVERAGE_DB
@@ -504,51 +582,54 @@ def run_tests(base_ref: str = "") -> tuple[int, list[str]]:
     """Run PR acceptance plus impacted unit tests and return the exit code and JUnit XML paths."""
     _reset_report_outputs()
 
-    impacted_targets = resolve_impacted_unit_tests(base_ref)
-    junit_xml_paths: list[str] = []
-    exit_codes: list[int] = []
+    try:
+        impacted_targets = resolve_impacted_unit_tests(base_ref)
+        junit_xml_paths: list[str] = []
+        exit_codes: list[int] = []
 
-    with open(DEFAULT_PYTEST_LOG, "w", encoding="utf-8") as log_file:
-        acceptance_xml = os.path.join(OUT_DIR, "test-results-acceptance.xml")
-        acceptance_rc = _run_pytest_suite(
-            PR_ACCEPTANCE_TARGETS,
-            acceptance_xml,
-            log_file,
-            suite_name="acceptance",
-            mark_expr=PR_HARNESS_MARK_EXPR,
-            emit_reports=not impacted_targets,
-        )
-        exit_codes.append(acceptance_rc)
-        junit_xml_paths.append(acceptance_xml)
-
-        if impacted_targets:
-            impacted_xml = os.path.join(OUT_DIR, "test-results-impacted-unit.xml")
-            impacted_rc = _run_pytest_suite(
-                impacted_targets,
-                impacted_xml,
+        with open(DEFAULT_PYTEST_LOG, "w", encoding="utf-8") as log_file:
+            acceptance_xml = os.path.join(OUT_DIR, "test-results-acceptance.xml")
+            acceptance_rc = _run_pytest_suite(
+                PR_ACCEPTANCE_TARGETS,
+                acceptance_xml,
                 log_file,
-                suite_name="impacted unit tests",
-                mark_expr=IMPACTED_UNIT_MARK_EXPR,
-                append=True,
-                emit_reports=True,
+                suite_name="acceptance",
+                mark_expr=PR_HARNESS_MARK_EXPR,
+                emit_reports=not impacted_targets,
             )
-            exit_codes.append(
-                _normalize_suite_exit_code(
-                    impacted_rc,
+            exit_codes.append(acceptance_rc)
+            junit_xml_paths.append(acceptance_xml)
+
+            if impacted_targets:
+                impacted_xml = os.path.join(OUT_DIR, "test-results-impacted-unit.xml")
+                impacted_rc = _run_pytest_suite(
+                    impacted_targets,
+                    impacted_xml,
+                    log_file,
                     suite_name="impacted unit tests",
-                    allow_empty_collection=True,
+                    mark_expr=IMPACTED_UNIT_MARK_EXPR,
+                    append=True,
+                    emit_reports=True,
                 )
-            )
-            junit_xml_paths.append(impacted_xml)
+                exit_codes.append(
+                    _normalize_suite_exit_code(
+                        impacted_rc,
+                        suite_name="impacted unit tests",
+                        allow_empty_collection=True,
+                    )
+                )
+                junit_xml_paths.append(impacted_xml)
 
-    merge_junit_results(junit_xml_paths)
+        merge_junit_results(junit_xml_paths)
 
-    if os.path.exists(DEFAULT_COVERAGE_DB):
-        os.remove(DEFAULT_COVERAGE_DB)
+        if os.path.exists(DEFAULT_COVERAGE_DB):
+            os.remove(DEFAULT_COVERAGE_DB)
 
-    exit_code = 0 if all(code == 0 for code in exit_codes) else 1
-    log(f"Overall pytest exit code: {exit_code}")
-    return exit_code, junit_xml_paths
+        exit_code = 0 if all(code == 0 for code in exit_codes) else 1
+        log(f"Overall pytest exit code: {exit_code}")
+        return exit_code, junit_xml_paths
+    finally:
+        _cleanup_pytest_basetemp()
 
 
 def merge_junit_results(junit_xml_paths: list[str], output_path: str | None = None) -> str:

--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -80,6 +80,7 @@ IMPACTED_TEST_MAPPING = [
     ("datus/configuration/", "tests/unit_tests/configuration/"),
     ("datus/models/", "tests/unit_tests/models/"),
     ("datus/storage/", "tests/unit_tests/storage/"),
+    ("datus/tools/db_tools/", "tests/unit_tests/tools/db_tools/"),
     ("datus/tools/", "tests/unit_tests/tools/"),
     ("datus/utils/", "tests/unit_tests/utils/"),
     ("ci/", "tests/unit_tests/ci/"),

--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -214,6 +214,10 @@ def _suite_pytest_basetemp(suite_name: str) -> str:
     return os.path.join(DEFAULT_PYTEST_BASETEMP, _slugify(suite_name))
 
 
+def _prepare_suite_pytest_basetemp(basetemp: str) -> None:
+    os.makedirs(os.path.dirname(basetemp), exist_ok=True)
+
+
 def _reset_report_outputs() -> None:
     for path in [
         DEFAULT_COVERAGE_XML,
@@ -291,6 +295,7 @@ def _run_pytest_suite(
 ) -> int:
     """Run one pytest suite and stream logs to stdout and the CI log file."""
     basetemp = _suite_pytest_basetemp(suite_name)
+    _prepare_suite_pytest_basetemp(basetemp)
     cmd = _build_pytest_command(
         targets,
         junit_xml,

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -306,10 +306,12 @@ class DBManager:
             db_path = db_config.uri or db_config.database
             if db_path.startswith("sqlite:///"):
                 db_path = db_path.replace("sqlite:///", "")
+            extra = db_config.extra or {}
             return SQLiteConfig(
                 db_path=db_path,
                 timeout_seconds=timeout_seconds,
                 database_name=None,  # Let connector extract from file path
+                read_only=_bool_extra(extra.get("read_only"), False),
             )
 
         elif db_type == DBType.DUCKDB:

--- a/datus/tools/db_tools/sqlite_connector.py
+++ b/datus/tools/db_tools/sqlite_connector.py
@@ -3,6 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import sqlite3
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, override
 
 from datus_db_core import BaseSqlConnector
@@ -28,6 +29,7 @@ class SQLiteConnector(BaseSqlConnector, MigrationTargetMixin):
     def __init__(self, config: SQLiteConfig):
         super().__init__(config, dialect=DBType.SQLITE)
         self.db_path = config.db_path.replace("sqlite:///", "")
+        self.read_only = config.read_only
         self.check_same_thread = config.check_same_thread
         self.connection: Optional[sqlite3.Connection] = None
 
@@ -45,10 +47,20 @@ class SQLiteConnector(BaseSqlConnector, MigrationTargetMixin):
             return
 
         try:
+            connect_path = self.db_path
+            connect_kwargs: Dict[str, Any] = {
+                "timeout": self.timeout_seconds,
+                "check_same_thread": self.check_same_thread,
+            }
+            if self.read_only and self.db_path != ":memory:":
+                if self.db_path.startswith("file:"):
+                    connect_path = self.db_path
+                else:
+                    connect_path = f"{Path(self.db_path).resolve().as_uri()}?mode=ro"
+                connect_kwargs["uri"] = True
             self.connection = sqlite3.connect(
-                self.db_path,
-                timeout=self.timeout_seconds,
-                check_same_thread=self.check_same_thread,
+                connect_path,
+                **connect_kwargs,
             )
             self.connection.row_factory = sqlite3.Row
         except Exception as e:

--- a/datus/tools/db_tools/sqlite_connector.py
+++ b/datus/tools/db_tools/sqlite_connector.py
@@ -5,6 +5,7 @@
 import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, override
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from datus_db_core import BaseSqlConnector
 from pandas import DataFrame
@@ -19,6 +20,25 @@ from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+
+def _read_only_sqlite_uri(db_path: str) -> str:
+    if not db_path.startswith("file:"):
+        return f"{Path(db_path).resolve().as_uri()}?mode=ro"
+
+    parts = urlsplit(db_path)
+    query: list[tuple[str, str]] = []
+    mode_seen = False
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key.lower() == "mode":
+            if not mode_seen:
+                query.append((key, "ro"))
+                mode_seen = True
+            continue
+        query.append((key, value))
+    if not mode_seen:
+        query.append(("mode", "ro"))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
 
 
 class SQLiteConnector(BaseSqlConnector, MigrationTargetMixin):
@@ -53,10 +73,7 @@ class SQLiteConnector(BaseSqlConnector, MigrationTargetMixin):
                 "check_same_thread": self.check_same_thread,
             }
             if self.read_only and self.db_path != ":memory:":
-                if self.db_path.startswith("file:"):
-                    connect_path = self.db_path
-                else:
-                    connect_path = f"{Path(self.db_path).resolve().as_uri()}?mode=ro"
+                connect_path = _read_only_sqlite_uri(self.db_path)
                 connect_kwargs["uri"] = True
             self.connection = sqlite3.connect(
                 connect_path,

--- a/tests/unit_tests/ci/test_run_merge_queue_tests.py
+++ b/tests/unit_tests/ci/test_run_merge_queue_tests.py
@@ -51,10 +51,12 @@ def test_build_pytest_command_includes_marker_junit_and_extra_args(tmp_path, run
         mark_expr="not nightly",
         junit_xml=junit_xml,
         extra_args=["--timeout=300", "-n", "auto"],
+        basetemp=tmp_path / "pytest-temp" / "unit",
     )
 
     assert command[:4] == [run_merge_queue_tests.sys.executable, "-m", "pytest", "tests/unit_tests/"]
-    assert command[4:6] == ["-m", "not nightly"]
+    assert command[4] == f"--basetemp={tmp_path / 'pytest-temp' / 'unit'}"
+    assert command[5:7] == ["-m", "not nightly"]
     assert f"--junitxml={junit_xml}" in command
     assert ["--timeout=300", "-n", "auto"] == command[-3:]
 
@@ -93,6 +95,7 @@ def test_main_runs_selected_suite_and_writes_report(tmp_path, monkeypatch, run_m
                 mark_expr="acceptance or component or llm_harness",
                 junit_xml=out_dir / "test-results-merge-acceptance-unit.xml",
                 extra_args=["--timeout=300", "--dist=loadscope", "-n", "auto"],
+                basetemp=run_merge_queue_tests.suite_pytest_basetemp("acceptance-unit"),
             ),
             "cwd": repo_root,
             "timeout": 10,

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -46,6 +46,17 @@ def test_select_impacted_unit_tests_includes_changed_unit_tests_and_dedupes():
     ]
 
 
+def test_select_impacted_unit_tests_maps_db_tools_to_db_tools_tests():
+    impacted = run_pr_tests.select_impacted_unit_tests(
+        [
+            "datus/tools/db_tools/sqlite_connector.py",
+            "datus/tools/db_tools/db_manager.py",
+        ]
+    )
+
+    assert impacted == ["tests/unit_tests/tools/db_tools/"]
+
+
 def test_select_impacted_unit_tests_maps_non_python_files_to_parent_directory():
     impacted = run_pr_tests.select_impacted_unit_tests(
         [

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -175,8 +175,7 @@ def _copy_california_schools_db(dest_path: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def real_agent_config(tmp_path, reset_global_singletons):
+def _create_real_agent_config(tmp_path, db_path: str, *, read_only_db: bool) -> AgentConfig:
     """Create a fully real AgentConfig backed by a real SQLite database.
 
     Includes:
@@ -187,11 +186,17 @@ def real_agent_config(tmp_path, reset_global_singletons):
     - agentic_nodes config for chat, gensql, gen_ext_knowledge, compare,
       gen_sql_summary, gen_metrics, gen_semantic_model, gen_report
     """
-    db_path = os.path.join(str(tmp_path), "california_schools.sqlite")
-    _copy_california_schools_db(db_path)
-
     # Create workspace subdirectory for filesystem tools
     os.makedirs(os.path.join(str(tmp_path), "workspace"), exist_ok=True)
+
+    datasource_config = {
+        "type": "sqlite",
+        "uri": db_path,
+        "name": "california_schools",
+        "default": True,
+    }
+    if read_only_db:
+        datasource_config["read_only"] = True
 
     config_kwargs = {
         "home": str(tmp_path),
@@ -206,12 +211,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
         },
         "services": {
             "datasources": {
-                "california_schools": {
-                    "type": "sqlite",
-                    "uri": db_path,
-                    "name": "california_schools",
-                    "default": True,
-                },
+                "california_schools": datasource_config,
             },
             "semantic_layer": {},
             "bi_platforms": {},
@@ -287,11 +287,35 @@ def real_agent_config(tmp_path, reset_global_singletons):
 
     # Set current datasource
     agent_config.current_datasource = "california_schools"
+    return agent_config
+
+
+@pytest.fixture
+def real_agent_config(tmp_path, reset_global_singletons):
+    """Create a fully real AgentConfig backed by a shared read-only SQLite database."""
+    agent_config = _create_real_agent_config(
+        tmp_path,
+        CALIFORNIA_SCHOOLS_DB,
+        read_only_db=True,
+    )
 
     yield agent_config
     # tmp_path is pytest-managed; storage backends here use
     # ``agent_config.path_manager.data_dir`` which is rooted at tmp_path, so no
     # cwd cleanup is needed.
+
+
+@pytest.fixture
+def mutable_real_agent_config(tmp_path, reset_global_singletons):
+    """Create a real AgentConfig with a per-test mutable SQLite database copy."""
+    db_path = os.path.join(str(tmp_path), "california_schools.sqlite")
+    _copy_california_schools_db(db_path)
+
+    yield _create_real_agent_config(
+        tmp_path,
+        db_path,
+        read_only_db=False,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_real_agent_config_sqlite_fixture.py
+++ b/tests/unit_tests/test_real_agent_config_sqlite_fixture.py
@@ -25,7 +25,7 @@ def test_real_agent_config_uses_shared_readonly_sample_db(real_agent_config, tmp
 
     write_result = tool.execute_ddl("CREATE TABLE datus_readonly_probe (id INT)")
     assert write_result.success == 0
-    assert "readonly" in write_result.error.lower() or "read-only" in write_result.error.lower()
+    assert "readonly" in write_result.error.lower().replace("-", "")
 
 
 def test_mutable_real_agent_config_gets_isolated_writable_copy(mutable_real_agent_config, tmp_path):

--- a/tests/unit_tests/test_real_agent_config_sqlite_fixture.py
+++ b/tests/unit_tests/test_real_agent_config_sqlite_fixture.py
@@ -1,0 +1,53 @@
+import sqlite3
+from pathlib import Path
+
+from datus.tools.func_tool.database import DBFuncTool
+from tests.unit_tests.conftest import CALIFORNIA_SCHOOLS_DB
+
+
+def _sqlite_uri_to_path(uri: str) -> Path:
+    if uri.startswith("sqlite:///"):
+        return Path(uri.removeprefix("sqlite:///")).resolve()
+    return Path(uri).resolve()
+
+
+def test_real_agent_config_uses_shared_readonly_sample_db(real_agent_config, tmp_path):
+    datasource = real_agent_config.services.datasources["california_schools"]
+    db_path = _sqlite_uri_to_path(datasource.uri)
+
+    assert db_path == Path(CALIFORNIA_SCHOOLS_DB).resolve()
+    assert datasource.extra == {"read_only": True}
+    assert not (tmp_path / "california_schools.sqlite").exists()
+
+    tool = DBFuncTool(agent_config=real_agent_config)
+    read_result = tool.read_query("SELECT COUNT(*) AS count FROM schools")
+    assert read_result.success == 1
+
+    write_result = tool.execute_ddl("CREATE TABLE datus_readonly_probe (id INT)")
+    assert write_result.success == 0
+    assert "readonly" in write_result.error.lower() or "read-only" in write_result.error.lower()
+
+
+def test_mutable_real_agent_config_gets_isolated_writable_copy(mutable_real_agent_config, tmp_path):
+    datasource = mutable_real_agent_config.services.datasources["california_schools"]
+    db_path = _sqlite_uri_to_path(datasource.uri)
+
+    assert db_path == tmp_path / "california_schools.sqlite"
+    assert db_path.exists()
+    assert datasource.extra is None
+
+    tool = DBFuncTool(agent_config=mutable_real_agent_config)
+    write_result = tool.execute_ddl("CREATE TABLE datus_mutable_probe (id INT)")
+    assert write_result.success == 1
+
+    read_result = tool.read_query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'datus_mutable_probe'"
+    )
+    assert read_result.success == 1
+    assert "datus_mutable_probe" in str(read_result.result)
+
+    with sqlite3.connect(CALIFORNIA_SCHOOLS_DB) as conn:
+        source_table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'datus_mutable_probe'"
+        ).fetchone()
+    assert source_table is None

--- a/tests/unit_tests/tools/db_tools/test_connector_sqlite.py
+++ b/tests/unit_tests/tools/db_tools/test_connector_sqlite.py
@@ -42,6 +42,31 @@ def test_connection(sqlite_connector: SQLiteConnector, db_path):
     assert sqlite_connector.connection is None
 
 
+def test_read_only_connection_rejects_writes(tmp_path):
+    db_path = tmp_path / "readonly.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.execute("INSERT INTO test (name) VALUES ('seed')")
+
+    connector = SQLiteConnector(SQLiteConfig(db_path=str(db_path), read_only=True))
+    try:
+        result = connector.execute({"sql_query": "SELECT * FROM test"}, result_format="list")
+        assert result.success is True
+        assert result.row_count == 1
+
+        write_result = connector.execute_ddl("CREATE TABLE should_fail (id INT)")
+        assert write_result.success is False
+        assert "readonly" in write_result.error.lower() or "read-only" in write_result.error.lower()
+    finally:
+        connector.close()
+
+    with sqlite3.connect(db_path) as conn:
+        table_exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'should_fail'"
+        ).fetchone()
+    assert table_exists is None
+
+
 def test_test_connection(tmp_path):
     db_path = tmp_path / "test.db"
     config = SQLiteConfig(db_path=str(db_path))

--- a/tests/unit_tests/tools/db_tools/test_connector_sqlite.py
+++ b/tests/unit_tests/tools/db_tools/test_connector_sqlite.py
@@ -56,7 +56,31 @@ def test_read_only_connection_rejects_writes(tmp_path):
 
         write_result = connector.execute_ddl("CREATE TABLE should_fail (id INT)")
         assert write_result.success is False
-        assert "readonly" in write_result.error.lower() or "read-only" in write_result.error.lower()
+        assert "readonly" in write_result.error.lower().replace("-", "")
+    finally:
+        connector.close()
+
+    with sqlite3.connect(db_path) as conn:
+        table_exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'should_fail'"
+        ).fetchone()
+    assert table_exists is None
+
+
+@pytest.mark.parametrize("uri_query", ["cache=shared", "mode=rw"])
+def test_read_only_file_uri_connection_rejects_writes(tmp_path, uri_query):
+    db_path = tmp_path / "readonly-uri.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+
+    connector = SQLiteConnector(SQLiteConfig(db_path=f"{db_path.as_uri()}?{uri_query}", read_only=True))
+    try:
+        result = connector.execute({"sql_query": "SELECT * FROM test"}, result_format="list")
+        assert result.success is True
+
+        write_result = connector.execute_ddl("CREATE TABLE should_fail (id INT)")
+        assert write_result.success is False
+        assert "readonly" in write_result.error.lower().replace("-", "")
     finally:
         connector.close()
 

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -7,7 +7,7 @@ import pytest
 from datus_db_core import BaseSqlConnector, DatusDbException
 from datus_db_core import ErrorCode as DbErrorCode
 
-from datus.tools.db_tools.config import DuckDBConfig
+from datus.tools.db_tools.config import DuckDBConfig, SQLiteConfig
 from datus.tools.db_tools.db_manager import (
     DBManager,
     _clean_str,
@@ -337,6 +337,16 @@ class TestDBManager:
         assert result.enable_external_access is False
         assert result.memory_limit == "2GB"
         assert result.iceberg == cfg.extra["iceberg"]
+
+    def test_sqlite_config_includes_read_only_extra_option(self):
+        mgr = DBManager({})
+        cfg = _cfg(type="sqlite", uri="sqlite:///test.db", extra={"read_only": "true"})
+
+        result = mgr._db_config_to_connection_config(cfg)
+
+        assert isinstance(result, SQLiteConfig)
+        assert result.db_path == "test.db"
+        assert result.read_only is True
 
     def test_close_closes_nested_multi_db_connections(self):
         mgr = DBManager({})


### PR DESCRIPTION
## Why

The fixed self-hosted CI runner can accumulate stale pytest temp directories under `/tmp` when pytest exits abnormally. The `real_agent_config` fixture also copied `california_schools.sqlite` into each test temp directory, which made those stale directories much larger over time.

## Solution

- Scope PR, merge-queue, and nightly pytest temp directories to run-specific basetemp paths under runner temp storage.
- Clean those basetemp paths from the Python CI harnesses and workflow cleanup steps, with path safety checks before removal.
- Let SQLite datasource config pass `read_only` through to `SQLiteConfig`, and open read-only SQLite connections with `mode=ro`.
- Make the default `real_agent_config` use the shared sample SQLite database read-only.
- Add `mutable_real_agent_config` for tests that need an isolated writable copy.
- Add unit coverage for read-only SQLite writes and fixture copy/isolation behavior.

## Test Cases

- `uv run python -m py_compile ci/run-pr-tests.py ci/run-merge-queue-tests.py datus/tools/db_tools/sqlite_connector.py datus/tools/db_tools/db_manager.py tests/unit_tests/conftest.py tests/unit_tests/test_real_agent_config_sqlite_fixture.py`
- `bash -n ci/run-nightly-tests.sh`
- `git diff --check`
- `uv run pytest tests/unit_tests/tools/db_tools/test_connector_sqlite.py tests/unit_tests/tools/db_tools/test_db_manager.py -q`
- `uv run pytest tests/unit_tests/agent/node -q`
- `uv run pytest tests/unit_tests/api/services -q`
- `rg -il "sqlite|california_schools|real_agent_config" tests/unit_tests -g '*.py' | sort | xargs env NO_COLOR=1 uv run pytest -q --basetemp=/tmp/datus-agent-sqlite-all` -> `5098 passed, 1 skipped, 1 xfailed, 2 warnings`
- `find /tmp/datus-agent-sqlite-all -name california_schools.sqlite -print | wc -l` -> `1` expected mutable fixture copy only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only SQLite support added so connections can be opened in read-only mode for safer data access.

* **Tests**
  * Fixtures updated: shared read-only sample DB plus a new mutable per-test writable fixture.
  * New tests confirm read-only connections reject writes and validate fixture behaviors.

* **Chores**
  * CI and nightly test runners now use deterministic per-run pytest temp directories with safer, guarded cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->