### PR TITLE
[BugFix] Honor agent.language for visual artifact metadata

### DIFF
--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -18,7 +18,7 @@ The published page is a sandboxed iframe. Unlike the report subagent's pre-baked
 
    `start_new_dashboard` requires **all three** of `slug` / `name` / `description`:
    - `slug`: lowercase ASCII matching `^[a-z0-9_]{1,80}$`. Doubles as the on-disk directory name. Pick something semantic and stable — `revenue_overview`, `merchant_health_q1`, `account_activity_live`. Avoid timestamps unless they disambiguate.
-   - `name`: human-readable display name. Any language; Chinese / mixed scripts welcome.
+   - `name`: human-readable display name. Follow the Response Language directive at the bottom of this prompt.
    - `description`: one-paragraph summary of what the dashboard tracks.
 
    The tool writes `dashboards/<slug>/manifest.json` on the spot.
@@ -126,7 +126,7 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
 1. **Understand the question** — extract time window, entity scope (region, segment, store …), and which axes are filter-driven vs fixed. Decide create vs edit vs reference-for-new.
 2. **For edits, locate the slug first** — `glob('dashboards/*/manifest.json')` + `read_file` each manifest to find the matching `name` → `slug` when the user references the dashboard by display name.
 3. **For creates, pick a non-colliding slug** — `glob('dashboards/*')` to see what's taken, then draft a semantic slug (`revenue_overview`, `merchant_health`).
-4. **Bind the dashboard** — call `start_new_dashboard(slug, name, description)` (creating) or `bind_existing_dashboard(dashboard_slug)` (editing) exactly once. For new dashboards, draft a meaningful `name` (Chinese is fine) and one-paragraph `description` from the user's intent before calling.
+4. **Bind the dashboard** — call `start_new_dashboard(slug, name, description)` (creating) or `bind_existing_dashboard(dashboard_slug)` (editing) exactly once. For new dashboards, draft a meaningful `name` and one-paragraph `description` from the user's intent before calling; both follow the Response Language directive.
 5. **Discover context — metrics FIRST.** Before deriving SQL from raw tables, you **MUST** consult the project's metric registry:
    - Start with `list_subject_tree` to see how metrics / semantic models / reference SQL are organised.
    - Call `search_metrics(query_text, subject_path)` and/or `list_metrics(path)` for every KPI / chart in the user's question. Use `get_metrics(subject_path, name)` to read full definitions.

--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -19,7 +19,7 @@ The published page is a sandboxed iframe. Unlike the report subagent's pre-baked
    `start_new_dashboard` requires **all three** of `slug` / `name` / `description`:
    - `slug`: lowercase ASCII matching `^[a-z0-9_]{1,80}$`. Doubles as the on-disk directory name. Pick something semantic and stable — `revenue_overview`, `merchant_health_q1`, `account_activity_live`. Avoid timestamps unless they disambiguate.
    - `name`: human-readable display name. Follow the Response Language directive at the bottom of this prompt.
-   - `description`: one-paragraph summary of what the dashboard tracks.
+   - `description`: one-paragraph summary of what the dashboard tracks. Same language convention as `name`.
 
    The tool writes `dashboards/<slug>/manifest.json` on the spot.
 

--- a/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
@@ -20,8 +20,8 @@ The published page is a static, sandboxed iframe. There is no live database in t
 
    `start_new_report` requires **all three** of `slug` / `name` / `description`:
    - `slug`: lowercase ASCII matching `^[a-z0-9_]{1,80}$`. Doubles as the on-disk directory name. Pick something semantic and stable — `account_activity_q1`, `revenue_by_region_2026`, `merchant_churn_analysis`. Avoid timestamps unless they disambiguate.
-   - `name`: human-readable display name. Any language; Chinese / mixed scripts welcome.
-   - `description`: one-paragraph summary of what the report argues.
+   - `name`: human-readable display name. Follow the Response Language directive at the bottom of this prompt.
+   - `description`: one-paragraph summary of what the report argues. Same language convention as `name`.
 
    The tool writes `reports/<slug>/manifest.json` on the spot.
 
@@ -127,7 +127,7 @@ If the user wants live filters / period selectors / re-runnable queries, that is
 1. **Understand the question** — extract time window, entity scope (region, segment, store …), and analytical themes. Decide create vs edit vs reference-for-new.
 2. **For edits, locate the slug first** — `glob('reports/*/manifest.json')` + `read_file` each manifest to find the matching `name` → `slug` when the user references the report by display name.
 3. **For creates, pick a non-colliding slug** — `glob('reports/*')` to see what's taken, then draft a semantic slug (`account_activity_q1`, `revenue_by_region`).
-4. **Bind the report** — call `start_new_report(slug, name, description)` (creating) or `bind_existing_report(report_slug)` (editing) exactly once. For new reports, draft a meaningful `name` (Chinese is fine) and one-paragraph `description` from the user's intent before calling.
+4. **Bind the report** — call `start_new_report(slug, name, description)` (creating) or `bind_existing_report(report_slug)` (editing) exactly once. For new reports, draft a meaningful `name` and one-paragraph `description` from the user's intent before calling; both follow the Response Language directive.
 5. **Discover context — metrics FIRST.** Before deriving SQL from raw tables, you **MUST** consult the project's metric registry:
    - Start with `list_subject_tree` to see how metrics / semantic models / reference SQL are organised.
    - Call `search_metrics(query_text, subject_path)` and/or `list_metrics(path)` for every analytical theme in the user's question. Use `get_metrics(subject_path, name)` to read the full definition of a candidate.

--- a/datus/prompts/prompt_templates/response_language_1.0.j2
+++ b/datus/prompts/prompt_templates/response_language_1.0.j2
@@ -1,4 +1,4 @@
 # Response Language
 - Use: {{ language_name }} ({{ language_code }})
-- Apply to: replies, sub-agent prompts, file comments/prose, `ask_user` questions
+- Apply to: replies, sub-agent prompts, file comments/prose, `ask_user` questions, and any human-readable text in generated artifacts
 - Exclude: code, SQL, identifiers, file paths, URLs, JSON keys

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1708,6 +1708,17 @@ class TestInjectResponseLanguage:
         assert "English (en)" in result
         assert result.startswith("BASE")
 
+    def test_apply_to_covers_generated_artifacts(self):
+        """The Response Language directive must cover artifact text — without
+        this clause LLMs treat report/dashboard ``name`` and ``description``
+        (and other artifact-internal prose) as outside the language scope and
+        emit them in the user's prompt language even when the global
+        ``agent.language`` is pinned to a different value.
+        """
+        node = _make_node(agent_config=self._agent_config("en"))
+        result = node._inject_response_language("BASE")
+        assert "generated artifacts" in result
+
     def test_chinese_override_uses_chinese_name(self):
         node = _make_node(agent_config=self._agent_config("zh"))
         result = node._inject_response_language("BASE")


### PR DESCRIPTION
## Why

With ``language=\"en\"`` pinned at the API surface (via
``/api/v1/chat/stream``'s ``language`` field, which flows into
``agent_config.language``), asking the ``gen_visual_report`` subagent a
question in Chinese — *\"探索一下 olist_products_dataset 数据库，捞 10
条数据生成一个简单的报告\"* — produced:

* SSE streaming reply: **English** ✅
* Final markdown summary: **English** ✅
* Report ``manifest.json`` ``name`` / ``description``: **Chinese** ❌

The artifact card rendered as *\"Olist 商品目录概览 · 对 Olist 电商平台商
品数据集…\"* inside an otherwise English session — visibly inconsistent.

Root cause is two conflicting instructions reaching the LLM:

1. ``response_language_1.0.j2`` — appended to every AgenticNode's system
   prompt — lists the Apply-to scope as *\"replies, sub-agent prompts,
   file comments/prose, ``ask_user`` questions\"*. Manifest fields don't
   obviously fall under any of those from the model's perspective.
2. ``gen_visual_report_system_1.0.j2`` and the dashboard mirror
   explicitly opted ``name`` / ``description`` out of any global
   language convention:
   - ``name``: *human-readable display name. **Any language; Chinese /
     mixed scripts welcome.***
   - Workflow step 4: *\"draft a meaningful ``name`` (**Chinese is
     fine**) and one-paragraph ``description`` from the user's intent
     before calling.\"*

Given the local *\"any language\"* carve-out on those exact two fields,
the model reasonably treated manifest metadata as exempt from the
global Response Language directive and followed the user's prompt
language. Same dynamic on dashboards.

## Solution

Targeted prompt fix on three files; no code or schema changes.

1. **Remove the carve-outs** in both visual prompts:
   - ``gen_visual_report_system_1.0.j2`` and
     ``gen_visual_dashboard_system_1.0.j2`` lines describing ``name`` /
     ``description`` now point back to the global directive — *\"Follow
     the Response Language directive at the bottom of this prompt.\"*
   - Workflow step 4 in both prompts now reads *\"…both follow the
     Response Language directive\"* instead of *\"(Chinese is fine)\"*.
2. **Extend the global Response Language Apply-to bullet** in
   ``response_language_1.0.j2`` with one generic clause:
   *\"…and any human-readable text in generated artifacts\"*. Kept
   intentionally generic — no specific field names — so future
   artifact types (gen_table outputs, scheduler job descriptions, etc.)
   inherit the same scope without another prompt edit.

When ``agent_config.language`` is unset (None / empty),
``_inject_response_language`` remains a no-op and the model picks the
language to match the user's question — the fix is targeted at the
*\"explicitly pinned\"* case where divergence is actually wrong.

## Test Cases

* New ``TestInjectResponseLanguage::test_apply_to_covers_generated_artifacts``
  in ``tests/unit_tests/agent/node/test_agentic_node.py`` constructs a
  node with ``language=\"en\"``, calls
  ``_inject_response_language(\"BASE\")``, and asserts the rendered
  block mentions *\"generated artifacts\"* — locks the new clause into
  the rendered output so a future template edit that drops it would be
  caught.
* Existing ``TestInjectResponseLanguage`` cases (English / Chinese /
  unknown code / None / empty / missing attribute / render failure)
  continue to pass — the new clause sits inside the same Apply-to line
  and doesn't change any existing assertion.
* ``ci/audit_tests.py --diff-only upstream/main`` → ``P0=0, P1=0``.
* Manual verification path: with ``language=\"en\"`` on the API, ask
  the visual report subagent in Chinese for a report. Expected:
  ``manifest.json`` ``name`` and ``description`` come back in English
  (matching the reply and markdown summary); the artifact card in the
  UI is consistently English. Repeat with ``language=\"zh\"`` and a
  Chinese question — both reply and manifest are Chinese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enforced a formal "Response Language" directive for dashboard and report name/description fields.
  * Extended the directive so all human-readable text in generated artifacts must follow the Response Language rules.
  * Updated workflows to require drafted names and descriptions to comply with the directive for new dashboards and reports.

* **Tests**
  * Added unit test coverage to verify the directive applies to generated artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->