### PR TITLE
[Tool] Add Grafana nightly BI coverage

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -113,6 +113,7 @@ jobs:
             ./external/datus-db-adapters/datus-spark \
             ./external/datus-bi-adapters/datus-bi-core \
             ./external/datus-bi-adapters/datus-bi-superset \
+            ./external/datus-bi-adapters/datus-bi-grafana \
             ./external/datus-scheduler-adapters/datus-scheduler-core \
             ./external/datus-scheduler-adapters/datus-scheduler-airflow
           uv run playwright install --with-deps chromium
@@ -243,6 +244,9 @@ jobs:
           echo "SUPERSET_PORT=18088" >> $GITHUB_ENV
           echo "SUPERSET_POSTGRES_PORT=15433" >> $GITHUB_ENV
           echo "SUPERSET_URL=http://127.0.0.1:18088" >> $GITHUB_ENV
+          echo "GRAFANA_PORT=13000" >> $GITHUB_ENV
+          echo "GRAFANA_POSTGRES_PORT=15435" >> $GITHUB_ENV
+          echo "GRAFANA_URL=http://127.0.0.1:13000" >> $GITHUB_ENV
           echo "AIRFLOW_HOST_PORT=18080" >> $GITHUB_ENV
           echo "AIRFLOW_URL=http://127.0.0.1:18080/api/v1" >> $GITHUB_ENV
           echo "POSTGRESQL_HOST_PORT=25432" >> $GITHUB_ENV

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -38,6 +38,7 @@ PACKAGE_NAMES = (
     "datus-spark",
     "datus-bi-core",
     "datus-bi-superset",
+    "datus-bi-grafana",
     "datus-scheduler-core",
     "datus-scheduler-airflow",
     "datus-semantic-core",

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -64,6 +64,7 @@ GREENPLUM_COMPOSE="${GREENPLUM_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-greenplum/dock
 HIVE_COMPOSE="${HIVE_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-hive/docker-compose.yml}"
 SPARK_COMPOSE="${SPARK_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-spark/docker-compose.yml}"
 SUPERSET_COMPOSE="${SUPERSET_COMPOSE:-${BI_ADAPTERS_ROOT}/datus-bi-superset/tests/integration/docker-compose.yml}"
+GRAFANA_COMPOSE="${GRAFANA_COMPOSE:-${BI_ADAPTERS_ROOT}/datus-bi-grafana/tests/integration/docker-compose.yml}"
 AIRFLOW_COMPOSE="${AIRFLOW_COMPOSE:-${SCHEDULER_ADAPTERS_ROOT}/datus-scheduler-airflow/tests/integration/docker-compose.yml}"
 
 COMPOSE_FILES=(
@@ -76,11 +77,13 @@ COMPOSE_FILES=(
   "$HIVE_COMPOSE"
   "$SPARK_COMPOSE"
   "$SUPERSET_COMPOSE"
+  "$GRAFANA_COMPOSE"
   "$AIRFLOW_COMPOSE"
 )
 
 COMPOSE_GROUPS=(
   "Superset Nightly Tests"
+  "Grafana Nightly Tests"
   "Airflow Nightly Tests"
   "PostgreSQL Adapter Tests"
   "MySQL Adapter Tests"
@@ -448,6 +451,7 @@ compose_project_slug() {
 
   case "$group_name" in
     "Superset Nightly Tests") echo "superset" ;;
+    "Grafana Nightly Tests") echo "grafana" ;;
     "Airflow Nightly Tests") echo "airflow" ;;
     "PostgreSQL Adapter Tests") echo "postgresql" ;;
     "MySQL Adapter Tests") echo "mysql" ;;
@@ -502,6 +506,7 @@ cleanup_all_compose() {
   for group_name in "${COMPOSE_GROUPS[@]}"; do
     case "$group_name" in
       "Superset Nightly Tests") compose_file="$SUPERSET_COMPOSE" ;;
+      "Grafana Nightly Tests") compose_file="$GRAFANA_COMPOSE" ;;
       "Airflow Nightly Tests") compose_file="$AIRFLOW_COMPOSE" ;;
       "PostgreSQL Adapter Tests") compose_file="$POSTGRES_COMPOSE" ;;
       "MySQL Adapter Tests") compose_file="$MYSQL_COMPOSE" ;;
@@ -714,6 +719,12 @@ export SUPERSET_POSTGRES_PORT="${SUPERSET_POSTGRES_PORT:-15433}"
 export SUPERSET_URL="${SUPERSET_URL:-http://127.0.0.1:${SUPERSET_PORT}}"
 export SUPERSET_USER="${SUPERSET_USER:-admin}"
 export SUPERSET_PASS="${SUPERSET_PASS:-admin}"
+export GRAFANA_PORT="${GRAFANA_PORT:-13000}"
+export GRAFANA_POSTGRES_HOST="${GRAFANA_POSTGRES_HOST:-127.0.0.1}"
+export GRAFANA_POSTGRES_PORT="${GRAFANA_POSTGRES_PORT:-15435}"
+export GRAFANA_URL="${GRAFANA_URL:-http://127.0.0.1:${GRAFANA_PORT}}"
+export GRAFANA_USER="${GRAFANA_USER:-admin}"
+export GRAFANA_PASS="${GRAFANA_PASS:-admin123}"
 export AIRFLOW_HOST_PORT="${AIRFLOW_HOST_PORT:-18080}"
 export AIRFLOW_URL="${AIRFLOW_URL:-http://127.0.0.1:${AIRFLOW_HOST_PORT}/api/v1}"
 export AIRFLOW_USER="${AIRFLOW_USER:-admin}"
@@ -974,6 +985,9 @@ compose_host_port_specs() {
   case "$group_name" in
     "Superset Nightly Tests")
       printf 'Superset web:%s\nSuperset PostgreSQL:%s\n' "${SUPERSET_PORT:-18088}" "${SUPERSET_POSTGRES_PORT:-15433}"
+      ;;
+    "Grafana Nightly Tests")
+      printf 'Grafana web:%s\nGrafana PostgreSQL:%s\n' "${GRAFANA_PORT:-13000}" "${GRAFANA_POSTGRES_PORT:-15435}"
       ;;
     "Airflow Nightly Tests")
       printf 'Airflow web:%s\n' "${AIRFLOW_HOST_PORT:-18080}"
@@ -1252,6 +1266,9 @@ wait_for_compose_client_readiness() {
     "Superset Nightly Tests")
       wait_for_http_readiness "Superset" "${SUPERSET_URL%/}/health" 300
       ;;
+    "Grafana Nightly Tests")
+      wait_for_http_readiness "Grafana" "${GRAFANA_URL%/}/api/health" 300
+      ;;
     "Airflow Nightly Tests")
       airflow_base="${AIRFLOW_URL%/}"
       airflow_base="${airflow_base%/api/v1}"
@@ -1385,6 +1402,7 @@ log "UNIT_TEST_HOME=$UNIT_TEST_HOME"
 log "NIGHTLY_PYTEST_BASETEMP=$NIGHTLY_PYTEST_BASETEMP"
 log "NIGHTLY_COMPOSE_PROJECT_PREFIX=$NIGHTLY_COMPOSE_PROJECT_PREFIX"
 log "SUPERSET_URL=$SUPERSET_URL SUPERSET_PORT=$SUPERSET_PORT SUPERSET_POSTGRES_HOST=$SUPERSET_POSTGRES_HOST SUPERSET_POSTGRES_PORT=$SUPERSET_POSTGRES_PORT"
+log "GRAFANA_URL=$GRAFANA_URL GRAFANA_PORT=$GRAFANA_PORT GRAFANA_POSTGRES_HOST=$GRAFANA_POSTGRES_HOST GRAFANA_POSTGRES_PORT=$GRAFANA_POSTGRES_PORT"
 log "AIRFLOW_URL=$AIRFLOW_URL AIRFLOW_HOST_PORT=$AIRFLOW_HOST_PORT"
 log "POSTGRESQL_HOST=${POSTGRESQL_HOST:-} POSTGRESQL_PORT=${POSTGRESQL_PORT:-} POSTGRESQL_HOST_PORT=${POSTGRESQL_HOST_PORT:-}"
 log "MYSQL_HOST=${MYSQL_HOST:-} MYSQL_PORT=${MYSQL_PORT:-} MYSQL_HOST_PORT=${MYSQL_HOST_PORT:-}"
@@ -1435,6 +1453,7 @@ NIGHTLY_DEDICATED_SUITE_DESELECTS=(
   --deselect tests/integration/agent/test_gen_dashboard_agentic.py
   --deselect tests/integration/agent/test_scheduler_agentic.py
   --deselect tests/integration/tools/test_bi_dashboard.py
+  --deselect tests/integration/tools/test_bi_grafana.py
   --deselect tests/integration/tools/test_reference_template.py
   --deselect tests/integration/adapters/test_postgresql.py
   --deselect tests/integration/adapters/test_mysql.py
@@ -1452,6 +1471,8 @@ run_logged "Main Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PR
 run_logged "Product E2E Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m "nightly and product_e2e and not provider_health" tests/ "${NIGHTLY_DEDICATED_SUITE_DESELECTS[@]}" --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 
 run_compose_suite "Superset Nightly Tests" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
+
+run_compose_suite "Grafana Nightly Tests" "$GRAFANA_COMPOSE" "postgres:300" "grafana:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/tools/test_bi_grafana.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5
 
 run_compose_suite "Airflow Nightly Tests" "$AIRFLOW_COMPOSE" "airflow:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/agent/test_scheduler_agentic.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 

--- a/tests/integration/tools/test_bi_grafana.py
+++ b/tests/integration/tools/test_bi_grafana.py
@@ -1,0 +1,123 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Grafana BI tool integration tests.
+
+These tests exercise the Datus BI tool layer against a real Grafana compose
+environment without involving an LLM.  The adapter's own repository owns the
+deeper Grafana contract tests; this suite verifies Datus wires the adapter,
+service config, and function-tool envelope correctly.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+import pytest
+
+from datus.configuration.agent_config import DashboardConfig, DatasetDbConfig, DbConfig
+from datus.tools.func_tool.bi_tools import BIFuncTool
+from tests.conftest import load_acceptance_config
+
+GRAFANA_URL = os.environ.get("GRAFANA_URL", "http://localhost:3000")
+GRAFANA_USER = os.environ.get("GRAFANA_USER", "admin")
+GRAFANA_PASS = os.environ.get("GRAFANA_PASS", "admin123")
+GRAFANA_POSTGRES_HOST = os.environ.get("GRAFANA_POSTGRES_HOST", "127.0.0.1")
+GRAFANA_POSTGRES_PORT = os.environ.get("GRAFANA_POSTGRES_PORT", "5434")
+
+
+def _is_grafana_running() -> bool:
+    try:
+        return httpx.get(f"{GRAFANA_URL.rstrip('/')}/api/health", timeout=5.0).is_success
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+def grafana_tool() -> BIFuncTool:
+    if not _is_grafana_running():
+        pytest.skip(f"Grafana not reachable at {GRAFANA_URL}. Run the Grafana compose service first.")
+    pytest.importorskip("datus_bi_grafana", reason="datus-bi-grafana package not installed")
+
+    config = load_acceptance_config(datasource="bird_school")
+    config.services.datasources["grafana_postgres"] = DbConfig(
+        type="postgresql",
+        host=GRAFANA_POSTGRES_HOST,
+        port=GRAFANA_POSTGRES_PORT,
+        username="grafana",
+        password="grafana",
+        database="grafana_data",
+        schema="public",
+    )
+    config.dashboard_config["grafana"] = DashboardConfig(
+        platform="grafana",
+        adapter_type="grafana",
+        api_base_url=GRAFANA_URL,
+        username=GRAFANA_USER,
+        password=GRAFANA_PASS,
+        dataset_db=DatasetDbConfig(
+            datasource_ref="grafana_postgres",
+            bi_database_name="datus-test-postgres",
+        ),
+        default=True,
+    )
+
+    tool = BIFuncTool(agent_config=config, bi_service="grafana")
+    if hasattr(tool.adapter, "find_or_create_datasource"):
+        tool.adapter.find_or_create_datasource(
+            name="datus-test-postgres",
+            db_type="grafana-postgresql-datasource",
+            url="postgres:5432",
+            user="grafana",
+            password="grafana",
+            database="grafana_data",
+        )
+    return tool
+
+
+@pytest.mark.nightly
+class TestGrafanaBIFuncTool:
+    def test_list_datasets_uses_real_grafana_adapter(self, grafana_tool: BIFuncTool):
+        result = grafana_tool.list_datasets(limit=10)
+
+        assert result.success == 1, result.error
+        assert isinstance(result.result, dict)
+        assert isinstance(result.result["items"], list)
+        names = [item["name"] for item in result.result["items"]]
+        assert "datus-test-postgres" in names
+
+    def test_dashboard_crud_uses_real_grafana_adapter(self, grafana_tool: BIFuncTool):
+        title = f"[Datus-Nightly] Grafana Tool {uuid.uuid4().hex[:8]}"
+        created_id = ""
+
+        try:
+            created = grafana_tool.create_dashboard(title=title, description="Created by Datus nightly")
+            assert created.success == 1, created.error
+            assert isinstance(created.result, dict)
+            assert isinstance(created.result["id"], str)
+            created_id = str(created.result["id"])
+            assert created.result["name"] == title
+            assert created.result["deliverable_target"]["platform"] == "grafana"
+            assert created.result["deliverable_target"]["dashboard_id"] == created_id
+
+            fetched = grafana_tool.get_dashboard(created_id)
+            assert fetched.success == 1, fetched.error
+            assert isinstance(fetched.result, dict)
+            assert fetched.result["name"] == title
+
+            listed = grafana_tool.list_dashboards(search=title, limit=10)
+            assert listed.success == 1, listed.error
+            assert isinstance(listed.result, dict)
+            assert isinstance(listed.result["items"], list)
+            assert any(str(item["id"]) == created_id for item in listed.result["items"])
+
+            deleted = grafana_tool.delete_dashboard(created_id)
+            created_id = ""
+            assert deleted.success == 1, deleted.error
+            assert deleted.result == {"deleted": True, "dashboard_id": str(created.result["id"])}
+        finally:
+            if created_id:
+                grafana_tool.delete_dashboard(created_id)


### PR DESCRIPTION
## Summary
- Add `datus-bi-grafana` sibling-source install to nightly.
- Add a dedicated Grafana compose suite to the nightly runner and manifest package list.
- Add deterministic Grafana BI tool integration coverage through `BIFuncTool` against real Grafana.

## Validation
- `bash -n ci/run-nightly-tests.sh`
- `uv run ruff check tests/integration/tools/test_bi_grafana.py ci/nightly_manifest.py`
- `uv run pytest tests/unit_tests/ci/test_nightly_manifest.py -q`
- `GRAFANA_URL=http://127.0.0.1:13000 GRAFANA_POSTGRES_HOST=127.0.0.1 GRAFANA_POSTGRES_PORT=15435 uv run pytest -m nightly tests/integration/tools/test_bi_grafana.py -q`

Closes #795
