### PR TITLE
[Tool] Clarify nightly Feishu failure summary

### DIFF
--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
       - name: Cache pip dependencies
         uses: actions/cache@v4
         with:
@@ -53,7 +58,7 @@ jobs:
       - name: Isolate test data directory
         run: |
           DATUS_TEST_HOME="${GITHUB_WORKSPACE}/.datus_test_data"
-          echo "DATUS_TEST_HOME=$DATUS_TEST_HOME" >> $GITHUB_ENV
+          echo "DATUS_TEST_HOME=$DATUS_TEST_HOME" >> "$GITHUB_ENV"
           sed -i "s|home: .datus_test_data|home: $DATUS_TEST_HOME|g" tests/conf/agent.yml
           sed -i "s|project_root: .datus_test_data/workspace|project_root: $DATUS_TEST_HOME/workspace|g" tests/conf/agent.yml
 
@@ -69,7 +74,7 @@ jobs:
               var_value=$(echo "$line" | cut -d'=' -f2-)
               echo "::add-mask::$var_value"
               echo "Loading variable: $var_name"
-              echo "$line" >> $GITHUB_ENV
+              echo "$line" >> "$GITHUB_ENV"
             fi
           done < .env
           echo "Environment variables loaded successfully"

--- a/ci/format-nightly-feishu-report.js
+++ b/ci/format-nightly-feishu-report.js
@@ -208,12 +208,19 @@ function summarizeClassification(classification, options = {}) {
 
   const blockingCounts = classification.summary.blocking_category_counts || {};
   const categoryCounts = classification.summary.category_counts || {};
+  const diagnosticCounts = {};
+  for (const [category, count] of Object.entries(categoryCounts)) {
+    const diagnosticCount = Number(count) - Number(blockingCounts[category] || 0);
+    if (diagnosticCount > 0) {
+      diagnosticCounts[category] = diagnosticCount;
+    }
+  }
   const blockingText = formatCounts(blockingCounts);
-  const allText = formatCounts(categoryCounts);
+  const diagnosticText = formatCounts(diagnosticCounts);
   const findings = Array.isArray(classification.findings) ? classification.findings : [];
   const blockingFindings = findings.filter((finding) => finding && finding.blocking);
   const warningFindings = findings.filter((finding) => finding && !finding.blocking);
-  const selectedFindings = [...blockingFindings, ...warningFindings].slice(0, maxFindings).map((finding) => {
+  const formatFinding = (finding) => {
     const category = finding.category || 'unknown_failure';
     const title = finding.title || 'Unclassified finding';
     const details = finding.details || {};
@@ -222,13 +229,17 @@ function summarizeClassification(classification, options = {}) {
     const nodeid = details.nodeid ? ` nodeid=${details.nodeid}` : '';
     const entryId = details.entry_id ? ` entry=${details.entry_id}` : '';
     return `[${category}] ${title}${suite}${exitCode}${nodeid}${entryId}`;
-  });
+  };
+  const selectedBlockingFindings = blockingFindings.slice(0, maxFindings).map(formatFinding);
+  const selectedDiagnosticFindings = warningFindings.slice(0, maxFindings).map(formatFinding);
 
   return {
     blockingText,
-    allText,
-    findings: selectedFindings,
-    omitted: Math.max(0, findings.length - selectedFindings.length),
+    diagnosticText,
+    blockingFindings: selectedBlockingFindings,
+    diagnosticFindings: selectedDiagnosticFindings,
+    omittedBlocking: Math.max(0, blockingFindings.length - selectedBlockingFindings.length),
+    omittedDiagnostics: Math.max(0, warningFindings.length - selectedDiagnosticFindings.length),
   };
 }
 
@@ -273,21 +284,38 @@ function buildNightlyFeishuMessage({
   }
 
   if (classificationSummary) {
-    lines.push(
-      `**Classification:** ${
-        classificationSummary.blockingText || 'no blocking classified failures'
-      }${classificationSummary.allText ? ` (all findings: ${classificationSummary.allText})` : ''}.`,
-    );
-  }
-
-  if (classificationSummary && classificationSummary.findings.length > 0) {
-    lines.push('', '### Failure Classification', fencedList(classificationSummary.findings, 'No classified findings.'));
-    if (classificationSummary.omitted > 0) {
-      lines.push(`_... ${classificationSummary.omitted} more classified finding(s) omitted._`);
+    lines.push(`**Blocking:** ${classificationSummary.blockingText || 'no blocking classified failures'}.`);
+    if (classificationSummary.diagnosticText) {
+      lines.push(`**Diagnostics:** ${classificationSummary.diagnosticText}.`);
     }
   }
 
-  if (report.failures.length > 0 && (!classificationSummary || classificationSummary.findings.length === 0)) {
+  if (classificationSummary && classificationSummary.blockingFindings.length > 0) {
+    lines.push(
+      '',
+      '### Blocking Failures',
+      fencedList(classificationSummary.blockingFindings, 'No blocking classified failures.'),
+    );
+    if (classificationSummary.omittedBlocking > 0) {
+      lines.push(`_... ${classificationSummary.omittedBlocking} more blocking finding(s) omitted._`);
+    }
+  }
+
+  if (classificationSummary && classificationSummary.diagnosticFindings.length > 0) {
+    lines.push(
+      '',
+      '### Diagnostic Signals',
+      fencedList(classificationSummary.diagnosticFindings, 'No diagnostic signals.'),
+    );
+    if (classificationSummary.omittedDiagnostics > 0) {
+      lines.push(`_... ${classificationSummary.omittedDiagnostics} more diagnostic signal(s) omitted._`);
+    }
+  }
+
+  if (
+    report.failures.length > 0 &&
+    (!classificationSummary || classificationSummary.blockingFindings.length === 0)
+  ) {
     lines.push('', '### Failures / Errors', fencedList(report.failures, 'No failures detected.'));
     if (report.truncatedFailures > 0) {
       lines.push(`_... ${report.truncatedFailures} more failure/error lines omitted._`);

--- a/tests/unit_tests/ci/test_format_nightly_feishu_report.py
+++ b/tests/unit_tests/ci/test_format_nightly_feishu_report.py
@@ -1,0 +1,103 @@
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_nightly_feishu_report_separates_blocking_failures_from_diagnostics(tmp_path):
+    (tmp_path / "nightly-manifest.json").write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "suite_count": 20,
+                    "collected_nodeid_count": 13557,
+                    "status_counts": {"failed": 3, "passed": 17},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "nightly-failure-classification.json").write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "blocking_category_counts": {
+                        "credential_or_config": 1,
+                        "docker_infra": 1,
+                        "product_regression": 2,
+                        "provider_outage": 1,
+                    },
+                    "category_counts": {
+                        "credential_or_config": 1,
+                        "docker_infra": 1,
+                        "known_flaky": 2,
+                        "product_regression": 2,
+                        "provider_outage": 2,
+                        "unknown_flaky": 4,
+                    },
+                },
+                "findings": [
+                    {
+                        "blocking": True,
+                        "category": "product_regression",
+                        "title": "Gen Agent Tests failed",
+                        "details": {"suite": "Gen Agent Tests", "exit_code": 1},
+                    },
+                    {
+                        "blocking": True,
+                        "category": "provider_outage",
+                        "title": "Product E2E Nightly Tests failed",
+                        "details": {"suite": "Product E2E Nightly Tests", "exit_code": 1},
+                    },
+                    {
+                        "blocking": False,
+                        "category": "known_flaky",
+                        "title": "Registered rerun observed",
+                        "details": {
+                            "nodeid": (
+                                "tests/integration/tools/test_bi_dashboard.py::"
+                                "TestE2EIntegration::test_complete_workflow"
+                            )
+                        },
+                    },
+                    {
+                        "blocking": False,
+                        "category": "unknown_flaky",
+                        "title": "Unregistered rerun observed",
+                        "details": {
+                            "nodeid": (
+                                "tests/integration/agent/test_gen_metrics_agentic.py::"
+                                "TestGenMetricsAgentic::test_execute_stream_generates_metric"
+                            )
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    script = f"""
+const {{ buildNightlyFeishuMessage }} = require({json.dumps(str(REPO_ROOT / "ci/format-nightly-feishu-report.js"))});
+const message = buildNightlyFeishuMessage({{
+  status: 'FAILED',
+  runNumber: '75',
+  runUrl: 'https://example.test/run/75',
+  date: '2026-05-18',
+  workspace: {json.dumps(str(tmp_path))},
+  logContent: '',
+}});
+console.log(message);
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    message = result.stdout
+
+    assert (
+        "**Blocking:** credential_or_config: 1, docker_infra: 1, product_regression: 2, provider_outage: 1." in message
+    )
+    assert "**Diagnostics:** known_flaky: 2, provider_outage: 1, unknown_flaky: 4." in message
+    assert "### Blocking Failures" in message
+    assert "### Diagnostic Signals" in message
+    assert "all findings" not in message
+    assert "### Failure Classification" not in message

--- a/tests/unit_tests/ci/test_format_nightly_feishu_report.py
+++ b/tests/unit_tests/ci/test_format_nightly_feishu_report.py
@@ -1,8 +1,30 @@
 import json
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _find_node_executable() -> str:
+    if node := shutil.which("node"):
+        return node
+
+    search_roots = []
+    for env_name in ("GITHUB_WORKSPACE", "RUNNER_TEMP"):
+        if value := os.environ.get(env_name):
+            search_roots.extend(Path(value).resolve().parents)
+
+    for root in search_roots:
+        externals_dir = root / "externals"
+        for candidate in externals_dir.glob("node*/bin/node"):
+            if candidate.is_file():
+                return str(candidate)
+
+    pytest.fail("node executable is required to test the nightly Feishu formatter")
 
 
 def test_nightly_feishu_report_separates_blocking_failures_from_diagnostics(tmp_path):
@@ -90,7 +112,7 @@ const message = buildNightlyFeishuMessage({{
 }});
 console.log(message);
 """
-    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    result = subprocess.run([_find_node_executable(), "-e", script], check=True, capture_output=True, text=True)
     message = result.stdout
 
     assert (


### PR DESCRIPTION
## Summary
- Split nightly Feishu classification into blocking failures and diagnostic signals.
- Stop showing non-blocking reruns/log warnings under a generic Failure Classification section.
- Add a formatter regression test for the mixed blocking/diagnostic case.

## Validation
- uv run ruff check tests/unit_tests/ci/test_format_nightly_feishu_report.py
- uv run pytest tests/unit_tests/ci/test_format_nightly_feishu_report.py -q
- TEST_CMD_TIMEOUT=900 uv run python ci/run-pr-tests.py upstream/main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly failure reports now show distinct "Blocking" and "Diagnostics" sections, with separate counts and omission notices for each and adjusted logic for when a generic failures section appears.

* **Tests**
  * Added a unit test to validate the formatted report contains separate Blocking and Diagnostic sections and omits the previous aggregated "all findings" text.

* **Chores**
  * CI workflow updated to ensure Node is available and environment variable persistence is more reliable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->