### PR TITLE
[Feature] Finalize artifact resilience + Claude temperature/top_p fix

### DIFF
--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -949,25 +949,38 @@ def run_finalize_analysis(
             "key_tables": [...],
         }
 
-    Or, on hard failure (LLM call exception or schema validation
-    failure)::
+    Or, on LLM failure (exception or schema validation failure)::
 
         {
             "ok": False,
             "warnings": [...],
             "error": "...",
+            "key_tables": [...],
+            "subject_refs_count": {"metrics": n, "reference_sql": n, "ext_knowledge": n},
         }
+
+    The deterministic, code-only outputs (``subject_refs.json`` and
+    ``manifest.key_tables``) are produced whether or not the finalize
+    LLM call succeeded — both are aggregated from on-disk artifacts
+    (``queries/*.brief.json`` / ``queries/*.sql``) and have no LLM
+    dependency. The follow-up ``ask_*`` consultant depends on
+    ``subject_refs.json`` for subject-library attribution and on
+    ``key_tables`` to skip schema-discovery round-trips, so we keep
+    those usable even when the analytical narrative
+    (``insights.json`` / ``suggested_questions.json``) is unavailable.
 
     Side effects on disk (all best-effort, surfaced via ``warnings``):
 
-    * ``analysis/insights.json`` (report only)
-    * ``analysis/suggested_questions.json``
+    * ``analysis/insights.json`` (report only, LLM-gated)
+    * ``analysis/suggested_questions.json`` (LLM-gated)
     * ``analysis/intent.md`` — curated in place by a separate, dedicated
       LLM call (:func:`run_intent_curation`) that returns a fresh
       markdown body via ``model.generate``; safety checks reject the
       rewrite on empty / fence-only / dramatically-shrunk output.
-    * ``analysis/subject_refs.json`` — present iff non-empty.
-    * ``manifest.json`` — ``key_tables`` field refreshed.
+      Gated on the main finalize LLM succeeding so we don't burn a
+      second LLM call when the first one is already broken.
+    * ``analysis/subject_refs.json`` — present iff non-empty. LLM-free.
+    * ``manifest.json`` — ``key_tables`` field refreshed. LLM-free.
     """
     warnings: List[str] = []
 
@@ -987,28 +1000,40 @@ def run_finalize_analysis(
         existing_suggested_questions=existing_sq,
     )
 
+    output: Optional[FinalizeAnalysisOutput] = None
+    llm_error: Optional[str] = None
+
     try:
         raw = model.generate_with_json_output(prompt)
     except Exception as exc:
         logger.warning("Finalize LLM call failed: %s", exc)
-        return {"ok": False, "warnings": warnings, "error": f"finalize llm call failed: {exc}"}
+        llm_error = f"finalize llm call failed: {exc}"
 
-    try:
-        output = parse_finalize_output(raw, artifact_kind=artifact_kind)
-    except Exception as exc:
-        logger.warning("Finalize output validation failed: %s", exc)
-        return {"ok": False, "warnings": warnings, "error": f"finalize output invalid: {exc}"}
+    if llm_error is None:
+        try:
+            output = parse_finalize_output(raw, artifact_kind=artifact_kind)
+        except Exception as exc:
+            logger.warning("Finalize output validation failed: %s", exc)
+            llm_error = f"finalize output invalid: {exc}"
 
-    warnings.extend(write_finalize_output(analysis_dir, output=output, artifact_kind=artifact_kind))
+    if output is not None:
+        warnings.extend(write_finalize_output(analysis_dir, output=output, artifact_kind=artifact_kind))
 
-    # Independent LLM call: curate intent.md by stripping operational
-    # nudges + pure render adjustments. Failures degrade to "leave the
-    # original file unchanged + record a warning" — never blocks the
-    # main artifact (which is already on disk by now).
-    curation_warning = run_intent_curation(model, analysis_dir / "intent.md")
-    if curation_warning:
-        warnings.append(curation_warning)
+        # Independent LLM call: curate intent.md by stripping operational
+        # nudges + pure render adjustments. Failures degrade to "leave the
+        # original file unchanged + record a warning" — never blocks the
+        # main artifact (which is already on disk by now). Gated on the
+        # main finalize LLM succeeding so we don't keep hammering the
+        # model when it's already returned us nothing usable.
+        curation_warning = run_intent_curation(model, analysis_dir / "intent.md")
+        if curation_warning:
+            warnings.append(curation_warning)
 
+    # Deterministic aggregations below — these only read files on disk
+    # and never call the LLM, so they run regardless of LLM success.
+    # That way an ask_* consultant always has its subject-library
+    # attribution index and key_tables hint to work with, even when the
+    # narrative-side outputs are missing.
     refs = aggregate_subject_refs(queries_dir)
     write_err = write_subject_refs(analysis_dir, refs)
     if write_err:
@@ -1022,15 +1047,31 @@ def run_finalize_analysis(
     if kt_err:
         warnings.append(kt_err)
 
+    subject_refs_count = {
+        "metrics": len(refs.metrics),
+        "reference_sql": len(refs.reference_sql),
+        "ext_knowledge": len(refs.ext_knowledge),
+    }
+
+    if llm_error is not None:
+        # LLM failed but the deterministic outputs are already on disk.
+        # Surface both signals: ``ok=False`` (narrative outputs missing,
+        # consumers should treat insights / suggested_questions as
+        # absent) AND the counts (so callers can see we DID land
+        # subject_refs / key_tables).
+        return {
+            "ok": False,
+            "warnings": warnings,
+            "error": llm_error,
+            "key_tables": key_tables,
+            "subject_refs_count": subject_refs_count,
+        }
+
     warnings.extend(consistency_check(queries_dir=queries_dir, output=output))
 
     return {
         "ok": True,
         "warnings": warnings,
         "key_tables": key_tables,
-        "subject_refs_count": {
-            "metrics": len(refs.metrics),
-            "reference_sql": len(refs.reference_sql),
-            "ext_knowledge": len(refs.ext_knowledge),
-        },
+        "subject_refs_count": subject_refs_count,
     }

--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -1059,6 +1059,22 @@ def run_finalize_analysis(
         # consumers should treat insights / suggested_questions as
         # absent) AND the counts (so callers can see we DID land
         # subject_refs / key_tables).
+        #
+        # Proactively delete any stale narrative files from a prior
+        # successful run so the "absent" signal stays accurate after an
+        # edit-mode rerun whose finalize LLM call fails. Mirrors the
+        # same stale-cleanup contract :func:`write_subject_refs` already
+        # enforces for ``subject_refs.json`` (present-iff-non-empty).
+        # Best-effort: a failed unlink degrades to a warning so finalize
+        # never raises on cleanup.
+        for stale_name in ("insights.json", "suggested_questions.json"):
+            stale_path = analysis_dir / stale_name
+            if stale_path.is_file():
+                try:
+                    stale_path.unlink()
+                except OSError as exc:
+                    logger.warning("Failed to remove stale %s: %s", stale_name, exc)
+                    warnings.append(f"failed to remove stale {stale_name}: {exc}")
         return {
             "ok": False,
             "warnings": warnings,

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -308,9 +308,15 @@ class ClaudeModel(OpenAICompatibleModel):
             Generated text response
         """
         if not self.use_native_api:
-            # Claude API does not allow both temperature and top_p simultaneously.
-            # Explicitly override top_p to None so the parent's default top_p=1.0
-            # is not added to the request — LiteLLM omits None-valued parameters.
+            # Anthropic rejects requests carrying BOTH ``temperature`` and
+            # ``top_p`` with HTTP 400 / ``invalid_request_error`` (the
+            # claude-sonnet-4.x family enforces this strictly). Setting
+            # ``top_p=None`` here is the agreed contract with the parent
+            # ``OpenAICompatibleModel._generate_operation``: an explicit
+            # ``None`` in kwargs tells it to omit the parameter from the
+            # final litellm payload entirely (rather than letting the
+            # non-reasoning default of ``top_p=1.0`` fall through). See
+            # the temperature / top_p block in ``openai_compatible.py``.
             kwargs["top_p"] = None
             self._inject_oauth_headers(kwargs)
             try:

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -374,15 +374,21 @@ class OpenAICompatibleModel(LLMBaseModel):
                     delay = base_delay * (2**attempt)  # Exponential backoff
                     logger.warning(
                         f"API error in {operation_name} (attempt {attempt + 1}/{max_retries + 1}): "
-                        f"{error_code.code} - {error_code.desc}. Retrying in {delay:.1f}s..."
+                        f"{error_code.code} - {error_code.desc}. Retrying in {delay:.1f}s... upstream={e!s}"
                     )
                     time.sleep(delay)
                     continue
                 else:
-                    # Max retries reached or non-retryable error
+                    # Max retries reached or non-retryable error. Surface the
+                    # upstream message verbatim — the wrapper code/desc is
+                    # often too generic (300002 = "Invalid request format,
+                    # content, or model response") and operators end up
+                    # grepping litellm tracebacks to figure out what really
+                    # broke. Keep ``str(e)`` on the same line so a single
+                    # CloudWatch entry has everything.
                     logger.error(
                         f"API error in {operation_name} after {attempt + 1} attempts: "
-                        f"{error_code.code} - {error_code.desc}"
+                        f"{error_code.code} - {error_code.desc}. upstream={e!s}"
                     )
                     raise DatusException(error_code)
             except Exception as e:
@@ -428,15 +434,18 @@ class OpenAICompatibleModel(LLMBaseModel):
                     delay = base_delay * (2**attempt)  # Exponential backoff
                     logger.warning(
                         f"API error in {operation_name} (attempt {attempt + 1}/{max_retries + 1}): "
-                        f"{error_code.code} - {error_code.desc}. Retrying in {delay:.1f}s..."
+                        f"{error_code.code} - {error_code.desc}. Retrying in {delay:.1f}s... upstream={e!s}"
                     )
                     await asyncio.sleep(delay)
                     continue
                 else:
-                    # Max retries reached or non-retryable error
+                    # Max retries reached or non-retryable error — same
+                    # reasoning as the sync ``_with_retry`` path: append
+                    # the upstream message so a single log line carries
+                    # both the wrapper classification and the raw cause.
                     logger.error(
                         f"API error in {operation_name} after {attempt + 1} attempts: "
-                        f"{error_code.code} - {error_code.desc}"
+                        f"{error_code.code} - {error_code.desc}. upstream={e!s}"
                     )
                     raise DatusException(error_code)
             except Exception as e:
@@ -476,9 +485,17 @@ class OpenAICompatibleModel(LLMBaseModel):
             if self.default_headers:
                 params["extra_headers"] = self.default_headers
 
-            # Add temperature: priority is kwargs > model_config > default (0.7)
+            # Add temperature: priority is kwargs > model_config > default (0.7).
+            # An explicit ``None`` in kwargs is the caller's "drop this param"
+            # signal — used by providers like Anthropic that reject some pairs
+            # (the claude-sonnet-4.x family rejects requests carrying BOTH
+            # ``temperature`` and ``top_p`` with HTTP 400 / invalid_request_error).
+            # Skip the param entirely; don't fall through to model_config /
+            # default — those branches would silently re-enable what the
+            # caller just asked us to drop.
             if "temperature" in kwargs:
-                params["temperature"] = kwargs["temperature"]
+                if kwargs["temperature"] is not None:
+                    params["temperature"] = kwargs["temperature"]
             elif self.model_config.temperature is not None:
                 # Use temperature from model config (e.g., kimi-k2.5 requires temperature=1)
                 params["temperature"] = self.model_config.temperature
@@ -486,9 +503,10 @@ class OpenAICompatibleModel(LLMBaseModel):
                 # Add default temperature only for non-reasoning models
                 params["temperature"] = 0.7
 
-            # Add top_p: priority is kwargs > model_config > default (1.0)
+            # Add top_p: same priority + same explicit-None contract as temperature above.
             if "top_p" in kwargs:
-                params["top_p"] = kwargs["top_p"]
+                if kwargs["top_p"] is not None:
+                    params["top_p"] = kwargs["top_p"]
             elif self.model_config.top_p is not None:
                 # Use top_p from model config (e.g., kimi-k2.5 requires top_p=0.95)
                 params["top_p"] = self.model_config.top_p

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -1169,6 +1169,40 @@ class TestRunFinalizeAnalysis:
         manifest = json.loads((artifact_dir / "manifest.json").read_text(encoding="utf-8"))
         assert manifest["key_tables"] == ["finbench.main.Account"]
 
+    def test_stale_narrative_files_removed_on_llm_failure(self, tmp_path: Path):
+        """An edit-mode rerun whose finalize LLM call fails must leave the
+        ``analysis/`` directory in a state consistent with the failure
+        return contract (insights / suggested_questions absent).
+
+        Mirrors the present-iff-non-empty cleanup ``write_subject_refs``
+        already enforces for ``subject_refs.json`` — without this, a
+        consumer reading ``analysis/insights.json`` after a failed
+        rerun would see stale narrative from the previous successful
+        run that doesn't match the current queries on disk.
+        """
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+        # Pretend a previous run produced narrative files on disk.
+        stale_insights = analysis_dir / "insights.json"
+        stale_sq = analysis_dir / "suggested_questions.json"
+        stale_insights.write_text(json.dumps({"insights": []}), encoding="utf-8")
+        stale_sq.write_text(json.dumps({"suggested_questions": []}), encoding="utf-8")
+
+        model = Mock(spec=["generate_with_json_output"])
+        model.generate_with_json_output.side_effect = RuntimeError("LLM is down")
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+        )
+
+        assert result["ok"] is False
+        assert not stale_insights.exists(), "stale insights.json must be removed when finalize LLM fails"
+        assert not stale_sq.exists(), "stale suggested_questions.json must be removed when finalize LLM fails"
+
     def test_intent_curation_skipped_when_main_llm_fails(self, tmp_path: Path):
         """Intent curation is itself an LLM call; skipping it when the
         primary finalize call has already failed avoids burning a second

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -1064,8 +1064,10 @@ class TestRunFinalizeAnalysis:
 
         assert result["ok"] is False
         assert "LLM is down" in result["error"]
-        # No analysis files were written when the LLM call failed up-front.
+        # Narrative outputs (insights / suggested_questions) are LLM-gated and
+        # therefore absent.
         assert not (analysis_dir / "insights.json").exists()
+        assert not (analysis_dir / "suggested_questions.json").exists()
 
     def test_schema_validation_failure_surfaces_as_error(self, tmp_path: Path):
         artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
@@ -1086,3 +1088,110 @@ class TestRunFinalizeAnalysis:
         assert result["ok"] is False
         assert "finalize output invalid" in result["error"]
         assert not (analysis_dir / "insights.json").exists()
+        assert not (analysis_dir / "suggested_questions.json").exists()
+
+    def test_subject_refs_and_key_tables_land_when_llm_exception(self, tmp_path: Path):
+        """Deterministic outputs are decoupled from the LLM call.
+
+        ``subject_refs.json`` is aggregated by walking ``queries/*.brief.json``
+        and ``manifest.key_tables`` is aggregated by parsing ``queries/*.sql``
+        with sqlglot — neither needs the model. The follow-up ``ask_*``
+        consultant depends on both to function, so a failed finalize LLM
+        must not strand them.
+        """
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(
+            tmp_path,
+            brief_uses={"metrics": ["metric:Sales/Revenue.gross_revenue"]},
+            sql_body="SELECT * FROM finbench.main.Account",
+        )
+
+        model = Mock(spec=["generate_with_json_output"])
+        model.generate_with_json_output.side_effect = RuntimeError("LLM is down")
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+        )
+
+        assert result["ok"] is False
+        assert "LLM is down" in result["error"]
+
+        # subject_refs.json was aggregated from the brief and persisted.
+        refs_path = analysis_dir / "subject_refs.json"
+        assert refs_path.is_file(), "subject_refs.json must be written even when the LLM fails"
+        refs = json.loads(refs_path.read_text(encoding="utf-8"))
+        assert [r["id"] for r in refs["metrics"]] == ["metric:Sales/Revenue.gross_revenue"]
+
+        # manifest.key_tables was aggregated by sqlglot and persisted.
+        manifest = json.loads((artifact_dir / "manifest.json").read_text(encoding="utf-8"))
+        assert manifest["key_tables"] == ["finbench.main.Account"]
+
+        # The result dict surfaces the deterministic counts so callers can
+        # see what landed alongside the error.
+        assert result["key_tables"] == ["finbench.main.Account"]
+        assert result["subject_refs_count"] == {"metrics": 1, "reference_sql": 0, "ext_knowledge": 0}
+
+    def test_subject_refs_and_key_tables_land_when_schema_validation_fails(self, tmp_path: Path):
+        """Same decoupling guarantee, but exercised on the schema-validation
+        failure path (LLM returned JSON the model rejected). Both fall back
+        through the same orchestrator branch."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(
+            tmp_path,
+            brief_uses={"metrics": ["metric:Sales/Revenue.gross_revenue"]},
+            sql_body="SELECT * FROM finbench.main.Account",
+        )
+
+        model = Mock(spec=["generate_with_json_output"])
+        # Missing suggested_questions — schema fails.
+        model.generate_with_json_output.return_value = {"insights": []}
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+        )
+
+        assert result["ok"] is False
+        assert "finalize output invalid" in result["error"]
+
+        refs_path = analysis_dir / "subject_refs.json"
+        assert refs_path.is_file()
+        refs = json.loads(refs_path.read_text(encoding="utf-8"))
+        assert [r["id"] for r in refs["metrics"]] == ["metric:Sales/Revenue.gross_revenue"]
+
+        manifest = json.loads((artifact_dir / "manifest.json").read_text(encoding="utf-8"))
+        assert manifest["key_tables"] == ["finbench.main.Account"]
+
+    def test_intent_curation_skipped_when_main_llm_fails(self, tmp_path: Path):
+        """Intent curation is itself an LLM call; skipping it when the
+        primary finalize call has already failed avoids burning a second
+        request on a model that just returned us nothing usable."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+        (analysis_dir / "intent.md").write_text(
+            "### [2026-05-14T10:00:00Z] mode: new\n> real intent\n",
+            encoding="utf-8",
+        )
+
+        model = Mock(spec=["generate_with_json_output", "generate"])
+        model.generate_with_json_output.side_effect = RuntimeError("LLM is down")
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+        )
+
+        assert result["ok"] is False
+        # ``model.generate`` is the intent curation entry point — it must
+        # not have been called when the primary finalize LLM blew up.
+        assert model.generate.call_count == 0

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -262,6 +262,36 @@ class TestClaudeModelGenerate:
             model.generate("hello")
         assert captured_kwargs.get("top_p") is None
 
+    def test_claude_generate_does_not_send_top_p_to_litellm(self):
+        """Regression test for the Anthropic "temperature and top_p" 400.
+
+        Exercises the full pipeline (no mock at the parent boundary) so
+        a regression in either layer surfaces:
+
+        - ClaudeModel.generate sets ``kwargs['top_p'] = None`` (its
+          contract for "drop this param").
+        - OpenAICompatibleModel._generate_operation must then omit
+          ``top_p`` from the litellm payload entirely — NOT forward
+          ``top_p=None`` and rely on the downstream library to filter
+          it (which has been observed to leak through to Anthropic
+          and trigger HTTP 400 / ``invalid_request_error``).
+        """
+        model = _make_claude_model()
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = "ok"
+        mock_resp.choices[0].message.reasoning_content = None
+        mock_resp.choices[0].finish_reason = "stop"
+        mock_resp.model = "claude-sonnet-4-5"
+        mock_resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("hello")
+        call_kwargs = mock_lit.call_args[1]
+        assert "top_p" not in call_kwargs, (
+            "Anthropic rejects requests with both temperature and top_p; "
+            f"the suppression contract must reach litellm.completion. Got top_p={call_kwargs.get('top_p')!r}."
+        )
+
     def test_native_api_path_calls_anthropic_client(self):
         cfg = _make_model_config(use_native_api=True)
         model = _make_claude_model(cfg)

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -280,6 +280,63 @@ class TestGenerate:
         call_kwargs = mock_lit.call_args[1]
         assert call_kwargs["top_p"] == 0.9
 
+    def test_top_p_explicit_none_drops_from_litellm_call(self):
+        """``kwargs['top_p'] = None`` is the caller's "drop this parameter"
+        signal — used by ClaudeModel.generate to honour Anthropic's
+        "temperature and top_p cannot both be specified" rule. The parent
+        must omit top_p from the final litellm payload entirely, NOT
+        forward ``top_p=None`` and rely on the downstream library to
+        filter it (which has been observed to leak through to Anthropic
+        and trigger HTTP 400 / invalid_request_error).
+        """
+        model = _make_model()
+        mock_resp = self._mock_litellm_response("ok")
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt", top_p=None)
+        call_kwargs = mock_lit.call_args[1]
+        assert "top_p" not in call_kwargs, (
+            "Explicit None in kwargs must suppress top_p; observed in call_kwargs "
+            f"as {call_kwargs.get('top_p')!r}."
+        )
+
+    def test_temperature_explicit_none_drops_from_litellm_call(self):
+        """Same suppression contract for temperature, kept symmetric so
+        callers can drop either knob the same way."""
+        model = _make_model()
+        mock_resp = self._mock_litellm_response("ok")
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt", temperature=None)
+        call_kwargs = mock_lit.call_args[1]
+        assert "temperature" not in call_kwargs
+
+    def test_top_p_explicit_none_wins_over_model_config(self):
+        """An explicit ``None`` from the caller must win over a
+        ``model_config.top_p`` value — otherwise ClaudeModel's
+        suppression would silently break on configs that carry a
+        non-default top_p (e.g. anything provider-tuned)."""
+        cfg = _make_model_config(top_p=0.95)
+        model = _make_model(cfg)
+        mock_resp = self._mock_litellm_response("ok")
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt", top_p=None)
+        call_kwargs = mock_lit.call_args[1]
+        assert "top_p" not in call_kwargs
+
+    def test_top_p_explicit_none_blocks_non_reasoning_default(self):
+        """When neither kwargs (non-None) nor model_config provide a
+        value, the non-reasoning code path defaults to ``top_p=1.0``.
+        An explicit ``None`` in kwargs must short-circuit BEFORE that
+        default kicks in — this is the exact path that broke for
+        Claude finalize."""
+        model = _make_model()
+        mock_resp = self._mock_litellm_response("ok")
+        # _uses_completion_tokens_parameter is unset → non-reasoning path,
+        # which is where the default ``top_p=1.0`` lives.
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt", top_p=None)
+        call_kwargs = mock_lit.call_args[1]
+        assert "top_p" not in call_kwargs
+
     def test_max_tokens_passed_through(self):
         model = _make_model()
         mock_resp = self._mock_litellm_response("ok")

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -295,8 +295,7 @@ class TestGenerate:
             model.generate("prompt", top_p=None)
         call_kwargs = mock_lit.call_args[1]
         assert "top_p" not in call_kwargs, (
-            "Explicit None in kwargs must suppress top_p; observed in call_kwargs "
-            f"as {call_kwargs.get('top_p')!r}."
+            f"Explicit None in kwargs must suppress top_p; observed in call_kwargs as {call_kwargs.get('top_p')!r}."
         )
 
     def test_temperature_explicit_none_drops_from_litellm_call(self):

--- a/tests/unit_tests/models/test_openai_compatible_retry.py
+++ b/tests/unit_tests/models/test_openai_compatible_retry.py
@@ -181,8 +181,9 @@ class TestRetryErrorLoggingIncludesUpstream:
         async def always_fails():
             raise _make_api_error(upstream)
 
-        with patch("asyncio.sleep", new_callable=AsyncMock), caplog.at_level(
-            logging.ERROR, logger="datus.models.openai_compatible"
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.ERROR, logger="datus.models.openai_compatible"),
         ):
             with pytest.raises(DatusException):
                 await mock_model._with_retry_async(always_fails, operation_name="text generation", max_retries=0)

--- a/tests/unit_tests/models/test_openai_compatible_retry.py
+++ b/tests/unit_tests/models/test_openai_compatible_retry.py
@@ -12,12 +12,15 @@ Covers:
 CI level: zero external deps, mock all SDK interactions.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agents.exceptions import ModelBehaviorError
+from openai import APIError
 
 from datus.models.openai_compatible import OpenAICompatibleModel
+from datus.utils.exceptions import DatusException
 
 
 @pytest.fixture
@@ -110,3 +113,82 @@ class TestWithRetryAsyncModelBehaviorError:
         assert sleep_delays[0] == 1.0
         assert sleep_delays[1] == 2.0
         assert sleep_delays[2] == 4.0
+
+
+class _FakeAPIError(APIError):
+    """A raisable :class:`APIError` whose ``str()`` is the upstream text.
+
+    ``MagicMock(spec=APIError)`` works for ``classify_openai_compatible_error``
+    (which only inspects ``str(e)``) but Python's ``raise`` machinery
+    refuses it ("exceptions must derive from BaseException"). A real
+    subclass keeps both the isinstance check in ``_with_retry`` and
+    Python's raise contract happy.
+    """
+
+    def __init__(self, message: str, status_code: int = 400):
+        # Skip ``APIError.__init__`` — it requires an httpx.Request we don't
+        # need for the test. Set the attributes the wrapper reads directly.
+        Exception.__init__(self, message)
+        self._message = message
+        self.status_code = status_code
+
+    def __str__(self) -> str:
+        return self._message
+
+
+def _make_api_error(message: str) -> APIError:
+    """Build a fake non-retryable APIError carrying the upstream message."""
+    return _FakeAPIError(message)
+
+
+class TestRetryErrorLoggingIncludesUpstream:
+    """Regression guard for the post-mortem on the Anthropic
+    ``temperature and top_p cannot both be specified`` 400.
+
+    The wrapper's ``error_code.code`` / ``error_code.desc`` rolls every
+    HTTP 400 into the generic ``300002 / Invalid request format,
+    content, or model response``, which gives operators nothing to
+    grep on. The upstream message (``str(e)``) carries the actual
+    cause and must appear in the same log line so a single CloudWatch
+    entry resolves the incident.
+    """
+
+    def test_sync_retry_final_error_log_includes_upstream_message(self, mock_model, caplog):
+        upstream = "`temperature` and `top_p` cannot both be specified for this model."
+
+        def always_fails():
+            raise _make_api_error(upstream)
+
+        with patch("time.sleep"), caplog.at_level(logging.ERROR, logger="datus.models.openai_compatible"):
+            with pytest.raises(DatusException):
+                mock_model._with_retry(always_fails, operation_name="text generation", max_retries=0)
+
+        # The wrapper classification (whatever code it lands on) AND the
+        # raw upstream cause must both appear in the final error log.
+        # The hardening contract is "operators get the actual upstream
+        # text on a single line"; the specific wrapper code is determined
+        # by classify_openai_compatible_error and tested elsewhere.
+        final_error_records = [r for r in caplog.records if "after" in r.getMessage() and "attempts" in r.getMessage()]
+        assert final_error_records, "expected an 'after N attempts' error log line"
+        msg = final_error_records[-1].getMessage()
+        assert "text generation" in msg
+        assert upstream in msg, f"upstream cause must be in the final error log; got: {msg!r}"
+
+    @pytest.mark.asyncio
+    async def test_async_retry_final_error_log_includes_upstream_message(self, mock_model, caplog):
+        upstream = "`temperature` and `top_p` cannot both be specified for this model."
+
+        async def always_fails():
+            raise _make_api_error(upstream)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock), caplog.at_level(
+            logging.ERROR, logger="datus.models.openai_compatible"
+        ):
+            with pytest.raises(DatusException):
+                await mock_model._with_retry_async(always_fails, operation_name="text generation", max_retries=0)
+
+        final_error_records = [r for r in caplog.records if "after" in r.getMessage() and "attempts" in r.getMessage()]
+        assert final_error_records, "expected an 'after N attempts' error log line"
+        msg = final_error_records[-1].getMessage()
+        assert "text generation" in msg
+        assert upstream in msg


### PR DESCRIPTION
This PR bundles two related fixes — both surfaced by the same dev incident where a ``gen_report`` run produced query + render artifacts but the ``analysis/`` directory shipped without ``insights.json`` / ``suggested_questions.json`` / ``subject_refs.json`` and ``manifest.key_tables`` stayed empty.

## 1. Make code-only finalize outputs survive an LLM failure

``run_finalize_analysis`` previously returned early the moment the finalize LLM call failed (either the request itself or the schema validation of its response), leaving ``analysis/subject_refs.json`` and ``manifest.key_tables`` unwritten — even though both are produced by pure-code aggregations that have no LLM dependency (``aggregate_subject_refs`` walks ``queries/*.brief.json``; ``aggregate_referenced_tables`` parses ``queries/*.sql`` with sqlglot).

The follow-up ``ask_*`` consultant depends on both files (subject-library attribution + key_tables hint to skip schema discovery). A broken LLM call was stranding consultants with neither.

Restructure the orchestrator so the deterministic aggregations always run, regardless of LLM success. Narrative outputs (``insights.json`` / ``suggested_questions.json``) and intent curation stay gated on the primary LLM call succeeding — those genuinely need ``output: FinalizeAnalysisOutput``, and re-running the second LLM call (intent curation) when the first one already failed just burns a request on a broken model.

LLM-failure return shape additively gains ``key_tables`` and ``subject_refs_count`` so callers can see what landed alongside the error. The existing non-test caller (``base_visual_artifact_agentic_node._run_finalize``) only reads ``warnings`` / ``error``, so the extra keys are non-breaking.

## 2. Stop sending both ``temperature`` and ``top_p`` to Anthropic; surface the upstream cause in logs

Root cause of the incident — pulled out of CloudWatch via the dev trace:

> ``litellm.BadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"\`temperature\` and \`top_p\` cannot both be specified for this model. ..."}}``

``ClaudeModel.generate`` sets ``kwargs["top_p"] = None`` before delegating to the parent so the request does not carry both knobs (Anthropic rejects that pair with HTTP 400; the claude-sonnet-4.x family enforces it strictly). The comment claimed "LiteLLM omits None-valued parameters" — in practice the parent's ``_generate_operation`` was writing ``params["top_p"] = None`` and litellm was forwarding it through to Anthropic, which counts ``null`` as "specified" and 400s the call.

This is exactly the path ``generate_with_json_output`` takes for the finalize stage. The 28 chat tool-call requests preceding the finalize call succeeded because ``generate_with_tools_stream`` gates ``temperature`` / ``top_p`` on ``model_config`` and never defaults them on Claude — only ``generate()`` has the "non-reasoning default ``top_p=1.0``" branch that re-introduced the parameter.

Fixes:
- In ``OpenAICompatibleModel._generate_operation`` treat an explicit ``None`` in kwargs as the caller's "drop this parameter" signal — skip the param entirely instead of falling through to model_config / non-reasoning defaults. Symmetric treatment for ``temperature`` and ``top_p``.
- Rewrite the comment in ``claude_model.py`` to describe the actual contract.
- ``_with_retry`` / ``_with_retry_async`` final-failure logs now append ``str(e)`` so a single record carries both the wrapper classification AND the raw upstream message. Diagnosing this bug originally required dumping the full litellm traceback from CloudWatch by hand because the wrapper only emitted ``300002 / Invalid request format, content, or model response`` — too generic to grep on.

## Test plan

- [x] ``pytest tests/unit_tests/models/`` — 675 passed (covers ``test_openai_compatible.py`` / ``test_openai_compatible_retry.py`` / ``test_claude_model.py``).
- [x] ``pytest tests/unit_tests/agent/node/test_visual_artifact_finalize.py`` — 65 passed.
- Existing failure-path tests tightened to also confirm ``suggested_questions.json`` is absent (alongside ``insights.json``).
- New ``test_subject_refs_and_key_tables_land_when_llm_exception`` / ``test_subject_refs_and_key_tables_land_when_schema_validation_fails``: ``subject_refs.json`` + ``manifest.key_tables`` land on both LLM failure modes.
- New ``test_intent_curation_skipped_when_main_llm_fails``: ``model.generate`` (intent curation entry point) must not be called when the primary finalize LLM fails.
- New ``test_top_p_explicit_none_drops_from_litellm_call`` / ``test_temperature_explicit_none_drops_from_litellm_call`` / ``test_top_p_explicit_none_wins_over_model_config`` / ``test_top_p_explicit_none_blocks_non_reasoning_default``: pin the "explicit None = drop" contract at the litellm boundary across kwargs / config / default precedence.
- New ``test_claude_generate_does_not_send_top_p_to_litellm``: end-to-end pipeline assertion that would have caught the original bug (ClaudeModel.generate → real parent → mocked ``litellm.completion`` → assert ``top_p`` absent).
- New ``TestRetryErrorLoggingIncludesUpstream``: both sync and async final-error logs must contain the upstream cause text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Finalization always writes deterministic artifacts (manifest/key tables, subject refs and counts) even if the AI step fails; errors are reported without short-circuiting aggregation. Stale narrative outputs are removed on failure and consistency checks are skipped when AI fails.
  * AI request parameter handling now omits explicitly unset fields (e.g., temperature/top_p) to avoid upstream API errors.

* **Tests**
  * Expanded tests covering AI failure paths, deterministic fallbacks, removal of stale narratives, intent curation skip, and parameter-omission behavior.

* **Documentation**
  * Clarified behavior: deterministic outputs remain available when the finalize AI call fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->