### PR TITLE
[BugFix] Gate top_p suppression on the routed provider, not the model class

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -308,16 +308,13 @@ class ClaudeModel(OpenAICompatibleModel):
             Generated text response
         """
         if not self.use_native_api:
-            # Anthropic rejects requests carrying BOTH ``temperature`` and
-            # ``top_p`` with HTTP 400 / ``invalid_request_error`` (the
-            # claude-sonnet-4.x family enforces this strictly). Setting
-            # ``top_p=None`` here is the agreed contract with the parent
-            # ``OpenAICompatibleModel._generate_operation``: an explicit
-            # ``None`` in kwargs tells it to omit the parameter from the
-            # final litellm payload entirely (rather than letting the
-            # non-reasoning default of ``top_p=1.0`` fall through). See
-            # the temperature / top_p block in ``openai_compatible.py``.
-            kwargs["top_p"] = None
+            # ``top_p`` suppression for Anthropic now lives in the parent
+            # ``OpenAICompatibleModel._generate_operation`` and is gated on
+            # ``litellm_adapter.provider == LLMProvider.CLAUDE`` — that gate
+            # fires for every ClaudeModel instance regardless of how the
+            # config's ``type`` field is wired, so the previous
+            # ``kwargs["top_p"] = None`` ceremony here is now redundant.
+            # OAuth header injection stays Claude-specific.
             self._inject_oauth_headers(kwargs)
             try:
                 return super().generate(prompt, enable_thinking=enable_thinking, **kwargs)

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -31,6 +31,7 @@ from datus.models.mcp_result_extractors import extract_sql_contexts
 from datus.models.mcp_utils import multiple_mcp_servers
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
 from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY, looks_like_failure
+from datus.utils.constants import LLMProvider
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_str
 from datus.utils.loggings import get_logger
@@ -485,14 +486,24 @@ class OpenAICompatibleModel(LLMBaseModel):
             if self.default_headers:
                 params["extra_headers"] = self.default_headers
 
+            # Anthropic rejects requests carrying BOTH ``temperature`` and
+            # ``top_p`` with HTTP 400 / ``invalid_request_error`` (the
+            # claude-sonnet-4.x family enforces this strictly). The gate is
+            # the **routed** provider (``litellm_adapter.provider``), not the
+            # model class — operators may configure ``type=openai`` but a
+            # Claude model name, in which case ``LiteLLMAdapter`` auto-routes
+            # to Anthropic; the suppression must still apply or the request
+            # 400s. ``temperature`` wins (mirrors the historical
+            # ``ClaudeModel.generate`` contract); ``top_p`` is dropped
+            # unconditionally for Claude regardless of kwargs / model_config
+            # / non-reasoning default.
+            routed_provider = getattr(self.litellm_adapter, "provider", "")
+            suppress_top_p = routed_provider == LLMProvider.CLAUDE
+
             # Add temperature: priority is kwargs > model_config > default (0.7).
             # An explicit ``None`` in kwargs is the caller's "drop this param"
-            # signal — used by providers like Anthropic that reject some pairs
-            # (the claude-sonnet-4.x family rejects requests carrying BOTH
-            # ``temperature`` and ``top_p`` with HTTP 400 / invalid_request_error).
-            # Skip the param entirely; don't fall through to model_config /
-            # default — those branches would silently re-enable what the
-            # caller just asked us to drop.
+            # signal — kept for symmetry with the top_p path even though
+            # Anthropic accepts ``temperature`` alone.
             if "temperature" in kwargs:
                 if kwargs["temperature"] is not None:
                     params["temperature"] = kwargs["temperature"]
@@ -503,8 +514,11 @@ class OpenAICompatibleModel(LLMBaseModel):
                 # Add default temperature only for non-reasoning models
                 params["temperature"] = 0.7
 
-            # Add top_p: same priority + same explicit-None contract as temperature above.
-            if "top_p" in kwargs:
+            # Add top_p: same priority + same explicit-None contract as
+            # temperature above, EXCEPT for Anthropic where we never send it.
+            if suppress_top_p:
+                pass
+            elif "top_p" in kwargs:
                 if kwargs["top_p"] is not None:
                     params["top_p"] = kwargs["top_p"]
             elif self.model_config.top_p is not None:

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -250,33 +250,19 @@ class TestClaudeModelGenerate:
         mock_super.assert_called_once()
         assert result == "from litellm"
 
-    def test_litellm_path_passes_top_p_none(self):
-        model = _make_claude_model()
-        captured_kwargs = {}
-
-        def capture_generate(self_inner, prompt, **kwargs):
-            captured_kwargs.update(kwargs)
-            return "ok"
-
-        with patch("datus.models.openai_compatible.OpenAICompatibleModel.generate", capture_generate):
-            model.generate("hello")
-        assert captured_kwargs.get("top_p") is None
-
     def test_claude_generate_does_not_send_top_p_to_litellm(self):
         """Regression test for the Anthropic "temperature and top_p" 400.
 
         Exercises the full pipeline (no mock at the parent boundary) so
-        a regression in either layer surfaces:
-
-        - ClaudeModel.generate sets ``kwargs['top_p'] = None`` (its
-          contract for "drop this param").
-        - OpenAICompatibleModel._generate_operation must then omit
-          ``top_p`` from the litellm payload entirely — NOT forward
-          ``top_p=None`` and rely on the downstream library to filter
-          it (which has been observed to leak through to Anthropic
-          and trigger HTTP 400 / ``invalid_request_error``).
+        a regression in either layer surfaces. The suppression is
+        owned by ``OpenAICompatibleModel._generate_operation`` and gates
+        on ``litellm_adapter.provider == LLMProvider.CLAUDE``, so this
+        test relies on ``_make_claude_model`` exposing the correct
+        runtime provider — override the fixture's default value
+        explicitly to make the contract visible.
         """
         model = _make_claude_model()
+        model.litellm_adapter.provider = "claude"
         mock_resp = MagicMock()
         mock_resp.choices = [MagicMock()]
         mock_resp.choices[0].message.content = "ok"

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -336,6 +336,70 @@ class TestGenerate:
         call_kwargs = mock_lit.call_args[1]
         assert "top_p" not in call_kwargs
 
+    # ------------------------------------------------------------------
+    # Provider-gated top_p suppression — Anthropic rejects requests with
+    # BOTH ``temperature`` and ``top_p`` set, so the suppression has to
+    # ride on the **routed** provider (``litellm_adapter.provider``), not
+    # on the model class. These tests run against a vanilla
+    # ``OpenAICompatibleModel`` (NOT ``ClaudeModel``) with the adapter's
+    # provider forced to ``"claude"`` — i.e. the dev configuration that
+    # broke prod: ``model_config.type='openai'`` plus a Claude model
+    # name auto-routed to Anthropic. The fix must trigger here too.
+    # ------------------------------------------------------------------
+
+    def test_top_p_suppressed_when_litellm_provider_is_claude_default_path(self):
+        """No kwargs, no model_config — the non-reasoning default would
+        normally set ``top_p=1.0``. Provider routing to Claude must
+        veto that and leave ``top_p`` absent from the payload."""
+        model = _make_model()
+        model.litellm_adapter.provider = "claude"
+        mock_resp = self._mock_litellm_response("ok")
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt")
+        call_kwargs = mock_lit.call_args[1]
+        assert "top_p" not in call_kwargs
+        # ``temperature`` is fine alone — Anthropic only complains when both are set.
+        assert call_kwargs.get("temperature") == 0.7
+
+    def test_top_p_suppressed_when_provider_is_claude_kwargs_value(self):
+        """An explicit non-None ``top_p`` in kwargs still loses to the
+        provider-level suppression — callers shouldn't be able to
+        accidentally re-enable a parameter Anthropic will 400 on."""
+        model = _make_model()
+        model.litellm_adapter.provider = "claude"
+        mock_resp = self._mock_litellm_response("ok")
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt", top_p=0.9)
+        call_kwargs = mock_lit.call_args[1]
+        assert "top_p" not in call_kwargs
+
+    def test_top_p_suppressed_when_provider_is_claude_config_value(self):
+        """A ``model_config.top_p`` value (e.g. inherited from a provider
+        preset) likewise loses to the suppression — the runtime contract
+        is "never send top_p to Anthropic", full stop."""
+        cfg = _make_model_config(top_p=0.95)
+        model = _make_model(cfg)
+        model.litellm_adapter.provider = "claude"
+        mock_resp = self._mock_litellm_response("ok")
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt")
+        call_kwargs = mock_lit.call_args[1]
+        assert "top_p" not in call_kwargs
+
+    def test_top_p_preserved_when_litellm_provider_is_not_claude(self):
+        """Suppression must NOT bleed into other providers. OpenAI,
+        DeepSeek, Kimi, etc. retain the historical default
+        ``top_p=1.0`` for non-reasoning paths."""
+        model = _make_model()
+        # Default provider in the fixture is already "openai", but pin it
+        # explicitly so the test reads unambiguously.
+        model.litellm_adapter.provider = "openai"
+        mock_resp = self._mock_litellm_response("ok")
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=mock_resp) as mock_lit:
+            model.generate("prompt")
+        call_kwargs = mock_lit.call_args[1]
+        assert call_kwargs.get("top_p") == 1.0
+
     def test_max_tokens_passed_through(self):
         model = _make_model()
         mock_resp = self._mock_litellm_response("ok")


### PR DESCRIPTION
## Summary

PR #813 added a ``kwargs["top_p"] = None`` hack inside ``ClaudeModel.generate`` to dodge Anthropic's "``temperature`` and ``top_p`` cannot both be specified" HTTP 400. **That fix worked only when the model factory actually instantiated ``ClaudeModel``** — i.e. when the operator wrote ``type: claude`` in the model config.

The dev cluster has a long-standing convention of writing ``type: openai`` for Claude models so that LiteLLM's auto-detection picks the routing target from the model name (``Auto-detected provider 'claude' from model name 'claude-sonnet-4-6' (configured as 'openai')``). In that path the factory loads ``OpenAIModel`` (no Claude override), so the ``kwargs["top_p"] = None`` ceremony never ran, the parent's non-reasoning default ``top_p=1.0`` fell through, both knobs reached Anthropic, and finalize blew up with the same HTTP 400 PR #813 thought it had killed.

Verified via dev pod ``datus-backend-dev-5b7b7b4446-hrx85`` on commit ``3b2b57b`` (which already includes PR #813's Datus-agent submodule pointer ``3f84999a``).

## Fix

Move the suppression from ``ClaudeModel.generate`` down into ``OpenAICompatibleModel._generate_operation`` and gate it on ``litellm_adapter.provider == LLMProvider.CLAUDE`` — that property already encodes the routed-not-configured provider, so it fires correctly whether ``type`` is ``claude`` or ``openai``. The historical ``ClaudeModel.generate`` line becomes unconditional dead code and is removed; its OAuth-header injection stays.

### Behavioral contract

For any model whose ``litellm_adapter.provider`` resolves to ``"claude"``:
- ``top_p`` is never sent to ``litellm.completion``, regardless of whether the caller passed it via kwargs, configured it on ``model_config``, or relied on the non-reasoning default.
- ``temperature`` continues to flow through normally (kwargs > model_config > 0.7 fallback). Anthropic accepts it alone — only the *pair* is rejected.

Non-Claude providers (openai, deepseek, kimi, etc.) are untouched.

## Test plan

- [x] ``pytest tests/unit_tests/models/`` — 678 passed
- [x] ``ruff format --check datus/ tests/`` — clean
- [x] End-to-end Python repro of the dev scenario (``model_config.type='openai'`` + Claude model name, ``OpenAICompatibleModel`` directly): params reaching ``litellm.completion`` contain ``temperature=0.7`` and **no** ``top_p``
- New ``test_top_p_suppressed_when_litellm_provider_is_claude_default_path``: vanilla ``OpenAICompatibleModel`` with ``adapter.provider="claude"``, no kwargs / no config → ``top_p`` absent, ``temperature=0.7`` present (the exact dev incident)
- New ``test_top_p_suppressed_when_provider_is_claude_kwargs_value``: explicit ``top_p=0.9`` in kwargs still loses to the suppression
- New ``test_top_p_suppressed_when_provider_is_claude_config_value``: ``model_config.top_p=0.95`` likewise loses
- New ``test_top_p_preserved_when_litellm_provider_is_not_claude``: openai provider keeps the historical ``top_p=1.0`` default — suppression is scoped to Claude and doesn't bleed
- Updated ``test_claude_generate_does_not_send_top_p_to_litellm``: pins the fixture's ``adapter.provider="claude"`` (matches production) so the assertion exercises the new gate end-to-end
- Dropped ``test_litellm_path_passes_top_p_none``: pinned the now-removed ``ClaudeModel.generate`` line; replaced by the parent-level end-to-end test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter handling for Claude models—the `top_p` parameter is now correctly suppressed when routing requests to Claude-based providers, ensuring compatibility with Claude's API constraints.

* **Tests**
  * Added test coverage to verify parameter suppression for Claude-routed providers across different configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->