### PR TITLE
[Tool] Add core flow acceptance coverage

### DIFF
--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -22,6 +22,7 @@ Tests verify:
 NO MOCK EXCEPT LLM: The only mock is LLMBaseModel.create_model -> MockLLMModel.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -263,7 +264,6 @@ class TestChatAgenticNodeToolSetup:
             agent_config=real_agent_config,
         )
 
-        assert node.bash_tool is not None
         assert isinstance(node.bash_tool, BashTool)
 
         # ``["*"]`` pattern: tool is exposed; per-call gating is handled by
@@ -321,6 +321,72 @@ class TestChatAgenticNodeToolSetup:
 
         assert node.execution_mode == "interactive"
         assert [t.name for t in node.ask_user_tool.available_tools()] == ["ask_user"]
+
+
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestChatMemoryFlowAcceptance:
+    """Deterministic chain-level coverage for chat memory write and later use."""
+
+    @pytest.mark.asyncio
+    async def test_chat_turn_writes_memory_and_later_turn_receives_it(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        memory_text = "# Memory\n\n## Revenue conventions\n- Net revenue excludes refunds.\n"
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall(
+                            name="write_file",
+                            arguments={
+                                "path": ".datus/memory/chat/MEMORY.md",
+                                "content": memory_text,
+                            },
+                        )
+                    ],
+                    content="Saved the revenue convention to memory.",
+                ),
+                build_simple_response("I will apply the saved net revenue convention."),
+            ]
+        )
+
+        first_turn = ChatAgenticNode(
+            node_id="chat_memory_writer",
+            description="Write chat memory",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        first_turn.input = ChatNodeInput(user_message="Remember that net revenue excludes refunds.")
+
+        action_manager = ActionHistoryManager()
+        async for _ in first_turn.execute_stream(action_manager):
+            pass
+
+        memory_file = Path(real_agent_config.project_root) / ".datus" / "memory" / "chat" / "MEMORY.md"
+        assert memory_file.read_text(encoding="utf-8") == memory_text
+
+        second_turn = ChatAgenticNode(
+            node_id="chat_memory_reader",
+            description="Read chat memory",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+        second_turn.input = ChatNodeInput(user_message="How should I define net revenue?")
+
+        action_manager = ActionHistoryManager()
+        async for _ in second_turn.execute_stream(action_manager):
+            pass
+
+        tool_calls = [item for item in mock_llm_create.tool_results if item["tool"] == "write_file"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["executed"] is True
+
+        second_model_call = mock_llm_create.call_history[-1]
+        assert second_model_call["method"] == "generate_with_tools_stream"
+        assert "Net revenue excludes refunds" in second_model_call["instruction"]
 
 
 # ===========================================================================

--- a/tests/unit_tests/agent/node/test_feedback_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_feedback_agentic_node.py
@@ -21,12 +21,13 @@ Design principle: NO mock except LLM.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
 from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.feedback_agentic_node_models import FeedbackNodeInput, FeedbackNodeResult
-from tests.unit_tests.mock_llm_model import build_simple_response
+from tests.unit_tests.mock_llm_model import MockToolCall, build_simple_response, build_tool_then_response
 
 # ---------------------------------------------------------------------------
 # Schema Model Tests
@@ -281,6 +282,56 @@ class TestFeedbackAgenticNodeExecution:
         assert isinstance(node.result, FeedbackNodeResult)
         assert node.result.success is False
         assert "boom" in node.result.error
+
+
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestFeedbackMemoryFlowAcceptance:
+    """Deterministic feedback flow coverage for updating caller memory."""
+
+    @pytest.mark.asyncio
+    async def test_feedback_writes_caller_memory_with_real_filesystem_tool(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
+        from datus.utils.memory_loader import load_memory_context
+
+        memory_text = "# Memory\n\n## SQL feedback\n- Charter-school detail queries should filter active campuses.\n"
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall(
+                            name="write_file",
+                            arguments={
+                                "path": ".datus/memory/chat/MEMORY.md",
+                                "content": memory_text,
+                            },
+                        )
+                    ],
+                    content="Archived the feedback into chat memory.",
+                )
+            ]
+        )
+
+        node = FeedbackAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.caller_node_name = "chat"
+        node.input = FeedbackNodeInput(
+            user_message="Remember that charter-school detail queries should filter active campuses."
+        )
+
+        action_manager = ActionHistoryManager()
+        async for _ in node.execute_stream(action_manager):
+            pass
+
+        memory_file = Path(real_agent_config.project_root) / ".datus" / "memory" / "chat" / "MEMORY.md"
+        assert memory_file.read_text(encoding="utf-8") == memory_text
+        assert "filter active campuses" in load_memory_context(real_agent_config.project_root, "chat")
+
+        tool_calls = [item for item in mock_llm_create.tool_results if item["tool"] == "write_file"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["executed"] is True
+        assert isinstance(node.result, FeedbackNodeResult)
+        assert node.result.success is True
+        assert node.result.response == "Archived the feedback into chat memory."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_core_entrypoint_acceptance.py
+++ b/tests/unit_tests/cli/test_core_entrypoint_acceptance.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import io
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -145,6 +146,33 @@ def test_cli_slash_commands_route_through_shared_repl_dispatch() -> None:
     saved_override = save_override.call_args.args[0]
     assert saved_override.default_datasource == "warehouse"
     cli.bg_sync.schedule.assert_called_once_with(datasource="warehouse", reason="switch")
+
+
+def test_quickstart_documented_repl_entrypoints_stay_routable() -> None:
+    """Quickstart REPL commands should remain valid slash/SQL/chat entrypoints."""
+    repo_root = Path(__file__).resolve().parents[3]
+    quickstart = (repo_root / "docs" / "getting_started" / "Quickstart.md").read_text(encoding="utf-8")
+    documented_slash_commands = ("/datasource", "/model", "/init", "/tables")
+
+    for command in documented_slash_commands:
+        assert command in quickstart
+        spec = lookup(command.removeprefix("/"))
+        if spec is None:
+            raise AssertionError(f"Quickstart command {command} is missing from slash registry")
+        assert spec.name == command.removeprefix("/")
+
+    cli = _build_core_cli()
+
+    parsed = [DatusCLI._parse_command(cli, command) for command in documented_slash_commands]
+    assert parsed == [
+        (CommandType.SLASH, "/datasource", ""),
+        (CommandType.SLASH, "/model", ""),
+        (CommandType.SLASH, "/init", ""),
+        (CommandType.SLASH, "/tables", ""),
+    ]
+
+    assert DatusCLI._parse_command(cli, "desc gold_vs_bitcoin")[0] == CommandType.SQL
+    assert DatusCLI._parse_command(cli, "Detailed analysis of gold-Bitcoin correlation.")[0] == CommandType.CHAT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add deterministic Quickstart smoke coverage for documented REPL slash, SQL, and chat entrypoints.
- Add chat memory acceptance coverage using the real filesystem write path and subsequent prompt injection.
- Add feedback acceptance coverage for writing caller memory through the real filesystem tool.

## Validation
- `uv run ruff check tests/unit_tests/cli/test_core_entrypoint_acceptance.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/agent/node/test_feedback_agentic_node.py`
- `uv run python ci/audit_tests.py --paths tests/unit_tests/cli/test_core_entrypoint_acceptance.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/agent/node/test_feedback_agentic_node.py`
- `uv run pytest tests/unit_tests/cli/test_core_entrypoint_acceptance.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/agent/node/test_feedback_agentic_node.py --tb=short --showlocals --disable-warnings --timeout=120 -q`
- `TEST_CMD_TIMEOUT=900 uv run python ci/run-pr-tests.py upstream/main`

Closes #746.
Closes #747.
Closes #748.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added acceptance test verifying chat node memory file persistence across sequential chat turns.
  * Added acceptance test validating feedback node memory updates to caller nodes.
  * Added acceptance test confirming documented quickstart CLI commands are properly routable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->