### PR TITLE
[Tool] Add nightly manifest artifact

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -384,7 +384,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nightly-test-results-${{ github.run_number }}
-          path: test_output_nightly_*.log
+          path: |
+            test_output_nightly_*.log
+            nightly-manifest.json
           retention-days: 7
 
       - name: Send Feishu notification

--- a/ci/format-nightly-feishu-report.js
+++ b/ci/format-nightly-feishu-report.js
@@ -35,6 +35,19 @@ function readLatestNightlyLog(workspace = '.') {
   }
 }
 
+function readNightlyManifest(workspace = '.') {
+  const manifestPath = path.join(workspace, 'nightly-manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function pushUnique(items, item) {
   const value = String(item || '').trim();
   if (value && !items.includes(value)) {
@@ -177,6 +190,7 @@ function buildNightlyFeishuMessage({
 } = {}) {
   const content = logContent == null ? readLatestNightlyLog(workspace).logContent : logContent;
   const report = summarizeNightlyLog(content);
+  const manifest = readNightlyManifest(workspace);
   const normalizedStatus = status || 'UNKNOWN';
   const isPassed = normalizedStatus === 'PASSED';
 
@@ -192,6 +206,18 @@ function buildNightlyFeishuMessage({
     lines.push('**Result:** No blocking failures detected. Passing case logs are omitted.');
   } else if (report.failures.length === 0) {
     lines.push('**Result:** Nightly did not complete successfully. No pytest failure nodeids were found in the log summary.');
+  }
+
+  if (manifest && manifest.summary) {
+    const counts = manifest.summary.status_counts || {};
+    const countText = Object.entries(counts)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ');
+    lines.push(
+      `**Manifest:** ${manifest.summary.suite_count || 0} suites, ${
+        manifest.summary.collected_nodeid_count || 0
+      } collected nodeids${countText ? ` (${countText})` : ''}.`,
+    );
   }
 
   if (report.failures.length > 0) {

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Generate and update the Datus nightly manifest artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+from datetime import UTC, datetime
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+NODEID_RE = re.compile(r"^(?P<nodeid>(?:tests|ci)/.*?\.py(?:::[^\s]+)+)(?:\s|$)")
+MANIFEST_NODEID_RE = re.compile(r"^DATUS_MANIFEST_NODEID\s+(?P<nodeid>.+)$")
+SUMMARY_RE = re.compile(r"=+\s+(?P<summary>.+?)\s+=+$")
+COUNT_RE = re.compile(
+    r"(?P<count>\d+)\s+"
+    r"(?P<kind>passed|failed|error|errors|skipped|xfailed|xpassed|deselected|rerun|reruns|selected)"
+)
+
+PACKAGE_NAMES = (
+    "datus-agent",
+    "datus-db-core",
+    "datus-sqlalchemy",
+    "datus-postgresql",
+    "datus-mysql",
+    "datus-clickhouse",
+    "datus-starrocks",
+    "datus-trino",
+    "datus-greenplum",
+    "datus-hive",
+    "datus-spark",
+    "datus-bi-core",
+    "datus-bi-superset",
+    "datus-scheduler-core",
+    "datus-scheduler-airflow",
+    "datus-semantic-core",
+    "datus-semantic-metricflow",
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version": 1, "suites": []}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid manifest JSON at {path}: {exc}") from exc
+
+
+def write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def git_output(repo: Path, *args: str) -> str:
+    try:
+        return subprocess.check_output(["git", "-C", str(repo), *args], text=True, stderr=subprocess.DEVNULL).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def repo_info(path: Path, name: str | None = None) -> dict[str, Any]:
+    exists = path.exists()
+    return {
+        "name": name or path.name,
+        "path": str(path),
+        "exists": exists,
+        "commit": git_output(path, "rev-parse", "HEAD") if exists else "",
+        "branch": git_output(path, "rev-parse", "--abbrev-ref", "HEAD") if exists else "",
+        "remote": git_output(path, "config", "--get", "remote.origin.url") if exists else "",
+        "dirty": bool(git_output(path, "status", "--porcelain")) if exists else False,
+    }
+
+
+def package_info(name: str) -> dict[str, Any]:
+    try:
+        dist = metadata.distribution(name)
+    except metadata.PackageNotFoundError:
+        return {"name": name, "installed": False}
+
+    direct_url = None
+    direct_url_text = dist.read_text("direct_url.json")
+    if direct_url_text:
+        try:
+            direct_url = json.loads(direct_url_text)
+        except json.JSONDecodeError:
+            direct_url = {"raw": direct_url_text}
+
+    return {
+        "name": name,
+        "installed": True,
+        "version": dist.version,
+        "location": str(Path(dist.locate_file(""))),
+        "direct_url": direct_url,
+    }
+
+
+def file_sha256(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return ""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def env_value(name: str) -> str:
+    return os.environ.get(name, "")
+
+
+def init_manifest(args: argparse.Namespace) -> None:
+    repo_root = Path(args.repo_root).resolve()
+    external_root = Path(args.external_repos_root).resolve()
+    manifest = {
+        "schema_version": 1,
+        "generated_at": utc_now(),
+        "run": {
+            "repository": env_value("GITHUB_REPOSITORY"),
+            "workflow": env_value("GITHUB_WORKFLOW"),
+            "run_id": env_value("GITHUB_RUN_ID"),
+            "run_number": env_value("GITHUB_RUN_NUMBER"),
+            "run_attempt": env_value("GITHUB_RUN_ATTEMPT"),
+            "ref": env_value("GITHUB_REF"),
+            "sha": env_value("GITHUB_SHA") or git_output(repo_root, "rev-parse", "HEAD"),
+            "event_name": env_value("GITHUB_EVENT_NAME"),
+            "nightly_group_filter": env_value("NIGHTLY_GROUP_FILTER"),
+        },
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "runner_name": env_value("RUNNER_NAME"),
+            "runner_os": env_value("RUNNER_OS"),
+            "runner_arch": env_value("RUNNER_ARCH"),
+        },
+        "paths": {
+            "repo_root": str(repo_root),
+            "external_repos_root": str(external_root),
+            "nightly_home": env_value("NIGHTLY_HOME") or env_value("DATUS_TEST_HOME"),
+            "nightly_project_root": env_value("NIGHTLY_PROJECT_ROOT"),
+            "nightly_pytest_basetemp": env_value("NIGHTLY_PYTEST_BASETEMP"),
+            "unit_test_home": env_value("UNIT_TEST_HOME") or env_value("NIGHTLY_UNIT_TEST_HOME"),
+            "log_file": env_value("LOG_FILE") or env_value("NIGHTLY_LOG_FILE"),
+        },
+        "repositories": [
+            repo_info(repo_root, "Datus-agent"),
+            repo_info(external_root / "datus-db-adapters"),
+            repo_info(external_root / "datus-bi-adapters"),
+            repo_info(external_root / "datus-scheduler-adapters"),
+            repo_info(external_root / "datus-semantic-adapter"),
+        ],
+        "packages": [package_info(name) for name in PACKAGE_NAMES],
+        "compose_projects": [],
+        "suites": [],
+    }
+    write_manifest(Path(args.output), manifest)
+
+
+def find_suite(manifest: dict[str, Any], name: str) -> dict[str, Any]:
+    suites = manifest.setdefault("suites", [])
+    for suite in suites:
+        if suite.get("name") == name:
+            return suite
+    suite = {"name": name}
+    suites.append(suite)
+    return suite
+
+
+def parse_command(raw: str) -> list[str]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return [raw]
+    return parsed if isinstance(parsed, list) else [str(parsed)]
+
+
+def record_suite(args: argparse.Namespace) -> None:
+    path = Path(args.output)
+    manifest = load_manifest(path)
+    suite = find_suite(manifest, args.name)
+    suite.update(
+        {
+            "mode": args.mode,
+            "kind": args.kind,
+            "status": args.status,
+            "exit_code": args.exit_code,
+            "started_at": args.started_at,
+            "ended_at": args.ended_at,
+            "command": parse_command(args.command_json),
+        }
+    )
+    if args.compose_file or args.compose_project:
+        compose_path = Path(args.compose_file) if args.compose_file else Path()
+        suite["compose"] = {
+            "project": args.compose_project,
+            "file": args.compose_file,
+            "file_sha256": file_sha256(compose_path) if args.compose_file else "",
+            "host_ports": parse_host_ports(args.host_ports),
+        }
+    write_manifest(path, manifest)
+
+
+def parse_host_ports(raw: str) -> list[dict[str, str]]:
+    if not raw:
+        return []
+    ports = []
+    for line in raw.splitlines():
+        if ":" not in line:
+            continue
+        label, port = line.rsplit(":", 1)
+        ports.append({"label": label.strip(), "port": port.strip()})
+    return ports
+
+
+def parse_collection_output(text: str) -> dict[str, Any]:
+    nodeids: list[str] = []
+    summaries: list[str] = []
+    counts: dict[str, int] = {}
+
+    for raw_line in text.replace("\r", "").splitlines():
+        line = strip_ansi(raw_line).strip()
+        if not line:
+            continue
+
+        manifest_nodeid_match = MANIFEST_NODEID_RE.match(line)
+        if manifest_nodeid_match:
+            nodeid = manifest_nodeid_match.group("nodeid")
+            if nodeid not in nodeids:
+                nodeids.append(nodeid)
+            continue
+
+        nodeid_match = NODEID_RE.match(line)
+        if nodeid_match:
+            nodeid = nodeid_match.group("nodeid")
+            if nodeid not in nodeids:
+                nodeids.append(nodeid)
+            continue
+
+        summary_match = SUMMARY_RE.match(line)
+        if summary_match:
+            summary = summary_match.group("summary").strip()
+            summaries.append(summary)
+            for count_match in COUNT_RE.finditer(summary):
+                kind = count_match.group("kind")
+                normalized = "errors" if kind == "error" else "reruns" if kind == "rerun" else kind
+                counts[normalized] = counts.get(normalized, 0) + int(count_match.group("count"))
+
+    if nodeids:
+        counts.setdefault("selected", len(nodeids))
+
+    return {
+        "nodeids": nodeids,
+        "counts": counts,
+        "summaries": summaries,
+        "raw_tail": tail_lines(text, 80),
+    }
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", text)
+
+
+def tail_lines(text: str, limit: int) -> list[str]:
+    lines = strip_ansi(text).replace("\r", "").splitlines()
+    return lines[-limit:]
+
+
+def record_collection(args: argparse.Namespace) -> None:
+    path = Path(args.output)
+    manifest = load_manifest(path)
+    suite = find_suite(manifest, args.name)
+    output_path = Path(args.collection_output)
+    text = output_path.read_text(encoding="utf-8", errors="replace") if output_path.exists() else ""
+    collection = parse_collection_output(text)
+    collection.update(
+        {
+            "exit_code": args.exit_code,
+            "collected_at": utc_now(),
+            "status": "passed" if args.exit_code == 0 else "failed",
+        }
+    )
+    suite["collection"] = collection
+    write_manifest(path, manifest)
+
+
+def record_compose_project(args: argparse.Namespace) -> None:
+    path = Path(args.output)
+    manifest = load_manifest(path)
+    projects = manifest.setdefault("compose_projects", [])
+    entry = {
+        "group": args.group,
+        "project": args.project,
+        "compose_file": args.compose_file,
+        "compose_file_sha256": file_sha256(Path(args.compose_file)),
+        "host_ports": parse_host_ports(args.host_ports),
+        "recorded_at": utc_now(),
+    }
+    projects[:] = [project for project in projects if project.get("group") != args.group]
+    projects.append(entry)
+    write_manifest(path, manifest)
+
+
+def finalize_manifest(args: argparse.Namespace) -> None:
+    path = Path(args.output)
+    manifest = load_manifest(path)
+    manifest["completed_at"] = utc_now()
+    manifest["exit_code"] = args.exit_code
+    manifest["summary"] = summarize_manifest(manifest)
+    write_manifest(path, manifest)
+
+
+def summarize_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    suites = manifest.get("suites", [])
+    status_counts: dict[str, int] = {}
+    collected_nodeids = 0
+    failed_suites = []
+    for suite in suites:
+        status = str(suite.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        collection = suite.get("collection") or {}
+        collected_nodeids += len(collection.get("nodeids") or [])
+        if status not in {"passed", "skipped"}:
+            failed_suites.append(suite.get("name"))
+
+    return {
+        "suite_count": len(suites),
+        "status_counts": status_counts,
+        "collected_nodeid_count": collected_nodeids,
+        "failed_suites": failed_suites,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("--output", required=True)
+    init_parser.add_argument("--repo-root", required=True)
+    init_parser.add_argument("--external-repos-root", required=True)
+    init_parser.set_defaults(func=init_manifest)
+
+    suite_parser = subparsers.add_parser("record-suite")
+    suite_parser.add_argument("--output", required=True)
+    suite_parser.add_argument("--name", required=True)
+    suite_parser.add_argument("--mode", required=True, choices=("blocking", "warn-only"))
+    suite_parser.add_argument("--kind", required=True)
+    suite_parser.add_argument("--status", required=True)
+    suite_parser.add_argument("--exit-code", required=True, type=int)
+    suite_parser.add_argument("--started-at", required=True)
+    suite_parser.add_argument("--ended-at", required=True)
+    suite_parser.add_argument("--command-json", required=True)
+    suite_parser.add_argument("--compose-file", default="")
+    suite_parser.add_argument("--compose-project", default="")
+    suite_parser.add_argument("--host-ports", default="")
+    suite_parser.set_defaults(func=record_suite)
+
+    collection_parser = subparsers.add_parser("record-collection")
+    collection_parser.add_argument("--output", required=True)
+    collection_parser.add_argument("--name", required=True)
+    collection_parser.add_argument("--exit-code", required=True, type=int)
+    collection_parser.add_argument("--collection-output", required=True)
+    collection_parser.set_defaults(func=record_collection)
+
+    compose_parser = subparsers.add_parser("record-compose-project")
+    compose_parser.add_argument("--output", required=True)
+    compose_parser.add_argument("--group", required=True)
+    compose_parser.add_argument("--project", required=True)
+    compose_parser.add_argument("--compose-file", required=True)
+    compose_parser.add_argument("--host-ports", default="")
+    compose_parser.set_defaults(func=record_compose_project)
+
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--output", required=True)
+    finalize_parser.add_argument("--exit-code", required=True, type=int)
+    finalize_parser.set_defaults(func=finalize_manifest)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/pytest_manifest_plugin.py
+++ b/ci/pytest_manifest_plugin.py
@@ -1,0 +1,10 @@
+"""Pytest plugin used by nightly manifest collection."""
+
+from __future__ import annotations
+
+
+def pytest_collection_finish(session):
+    print("DATUS_MANIFEST_NODEIDS_START")
+    for item in session.items:
+        print(f"DATUS_MANIFEST_NODEID {item.nodeid}")
+    print("DATUS_MANIFEST_NODEIDS_END")

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -9,6 +9,9 @@ cd "$REPO_ROOT" || {
 }
 
 LOG_FILE="${NIGHTLY_LOG_FILE:-test_output_nightly_$(date +%Y%m%d_%H%M%S).log}"
+NIGHTLY_MANIFEST_FILE="${NIGHTLY_MANIFEST_FILE:-nightly-manifest.json}"
+NIGHTLY_MANIFEST_ENABLED="${NIGHTLY_MANIFEST_ENABLED:-1}"
+NIGHTLY_MANIFEST_FINALIZED=0
 test_exit_code=0
 last_command_exit_code=0
 NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
@@ -25,6 +28,7 @@ UNIT_TEST_HOME="${NIGHTLY_UNIT_TEST_HOME:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-
 UNIT_TEST_PROJECT_ROOT="${NIGHTLY_UNIT_TEST_PROJECT_ROOT:-${UNIT_TEST_HOME}/workspace}"
 NIGHTLY_PYTEST_BASETEMP="${NIGHTLY_PYTEST_BASETEMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-nightly-pytest-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}}"
 AGENT_TEST_CONFIG_BACKUP="${AGENT_TEST_CONFIG_BACKUP:-${TMPDIR:-/tmp}/datus-agent-nightly-config-${GITHUB_RUN_ID:-$$}.bak}"
+export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP
 
 default_repo_root() {
   local explicit_root="$1"
@@ -84,6 +88,131 @@ COMPOSE_GROUPS=(
 
 log() {
   echo "$@" | tee -a "$LOG_FILE"
+}
+
+utc_now() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+manifest_command_json() {
+  python3 -c 'import json, sys; print(json.dumps(sys.argv[1:]))' "$@"
+}
+
+manifest_update() {
+  if [ "$NIGHTLY_MANIFEST_ENABLED" != "1" ]; then
+    return 0
+  fi
+
+  if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+    "${REPO_ROOT}/.venv/bin/python" ci/nightly_manifest.py "$@" 2>>"$LOG_FILE"
+  elif command -v uv >/dev/null 2>&1; then
+    uv run python ci/nightly_manifest.py "$@" 2>>"$LOG_FILE"
+  else
+    python3 ci/nightly_manifest.py "$@" 2>>"$LOG_FILE"
+  fi
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "WARNING: nightly manifest update failed: ci/nightly_manifest.py $*" | tee -a "$LOG_FILE" >&2
+    return 0
+  fi
+}
+
+manifest_init() {
+  manifest_update init \
+    --output "$NIGHTLY_MANIFEST_FILE" \
+    --repo-root "$REPO_ROOT" \
+    --external-repos-root "$EXTERNAL_REPOS_ROOT"
+}
+
+manifest_record_suite() {
+  local group_name="$1"
+  local mode="$2"
+  local kind="$3"
+  local status="$4"
+  local exit_code="$5"
+  local started_at="$6"
+  local ended_at="$7"
+  shift 7
+
+  local command_json
+  command_json="$(manifest_command_json "$@")"
+
+  manifest_update record-suite \
+    --output "$NIGHTLY_MANIFEST_FILE" \
+    --name "$group_name" \
+    --mode "$mode" \
+    --kind "$kind" \
+    --status "$status" \
+    --exit-code "$exit_code" \
+    --started-at "$started_at" \
+    --ended-at "$ended_at" \
+    --command-json "$command_json" \
+    --compose-file "${NIGHTLY_CURRENT_COMPOSE_FILE:-}" \
+    --compose-project "${NIGHTLY_CURRENT_COMPOSE_PROJECT:-}" \
+    --host-ports "${NIGHTLY_CURRENT_HOST_PORTS:-}"
+}
+
+manifest_record_collection() {
+  local group_name="$1"
+  local exit_code="$2"
+  local output_file="$3"
+
+  manifest_update record-collection \
+    --output "$NIGHTLY_MANIFEST_FILE" \
+    --name "$group_name" \
+    --exit-code "$exit_code" \
+    --collection-output "$output_file"
+}
+
+manifest_record_compose_project() {
+  local group_name="$1"
+  local project_name="$2"
+  local compose_file="$3"
+  local host_ports="$4"
+
+  manifest_update record-compose-project \
+    --output "$NIGHTLY_MANIFEST_FILE" \
+    --group "$group_name" \
+    --project "$project_name" \
+    --compose-file "$compose_file" \
+    --host-ports "$host_ports"
+}
+
+manifest_finalize() {
+  if [ "$NIGHTLY_MANIFEST_FINALIZED" = "1" ]; then
+    return 0
+  fi
+  NIGHTLY_MANIFEST_FINALIZED=1
+  manifest_update finalize --output "$NIGHTLY_MANIFEST_FILE" --exit-code "$test_exit_code"
+}
+
+command_contains_pytest() {
+  local arg
+  for arg in "$@"; do
+    if [ "$arg" = "pytest" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+collect_pytest_suite() {
+  local group_name="$1"
+  shift
+
+  if ! command_contains_pytest "$@"; then
+    return 0
+  fi
+
+  local output_file="${NIGHTLY_PYTEST_BASETEMP}/manifest-collect-${group_name//[^A-Za-z0-9_-]/_}.log"
+  mkdir -p "$NIGHTLY_PYTEST_BASETEMP"
+  PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:$PYTHONPATH}" "$@" -p ci.pytest_manifest_plugin --collect-only >"$output_file" 2>&1
+  local collect_status=$?
+  manifest_record_collection "$group_name" "$collect_status" "$output_file"
+  if [ "$collect_status" -ne 0 ]; then
+    log "WARNING: collection failed for ${group_name}; continuing and preserving failure in manifest."
+  fi
+  return 0
 }
 
 should_run_group() {
@@ -460,6 +589,9 @@ ensure_nightly_kb_data() {
 
 cleanup_all() {
   set +e
+  if [ "${NIGHTLY_SKIP_MANIFEST_FINALIZE:-0}" != "1" ]; then
+    manifest_finalize
+  fi
   restore_agent_test_config
   rm -f "$AGENT_TEST_CONFIG_BACKUP"
   if validate_pytest_basetemp "$NIGHTLY_PYTEST_BASETEMP"; then
@@ -469,6 +601,7 @@ cleanup_all() {
 }
 
 if [ "${1:-}" = "--cleanup-only" ]; then
+  NIGHTLY_SKIP_MANIFEST_FINALIZE=1
   cleanup_all
   exit 0
 fi
@@ -576,12 +709,22 @@ run_logged_unfiltered() {
 
   log ""
   log "=== ${group_name} ==="
+  local started_at
+  started_at="$(utc_now)"
+  collect_pytest_suite "$group_name" "$@"
   "$@" 2>&1 | tee -a "$LOG_FILE"
   local cmd_status=${PIPESTATUS[0]}
+  local ended_at
+  ended_at="$(utc_now)"
   last_command_exit_code="$cmd_status"
   if [ "$cmd_status" -ne 0 ]; then
     test_exit_code="$cmd_status"
   fi
+  local status="passed"
+  if [ "$cmd_status" -ne 0 ]; then
+    status="failed"
+  fi
+  manifest_record_suite "$group_name" "blocking" "command" "$status" "$cmd_status" "$started_at" "$ended_at" "$@"
   return 0
 }
 
@@ -592,6 +735,9 @@ run_logged() {
     log ""
     log "=== Skipping ${group_name} (NIGHTLY_GROUP_FILTER=${NIGHTLY_GROUP_FILTER}) ==="
     last_command_exit_code=0
+    local now
+    now="$(utc_now)"
+    manifest_record_suite "$group_name" "blocking" "command" "skipped" 0 "$now" "$now" "$@"
     return 0
   fi
 
@@ -604,12 +750,22 @@ run_logged_warn_only_unfiltered() {
 
   log ""
   log "=== ${group_name} (warn-only) ==="
+  local started_at
+  started_at="$(utc_now)"
+  collect_pytest_suite "$group_name" "$@"
   "$@" 2>&1 | tee -a "$LOG_FILE"
   local cmd_status=${PIPESTATUS[0]}
+  local ended_at
+  ended_at="$(utc_now)"
   last_command_exit_code="$cmd_status"
   if [ "$cmd_status" -ne 0 ]; then
     log "WARNING: ${group_name} failed with exit code ${cmd_status}; continuing because this group is non-blocking."
   fi
+  local status="passed"
+  if [ "$cmd_status" -ne 0 ]; then
+    status="failed"
+  fi
+  manifest_record_suite "$group_name" "warn-only" "command" "$status" "$cmd_status" "$started_at" "$ended_at" "$@"
   return 0
 }
 
@@ -620,6 +776,9 @@ run_logged_warn_only() {
     log ""
     log "=== Skipping ${group_name} (NIGHTLY_GROUP_FILTER=${NIGHTLY_GROUP_FILTER}) ==="
     last_command_exit_code=0
+    local now
+    now="$(utc_now)"
+    manifest_record_suite "$group_name" "warn-only" "command" "skipped" 0 "$now" "$now" "$@"
     return 0
   fi
 
@@ -1047,6 +1206,8 @@ run_compose_suite() {
   shift 2
   local service_specs=()
   local project_name
+  local started_at
+  started_at="$(utc_now)"
 
   while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
     service_specs+=("$1")
@@ -1062,24 +1223,32 @@ run_compose_suite() {
   if ! should_run_group "$group_name"; then
     log ""
     log "=== Skipping ${group_name} (NIGHTLY_GROUP_FILTER=${NIGHTLY_GROUP_FILTER}) ==="
+    local now
+    now="$(utc_now)"
+    manifest_record_suite "$group_name" "blocking" "compose" "skipped" 0 "$now" "$now" "$@"
     return 0
   fi
 
   project_name="$(compose_project_name "$group_name")"
+  local host_ports
+  host_ports="$(compose_host_port_specs "$group_name")"
+  manifest_record_compose_project "$group_name" "$project_name" "$compose_file" "$host_ports"
   log ""
   log "=== Starting ${group_name} Services (project=${project_name}) ==="
   log "Compose file: ${compose_file}"
   log "Host ports:"
-  compose_host_port_specs "$group_name" | sed 's/^/  /' | tee -a "$LOG_FILE"
+  printf '%s\n' "$host_ports" | sed 's/^/  /' | tee -a "$LOG_FILE"
 
   compose_down "$compose_file" "$project_name"
   if ! check_compose_host_ports_available "$group_name"; then
     log "Skipping ${group_name} startup because required host ports are unavailable"
+    manifest_record_suite "$group_name" "blocking" "compose" "failed" "$test_exit_code" "$started_at" "$(utc_now)" "$@"
     return 0
   fi
 
   if ! compose_up "$project_name" "$compose_file"; then
     compose_down "$compose_file" "$project_name"
+    manifest_record_suite "$group_name" "blocking" "compose" "failed" "$test_exit_code" "$started_at" "$(utc_now)" "$@"
     return 0
   fi
 
@@ -1089,6 +1258,7 @@ run_compose_suite() {
     local timeout_seconds="${spec##*:}"
     if ! wait_for_service_health "$project_name" "$compose_file" "$service_name" "$timeout_seconds"; then
       compose_down "$compose_file" "$project_name"
+      manifest_record_suite "$group_name" "blocking" "compose" "failed" "$test_exit_code" "$started_at" "$(utc_now)" "$@"
       return 0
     fi
   done
@@ -1096,10 +1266,17 @@ run_compose_suite() {
   if ! wait_for_compose_client_readiness "$group_name"; then
     dump_compose_diagnostics "$project_name" "$compose_file" "$group_name"
     compose_down "$compose_file" "$project_name"
+    manifest_record_suite "$group_name" "blocking" "compose" "failed" "$test_exit_code" "$started_at" "$(utc_now)" "$@"
     return 0
   fi
 
+  NIGHTLY_CURRENT_COMPOSE_FILE="$compose_file"
+  NIGHTLY_CURRENT_COMPOSE_PROJECT="$project_name"
+  NIGHTLY_CURRENT_HOST_PORTS="$host_ports"
   run_logged "$group_name" "$@"
+  NIGHTLY_CURRENT_COMPOSE_FILE=""
+  NIGHTLY_CURRENT_COMPOSE_PROJECT=""
+  NIGHTLY_CURRENT_HOST_PORTS=""
   if [ "$last_command_exit_code" -ne 0 ]; then
     dump_compose_diagnostics "$project_name" "$compose_file" "$group_name"
   fi
@@ -1110,7 +1287,10 @@ run_compose_suite() {
   return 0
 }
 
+manifest_init
+
 log "Nightly log: $LOG_FILE"
+log "Nightly manifest: $NIGHTLY_MANIFEST_FILE"
 log "DB_ADAPTERS_ROOT=$DB_ADAPTERS_ROOT"
 log "BI_ADAPTERS_ROOT=$BI_ADAPTERS_ROOT"
 log "SCHEDULER_ADAPTERS_ROOT=$SCHEDULER_ADAPTERS_ROOT"
@@ -1203,8 +1383,11 @@ run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME"
 
 run_logged_unfiltered "Flaky Log Classification" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --log-file "$LOG_FILE" --warn-only
 
+manifest_finalize
+
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "log_file=$LOG_FILE" >> "$GITHUB_OUTPUT"
+  echo "manifest_file=$NIGHTLY_MANIFEST_FILE" >> "$GITHUB_OUTPUT"
   echo "test_exit_code=$test_exit_code" >> "$GITHUB_OUTPUT"
 fi
 

--- a/tests/unit_tests/ci/test_nightly_manifest.py
+++ b/tests/unit_tests/ci/test_nightly_manifest.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "nightly_manifest.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("nightly_manifest", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load nightly_manifest module from {MODULE_PATH}")
+nightly_manifest = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(nightly_manifest)
+
+
+def test_parse_collection_output_extracts_nodeids_and_counts():
+    parsed = nightly_manifest.parse_collection_output(
+        "\n".join(
+            [
+                "DATUS_MANIFEST_NODEIDS_START",
+                "DATUS_MANIFEST_NODEID tests/integration/tools/test_mcp_server.py::test_list_tools",
+                "DATUS_MANIFEST_NODEID tests/integration/tools/test_mcp_server.py::test_read_query",
+                "DATUS_MANIFEST_NODEIDS_END",
+                "===== 2 selected, 10 deselected in 0.12s =====",
+            ]
+        )
+    )
+
+    assert parsed["nodeids"] == [
+        "tests/integration/tools/test_mcp_server.py::test_list_tools",
+        "tests/integration/tools/test_mcp_server.py::test_read_query",
+    ]
+    assert parsed["counts"] == {"selected": 2, "deselected": 10}
+
+
+def test_record_collection_and_finalize_manifest(tmp_path):
+    manifest_path = tmp_path / "nightly-manifest.json"
+    collection_output = tmp_path / "collect.log"
+
+    assert (
+        nightly_manifest.main(
+            [
+                "init",
+                "--output",
+                str(manifest_path),
+                "--repo-root",
+                str(Path.cwd()),
+                "--external-repos-root",
+                str(tmp_path / "external"),
+            ]
+        )
+        == 0
+    )
+    collection_output.write_text(
+        "DATUS_MANIFEST_NODEID tests/unit_tests/ci/test_nightly_manifest.py::test_example\n"
+        "===== 1 selected, 3 deselected in 0.01s =====\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        nightly_manifest.main(
+            [
+                "record-suite",
+                "--output",
+                str(manifest_path),
+                "--name",
+                "Example Suite",
+                "--mode",
+                "blocking",
+                "--kind",
+                "command",
+                "--status",
+                "passed",
+                "--exit-code",
+                "0",
+                "--started-at",
+                "2026-05-17T00:00:00Z",
+                "--ended-at",
+                "2026-05-17T00:00:01Z",
+                "--command-json",
+                json.dumps(["uv", "run", "pytest"]),
+            ]
+        )
+        == 0
+    )
+    assert (
+        nightly_manifest.main(
+            [
+                "record-collection",
+                "--output",
+                str(manifest_path),
+                "--name",
+                "Example Suite",
+                "--exit-code",
+                "0",
+                "--collection-output",
+                str(collection_output),
+            ]
+        )
+        == 0
+    )
+    assert nightly_manifest.main(["finalize", "--output", str(manifest_path), "--exit-code", "0"]) == 0
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["summary"]["suite_count"] == 1
+    assert manifest["summary"]["collected_nodeid_count"] == 1
+    assert manifest["suites"][0]["collection"]["counts"] == {"selected": 1, "deselected": 3}


### PR DESCRIPTION
## Summary
- Generate and upload `nightly-manifest.json` for nightly runs.
- Capture actual pytest collection nodeids, suite status, external repo commits, package metadata, and compose project metadata.
- Add a concise manifest summary line to the Feishu nightly report.

## Validation
- `uv run ruff format --check ci/nightly_manifest.py ci/pytest_manifest_plugin.py tests/unit_tests/ci/test_nightly_manifest.py`
- `uv run ruff check ci/nightly_manifest.py ci/pytest_manifest_plugin.py tests/unit_tests/ci/test_nightly_manifest.py`
- `uv run pytest tests/unit_tests/ci/test_nightly_manifest.py -q`
- `bash -n ci/run-nightly-tests.sh`
- `TEST_CMD_TIMEOUT=600 uv run python ci/run-pr-tests.py upstream/main`

Closes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly test execution to generate and track test run manifests, including test metadata, suite status, and collection results.
  * Improved test reporting with manifest information and summary statistics.

* **Tests**
  * Added unit tests for nightly manifest generation and collection output parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->