### PR TITLE
[Tool] Publish docs by minor version

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,13 +9,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to deploy (e.g. v0.2.6). Uses the tag ref if empty.'
+        description: 'Release tag to deploy into its minor docs line, e.g. v0.3.7 -> 0.3. Uses dev if empty.'
         required: false
         default: ''
 permissions:
   contents: write
 env:
-  DOCS_MIN_VISIBLE_VERSION: "0.2.6"
+  DOCS_MIN_VISIBLE_MINOR: "0.2"
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -52,72 +52,15 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_TYPE_VALUE: ${{ github.ref_type }}
+          GITHUB_REF_NAME_VALUE: ${{ github.ref_name }}
         run: |
-          echo "DOCS_SKIP_DEPLOY=false" >> "${GITHUB_ENV}"
-          echo "DOCS_BUILD_CONFIG=mkdocs.yml" >> "${GITHUB_ENV}"
-          echo "DOCS_SOURCE_REF=" >> "${GITHUB_ENV}"
-          # workflow_dispatch with explicit version input
-          if [[ "${EVENT_NAME}" == "workflow_dispatch" && -n "${INPUT_VERSION}" ]]; then
-            VERSION="${INPUT_VERSION}"
-            VERSION="${VERSION#v}"
-            if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.+-]+)?$ ]]; then
-              echo "::error::Invalid version format: ${VERSION}"
-              exit 1
-            fi
-            # Build docs from the tagged content while keeping the current
-            # workflow and main-branch docs configuration.
-            if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
-              CHECKED_OUT_REF="v${VERSION}"
-            elif git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
-              CHECKED_OUT_REF="${VERSION}"
-            else
-              echo "::error::Tag v${VERSION} or ${VERSION} not found"
-              exit 1
-            fi
-            echo "DOCS_SOURCE_REF=${CHECKED_OUT_REF}" >> "${GITHUB_ENV}"
-            echo "DOCS_EDIT_URI=edit/${CHECKED_OUT_REF}/docs/" >> "${GITHUB_ENV}"
-            echo "DOCS_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-            echo "DOCS_ALIASES=" >> "${GITHUB_ENV}"
-            echo "DOCS_SET_DEFAULT=" >> "${GITHUB_ENV}"
-            if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              SHOULD_PROMOTE_LATEST="$(
-                VERSION="${VERSION}" python -c 'import json, os, re, subprocess; from packaging.version import Version; current = Version(os.environ["VERSION"]); raw = subprocess.check_output(["mike", "list", "-j"], text=True) if True else "[]"; stable = [Version(str(item.get("version", ""))) for item in json.loads(raw or "[]") if re.fullmatch(r"\d+\.\d+\.\d+", str(item.get("version", "")))]; print("true" if not stable or current >= max(stable) else "false")' 2>/dev/null || echo "true"
-              )"
-              if [[ "${SHOULD_PROMOTE_LATEST}" == "true" ]]; then
-                echo "DOCS_ALIASES=latest" >> "${GITHUB_ENV}"
-                echo "DOCS_SET_DEFAULT=latest" >> "${GITHUB_ENV}"
-              fi
-            fi
-          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-            if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.+-]+)?$ ]]; then
-              echo "DOCS_SKIP_DEPLOY=true" >> "${GITHUB_ENV}"
-              echo "DOCS_VERSION=" >> "${GITHUB_ENV}"
-              echo "DOCS_ALIASES=" >> "${GITHUB_ENV}"
-              echo "DOCS_SET_DEFAULT=" >> "${GITHUB_ENV}"
-              echo "DOCS_EDIT_URI=edit/${GITHUB_REF_NAME}/docs/" >> "${GITHUB_ENV}"
-              exit 0
-            fi
-            echo "DOCS_SOURCE_REF=${GITHUB_REF_NAME}" >> "${GITHUB_ENV}"
-            echo "DOCS_EDIT_URI=edit/${GITHUB_REF_NAME}/docs/" >> "${GITHUB_ENV}"
-            echo "DOCS_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-            echo "DOCS_ALIASES=" >> "${GITHUB_ENV}"
-            echo "DOCS_SET_DEFAULT=" >> "${GITHUB_ENV}"
-            if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              SHOULD_PROMOTE_LATEST="$(
-                VERSION="${VERSION}" python -c 'import json, os, re, subprocess; from packaging.version import Version; current = Version(os.environ["VERSION"]); raw = subprocess.check_output(["mike", "list", "-j"], text=True) if True else "[]"; stable = [Version(str(item.get("version", ""))) for item in json.loads(raw or "[]") if re.fullmatch(r"\d+\.\d+\.\d+", str(item.get("version", "")))]; print("true" if not stable or current >= max(stable) else "false")' 2>/dev/null || echo "true"
-              )"
-              if [[ "${SHOULD_PROMOTE_LATEST}" == "true" ]]; then
-                echo "DOCS_ALIASES=latest" >> "${GITHUB_ENV}"
-                echo "DOCS_SET_DEFAULT=latest" >> "${GITHUB_ENV}"
-              fi
-            fi
-          else
-            echo "DOCS_VERSION=dev" >> "${GITHUB_ENV}"
-            echo "DOCS_ALIASES=" >> "${GITHUB_ENV}"
-            echo "DOCS_SET_DEFAULT=" >> "${GITHUB_ENV}"
-            echo "DOCS_EDIT_URI=edit/main/docs/" >> "${GITHUB_ENV}"
-          fi
+          versions_json="$(mike list -j 2>/dev/null || echo '[]')"
+          PUBLISHED_DOCS_JSON="${versions_json}" python ci/docs_versioning.py resolve \
+            --input-version "${INPUT_VERSION}" \
+            --event-name "${EVENT_NAME}" \
+            --github-ref-type "${GITHUB_REF_TYPE_VALUE}" \
+            --github-ref-name "${GITHUB_REF_NAME_VALUE}" >> "${GITHUB_ENV}"
       - name: Prepare docs build context
         if: env.DOCS_SKIP_DEPLOY != 'true' && env.DOCS_SOURCE_REF != ''
         run: |
@@ -149,49 +92,4 @@ jobs:
       - name: Hide legacy docs versions
         if: env.DOCS_SKIP_DEPLOY != 'true'
         run: |
-          python - <<'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-          from packaging.version import Version
-
-          threshold = Version(os.environ["DOCS_MIN_VISIBLE_VERSION"])
-          raw = subprocess.check_output(["mike", "list", "-j"], text=True)
-          versions = json.loads(raw or "[]")
-
-          changed = False
-          for item in versions:
-              version = str(item.get("version", ""))
-              props = item.get("properties") or {}
-              hidden = bool(props.get("hidden", False))
-
-              if version == "dev":
-                  target_hidden = False
-              elif re.fullmatch(r"\d+\.\d+\.\d+([.-][0-9A-Za-z.+-]+)?", version):
-                  target_hidden = Version(version) < threshold
-              else:
-                  target_hidden = False
-
-              if hidden == target_hidden:
-                  continue
-
-              subprocess.run(
-                  [
-                      "mike",
-                      "props",
-                      version,
-                      "--set",
-                      f"hidden={'true' if target_hidden else 'false'}",
-                      "--allow-empty",
-                  ],
-                  check=True,
-              )
-              changed = True
-
-          if changed:
-              subprocess.run(["git", "push", "--", "origin", "gh-pages"], check=True)
-          else:
-              print("No legacy version visibility changes needed.")
-          PY
+          python ci/docs_versioning.py hide-legacy --min-visible-minor "${DOCS_MIN_VISIBLE_MINOR}"

--- a/ci/docs_versioning.py
+++ b/ci/docs_versioning.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Resolve and maintain Datus docs versions for MkDocs/mike deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from packaging.version import InvalidVersion, Version
+
+FULL_RELEASE_RE = re.compile(r"^v?(?P<version>\d+\.\d+\.\d+[0-9A-Za-z.+-]*)$")
+STABLE_PATCH_RE = re.compile(r"^\d+\.\d+\.\d+$")
+MINOR_RE = re.compile(r"^\d+\.\d+$")
+
+
+@dataclass(frozen=True)
+class DocsVersionMetadata:
+    skip_deploy: bool
+    build_config: str = "mkdocs.yml"
+    source_ref: str = ""
+    edit_uri: str = "edit/main/docs/"
+    docs_version: str = ""
+    aliases: tuple[str, ...] = ()
+    set_default: str = ""
+
+    def to_github_env(self) -> str:
+        return "\n".join(
+            [
+                f"DOCS_SKIP_DEPLOY={'true' if self.skip_deploy else 'false'}",
+                f"DOCS_BUILD_CONFIG={self.build_config}",
+                f"DOCS_SOURCE_REF={self.source_ref}",
+                f"DOCS_EDIT_URI={self.edit_uri}",
+                f"DOCS_VERSION={self.docs_version}",
+                f"DOCS_ALIASES={' '.join(self.aliases)}",
+                f"DOCS_SET_DEFAULT={self.set_default}",
+            ]
+        )
+
+
+def parse_release_version(raw_version: str) -> Version:
+    match = FULL_RELEASE_RE.fullmatch(raw_version.strip())
+    if not match:
+        raise ValueError(f"Invalid release version format: {raw_version}")
+    try:
+        return Version(match.group("version"))
+    except InvalidVersion as exc:
+        raise ValueError(f"Invalid release version: {raw_version}") from exc
+
+
+def is_stable_patch(version: Version) -> bool:
+    return STABLE_PATCH_RE.fullmatch(str(version)) is not None
+
+
+def docs_minor_label(version: Version) -> str:
+    return f"{version.major}.{version.minor}"
+
+
+def git_tag_exists(tag: str, repo_root: Path = Path(".")) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
+        cwd=repo_root,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def resolve_source_tag(version: Version, tag_exists: Callable[[str], bool]) -> str:
+    version_text = str(version)
+    for candidate in (f"v{version_text}", version_text):
+        if tag_exists(candidate):
+            return candidate
+    raise ValueError(f"Tag v{version_text} or {version_text} not found")
+
+
+def parse_published_versions(raw_json: str) -> list[Version]:
+    try:
+        items = json.loads(raw_json or "[]")
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(items, list):
+        return []
+
+    versions: list[Version] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        raw_version = str(item.get("version") or "")
+        if not (MINOR_RE.fullmatch(raw_version) or STABLE_PATCH_RE.fullmatch(raw_version)):
+            continue
+        try:
+            versions.append(Version(raw_version))
+        except InvalidVersion:
+            continue
+    return versions
+
+
+def should_promote_latest(current_version: Version, published_versions_json: str) -> bool:
+    stable_versions = parse_published_versions(published_versions_json)
+    return not stable_versions or current_version >= max(stable_versions)
+
+
+def resolve_docs_metadata(
+    *,
+    event_name: str,
+    github_ref_type: str,
+    github_ref_name: str,
+    input_version: str = "",
+    published_versions_json: str = "[]",
+    tag_exists: Callable[[str], bool] = git_tag_exists,
+) -> DocsVersionMetadata:
+    if event_name == "workflow_dispatch" and input_version.strip():
+        version = parse_release_version(input_version)
+        if not is_stable_patch(version):
+            raise ValueError("Versioned docs deploy only supports stable patch versions, for example v0.3.7")
+        source_ref = resolve_source_tag(version, tag_exists)
+        return version_metadata_for_stable_tag(source_ref, version, published_versions_json)
+
+    if github_ref_type == "tag":
+        try:
+            version = parse_release_version(github_ref_name)
+        except ValueError:
+            return DocsVersionMetadata(skip_deploy=True, edit_uri=f"edit/{github_ref_name}/docs/")
+        if not is_stable_patch(version):
+            return DocsVersionMetadata(skip_deploy=True, edit_uri=f"edit/{github_ref_name}/docs/")
+        return version_metadata_for_stable_tag(github_ref_name, version, published_versions_json)
+
+    return DocsVersionMetadata(skip_deploy=False, docs_version="dev")
+
+
+def version_metadata_for_stable_tag(
+    source_ref: str,
+    version: Version,
+    published_versions_json: str,
+) -> DocsVersionMetadata:
+    aliases: tuple[str, ...] = ()
+    set_default = ""
+    if should_promote_latest(version, published_versions_json):
+        aliases = ("latest",)
+        set_default = "latest"
+    return DocsVersionMetadata(
+        skip_deploy=False,
+        source_ref=source_ref,
+        edit_uri=f"edit/{source_ref}/docs/",
+        docs_version=docs_minor_label(version),
+        aliases=aliases,
+        set_default=set_default,
+    )
+
+
+def parse_minor(raw_minor: str) -> tuple[int, int]:
+    if not MINOR_RE.fullmatch(raw_minor):
+        raise ValueError(f"Invalid minor docs version: {raw_minor}")
+    major, minor = raw_minor.split(".", maxsplit=1)
+    return int(major), int(minor)
+
+
+def should_hide_docs_version(version: str, min_visible_minor: tuple[int, int]) -> bool:
+    if version == "dev":
+        return False
+    if MINOR_RE.fullmatch(version):
+        major, minor = parse_minor(version)
+        return (major, minor) < min_visible_minor
+    if FULL_RELEASE_RE.fullmatch(version):
+        return True
+    return False
+
+
+def hide_legacy_docs_versions(min_visible_minor: tuple[int, int]) -> bool:
+    raw = subprocess.check_output(["mike", "list", "-j"], text=True)
+    versions = json.loads(raw or "[]")
+    changed = False
+
+    for item in versions:
+        if not isinstance(item, dict):
+            continue
+        version = str(item.get("version") or "")
+        props = item.get("properties") or {}
+        hidden = bool(props.get("hidden", False))
+        target_hidden = should_hide_docs_version(version, min_visible_minor)
+        if hidden == target_hidden:
+            continue
+
+        subprocess.run(
+            [
+                "mike",
+                "props",
+                version,
+                "--set",
+                f"hidden={'true' if target_hidden else 'false'}",
+                "--allow-empty",
+            ],
+            check=True,
+        )
+        changed = True
+
+    if changed:
+        subprocess.run(["git", "push", "--", "origin", "gh-pages"], check=True)
+    return changed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resolve = subparsers.add_parser("resolve", help="Resolve docs deployment metadata and print GitHub env lines")
+    resolve.add_argument("--input-version", default="")
+    resolve.add_argument("--event-name", required=True)
+    resolve.add_argument("--github-ref-type", required=True)
+    resolve.add_argument("--github-ref-name", required=True)
+    resolve.add_argument("--published-versions-json", default=None)
+
+    hide = subparsers.add_parser("hide-legacy", help="Hide patch/pre-release docs versions from mike version picker")
+    hide.add_argument("--min-visible-minor", required=True)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "resolve":
+        try:
+            metadata = resolve_docs_metadata(
+                event_name=args.event_name,
+                github_ref_type=args.github_ref_type,
+                github_ref_name=args.github_ref_name,
+                input_version=args.input_version,
+                published_versions_json=args.published_versions_json
+                if args.published_versions_json is not None
+                else os.environ.get("PUBLISHED_DOCS_JSON", "[]"),
+            )
+        except ValueError as exc:
+            print(f"::error::{exc}", file=sys.stderr)
+            return 1
+        print(metadata.to_github_env())
+        return 0
+
+    if args.command == "hide-legacy":
+        min_visible_minor = parse_minor(args.min_visible_minor)
+        changed = hide_legacy_docs_versions(min_visible_minor)
+        if not changed:
+            print("No docs version visibility changes needed.")
+        return 0
+
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/docs_versioning.py
+++ b/ci/docs_versioning.py
@@ -9,9 +9,8 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Callable, NamedTuple
 
 from packaging.version import InvalidVersion, Version
 
@@ -20,8 +19,7 @@ STABLE_PATCH_RE = re.compile(r"^\d+\.\d+\.\d+$")
 MINOR_RE = re.compile(r"^\d+\.\d+$")
 
 
-@dataclass(frozen=True)
-class DocsVersionMetadata:
+class DocsVersionMetadata(NamedTuple):
     skip_deploy: bool
     build_config: str = "mkdocs.yml"
     source_ref: str = ""

--- a/ci/docs_versioning.py
+++ b/ci/docs_versioning.py
@@ -82,10 +82,10 @@ def resolve_source_tag(version: Version, tag_exists: Callable[[str], bool]) -> s
 def parse_published_versions(raw_json: str) -> list[Version]:
     try:
         items = json.loads(raw_json or "[]")
-    except json.JSONDecodeError:
-        return []
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid published versions JSON") from exc
     if not isinstance(items, list):
-        return []
+        raise ValueError("Invalid published versions JSON: expected a list")
 
     versions: list[Version] = []
     for item in items:
@@ -242,7 +242,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "hide-legacy":
-        min_visible_minor = parse_minor(args.min_visible_minor)
+        try:
+            min_visible_minor = parse_minor(args.min_visible_minor)
+        except ValueError as exc:
+            print(f"::error::Invalid --min-visible-minor: {exc}", file=sys.stderr)
+            return 1
         changed = hide_legacy_docs_versions(min_visible_minor)
         if not changed:
             print("No docs version visibility changes needed.")

--- a/tests/unit_tests/ci/test_docs_versioning.py
+++ b/tests/unit_tests/ci/test_docs_versioning.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "docs_versioning.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("docs_versioning", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load docs_versioning module from {MODULE_PATH}")
+docs_versioning = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = docs_versioning
+MODULE_SPEC.loader.exec_module(docs_versioning)
+
+
+def test_tag_patch_release_deploys_to_minor_docs_and_promotes_latest():
+    metadata = docs_versioning.resolve_docs_metadata(
+        event_name="push",
+        github_ref_type="tag",
+        github_ref_name="v0.3.7",
+        published_versions_json=json.dumps([{"version": "0.2"}, {"version": "0.3.6"}]),
+    )
+
+    assert metadata.skip_deploy is False
+    assert metadata.source_ref == "v0.3.7"
+    assert metadata.docs_version == "0.3"
+    assert metadata.aliases == ("latest",)
+    assert metadata.set_default == "latest"
+    assert metadata.edit_uri == "edit/v0.3.7/docs/"
+
+
+def test_tag_patch_release_does_not_promote_latest_when_newer_minor_exists():
+    metadata = docs_versioning.resolve_docs_metadata(
+        event_name="push",
+        github_ref_type="tag",
+        github_ref_name="v0.3.8",
+        published_versions_json=json.dumps([{"version": "0.4"}]),
+    )
+
+    assert metadata.docs_version == "0.3"
+    assert metadata.aliases == ()
+    assert metadata.set_default == ""
+
+
+def test_prerelease_tag_is_skipped():
+    metadata = docs_versioning.resolve_docs_metadata(
+        event_name="push",
+        github_ref_type="tag",
+        github_ref_name="v0.4.0rc1",
+    )
+
+    assert metadata.skip_deploy is True
+    assert metadata.docs_version == ""
+    assert metadata.edit_uri == "edit/v0.4.0rc1/docs/"
+
+
+def test_main_push_deploys_dev_docs():
+    metadata = docs_versioning.resolve_docs_metadata(
+        event_name="push",
+        github_ref_type="branch",
+        github_ref_name="main",
+    )
+
+    assert metadata.skip_deploy is False
+    assert metadata.source_ref == ""
+    assert metadata.docs_version == "dev"
+    assert metadata.edit_uri == "edit/main/docs/"
+
+
+def test_manual_version_resolves_existing_tag():
+    metadata = docs_versioning.resolve_docs_metadata(
+        event_name="workflow_dispatch",
+        github_ref_type="branch",
+        github_ref_name="main",
+        input_version="0.3.7",
+        tag_exists=lambda tag: tag == "v0.3.7",
+    )
+
+    assert metadata.source_ref == "v0.3.7"
+    assert metadata.docs_version == "0.3"
+
+
+def test_manual_version_requires_stable_patch_release():
+    try:
+        docs_versioning.resolve_docs_metadata(
+            event_name="workflow_dispatch",
+            github_ref_type="branch",
+            github_ref_name="main",
+            input_version="v0.4.0rc1",
+        )
+    except ValueError as exc:
+        assert "stable patch versions" in str(exc)
+    else:
+        raise AssertionError("Expected prerelease manual docs deploy to fail")
+
+
+def test_github_env_output_contains_minor_version_and_aliases():
+    metadata = docs_versioning.DocsVersionMetadata(
+        skip_deploy=False,
+        source_ref="v0.3.7",
+        edit_uri="edit/v0.3.7/docs/",
+        docs_version="0.3",
+        aliases=("latest",),
+        set_default="latest",
+    )
+
+    assert metadata.to_github_env().splitlines() == [
+        "DOCS_SKIP_DEPLOY=false",
+        "DOCS_BUILD_CONFIG=mkdocs.yml",
+        "DOCS_SOURCE_REF=v0.3.7",
+        "DOCS_EDIT_URI=edit/v0.3.7/docs/",
+        "DOCS_VERSION=0.3",
+        "DOCS_ALIASES=latest",
+        "DOCS_SET_DEFAULT=latest",
+    ]
+
+
+def test_docs_version_visibility_hides_patch_and_old_minor_versions():
+    min_visible_minor = docs_versioning.parse_minor("0.2")
+
+    assert docs_versioning.should_hide_docs_version("dev", min_visible_minor) is False
+    assert docs_versioning.should_hide_docs_version("0.1", min_visible_minor) is True
+    assert docs_versioning.should_hide_docs_version("0.2", min_visible_minor) is False
+    assert docs_versioning.should_hide_docs_version("0.3", min_visible_minor) is False
+    assert docs_versioning.should_hide_docs_version("0.3.7", min_visible_minor) is True
+    assert docs_versioning.should_hide_docs_version("0.4.0rc1", min_visible_minor) is True
+    assert docs_versioning.should_hide_docs_version("latest", min_visible_minor) is False

--- a/tests/unit_tests/ci/test_docs_versioning.py
+++ b/tests/unit_tests/ci/test_docs_versioning.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import sys
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "docs_versioning.py"
@@ -10,7 +9,6 @@ MODULE_SPEC = importlib.util.spec_from_file_location("docs_versioning", MODULE_P
 if MODULE_SPEC is None or MODULE_SPEC.loader is None:
     raise RuntimeError(f"Unable to load docs_versioning module from {MODULE_PATH}")
 docs_versioning = importlib.util.module_from_spec(MODULE_SPEC)
-sys.modules[MODULE_SPEC.name] = docs_versioning
 MODULE_SPEC.loader.exec_module(docs_versioning)
 
 

--- a/tests/unit_tests/ci/test_docs_versioning.py
+++ b/tests/unit_tests/ci/test_docs_versioning.py
@@ -41,6 +41,34 @@ def test_tag_patch_release_does_not_promote_latest_when_newer_minor_exists():
     assert metadata.set_default == ""
 
 
+def test_published_versions_malformed_json_fails_closed():
+    try:
+        docs_versioning.resolve_docs_metadata(
+            event_name="push",
+            github_ref_type="tag",
+            github_ref_name="v0.3.8",
+            published_versions_json="{not-json",
+        )
+    except ValueError as exc:
+        assert "Invalid published versions JSON" in str(exc)
+    else:
+        raise AssertionError("Expected malformed published versions JSON to fail")
+
+
+def test_published_versions_non_list_json_fails_closed():
+    try:
+        docs_versioning.resolve_docs_metadata(
+            event_name="push",
+            github_ref_type="tag",
+            github_ref_name="v0.3.8",
+            published_versions_json=json.dumps({"version": "0.3"}),
+        )
+    except ValueError as exc:
+        assert "expected a list" in str(exc)
+    else:
+        raise AssertionError("Expected non-list published versions JSON to fail")
+
+
 def test_prerelease_tag_is_skipped():
     metadata = docs_versioning.resolve_docs_metadata(
         event_name="push",
@@ -124,3 +152,12 @@ def test_docs_version_visibility_hides_patch_and_old_minor_versions():
     assert docs_versioning.should_hide_docs_version("0.3.7", min_visible_minor) is True
     assert docs_versioning.should_hide_docs_version("0.4.0rc1", min_visible_minor) is True
     assert docs_versioning.should_hide_docs_version("latest", min_visible_minor) is False
+
+
+def test_hide_legacy_cli_reports_invalid_minor(capsys):
+    result = docs_versioning.main(["hide-legacy", "--min-visible-minor", "0.2.6"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "::error::Invalid --min-visible-minor" in captured.err
+    assert "Invalid minor docs version: 0.2.6" in captured.err


### PR DESCRIPTION
## Summary
- Deploy stable release docs into minor version lines, e.g. `v0.3.7` updates docs version `0.3` instead of creating `0.3.7`.
- Keep `latest` promotion based on the full stable release version while preserving `dev` for main-branch docs.
- Skip automatic versioned docs deploy for pre-release tags and hide legacy patch/pre-release docs versions from the mike version picker.
- Move docs version resolution and visibility policy into `ci/docs_versioning.py` with unit coverage.

## Validation
- `actionlint -shellcheck '' .github/workflows/deploy-docs.yml`
- `python3 -m py_compile ci/docs_versioning.py`
- `uv run ruff check ci/docs_versioning.py tests/unit_tests/ci/test_docs_versioning.py`
- `uv run ruff format --check ci/docs_versioning.py tests/unit_tests/ci/test_docs_versioning.py`
- `uv run pytest tests/unit_tests/ci/test_docs_versioning.py tests/unit_tests/ci/test_prepare_docs_build.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a docs versioning CLI and wired it into the docs deployment workflow to resolve deploy targets, promote aliases, manage minor-version lines, and hide legacy docs automatically.
  * Updated the deployment trigger input and environment handling to emphasize minor-version deployments and a dev default.

* **Tests**
  * Added unit tests covering resolution logic, alias/default promotion, legacy-hiding behavior, error cases for malformed inputs, and various deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->