### PR TITLE
[Feature] Filter use_tools tool_types per agent type

### DIFF
--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -58,31 +58,77 @@ _USER_FACING_TOOL_CATEGORIES: tuple[str, ...] = (
     "filesystem_tools",
 )
 
-_ALL_TOOL_TYPES: dict[str, dict[str, list[str]]] = {
-    category: {"tools": sorted(VALID_TOOL_METHODS[category])} for category in _USER_FACING_TOOL_CATEGORIES
-}
-
 # Filesystem methods an ``ask_*`` agent may use. Mirrors the read-only intent
 # documented in the ``ask_report`` / ``ask_dashboard`` entries of
 # :data:`SUBAGENT_TOOL_REFERENCE`: the consultant reads ``analysis/`` and
 # ``queries/`` to answer follow-ups but must never mutate the artifact.
 _ASK_AGENT_FILESYSTEM_READ_ONLY: tuple[str, ...] = ("glob", "grep", "read_file")
 
-# Read-only catalog returned by ``GET /agent/use_tools`` for ``ask_*`` agents.
-# Replaces the full ``_ALL_TOOL_TYPES`` so the editor never surfaces
-# ``filesystem_tools.write_file`` / ``edit_file`` as available options.
-_ASK_AGENT_TOOL_TYPES: dict[str, dict[str, list[str]]] = {
-    **{
-        category: _ALL_TOOL_TYPES[category]
-        for category in _USER_FACING_TOOL_CATEGORIES
-        if category != "filesystem_tools"
-    },
-    "filesystem_tools": {"tools": list(_ASK_AGENT_FILESYSTEM_READ_ONLY)},
+# Per-agent-type editor whitelist. Previously the saas frontend
+# (``tool-tree.ts`` ``enableToolGroup``) decided which categories the picker
+# would render — only ``gen_sql`` and the catch-all else branch (effectively
+# ``gen_report``) were handled explicitly, which hid filesystem_tools from
+# ask_* even though those agents preselect ``filesystem_tools.read_file`` /
+# ``glob`` / ``grep`` in their defaults. The API is now the single source of
+# truth: each agent type returns exactly the categories the editor should
+# surface, and the frontend can render whatever it receives.
+_TOOL_CATEGORIES_BY_AGENT_TYPE: dict[str, tuple[str, ...]] = {
+    "chat": _USER_FACING_TOOL_CATEGORIES,
+    "gen_sql": (
+        "db_tools",
+        "semantic_tools",
+        "context_search_tools",
+    ),
+    "gen_report": (
+        "db_tools",
+        "semantic_tools",
+        "context_search_tools",
+        "date_parsing_tools",
+        "reference_template_tools",
+    ),
+    "ask_report": (
+        "db_tools",
+        "semantic_tools",
+        "context_search_tools",
+        "reference_template_tools",
+        "date_parsing_tools",
+        "filesystem_tools",
+    ),
+    "ask_dashboard": (
+        "db_tools",
+        "semantic_tools",
+        "context_search_tools",
+        "reference_template_tools",
+        "date_parsing_tools",
+        "filesystem_tools",
+    ),
 }
+
+
+def _build_tool_types(agent_type: str) -> dict[str, dict[str, list[str]]]:
+    """Compose the ``tool_types`` block returned by ``GET /agent/use_tools``
+    for ``agent_type``. Categories are restricted to the per-type whitelist
+    in :data:`_TOOL_CATEGORIES_BY_AGENT_TYPE`; for ``ask_*`` agents,
+    ``filesystem_tools`` is further restricted to the read-only subset so
+    the editor picker never surfaces ``write_file`` / ``edit_file`` as
+    selectable options. ``_validate_tools_for_agent_type`` reads back from
+    the same block, so the per-type catalog stays the single allowlist for
+    both the picker and the write-path validator.
+    """
+    is_ask_agent = agent_type in {"ask_report", "ask_dashboard"}
+    tool_types: dict[str, dict[str, list[str]]] = {}
+    for category in _TOOL_CATEGORIES_BY_AGENT_TYPE[agent_type]:
+        if is_ask_agent and category == "filesystem_tools":
+            tool_types[category] = {"tools": list(_ASK_AGENT_FILESYSTEM_READ_ONLY)}
+        else:
+            tool_types[category] = {"tools": sorted(VALID_TOOL_METHODS[category])}
+    return tool_types
+
 
 # Per-agent-type tool reference. Mirrors the saas Datus-backend contract:
 # ``default_tools`` are wildcard / specific patterns preselected for the type,
-# ``tool_types`` is the full catalog of allowed categories with their methods.
+# ``tool_types`` is the curated catalog of categories the editor should
+# surface for that type (built via :func:`_build_tool_types`).
 SUBAGENT_TOOL_REFERENCE: dict[str, dict[str, Any]] = {
     "chat": {
         "default_tools": [
@@ -93,7 +139,7 @@ SUBAGENT_TOOL_REFERENCE: dict[str, dict[str, Any]] = {
             "filesystem_tools.*",
             "platform_doc_tools.*",
         ],
-        "tool_types": _ALL_TOOL_TYPES,
+        "tool_types": _build_tool_types("chat"),
     },
     "gen_sql": {
         "default_tools": [
@@ -101,14 +147,14 @@ SUBAGENT_TOOL_REFERENCE: dict[str, dict[str, Any]] = {
             "semantic_tools.*",
             "context_search_tools.*",
         ],
-        "tool_types": _ALL_TOOL_TYPES,
+        "tool_types": _build_tool_types("gen_sql"),
     },
     "gen_report": {
         "default_tools": [
             "semantic_tools.*",
             "context_search_tools.list_subject_tree",
         ],
-        "tool_types": _ALL_TOOL_TYPES,
+        "tool_types": _build_tool_types("gen_report"),
     },
     # ask_report / ask_dashboard: read-only follow-up consultant for a single
     # visual artifact. Default tools cover data exploration (db_tools read
@@ -133,7 +179,7 @@ SUBAGENT_TOOL_REFERENCE: dict[str, dict[str, Any]] = {
             "filesystem_tools.glob",
             "filesystem_tools.grep",
         ],
-        "tool_types": _ASK_AGENT_TOOL_TYPES,
+        "tool_types": _build_tool_types("ask_report"),
     },
     "ask_dashboard": {
         "default_tools": [
@@ -152,7 +198,7 @@ SUBAGENT_TOOL_REFERENCE: dict[str, dict[str, Any]] = {
             "filesystem_tools.glob",
             "filesystem_tools.grep",
         ],
-        "tool_types": _ASK_AGENT_TOOL_TYPES,
+        "tool_types": _build_tool_types("ask_dashboard"),
     },
 }
 

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 
 from datus.api.services.agent_service import (
+    _ASK_AGENT_FILESYSTEM_READ_ONLY,
+    _TOOL_CATEGORIES_BY_AGENT_TYPE,
     _USER_FACING_TOOL_CATEGORIES,
     BUILTIN_SUBAGENTS,
     SUBAGENT_TOOL_REFERENCE,
@@ -14,6 +16,7 @@ from datus.api.services.agent_service import (
     VALID_TOOL_METHODS,
     AgentService,
     _build_scoped_context,
+    _build_tool_types,
     _classify_subject_paths,
     _format_csv,
     _merge_subjects_from_scoped_context,
@@ -218,8 +221,15 @@ class TestConstants:
         """gen_sql tool reference has the saas {default_tools, tool_types} shape."""
         entry = SUBAGENT_TOOL_REFERENCE["gen_sql"]
         assert set(entry.keys()) == {"default_tools", "tool_types"}
-        # tool_types is the user-facing curated subset, not every VALID_TOOL_METHODS key
-        assert set(entry["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        # gen_sql surfaces only the 3 categories the saas editor renders for
+        # the type — db / semantic / context_search. Other categories
+        # (filesystem / date_parsing / reference_template) are intentionally
+        # hidden so the picker matches the actual default_tools surface.
+        assert set(entry["tool_types"].keys()) == {
+            "db_tools",
+            "semantic_tools",
+            "context_search_tools",
+        }
         for category, payload in entry["tool_types"].items():
             assert payload == {"tools": sorted(VALID_TOOL_METHODS[category])}
         # gen_sql defaults to db / semantic / context_search wildcards (matches saas)
@@ -276,6 +286,16 @@ class TestConstants:
             "semantic_tools.*",
             "context_search_tools.list_subject_tree",
         ]
+        # gen_report exposes db / semantic / context_search plus date_parsing
+        # and reference_template — the 5-category surface the saas editor's
+        # else-branch rendered before the per-type whitelist moved server-side.
+        assert set(entry["tool_types"].keys()) == {
+            "db_tools",
+            "semantic_tools",
+            "context_search_tools",
+            "date_parsing_tools",
+            "reference_template_tools",
+        }
 
     def test_tool_reference_chat_has_full_default_set(self):
         """chat default_tools enumerates every non-semantic category as wildcard."""
@@ -288,6 +308,12 @@ class TestConstants:
             "filesystem_tools.*",
             "platform_doc_tools.*",
         ]
+        # chat is the most permissive agent type — the picker surfaces every
+        # user-facing category. ``platform_doc_tools`` stays in default_tools
+        # but not in tool_types (matches the documented "valid tool, hidden
+        # from picker" precedent for platform_doc_tools).
+        assert set(entry["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        assert "platform_doc_tools" not in entry["tool_types"]
 
     def test_reference_template_tools_registered(self):
         """reference_template_tools category exposes the 4 expected methods."""
@@ -337,8 +363,13 @@ class TestGetUseTools:
             "semantic_tools.*",
             "context_search_tools.*",
         ]
-        # tool_types covers exactly the user-facing curated categories, each as {"tools": [...]}
-        assert set(result.data["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        # gen_sql surfaces only 3 categories — the per-type whitelist matches
+        # the saas editor's ``gen_sql`` branch in tool-tree.ts.
+        assert set(result.data["tool_types"].keys()) == {
+            "db_tools",
+            "semantic_tools",
+            "context_search_tools",
+        }
         for category, payload in result.data["tool_types"].items():
             assert list(payload.keys()) == ["tools"]
             assert payload["tools"] == sorted(VALID_TOOL_METHODS[category])
@@ -351,7 +382,16 @@ class TestGetUseTools:
             "semantic_tools.*",
             "context_search_tools.list_subject_tree",
         ]
-        assert set(result.data["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        # gen_report's 5-category surface mirrors the saas editor's else
+        # branch — no filesystem_tools because the type has no filesystem
+        # defaults and the picker historically excluded it.
+        assert set(result.data["tool_types"].keys()) == {
+            "db_tools",
+            "semantic_tools",
+            "context_search_tools",
+            "date_parsing_tools",
+            "reference_template_tools",
+        }
 
     def test_chat_includes_reference_template_tools_in_default(self):
         """chat default_tools wires up reference_template_tools.* (saas parity)."""
@@ -359,6 +399,76 @@ class TestGetUseTools:
         assert result.success is True
         assert "reference_template_tools.*" in result.data["default_tools"]
         assert "reference_template_tools" in result.data["tool_types"]
+        # chat is the most permissive agent type; its tool_types covers every
+        # user-facing category so the editor can surface them all.
+        assert set(result.data["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+
+    @pytest.mark.parametrize("agent_type", ["ask_report", "ask_dashboard"])
+    def test_ask_agent_tool_types_includes_filesystem_read_only(self, agent_type):
+        """ask_* exposes filesystem_tools as a read-only subset (glob / grep
+        / read_file) — the editor picker needs to render the category so
+        operators can see (and tweak) the read-side default_tools."""
+        result = AgentService.get_use_tools(agent_type)
+        assert result.success is True
+        tool_types = result.data["tool_types"]
+        # ask_* surfaces 6 categories — the 5 from gen_report's else-branch
+        # plus filesystem_tools restricted to the read-only methods.
+        assert set(tool_types.keys()) == {
+            "db_tools",
+            "semantic_tools",
+            "context_search_tools",
+            "reference_template_tools",
+            "date_parsing_tools",
+            "filesystem_tools",
+        }
+        assert set(tool_types["filesystem_tools"]["tools"]) == set(_ASK_AGENT_FILESYSTEM_READ_ONLY)
+
+
+class TestPerAgentTypeCategoryWhitelist:
+    """Tests for the per-agent-type editor whitelist that previously lived
+    only in the saas frontend (tool-tree.ts).
+
+    The whitelist is now the API's single source of truth: the editor
+    renders whatever ``tool_types`` it receives, and the same block gates
+    the write-path validation for ``ask_*`` agents via
+    :func:`_validate_tools_for_agent_type`.
+    """
+
+    def test_every_subagent_type_has_a_whitelist(self):
+        """Every entry in :data:`SUBAGENT_TOOL_REFERENCE` must have a
+        corresponding category whitelist — otherwise ``_build_tool_types``
+        would KeyError at import time."""
+        for agent_type in SUBAGENT_TOOL_REFERENCE:
+            assert agent_type in _TOOL_CATEGORIES_BY_AGENT_TYPE, (
+                f"{agent_type!r} is missing from _TOOL_CATEGORIES_BY_AGENT_TYPE"
+            )
+
+    def test_whitelist_only_references_known_categories(self):
+        """Every category mentioned in the whitelist must also be a real
+        VALID_TOOL_METHODS entry — otherwise ``_build_tool_types`` would
+        KeyError when composing ``tool_types``."""
+        for agent_type, categories in _TOOL_CATEGORIES_BY_AGENT_TYPE.items():
+            for category in categories:
+                assert category in VALID_TOOL_METHODS, (
+                    f"{agent_type!r} whitelist references unknown category {category!r}"
+                )
+
+    def test_build_tool_types_returns_per_type_categories(self):
+        """``_build_tool_types(agent_type)`` returns exactly the whitelisted
+        categories, in the order declared, with the full method set per
+        category."""
+        for agent_type, categories in _TOOL_CATEGORIES_BY_AGENT_TYPE.items():
+            tool_types = _build_tool_types(agent_type)
+            assert list(tool_types.keys()) == list(categories)
+            for category in categories:
+                payload = tool_types[category]
+                assert set(payload.keys()) == {"tools"}
+                if agent_type in {"ask_report", "ask_dashboard"} and category == "filesystem_tools":
+                    # ask_* filesystem is the read-only subset — write tools
+                    # must be absent and the read trio must be present.
+                    assert set(payload["tools"]) == set(_ASK_AGENT_FILESYSTEM_READ_ONLY)
+                else:
+                    assert payload["tools"] == sorted(VALID_TOOL_METHODS[category])
 
     def test_payload_no_longer_wraps_in_tools_key(self):
         """Old shape {"tools": [...]} is gone — data is now {default_tools, tool_types}."""


### PR DESCRIPTION
## Summary

- `GET /agent/use_tools` now returns a `tool_types` catalog narrowed to the agent type. Previously every entry returned the full `_USER_FACING_TOOL_CATEGORIES` block (or `_ASK_AGENT_TOOL_TYPES` for `ask_*`), and the saas frontend ([`tool-tree.ts`](https://github.com/Datus-ai/Datus-saas/blob/main/packages/web-common/src/modules/agents/components/EditAgent/ToolSelection/tool-tree.ts) `enableToolGroup`) clipped it down per type. That split hid `filesystem_tools` on `ask_report` / `ask_dashboard` even though their defaults preselect `filesystem_tools.read_file` / `glob` / `grep` — the operator saw the tags but had no way to inspect or tweak them in the picker tree.
- Move the whitelist to the API so it is the single source of truth: introduce `_TOOL_CATEGORIES_BY_AGENT_TYPE` and `_build_tool_types`, and have each `SUBAGENT_TOOL_REFERENCE` entry compose its own `tool_types` slice. `ask_*` keeps `filesystem_tools` restricted to the read-only subset (`glob` / `grep` / `read_file`) so the picker still hides `write_file` / `edit_file` and `_validate_tools_for_agent_type` still rejects writes on the create path.
- Per-type surface returned by the API after this change:
  - `chat`: 6 user-facing categories (db / semantic / context_search / reference_template / date_parsing / filesystem)
  - `gen_sql`: 3 (db / semantic / context_search) — matches `tool-tree.ts` gen_sql branch
  - `gen_report`: 5 (above + date_parsing + reference_template) — matches the existing saas else branch
  - `ask_report` / `ask_dashboard`: 6 (gen_report set + read-only filesystem_tools) — restores the previously hidden filesystem category
- No saas frontend changes required.

## Test plan

- [x] `pytest tests/unit_tests/api/services/test_agent_service.py tests/unit_tests/api/services/test_agent_service_ask.py` — 154 passed
- Updated `TestConstants` / `TestGetUseTools` to assert the per-type `tool_types.keys()` instead of the full user-facing tuple
- Added `TestPerAgentTypeCategoryWhitelist` covering the new constant and helper:
  - every `SUBAGENT_TOOL_REFERENCE` key has a whitelist
  - whitelists only reference known `VALID_TOOL_METHODS` categories
  - `_build_tool_types` returns the correct shape (ordered, full method set, ask_* filesystem read-only subset)
- Existing `_validate_tools_for_agent_type` ask_* tests continue to pass (the validator still reads from the same `tool_types` block)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for agent tool management and validation to enhance code maintainability and scalability.

* **Tests**
  * Expanded test coverage to comprehensively validate agent tool type assignment and enforcement across all agent types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->