### PR TITLE
[BugFix] Fix ext knowledge nightly input schema

### DIFF
--- a/tests/integration/agent/test_gen_ext_knowledge_agentic.py
+++ b/tests/integration/agent/test_gen_ext_knowledge_agentic.py
@@ -98,7 +98,6 @@ class TestGenExtKnowledgeAgentic:
                 "Write the knowledge YAML file with appropriate search_text and explanation."
             ),
             question="What is the Eligible Free Rate for California schools?",
-            search_text="Eligible Free Rate",
             gold_sql="SELECT `Free Meal Count (K-12)` * 1.0 / `Enrollment (K-12)` AS eligible_free_rate FROM frpm",
         )
 
@@ -128,9 +127,11 @@ class TestGenExtKnowledgeAgentic:
         )
 
         node.input = ExtKnowledgeNodeInput(
-            user_message="Define external knowledge for: what does 'Eligible Free Rate' mean for California schools?",
+            user_message=(
+                "Define external knowledge for: what does 'Eligible Free Rate' mean for California schools? "
+                "Use 'Eligible Free Rate' as the search_text."
+            ),
             question="What does Eligible Free Rate mean?",
-            search_text="Eligible Free Rate",
         )
 
         action_manager = ActionHistoryManager()


### PR DESCRIPTION
## Why

Nightly failed after #772 removed the obsolete `search_text` field from `ExtKnowledgeNodeInput`, while `tests/integration/agent/test_gen_ext_knowledge_agentic.py` still passed that field into the schema. Pydantic rejects extra inputs, so the gen ext knowledge nightly suite failed before the real workflow could run.

## Solution

Remove the stale `search_text=` arguments from the nightly integration tests. For the question-only case, keep the test intent by moving the desired search text into `user_message`, where the generation workflow now expects user instructions.

## Test Cases

- `uv run python -c "from datus.schemas.ext_knowledge_agentic_node_models import ExtKnowledgeNodeInput; ExtKnowledgeNodeInput(user_message='Generate external knowledge for Eligible Free Rate. Write search_text and explanation.', question='What is the Eligible Free Rate?', gold_sql='SELECT 1'); ExtKnowledgeNodeInput(user_message=\"Define external knowledge for Eligible Free Rate. Use 'Eligible Free Rate' as the search_text.\", question='What does Eligible Free Rate mean?'); print('ok')"`
- `uv run pytest tests/unit_tests/schemas/test_ext_knowledge_agentic_node_models.py tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py --tb=short -q`
- `uv run pytest --collect-only -m nightly tests/integration/agent/test_gen_ext_knowledge_agentic.py -q`
- from isolated cwd: `PYTHONPATH=/Users/kangxue/work/datus/agent-1 /Users/kangxue/work/datus/agent-1/.venv/bin/python -m pytest -c /Users/kangxue/work/datus/agent-1/pytest.ini -m nightly /Users/kangxue/work/datus/agent-1/tests/integration/agent/test_gen_ext_knowledge_agentic.py --tb=short --verbose --timeout=600 --reruns 0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configurations for extended knowledge agent functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->