### PR TITLE
[Tool] Comment merge queue failures on PR

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -201,15 +201,20 @@ jobs:
             }
 
             for (const issue_number of prNumbers) {
-              const { data: comments } = await github.rest.issues.listComments({
+              let existing = null;
+              for await (const response of github.paginate.iterator(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number,
                 per_page: 100,
-              });
-              const existing = comments.find(
-                (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker),
-              );
+              })) {
+                existing = response.data.find(
+                  (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker),
+                );
+                if (existing) {
+                  break;
+                }
+              }
               if (existing) {
                 await github.rest.issues.updateComment({
                   owner: context.repo.owner,

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -134,7 +134,99 @@ jobs:
       - merge-queue-gate
     if: ${{ always() && needs.merge-queue-gate.result == 'failure' }}
     runs-on: self-hosted
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     steps:
+      - name: Checkout notification helper
+        if: ${{ github.event_name == 'merge_group' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Download merge queue artifacts
+        if: ${{ github.event_name == 'merge_group' }}
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: merge-queue-results
+          path: ci/merge-queue-artifacts
+
+      - name: Build PR failure comment
+        if: ${{ github.event_name == 'merge_group' }}
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          python3 ci/build_merge_queue_failure_comment.py \
+            --artifacts-dir ci/merge-queue-artifacts \
+            --output ci/merge-queue-failure-comment.md \
+            --repository "${{ github.repository }}" \
+            --workflow "${{ github.workflow }}" \
+            --event "${{ github.event_name }}" \
+            --ref "${{ github.ref }}" \
+            --sha "${{ github.sha }}" \
+            --run-number "${{ github.run_number }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Comment on PR with merge queue failure
+        if: ${{ github.event_name == 'merge_group' }}
+        uses: actions/github-script@v7
+        env:
+          COMMENT_PATH: ci/merge-queue-failure-comment.md
+        with:
+          script: |
+            const fs = require('fs');
+            const commentPath = process.env.COMMENT_PATH;
+            if (!fs.existsSync(commentPath)) {
+              core.warning(`Merge queue failure comment was not generated: ${commentPath}`);
+              return;
+            }
+
+            const body = fs.readFileSync(commentPath, 'utf8');
+            const marker = '<!-- datus-merge-queue-failure-comment -->';
+            const sources = [
+              context.ref,
+              context.payload?.merge_group?.head_ref,
+              context.payload?.merge_group?.base_ref,
+            ].filter(Boolean).join('\n');
+            const prNumbers = [
+              ...new Set([...sources.matchAll(/(?:^|[/-])pr-(\d+)(?=[/-]|$)/g)].map((match) => Number(match[1]))),
+            ];
+
+            if (prNumbers.length === 0) {
+              core.warning(`Unable to determine PR number from merge queue ref: ${context.ref}`);
+              return;
+            }
+
+            for (const issue_number of prNumbers) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                per_page: 100,
+              });
+              const existing = comments.find(
+                (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker),
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  body,
+                });
+              }
+            }
+
       - name: Send Feishu failure notification
         uses: actions/github-script@v7
         env:

--- a/ci/build_merge_queue_failure_comment.py
+++ b/ci/build_merge_queue_failure_comment.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Build a PR comment that summarizes a failed merge queue run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import textwrap
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Sequence
+
+COMMENT_MARKER = "<!-- datus-merge-queue-failure-comment -->"
+DEFAULT_MAX_FAILURES = 5
+DEFAULT_MAX_DETAIL_CHARS = 1800
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _truncate(value: str, max_chars: int = DEFAULT_MAX_DETAIL_CHARS) -> str:
+    value = value.strip()
+    if len(value) <= max_chars:
+        return value
+    return value[: max_chars - 40].rstrip() + "\n... truncated ..."
+
+
+def _fence(value: str) -> str:
+    sanitized = value.replace("```", "` ` `")
+    return f"```text\n{sanitized}\n```"
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_suite_results(artifacts_dir: Path) -> list[dict[str, Any]]:
+    for path in sorted(artifacts_dir.rglob("merge-queue-results.json")):
+        data = _load_json(path)
+        if not data:
+            continue
+        results = data.get("results", [])
+        if isinstance(results, list):
+            return [result for result in results if isinstance(result, dict)]
+    return []
+
+
+def load_junit_failures(artifacts_dir: Path, *, max_failures: int = DEFAULT_MAX_FAILURES) -> list[dict[str, str]]:
+    failures: list[dict[str, str]] = []
+    for path in sorted(artifacts_dir.rglob("test-results-merge-*.xml")):
+        try:
+            root = ET.parse(path).getroot()
+        except (ET.ParseError, OSError):
+            continue
+
+        for testcase in root.iter():
+            if _local_name(testcase.tag) != "testcase":
+                continue
+            fault = None
+            for child in testcase:
+                if _local_name(child.tag) in {"failure", "error"}:
+                    fault = child
+                    break
+            if fault is None:
+                continue
+
+            failures.append(
+                {
+                    "file": path.name,
+                    "classname": testcase.attrib.get("classname", ""),
+                    "name": testcase.attrib.get("name", ""),
+                    "message": fault.attrib.get("message", ""),
+                    "details": fault.text or "",
+                    "kind": _local_name(fault.tag),
+                }
+            )
+            if len(failures) >= max_failures:
+                return failures
+    return failures
+
+
+def failed_jobs_from_needs(needs_json: str | None) -> str:
+    if not needs_json:
+        return "unknown"
+    try:
+        needs = json.loads(needs_json)
+    except json.JSONDecodeError:
+        return "unknown"
+    if not isinstance(needs, dict):
+        return "unknown"
+    failed = [name for name, job in needs.items() if isinstance(job, dict) and job.get("result") == "failure"]
+    return ", ".join(failed) if failed else "unknown"
+
+
+def _format_suite_results(results: Sequence[dict[str, Any]]) -> list[str]:
+    if not results:
+        return ["- No merge queue suite summary artifact was found."]
+
+    lines: list[str] = []
+    for result in results:
+        suite = result.get("suite", "unknown")
+        exit_code = result.get("exit_code", "unknown")
+        targets = result.get("targets", [])
+        target_count = len(targets) if isinstance(targets, list) else "unknown"
+        status = "failed" if exit_code != 0 else "passed"
+        lines.append(f"- `{suite}`: {status}, exit code `{exit_code}`, targets `{target_count}`")
+    return lines
+
+
+def _format_failures(failures: Sequence[dict[str, str]]) -> list[str]:
+    if not failures:
+        return ["No JUnit failure details were found in the merge queue artifacts. Use the linked run logs."]
+
+    lines: list[str] = []
+    for index, failure in enumerate(failures, 1):
+        classname = failure["classname"]
+        name = failure["name"]
+        test_id = f"{classname}::{name}" if classname else name
+        lines.append(f"{index}. `{test_id}`")
+        if failure["message"]:
+            lines.append(f"   - {failure['kind']}: `{_truncate(failure['message'], 240)}`")
+        if failure["details"]:
+            lines.append("")
+            lines.append(_fence(_truncate(failure["details"])))
+    return lines
+
+
+def build_comment(
+    *,
+    artifacts_dir: Path,
+    repository: str,
+    workflow: str,
+    event_name: str,
+    ref: str,
+    sha: str,
+    run_number: str,
+    run_url: str,
+    failed_jobs: str,
+    max_failures: int = DEFAULT_MAX_FAILURES,
+) -> str:
+    suite_results = load_suite_results(artifacts_dir)
+    failures = load_junit_failures(artifacts_dir, max_failures=max_failures)
+
+    lines = [
+        COMMENT_MARKER,
+        "## Merge Queue Failure",
+        "",
+        "This PR was removed from the merge queue because the real `merge_group` run failed. "
+        "PR head checks can still look green because this ran on GitHub's synthetic queue ref.",
+        "",
+        f"- Repository: `{repository}`",
+        f"- Workflow: `{workflow}`",
+        f"- Event: `{event_name}`",
+        f"- Queue ref: `{ref}`",
+        f"- Queue SHA: `{sha}`",
+        f"- Failed jobs: `{failed_jobs}`",
+        f"- Run: [#{run_number}]({run_url})",
+        "",
+        "### Suite Summary",
+        *_format_suite_results(suite_results),
+        "",
+        "### Failure Details",
+        *_format_failures(failures),
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifacts-dir", type=Path, default=Path("ci/merge-queue-artifacts"))
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", "unknown"))
+    parser.add_argument("--workflow", default=os.environ.get("GITHUB_WORKFLOW", "unknown"))
+    parser.add_argument("--event", default=os.environ.get("GITHUB_EVENT_NAME", "unknown"))
+    parser.add_argument("--ref", default=os.environ.get("GITHUB_REF", "unknown"))
+    parser.add_argument("--sha", default=os.environ.get("GITHUB_SHA", "unknown"))
+    parser.add_argument("--run-number", default=os.environ.get("GITHUB_RUN_NUMBER", "unknown"))
+    parser.add_argument(
+        "--run-url",
+        default=(
+            f"{os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}/"
+            f"{os.environ.get('GITHUB_REPOSITORY', 'unknown')}/actions/runs/"
+            f"{os.environ.get('GITHUB_RUN_ID', 'unknown')}"
+        ),
+    )
+    parser.add_argument("--failed-jobs", default=failed_jobs_from_needs(os.environ.get("NEEDS_JSON")))
+    parser.add_argument("--max-failures", type=int, default=DEFAULT_MAX_FAILURES)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    comment = build_comment(
+        artifacts_dir=args.artifacts_dir,
+        repository=args.repository,
+        workflow=args.workflow,
+        event_name=args.event,
+        ref=args.ref,
+        sha=args.sha,
+        run_number=args.run_number,
+        run_url=args.run_url,
+        failed_jobs=args.failed_jobs,
+        max_failures=args.max_failures,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(textwrap.dedent(comment), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/build_merge_queue_failure_comment.py
+++ b/ci/build_merge_queue_failure_comment.py
@@ -46,14 +46,15 @@ def _load_json(path: Path) -> dict[str, Any] | None:
 
 
 def load_suite_results(artifacts_dir: Path) -> list[dict[str, Any]]:
+    suite_results: list[dict[str, Any]] = []
     for path in sorted(artifacts_dir.rglob("merge-queue-results.json")):
         data = _load_json(path)
         if not data:
             continue
         results = data.get("results", [])
         if isinstance(results, list):
-            return [result for result in results if isinstance(result, dict)]
-    return []
+            suite_results.extend(result for result in results if isinstance(result, dict))
+    return suite_results
 
 
 def load_junit_failures(artifacts_dir: Path, *, max_failures: int = DEFAULT_MAX_FAILURES) -> list[dict[str, str]]:

--- a/tests/unit_tests/ci/test_build_merge_queue_failure_comment.py
+++ b/tests/unit_tests/ci/test_build_merge_queue_failure_comment.py
@@ -43,6 +43,26 @@ def test_build_comment_includes_suite_and_junit_failure_details(tmp_path, build_
         + "\n",
         encoding="utf-8",
     )
+    nested_artifacts_dir = artifacts_dir / "nested"
+    nested_artifacts_dir.mkdir()
+    (nested_artifacts_dir / "merge-queue-results.json").write_text(
+        dedent(
+            """
+            {
+              "results": [
+                {
+                  "suite": "unit-tests",
+                  "status": "success",
+                  "exit_code": 0,
+                  "targets": ["tests/unit_tests"]
+                }
+              ]
+            }
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
     (artifacts_dir / "test-results-merge-acceptance-integration.xml").write_text(
         dedent(
             """
@@ -81,6 +101,7 @@ def test_build_comment_includes_suite_and_junit_failure_details(tmp_path, build_
     assert "- Failed jobs: `merge-queue-gate`" in comment
     assert "- Run: [#195](https://github.com/Datus-ai/Datus-agent/actions/runs/26038673148)" in comment
     assert "- `acceptance-integration`: failed, exit code `1`, targets `1`" in comment
+    assert "- `unit-tests`: passed, exit code `0`, targets `1`" in comment
     assert "`tests.integration.cli.test_cli_commands::test_save_command`" in comment
     assert "assert '/tmp/test_output.json' in stdout" in comment
     assert "AssertionError: assert '/tmp/test_output.json' in 'Save Output'" in comment

--- a/tests/unit_tests/ci/test_build_merge_queue_failure_comment.py
+++ b/tests/unit_tests/ci/test_build_merge_queue_failure_comment.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "build_merge_queue_failure_comment.py"
+
+
+@pytest.fixture()
+def build_merge_queue_failure_comment(monkeypatch):
+    module_name = "_test_build_merge_queue_failure_comment"
+    module_spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    if module_spec is None or module_spec.loader is None:
+        raise AssertionError(f"Unable to load build_merge_queue_failure_comment from {MODULE_PATH}")
+    module = importlib.util.module_from_spec(module_spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    module_spec.loader.exec_module(module)
+    return module
+
+
+def test_build_comment_includes_suite_and_junit_failure_details(tmp_path, build_merge_queue_failure_comment):
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "merge-queue-results.json").write_text(
+        dedent(
+            """
+            {
+              "results": [
+                {
+                  "suite": "acceptance-integration",
+                  "status": "failure",
+                  "exit_code": 1,
+                  "targets": ["tests/integration/cli/test_cli_commands.py"]
+                }
+              ]
+            }
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (artifacts_dir / "test-results-merge-acceptance-integration.xml").write_text(
+        dedent(
+            """
+            <testsuites>
+              <testsuite name="acceptance-integration" tests="1" failures="1">
+                <testcase classname="tests.integration.cli.test_cli_commands" name="test_save_command">
+                  <failure message="assert '/tmp/test_output.json' in stdout">
+                    AssertionError: assert '/tmp/test_output.json' in 'Save Output'
+                  </failure>
+                </testcase>
+              </testsuite>
+            </testsuites>
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    comment = build_merge_queue_failure_comment.build_comment(
+        artifacts_dir=artifacts_dir,
+        repository="Datus-ai/Datus-agent",
+        workflow="Merge Queue Gate",
+        event_name="merge_group",
+        ref="refs/heads/gh-readonly-queue/main/pr-814-abc123",
+        sha="c315c3536ce61aab2729364679c14de62c0ef954",
+        run_number="195",
+        run_url="https://github.com/Datus-ai/Datus-agent/actions/runs/26038673148",
+        failed_jobs="merge-queue-gate",
+    )
+
+    assert build_merge_queue_failure_comment.COMMENT_MARKER in comment
+    assert "## Merge Queue Failure" in comment
+    assert "synthetic queue ref" in comment
+    assert "- Event: `merge_group`" in comment
+    assert "- Queue ref: `refs/heads/gh-readonly-queue/main/pr-814-abc123`" in comment
+    assert "- Failed jobs: `merge-queue-gate`" in comment
+    assert "- Run: [#195](https://github.com/Datus-ai/Datus-agent/actions/runs/26038673148)" in comment
+    assert "- `acceptance-integration`: failed, exit code `1`, targets `1`" in comment
+    assert "`tests.integration.cli.test_cli_commands::test_save_command`" in comment
+    assert "assert '/tmp/test_output.json' in stdout" in comment
+    assert "AssertionError: assert '/tmp/test_output.json' in 'Save Output'" in comment
+
+
+def test_build_comment_explains_missing_artifacts(tmp_path, build_merge_queue_failure_comment):
+    comment = build_merge_queue_failure_comment.build_comment(
+        artifacts_dir=tmp_path / "missing-artifacts",
+        repository="Datus-ai/Datus-agent",
+        workflow="Merge Queue Gate",
+        event_name="merge_group",
+        ref="refs/heads/gh-readonly-queue/main/pr-814-abc123",
+        sha="c315c3536ce61aab2729364679c14de62c0ef954",
+        run_number="195",
+        run_url="https://github.com/Datus-ai/Datus-agent/actions/runs/26038673148",
+        failed_jobs="merge-queue-gate",
+    )
+
+    assert "- No merge queue suite summary artifact was found." in comment
+    assert "No JUnit failure details were found in the merge queue artifacts. Use the linked run logs." in comment
+
+
+def test_failed_jobs_from_needs_extracts_failed_jobs(build_merge_queue_failure_comment):
+    needs_json = dedent(
+        """
+        {
+          "merge-queue-gate": {"result": "failure"},
+          "other-job": {"result": "success"}
+        }
+        """
+    )
+
+    assert build_merge_queue_failure_comment.failed_jobs_from_needs(needs_json) == "merge-queue-gate"
+
+
+def test_main_writes_comment_file(tmp_path, build_merge_queue_failure_comment):
+    output = tmp_path / "comment.md"
+
+    assert (
+        build_merge_queue_failure_comment.main(
+            [
+                "--artifacts-dir",
+                str(tmp_path / "missing-artifacts"),
+                "--output",
+                str(output),
+                "--repository",
+                "Datus-ai/Datus-agent",
+                "--workflow",
+                "Merge Queue Gate",
+                "--event",
+                "merge_group",
+                "--ref",
+                "refs/heads/gh-readonly-queue/main/pr-814-abc123",
+                "--sha",
+                "c315c3536ce61aab2729364679c14de62c0ef954",
+                "--run-number",
+                "195",
+                "--run-url",
+                "https://github.com/Datus-ai/Datus-agent/actions/runs/26038673148",
+                "--failed-jobs",
+                "merge-queue-gate",
+            ]
+        )
+        == 0
+    )
+
+    assert build_merge_queue_failure_comment.COMMENT_MARKER in output.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a merge_group failure comment on the related PR when merge queue gate fails
- include run metadata, suite summary artifacts, and first JUnit failure details in the comment
- keep the existing Feishu notification path unchanged

## Validation
- uv run ruff check ci/build_merge_queue_failure_comment.py tests/unit_tests/ci/test_build_merge_queue_failure_comment.py
- uv run pytest tests/unit_tests/ci/test_build_merge_queue_failure_comment.py -q
- uv run python - <<'PY'
from pathlib import Path
import yaml
path = Path('.github/workflows/merge-queue.yml')
yaml.safe_load(path.read_text(encoding='utf-8'))
print(f'parsed {path}')
PY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically post or update a detailed merge-queue failure comment on affected PRs, summarizing suite results, failing tests, failed jobs, and run links.

* **Chores**
  * CI workflow enhanced to generate and publish merge-queue failure comments for merge-group failures.

* **Tests**
  * Added unit tests for comment generation, artifact fallbacks, failed-jobs extraction, and CLI output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->