### PR TITLE
[Feature] surface visual-artifact completion as an SSE artifact card

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -28,6 +28,8 @@ Anything that's *byte-identical* between the two node files lives here.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any, AsyncGenerator, ClassVar, Dict, Generic, List, Literal, Optional, Type, TypeVar
 
 from pydantic import BaseModel
@@ -463,6 +465,30 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             if value:
                 return value
         return None
+
+    def _read_artifact_manifest(self, artifact_slug: Optional[str]) -> Dict[str, Any]:
+        """Return the parsed manifest.json for ``artifact_slug`` or an empty dict.
+
+        Used to surface ``name`` / ``description`` / ``created_at`` in the
+        node result so the SSE artifact card can be rendered without a
+        follow-up call to ``/api/v1/report/detail``. Missing or unreadable
+        manifests are treated as soft-failures because the run may have
+        crashed before binding (mode is then ``None`` too).
+        """
+        if not artifact_slug:
+            return {}
+        project_root = getattr(self.agent_config, "project_root", None) if self.agent_config else None
+        if not project_root:
+            return {}
+        manifest_path = Path(project_root) / self.ARTIFACT_ROOT_DIR_NAME / artifact_slug / "manifest.json"
+        if not manifest_path.is_file():
+            return {}
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.debug("Failed to read %s manifest %s: %s", self.ARTIFACT_KIND, manifest_path, exc)
+            return {}
+        return data if isinstance(data, dict) else {}
 
     def _prepare_artifacts(self, user_input: InputT) -> None:
         """Wire artifact tools into ``self.tools`` and reset the active slug.

--- a/datus/agent/node/gen_visual_dashboard_agentic_node.py
+++ b/datus/agent/node/gen_visual_dashboard_agentic_node.py
@@ -113,6 +113,8 @@ class GenVisualDashboardAgenticNode(
         all_actions: List[ActionHistory],
         tool_calls: List[ActionHistory],
     ) -> GenVisualDashboardNodeResult:
+        manifest = self._read_artifact_manifest(artifact_slug)
+        mode = getattr(self.artifact_tools, "mode", None) if self.artifact_tools is not None else None
         return GenVisualDashboardNodeResult(
             success=app_jsx_rel_path is not None,
             response=response_content,
@@ -121,6 +123,10 @@ class GenVisualDashboardAgenticNode(
             render_file_count=render_file_count,
             template_count=len(query_actions),
             tokens_used=tokens_used,
+            artifact_mode=mode,
+            name=manifest.get("name"),
+            description=manifest.get("description"),
+            created_at=manifest.get("created_at"),
             action_history=[a.model_dump() for a in all_actions],
             execution_stats={
                 "total_actions": len(all_actions),
@@ -131,12 +137,18 @@ class GenVisualDashboardAgenticNode(
         )
 
     def _build_error_result(self, exc: BaseException) -> GenVisualDashboardNodeResult:
+        mode = getattr(self.artifact_tools, "mode", None) if self.artifact_tools is not None else None
+        manifest = self._read_artifact_manifest(self._active_artifact_slug)
         return GenVisualDashboardNodeResult(
             success=False,
             error=str(exc),
             response="Sorry, I encountered an error while generating the visual dashboard.",
             dashboard_slug=self._active_artifact_slug,
             tokens_used=0,
+            artifact_mode=mode,
+            name=manifest.get("name"),
+            description=manifest.get("description"),
+            created_at=manifest.get("created_at"),
         )
 
     # No CLI-mode HTML compile for dashboards — they need a live

--- a/datus/agent/node/gen_visual_report_agentic_node.py
+++ b/datus/agent/node/gen_visual_report_agentic_node.py
@@ -121,6 +121,8 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
         all_actions: List[ActionHistory],
         tool_calls: List[ActionHistory],
     ) -> GenVisualReportNodeResult:
+        manifest = self._read_artifact_manifest(artifact_slug)
+        mode = getattr(self.artifact_tools, "mode", None) if self.artifact_tools is not None else None
         return GenVisualReportNodeResult(
             success=app_jsx_rel_path is not None,
             response=response_content,
@@ -130,6 +132,10 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
             html_path=None,  # filled in by _post_validate_hook on success
             query_count=len(query_actions),
             tokens_used=tokens_used,
+            artifact_mode=mode,
+            name=manifest.get("name"),
+            description=manifest.get("description"),
+            created_at=manifest.get("created_at"),
             action_history=[a.model_dump() for a in all_actions],
             execution_stats={
                 "total_actions": len(all_actions),
@@ -140,12 +146,18 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
         )
 
     def _build_error_result(self, exc: BaseException) -> GenVisualReportNodeResult:
+        mode = getattr(self.artifact_tools, "mode", None) if self.artifact_tools is not None else None
+        manifest = self._read_artifact_manifest(self._active_artifact_slug)
         return GenVisualReportNodeResult(
             success=False,
             error=str(exc),
             response="Sorry, I encountered an error while generating the visual report.",
             report_slug=self._active_artifact_slug,
             tokens_used=0,
+            artifact_mode=mode,
+            name=manifest.get("name"),
+            description=manifest.get("description"),
+            created_at=manifest.get("created_at"),
         )
 
     def _post_validate_hook(self, artifact_slug: str, result: GenVisualReportNodeResult) -> None:

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -1,7 +1,7 @@
 """Pydantic models for CLI Command Type API endpoints."""
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -420,6 +420,39 @@ class ICodePayload(IMessageContentPayload):
 
     code_type: str = Field(..., description="Code type (json, xml, sql, etc.)")
     content: str = Field(..., description="Code content")
+
+
+class IArtifactPayload(IMessageContentPayload):
+    """Artifact card content payload.
+
+    Emitted as a single ``IMessageContent(type='artifact')`` after a
+    ``gen_visual_report`` / ``gen_visual_dashboard`` subagent run finishes
+    successfully. The frontend renders a clickable card from this payload
+    that opens the artifact viewer without an extra round-trip — every
+    field that the card needs to render is included here.
+
+    ``mode`` reuses the backend artifact-tools vocabulary (``'new'`` when
+    the LLM called ``start_new_*``, ``'edit'`` when it called
+    ``bind_existing_*``) so there is no mapping layer between the
+    NodeResult and the wire payload.
+    """
+
+    slug: str = Field(..., description="Stable artifact identifier, doubles as the on-disk directory name.")
+    kind: Literal["report", "dashboard"] = Field(..., description="Which artifact viewer to open.")
+    mode: Optional[Literal["new", "edit"]] = Field(
+        default=None,
+        description="Whether this run created a fresh artifact or edited an existing one.",
+    )
+    name: Optional[str] = Field(default=None, description="Display name from manifest.json.")
+    description: Optional[str] = Field(default=None, description="Short description from manifest.json.")
+    created_at: Optional[str] = Field(
+        default=None,
+        description="ISO-8601 UTC timestamp from manifest.json.",
+    )
+    preview_summary: Optional[str] = Field(
+        default=None,
+        description="Truncated LLM final response (~200 chars) for the card subtitle.",
+    )
 
 
 class IMessageContent(BaseModel):

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -428,28 +428,29 @@ def action_to_sse_event(
             else:
                 return None
         elif (
-            role == ActionRole.ASSISTANT
-            and status == ActionStatus.SUCCESS
-            and action.action_type.endswith("_response")
-            and isinstance(action.output, dict)
-            and action.output.get("artifact_kind") in ("report", "dashboard")
-        ):
-            # gen_visual_report / gen_visual_dashboard completion — emit an
-            # artifact card the frontend can render directly. Fires
-            # regardless of ``include_final_response`` because the card is
-            # not a substitute for the final markdown response; the LLM's
-            # streamed response is already in the buffer ahead of us.
-            contents = _build_artifact_content(action)
-            if contents is None:
-                return None
-        elif (
             role == ActionRole.ASSISTANT and status == ActionStatus.SUCCESS and action.action_type.endswith("_response")
         ):
-            if not include_final_response:
-                return None  # ignore parsed final response
-            contents = _build_response_content(action)
-            if not contents:
-                return None
+            # gen_visual_report / gen_visual_dashboard completions ship an
+            # ``artifact_kind`` on the output — try to render an artifact
+            # card the frontend can open directly. The card fires
+            # regardless of ``include_final_response`` because it is not a
+            # substitute for the LLM's prose (already streamed earlier as
+            # a separate response action); it is purely additive.
+            contents = None
+            if isinstance(action.output, dict) and action.output.get("artifact_kind") in ("report", "dashboard"):
+                contents = _build_artifact_content(action)
+
+            # Either this is a plain wrapper response (no artifact) or the
+            # artifact payload was malformed (e.g. missing slug). Don't
+            # drop the event silently — fall back to the standard
+            # ``_response`` handling so the assistant's parsed output can
+            # still be surfaced to history tooling when requested.
+            if contents is None:
+                if not include_final_response:
+                    return None  # ignore parsed final response
+                contents = _build_response_content(action)
+                if not contents:
+                    return None
         elif _is_plain_assistant_response(action):
             contents = _build_response_content(action)
             if not contents:

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -279,6 +279,43 @@ def _build_interaction_content(action: ActionHistory) -> List[IMessageContent]:
     return [IMessageContent(type="user-interaction", payload=payload_data)]
 
 
+_ARTIFACT_PREVIEW_LIMIT = 200
+
+
+def _build_artifact_content(action: ActionHistory) -> Optional[List[IMessageContent]]:
+    """Build an artifact-card content block from a finished gen_visual_* run.
+
+    Returns ``None`` when the action does not actually carry an artifact
+    payload (missing slug or kind) so the caller can fall back to the
+    regular ``_response`` markdown rendering.
+
+    The payload mirrors :class:`IArtifactPayload`. ``mode`` reuses the
+    backend artifact-tools vocabulary (``'new'`` / ``'edit'``) so there
+    is no translation layer between the NodeResult and the wire payload.
+    """
+    output = action.output if isinstance(action.output, dict) else {}
+    slug = output.get("report_slug") or output.get("dashboard_slug")
+    kind = output.get("artifact_kind")
+    if not slug or kind not in ("report", "dashboard"):
+        return None
+
+    response_text = output.get("response") or ""
+    preview = response_text.strip() if isinstance(response_text, str) else ""
+    if len(preview) > _ARTIFACT_PREVIEW_LIMIT:
+        preview = preview[:_ARTIFACT_PREVIEW_LIMIT].rstrip() + "…"
+
+    payload: dict[str, Any] = {
+        "slug": slug,
+        "kind": kind,
+        "mode": output.get("artifact_mode"),
+        "name": output.get("name"),
+        "description": output.get("description"),
+        "created_at": output.get("created_at"),
+        "preview_summary": preview or None,
+    }
+    return [IMessageContent(type="artifact", payload=payload)]
+
+
 def _build_subagent_complete_content(action: ActionHistory) -> List[IMessageContent]:
     """Build content for sub-agent completion summary event.
 
@@ -389,6 +426,21 @@ def action_to_sse_event(
                 contents = _build_user_content(action)
                 sse_role = "user"
             else:
+                return None
+        elif (
+            role == ActionRole.ASSISTANT
+            and status == ActionStatus.SUCCESS
+            and action.action_type.endswith("_response")
+            and isinstance(action.output, dict)
+            and action.output.get("artifact_kind") in ("report", "dashboard")
+        ):
+            # gen_visual_report / gen_visual_dashboard completion — emit an
+            # artifact card the frontend can render directly. Fires
+            # regardless of ``include_final_response`` because the card is
+            # not a substitute for the final markdown response; the LLM's
+            # streamed response is already in the buffer ahead of us.
+            contents = _build_artifact_content(action)
+            if contents is None:
                 return None
         elif (
             role == ActionRole.ASSISTANT and status == ActionStatus.SUCCESS and action.action_type.endswith("_response")

--- a/datus/schemas/gen_visual_dashboard_models.py
+++ b/datus/schemas/gen_visual_dashboard_models.py
@@ -148,6 +148,26 @@ class GenVisualDashboardNodeResult(BaseResult):
     render_file_count: int = Field(default=0, description="Number of files persisted under dashboards/<slug>/render/")
     template_count: int = Field(default=0, description="Number of templates persisted under queries/")
     tokens_used: int = Field(default=0, description="Total tokens used during this run")
+    artifact_kind: Literal["dashboard"] = Field(
+        default="dashboard",
+        description="Artifact kind, fixed for this node. Carried into the SSE artifact payload so the frontend can pick the right viewer without reading the action_type.",
+    )
+    artifact_mode: Optional[Literal["new", "edit"]] = Field(
+        default=None,
+        description="Whether the LLM chose start_new_dashboard (new) or bind_existing_dashboard (edit). None when the run failed before binding.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Display name copied from manifest.json so the frontend can render the artifact card without a second round-trip.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="Short description copied from manifest.json.",
+    )
+    created_at: Optional[str] = Field(
+        default=None,
+        description="ISO-8601 UTC timestamp copied from manifest.json; reflects creation time even for 'edit' mode.",
+    )
 
 
 def parse_datus_params_header(sql_template: str) -> List[TemplateParamDecl]:

--- a/datus/schemas/gen_visual_report_models.py
+++ b/datus/schemas/gen_visual_report_models.py
@@ -98,3 +98,23 @@ class GenVisualReportNodeResult(BaseResult):
     html_path: Optional[str] = Field(None, description="Path to compiled index.html (CLI mode only)")
     query_count: int = Field(default=0, description="Number of queries persisted under queries/")
     tokens_used: int = Field(default=0, description="Total tokens used during this run")
+    artifact_kind: Literal["report"] = Field(
+        default="report",
+        description="Artifact kind, fixed for this node. Carried into the SSE artifact payload so the frontend can pick the right viewer without reading the action_type.",
+    )
+    artifact_mode: Optional[Literal["new", "edit"]] = Field(
+        default=None,
+        description="Whether the LLM chose start_new_report (new) or bind_existing_report (edit). None when the run failed before binding.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Display name copied from manifest.json so the frontend can render the artifact card without a second round-trip.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="Short description copied from manifest.json.",
+    )
+    created_at: Optional[str] = Field(
+        default=None,
+        description="ISO-8601 UTC timestamp copied from manifest.json; reflects creation time even for 'edit' mode.",
+    )

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -308,6 +308,14 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     # No save_query_template in this run — the seed wrote the template directly.
     assert result["template_count"] == 0
 
+    # Artifact card fields are populated from manifest.json so the SSE
+    # artifact event ships everything the frontend needs in one hop.
+    assert result["artifact_kind"] == "dashboard"
+    assert result["artifact_mode"] == "edit"
+    assert result["name"] == "e2e demo dashboard"
+    assert result["description"] == "End-to-end seeded dashboard."
+    assert result["created_at"] == "2026-05-14T00:00:00Z"
+
 
 @pytest.mark.asyncio
 async def test_execute_stream_fails_when_no_binding(real_agent_config, mock_llm_create):

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -278,6 +278,14 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     assert result["html_path"] == expected_html_rel
     assert (report_dir / "index.html").is_file()
 
+    # Artifact card fields surface through the result so the SSE artifact
+    # event can be built without touching disk a second time.
+    assert result["artifact_kind"] == "report"
+    assert result["artifact_mode"] == "edit"  # bind_existing_report path
+    assert result["name"] == "seeded report"
+    assert result["description"] == "Unit-test seeded report."
+    assert result["created_at"] == "2026-05-13T00:00:00Z"
+
 
 class TestReportDistResolution:
     """Verify the CLI flag → node_config priority for offline asset overrides."""
@@ -416,6 +424,14 @@ async def test_execute_stream_without_binding_marks_failure(real_agent_config, m
     error = result.get("error") or ""
     assert "start_new_report" in error
     assert "bind_existing_report" in error
+    # When no binding ever happened, the artifact-card fields stay None —
+    # the SSE dispatcher then skips the artifact event and falls through
+    # to the regular error path.
+    assert result["artifact_kind"] == "report"
+    assert result["artifact_mode"] is None
+    assert result["name"] is None
+    assert result["description"] is None
+    assert result["created_at"] is None
 
 
 @pytest.mark.asyncio
@@ -456,3 +472,10 @@ async def test_execute_stream_bound_but_no_validate_marks_failure(real_agent_con
     assert result["report_slug"] == "halfway"
     assert result["query_count"] == 0
     assert "validate_render never returned success" in (result.get("error") or "")
+    # start_new_report ran so mode=new and the manifest fields are populated;
+    # the slug exists but the run still counts as failed because
+    # validate_render never succeeded.
+    assert result["artifact_mode"] == "new"
+    assert result["name"] == "halfway"
+    assert result["description"] == "Bound but never validated — unit-test fixture."
+    assert result["created_at"]  # ISO timestamp written by start_new_report

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -301,6 +301,154 @@ class TestBuildSubagentCompleteContent:
         assert contents[0].payload["error"] == "cancelled"
 
 
+class TestBuildArtifactContent:
+    """Tests for _build_artifact_content — visual report/dashboard completion cards."""
+
+    def test_report_create_mode_emits_full_payload(self):
+        """A finished gen_visual_report run carries every field the frontend card needs."""
+        from datus.api.services.action_sse_converter import _build_artifact_content
+
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={
+                "artifact_kind": "report",
+                "artifact_mode": "new",
+                "report_slug": "q3_revenue",
+                "name": "Q3 Revenue Report",
+                "description": "Quarterly revenue breakdown.",
+                "created_at": "2026-05-16T10:00:00Z",
+                "response": "Generated a five-chart report covering Q3 revenue trends.",
+            },
+        )
+        contents = _build_artifact_content(action)
+        assert contents is not None
+        assert len(contents) == 1
+        assert contents[0].type == "artifact"
+        payload = contents[0].payload
+        assert payload["slug"] == "q3_revenue"
+        assert payload["kind"] == "report"
+        assert payload["mode"] == "new"
+        assert payload["name"] == "Q3 Revenue Report"
+        assert payload["description"] == "Quarterly revenue breakdown."
+        assert payload["created_at"] == "2026-05-16T10:00:00Z"
+        assert payload["preview_summary"] == "Generated a five-chart report covering Q3 revenue trends."
+
+    def test_dashboard_edit_mode_uses_dashboard_slug(self):
+        """gen_visual_dashboard runs surface dashboard_slug as the artifact slug."""
+        from datus.api.services.action_sse_converter import _build_artifact_content
+
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_dashboard_response",
+            output={
+                "artifact_kind": "dashboard",
+                "artifact_mode": "edit",
+                "dashboard_slug": "sales_overview",
+                "name": "Sales Overview",
+                "description": None,
+                "created_at": "2026-05-10T08:00:00Z",
+                "response": "Updated the sales overview dashboard.",
+            },
+        )
+        contents = _build_artifact_content(action)
+        assert contents is not None
+        payload = contents[0].payload
+        assert payload["slug"] == "sales_overview"
+        assert payload["kind"] == "dashboard"
+        assert payload["mode"] == "edit"
+        assert payload["description"] is None
+
+    def test_missing_slug_returns_none(self):
+        """No slug means the run never bound an artifact — fall back to the regular response path."""
+        from datus.api.services.action_sse_converter import _build_artifact_content
+
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={"artifact_kind": "report", "report_slug": None, "response": "no-op"},
+        )
+        assert _build_artifact_content(action) is None
+
+    def test_missing_kind_returns_none(self):
+        """A response action without artifact_kind is not a visual-artifact response — caller falls back."""
+        from datus.api.services.action_sse_converter import _build_artifact_content
+
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="chat_response",
+            output={"report_slug": "x", "response": "..."},
+        )
+        assert _build_artifact_content(action) is None
+
+    def test_unknown_kind_returns_none(self):
+        """Kinds outside {'report','dashboard'} are rejected so the frontend never sees a card it can't open."""
+        from datus.api.services.action_sse_converter import _build_artifact_content
+
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={"artifact_kind": "notebook", "report_slug": "x", "response": "..."},
+        )
+        assert _build_artifact_content(action) is None
+
+    def test_long_response_truncated_with_ellipsis(self):
+        """Preview summary is capped to keep the card readable."""
+        from datus.api.services.action_sse_converter import _ARTIFACT_PREVIEW_LIMIT, _build_artifact_content
+
+        long_text = "x" * (_ARTIFACT_PREVIEW_LIMIT + 50)
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={
+                "artifact_kind": "report",
+                "report_slug": "x",
+                "response": long_text,
+            },
+        )
+        contents = _build_artifact_content(action)
+        assert contents is not None
+        preview = contents[0].payload["preview_summary"]
+        assert preview.endswith("…")
+        assert len(preview) <= _ARTIFACT_PREVIEW_LIMIT + 1
+
+    def test_empty_response_makes_preview_none(self):
+        """An empty LLM response should yield ``preview_summary=None`` rather than an empty string."""
+        from datus.api.services.action_sse_converter import _build_artifact_content
+
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={
+                "artifact_kind": "report",
+                "report_slug": "x",
+                "response": "   ",
+            },
+        )
+        contents = _build_artifact_content(action)
+        assert contents is not None
+        assert contents[0].payload["preview_summary"] is None
+
+    def test_non_dict_output_returns_none(self):
+        """Defensive: action.output may be a string in legacy paths — must not crash."""
+        from datus.api.services.action_sse_converter import _build_artifact_content
+
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output="plain text",
+        )
+        assert _build_artifact_content(action) is None
+
+
 class TestBuildUserContent:
     """Tests for _build_user_content."""
 
@@ -721,6 +869,82 @@ class TestActionToSSEEvent:
         event = _assert_sse_event(event)
         assert event.data.payload.role == "user"
         assert event.data.payload.content[0].type == "markdown"
+
+    def test_visual_report_response_emits_artifact_without_final_response_flag(self):
+        """gen_visual_report completion fires an artifact event even when include_final_response=False.
+
+        The artifact card is not a substitute for the streamed markdown response —
+        the LLM's text has already gone through earlier action events — so the
+        dispatcher must not gate it behind the regular ``include_final_response``
+        toggle.
+        """
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={
+                "artifact_kind": "report",
+                "artifact_mode": "new",
+                "report_slug": "q3_revenue",
+                "name": "Q3 Revenue",
+                "description": "",
+                "response": "Done.",
+            },
+        )
+        event = action_to_sse_event(action, event_id=200, message_id="msg-200")
+        event = _assert_sse_event(event)
+        assert event.data.type == SSEDataType.CREATE_MESSAGE
+        content = event.data.payload.content[0]
+        assert content.type == "artifact"
+        assert content.payload["slug"] == "q3_revenue"
+        assert content.payload["kind"] == "report"
+        assert content.payload["mode"] == "new"
+
+    def test_visual_dashboard_response_emits_artifact(self):
+        """gen_visual_dashboard completion emits artifact card with kind='dashboard'."""
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_dashboard_response",
+            output={
+                "artifact_kind": "dashboard",
+                "artifact_mode": "edit",
+                "dashboard_slug": "sales_overview",
+                "name": "Sales Overview",
+                "description": "Quarterly sales view.",
+                "response": "Updated.",
+            },
+        )
+        event = action_to_sse_event(action, event_id=201, message_id="msg-201")
+        event = _assert_sse_event(event)
+        content = event.data.payload.content[0]
+        assert content.type == "artifact"
+        assert content.payload["slug"] == "sales_overview"
+        assert content.payload["kind"] == "dashboard"
+
+    def test_failed_visual_report_response_falls_through_to_error(self):
+        """A FAILED gen_visual_report_response is not an artifact event — must surface as error.
+
+        The base node emits ``_response`` actions with ``status=FAILED`` when
+        validate_render never succeeded; in that case the output still carries
+        ``artifact_kind`` but no usable slug. The dispatcher's FAILED catch-all
+        should win so the frontend renders the failure, not a broken card.
+        """
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.FAILED,
+            action_type="gen_visual_report_response",
+            output={
+                "artifact_kind": "report",
+                "report_slug": None,
+                "error": "validate_render never returned success",
+            },
+        )
+        event = action_to_sse_event(action, event_id=202, message_id="msg-202")
+        event = _assert_sse_event(event)
+        content = event.data.payload.content[0]
+        assert content.type == "error"
+        assert "validate_render" in content.payload["content"]
 
     def test_assistant_response_action_is_skipped(self):
         """ASSISTANT + SUCCESS + _response action_type returns None."""

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -323,7 +323,7 @@ class TestBuildArtifactContent:
             },
         )
         contents = _build_artifact_content(action)
-        assert contents is not None
+        assert isinstance(contents, list)
         assert len(contents) == 1
         assert contents[0].type == "artifact"
         payload = contents[0].payload
@@ -354,7 +354,7 @@ class TestBuildArtifactContent:
             },
         )
         contents = _build_artifact_content(action)
-        assert contents is not None
+        assert isinstance(contents, list)
         payload = contents[0].payload
         assert payload["slug"] == "sales_overview"
         assert payload["kind"] == "dashboard"
@@ -413,7 +413,7 @@ class TestBuildArtifactContent:
             },
         )
         contents = _build_artifact_content(action)
-        assert contents is not None
+        assert isinstance(contents, list)
         preview = contents[0].payload["preview_summary"]
         assert preview.endswith("…")
         assert len(preview) <= _ARTIFACT_PREVIEW_LIMIT + 1
@@ -433,7 +433,7 @@ class TestBuildArtifactContent:
             },
         )
         contents = _build_artifact_content(action)
-        assert contents is not None
+        assert isinstance(contents, list)
         assert contents[0].payload["preview_summary"] is None
 
     def test_non_dict_output_returns_none(self):
@@ -921,6 +921,49 @@ class TestActionToSSEEvent:
         assert content.type == "artifact"
         assert content.payload["slug"] == "sales_overview"
         assert content.payload["kind"] == "dashboard"
+
+    def test_artifact_response_with_missing_slug_falls_back_to_markdown_when_requested(self):
+        """Malformed artifact payloads must not suppress the assistant's prose.
+
+        ``artifact_kind`` is set but ``report_slug`` is missing — the artifact
+        builder returns None. Instead of dropping the wrapper event entirely,
+        the converter falls back to the standard ``_response`` markdown
+        handler so history tooling (``include_final_response=True``) still
+        surfaces the LLM's response text.
+        """
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={
+                "artifact_kind": "report",
+                "report_slug": None,
+                "response": "I got partway but never bound a report.",
+            },
+        )
+        event = action_to_sse_event(action, event_id=203, message_id="msg-203", include_final_response=True)
+        event = _assert_sse_event(event)
+        content = event.data.payload.content[0]
+        assert content.type == "markdown"
+        assert content.payload["content"] == "I got partway but never bound a report."
+
+    def test_artifact_response_with_missing_slug_drops_event_in_streaming_mode(self):
+        """In streaming chat mode (``include_final_response=False``) the
+        malformed-artifact fallback honors the same gating as a normal
+        wrapper response — no markdown bubble is emitted because the LLM's
+        prose was already streamed via earlier response actions."""
+        action = _make_action(
+            role=ActionRole.ASSISTANT,
+            status=ActionStatus.SUCCESS,
+            action_type="gen_visual_report_response",
+            output={
+                "artifact_kind": "report",
+                "report_slug": None,
+                "response": "stream already covered this",
+            },
+        )
+        event = action_to_sse_event(action, event_id=204, message_id="msg-204")
+        assert event is None
 
     def test_failed_visual_report_response_falls_through_to_error(self):
         """A FAILED gen_visual_report_response is not an artifact event — must surface as error.


### PR DESCRIPTION
## Why

When ``gen_visual_report`` / ``gen_visual_dashboard`` finishes, the chat
stream today emits a generic markdown ``_response`` event — the frontend
has no way to know an artifact was produced without parsing free-form
text or making a follow-up ``/api/v1/report/detail`` call.

The Datus-saas chat UI wants to render a clickable artifact card the
moment the run completes, so users can jump straight into the report /
dashboard viewer. This PR is the backend side of that contract.

## Solution

Add a new ``artifact`` content type to ``IMessageContent`` and a matching
``IArtifactPayload`` schema (``slug``, ``kind``, ``mode``, ``name``,
``description``, ``created_at``, ``preview_summary``). The chat stream's
existing ``message`` SSE event now carries this content block whenever a
gen_visual_* subagent's terminal ``_response`` action lands successfully.

- ``GenVisualReportNodeResult`` / ``GenVisualDashboardNodeResult`` gain
  ``artifact_kind`` (fixed Literal per node), ``artifact_mode``
  (``new`` / ``edit`` — reuses the existing ``ReportArtifactTools.mode``
  vocabulary so there is zero translation between Python and the wire),
  plus ``name`` / ``description`` / ``created_at`` populated from the
  on-disk ``manifest.json`` via a new ``_read_artifact_manifest`` helper
  on the base node.
- ``action_to_sse_event`` gets a new branch that pre-empts the regular
  ``_response`` handler when ``output.artifact_kind`` is set. The branch
  fires regardless of ``include_final_response`` because the card is a
  supplement to — not a substitute for — the streamed markdown response;
  the LLM's prose has already gone through earlier action events.
- Failed ``_response`` actions (``status=FAILED``) fall through to the
  existing error branch unchanged, so the frontend never sees a broken
  card with no slug.

Design decisions worth flagging:

- **No URL synthesis on the backend.** The card payload omits a
  pre-computed URL because CLI / SaaS / future viewer routes diverge —
  the frontend builds the URL from ``kind + slug`` itself.
- **mode stays as ``new``/``edit``** end-to-end. Earlier draft mapped
  to ``create``/``update`` in the SSE layer; we ditched that to keep
  the action history, NodeResult, and SSE payload using one vocabulary.
- **No new SSE event type.** The card is just another
  ``IMessageContent`` inside the existing ``message`` event, so the
  frontend's existing message-stream plumbing handles it without
  protocol changes.

## Test Cases

- ``tests/unit_tests/api/services/test_action_sse_converter.py``
  - new ``TestBuildArtifactContent`` covering report/dashboard happy
    path, missing slug, missing kind, unknown kind, response truncation,
    empty response, and non-dict output.
  - new dispatcher tests in ``TestActionToSSEEvent`` for visual report
    success without the final-response flag, visual dashboard success,
    and the FAILED fall-through to the error branch.
- ``tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py``
  - extended the e2e test to assert the new manifest-sourced fields on
    success; extended the two failure-path tests to verify ``mode`` and
    manifest fields are populated only when binding actually happened.
- ``tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py``
  - extended the e2e test with the same artifact-field assertions.

Local CI gates:

- ``uv run ruff format . && uv run ruff check --fix .`` — clean.
- ``uv run pytest tests/unit_tests/ -m "not nightly"`` — 13254 passed;
  the 3 failures / 14 errors observed pre-exist on upstream/main and
  reproduce there (missing local benchmark fixtures); none touch the
  files in this PR.
- Coverage: 82.44% overall; diff-cover 83% on the changed lines
  (uncovered lines are CLI-only browser-open paths and error logging).
- ``ci/audit_tests.py --diff-only upstream/main`` — P0=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual reports and dashboards now show artifact cards with name, description and creation timestamp
  * Artifact mode indicator (new vs. edit) displayed on artifact cards
  * Generated artifact previews include a trimmed summary with an ellipsis for long outputs

* **Tests**
  * Added coverage for artifact card generation and SSE artifact notifications including preview/truncation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->