### PR TITLE
[Enhancement] Allow delete_file in auto profile workspace writes

### DIFF
--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -144,6 +144,7 @@ _AUTO_EXTRA_RULES = [
     # the zone branch (ASK in auto, ALLOW only in dangerous).
     _rule("filesystem_tools", "write_file", PermissionLevel.ALLOW),
     _rule("filesystem_tools", "edit_file", PermissionLevel.ALLOW),
+    _rule("filesystem_tools", "delete_file", PermissionLevel.ALLOW),
     # plan writes
     _rule("tools", "todo_write", PermissionLevel.ALLOW),
     _rule("tools", "todo_update", PermissionLevel.ALLOW),

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -121,12 +121,13 @@ class TestAutoProfile:
 
     def test_workspace_writes_allowed(self):
         config = AUTO
-        # ``write_file`` / ``edit_file`` are the full set of write tools
-        # ``FilesystemFuncTool`` exposes today (``create_directory`` /
-        # ``move_file`` were removed in the #561 refactor and used to live here
-        # as dead rules — see ``test_dead_filesystem_rules_absent``).
+        # ``write_file`` / ``edit_file`` / ``delete_file`` are the full set of
+        # write tools ``FilesystemFuncTool`` exposes today (``create_directory``
+        # / ``move_file`` were removed in the #561 refactor and used to live
+        # here as dead rules — see ``test_dead_filesystem_rules_absent``).
         assert _resolve(config, "filesystem_tools", "write_file") == PermissionLevel.ALLOW
         assert _resolve(config, "filesystem_tools", "edit_file") == PermissionLevel.ALLOW
+        assert _resolve(config, "filesystem_tools", "delete_file") == PermissionLevel.ALLOW
 
     def test_bi_write_allowed_delete_asks(self):
         """Auto downgrades NORMAL's DENY on destructives to ASK — user is
@@ -180,7 +181,7 @@ class TestFilesystemRuleSurface:
     """
 
     _DEAD_PATTERNS = ("list_*", "directory_tree", "search_files", "create_directory", "move_file")
-    _LIVE_PATTERNS = ("read_*", "glob", "grep", "write_file", "edit_file")
+    _LIVE_PATTERNS = ("read_*", "glob", "grep", "write_file", "edit_file", "delete_file")
 
     def test_dead_filesystem_rules_absent(self):
         for cfg in (NORMAL, AUTO):


### PR DESCRIPTION
## Why

The `auto` profile pre-approves filesystem **workspace writes** (`write_file`, `edit_file`) for INTERNAL paths so users in productive flows aren't prompted for every edit. `delete_file` was missing from this set — deleting a workspace file still fell through to `default=ASK`, which is inconsistent with the rest of the workspace-write posture and surprising for users who've opted into `auto`.

## Solution

- Add `filesystem_tools.delete_file → ALLOW` alongside `write_file` / `edit_file` in `_AUTO_EXTRA_RULES` (`datus/tools/permission/profiles.py`).
- EXTERNAL paths are still gated by the zone branch in `PermissionHooks._handle_filesystem_zone` (ASK in `auto`, ALLOW only in `dangerous`), so this only affects INTERNAL workspace deletions.
- `normal` profile is unchanged — `delete_file` there still falls through to `default=ASK`.

## Test Cases

`tests/unit_tests/tools/permission/test_profiles.py`:

- `TestAutoProfile::test_workspace_writes_allowed` — assert `delete_file == ALLOW` (alongside the existing `write_file` / `edit_file` asserts).
- `TestFilesystemRuleSurface::_LIVE_PATTERNS` — add `delete_file` so the rule-surface contract test (`test_live_filesystem_rules_cover_actual_tool_surface`) stays in lock-step with `FilesystemFuncTool.available_tools()`.

All 29 tests in `test_profiles.py` pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `auto` permission profile now explicitly permits file deletion operations in addition to existing write capabilities.

* **Tests**
  * Updated test suite to validate file deletion permissions are correctly allowed under the `auto` profile.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->