### PR TITLE
[Tool] Fast-fail merge queue storage acceptance

### DIFF
--- a/ci/run-merge-queue-tests.py
+++ b/ci/run-merge-queue-tests.py
@@ -23,7 +23,7 @@ from typing import Any, Sequence
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = REPO_ROOT / "ci"
 DEFAULT_REPORT = OUT_DIR / "merge-queue-results.json"
-DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("MERGE_QUEUE_TEST_TIMEOUT", "1800"))
+DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("MERGE_QUEUE_TEST_TIMEOUT", "600"))
 PYTEST_BASETEMP_ENV = "DATUS_CI_PYTEST_BASETEMP"
 
 ACCEPTANCE_MARK_EXPR = "acceptance"
@@ -200,14 +200,14 @@ def suite_definitions() -> dict[str, dict[str, Any]]:
             "targets": unit_targets,
             "mark_expr": pr_harness_mark_expr,
             "junit_xml": OUT_DIR / "test-results-merge-acceptance-unit.xml",
-            "extra_args": ["--timeout=300", "--dist=loadscope", "-n", "auto"],
+            "extra_args": ["--timeout=120", "--dist=loadscope", "-n", "auto"],
         },
         "acceptance-integration": {
             "description": "Deterministic acceptance integration coverage reused from the PR harness.",
             "targets": integration_targets,
             "mark_expr": ACCEPTANCE_MARK_EXPR,
             "junit_xml": OUT_DIR / "test-results-merge-acceptance.xml",
-            "extra_args": ["--timeout=300"],
+            "extra_args": ["--timeout=120"],
         },
     }
 

--- a/tests/integration/storage/test_doc_search.py
+++ b/tests/integration/storage/test_doc_search.py
@@ -11,12 +11,16 @@ against a real LanceDB-backed store with auto-constructed test data.
 
 from typing import List
 
+import numpy as np
 import pytest
+from lancedb.embeddings.base import TextEmbeddingFunction
+from lancedb.embeddings.registry import register
 
 from datus.configuration.agent_config import AgentConfig
 from datus.configuration.agent_config_loader import load_agent_config
 from datus.storage.document.schemas import PlatformDocChunk
 from datus.storage.document.store import document_store
+from datus.storage.embedding_models import EMBEDDING_MODELS, EmbeddingModel
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -27,6 +31,39 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 TEST_PLATFORM = "test_search_tool"
+
+
+@register("datus_test_deterministic")
+class _DeterministicDocEmbedding(TextEmbeddingFunction):
+    """Small deterministic LanceDB embedding for merge-queue-safe doc search tests."""
+
+    dim: int = 8
+
+    def ndims(self):
+        return self.dim
+
+    def generate_embeddings(self, texts, *args, **kwargs):
+        vectors = []
+        for text in list(texts):
+            value = str(text or "")
+            buckets = [0.0] * self.dim
+            for index, char in enumerate(value):
+                buckets[index % self.dim] += (ord(char) % 53) / 53.0
+            norm = float(np.linalg.norm(buckets)) or 1.0
+            vectors.append([bucket / norm for bucket in buckets])
+        return vectors
+
+
+@pytest.fixture(autouse=True)
+def deterministic_document_embedding(monkeypatch):
+    """Keep document-search acceptance off real fastembed/model cache state."""
+    document_store.cache_clear()
+    model = EmbeddingModel(model_name="datus-test-deterministic", dim_size=8)
+    model._model = _DeterministicDocEmbedding()
+    model.model_initialization_attempted = True
+    monkeypatch.setitem(EMBEDDING_MODELS, "document", model)
+    yield
+    document_store.cache_clear()
 
 
 def _make_chunk(
@@ -175,26 +212,27 @@ class TestSearchTool:
     def test_list_document_nav_returns_tree(self):
         """list_document_nav should return a hierarchical navigation tree."""
         result = self.tool.list_document_nav(platform=TEST_PLATFORM, version="v1")
-        assert result.success, f"list_document_nav failed: {result.error}"
+        assert result.success is True, f"list_document_nav failed: {result.error}"
         assert result.platform == TEST_PLATFORM
-        assert result.total_docs > 0, "Should have at least 1 unique doc"
-        assert len(result.nav_tree) > 0, "Nav tree should not be empty"
+        assert result.total_docs == 4
+        assert result.nav_tree != []
 
         # Each top-level item should be a pure tree node with name and children
         for item in result.nav_tree:
-            assert "name" in item or "version" in item, "Tree node should have 'name' or 'version'"
             if "name" in item:
                 assert "children" in item, "Tree node should have 'children'"
                 assert isinstance(item["children"], list), "children should be a list"
                 assert item["name"], "name should not be empty"
-            else:
+            elif "version" in item:
                 assert "tree" in item, "Multi versions should have 'tree'"
+            else:
+                raise AssertionError(f"Tree node should have 'name' or 'version': {item}")
 
     def test_list_document_nav_empty_platform(self):
         """list_document_nav for a non-existent platform returns empty tree."""
         result = self.tool.list_document_nav(platform="nonexistent_platform_xyz")
 
-        assert result.success
+        assert result.success is True
         assert result.total_docs == 0
         assert result.nav_tree == []
 
@@ -202,7 +240,8 @@ class TestSearchTool:
         """get_document should retrieve chunks when given a title from the nav tree."""
         # First get the nav tree to find a real title
         nav_result = self.tool.list_document_nav(platform=TEST_PLATFORM, version="v1")
-        assert nav_result.success and len(nav_result.nav_tree) > 0
+        assert nav_result.success is True
+        assert nav_result.nav_tree != []
 
         # Find a leaf node (node with empty children) from the pure tree
         def _find_first_doc(nodes):
@@ -225,7 +264,7 @@ class TestSearchTool:
         # Use the title to get document chunks
         result = self.tool.get_document(platform=TEST_PLATFORM, titles=[title], version="v1")
 
-        assert result.success, f"get_document failed: {result.error}"
+        assert result.success is True, f"get_document failed: {result.error}"
         assert result.platform == TEST_PLATFORM
         assert result.chunk_count > 0, f"Should find chunks for title '{title}'"
         assert len(result.chunks) == result.chunk_count
@@ -242,7 +281,7 @@ class TestSearchTool:
             titles=["ZZZZZ_NONEXISTENT_TITLE_ZZZZZ"],
         )
 
-        assert result.success
+        assert result.success is True
         assert result.chunk_count == 0
         assert result.chunks == []
 
@@ -257,11 +296,11 @@ class TestSearchTool:
             top_n=3,
         )
 
-        assert result.success, f"search_document failed: {result.error}"
-        assert result.doc_count > 0, "Should find at least one result for keyword DATE_TRUNC"
+        assert result.success is True, f"search_document failed: {result.error}"
+        assert result.doc_count == 3
 
         assert "DATE_TRUNC" in result.docs, "Keyword 'DATE_TRUNC' missing from result.docs"
-        assert len(result.docs["DATE_TRUNC"]) > 0, "No results for keyword 'DATE_TRUNC'"
+        assert len(result.docs["DATE_TRUNC"]) == 3
 
         # Verify chunk fields from the first result
         first_chunk = result.docs["DATE_TRUNC"][0]
@@ -279,10 +318,11 @@ class TestSearchTool:
             top_n=3,
         )
 
-        assert result.success, f"search_document failed: {result.error}"
+        assert result.success is True, f"search_document failed: {result.error}"
         # Each keyword should have its own entry in the docs dict
         for keyword in ["DATE_TRUNC", "CURRENT_DATE"]:
             assert keyword in result.docs, f"Keyword '{keyword}' missing from result.docs"
+            assert len(result.docs[keyword]) == 3
 
     def test_search_document_wrong_platform(self):
         """search_document on a non-existent platform returns empty results."""
@@ -292,7 +332,7 @@ class TestSearchTool:
             top_n=3,
         )
 
-        assert result.success
+        assert result.success is True
         assert result.doc_count == 0
 
     # ----- delete_docs -----

--- a/tests/integration/storage/test_fastembed_lancedb_smoke.py
+++ b/tests/integration/storage/test_fastembed_lancedb_smoke.py
@@ -1,0 +1,69 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Nightly smoke for the real FastEmbed + LanceDB document-store path."""
+
+from __future__ import annotations
+
+import pytest
+from datus_storage_base.backend_config import StorageBackendConfig
+
+from datus.storage.backend_holder import create_vector_connection, init_backends, reset_backends
+from datus.storage.document.schemas import PlatformDocChunk
+from datus.storage.document.store import DocumentStore
+from datus.storage.embedding_models import EmbeddingModel
+from datus.utils.constants import EmbeddingProvider
+
+pytestmark = [pytest.mark.nightly, pytest.mark.timeout(90)]
+
+
+def _chunk(doc_path: str, chunk_index: int, text: str) -> PlatformDocChunk:
+    return PlatformDocChunk(
+        chunk_id=PlatformDocChunk.generate_chunk_id(doc_path, chunk_index, "nightly"),
+        chunk_text=text,
+        chunk_index=chunk_index,
+        title="FastEmbed LanceDB Smoke",
+        titles=["FastEmbed LanceDB Smoke"],
+        nav_path=["Storage", "Smoke"],
+        group_name="Storage",
+        hierarchy="Storage > Smoke > FastEmbed LanceDB Smoke",
+        version="nightly",
+        source_type="local",
+        source_url="",
+        doc_path=doc_path,
+        keywords=["fastembed", "lancedb"],
+        language="en",
+    )
+
+
+def test_real_fastembed_lancedb_document_store_round_trip(tmp_path):
+    """The real FastEmbed adapter should write and query LanceDB without long retry stalls."""
+    store = None
+    try:
+        init_backends(StorageBackendConfig(), data_dir=str(tmp_path / "data"))
+        model = EmbeddingModel(
+            model_name="all-MiniLM-L6-v2",
+            dim_size=384,
+            registry_name=EmbeddingProvider.FASTEMBED,
+            batch_size=2,
+        )
+        store = DocumentStore(embedding_model=model, db=create_vector_connection("fastembed_lancedb_smoke"))
+        stored = store.store_chunks(
+            [
+                _chunk("docs/storage/fastembed.md", 0, "FastEmbed writes document vectors into LanceDB."),
+                _chunk("docs/storage/lancedb.md", 1, "LanceDB searches document chunks using vector embeddings."),
+            ]
+        )
+
+        assert stored == 2
+        assert store.table.count_rows() == 2
+        results = store.search_docs("document vector search", version="nightly", top_n=1)
+        assert len(results) == 1
+        assert "chunk_text" in results[0]
+    finally:
+        try:
+            if store is not None:
+                store.delete_docs(version=None)
+        finally:
+            reset_backends()

--- a/tests/unit_tests/ci/test_run_merge_queue_tests.py
+++ b/tests/unit_tests/ci/test_run_merge_queue_tests.py
@@ -50,7 +50,7 @@ def test_build_pytest_command_includes_marker_junit_and_extra_args(tmp_path, run
         ["tests/unit_tests/"],
         mark_expr="not nightly",
         junit_xml=junit_xml,
-        extra_args=["--timeout=300", "-n", "auto"],
+        extra_args=["--timeout=120", "-n", "auto"],
         basetemp=tmp_path / "pytest-temp" / "unit",
     )
 
@@ -58,7 +58,7 @@ def test_build_pytest_command_includes_marker_junit_and_extra_args(tmp_path, run
     assert command[4] == f"--basetemp={tmp_path / 'pytest-temp' / 'unit'}"
     assert command[5:7] == ["-m", "not nightly"]
     assert f"--junitxml={junit_xml}" in command
-    assert ["--timeout=300", "-n", "auto"] == command[-3:]
+    assert ["--timeout=120", "-n", "auto"] == command[-3:]
 
 
 def test_main_runs_selected_suite_and_writes_report(tmp_path, monkeypatch, run_merge_queue_tests):
@@ -94,7 +94,7 @@ def test_main_runs_selected_suite_and_writes_report(tmp_path, monkeypatch, run_m
                 ["tests/unit_tests/"],
                 mark_expr="acceptance or component or llm_harness",
                 junit_xml=out_dir / "test-results-merge-acceptance-unit.xml",
-                extra_args=["--timeout=300", "--dist=loadscope", "-n", "auto"],
+                extra_args=["--timeout=120", "--dist=loadscope", "-n", "auto"],
                 basetemp=run_merge_queue_tests.suite_pytest_basetemp("acceptance-unit"),
             ),
             "cwd": repo_root,


### PR DESCRIPTION
## Summary
- Reduce merge queue suite timeout from 30 minutes to 10 minutes and per-test timeout from 300s to 120s.
- Keep document-search acceptance deterministic by using a tiny in-test LanceDB embedding instead of the real fastembed model/cache.
- Update merge queue runner unit expectations for the shorter timeout.

## Root cause
The failed merge_group run entered fastembed/LanceDB internal retry while doc-search acceptance was using the real document embedding model. The warning `TextEncodeInput must be Union[...]` came from that real embedding path, and the library backoff delayed the suite until pytest-timeout killed LanceDB operations. These cases are harness correctness checks, so they should not depend on real embedding model/cache state.

## Validation
- uv run ruff check ci/run-merge-queue-tests.py tests/unit_tests/ci/test_run_merge_queue_tests.py tests/integration/storage/test_doc_search.py
- uv run pytest tests/unit_tests/ci/test_run_merge_queue_tests.py tests/integration/storage/test_doc_search.py tests/integration/storage/test_storage_layout.py -m "acceptance or not acceptance" --tb=short --showlocals --disable-warnings --timeout=120 -q
- MERGE_QUEUE_TEST_TIMEOUT=600 uv run python ci/run-merge-queue-tests.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Shortened default merge-queue test timeouts to speed up CI runs.

* **Tests**
  * Made document search integration tests more deterministic for consistent search results.
  * Tightened assertions in document search tests for more reliable verification.
  * Updated unit tests to match the new, shorter timeout settings.
  * Added a nightly smoke test covering a real document storage and search round-trip.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->