### PR TITLE
[Tool] Add provider coverage manifest

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -388,6 +388,7 @@ jobs:
             test_output_nightly_*.log
             nightly-manifest.json
             nightly-failure-classification.json
+            provider-coverage-manifest.json
           retention-days: 7
 
       - name: Send Feishu notification

--- a/ci/format-nightly-feishu-report.js
+++ b/ci/format-nightly-feishu-report.js
@@ -272,7 +272,7 @@ function summarizeProviderCoverage(providerCoverage) {
   const errorCount = summary.coverage_error_count || 0;
   const errorText = errorCount > 0 ? `, coverage errors: ${errorCount}` : '';
 
-  return `${providersTotal} providers, ${deterministicCovered} deterministic covered, ${liveDeclared} live smoke declared, ${liveCollected} live smoke collected, ${liveMissing} live smoke not tested${errorText}`;
+  return `${providersTotal} providers, ${deterministicCovered} deterministic covered, ${liveDeclared} live smoke declared, ${liveCollected} live smoke collected, ${liveMissing} live smoke missing/undeclared${errorText}`;
 }
 
 function buildNightlyFeishuMessage({

--- a/ci/format-nightly-feishu-report.js
+++ b/ci/format-nightly-feishu-report.js
@@ -61,6 +61,19 @@ function readFailureClassification(workspace = '.') {
   }
 }
 
+function readProviderCoverageManifest(workspace = '.') {
+  const manifestPath = path.join(workspace, 'provider-coverage-manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function pushUnique(items, item) {
   const value = String(item || '').trim();
   if (value && !items.includes(value)) {
@@ -243,6 +256,25 @@ function summarizeClassification(classification, options = {}) {
   };
 }
 
+function summarizeProviderCoverage(providerCoverage) {
+  if (!providerCoverage || !providerCoverage.summary) {
+    return null;
+  }
+
+  const summary = providerCoverage.summary;
+  const providersTotal = summary.providers_total || 0;
+  const deterministicCovered = summary.deterministic_covered || 0;
+  const liveDeclared = summary.live_provider_health_declared || 0;
+  const liveCollected = summary.live_provider_health_collected || 0;
+  const liveMissing = Array.isArray(summary.live_provider_health_missing)
+    ? summary.live_provider_health_missing.length
+    : 0;
+  const errorCount = summary.coverage_error_count || 0;
+  const errorText = errorCount > 0 ? `, coverage errors: ${errorCount}` : '';
+
+  return `${providersTotal} providers, ${deterministicCovered} deterministic covered, ${liveDeclared} live smoke declared, ${liveCollected} live smoke collected, ${liveMissing} live smoke not tested${errorText}`;
+}
+
 function buildNightlyFeishuMessage({
   status,
   runNumber,
@@ -255,7 +287,9 @@ function buildNightlyFeishuMessage({
   const report = summarizeNightlyLog(content);
   const manifest = readNightlyManifest(workspace);
   const classification = readFailureClassification(workspace);
+  const providerCoverage = readProviderCoverageManifest(workspace);
   const classificationSummary = summarizeClassification(classification);
+  const providerCoverageSummary = summarizeProviderCoverage(providerCoverage);
   const normalizedStatus = status || 'UNKNOWN';
   const isPassed = normalizedStatus === 'PASSED';
 
@@ -288,6 +322,10 @@ function buildNightlyFeishuMessage({
     if (classificationSummary.diagnosticText) {
       lines.push(`**Diagnostics:** ${classificationSummary.diagnosticText}.`);
     }
+  }
+
+  if (providerCoverageSummary) {
+    lines.push(`**Provider Coverage:** ${providerCoverageSummary}.`);
   }
 
   if (classificationSummary && classificationSummary.blockingFindings.length > 0) {
@@ -344,7 +382,9 @@ module.exports = {
   findLatestNightlyLog,
   readFailureClassification,
   readLatestNightlyLog,
+  readProviderCoverageManifest,
   summarizeClassification,
+  summarizeProviderCoverage,
   stripAnsi,
   summarizeNightlyLog,
 };

--- a/ci/provider-coverage.yml
+++ b/ci/provider-coverage.yml
@@ -1,0 +1,177 @@
+version: 1
+
+providers:
+  openai:
+    required_env:
+      - OPENAI_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_openai_model.py::TestOpenAIModel
+        - tests/unit_tests/models/test_openai_compatible.py::TestOpenAICompatibleModelInit
+        - tests/unit_tests/models/test_base.py::TestCreateModelCache
+        - tests/unit_tests/configuration/test_agent_config.py::TestProviderConfigurationDispatch
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_other_models.py::TestOpenAIModel
+
+  deepseek:
+    required_env:
+      - DEEPSEEK_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_sdk_patches.py::TestDeepSeekHistorySanitization
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_deepseek_model.py::TestDeepSeekModel
+
+  claude:
+    required_env:
+      - ANTHROPIC_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelInit
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelGenerate
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelGenerateWithTools
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_claude_model.py::TestClaudeModel
+
+  kimi:
+    required_env:
+      - KIMI_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_openai_model.py::TestKimiModel
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_other_models.py::TestKimiModel
+
+  qwen:
+    required_env:
+      - DASHSCOPE_API_KEY
+      - QWEN_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_openai_model.py::TestQwenModel
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_qwen_model.py::TestQwenModel
+
+  gemini:
+    required_env:
+      - GEMINI_API_KEY
+      - GOOGLE_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_openai_model.py::TestGeminiModel
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_other_models.py::TestGeminiModel
+
+  minimax:
+    required_env:
+      - MINIMAX_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_openai_model.py::TestMiniMaxModel
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
+  glm:
+    required_env:
+      - GLM_API_KEY
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_openai_model.py::TestGLMModel
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
+  alibaba_coding:
+    required_env:
+      - DASHSCOPE_API_KEY
+    deterministic:
+      inherits_from: claude
+      nodeids:
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelInit
+        - tests/unit_tests/configuration/test_agent_config.py::TestProviderConfigurationDispatch
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
+  bigmodel_coding:
+    required_env:
+      - GLM_API_KEY
+    deterministic:
+      inherits_from: claude
+      nodeids:
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelInit
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
+  zai_coding:
+    required_env:
+      - GLM_API_KEY
+    deterministic:
+      inherits_from: claude
+      nodeids:
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelInit
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
+  minimax_coding:
+    required_env:
+      - MINIMAX_API_KEY
+    deterministic:
+      inherits_from: claude
+      nodeids:
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelInit
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
+  kimi_coding:
+    required_env:
+      - KIMI_API_KEY
+    deterministic:
+      inherits_from: claude
+      nodeids:
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelInit
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
+  claude_subscription:
+    required_env:
+      - CLAUDE_CODE_OAUTH_TOKEN
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelSubscriptionAuth
+        - tests/unit_tests/models/test_claude_model.py::TestClaudeModelOAuthHeaders
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_claude_subscription.py::TestClaudeSubscriptionModel
+        - tests/integration/models/test_claude_subscription.py::TestClaudeSubscriptionMultiModel
+
+  codex:
+    required_env:
+      - CODEX_OAUTH_TOKEN
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_codex_model.py::TestCodexModelInit
+        - tests/unit_tests/models/test_codex_model.py::TestCodexModelGenerate
+        - tests/unit_tests/models/test_codex_model.py::TestCodexModelGenerateWithTools
+    live_provider_health:
+      mode: warn-only
+      nodeids:
+        - tests/integration/models/test_codex_model.py::TestCodexModel

--- a/ci/provider_coverage_manifest.py
+++ b/ci/provider_coverage_manifest.py
@@ -47,6 +47,19 @@ def normalize_list(value: Any) -> list[str]:
     raise ValueError(f"expected list[str], got {value!r}")
 
 
+def append_error(errors: list[str], message: str) -> None:
+    if message not in errors:
+        errors.append(message)
+
+
+def normalize_list_or_error(value: Any, errors: list[str], field_name: str) -> list[str]:
+    try:
+        return normalize_list(value)
+    except ValueError as exc:
+        append_error(errors, f"{field_name}: {exc}")
+        return []
+
+
 def split_nodeid(nodeid: str) -> tuple[Path, str]:
     if "::" not in nodeid:
         return Path(nodeid), ""
@@ -66,7 +79,7 @@ def class_or_function_exists(repo_root: Path, nodeid: str) -> bool:
         return True
     text = full_path.read_text(encoding="utf-8", errors="replace")
     escaped = re.escape(first)
-    return bool(re.search(rf"^\s*(class|def)\s+{escaped}\b", text, flags=re.MULTILINE))
+    return bool(re.search(rf"^\s*(class|(?:async\s+)?def)\s+{escaped}\b", text, flags=re.MULTILINE))
 
 
 def validate_coverage_config(repo_root: Path, catalog: dict[str, Any], coverage: dict[str, Any]) -> list[str]:
@@ -92,10 +105,16 @@ def validate_coverage_config(repo_root: Path, catalog: dict[str, Any], coverage:
             if not isinstance(section, dict):
                 errors.append(f"{provider_id}.{section_name}: must be a mapping")
                 continue
-            for nodeid in normalize_list(section.get("nodeids")):
+            nodeids = normalize_list_or_error(
+                section.get("nodeids"),
+                errors,
+                f"{provider_id}.{section_name}.nodeids",
+            )
+            for nodeid in nodeids:
                 if not class_or_function_exists(repo_root, nodeid):
                     errors.append(f"{provider_id}.{section_name}: nodeid target does not exist: {nodeid}")
-        for env_name in normalize_list(declaration.get("required_env")):
+        required_env = normalize_list_or_error(declaration.get("required_env"), errors, f"{provider_id}.required_env")
+        for env_name in required_env:
             if not re.fullmatch(r"[A-Z][A-Z0-9_]*", env_name):
                 errors.append(f"{provider_id}.required_env: invalid env var name: {env_name}")
 
@@ -111,11 +130,13 @@ def provider_health_suite(manifest: dict[str, Any] | None) -> dict[str, Any] | N
     return None
 
 
-def collected_nodeids_for(suite: dict[str, Any] | None) -> list[str]:
+def collected_nodeids_for(suite: dict[str, Any] | None, errors: list[str] | None = None) -> list[str]:
     if not suite:
         return []
     collection = suite.get("collection") or {}
-    return normalize_list(collection.get("nodeids"))
+    if errors is None:
+        return normalize_list(collection.get("nodeids"))
+    return normalize_list_or_error(collection.get("nodeids"), errors, "nightly.provider_health.collection.nodeids")
 
 
 def match_declared_nodeids(declared: list[str], collected: list[str]) -> list[str]:
@@ -126,12 +147,19 @@ def match_declared_nodeids(declared: list[str], collected: list[str]) -> list[st
     return matched
 
 
-def provider_required_env(provider_catalog: dict[str, Any], declaration: dict[str, Any]) -> list[str]:
+def provider_required_env(
+    provider_catalog: dict[str, Any],
+    declaration: dict[str, Any],
+    coverage_errors: list[str],
+    provider_id: str,
+) -> list[str]:
     env_names = []
     catalog_env = provider_catalog.get("api_key_env")
     if isinstance(catalog_env, str) and catalog_env:
         env_names.append(catalog_env)
-    env_names.extend(normalize_list(declaration.get("required_env")))
+    env_names.extend(
+        normalize_list_or_error(declaration.get("required_env"), coverage_errors, f"{provider_id}.required_env")
+    )
     return sorted(set(env_names))
 
 
@@ -149,11 +177,20 @@ def build_provider_entry(
     declaration: dict[str, Any],
     provider_suite: dict[str, Any] | None,
     collected_provider_nodeids: list[str],
+    coverage_errors: list[str],
 ) -> dict[str, Any]:
     deterministic = declaration.get("deterministic") or {}
     live = declaration.get("live_provider_health") or {}
-    deterministic_nodeids = normalize_list(deterministic.get("nodeids"))
-    live_nodeids = normalize_list(live.get("nodeids"))
+    deterministic_nodeids = normalize_list_or_error(
+        deterministic.get("nodeids"),
+        coverage_errors,
+        f"{provider_id}.deterministic.nodeids",
+    )
+    live_nodeids = normalize_list_or_error(
+        live.get("nodeids"),
+        coverage_errors,
+        f"{provider_id}.live_provider_health.nodeids",
+    )
     matched_live_nodeids = match_declared_nodeids(live_nodeids, collected_provider_nodeids)
     live_mode = str(live.get("mode") or ("warn-only" if live_nodeids else "not-tested"))
 
@@ -171,9 +208,9 @@ def build_provider_entry(
         "auth_type": provider_catalog.get("auth_type", "api_key"),
         "base_url": provider_catalog.get("base_url", ""),
         "default_model": provider_catalog.get("default_model", ""),
-        "models": normalize_list(provider_catalog.get("models")),
+        "models": normalize_list_or_error(provider_catalog.get("models"), coverage_errors, f"{provider_id}.models"),
         "models_from": provider_catalog.get("models_from", ""),
-        "required_env": provider_required_env(provider_catalog, declaration),
+        "required_env": provider_required_env(provider_catalog, declaration, coverage_errors, provider_id),
         "coverage": {
             "deterministic": {
                 "status": coverage_status(deterministic_nodeids, str(deterministic.get("inherits_from") or "")),
@@ -239,7 +276,7 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
     catalog_providers = catalog.get("providers") or {}
     declarations = coverage.get("providers") or {}
     suite = provider_health_suite(nightly_manifest)
-    collected_provider_nodeids = collected_nodeids_for(suite)
+    collected_provider_nodeids = collected_nodeids_for(suite, coverage_errors)
 
     providers = []
     for provider_id in sorted(catalog_providers):
@@ -252,6 +289,7 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
                 declaration,
                 suite,
                 collected_provider_nodeids,
+                coverage_errors,
             )
         )
 

--- a/ci/provider_coverage_manifest.py
+++ b/ci/provider_coverage_manifest.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Generate the Datus provider coverage manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def read_json(path: Path | None) -> dict[str, Any] | None:
+    if not path or not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def normalize_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    raise ValueError(f"expected list[str], got {value!r}")
+
+
+def split_nodeid(nodeid: str) -> tuple[Path, str]:
+    if "::" not in nodeid:
+        return Path(nodeid), ""
+    path_text, suffix = nodeid.split("::", 1)
+    return Path(path_text), suffix
+
+
+def class_or_function_exists(repo_root: Path, nodeid: str) -> bool:
+    path, suffix = split_nodeid(nodeid)
+    full_path = repo_root / path
+    if not full_path.exists():
+        return False
+    if not suffix:
+        return True
+    first = suffix.split("::", 1)[0]
+    if not first:
+        return True
+    text = full_path.read_text(encoding="utf-8", errors="replace")
+    escaped = re.escape(first)
+    return bool(re.search(rf"^\s*(class|def)\s+{escaped}\b", text, flags=re.MULTILINE))
+
+
+def validate_coverage_config(repo_root: Path, catalog: dict[str, Any], coverage: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if coverage.get("version") != 1:
+        errors.append("provider coverage version must be 1")
+
+    catalog_providers = set((catalog.get("providers") or {}).keys())
+    declarations = coverage.get("providers")
+    if not isinstance(declarations, dict):
+        errors.append("provider coverage 'providers' must be a mapping")
+        return errors
+
+    for provider_id, declaration in declarations.items():
+        if provider_id not in catalog_providers:
+            errors.append(f"{provider_id}: declared provider is not present in conf/providers.yml")
+            continue
+        if not isinstance(declaration, dict):
+            errors.append(f"{provider_id}: provider declaration must be a mapping")
+            continue
+        for section_name in ("deterministic", "live_provider_health"):
+            section = declaration.get(section_name) or {}
+            if not isinstance(section, dict):
+                errors.append(f"{provider_id}.{section_name}: must be a mapping")
+                continue
+            for nodeid in normalize_list(section.get("nodeids")):
+                if not class_or_function_exists(repo_root, nodeid):
+                    errors.append(f"{provider_id}.{section_name}: nodeid target does not exist: {nodeid}")
+        for env_name in normalize_list(declaration.get("required_env")):
+            if not re.fullmatch(r"[A-Z][A-Z0-9_]*", env_name):
+                errors.append(f"{provider_id}.required_env: invalid env var name: {env_name}")
+
+    return errors
+
+
+def provider_health_suite(manifest: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not manifest:
+        return None
+    for suite in manifest.get("suites") or []:
+        if suite.get("name") == "Provider Health Tests":
+            return suite
+    return None
+
+
+def collected_nodeids_for(suite: dict[str, Any] | None) -> list[str]:
+    if not suite:
+        return []
+    collection = suite.get("collection") or {}
+    return normalize_list(collection.get("nodeids"))
+
+
+def match_declared_nodeids(declared: list[str], collected: list[str]) -> list[str]:
+    matched: list[str] = []
+    for nodeid in collected:
+        if any(nodeid == declared_nodeid or nodeid.startswith(f"{declared_nodeid}::") for declared_nodeid in declared):
+            matched.append(nodeid)
+    return matched
+
+
+def provider_required_env(provider_catalog: dict[str, Any], declaration: dict[str, Any]) -> list[str]:
+    env_names = []
+    catalog_env = provider_catalog.get("api_key_env")
+    if isinstance(catalog_env, str) and catalog_env:
+        env_names.append(catalog_env)
+    env_names.extend(normalize_list(declaration.get("required_env")))
+    return sorted(set(env_names))
+
+
+def coverage_status(nodeids: list[str], inherited_from: str = "") -> str:
+    if inherited_from:
+        return "inherited"
+    if nodeids:
+        return "covered"
+    return "missing"
+
+
+def build_provider_entry(
+    provider_id: str,
+    provider_catalog: dict[str, Any],
+    declaration: dict[str, Any],
+    provider_suite: dict[str, Any] | None,
+    collected_provider_nodeids: list[str],
+) -> dict[str, Any]:
+    deterministic = declaration.get("deterministic") or {}
+    live = declaration.get("live_provider_health") or {}
+    deterministic_nodeids = normalize_list(deterministic.get("nodeids"))
+    live_nodeids = normalize_list(live.get("nodeids"))
+    matched_live_nodeids = match_declared_nodeids(live_nodeids, collected_provider_nodeids)
+    live_mode = str(live.get("mode") or ("warn-only" if live_nodeids else "not-tested"))
+
+    live_status = "not_declared"
+    if live_nodeids:
+        live_status = "declared"
+        if provider_suite:
+            live_status = "collected" if matched_live_nodeids else "declared_not_collected"
+    elif live_mode == "not-tested":
+        live_status = "not_tested"
+
+    return {
+        "id": provider_id,
+        "type": provider_catalog.get("type", ""),
+        "auth_type": provider_catalog.get("auth_type", "api_key"),
+        "base_url": provider_catalog.get("base_url", ""),
+        "default_model": provider_catalog.get("default_model", ""),
+        "models": normalize_list(provider_catalog.get("models")),
+        "models_from": provider_catalog.get("models_from", ""),
+        "required_env": provider_required_env(provider_catalog, declaration),
+        "coverage": {
+            "deterministic": {
+                "status": coverage_status(deterministic_nodeids, str(deterministic.get("inherits_from") or "")),
+                "inherits_from": deterministic.get("inherits_from", ""),
+                "nodeids": deterministic_nodeids,
+            },
+            "live_provider_health": {
+                "status": live_status,
+                "mode": live_mode,
+                "nodeids": live_nodeids,
+                "collected_nodeids": matched_live_nodeids,
+            },
+        },
+    }
+
+
+def summarize(entries: list[dict[str, Any]], coverage_errors: list[str]) -> dict[str, Any]:
+    deterministic_covered = [
+        entry["id"] for entry in entries if entry["coverage"]["deterministic"]["status"] in {"covered", "inherited"}
+    ]
+    live_declared = [
+        entry["id"]
+        for entry in entries
+        if entry["coverage"]["live_provider_health"]["status"] in {"declared", "collected", "declared_not_collected"}
+    ]
+    live_collected = [
+        entry["id"] for entry in entries if entry["coverage"]["live_provider_health"]["status"] == "collected"
+    ]
+    missing_declared = [
+        entry["id"]
+        for entry in entries
+        if entry["coverage"]["deterministic"]["status"] == "missing"
+        and entry["coverage"]["live_provider_health"]["status"] in {"not_declared", "not_tested"}
+    ]
+    deterministic_missing = [
+        entry["id"] for entry in entries if entry["coverage"]["deterministic"]["status"] == "missing"
+    ]
+    live_missing = [
+        entry["id"]
+        for entry in entries
+        if entry["coverage"]["live_provider_health"]["status"] in {"not_declared", "not_tested"}
+    ]
+    return {
+        "providers_total": len(entries),
+        "deterministic_covered": len(deterministic_covered),
+        "live_provider_health_declared": len(live_declared),
+        "live_provider_health_collected": len(live_collected),
+        "deterministic_missing": deterministic_missing,
+        "live_provider_health_missing": live_missing,
+        "missing_declared_coverage": missing_declared,
+        "coverage_error_count": len(coverage_errors),
+    }
+
+
+def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root).resolve()
+    provider_catalog_path = Path(args.provider_catalog)
+    coverage_config_path = Path(args.coverage_config)
+    nightly_manifest = read_json(Path(args.nightly_manifest)) if args.nightly_manifest else None
+    catalog = read_yaml(provider_catalog_path)
+    coverage = read_yaml(coverage_config_path)
+    coverage_errors = validate_coverage_config(repo_root, catalog, coverage)
+    catalog_providers = catalog.get("providers") or {}
+    declarations = coverage.get("providers") or {}
+    suite = provider_health_suite(nightly_manifest)
+    collected_provider_nodeids = collected_nodeids_for(suite)
+
+    providers = []
+    for provider_id in sorted(catalog_providers):
+        provider_catalog = catalog_providers[provider_id] or {}
+        declaration = declarations.get(provider_id) or {}
+        providers.append(
+            build_provider_entry(
+                provider_id,
+                provider_catalog,
+                declaration,
+                suite,
+                collected_provider_nodeids,
+            )
+        )
+
+    missing_declarations = sorted(set(catalog_providers) - set(declarations))
+    for provider_id in missing_declarations:
+        coverage_errors.append(f"{provider_id}: provider has no coverage declaration")
+
+    return {
+        "schema_version": 1,
+        "generated_at": utc_now(),
+        "catalog": {
+            "source": str(provider_catalog_path),
+            "provider_count": len(catalog_providers),
+        },
+        "coverage_config": {
+            "source": str(coverage_config_path),
+            "declared_provider_count": len(declarations),
+        },
+        "nightly": {
+            "manifest": str(args.nightly_manifest or ""),
+            "provider_health_suite_status": suite.get("status") if suite else "",
+            "provider_health_suite_mode": suite.get("mode") if suite else "",
+            "provider_health_collected_nodeids": len(collected_provider_nodeids),
+        },
+        "providers": providers,
+        "summary": summarize(providers, coverage_errors),
+        "coverage_errors": coverage_errors,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--provider-catalog", default="conf/providers.yml")
+    parser.add_argument("--coverage-config", default="ci/provider-coverage.yml")
+    parser.add_argument("--nightly-manifest", default="nightly-manifest.json")
+    parser.add_argument("--output", default="provider-coverage-manifest.json")
+    parser.add_argument("--strict", action="store_true", help="Fail when coverage errors are present")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    manifest = build_manifest(args)
+    write_json(Path(args.output), manifest)
+    if args.strict and manifest["coverage_errors"]:
+        for error in manifest["coverage_errors"]:
+            print(f"ERROR: {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -15,6 +15,9 @@ NIGHTLY_MANIFEST_FINALIZED=0
 NIGHTLY_FAILURE_CLASSIFICATION_FILE="${NIGHTLY_FAILURE_CLASSIFICATION_FILE:-nightly-failure-classification.json}"
 NIGHTLY_FAILURE_CLASSIFICATION_ENABLED="${NIGHTLY_FAILURE_CLASSIFICATION_ENABLED:-1}"
 NIGHTLY_FAILURE_CLASSIFICATION_FINALIZED=0
+PROVIDER_COVERAGE_MANIFEST_FILE="${PROVIDER_COVERAGE_MANIFEST_FILE:-provider-coverage-manifest.json}"
+PROVIDER_COVERAGE_MANIFEST_ENABLED="${PROVIDER_COVERAGE_MANIFEST_ENABLED:-1}"
+PROVIDER_COVERAGE_MANIFEST_FINALIZED=0
 test_exit_code=0
 last_command_exit_code=0
 NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
@@ -31,7 +34,7 @@ UNIT_TEST_HOME="${NIGHTLY_UNIT_TEST_HOME:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-
 UNIT_TEST_PROJECT_ROOT="${NIGHTLY_UNIT_TEST_PROJECT_ROOT:-${UNIT_TEST_HOME}/workspace}"
 NIGHTLY_PYTEST_BASETEMP="${NIGHTLY_PYTEST_BASETEMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-nightly-pytest-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}}"
 AGENT_TEST_CONFIG_BACKUP="${AGENT_TEST_CONFIG_BACKUP:-${TMPDIR:-/tmp}/datus-agent-nightly-config-${GITHUB_RUN_ID:-$$}.bak}"
-export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP
+export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE PROVIDER_COVERAGE_MANIFEST_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP
 
 default_repo_root() {
   local explicit_root="$1"
@@ -223,6 +226,44 @@ failure_classification_finalize() {
     NIGHTLY_FAILURE_CLASSIFICATION_FINALIZED=1
   else
     echo "WARNING: nightly failure classification artifact was not written; will retry if cleanup runs again." | tee -a "$LOG_FILE" >&2
+  fi
+  return 0
+}
+
+provider_coverage_update() {
+  if [ "$PROVIDER_COVERAGE_MANIFEST_ENABLED" != "1" ]; then
+    return 0
+  fi
+
+  if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+    "${REPO_ROOT}/.venv/bin/python" ci/provider_coverage_manifest.py "$@" 2>>"$LOG_FILE"
+  elif command -v uv >/dev/null 2>&1; then
+    uv run python ci/provider_coverage_manifest.py "$@" 2>>"$LOG_FILE"
+  else
+    python3 ci/provider_coverage_manifest.py "$@" 2>>"$LOG_FILE"
+  fi
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "WARNING: provider coverage manifest update failed: ci/provider_coverage_manifest.py $*" | tee -a "$LOG_FILE" >&2
+    return "$status"
+  fi
+  return 0
+}
+
+provider_coverage_finalize() {
+  if [ "$PROVIDER_COVERAGE_MANIFEST_FINALIZED" = "1" ]; then
+    return 0
+  fi
+  if provider_coverage_update \
+    --repo-root "$REPO_ROOT" \
+    --provider-catalog conf/providers.yml \
+    --coverage-config ci/provider-coverage.yml \
+    --nightly-manifest "$NIGHTLY_MANIFEST_FILE" \
+    --output "$PROVIDER_COVERAGE_MANIFEST_FILE" &&
+    [ -s "$PROVIDER_COVERAGE_MANIFEST_FILE" ]; then
+    PROVIDER_COVERAGE_MANIFEST_FINALIZED=1
+  else
+    echo "WARNING: provider coverage manifest artifact was not written; will retry if cleanup runs again." | tee -a "$LOG_FILE" >&2
   fi
   return 0
 }
@@ -632,6 +673,7 @@ cleanup_all() {
   set +e
   if [ "${NIGHTLY_SKIP_MANIFEST_FINALIZE:-0}" != "1" ]; then
     manifest_finalize
+    provider_coverage_finalize
     failure_classification_finalize
   fi
   restore_agent_test_config
@@ -1427,12 +1469,14 @@ run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME"
 run_logged_unfiltered "Flaky Log Classification" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --log-file "$LOG_FILE" --warn-only
 
 manifest_finalize
+provider_coverage_finalize
 failure_classification_finalize
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "log_file=$LOG_FILE" >> "$GITHUB_OUTPUT"
   echo "manifest_file=$NIGHTLY_MANIFEST_FILE" >> "$GITHUB_OUTPUT"
   echo "failure_classification_file=$NIGHTLY_FAILURE_CLASSIFICATION_FILE" >> "$GITHUB_OUTPUT"
+  echo "provider_coverage_manifest_file=$PROVIDER_COVERAGE_MANIFEST_FILE" >> "$GITHUB_OUTPUT"
   echo "test_exit_code=$test_exit_code" >> "$GITHUB_OUTPUT"
 fi
 

--- a/tests/unit_tests/ci/test_provider_coverage_manifest.py
+++ b/tests/unit_tests/ci/test_provider_coverage_manifest.py
@@ -131,6 +131,85 @@ def test_build_manifest_reports_missing_declarations(tmp_path):
     assert manifest["summary"]["missing_declared_coverage"] == ["openai"]
 
 
+def test_class_or_function_exists_matches_async_functions(tmp_path):
+    test_file = tmp_path / "tests" / "test_async_provider.py"
+    test_file.parent.mkdir()
+    test_file.write_text(
+        "class TestProvider:\n"
+        "    async def test_async_method(self):\n"
+        "        pass\n\n"
+        "async def test_async_function():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    assert provider_coverage_manifest.class_or_function_exists(
+        tmp_path,
+        "tests/test_async_provider.py::test_async_function",
+    )
+    assert provider_coverage_manifest.class_or_function_exists(
+        tmp_path,
+        "tests/test_async_provider.py::TestProvider::test_async_method",
+    )
+
+
+def test_build_manifest_reports_invalid_list_fields_without_raising(tmp_path):
+    catalog = tmp_path / "providers.yml"
+    coverage = tmp_path / "provider-coverage.yml"
+    nightly_manifest = tmp_path / "nightly-manifest.json"
+    write_yaml(
+        catalog,
+        {
+            "providers": {
+                "openai": {
+                    "type": "openai",
+                    "api_key_env": "OPENAI_API_KEY",
+                    "default_model": "gpt-5.5",
+                    "models": "gpt-5.5",
+                }
+            }
+        },
+    )
+    write_yaml(
+        coverage,
+        {
+            "version": 1,
+            "providers": {
+                "openai": {
+                    "required_env": "OPENAI_API_KEY",
+                    "deterministic": {"nodeids": "tests/unit_tests/models/test_openai_model.py"},
+                    "live_provider_health": {"mode": "warn-only", "nodeids": [123]},
+                }
+            },
+        },
+    )
+    write_json(
+        nightly_manifest,
+        {
+            "suites": [
+                {
+                    "name": "Provider Health Tests",
+                    "collection": {"nodeids": "tests/integration/models/test_other_models.py"},
+                }
+            ]
+        },
+    )
+
+    manifest = provider_coverage_manifest.build_manifest(make_args(tmp_path, catalog, coverage, nightly_manifest))
+
+    assert manifest["providers"][0]["models"] == []
+    assert manifest["providers"][0]["required_env"] == ["OPENAI_API_KEY"]
+    assert manifest["nightly"]["provider_health_collected_nodeids"] == 0
+    assert manifest["coverage_errors"] == [
+        "openai.deterministic.nodeids: expected list[str], got 'tests/unit_tests/models/test_openai_model.py'",
+        "openai.live_provider_health.nodeids: expected list[str], got [123]",
+        "openai.required_env: expected list[str], got 'OPENAI_API_KEY'",
+        "nightly.provider_health.collection.nodeids: expected list[str], got 'tests/integration/models/test_other_models.py'",
+        "openai.models: expected list[str], got 'gpt-5.5'",
+    ]
+    assert manifest["summary"]["coverage_error_count"] == 5
+
+
 def test_repo_provider_coverage_config_is_valid():
     catalog = provider_coverage_manifest.read_yaml(REPO_ROOT / "conf" / "providers.yml")
     coverage = provider_coverage_manifest.read_yaml(REPO_ROOT / "ci" / "provider-coverage.yml")

--- a/tests/unit_tests/ci/test_provider_coverage_manifest.py
+++ b/tests/unit_tests/ci/test_provider_coverage_manifest.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import yaml
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "provider_coverage_manifest.py"
+REPO_ROOT = MODULE_PATH.parents[1]
+MODULE_SPEC = importlib.util.spec_from_file_location("provider_coverage_manifest", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load provider_coverage_manifest module from {MODULE_PATH}")
+provider_coverage_manifest = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(provider_coverage_manifest)
+
+
+def write_yaml(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=True), encoding="utf-8")
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def make_args(tmp_path: Path, catalog: Path, coverage: Path, nightly_manifest: Path | None = None):
+    return type(
+        "Args",
+        (),
+        {
+            "repo_root": str(REPO_ROOT),
+            "provider_catalog": str(catalog),
+            "coverage_config": str(coverage),
+            "nightly_manifest": str(nightly_manifest or tmp_path / "missing-nightly-manifest.json"),
+            "output": str(tmp_path / "provider-coverage-manifest.json"),
+            "strict": False,
+        },
+    )()
+
+
+def test_build_manifest_matches_collected_provider_health_nodeids(tmp_path):
+    catalog = tmp_path / "providers.yml"
+    coverage = tmp_path / "provider-coverage.yml"
+    nightly_manifest = tmp_path / "nightly-manifest.json"
+    write_yaml(
+        catalog,
+        {
+            "providers": {
+                "openai": {
+                    "type": "openai",
+                    "api_key_env": "OPENAI_API_KEY",
+                    "base_url": "https://api.openai.com/v1",
+                    "default_model": "gpt-5.5",
+                    "models": ["gpt-5.5"],
+                }
+            }
+        },
+    )
+    write_yaml(
+        coverage,
+        {
+            "version": 1,
+            "providers": {
+                "openai": {
+                    "required_env": ["OPENAI_API_KEY"],
+                    "deterministic": {"nodeids": ["tests/unit_tests/models/test_openai_model.py::TestOpenAIModel"]},
+                    "live_provider_health": {
+                        "mode": "warn-only",
+                        "nodeids": ["tests/integration/models/test_other_models.py::TestOpenAIModel"],
+                    },
+                }
+            },
+        },
+    )
+    write_json(
+        nightly_manifest,
+        {
+            "suites": [
+                {
+                    "name": "Provider Health Tests",
+                    "status": "passed",
+                    "mode": "warn-only",
+                    "collection": {
+                        "nodeids": [
+                            "tests/integration/models/test_other_models.py::TestOpenAIModel::test_generate_basic"
+                        ]
+                    },
+                }
+            ]
+        },
+    )
+
+    manifest = provider_coverage_manifest.build_manifest(make_args(tmp_path, catalog, coverage, nightly_manifest))
+
+    assert manifest["coverage_errors"] == []
+    assert manifest["nightly"]["provider_health_collected_nodeids"] == 1
+    assert manifest["summary"]["providers_total"] == 1
+    assert manifest["summary"]["deterministic_covered"] == 1
+    assert manifest["summary"]["live_provider_health_declared"] == 1
+    assert manifest["summary"]["live_provider_health_collected"] == 1
+    provider = manifest["providers"][0]
+    assert provider["required_env"] == ["OPENAI_API_KEY"]
+    assert provider["coverage"]["live_provider_health"]["status"] == "collected"
+    assert provider["coverage"]["live_provider_health"]["collected_nodeids"] == [
+        "tests/integration/models/test_other_models.py::TestOpenAIModel::test_generate_basic"
+    ]
+
+
+def test_build_manifest_reports_missing_declarations(tmp_path):
+    catalog = tmp_path / "providers.yml"
+    coverage = tmp_path / "provider-coverage.yml"
+    write_yaml(
+        catalog,
+        {
+            "providers": {
+                "openai": {
+                    "type": "openai",
+                    "api_key_env": "OPENAI_API_KEY",
+                    "default_model": "gpt-5.5",
+                    "models": ["gpt-5.5"],
+                }
+            }
+        },
+    )
+    write_yaml(coverage, {"version": 1, "providers": {}})
+
+    manifest = provider_coverage_manifest.build_manifest(make_args(tmp_path, catalog, coverage))
+
+    assert manifest["summary"]["coverage_error_count"] == 1
+    assert manifest["coverage_errors"] == ["openai: provider has no coverage declaration"]
+    assert manifest["summary"]["missing_declared_coverage"] == ["openai"]
+
+
+def test_repo_provider_coverage_config_is_valid():
+    catalog = provider_coverage_manifest.read_yaml(REPO_ROOT / "conf" / "providers.yml")
+    coverage = provider_coverage_manifest.read_yaml(REPO_ROOT / "ci" / "provider-coverage.yml")
+
+    assert provider_coverage_manifest.validate_coverage_config(REPO_ROOT, catalog, coverage) == []


### PR DESCRIPTION
## Why

Closes #751. Nightly currently tells us whether provider smoke tests ran, but it does not produce a structured view of provider catalog coverage, deterministic coverage, and live provider health coverage.

## Solution

- Add `ci/provider-coverage.yml` as the provider coverage declaration for every provider in `conf/providers.yml`.
- Add `ci/provider_coverage_manifest.py` to generate `provider-coverage-manifest.json` from the provider catalog, coverage declaration, and nightly manifest collection data.
- Wire the manifest into nightly finalization, upload it as a nightly artifact, and include a compact provider coverage line in the Feishu report.
- Add unit tests for manifest generation, missing declaration detection, and repo coverage declaration validation.

## Test Cases

- `uv run pytest tests/unit_tests/ci/test_provider_coverage_manifest.py -q`
- `uv run python ci/provider_coverage_manifest.py --repo-root . --provider-catalog conf/providers.yml --coverage-config ci/provider-coverage.yml --output /tmp/provider-coverage-manifest.json --strict`
- `node` smoke test for `ci/format-nightly-feishu-report.js` provider coverage summary
- `uv run python ci/audit_tests.py --repo-root . --paths tests/unit_tests/ci/test_provider_coverage_manifest.py --json /tmp/datus-audit-751-path.json`
- `bash -n ci/run-nightly-tests.sh`
- `TEST_CMD_TIMEOUT=600 uv run python ci/run-pr-tests.py upstream/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly Feishu reports now include a "Provider Coverage" summary line when available.
  * Nightly artifacts now publish a provider coverage manifest alongside logs and reports.

* **Chores**
  * CI pipeline enhanced to generate, validate, finalize, and publish a provider coverage manifest as part of nightly runs.

* **Tests**
  * Added unit tests for manifest generation, validation, merging with nightly health data, and nodeid existence checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->