### PR TITLE
[Refactor] Flatten report_html_renderer payload to {files: [{path, content}]}

### DIFF
--- a/datus/agent/node/report_html_renderer.py
+++ b/datus/agent/node/report_html_renderer.py
@@ -111,7 +111,14 @@ def _read_artifact_files(report_dir: Path) -> List[Dict[str, str]]:
     ``render/app.jsx``, ``queries/q.sql``). Only directories listed in
     ``_ARTIFACT_DIRS`` are walked, and each entry's suffix is checked against
     the allowlist so a stray scratch file doesn't bloat the inline payload.
+
+    Each candidate path is resolved before reading so that a symlink under
+    ``render/`` / ``queries/`` cannot exfiltrate a file from outside the
+    report directory into the inline HTML payload — the LLM controls these
+    paths and a stray ``ln -s /etc/passwd render/foo.jsx`` would otherwise
+    end up in the bundle.
     """
+    report_dir_resolved = report_dir.resolve()
     entries: List[Dict[str, str]] = []
     for sub, (allowed_suffixes, recursive) in _ARTIFACT_DIRS.items():
         root = report_dir / sub
@@ -121,8 +128,14 @@ def _read_artifact_files(report_dir: Path) -> List[Dict[str, str]]:
         for path in iterator:
             if not path.is_file() or path.suffix.lower() not in allowed_suffixes:
                 continue
-            rel = path.relative_to(report_dir).as_posix()
-            entries.append({"path": rel, "content": path.read_text(encoding="utf-8")})
+            resolved = path.resolve()
+            try:
+                rel = resolved.relative_to(report_dir_resolved).as_posix()
+            except ValueError:
+                # Symlink (or other indirection) escapes the report root —
+                # drop silently rather than leak content from outside.
+                continue
+            entries.append({"path": rel, "content": resolved.read_text(encoding="utf-8")})
     entries.sort(key=lambda entry: entry["path"])
     return entries
 

--- a/datus/agent/node/report_html_renderer.py
+++ b/datus/agent/node/report_html_renderer.py
@@ -8,13 +8,16 @@ Compile a Datus report artifact into a single self-contained ``index.html``.
 Used only by the Datus-CLI path. SaaS deployments render dynamically through
 the backend ``/api/v1/report/detail`` endpoint and do not call this function.
 
-The generated HTML inlines two payloads next to ``@datus/web-report``:
+The generated HTML inlines a single payload next to ``@datus/web-report``:
 
-* The agent's ``render/`` tree as ``render_files: [{name, content}, ...]``
-  inside a single ``<script type="application/json">`` block. ``name`` is
-  the path relative to ``render/`` (e.g. ``app.jsx``, ``kpi-banner.jsx``,
-  ``charts/trend.jsx``).
-* ``queries/<slug>.sql`` + ``.json`` as ``queries: [{name, content}, ...]``.
+* ``files: [{path, content}, ...]`` inside one ``<script type="application/json">``
+  block. ``path`` is **slug-relative** and includes the top-level directory
+  prefix (e.g. ``render/app.jsx``, ``render/charts/trend.jsx``,
+  ``queries/sales_by_zone.sql``). Allowed prefixes: ``render/`` (.jsx / .js /
+  .css / .json, recursive — JSON allowed for sidecars an LLM may park next
+  to its modules) and ``queries/`` (.sql / .json, one level). This matches
+  the ``IPublishedReportArtifact`` / ``IReportDetail`` shape that
+  ``@datus/web-report`` consumes via ``splitArtifactFiles(detail.files)``.
 
 ``@datus/web-report`` boots the standalone viewer, which spins up the
 sandboxed iframe runtime; the runtime Babel-compiles each module on demand
@@ -39,7 +42,7 @@ import json
 import re
 import shutil
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from datus.utils.loggings import get_logger
 
@@ -56,7 +59,20 @@ _JS_URL_PLACEHOLDER = "__DATUS_REPORT_JS_URL__"
 # runtime falls back to the report id when this isn't present.
 _TITLE_ANNOTATION_RE = re.compile(r"@datus-title\s+([^\n*/]+?)(?:\s*\*/|\s*\n|$)")
 
-_RENDER_ALLOWED_SUFFIXES = {".jsx", ".js", ".css"}
+# Per-prefix allowlist driving the flat artifact walker. Each entry maps a
+# slug-relative top-level directory to ``(allowed_suffixes, recursive)``:
+#
+#   * ``render/``  — recursive (.jsx subdirs like charts/, shared/)
+#   * ``queries/`` — one level (LLM writes flat <slug>.sql/.json pairs)
+#
+# Mirrors ``_ARTIFACT_DIRS`` in
+# ``Datus-backend/datus_backend/services/report_service.py`` so the
+# CLI-emitted HTML payload and the saas-emitted ``IPublishedReportArtifact``
+# share one shape.
+_ARTIFACT_DIRS: Dict[str, Tuple[Tuple[str, ...], bool]] = {
+    "render": ((".jsx", ".js", ".css", ".json"), True),
+    "queries": ((".sql", ".json"), False),
+}
 
 # CDN URLs used when no offline dist is supplied. Keep the pinned version in
 # lockstep with ``packages/web-report/package.json``.
@@ -88,30 +104,26 @@ def _extract_title(app_jsx: str, fallback: str) -> str:
     return fallback
 
 
-def _read_queries(queries_dir: Path) -> List[Dict[str, str]]:
-    """Return file entries in deterministic order (alphabetical by name)."""
-    if not queries_dir.is_dir():
-        return []
-    entries: List[Dict[str, str]] = []
-    for path in sorted(queries_dir.iterdir(), key=lambda p: p.name):
-        if path.suffix not in {".sql", ".json"} or not path.is_file():
-            continue
-        entries.append({"name": path.name, "content": path.read_text(encoding="utf-8")})
-    return entries
+def _read_artifact_files(report_dir: Path) -> List[Dict[str, str]]:
+    """Return artifact files as ``[{path, content}, ...]``, deterministically sorted.
 
-
-def _read_render_files(render_dir: Path) -> List[Dict[str, str]]:
-    """Return render/ files keyed by path relative to render/, deterministically sorted.
-
-    ``name`` mirrors the iframe's module key convention (path-with-extension,
-    e.g. ``app.jsx``, ``charts/trend.jsx``); ``content`` is the raw source.
+    ``path`` is **slug-relative**, including the top-level directory (e.g.
+    ``render/app.jsx``, ``queries/q.sql``). Only directories listed in
+    ``_ARTIFACT_DIRS`` are walked, and each entry's suffix is checked against
+    the allowlist so a stray scratch file doesn't bloat the inline payload.
     """
     entries: List[Dict[str, str]] = []
-    for path in sorted(render_dir.rglob("*")):
-        if not path.is_file() or path.suffix.lower() not in _RENDER_ALLOWED_SUFFIXES:
+    for sub, (allowed_suffixes, recursive) in _ARTIFACT_DIRS.items():
+        root = report_dir / sub
+        if not root.is_dir():
             continue
-        rel = path.relative_to(render_dir).as_posix()
-        entries.append({"name": rel, "content": path.read_text(encoding="utf-8")})
+        iterator = root.rglob("*") if recursive else root.iterdir()
+        for path in iterator:
+            if not path.is_file() or path.suffix.lower() not in allowed_suffixes:
+                continue
+            rel = path.relative_to(report_dir).as_posix()
+            entries.append({"path": rel, "content": path.read_text(encoding="utf-8")})
+    entries.sort(key=lambda entry: entry["path"])
     return entries
 
 
@@ -201,8 +213,7 @@ def render_report_html(
         raise FileNotFoundError(f"render/app.jsx not found under {report_dir}")
 
     app_jsx = app_jsx_path.read_text(encoding="utf-8")
-    render_files = _read_render_files(render_dir)
-    queries = _read_queries(report_dir / "queries")
+    files = _read_artifact_files(report_dir)
 
     dist_dir = _resolve_dist(report_dist)
     if dist_dir is not None:
@@ -220,8 +231,7 @@ def render_report_html(
         "slug": report_slug,
         "title": title,
         "created_at": created_at,
-        "render_files": render_files,
-        "queries": queries,
+        "files": files,
     }
     payload_json = _escape_for_script_tag(json.dumps(payload, ensure_ascii=False))
     rendered = (

--- a/datus/agent/node/report_html_renderer.py
+++ b/datus/agent/node/report_html_renderer.py
@@ -76,7 +76,7 @@ _ARTIFACT_DIRS: Dict[str, Tuple[Tuple[str, ...], bool]] = {
 
 # CDN URLs used when no offline dist is supplied. Keep the pinned version in
 # lockstep with ``packages/web-report/package.json``.
-_CDN_REPORT_VERSION = "0.1.0"
+_CDN_REPORT_VERSION = "~0.1.0"
 _CDN_REPORT_CSS = f"https://unpkg.com/@datus/web-report@{_CDN_REPORT_VERSION}/dist/index.css"
 _CDN_REPORT_JS = f"https://unpkg.com/@datus/web-report@{_CDN_REPORT_VERSION}/dist/index.umd.js"
 

--- a/tests/unit_tests/agent/node/test_report_html_renderer.py
+++ b/tests/unit_tests/agent/node/test_report_html_renderer.py
@@ -71,7 +71,13 @@ def test_render_report_html_writes_index_file(tmp_path: Path):
     assert out_path.is_file()
 
 
-def test_render_report_html_includes_render_files_and_queries(tmp_path: Path):
+def test_render_report_html_includes_flat_files(tmp_path: Path):
+    """Payload is a single ``files`` list with slug-relative paths.
+
+    Matches the ``IPublishedReportArtifact`` / ``IReportDetail`` shape that
+    ``@datus/web-report`` consumes via ``splitArtifactFiles(detail.files)``;
+    ``render_files`` / ``queries`` are no longer separate top-level keys.
+    """
     _seed_report(tmp_path, report_slug="demo_003")
     out_path = render_report_html(project_root=tmp_path, report_slug="demo_003")
     body = out_path.read_text(encoding="utf-8")
@@ -83,12 +89,20 @@ def test_render_report_html_includes_render_files_and_queries(tmp_path: Path):
     data = json.loads(payload_unescaped)
 
     assert data["slug"] == "demo_003"
-    render_names = {f["name"] for f in data["render_files"]}
-    assert render_names == {"app.jsx", "kpi-banner.jsx"}
-    app_entry = next(f for f in data["render_files"] if f["name"] == "app.jsx")
+    assert "render_files" not in data
+    assert "queries" not in data
+    file_paths = {f["path"] for f in data["files"]}
+    assert file_paths == {
+        "render/app.jsx",
+        "render/kpi-banner.jsx",
+        "queries/q.sql",
+        "queries/q.json",
+    }
+    app_entry = next(f for f in data["files"] if f["path"] == "render/app.jsx")
     assert "useDatusArtifact" in app_entry["content"]
-    query_names = {q["name"] for q in data["queries"]}
-    assert query_names == {"q.sql", "q.json"}
+    # The list is sorted by path for deterministic embedding into the
+    # inline JSON block (regressions here would surface as flaky diffs).
+    assert [f["path"] for f in data["files"]] == sorted(file_paths)
     assert "T" in data["created_at"] and data["created_at"].endswith("Z")
 
 
@@ -105,8 +119,8 @@ def test_render_report_html_walks_nested_render_dirs(tmp_path: Path):
     start = body.index('id="datus-report-data">') + len('id="datus-report-data">')
     end = body.index("</script>", start)
     data = json.loads(body[start:end].replace("<\\/", "</"))
-    render_names = {f["name"] for f in data["render_files"]}
-    assert "charts/trend.jsx" in render_names
+    file_paths = {f["path"] for f in data["files"]}
+    assert "render/charts/trend.jsx" in file_paths
 
 
 def test_render_report_html_missing_app_jsx_raises(tmp_path: Path):

--- a/tests/unit_tests/agent/node/test_report_html_renderer.py
+++ b/tests/unit_tests/agent/node/test_report_html_renderer.py
@@ -123,6 +123,39 @@ def test_render_report_html_walks_nested_render_dirs(tmp_path: Path):
     assert "render/charts/trend.jsx" in file_paths
 
 
+def test_render_report_html_rejects_symlink_escaping_report_root(tmp_path: Path):
+    """A symlink under ``render/`` that resolves outside the report dir is dropped.
+
+    The LLM controls everything under ``reports/<slug>/``; without the
+    resolve-and-check guard, ``ln -s /etc/passwd render/foo.jsx`` would
+    end up inlined into the standalone HTML payload. Locks the contract
+    that the walker only emits content that physically lives inside the
+    report directory.
+    """
+    _seed_report(tmp_path, report_slug="escape_001")
+    report_dir = tmp_path / "reports" / "escape_001"
+
+    # Drop a file outside the report tree, then symlink to it from under
+    # ``render/``. The symlink's name is a normal allowed suffix so the
+    # only thing keeping it out is the resolve-and-relative_to check.
+    outside_secret = tmp_path / "outside_secret.jsx"
+    outside_secret.write_text("export default 'SECRET';\n", encoding="utf-8")
+    (report_dir / "render" / "leak.jsx").symlink_to(outside_secret)
+
+    out_path = render_report_html(project_root=tmp_path, report_slug="escape_001")
+    body = out_path.read_text(encoding="utf-8")
+    start = body.index('id="datus-report-data">') + len('id="datus-report-data">')
+    end = body.index("</script>", start)
+    data = json.loads(body[start:end].replace("<\\/", "</"))
+
+    file_paths = {f["path"] for f in data["files"]}
+    assert "render/leak.jsx" not in file_paths
+    # The seeded files are still present — the guard didn't blow up the walker.
+    assert "render/app.jsx" in file_paths
+    # The secret content must not appear anywhere in the rendered HTML.
+    assert "SECRET" not in body
+
+
 def test_render_report_html_missing_app_jsx_raises(tmp_path: Path):
     (tmp_path / "reports" / "missing" / "queries").mkdir(parents=True)
     (tmp_path / "reports" / "missing" / "render").mkdir()


### PR DESCRIPTION
## Why

The standalone CLI HTML viewer (`@datus/web-report`) and the SaaS-side report detail / publish endpoints used to ship two different artifact shapes:

- Standalone HTML inlined `{render_files: [{name}], queries: [{name}]}`.
- SaaS wire / `IPublishedReportArtifact` shipped the same split keys.

The SaaS wire is now flat — `{manifest, files: [{path, content}, ...]}` with slug-relative paths — and `@datus/web-report` consumes it via `splitArtifactFiles(detail.files)` (see `Datus-saas/packages/web-report/src/index.ts` and `packages/web-common/src/modules/artifact/split-artifact-files.ts`). The CLI emitter in this repo still produced the old shape, so the standalone viewer would see `detail.files === undefined` and bail to an empty render.

Companion changes already in flight:

- Datus-backend PR https://github.com/Datus-ai/Datus-backend/pull/252 — flips the SaaS-side wire to `{manifest, files[]}`.
- Datus-saas PR https://github.com/Datus-ai/Datus-saas/pull/377 — updates the consumer types + helpers + viewers.

## Solution

- Collapse `_read_render_files` + `_read_queries` into one `_read_artifact_files` walker driven by a per-prefix allowlist (`_ARTIFACT_DIRS`) that mirrors `Datus-backend/datus_backend/services/report_service.py::_ARTIFACT_DIRS`. Each entry maps a slug-relative top-level directory to `(allowed_suffixes, recursive)`.
- Payload becomes `{slug, title, created_at, files: [{path, content}]}` — paths are slug-relative (`render/app.jsx`, `queries/q.sql`, …), sorted alphabetically for deterministic JSON embedding.
- Adding a new top-level directory under `reports/<slug>/` is now a one-line `_ARTIFACT_DIRS` change with no payload-shape bump.

## Test Cases

- `test_render_report_html_includes_flat_files` (was `…_includes_render_files_and_queries`) — asserts the new top-level `files` key, absence of the old `render_files` / `queries` keys, the expected slug-relative paths, the unchanged `app.jsx` source content, and the deterministic sort.
- `test_render_report_html_walks_nested_render_dirs` — asserts nested paths land under `render/charts/trend.jsx`.
- Existing CDN / offline / title fallback / missing-app.jsx cases pass unchanged.

Local checks:

- `uv run ruff format` + `uv run ruff check --fix` — clean
- `uv run pytest tests/unit_tests/agent/node/test_report_html_renderer.py -q` — 10 passed
- `uv run python ci/audit_tests.py --diff-only upstream/main` — `no test files to scan` (P0=0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified HTML report artifact payload into a single flattened "files" array with consistent slug-relative paths.
  * Enforced allowlisted artifact locations and permitted file types; deterministic sorting for repeatable outputs.
  * Prevented inclusion of files symlinked to locations outside the report root for safer packaging.

* **Tests**
  * Updated tests to validate the flattened files format, ordering, nested assets, and symlink-escape rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->