### PR TITLE
[Tool] Complete agentic workflow acceptance coverage

### DIFF
--- a/tests/unit_tests/agent/node/test_compare_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_compare_agentic_node.py
@@ -210,6 +210,50 @@ class TestCompareAgenticNodeExecution:
                 pass
 
 
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestCompareProductFlowAcceptance:
+    """Deterministic coverage for compare's SQL verification path."""
+
+    @pytest.mark.asyncio
+    async def test_compare_verifies_sql_with_real_read_query_tool(self, real_agent_config, mock_llm_create):
+        node = _create_compare_node(real_agent_config)
+
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall(
+                            name="read_query",
+                            arguments={"sql": "SELECT COUNT(*) AS row_count FROM satscores"},
+                        ),
+                    ],
+                    content=json.dumps(
+                        {
+                            "explanation": "The SQL can be verified against satscores and answers the request.",
+                            "suggest": "Keep the aggregate query unchanged.",
+                            "output": "verified",
+                        }
+                    ),
+                )
+            ]
+        )
+        node.model = mock_llm_create
+        node.input = _create_compare_input()
+
+        actions = []
+        async for action in node.execute_stream():
+            actions.append(action)
+
+        read_query_results = [item for item in mock_llm_create.tool_results if item["tool"] == "read_query"]
+        assert len(read_query_results) == 1
+        assert read_query_results[0]["executed"] is True
+        assert "row_count" in str(read_query_results[0]["output"])
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert actions[-1].output["success"] is True
+        assert "aggregate query" in actions[-1].output["suggest"]
+
+
 # ===========================================================================
 # Test Static/Utility Methods
 # ===========================================================================

--- a/tests/unit_tests/agent/node/test_explore_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_explore_agentic_node.py
@@ -356,6 +356,57 @@ class TestExploreAgenticNodeExecution:
                 pass
 
 
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestExploreProductFlowAcceptance:
+    """Deterministic coverage for read-only data exploration."""
+
+    @pytest.mark.asyncio
+    async def test_explore_lists_describes_and_samples_real_database(self, real_agent_config, mock_llm_create):
+        """Explore should traverse the real read-only DB tools without write access."""
+        from datus.agent.node.explore_agentic_node import ExploreAgenticNode
+
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall(name="list_tables", arguments={}),
+                        MockToolCall(name="describe_table", arguments={"table_name": "satscores"}),
+                        MockToolCall(
+                            name="read_query",
+                            arguments={"sql": "SELECT cds, AvgScrRead FROM satscores LIMIT 2"},
+                        ),
+                    ],
+                    content="The satscores table includes school identifiers and SAT score columns.",
+                ),
+            ]
+        )
+
+        node = ExploreAgenticNode(
+            node_id="test_explore_acceptance",
+            description="Explore acceptance",
+            node_type=NodeType.TYPE_EXPLORE,
+            agent_config=real_agent_config,
+            node_name="explore",
+        )
+        node.input = ExploreNodeInput(
+            user_message="Explore SAT score fields and provide a small sample.",
+            database="california_schools",
+        )
+
+        ahm = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(ahm):
+            actions.append(action)
+
+        executed_tools = {item["tool"] for item in mock_llm_create.tool_results if item["executed"]}
+        assert {"list_tables", "describe_table", "read_query"} <= executed_tools
+        assert "AvgScrRead" in str(mock_llm_create.tool_results)
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert node.result.success is True
+        assert "satscores" in node.result.response
+
+
 class TestExploreNodeTypeRegistration:
     """Tests for ExploreAgenticNode type registration."""
 

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -821,6 +821,79 @@ class TestGenDashboardExecuteStream:
                         pass
 
 
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestGenDashboardProductFlowAcceptance:
+    """Deterministic coverage for BI dashboard write workflow wiring."""
+
+    @pytest.mark.asyncio
+    async def test_dashboard_creates_dashboard_dataset_and_chart(self, real_agent_config, mock_llm_create):
+        from datus.schemas.action_history import ActionHistoryManager, ActionStatus
+        from datus.schemas.gen_dashboard_agentic_node_models import GenDashboardNodeInput
+        from tests.unit_tests.mock_llm_model import MockToolCall, build_tool_then_response
+
+        _add_dashboard_config(real_agent_config)
+        _bi_core_mock.adapter_registry.get.return_value = lambda **kwargs: FullMockAdapter()
+        with patch.dict(sys.modules, _BI_MODULES_PATCH):
+            from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
+
+            node = GenDashboardAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+            node.input = GenDashboardNodeInput(
+                user_message="Create a SAT score dashboard with one reading score chart.",
+                database="california_schools",
+            )
+            mock_llm_create.reset(
+                responses=[
+                    build_tool_then_response(
+                        tool_calls=[
+                            MockToolCall(
+                                "create_dashboard",
+                                {
+                                    "title": "SAT Score Dashboard",
+                                    "description": "School SAT score summary",
+                                },
+                            ),
+                            MockToolCall(
+                                "create_dataset",
+                                {
+                                    "name": "satscores_dataset",
+                                    "database_id": "1",
+                                    "sql": "SELECT cds, AvgScrRead FROM satscores",
+                                },
+                            ),
+                            MockToolCall(
+                                "create_chart",
+                                {
+                                    "chart_type": "bar",
+                                    "title": "Average Reading Score",
+                                    "dataset_id": "3",
+                                    "metrics": "AVG(AvgScrRead)",
+                                    "dimensions": "cds",
+                                    "dashboard_id": "10",
+                                },
+                            ),
+                        ],
+                        content="Created the SAT score dashboard with a reading score chart.",
+                    )
+                ]
+            )
+
+            ahm = ActionHistoryManager()
+            actions = []
+            async for action in node.execute_stream(ahm):
+                actions.append(action)
+
+        executed_tools = [item["tool"] for item in mock_llm_create.tool_results if item["executed"]]
+        assert executed_tools == ["create_dashboard", "create_dataset", "create_chart"]
+        result_by_tool = {item["tool"]: item["output"]["result"] for item in mock_llm_create.tool_results}
+        assert result_by_tool["create_dashboard"]["id"] == 10
+        assert result_by_tool["create_dataset"]["id"] == 3
+        assert result_by_tool["create_chart"]["id"] == 5
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert actions[-1].output["success"] is True
+        assert "reading score chart" in actions[-1].output["response"]
+
+
 # ---------------------------------------------------------------------------
 # Template Context Tests
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
@@ -23,8 +23,12 @@ Design principle: NO mock except LLM.
 - The ONLY mock: LLMBaseModel.create_model -> MockLLMModel (via `mock_llm_create`)
 """
 
+import json
+
 import pytest
 
+from datus.schemas.action_history import ActionHistoryManager, ActionStatus
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
 from tests.unit_tests.agent.node._builtin_node_test_helpers import (
     check_dynamic_db_func_tool,
     check_execute_stream_basic_workflow,
@@ -42,6 +46,7 @@ from tests.unit_tests.agent.node._builtin_node_test_helpers import (
     check_standard_db_tools,
     check_tools_include,
 )
+from tests.unit_tests.mock_llm_model import MockToolCall, build_tool_then_response
 
 # ---------------------------------------------------------------------------
 # Initialization Tests
@@ -165,6 +170,58 @@ class TestGenJobExecution:
             mock_llm_create,
             "Build ETL job",
         )
+
+
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestGenJobWritePathAcceptance:
+    """Deterministic coverage for the gen_job DDL + DML path."""
+
+    @pytest.mark.asyncio
+    async def test_gen_job_creates_table_inserts_rows_and_reads_back(self, mutable_real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
+
+        create_sql = "CREATE TABLE job_school_summary (school_count INTEGER)"
+        insert_sql = "INSERT INTO job_school_summary (school_count) SELECT COUNT(*) FROM schools"
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall("execute_ddl", {"sql": create_sql}),
+                        MockToolCall(
+                            "execute_write",
+                            {
+                                "sql": insert_sql,
+                                "min_rows": 1,
+                                "max_rows": 1,
+                            },
+                        ),
+                    ],
+                    content=json.dumps(
+                        {
+                            "status": "created",
+                            "target_table": "job_school_summary",
+                        }
+                    ),
+                )
+            ]
+        )
+
+        node = GenJobAgenticNode(agent_config=mutable_real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Create a summary job table with the number of schools.")
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        executed_tools = [item["tool"] for item in mock_llm_create.tool_results if item["executed"]]
+        assert executed_tools == ["execute_ddl", "execute_write"]
+        query_result = node.db_func_tool.read_query("SELECT school_count FROM job_school_summary")
+        assert query_result.success == 1
+        assert "school_count" in str(query_result.result)
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert "job_school_summary" in str(actions[-1].output)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
@@ -668,6 +668,63 @@ class TestExecuteStreamGenReportError:
         assert last.action_type == "error"
 
 
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestGenReportProductFlowAcceptance:
+    """Deterministic coverage for report generation over real DB tools."""
+
+    @pytest.mark.asyncio
+    async def test_report_uses_schema_and_query_results_to_build_report(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
+
+        report_json = json.dumps(
+            {
+                "report": "## SAT Reading Summary\n\nThe report uses satscores and average reading scores.",
+                "data_sources": ["satscores"],
+                "key_findings": ["AvgScrRead is available for SAT reading analysis."],
+            }
+        )
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall("describe_table", {"table_name": "satscores"}),
+                        MockToolCall(
+                            "read_query",
+                            {"sql": "SELECT AVG(AvgScrRead) AS avg_read_score FROM satscores"},
+                        ),
+                    ],
+                    content=report_json,
+                )
+            ]
+        )
+
+        node = GenReportAgenticNode(
+            node_id="report_acceptance",
+            description="Report acceptance",
+            node_type=NodeType.TYPE_GEN_REPORT,
+            agent_config=real_agent_config,
+            node_name="gen_report",
+            execution_mode="workflow",
+        )
+        node.input = GenReportNodeInput(
+            user_message="Create a short SAT reading score summary.",
+            database="california_schools",
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        executed_tools = {item["tool"] for item in mock_llm_create.tool_results if item["executed"]}
+        assert {"describe_table", "read_query"} <= executed_tools
+        assert "avg_read_score" in str(mock_llm_create.tool_results)
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert actions[-1].output["success"] is True
+        assert "SAT Reading Summary" in actions[-1].output["response"]
+
+
 class TestGenReportSystemPromptCurrentDate:
     """Verify current_date is injected into the system prompt."""
 

--- a/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
@@ -284,6 +284,47 @@ class TestGenTableAgenticNodeExecution:
         assert "california_schools" in prompt
 
 
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestGenTableWritePathAcceptance:
+    """Deterministic product-flow coverage for the gen_table DDL path."""
+
+    @pytest.mark.asyncio
+    async def test_gen_table_executes_ctas_and_result_is_queryable(self, mutable_real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
+
+        ctas_sql = "CREATE TABLE school_count_summary AS SELECT COUNT(*) AS school_count FROM schools"
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall("execute_ddl", {"sql": ctas_sql}),
+                    ],
+                    content="Created school_count_summary.",
+                )
+            ]
+        )
+
+        node = GenTableAgenticNode(agent_config=mutable_real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Create a table with the total number of schools.")
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        tool_results = [item for item in mock_llm_create.tool_results if item["tool"] == "execute_ddl"]
+        assert len(tool_results) == 1
+        assert tool_results[0]["executed"] is True
+        assert "school_count_summary" in str(tool_results[0]["output"])
+
+        query_result = node.db_func_tool.read_query("SELECT school_count FROM school_count_summary")
+        assert query_result.success == 1
+        assert "school_count" in str(query_result.result)
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert "school_count_summary" in str(actions[-1].output)
+
+
 # ---------------------------------------------------------------------------
 # Template Context Tests
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
@@ -60,6 +60,73 @@ def _make_mock_scheduler_tools():
     return mock_tools
 
 
+class _ExecutableSchedulerTools:
+    """Small in-memory SchedulerTools substitute for deterministic node acceptance."""
+
+    def __init__(self):
+        self.jobs = {}
+        self.runs = {}
+
+    def available_tools(self):
+        from datus.tools.func_tool.base import trans_to_function_tool
+
+        return [
+            trans_to_function_tool(self.submit_sql_job),
+            trans_to_function_tool(self.trigger_scheduler_job),
+            trans_to_function_tool(self.get_scheduler_job),
+            trans_to_function_tool(self.list_job_runs),
+            trans_to_function_tool(self.get_run_log),
+        ]
+
+    def submit_sql_job(self, job_name: str, sql_file_path: str, conn_id=None, schedule=None, description=None):
+        from datus.tools.func_tool import FuncToolResult
+
+        job_id = job_name.lower().replace(" ", "_")
+        self.jobs[job_id] = {
+            "job_id": job_id,
+            "job_name": job_name,
+            "sql_file_path": sql_file_path,
+            "conn_id": conn_id or "default_sql",
+            "schedule": schedule,
+            "description": description,
+            "status": "active",
+        }
+        return FuncToolResult(
+            result={
+                **self.jobs[job_id],
+                "scheduler": "fake",
+                "platform": "fake",
+            }
+        )
+
+    def trigger_scheduler_job(self, job_id: str):
+        from datus.tools.func_tool import FuncToolResult
+
+        run = {"run_id": "manual__001", "job_id": job_id, "status": "success"}
+        self.runs.setdefault(job_id, []).append(run)
+        return FuncToolResult(result=run)
+
+    def get_scheduler_job(self, job_id: str):
+        from datus.tools.func_tool import FuncToolResult
+
+        job = self.jobs.get(job_id)
+        if job is None:
+            return FuncToolResult(result={"found": False, "job_id": job_id})
+        return FuncToolResult(result={"found": True, **job})
+
+    def list_job_runs(self, job_id: str, limit: int = 10, offset: int = 0):
+        from datus.tools.func_tool import FuncToolResult
+        from datus.tools.func_tool.base import FuncToolListResult
+
+        rows = self.runs.get(job_id, [])[offset : offset + limit]
+        return FuncToolResult(result=FuncToolListResult(items=rows, total=len(self.runs.get(job_id, []))).model_dump())
+
+    def get_run_log(self, job_id: str, run_id: str):
+        from datus.tools.func_tool import FuncToolResult
+
+        return FuncToolResult(result={"job_id": job_id, "run_id": run_id, "log": "finished successfully"})
+
+
 def _scheduler_service_config():
     return {
         "name": "airflow_local",
@@ -493,6 +560,74 @@ class TestSchedulerExecuteStream:
                 with pytest.raises(ExecutionInterrupted):
                     async for _ in node.execute_stream():
                         pass
+
+
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestSchedulerProductFlowAcceptance:
+    """Deterministic coverage for scheduler submit/trigger/read-back workflow."""
+
+    @pytest.mark.asyncio
+    async def test_scheduler_submits_triggers_polls_and_reads_log(self, real_agent_config, mock_llm_create):
+        from datus.schemas.action_history import ActionHistoryManager, ActionStatus
+        from datus.schemas.scheduler_agentic_node_models import SchedulerNodeInput
+        from tests.unit_tests.mock_llm_model import MockToolCall, build_tool_then_response
+
+        scheduler_tools = _ExecutableSchedulerTools()
+        _add_scheduler_config(real_agent_config)
+        with patch(_SCHEDULER_TOOLS_PATCH, return_value=scheduler_tools):
+            from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
+
+            node = SchedulerAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+            node.input = SchedulerNodeInput(
+                user_message="Submit a daily SAT summary job and verify the first run.",
+                database="california_schools",
+            )
+            mock_llm_create.reset(
+                responses=[
+                    build_tool_then_response(
+                        tool_calls=[
+                            MockToolCall(
+                                "submit_sql_job",
+                                {
+                                    "job_name": "daily_sat_summary",
+                                    "sql_file_path": "jobs/daily_sat_summary.sql",
+                                    "schedule": "0 8 * * *",
+                                    "description": "Daily SAT summary",
+                                },
+                            ),
+                            MockToolCall("trigger_scheduler_job", {"job_id": "daily_sat_summary"}),
+                            MockToolCall("get_scheduler_job", {"job_id": "daily_sat_summary"}),
+                            MockToolCall("list_job_runs", {"job_id": "daily_sat_summary", "limit": 5}),
+                            MockToolCall(
+                                "get_run_log",
+                                {"job_id": "daily_sat_summary", "run_id": "manual__001"},
+                            ),
+                        ],
+                        content="Submitted and verified the daily SAT summary scheduler job.",
+                    )
+                ]
+            )
+
+            ahm = ActionHistoryManager()
+            actions = []
+            async for action in node.execute_stream(ahm):
+                actions.append(action)
+
+        executed_tools = [item["tool"] for item in mock_llm_create.tool_results if item["executed"]]
+        assert executed_tools == [
+            "submit_sql_job",
+            "trigger_scheduler_job",
+            "get_scheduler_job",
+            "list_job_runs",
+            "get_run_log",
+        ]
+        assert scheduler_tools.jobs["daily_sat_summary"]["status"] == "active"
+        assert scheduler_tools.runs["daily_sat_summary"][0]["run_id"] == "manual__001"
+        assert "finished successfully" in str(mock_llm_create.tool_results[-1]["output"])
+        assert actions[-1].status == ActionStatus.SUCCESS
+        assert actions[-1].output["success"] is True
+        assert "daily SAT summary scheduler job" in actions[-1].output["response"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
@@ -11,6 +11,7 @@ execute_stream flow, and system prompt rendering.
 NO MOCK EXCEPT LLM: The only mock is LLMBaseModel.create_model -> MockLLMModel.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,7 +22,7 @@ from datus.schemas.action_history import ActionHistoryManager, ActionRole, Actio
 from datus.schemas.gen_skill_agentic_node_models import SkillCreatorNodeInput, SkillCreatorNodeResult
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.skill_tools.skill_func_tool import SkillFuncTool
-from tests.unit_tests.mock_llm_model import MockLLMModel, build_simple_response
+from tests.unit_tests.mock_llm_model import MockLLMModel, MockToolCall, build_simple_response, build_tool_then_response
 
 
 class TestSkillCreatorAgenticNodeInit:
@@ -475,6 +476,164 @@ class TestSkillCreatorExecution:
         assert actions[-1].status == ActionStatus.FAILED
         assert isinstance(node.result, SkillCreatorNodeResult)
         assert node.result.success is False
+
+
+@pytest.mark.acceptance
+@pytest.mark.llm_harness
+class TestSkillCreatorLifecycleAcceptance:
+    """Deterministic create/optimize skill lifecycle coverage with real tools."""
+
+    @pytest.mark.asyncio
+    async def test_create_skill_writes_validates_and_discovers_skill(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
+        from datus.tools.skill_tools import SkillConfig, SkillManager
+
+        skill_name = "school-quality-skill"
+        skill_path = Path(real_agent_config.project_root) / ".datus" / "skills" / skill_name / "SKILL.md"
+        skill_content = """---
+name: school-quality-skill
+description: Analyze school quality indicators from education datasets.
+allowed_agents:
+  - chat
+  - gen_skill
+---
+# School Quality Skill
+
+Use this skill when the user asks for school quality analysis.
+"""
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall("load_skill", {"skill_name": "create-skill"}),
+                        MockToolCall(
+                            "write_file",
+                            {
+                                "path": f".datus/skills/{skill_name}/SKILL.md",
+                                "content": skill_content,
+                            },
+                        ),
+                        MockToolCall("validate_skill", {"skill_path": str(skill_path)}),
+                    ],
+                    content=f"Created and validated {skill_name}.",
+                )
+            ]
+        )
+
+        node = SkillCreatorAgenticNode(
+            node_id="skill_creator_create_acceptance",
+            description="Create skill acceptance",
+            node_type=NodeType.TYPE_GEN_SKILL,
+            agent_config=real_agent_config,
+            node_name="gen_skill",
+            execution_mode="workflow",
+        )
+        node.input = SkillCreatorNodeInput(user_message=f"Create a {skill_name} skill.")
+
+        action_manager = ActionHistoryManager()
+        async for _ in node.execute_stream(action_manager):
+            pass
+
+        assert skill_path.read_text(encoding="utf-8") == skill_content
+        tool_results = {item["tool"]: item for item in mock_llm_create.tool_results}
+        assert tool_results["load_skill"]["executed"] is True
+        assert tool_results["write_file"]["executed"] is True
+        assert tool_results["validate_skill"]["executed"] is True
+        assert "PASS" in str(tool_results["validate_skill"]["output"])
+
+        manager = SkillManager(config=SkillConfig(directories=[str(skill_path.parent)]))
+        discovered = manager.get_skill(skill_name)
+        assert discovered.name == skill_name
+        ok, message, loaded_content = manager.load_skill(skill_name, "chat")
+        assert ok is True
+        assert message == f"Skill '{skill_name}' loaded successfully"
+        assert "School Quality Skill" in loaded_content
+        assert isinstance(node.result, SkillCreatorNodeResult)
+        assert node.result.success is True
+
+    @pytest.mark.asyncio
+    async def test_optimize_skill_reads_updates_validates_and_reloads_skill(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
+        from datus.tools.skill_tools import SkillConfig, SkillManager
+
+        skill_name = "district-profile-skill"
+        skill_dir = Path(real_agent_config.project_root) / ".datus" / "skills" / skill_name
+        skill_path = skill_dir / "SKILL.md"
+        original_content = """---
+name: district-profile-skill
+description: Build concise district profile summaries from education datasets.
+allowed_agents:
+  - chat
+  - gen_skill
+---
+# District Profile Skill
+
+Summarize district-level facts.
+"""
+        updated_content = """---
+name: district-profile-skill
+description: Build district profile summaries with enrollment and performance checks.
+allowed_agents:
+  - chat
+  - gen_skill
+---
+# District Profile Skill
+
+Summarize district-level facts and verify enrollment and performance metrics.
+"""
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_path.write_text(original_content, encoding="utf-8")
+
+        mock_llm_create.reset(
+            responses=[
+                build_tool_then_response(
+                    tool_calls=[
+                        MockToolCall("load_skill", {"skill_name": "optimize-skill"}),
+                        MockToolCall("read_file", {"path": f".datus/skills/{skill_name}/SKILL.md"}),
+                        MockToolCall(
+                            "write_file",
+                            {
+                                "path": f".datus/skills/{skill_name}/SKILL.md",
+                                "content": updated_content,
+                            },
+                        ),
+                        MockToolCall("validate_skill", {"skill_path": str(skill_path)}),
+                    ],
+                    content=f"Optimized and validated {skill_name}.",
+                )
+            ]
+        )
+
+        node = SkillCreatorAgenticNode(
+            node_id="skill_creator_optimize_acceptance",
+            description="Optimize skill acceptance",
+            node_type=NodeType.TYPE_GEN_SKILL,
+            agent_config=real_agent_config,
+            node_name="gen_skill",
+            execution_mode="workflow",
+        )
+        node.input = SkillCreatorNodeInput(user_message=f"Optimize {skill_name}.")
+
+        action_manager = ActionHistoryManager()
+        async for _ in node.execute_stream(action_manager):
+            pass
+
+        assert skill_path.read_text(encoding="utf-8") == updated_content
+        tool_results = {item["tool"]: item for item in mock_llm_create.tool_results}
+        assert tool_results["load_skill"]["executed"] is True
+        assert tool_results["read_file"]["executed"] is True
+        assert "Summarize district-level facts." in str(tool_results["read_file"]["output"])
+        assert tool_results["write_file"]["executed"] is True
+        assert tool_results["validate_skill"]["executed"] is True
+        assert "PASS" in str(tool_results["validate_skill"]["output"])
+
+        manager = SkillManager(config=SkillConfig(directories=[str(skill_dir)]))
+        ok, message, loaded_content = manager.load_skill(skill_name, "chat")
+        assert ok is True
+        assert message == f"Skill '{skill_name}' loaded successfully"
+        assert "verify enrollment and performance metrics" in loaded_content
+        assert isinstance(node.result, SkillCreatorNodeResult)
+        assert node.result.success is True
 
 
 class TestSkillCreatorConfigOverrides:


### PR DESCRIPTION
## Summary
- Add deterministic skill creator lifecycle acceptance for create-skill and optimize-skill through real filesystem, validation, and SkillManager discovery/load paths.
- Add deterministic write-path acceptance for gen_table and gen_job against mutable SQLite, including CTAS, DDL, DML, and read-back checks.
- Complete #745 coverage by adding compare, explore, gen_report, gen_dashboard, and scheduler acceptance flows with real node wiring and executable tools/fakes where external services are optional.

## Validation
- `uv run ruff check tests/unit_tests/agent/node/test_compare_agentic_node.py tests/unit_tests/agent/node/test_explore_agentic_node.py tests/unit_tests/agent/node/test_gen_report_agentic_node.py tests/unit_tests/agent/node/test_gen_job_agentic_node.py tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py tests/unit_tests/agent/node/test_scheduler_agentic_node.py`
- `uv run python ci/audit_tests.py --paths tests/unit_tests/agent/node/test_compare_agentic_node.py tests/unit_tests/agent/node/test_explore_agentic_node.py tests/unit_tests/agent/node/test_gen_report_agentic_node.py tests/unit_tests/agent/node/test_gen_job_agentic_node.py tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py tests/unit_tests/agent/node/test_scheduler_agentic_node.py`
- `uv run pytest tests/unit_tests/agent/node/test_compare_agentic_node.py::TestCompareProductFlowAcceptance tests/unit_tests/agent/node/test_explore_agentic_node.py::TestExploreProductFlowAcceptance tests/unit_tests/agent/node/test_gen_report_agentic_node.py::TestGenReportProductFlowAcceptance tests/unit_tests/agent/node/test_gen_job_agentic_node.py::TestGenJobWritePathAcceptance tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py::TestGenDashboardProductFlowAcceptance tests/unit_tests/agent/node/test_scheduler_agentic_node.py::TestSchedulerProductFlowAcceptance -q`
- `uv run pytest tests/unit_tests/agent/node/test_compare_agentic_node.py tests/unit_tests/agent/node/test_explore_agentic_node.py tests/unit_tests/agent/node/test_gen_report_agentic_node.py tests/unit_tests/agent/node/test_gen_job_agentic_node.py tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py tests/unit_tests/agent/node/test_scheduler_agentic_node.py -q`
- `TEST_CMD_TIMEOUT=900 uv run python ci/run-pr-tests.py upstream/main`

Closes #745.
Closes #749.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive acceptance tests covering table generation, skill creation/optimization, comparison, exploration, dashboard/job/report generation, and scheduler workflows to improve end-to-end validation of database, dashboard, reporting, job, scheduler, and skill flows.
* **Chores**
  * Internal test coverage only — no user-facing changes or required actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->