### PR TITLE
[Feature] Per-request permission profile override for SaaS chat

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -291,6 +291,15 @@ class StreamChatInput(ChatInput):
         default=None,
         description="Source session to seed the agent with (currently used by feedback agent to copy history).",
     )
+    permission_mode: Optional[Literal["normal", "auto", "dangerous"]] = Field(
+        default=None,
+        description=(
+            "Per-request permission profile override. When set, the chat node's PermissionManager "
+            "is switched to this profile for the duration of the request without mutating shared "
+            "AgentConfig state — required so concurrent SaaS users don't pollute each other's "
+            "profile. None falls back to ``agent_config.active_profile_name``."
+        ),
+    )
 
 
 class FeedbackChatInput(ChatInput):

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -757,8 +757,17 @@ class ChatTaskManager:
         No-ops when ``permission_mode`` is falsy, the node has no
         ``permission_manager`` (e.g. workflow nodes that skip the skill
         setup), or the requested profile already matches the active one.
-        Logs and swallows ``DatusException`` from ``switch_profile`` so a
-        malformed override never aborts the entire chat turn.
+        Failure handling is split deliberately:
+
+        * Building ``user_overrides`` from ``agent.yml`` fails closed —
+          raises so the outer ``_run_loop`` aborts the turn and emits an
+          SSE error. Silently dropping malformed user rules would apply
+          the bare profile base, which can be **broader** than the
+          operator-configured posture (e.g. yaml had an explicit DENY
+          we'd lose), so the safe move is to refuse the switch loudly.
+        * ``switch_profile`` failures (unknown profile, malformed merge
+          result) are logged and swallowed because at that point the
+          node still has its original, server-default profile installed.
         """
         if not permission_mode:
             return
@@ -774,13 +783,19 @@ class ChatTaskManager:
         raw_user = {k: v for k, v in raw_permissions.items() if k != "profile"}
         try:
             user_overrides = build_user_overrides(permission_mode, raw_user)
-        except Exception as e:
-            logger.warning(
-                "Failed to build user overrides for permission_mode=%r: %s; applying profile base only",
+        except Exception as exc:
+            logger.error(
+                "Cannot build user overrides for permission_mode=%r from agent.yml: %s; "
+                "refusing to switch profile to avoid broadening permissions beyond the "
+                "operator-configured rules",
                 permission_mode,
-                e,
+                exc,
+                exc_info=True,
             )
-            user_overrides = None
+            raise RuntimeError(
+                f"Failed to apply permission_mode={permission_mode!r}: "
+                f"agent.yml permissions.rules is malformed ({exc})"
+            ) from exc
 
         try:
             permission_manager.switch_profile(permission_mode, user_overrides=user_overrides)

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -488,6 +488,15 @@ class ChatTaskManager:
             node = await asyncio.to_thread(_init_node)
             task.node = node
 
+            # Per-request permission profile override. We deliberately do
+            # NOT mutate ``agent_config.active_profile_name`` here because
+            # the AgentConfig instance is shared across concurrent SaaS
+            # users; rewriting it on one request would leak the new profile
+            # to every other in-flight or future request. Instead we
+            # switch the freshly created node's PermissionManager in
+            # place — it is scoped to this request only.
+            self._apply_permission_mode_override(node, agent_config, request.permission_mode)
+
             await self._push_event(
                 task,
                 SSEEvent(
@@ -724,6 +733,70 @@ class ChatTaskManager:
             execution_mode=execution_mode,
             node_id=node_id,
             session_id=session_id if session_id is not None else node_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Per-request permission profile override
+    # ------------------------------------------------------------------
+
+    def _apply_permission_mode_override(
+        self,
+        node: AgenticNode,
+        agent_config: AgentConfig,
+        permission_mode: Optional[str],
+    ) -> None:
+        """Apply a per-request permission profile to the freshly created node.
+
+        Switches ``node.permission_manager`` to ``permission_mode`` without
+        touching ``agent_config.active_profile_name`` — the AgentConfig is
+        shared by every concurrent request in the SaaS deployment, so
+        mutating it would leak the override across users. The CLI's
+        ``/profile`` flow can still mutate the global field because it
+        owns the process exclusively; this API path cannot.
+
+        No-ops when ``permission_mode`` is falsy, the node has no
+        ``permission_manager`` (e.g. workflow nodes that skip the skill
+        setup), or the requested profile already matches the active one.
+        Logs and swallows ``DatusException`` from ``switch_profile`` so a
+        malformed override never aborts the entire chat turn.
+        """
+        if not permission_mode:
+            return
+        permission_manager = getattr(node, "permission_manager", None)
+        if permission_manager is None:
+            return
+        if getattr(permission_manager, "active_profile", None) == permission_mode:
+            return
+
+        from datus.tools.permission.profiles import build_user_overrides
+
+        raw_permissions = getattr(agent_config, "_raw_permissions", {}) or {}
+        raw_user = {k: v for k, v in raw_permissions.items() if k != "profile"}
+        try:
+            user_overrides = build_user_overrides(permission_mode, raw_user)
+        except Exception as e:
+            logger.warning(
+                "Failed to build user overrides for permission_mode=%r: %s; applying profile base only",
+                permission_mode,
+                e,
+            )
+            user_overrides = None
+
+        try:
+            permission_manager.switch_profile(permission_mode, user_overrides=user_overrides)
+        except Exception as e:
+            logger.error(
+                "Failed to switch permission profile to %r for session=%s: %s",
+                permission_mode,
+                getattr(node, "session_id", None),
+                e,
+            )
+            return
+
+        logger.info(
+            "Applied per-request permission profile %r for session=%s",
+            permission_mode,
+            getattr(node, "session_id", None),
         )
 
     # ------------------------------------------------------------------

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -793,8 +793,7 @@ class ChatTaskManager:
                 exc_info=True,
             )
             raise RuntimeError(
-                f"Failed to apply permission_mode={permission_mode!r}: "
-                f"agent.yml permissions.rules is malformed ({exc})"
+                f"Failed to apply permission_mode={permission_mode!r}: agent.yml permissions.rules is malformed ({exc})"
             ) from exc
 
         try:

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -205,6 +205,38 @@ def get_profile(name: str) -> PermissionConfig:
         raise ValueError(f"Unknown profile {name!r}. Valid options: {', '.join(PROFILE_NAMES)}") from e
 
 
+def build_user_overrides(
+    profile_name: str,
+    user_raw: Optional[dict] = None,
+) -> Optional[PermissionConfig]:
+    """Construct the ``user_overrides`` PermissionConfig for ``switch_profile``.
+
+    Mirrors the default-permission injection in :func:`build_effective_config`
+    so a runtime profile switch preserves the new profile's safety posture
+    instead of inheriting ``PermissionConfig.from_dict``'s built-in
+    ``"allow"`` default. Returns ``None`` when there are no user rules to
+    layer — callers can pass that directly to ``switch_profile``.
+
+    Args:
+        profile_name: Target profile name; raises ``ValueError`` if unknown.
+        user_raw: Raw user permissions dict (without the ``profile`` key).
+
+    Returns:
+        The user-overrides ``PermissionConfig``, or ``None`` if ``user_raw``
+        is empty.
+    """
+    if not user_raw:
+        return None
+    if "default" not in user_raw and "default_permission" not in user_raw:
+        base = get_profile(profile_name)
+        dp = base.default_permission
+        user_raw = {
+            **user_raw,
+            "default_permission": dp.value if hasattr(dp, "value") else dp,
+        }
+    return PermissionConfig.from_dict(user_raw)
+
+
 def build_effective_config(
     profile_name: str,
     user_raw: Optional[dict] = None,

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -127,6 +127,93 @@ class TestChatTaskManagerCreateNodeInteractive:
         assert manager.get_task("nonexistent") is None
 
 
+class TestApplyPermissionModeOverride:
+    """Verify per-request permission profile override semantics.
+
+    These tests intentionally use lightweight stubs instead of a real
+    AgentConfig/ChatAgenticNode pair: the override path is a pure
+    delegation to ``PermissionManager.switch_profile`` and the
+    interesting branches (no-op vs. real switch vs. graceful failure)
+    are easier to assert directly.
+    """
+
+    def _make_agent_config(self, raw_permissions=None):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            active_profile_name="normal",
+            _raw_permissions=raw_permissions or {},
+        )
+
+    def _make_node(self, current_profile="normal", switch_side_effect=None):
+        node = MagicMock()
+        node.session_id = "sess-x"
+        if current_profile is None:
+            node.permission_manager = None
+            return node
+        pm = MagicMock()
+        pm.active_profile = current_profile
+        if switch_side_effect is not None:
+            pm.switch_profile.side_effect = switch_side_effect
+        node.permission_manager = pm
+        return node
+
+    def test_noop_when_permission_mode_is_none(self):
+        """Falsy permission_mode must leave permission_manager alone."""
+        manager = ChatTaskManager()
+        node = self._make_node()
+        manager._apply_permission_mode_override(node, self._make_agent_config(), None)
+        node.permission_manager.switch_profile.assert_not_called()
+
+    def test_noop_when_node_has_no_permission_manager(self):
+        """Nodes without a permission_manager (e.g. workflow) are tolerated."""
+        manager = ChatTaskManager()
+        node = self._make_node(current_profile=None)
+        manager._apply_permission_mode_override(node, self._make_agent_config(), "dangerous")
+        # No exception, no attribute access beyond what's expected.
+
+    def test_noop_when_already_on_target_profile(self):
+        """Requested profile == active profile must skip the switch."""
+        manager = ChatTaskManager()
+        node = self._make_node(current_profile="dangerous")
+        manager._apply_permission_mode_override(node, self._make_agent_config(), "dangerous")
+        node.permission_manager.switch_profile.assert_not_called()
+
+    def test_switches_profile_without_user_overrides(self):
+        """When _raw_permissions is empty, switch_profile receives user_overrides=None."""
+        manager = ChatTaskManager()
+        node = self._make_node(current_profile="normal")
+        manager._apply_permission_mode_override(node, self._make_agent_config(), "auto")
+        node.permission_manager.switch_profile.assert_called_once_with("auto", user_overrides=None)
+
+    def test_switches_profile_with_user_overrides(self):
+        """Non-empty _raw_permissions yields a built user_overrides config."""
+        from datus.tools.permission.permission_config import PermissionConfig
+
+        manager = ChatTaskManager()
+        node = self._make_node(current_profile="normal")
+        raw = {"rules": [{"tool": "db_tools", "pattern": "*", "permission": "ask"}]}
+        manager._apply_permission_mode_override(node, self._make_agent_config(raw), "dangerous")
+
+        node.permission_manager.switch_profile.assert_called_once()
+        args, kwargs = node.permission_manager.switch_profile.call_args
+        assert args == ("dangerous",)
+        assert isinstance(kwargs["user_overrides"], PermissionConfig)
+
+    def test_swallows_switch_profile_failure(self):
+        """A malformed override must not abort the chat turn."""
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        manager = ChatTaskManager()
+        node = self._make_node(
+            current_profile="normal",
+            switch_side_effect=DatusException(code=ErrorCode.COMMON_CONFIG_ERROR),
+        )
+        # Should not raise.
+        manager._apply_permission_mode_override(node, self._make_agent_config(), "auto")
+        node.permission_manager.switch_profile.assert_called_once()
+
+
 class TestChatTaskManagerBehavior:
     """Tests for ChatTaskManager task tracking."""
 

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -169,8 +169,11 @@ class TestApplyPermissionModeOverride:
         """Nodes without a permission_manager (e.g. workflow) are tolerated."""
         manager = ChatTaskManager()
         node = self._make_node(current_profile=None)
+        assert node.permission_manager is None
         manager._apply_permission_mode_override(node, self._make_agent_config(), "dangerous")
-        # No exception, no attribute access beyond what's expected.
+        # Permission manager must remain untouched — the override path is
+        # silently skipped when the node never had one to begin with.
+        assert node.permission_manager is None
 
     def test_noop_when_already_on_target_profile(self):
         """Requested profile == active profile must skip the switch."""
@@ -199,6 +202,32 @@ class TestApplyPermissionModeOverride:
         args, kwargs = node.permission_manager.switch_profile.call_args
         assert args == ("dangerous",)
         assert isinstance(kwargs["user_overrides"], PermissionConfig)
+
+    def test_raises_when_user_overrides_build_fails(self, monkeypatch):
+        """Fail closed if agent.yml permissions.rules can't be parsed.
+
+        Silently dropping malformed user rules and applying the bare
+        profile base would broaden permissions beyond the operator's
+        intent, so the override path must surface the error instead.
+        """
+        manager = ChatTaskManager()
+        node = self._make_node(current_profile="normal")
+
+        def _explode(*_args, **_kwargs):
+            raise ValueError("malformed rule")
+
+        monkeypatch.setattr(
+            "datus.tools.permission.profiles.build_user_overrides",
+            _explode,
+        )
+
+        with pytest.raises(RuntimeError, match="permission_mode='auto'"):
+            manager._apply_permission_mode_override(
+                node,
+                self._make_agent_config({"rules": [{"bad": "shape"}]}),
+                "auto",
+            )
+        node.permission_manager.switch_profile.assert_not_called()
 
     def test_swallows_switch_profile_failure(self):
         """A malformed override must not abort the chat turn."""


### PR DESCRIPTION
## Summary
- Adds optional `permission_mode` (normal/auto/dangerous) to `StreamChatInput` so the web client can pick a permission profile per request.
- The override is applied to the freshly created node's `PermissionManager` only; `agent_config.active_profile_name` is left untouched so concurrent SaaS users don't pollute each other.
- Extracts `build_user_overrides` from the CLI `/profile` flow so the default-permission injection (preserving the target profile's safety posture across `merge_with`) lives in one place.

## Why
The CLI `/profile` command flips `agent_config.active_profile_name` because the CLI owns its process exclusively. In SaaS one `AgentConfig` is shared by every concurrent request — mutating the global field would leak a `dangerous` choice from one user to all in-flight requests. Each `stream_chat` call already creates a brand-new node, so switching that single node's `PermissionManager` is sufficient and safe.

## Behaviour
- `permission_mode` unset → behaviour unchanged (node reads `agent_config.active_profile_name`, default `"normal"`).
- `permission_mode` set → after `_init_node`, the node's `PermissionManager.switch_profile(mode, user_overrides=...)` is called. `user_overrides` is built from `agent_config._raw_permissions` so any YAML-declared `permissions.rules` still layer on top.
- Failures in `switch_profile` (unknown profile / malformed overrides) are logged and the chat turn continues on the original profile rather than aborting.
- Dangerous-mode second confirmation is the web client's responsibility (no TTY here); the backend trusts the request.

## Test plan
- [x] `pytest tests/unit_tests/api/services/test_chat_task_manager.py tests/unit_tests/tools/permission/` (238 passed)
- [x] New `TestApplyPermissionModeOverride` covers: no-op when mode unset / no permission_manager / already-matching profile, switches with and without user_overrides, swallows `DatusException`.
- [ ] End-to-end smoke once the matching SaaS PR lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat requests can include an optional permission_mode ("normal", "auto", "dangerous") to temporarily override an agent’s permission profile for a single request without changing the agent’s base profile. Per-request overrides apply only for that turn and log the applied profile when successful.

* **Tests**
  * Added tests for permission-mode behavior: no-op cases, application with user-specific rules, and error-handling (including when applying a profile fails).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->