### PR TITLE
[Tool] Use package metadata for runtime version

### DIFF
--- a/ci/check_release_readiness.py
+++ b/ci/check_release_readiness.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import argparse
-import ast
 import importlib.metadata as metadata
 import json
 import subprocess
@@ -52,19 +51,6 @@ def read_pyproject_version(repo_root: Path) -> Version:
     return Version(version)
 
 
-def read_package_init_version(repo_root: Path) -> Version:
-    init_path = repo_root / "datus" / "__init__.py"
-    module = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
-    for node in module.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        if not any(isinstance(target, ast.Name) and target.id == "__version__" for target in node.targets):
-            continue
-        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-            return Version(node.value.value)
-    raise ValueError(f"Unable to find string __version__ assignment in {init_path}")
-
-
 def parse_dependency_list(requirement_lines: Iterable[str]) -> dict[str, Requirement]:
     requirements: dict[str, Requirement] = {}
     for raw_line in requirement_lines:
@@ -101,12 +87,6 @@ def lower_bound(requirement: Requirement) -> Version | None:
 def check_source_version_consistency(repo_root: Path, expected_version: str | None = None) -> list[str]:
     errors: list[str] = []
     pyproject_version = read_pyproject_version(repo_root)
-    init_version = read_package_init_version(repo_root)
-
-    if pyproject_version != init_version:
-        errors.append(
-            f"Version mismatch: pyproject.toml project.version={pyproject_version}, datus.__version__={init_version}"
-        )
 
     if expected_version is not None and pyproject_version != Version(expected_version):
         errors.append(f"Expected release version {expected_version}, but pyproject.toml has {pyproject_version}")

--- a/ci/prepare_release.py
+++ b/ci/prepare_release.py
@@ -71,23 +71,6 @@ def update_project_version(pyproject_path: Path, version: Version) -> bool:
     return changed
 
 
-def update_init_version(init_path: Path, version: Version) -> bool:
-    content = init_path.read_text(encoding="utf-8")
-    updated, count = re.subn(
-        r'^__version__ = "[^"]+"$',
-        f'__version__ = "{version}"',
-        content,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    if count != 1:
-        raise ValueError(f"Unable to update __version__ in {init_path}")
-    if updated != content:
-        init_path.write_text(updated, encoding="utf-8")
-        return True
-    return False
-
-
 def update_dependency_lower_bounds(path: Path, bounds: dict[str, Version], *, quoted: bool) -> bool:
     content = path.read_text(encoding="utf-8")
     updated = content
@@ -126,13 +109,10 @@ def prepare_release(
     changed: list[Path] = []
 
     pyproject_path = repo_root / "pyproject.toml"
-    init_path = repo_root / "datus" / "__init__.py"
     requirements_path = repo_root / "requirements.txt"
 
     if update_project_version(pyproject_path, version):
         changed.append(pyproject_path)
-    if update_init_version(init_path, version):
-        changed.append(init_path)
 
     if update_adapter_bounds:
         bounds = latest_adapter_bounds(timeout=pypi_timeout, allow_prerelease=allow_prerelease)

--- a/datus/__init__.py
+++ b/datus/__init__.py
@@ -5,10 +5,44 @@
 """Datus - Data engineering agent builds evolvable context for your data system"""
 
 import os
+import tomllib
+from importlib import metadata as importlib_metadata
+from pathlib import Path
 
 # LiteLLM otherwise GETs https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
 # at import time. We don't rely on the freshest cost map, so default to the
 # bundled backup. User can opt back in by setting the env var to "false".
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")
 
-__version__ = "0.3.0"
+_DISTRIBUTION_NAME = "datus-agent"
+
+
+def _read_source_tree_version() -> str | None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    try:
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    project = pyproject.get("project")
+    if not isinstance(project, dict) or project.get("name") != _DISTRIBUTION_NAME:
+        return None
+
+    version = project.get("version")
+    return version if isinstance(version, str) and version else None
+
+
+def _package_version() -> str:
+    # Source checkouts may run without installing the current package, while a
+    # stale global datus-agent distribution can still exist on the runner.
+    source_tree_version = _read_source_tree_version()
+    if source_tree_version is not None:
+        return source_tree_version
+
+    try:
+        return importlib_metadata.version(_DISTRIBUTION_NAME)
+    except importlib_metadata.PackageNotFoundError:
+        return "0+unknown"
+
+
+__version__ = _package_version()

--- a/tests/unit_tests/ci/test_check_release_readiness.py
+++ b/tests/unit_tests/ci/test_check_release_readiness.py
@@ -24,11 +24,11 @@ def check_release_readiness(monkeypatch):
     return module
 
 
-def _write_release_repo(tmp_path: Path, *, version: str = "0.2.6", init_version: str | None = None) -> Path:
+def _write_release_repo(tmp_path: Path, *, version: str = "0.2.6") -> Path:
     repo_root = tmp_path
     (repo_root / "datus").mkdir()
     (repo_root / "datus" / "__init__.py").write_text(
-        f'__version__ = "{init_version or version}"\n',
+        'raise RuntimeError("release readiness should not import datus")\n',
         encoding="utf-8",
     )
     (repo_root / "pyproject.toml").write_text(
@@ -69,14 +69,13 @@ def test_source_version_consistency_accepts_matching_versions(tmp_path, check_re
     assert errors == []
 
 
-def test_source_version_consistency_rejects_mismatched_init_version(tmp_path, check_release_readiness):
-    repo_root = _write_release_repo(tmp_path, version="0.2.6", init_version="0.2.5")
+def test_source_version_consistency_uses_pyproject_as_source_of_truth(tmp_path, check_release_readiness):
+    repo_root = _write_release_repo(tmp_path, version="0.2.6")
+    (repo_root / "datus" / "__init__.py").write_text('__version__ = "0.2.5"\n', encoding="utf-8")
 
     errors = check_release_readiness.check_source_version_consistency(repo_root)
 
-    assert "Version mismatch" in errors[0]
-    assert "0.2.6" in errors[0]
-    assert "0.2.5" in errors[0]
+    assert errors == []
 
 
 def test_source_version_consistency_rejects_unexpected_release_version(tmp_path, check_release_readiness):

--- a/tests/unit_tests/ci/test_prepare_release.py
+++ b/tests/unit_tests/ci/test_prepare_release.py
@@ -32,7 +32,12 @@ def _write_release_repo(tmp_path: Path) -> Path:
             '''
             """Datus"""
 
-            __version__ = "0.2.6"
+            from importlib import metadata as importlib_metadata
+
+            try:
+                __version__ = importlib_metadata.version("datus-agent")
+            except importlib_metadata.PackageNotFoundError:
+                __version__ = "0+unknown"
             '''
         ).lstrip(),
         encoding="utf-8",
@@ -109,12 +114,11 @@ def test_prepare_release_updates_version_and_adapter_bounds(tmp_path, monkeypatc
     )
 
     assert {path.relative_to(repo_root).as_posix() for path in changed} == {
-        "datus/__init__.py",
         "pyproject.toml",
         "requirements.txt",
     }
     assert 'version = "0.2.7"' in (repo_root / "pyproject.toml").read_text(encoding="utf-8")
-    assert '__version__ = "0.2.7"' in (repo_root / "datus" / "__init__.py").read_text(encoding="utf-8")
+    assert 'version("datus-agent")' in (repo_root / "datus" / "__init__.py").read_text(encoding="utf-8")
     assert '"datus-db-core>=0.1.4"' in (repo_root / "pyproject.toml").read_text(encoding="utf-8")
     assert "datus-semantic-core>=0.2.1" in (repo_root / "requirements.txt").read_text(encoding="utf-8")
 
@@ -138,7 +142,6 @@ def test_prepare_release_can_leave_adapter_bounds_unchanged(tmp_path, monkeypatc
     )
 
     assert {path.relative_to(repo_root).as_posix() for path in changed} == {
-        "datus/__init__.py",
         "pyproject.toml",
     }
     assert '"datus-db-core>=0.1.3"' in (repo_root / "pyproject.toml").read_text(encoding="utf-8")

--- a/tests/unit_tests/test_package_version.py
+++ b/tests/unit_tests/test_package_version.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.metadata as metadata
+import importlib.util
+import tomllib
+from pathlib import Path
+
+INIT_PATH = Path(__file__).resolve().parents[2] / "datus" / "__init__.py"
+PYPROJECT_PATH = INIT_PATH.parents[1] / "pyproject.toml"
+
+
+def _load_datus_init(init_path: Path = INIT_PATH):
+    module_spec = importlib.util.spec_from_file_location("_test_datus_init", init_path)
+    if module_spec is None or module_spec.loader is None:
+        raise AssertionError(f"Unable to load datus package init from {init_path}")
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+    return module
+
+
+def _project_version() -> str:
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    return pyproject["project"]["version"]
+
+
+def _copied_init_without_pyproject(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "site-packages" / "datus"
+    package_dir.mkdir(parents=True)
+    init_path = package_dir / "__init__.py"
+    init_path.write_text(INIT_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    return init_path
+
+
+def _patch_pyproject_read(monkeypatch, value: str | Exception) -> None:
+    original_read_text = Path.read_text
+
+    def fake_read_text(self: Path, *args, **kwargs) -> str:
+        if self.name == "pyproject.toml":
+            if isinstance(value, Exception):
+                raise value
+            return value
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+
+def test_source_checkout_version_comes_from_pyproject(monkeypatch):
+    requested_names: list[str] = []
+
+    def fake_version(distribution_name: str) -> str:
+        requested_names.append(distribution_name)
+        return "0.2.6"
+
+    monkeypatch.setattr(metadata, "version", fake_version)
+
+    module = _load_datus_init()
+
+    assert module.__version__ == _project_version()
+    assert requested_names == []
+
+
+def test_source_checkout_falls_back_to_distribution_when_pyproject_is_unavailable(monkeypatch):
+    requested_names: list[str] = []
+
+    def fake_version(distribution_name: str) -> str:
+        requested_names.append(distribution_name)
+        return "1.2.3"
+
+    _patch_pyproject_read(monkeypatch, OSError("missing pyproject"))
+    monkeypatch.setattr(metadata, "version", fake_version)
+
+    module = _load_datus_init()
+
+    assert module.__version__ == "1.2.3"
+    assert requested_names == ["datus-agent"]
+
+
+def test_source_checkout_ignores_unrelated_pyproject(monkeypatch):
+    requested_names: list[str] = []
+
+    def fake_version(distribution_name: str) -> str:
+        requested_names.append(distribution_name)
+        return "1.2.3"
+
+    _patch_pyproject_read(monkeypatch, '[project]\nname = "other-package"\nversion = "9.9.9"\n')
+    monkeypatch.setattr(metadata, "version", fake_version)
+
+    module = _load_datus_init()
+
+    assert module.__version__ == "1.2.3"
+    assert requested_names == ["datus-agent"]
+
+
+def test_installed_package_version_comes_from_distribution_metadata(monkeypatch, tmp_path):
+    init_path = _copied_init_without_pyproject(tmp_path)
+    requested_names: list[str] = []
+
+    def fake_version(distribution_name: str) -> str:
+        requested_names.append(distribution_name)
+        return "1.2.3"
+
+    monkeypatch.setattr(metadata, "version", fake_version)
+
+    module = _load_datus_init(init_path)
+
+    assert module.__version__ == "1.2.3"
+    assert requested_names == ["datus-agent"]
+
+
+def test_package_version_falls_back_when_distribution_metadata_is_missing(monkeypatch):
+    def fake_version(_distribution_name: str) -> str:
+        raise metadata.PackageNotFoundError("datus-agent")
+
+    _patch_pyproject_read(monkeypatch, OSError("missing pyproject"))
+    monkeypatch.setattr(metadata, "version", fake_version)
+
+    module = _load_datus_init()
+
+    assert module.__version__ == "0+unknown"


### PR DESCRIPTION
## Summary
- derive datus.__version__ from installed datus-agent package metadata
- make pyproject.toml the only source version updated by release tooling
- update release-readiness and release-preparation tests for the new source-of-truth model

## Validation
- uv run pytest tests/unit_tests/test_package_version.py tests/unit_tests/ci/test_check_release_readiness.py tests/unit_tests/ci/test_prepare_release.py
- uv run ruff check datus/__init__.py ci/check_release_readiness.py ci/prepare_release.py tests/unit_tests/test_package_version.py tests/unit_tests/ci/test_check_release_readiness.py tests/unit_tests/ci/test_prepare_release.py
- uv run python ci/check_release_readiness.py --repo-root . --check-installed-metadata --check-console-versions
- uv run python -m build --wheel --sdist --outdir /tmp/datus-version-check-dist
- uv run twine check /tmp/datus-version-check-dist/*
- clean venv wheel import check for datus.__version__
- uv run pytest tests/unit_tests/ --maxfail=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switch to dynamic package metadata for versioning with a "0+unknown" fallback; stop treating the package initializer as the authoritative source for release version checks.
  * Stop updating the package initializer during release preparation; version updates are now driven from project metadata.
  * Remove the automatic consistency check against the initializer’s hard-coded version while preserving explicit expected-version validation.
* **Tests**
  * Update and add unit tests to validate dynamic version resolution, fallback behaviors, and adjusted release-preparation expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->