### PR TITLE
[Tool] Add nightly failure classification artifact

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -387,6 +387,7 @@ jobs:
           path: |
             test_output_nightly_*.log
             nightly-manifest.json
+            nightly-failure-classification.json
           retention-days: 7
 
       - name: Send Feishu notification

--- a/ci/classify_nightly_failures.py
+++ b/ci/classify_nightly_failures.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Classify nightly failures into routing-friendly structured categories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import check_flaky_registry
+
+CATEGORIES = (
+    "product_regression",
+    "provider_outage",
+    "docker_infra",
+    "known_flaky",
+    "unknown_flaky",
+    "harness_setup",
+    "credential_or_config",
+    "unknown_failure",
+)
+
+PROVIDER_SUITE_PATTERNS = (re.compile(r"\b(provider_health|Provider Health Tests)\b", re.IGNORECASE),)
+PROVIDER_ERROR_PATTERNS = (
+    re.compile(
+        r"\b(429|529|rate limit|quota|overload|ProviderError|APITimeout|APIConnectionError)\b",
+        re.IGNORECASE,
+    ),
+)
+DOCKER_SUITE_PATTERNS = (
+    re.compile(r"\b(compose|container|service health|readiness|unhealthy|timed out waiting)\b", re.IGNORECASE),
+)
+DOCKER_ERROR_PATTERNS = (
+    re.compile(r"\b(Host port is already in use|No container found|Docker .* required)\b", re.IGNORECASE),
+    re.compile(r"\b(service health|readiness|unhealthy|timed out waiting)\b", re.IGNORECASE),
+)
+CREDENTIAL_PATTERNS = (
+    re.compile(r"\b(unauthorized|forbidden|authentication failed|invalid api key)\b", re.IGNORECASE),
+    re.compile(r"\b(missing|not set|empty|invalid)\s+(api key|credential|secret|token|password)\b", re.IGNORECASE),
+    re.compile(r"\b[A-Z0-9_]+_(KEY|TOKEN|SECRET|PASSWORD)\b.*\b(missing|not set|empty|invalid)\b", re.IGNORECASE),
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def read_text(path: Path | None) -> str:
+    if not path or not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def read_json(path: Path | None) -> tuple[dict[str, Any] | None, str]:
+    if not path or not path.exists():
+        return None, "missing"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, f"invalid json: {exc}"
+    if not isinstance(data, dict):
+        return None, f"expected json object, got {type(data).__name__}"
+    return data, ""
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", text)
+
+
+def tail_lines(text: str, limit: int = 80) -> list[str]:
+    lines = strip_ansi(text).replace("\r", "").splitlines()
+    return lines[-limit:]
+
+
+def command_text(suite: dict[str, Any]) -> str:
+    command = suite.get("command") or []
+    if isinstance(command, list):
+        return " ".join(str(part) for part in command)
+    return str(command)
+
+
+def add_finding(
+    findings: list[dict[str, Any]],
+    *,
+    category: str,
+    title: str,
+    severity: str,
+    blocking: bool,
+    source: str,
+    details: dict[str, Any] | None = None,
+) -> None:
+    if category not in CATEGORIES:
+        category = "unknown_failure"
+    finding = {
+        "category": category,
+        "title": title,
+        "severity": severity,
+        "blocking": blocking,
+        "source": source,
+    }
+    if details:
+        finding["details"] = details
+    findings.append(finding)
+
+
+def match_any(patterns: tuple[re.Pattern[str], ...], text: str) -> bool:
+    return any(pattern.search(text) for pattern in patterns)
+
+
+def suite_category(suite: dict[str, Any]) -> str:
+    name = str(suite.get("name") or "")
+    kind = str(suite.get("kind") or "")
+    mode = str(suite.get("mode") or "")
+    text = " ".join([name, kind, mode, command_text(suite)])
+
+    if name in {"Flaky Registry Check", "Flaky Log Classification"}:
+        return "harness_setup"
+    if match_any(PROVIDER_SUITE_PATTERNS, text):
+        return "provider_outage"
+    if kind == "compose" or match_any(DOCKER_SUITE_PATTERNS, text):
+        return "docker_infra"
+    return "product_regression"
+
+
+def classify_flaky_registry(
+    registry_path: Path,
+    log_file: Path | None,
+    findings: list[dict[str, Any]],
+) -> list[str]:
+    errors: list[str] = []
+    if not log_file or not log_file.exists():
+        return errors
+
+    try:
+        registry = check_flaky_registry.validate_registry(
+            check_flaky_registry.load_registry(registry_path), strict=False
+        )
+        registered, unregistered, patterns = check_flaky_registry.classify_log(log_file, registry)
+    except Exception as exc:  # noqa: BLE001 - classifier must preserve failure details without failing nightly.
+        errors.append(str(exc))
+        add_finding(
+            findings,
+            category="harness_setup",
+            title="Flaky registry classification failed",
+            severity="warning",
+            blocking=False,
+            source="flaky_registry",
+            details={"error": str(exc), "registry": str(registry_path)},
+        )
+        return errors
+
+    for nodeid in sorted(set(registered)):
+        add_finding(
+            findings,
+            category="known_flaky",
+            title="Registered rerun observed",
+            severity="warning",
+            blocking=False,
+            source="flaky_registry",
+            details={"nodeid": nodeid},
+        )
+    for entry_id in sorted(set(patterns)):
+        add_finding(
+            findings,
+            category="known_flaky",
+            title="Registered log warning observed",
+            severity="warning",
+            blocking=False,
+            source="flaky_registry",
+            details={"entry_id": entry_id},
+        )
+    for nodeid in sorted(set(unregistered)):
+        add_finding(
+            findings,
+            category="unknown_flaky",
+            title="Unregistered rerun observed",
+            severity="warning",
+            blocking=False,
+            source="flaky_registry",
+            details={"nodeid": nodeid},
+        )
+    return errors
+
+
+def classify_suites(manifest: dict[str, Any] | None, log_text: str, findings: list[dict[str, Any]]) -> None:
+    if not manifest:
+        return
+
+    for suite in manifest.get("suites") or []:
+        name = str(suite.get("name") or "unknown suite")
+        mode = str(suite.get("mode") or "blocking")
+        status = str(suite.get("status") or "unknown")
+        exit_code = suite.get("exit_code")
+        collection = suite.get("collection") or {}
+        collection_status = collection.get("status")
+
+        if collection_status == "failed":
+            add_finding(
+                findings,
+                category="harness_setup",
+                title=f"{name} collection failed",
+                severity="error" if mode == "blocking" else "warning",
+                blocking=mode == "blocking",
+                source="manifest.collection",
+                details={
+                    "suite": name,
+                    "collection_exit_code": collection.get("exit_code"),
+                    "raw_tail": collection.get("raw_tail") or [],
+                },
+            )
+            if status not in {"passed", "skipped"}:
+                continue
+
+        if status in {"passed", "skipped"}:
+            continue
+
+        category = suite_category(suite)
+        blocking = mode == "blocking"
+        add_finding(
+            findings,
+            category=category,
+            title=f"{name} failed",
+            severity="error" if blocking else "warning",
+            blocking=blocking,
+            source="manifest.suite",
+            details={
+                "suite": name,
+                "mode": mode,
+                "kind": suite.get("kind"),
+                "exit_code": exit_code,
+                "started_at": suite.get("started_at"),
+                "ended_at": suite.get("ended_at"),
+                "command": suite.get("command") or [],
+                "compose": suite.get("compose"),
+            },
+        )
+
+
+def classify_log_patterns(log_text: str, findings: list[dict[str, Any]]) -> None:
+    if not log_text:
+        return
+    if match_any(CREDENTIAL_PATTERNS, log_text):
+        add_finding(
+            findings,
+            category="credential_or_config",
+            title="Credential or configuration error pattern observed",
+            severity="error",
+            blocking=True,
+            source="log.pattern",
+            details={"log_tail": tail_lines(log_text, 40)},
+        )
+    if match_any(DOCKER_ERROR_PATTERNS, log_text):
+        add_finding(
+            findings,
+            category="docker_infra",
+            title="Docker or service readiness error pattern observed",
+            severity="error",
+            blocking=True,
+            source="log.pattern",
+            details={"log_tail": tail_lines(log_text, 40)},
+        )
+    if match_any(PROVIDER_ERROR_PATTERNS, log_text):
+        add_finding(
+            findings,
+            category="provider_outage",
+            title="Provider failure pattern observed",
+            severity="warning",
+            blocking=False,
+            source="log.pattern",
+            details={"log_tail": tail_lines(log_text, 40)},
+        )
+
+
+def summarize_findings(findings: list[dict[str, Any]]) -> dict[str, Any]:
+    category_counts = Counter(str(finding.get("category")) for finding in findings)
+    blocking_category_counts = Counter(
+        str(finding.get("category")) for finding in findings if bool(finding.get("blocking"))
+    )
+    severity_counts = Counter(str(finding.get("severity")) for finding in findings)
+    return {
+        "finding_count": len(findings),
+        "category_counts": dict(sorted(category_counts.items())),
+        "blocking_category_counts": dict(sorted(blocking_category_counts.items())),
+        "severity_counts": dict(sorted(severity_counts.items())),
+    }
+
+
+def build_classification(args: argparse.Namespace) -> dict[str, Any]:
+    manifest_path = Path(args.manifest) if args.manifest else None
+    log_file = Path(args.log_file) if args.log_file else None
+    registry_path = Path(args.registry)
+    manifest, manifest_error = read_json(manifest_path)
+    log_text = read_text(log_file)
+    findings: list[dict[str, Any]] = []
+    classifier_errors: list[str] = []
+
+    if manifest_error:
+        add_finding(
+            findings,
+            category="harness_setup",
+            title="Nightly manifest unavailable",
+            severity="error",
+            blocking=True,
+            source="manifest",
+            details={"manifest": str(manifest_path), "error": manifest_error},
+        )
+
+    classifier_errors.extend(classify_flaky_registry(registry_path, log_file, findings))
+    classify_suites(manifest, log_text, findings)
+    classify_log_patterns(log_text, findings)
+
+    if args.exit_code != 0 and not any(finding.get("blocking") for finding in findings):
+        add_finding(
+            findings,
+            category="unknown_failure",
+            title="Nightly failed without a classified blocking finding",
+            severity="error",
+            blocking=True,
+            source="exit_code",
+            details={"exit_code": args.exit_code, "log_tail": tail_lines(log_text, 80)},
+        )
+
+    status = "passed" if args.exit_code == 0 else "failed"
+    return {
+        "schema_version": 1,
+        "generated_at": utc_now(),
+        "status": status,
+        "exit_code": args.exit_code,
+        "sources": {
+            "manifest": str(manifest_path) if manifest_path else "",
+            "log_file": str(log_file) if log_file else "",
+            "registry": str(registry_path),
+        },
+        "summary": summarize_findings(findings),
+        "findings": findings,
+        "classifier_errors": classifier_errors,
+    }
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default="nightly-manifest.json")
+    parser.add_argument("--log-file", default="")
+    parser.add_argument("--registry", default="ci/flaky-registry.yml")
+    parser.add_argument("--output", default="nightly-failure-classification.json")
+    parser.add_argument("--exit-code", type=int, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    classification = build_classification(args)
+    write_json(Path(args.output), classification)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/format-nightly-feishu-report.js
+++ b/ci/format-nightly-feishu-report.js
@@ -48,6 +48,19 @@ function readNightlyManifest(workspace = '.') {
   }
 }
 
+function readFailureClassification(workspace = '.') {
+  const classificationPath = path.join(workspace, 'nightly-failure-classification.json');
+  if (!fs.existsSync(classificationPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(classificationPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function pushUnique(items, item) {
   const value = String(item || '').trim();
   if (value && !items.includes(value)) {
@@ -180,6 +193,45 @@ function fencedList(items, emptyText) {
   return ['```text', ...items, '```'].join('\n');
 }
 
+function formatCounts(counts = {}) {
+  return Object.entries(counts)
+    .filter(([, value]) => Number(value) > 0)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ');
+}
+
+function summarizeClassification(classification, options = {}) {
+  const maxFindings = options.maxFindings || 8;
+  if (!classification || !classification.summary) {
+    return null;
+  }
+
+  const blockingCounts = classification.summary.blocking_category_counts || {};
+  const categoryCounts = classification.summary.category_counts || {};
+  const blockingText = formatCounts(blockingCounts);
+  const allText = formatCounts(categoryCounts);
+  const findings = Array.isArray(classification.findings) ? classification.findings : [];
+  const blockingFindings = findings.filter((finding) => finding && finding.blocking);
+  const warningFindings = findings.filter((finding) => finding && !finding.blocking);
+  const selectedFindings = [...blockingFindings, ...warningFindings].slice(0, maxFindings).map((finding) => {
+    const category = finding.category || 'unknown_failure';
+    const title = finding.title || 'Unclassified finding';
+    const details = finding.details || {};
+    const suite = details.suite ? ` suite=${details.suite}` : '';
+    const exitCode = details.exit_code != null ? ` exit_code=${details.exit_code}` : '';
+    const nodeid = details.nodeid ? ` nodeid=${details.nodeid}` : '';
+    const entryId = details.entry_id ? ` entry=${details.entry_id}` : '';
+    return `[${category}] ${title}${suite}${exitCode}${nodeid}${entryId}`;
+  });
+
+  return {
+    blockingText,
+    allText,
+    findings: selectedFindings,
+    omitted: Math.max(0, findings.length - selectedFindings.length),
+  };
+}
+
 function buildNightlyFeishuMessage({
   status,
   runNumber,
@@ -191,6 +243,8 @@ function buildNightlyFeishuMessage({
   const content = logContent == null ? readLatestNightlyLog(workspace).logContent : logContent;
   const report = summarizeNightlyLog(content);
   const manifest = readNightlyManifest(workspace);
+  const classification = readFailureClassification(workspace);
+  const classificationSummary = summarizeClassification(classification);
   const normalizedStatus = status || 'UNKNOWN';
   const isPassed = normalizedStatus === 'PASSED';
 
@@ -210,9 +264,7 @@ function buildNightlyFeishuMessage({
 
   if (manifest && manifest.summary) {
     const counts = manifest.summary.status_counts || {};
-    const countText = Object.entries(counts)
-      .map(([key, value]) => `${key}: ${value}`)
-      .join(', ');
+    const countText = formatCounts(counts);
     lines.push(
       `**Manifest:** ${manifest.summary.suite_count || 0} suites, ${
         manifest.summary.collected_nodeid_count || 0
@@ -220,7 +272,22 @@ function buildNightlyFeishuMessage({
     );
   }
 
-  if (report.failures.length > 0) {
+  if (classificationSummary) {
+    lines.push(
+      `**Classification:** ${
+        classificationSummary.blockingText || 'no blocking classified failures'
+      }${classificationSummary.allText ? ` (all findings: ${classificationSummary.allText})` : ''}.`,
+    );
+  }
+
+  if (classificationSummary && classificationSummary.findings.length > 0) {
+    lines.push('', '### Failure Classification', fencedList(classificationSummary.findings, 'No classified findings.'));
+    if (classificationSummary.omitted > 0) {
+      lines.push(`_... ${classificationSummary.omitted} more classified finding(s) omitted._`);
+    }
+  }
+
+  if (report.failures.length > 0 && (!classificationSummary || classificationSummary.findings.length === 0)) {
     lines.push('', '### Failures / Errors', fencedList(report.failures, 'No failures detected.'));
     if (report.truncatedFailures > 0) {
       lines.push(`_... ${report.truncatedFailures} more failure/error lines omitted._`);
@@ -247,7 +314,9 @@ function buildNightlyFeishuMessage({
 module.exports = {
   buildNightlyFeishuMessage,
   findLatestNightlyLog,
+  readFailureClassification,
   readLatestNightlyLog,
+  summarizeClassification,
   stripAnsi,
   summarizeNightlyLog,
 };

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -12,6 +12,9 @@ LOG_FILE="${NIGHTLY_LOG_FILE:-test_output_nightly_$(date +%Y%m%d_%H%M%S).log}"
 NIGHTLY_MANIFEST_FILE="${NIGHTLY_MANIFEST_FILE:-nightly-manifest.json}"
 NIGHTLY_MANIFEST_ENABLED="${NIGHTLY_MANIFEST_ENABLED:-1}"
 NIGHTLY_MANIFEST_FINALIZED=0
+NIGHTLY_FAILURE_CLASSIFICATION_FILE="${NIGHTLY_FAILURE_CLASSIFICATION_FILE:-nightly-failure-classification.json}"
+NIGHTLY_FAILURE_CLASSIFICATION_ENABLED="${NIGHTLY_FAILURE_CLASSIFICATION_ENABLED:-1}"
+NIGHTLY_FAILURE_CLASSIFICATION_FINALIZED=0
 test_exit_code=0
 last_command_exit_code=0
 NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
@@ -28,7 +31,7 @@ UNIT_TEST_HOME="${NIGHTLY_UNIT_TEST_HOME:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-
 UNIT_TEST_PROJECT_ROOT="${NIGHTLY_UNIT_TEST_PROJECT_ROOT:-${UNIT_TEST_HOME}/workspace}"
 NIGHTLY_PYTEST_BASETEMP="${NIGHTLY_PYTEST_BASETEMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-nightly-pytest-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}}"
 AGENT_TEST_CONFIG_BACKUP="${AGENT_TEST_CONFIG_BACKUP:-${TMPDIR:-/tmp}/datus-agent-nightly-config-${GITHUB_RUN_ID:-$$}.bak}"
-export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP
+export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP
 
 default_repo_root() {
   local explicit_root="$1"
@@ -184,6 +187,44 @@ manifest_finalize() {
   fi
   NIGHTLY_MANIFEST_FINALIZED=1
   manifest_update finalize --output "$NIGHTLY_MANIFEST_FILE" --exit-code "$test_exit_code"
+}
+
+failure_classification_update() {
+  if [ "$NIGHTLY_FAILURE_CLASSIFICATION_ENABLED" != "1" ]; then
+    return 0
+  fi
+
+  if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+    "${REPO_ROOT}/.venv/bin/python" ci/classify_nightly_failures.py "$@" 2>>"$LOG_FILE"
+  elif command -v uv >/dev/null 2>&1; then
+    uv run python ci/classify_nightly_failures.py "$@" 2>>"$LOG_FILE"
+  else
+    python3 ci/classify_nightly_failures.py "$@" 2>>"$LOG_FILE"
+  fi
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "WARNING: nightly failure classification update failed: ci/classify_nightly_failures.py $*" | tee -a "$LOG_FILE" >&2
+    return "$status"
+  fi
+  return 0
+}
+
+failure_classification_finalize() {
+  if [ "$NIGHTLY_FAILURE_CLASSIFICATION_FINALIZED" = "1" ]; then
+    return 0
+  fi
+  if failure_classification_update \
+    --manifest "$NIGHTLY_MANIFEST_FILE" \
+    --log-file "$LOG_FILE" \
+    --registry ci/flaky-registry.yml \
+    --output "$NIGHTLY_FAILURE_CLASSIFICATION_FILE" \
+    --exit-code "$test_exit_code" &&
+    [ -s "$NIGHTLY_FAILURE_CLASSIFICATION_FILE" ]; then
+    NIGHTLY_FAILURE_CLASSIFICATION_FINALIZED=1
+  else
+    echo "WARNING: nightly failure classification artifact was not written; will retry if cleanup runs again." | tee -a "$LOG_FILE" >&2
+  fi
+  return 0
 }
 
 command_contains_pytest() {
@@ -591,6 +632,7 @@ cleanup_all() {
   set +e
   if [ "${NIGHTLY_SKIP_MANIFEST_FINALIZE:-0}" != "1" ]; then
     manifest_finalize
+    failure_classification_finalize
   fi
   restore_agent_test_config
   rm -f "$AGENT_TEST_CONFIG_BACKUP"
@@ -1291,6 +1333,7 @@ manifest_init
 
 log "Nightly log: $LOG_FILE"
 log "Nightly manifest: $NIGHTLY_MANIFEST_FILE"
+log "Nightly failure classification: $NIGHTLY_FAILURE_CLASSIFICATION_FILE"
 log "DB_ADAPTERS_ROOT=$DB_ADAPTERS_ROOT"
 log "BI_ADAPTERS_ROOT=$BI_ADAPTERS_ROOT"
 log "SCHEDULER_ADAPTERS_ROOT=$SCHEDULER_ADAPTERS_ROOT"
@@ -1384,10 +1427,12 @@ run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME"
 run_logged_unfiltered "Flaky Log Classification" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --log-file "$LOG_FILE" --warn-only
 
 manifest_finalize
+failure_classification_finalize
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "log_file=$LOG_FILE" >> "$GITHUB_OUTPUT"
   echo "manifest_file=$NIGHTLY_MANIFEST_FILE" >> "$GITHUB_OUTPUT"
+  echo "failure_classification_file=$NIGHTLY_FAILURE_CLASSIFICATION_FILE" >> "$GITHUB_OUTPUT"
   echo "test_exit_code=$test_exit_code" >> "$GITHUB_OUTPUT"
 fi
 

--- a/tests/unit_tests/ci/test_classify_nightly_failures.py
+++ b/tests/unit_tests/ci/test_classify_nightly_failures.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+CI_DIR = Path(__file__).resolve().parents[3] / "ci"
+sys.path.insert(0, str(CI_DIR))
+MODULE_PATH = CI_DIR / "classify_nightly_failures.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("classify_nightly_failures", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load classify_nightly_failures module from {MODULE_PATH}")
+classify_nightly_failures = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(classify_nightly_failures)
+
+
+def _registry() -> str:
+    return """
+version: 1
+entries:
+  - id: kimi-mcp-provider-529
+    type: test
+    nodeid: tests/integration/models/test_other_models.py::TestKimiModel::test_generate_with_mcp
+    owner: agent-runtime
+    layer: provider_health
+    reason: Provider overload rerun is known.
+    allowed_until: 2999-01-01
+    allowed_in:
+      - nightly
+  - id: litellm-async-pending-task-teardown
+    type: log_pattern
+    pattern: "Task was destroyed but it is pending"
+    owner: agent-runtime
+    layer: provider_health
+    reason: LiteLLM teardown warning.
+    allowed_until: 2999-01-01
+    allowed_in:
+      - nightly
+"""
+
+
+def test_classifies_manifest_suite_failures_and_known_flaky(tmp_path):
+    manifest = {
+        "schema_version": 1,
+        "suites": [
+            {
+                "name": "PostgreSQL Adapter Tests",
+                "mode": "blocking",
+                "kind": "compose",
+                "status": "failed",
+                "exit_code": 1,
+                "command": ["uv", "run", "pytest", "tests/integration/adapters/test_postgresql.py"],
+            },
+            {
+                "name": "Provider Health Tests",
+                "mode": "warn-only",
+                "kind": "command",
+                "status": "failed",
+                "exit_code": 1,
+                "command": ["uv", "run", "pytest", "-m", "provider_health"],
+            },
+        ],
+    }
+    manifest_file = tmp_path / "nightly-manifest.json"
+    log_file = tmp_path / "nightly.log"
+    registry_file = tmp_path / "flaky-registry.yml"
+    output_file = tmp_path / "classification.json"
+    manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+    registry_file.write_text(_registry(), encoding="utf-8")
+    log_file.write_text(
+        "\n".join(
+            [
+                "Host port is already in use PostgreSQL: 15432",
+                "RERUN tests/integration/models/test_other_models.py::TestKimiModel::test_generate_with_mcp",
+                "Task was destroyed but it is pending",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        classify_nightly_failures.main(
+            [
+                "--manifest",
+                str(manifest_file),
+                "--log-file",
+                str(log_file),
+                "--registry",
+                str(registry_file),
+                "--output",
+                str(output_file),
+                "--exit-code",
+                "1",
+            ]
+        )
+        == 0
+    )
+
+    classification = json.loads(output_file.read_text(encoding="utf-8"))
+
+    assert classification["status"] == "failed"
+    assert classification["summary"]["blocking_category_counts"]["docker_infra"] >= 1
+    assert classification["summary"]["category_counts"]["provider_outage"] >= 1
+    assert classification["summary"]["category_counts"]["known_flaky"] == 2
+    assert any(finding["details"].get("suite") == "PostgreSQL Adapter Tests" for finding in classification["findings"])
+
+
+def test_preserves_unknown_failure_when_exit_code_has_no_signal(tmp_path):
+    manifest_file = tmp_path / "nightly-manifest.json"
+    log_file = tmp_path / "nightly.log"
+    registry_file = tmp_path / "flaky-registry.yml"
+    output_file = tmp_path / "classification.json"
+    manifest_file.write_text(json.dumps({"schema_version": 1, "suites": []}), encoding="utf-8")
+    registry_file.write_text("version: 1\nentries: []\n", encoding="utf-8")
+    log_file.write_text("nightly stopped unexpectedly\n", encoding="utf-8")
+
+    assert (
+        classify_nightly_failures.main(
+            [
+                "--manifest",
+                str(manifest_file),
+                "--log-file",
+                str(log_file),
+                "--registry",
+                str(registry_file),
+                "--output",
+                str(output_file),
+                "--exit-code",
+                "2",
+            ]
+        )
+        == 0
+    )
+
+    classification = json.loads(output_file.read_text(encoding="utf-8"))
+
+    assert classification["summary"]["blocking_category_counts"] == {"unknown_failure": 1}
+    assert classification["findings"][0]["details"]["log_tail"] == ["nightly stopped unexpectedly"]
+
+
+def test_non_object_manifest_is_harness_setup_failure(tmp_path):
+    manifest_file = tmp_path / "nightly-manifest.json"
+    log_file = tmp_path / "nightly.log"
+    registry_file = tmp_path / "flaky-registry.yml"
+    output_file = tmp_path / "classification.json"
+    manifest_file.write_text("[]\n", encoding="utf-8")
+    registry_file.write_text("version: 1\nentries: []\n", encoding="utf-8")
+    log_file.write_text("", encoding="utf-8")
+
+    assert (
+        classify_nightly_failures.main(
+            [
+                "--manifest",
+                str(manifest_file),
+                "--log-file",
+                str(log_file),
+                "--registry",
+                str(registry_file),
+                "--output",
+                str(output_file),
+                "--exit-code",
+                "1",
+            ]
+        )
+        == 0
+    )
+
+    classification = json.loads(output_file.read_text(encoding="utf-8"))
+
+    assert classification["summary"]["blocking_category_counts"] == {"harness_setup": 1}
+    assert classification["findings"][0]["details"]["error"] == "expected json object, got list"
+
+
+def test_collection_failure_does_not_duplicate_suite_failure(tmp_path):
+    manifest_file = tmp_path / "nightly-manifest.json"
+    log_file = tmp_path / "nightly.log"
+    registry_file = tmp_path / "flaky-registry.yml"
+    output_file = tmp_path / "classification.json"
+    manifest_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "suites": [
+                    {
+                        "name": "Main Nightly Tests",
+                        "mode": "blocking",
+                        "kind": "command",
+                        "status": "failed",
+                        "exit_code": 2,
+                        "collection": {"status": "failed", "exit_code": 2, "raw_tail": ["collection error"]},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry_file.write_text("version: 1\nentries: []\n", encoding="utf-8")
+    log_file.write_text("collection failed\n", encoding="utf-8")
+
+    assert (
+        classify_nightly_failures.main(
+            [
+                "--manifest",
+                str(manifest_file),
+                "--log-file",
+                str(log_file),
+                "--registry",
+                str(registry_file),
+                "--output",
+                str(output_file),
+                "--exit-code",
+                "2",
+            ]
+        )
+        == 0
+    )
+
+    classification = json.loads(output_file.read_text(encoding="utf-8"))
+
+    assert classification["summary"]["blocking_category_counts"] == {"harness_setup": 1}
+    assert len(classification["findings"]) == 1
+
+
+def test_passed_provider_suite_header_does_not_create_provider_finding(tmp_path):
+    manifest_file = tmp_path / "nightly-manifest.json"
+    log_file = tmp_path / "nightly.log"
+    registry_file = tmp_path / "flaky-registry.yml"
+    output_file = tmp_path / "classification.json"
+    manifest_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "suites": [
+                    {
+                        "name": "Provider Health Tests",
+                        "mode": "warn-only",
+                        "kind": "command",
+                        "status": "passed",
+                        "exit_code": 0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry_file.write_text("version: 1\nentries: []\n", encoding="utf-8")
+    log_file.write_text("=== Provider Health Tests (warn-only) ===\n1 passed\n", encoding="utf-8")
+
+    assert (
+        classify_nightly_failures.main(
+            [
+                "--manifest",
+                str(manifest_file),
+                "--log-file",
+                str(log_file),
+                "--registry",
+                str(registry_file),
+                "--output",
+                str(output_file),
+                "--exit-code",
+                "0",
+            ]
+        )
+        == 0
+    )
+
+    classification = json.loads(output_file.read_text(encoding="utf-8"))
+
+    assert classification["summary"]["finding_count"] == 0
+
+
+def test_verbose_token_test_names_do_not_create_credential_finding(tmp_path):
+    manifest_file = tmp_path / "nightly-manifest.json"
+    log_file = tmp_path / "nightly.log"
+    registry_file = tmp_path / "flaky-registry.yml"
+    output_file = tmp_path / "classification.json"
+    manifest_file.write_text(json.dumps({"schema_version": 1, "suites": []}), encoding="utf-8")
+    registry_file.write_text("version: 1\nentries: []\n", encoding="utf-8")
+    log_file.write_text(
+        "tests/unit_tests/auth/test_token_storage.py::test_save_token PASSED\n"
+        "tests/unit_tests/auth/test_claude_credential.py::test_source PASSED\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        classify_nightly_failures.main(
+            [
+                "--manifest",
+                str(manifest_file),
+                "--log-file",
+                str(log_file),
+                "--registry",
+                str(registry_file),
+                "--output",
+                str(output_file),
+                "--exit-code",
+                "0",
+            ]
+        )
+        == 0
+    )
+
+    classification = json.loads(output_file.read_text(encoding="utf-8"))
+
+    assert classification["summary"]["finding_count"] == 0


### PR DESCRIPTION
## Summary
- Generate `nightly-failure-classification.json` from the nightly manifest, nightly log, and flaky registry.
- Classify failures into product regression, provider outage, docker infra, known flaky, unknown flaky, harness setup, credential/config, or unknown failure.
- Upload the classification artifact and use it in the Feishu nightly report before falling back to raw log snippets.

## Validation
- `uv run ruff format --check ci/classify_nightly_failures.py tests/unit_tests/ci/test_classify_nightly_failures.py`
- `uv run ruff check ci/classify_nightly_failures.py tests/unit_tests/ci/test_classify_nightly_failures.py`
- `uv run pytest tests/unit_tests/ci/test_classify_nightly_failures.py tests/unit_tests/ci/test_check_flaky_registry.py -q`
- `bash -n ci/run-nightly-tests.sh`
- `uv run python ci/audit_tests.py --repo-root . --diff-only upstream/main --json /tmp/datus-audit-739-diff.json`
- `TEST_CMD_TIMEOUT=600 uv run python ci/run-pr-tests.py upstream/main`

Closes #739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly test failures are automatically classified into structured categories (provider outages, service readiness, credential/config issues) and the classification JSON is persisted as a nightly artifact.
  * Classification summaries are incorporated into the nightly report output for clearer visibility of blocking vs non-blocking issues.

* **Chores (CI)**
  * Nightly workflow and runner finalized to produce and export the classification artifact and expose its path.

* **Tests**
  * Added unit tests covering classification behaviors, known-flaky detection, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->