### PR TITLE
[Feature] Allow user text insertion during a running agent turn

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -22,7 +22,7 @@ from agents.extensions.memory import AdvancedSQLiteSession
 from agents.mcp import MCPServerStdio
 
 from datus.agent.node.node import Node
-from datus.cli.execution_state import ExecutionInterrupted, InteractionBroker, InterruptController
+from datus.cli.execution_state import ExecutionInterrupted, InteractionBroker, InterruptController, PendingInputQueue
 from datus.configuration.agent_config import AgentConfig
 from datus.models.base import LLMBaseModel
 from datus.prompts.prompt_manager import get_prompt_manager
@@ -242,6 +242,14 @@ class AgenticNode(Node):
 
         self.interaction_broker = InteractionBroker()
         self.interrupt_controller = InterruptController()
+
+        # Per-chat-session queue of free-text user messages staged during
+        # an agent run. Set to a real ``PendingInputQueue`` by interactive
+        # callers (CLI/TUI and the API ``/insert`` route) before
+        # ``execute_stream``; ``None`` for non-interactive callers so they
+        # keep current behavior. Lifecycle is owned by the caller — the
+        # node treats it as a borrowed reference and never replaces it.
+        self.pending_input_queue: Optional[PendingInputQueue] = None
 
         # Plan mode state (managed at base class, shared by all subclasses).
         # Activated manually via REPL/CLI for the current primary agent; sub-agents
@@ -1823,7 +1831,13 @@ class AgenticNode(Node):
                 message_args={"field_name": "input"},
             )
 
-        ctx = StreamRunContext(user_input=self.input, action_history_manager=ahm)
+        ctx = StreamRunContext(
+            user_input=self.input,
+            action_history_manager=ahm,
+            # Tolerate test doubles that bypass ``AgenticNode.__init__``
+            # and therefore don't have ``pending_input_queue`` set.
+            pending_input_queue=getattr(self, "pending_input_queue", None),
+        )
 
         node_name = self.get_node_name()
         logger.info(
@@ -1977,6 +1991,10 @@ class AgenticNode(Node):
             hooks=self._compose_run_hooks(ctx),
             agent_name=self.get_node_name(),
             interrupt_controller=self.interrupt_controller,
+            pending_input_queue=ctx.pending_input_queue,
+            # Defensive: test doubles that bypass ``AgenticNode.__init__``
+            # may not have a broker; the model layer skips emit when None.
+            interaction_broker=getattr(self, "interaction_broker", None),
         ):
             rewritten = self._maybe_rewrite_stream_action(stream_action, ctx)
             action_to_yield = rewritten or stream_action

--- a/datus/agent/node/stream_run_context.py
+++ b/datus/agent/node/stream_run_context.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 if TYPE_CHECKING:
     from agents.extensions.memory import AdvancedSQLiteSession
 
+    from datus.cli.execution_state import PendingInputQueue
     from datus.schemas.action_history import ActionHistoryManager
     from datus.schemas.base import BaseInput
 
@@ -62,3 +63,12 @@ class StreamRunContext:
 
     # Free-form scratchpad for subclass hooks to share state.
     extras: Dict[str, Any] = field(default_factory=dict)
+
+    # Per-run queue of free-text user messages staged during an agent run.
+    # When set (typically by interactive callers like CLI/TUI and the API
+    # ``/insert`` endpoint), the model layer attaches a
+    # ``call_model_input_filter`` that drains this queue before each LLM
+    # turn so injected text is seen on the very next request within the
+    # same run. ``None`` for non-interactive callers (regression tests,
+    # batch workflows) — those keep current behavior.
+    pending_input_queue: Optional["PendingInputQueue"] = None

--- a/datus/api/models/chat_models.py
+++ b/datus/api/models/chat_models.py
@@ -50,3 +50,22 @@ class ToolResultData(BaseModel):
 
     call_tool_id: str = Field(..., description="Unique identifier for the tool call")
     status: str = Field(..., description="Status of the tool result submission", examples=["received"])
+
+
+class InsertMessageInput(BaseModel):
+    """Input for appending a free-text user message to a running chat."""
+
+    session_id: str = Field(..., description="Active chat session id")
+    message: str = Field(
+        ...,
+        min_length=1,
+        max_length=4000,
+        description="Free-text user message to inject into the agent's pending input queue",
+    )
+
+
+class InsertMessageData(BaseModel):
+    """Data for /chat/insert response."""
+
+    session_id: str = Field(..., description="Session id the message was queued for")
+    queued_count: int = Field(..., description="Number of pending items in the queue after this push")

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -26,6 +26,8 @@ from datus.api.hooks import (
 )
 from datus.api.models.base_models import Result
 from datus.api.models.chat_models import (
+    InsertMessageData,
+    InsertMessageInput,
     ResumeChatInput,
     StopChatInput,
     ToolResultData,
@@ -320,6 +322,57 @@ async def submit_user_interaction(
     return Result[dict](
         success=success,
         data={"interaction_key": request.interaction_key, "submitted": success},
+    )
+
+
+# ========== Insert Message (mid-run user input) ==========
+
+
+@router.post(
+    "/insert",
+    response_model=Result[InsertMessageData],
+    summary="Insert user message into a running chat",
+    description=(
+        "Append a free-text user message to the agent's pending input queue. The message "
+        "is delivered to the model before its next LLM turn within the same run via the "
+        "OpenAI Agents SDK ``call_model_input_filter`` hook. If the run has already entered "
+        "its final turn, the message will auto-continue the conversation in a follow-up run "
+        "(up to a small cap on consecutive continuations)."
+    ),
+)
+async def insert_message(
+    request: InsertMessageInput,
+    svc: ServiceDep,
+) -> Result[InsertMessageData]:
+    task_manager = svc.task_manager
+    task = task_manager.get_task(request.session_id)
+    if task is None or task.node is None:
+        return Result[InsertMessageData](
+            success=False,
+            errorCode="SESSION_NOT_RUNNING",
+            errorMessage="No active chat task for this session",
+        )
+
+    text = request.message.strip()
+    if not text:
+        return Result[InsertMessageData](
+            success=False,
+            errorCode="INVALID_INPUT",
+            errorMessage="message must be non-empty after stripping whitespace",
+        )
+
+    queue = getattr(task.node, "pending_input_queue", None)
+    if queue is None:
+        return Result[InsertMessageData](
+            success=False,
+            errorCode="QUEUE_UNAVAILABLE",
+            errorMessage="Pending input queue is not initialized for this session",
+        )
+
+    queue.push(text)
+    return Result[InsertMessageData](
+        success=True,
+        data=InsertMessageData(session_id=request.session_id, queued_count=len(queue)),
     )
 
 

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -422,7 +422,12 @@ def action_to_sse_event(
             if contents is None:
                 return None
         elif role == ActionRole.USER:
-            if include_user_message:
+            # ``user_insert`` is a mid-run injection: text the user typed
+            # into the TUI / POSTed to ``/chat/insert`` while the agent
+            # was already streaming. It must always reach the SSE client,
+            # independent of ``include_user_message`` (which gates the
+            # initial-request action that the caller already knows about).
+            if include_user_message or action.action_type == "user_insert":
                 contents = _build_user_content(action)
                 sse_role = "user"
             else:

--- a/datus/cli/action_display/display.py
+++ b/datus/cli/action_display/display.py
@@ -372,7 +372,14 @@ class ActionHistoryDisplay:
                 self.console,
                 [self.renderer.render_user_header(user_message), self.renderer.render_separator()],
             )
-            non_user_actions = [a for a in actions if not (a.role == ActionRole.USER and a.depth == 0)]
+            # Drop the initial USER request (already rendered by render_user_header)
+            # but keep mid-run ``user_insert`` injections so they remain visible
+            # in history reprints (including Ctrl+O verbose toggle).
+            non_user_actions = [
+                a
+                for a in actions
+                if not (a.role == ActionRole.USER and a.depth == 0 and a.action_type != "user_insert")
+            ]
             self.render_action_history(non_user_actions, verbose=verbose)
             if per_turn_callback:
                 per_turn_callback(actions)

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -600,9 +600,15 @@ class InlineStreamingContext:
                         self.display.renderer.render_separator(),
                     ],
                 )
-            # 3. Render already-processed actions
+            # 3. Render already-processed actions. The initial USER request
+            # is dropped on reprint because it was already echoed at the
+            # top of the turn; mid-run ``user_insert`` injections are kept
+            # — they only ever appear in this list and must remain visible
+            # after a Ctrl+O verbose toggle.
             current_actions = [
-                a for a in self.actions[: self._processed_index] if not (a.role == ActionRole.USER and a.depth == 0)
+                a
+                for a in self.actions[: self._processed_index]
+                if not (a.role == ActionRole.USER and a.depth == 0 and a.action_type != "user_insert")
             ]
             self.display.render_action_history(current_actions, verbose=verbose, _show_partial_done=False)
             # 3a. Render the streaming main-agent body (from the active

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -24,7 +24,7 @@ from rich.syntax import Syntax
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
 from datus.cli.action_display.display import ActionHistoryDisplay
 from datus.cli.cli_styles import CODE_THEME
-from datus.cli.execution_state import ExecutionInterrupted, auto_submit_interaction
+from datus.cli.execution_state import ExecutionInterrupted, PendingInputQueue, auto_submit_interaction
 from datus.cli.list_selector_app import ListItem, ListSelectorApp
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
@@ -248,19 +248,58 @@ class ChatCommands:
         )
         return f"{message.rstrip()}\n\n{annotation}"
 
+    # Hard cap on how many extra turns the chat layer will auto-spawn to
+    # drain a non-empty :class:`PendingInputQueue` after a run finishes
+    # (final-turn residue case). Bounded so a misbehaving producer cannot
+    # turn the agent into a perpetual motion machine; the remaining
+    # backlog is surfaced as a warning and waits for the next manual
+    # prompt.
+    MAX_AUTO_CONTINUATIONS = 3
+
     def execute_chat_command(
         self,
         message: str,
         plan_mode: bool = False,
         subagent_name: Optional[str] = None,
     ):
-        """Execute a chat command in interactive REPL mode."""
-        self._execute_chat(
-            message,
-            plan_mode=plan_mode,
-            subagent_name=subagent_name,
-            interactive=True,
-        )
+        """Execute a chat command in interactive REPL mode.
+
+        Wraps :meth:`_execute_chat` in an auto-continuation loop: when the
+        agent finishes a run but the pending-input queue is non-empty
+        (final-turn residue — messages pushed by the user / API after the
+        SDK has already left its per-turn ``call_model_input_filter``
+        hook), drain those messages and feed them into a fresh run so they
+        are not silently dropped.
+        """
+        current_message = message
+        continuations = 0
+        while True:
+            self._execute_chat(
+                current_message,
+                plan_mode=plan_mode,
+                subagent_name=subagent_name,
+                interactive=True,
+            )
+
+            node = self.current_node
+            queue = node.pending_input_queue if node is not None else None
+            if queue is None or len(queue) == 0:
+                break
+
+            if node.interrupt_controller.is_interrupted:
+                queue.clear()
+                break
+
+            if continuations >= self.MAX_AUTO_CONTINUATIONS:
+                self.console.print(
+                    f"[yellow]{len(queue)} queued message(s) skipped — auto-continuation cap reached. "
+                    "Send a new prompt to flush them.[/]"
+                )
+                break
+
+            residual = queue.drain_all()
+            current_message = "\n\n".join(residual)
+            continuations += 1
 
     def _resolve_clean_output(
         self,
@@ -354,6 +393,14 @@ class ChatCommands:
                 self.current_node = self._create_new_node(None)
                 current_node = self.current_node
 
+            # Ensure the node has a pending-input queue so the TUI Enter
+            # handler, the API ``/insert`` route, and the model layer's
+            # ``call_model_input_filter`` can all push and drain through
+            # the same instance. Lazy-init keeps non-interactive callers
+            # (which never reach here) at their default ``None``.
+            if current_node.pending_input_queue is None:
+                current_node.pending_input_queue = PendingInputQueue()
+
             # Create input using shared method
             node_input, node_type = self.create_node_input(
                 message, current_node, at_tables, at_metrics, at_sqls, plan_mode
@@ -401,8 +448,12 @@ class ChatCommands:
                     async for action in current_node.execute_stream_with_interactions(
                         action_history_manager=self.cli.actions
                     ):
-                        # Skip USER actions (depth=0) — already printed by _echo_user_input
-                        if action.role == ActionRole.USER and action.depth == 0:
+                        # Skip USER actions (depth=0) — already printed by _echo_user_input.
+                        # ``user_insert`` is the exception: it represents text the
+                        # user injected mid-run via the TUI / API ``/insert`` route,
+                        # which has *not* been echoed yet and needs to be rendered
+                        # the moment the model layer flushes it into the next turn.
+                        if action.role == ActionRole.USER and action.depth == 0 and action.action_type != "user_insert":
                             continue
                         # Streaming text deltas go to their own queue. Sub-agent
                         # deltas (depth > 0) are ignored here — they'd pollute
@@ -513,6 +564,8 @@ class ChatCommands:
                             self.cli.run_on_bg_loop(run_chat_stream())
                         except KeyboardInterrupt:
                             current_node.interrupt_controller.interrupt()
+                            if current_node.pending_input_queue is not None:
+                                current_node.pending_input_queue.clear()
                             logger.info("KeyboardInterrupt caught, execution interrupted gracefully")
                         except ExecutionInterrupted:
                             logger.info("ExecutionInterrupted caught, execution stopped gracefully")

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -23,7 +23,7 @@ from rich.syntax import Syntax
 
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
 from datus.cli.action_display.display import ActionHistoryDisplay
-from datus.cli.cli_styles import CODE_THEME
+from datus.cli.cli_styles import CODE_THEME, print_warning
 from datus.cli.execution_state import ExecutionInterrupted, PendingInputQueue, auto_submit_interaction
 from datus.cli.list_selector_app import ListItem, ListSelectorApp
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
@@ -291,9 +291,10 @@ class ChatCommands:
                 break
 
             if continuations >= self.MAX_AUTO_CONTINUATIONS:
-                self.console.print(
-                    f"[yellow]{len(queue)} queued message(s) skipped — auto-continuation cap reached. "
-                    "Send a new prompt to flush them.[/]"
+                print_warning(
+                    self.console,
+                    f"{len(queue)} queued message(s) skipped — auto-continuation cap reached. "
+                    "Send a new prompt to flush them.",
                 )
                 break
 

--- a/datus/cli/cli_styles.py
+++ b/datus/cli/cli_styles.py
@@ -129,6 +129,15 @@ STATUS_BAR_STYLE: dict[str, str] = {
     "todo-sidebar.in_progress": "#f1fa8c",
     "todo-sidebar.completed": "#50fa7b",
     "todo-sidebar.failed": "#ff5555",
+    # Pinned queue-preview box above the status bar. Visible only while
+    # the agent is streaming and the user has typed mid-run messages
+    # that are waiting to be flushed into the model's next turn. Per
+    # CLAUDE.md only the header may use ``bold``; rows use the same
+    # hint colour as the rest of the status furniture so the box reads
+    # as ambient context, not as a transcript.
+    "queue-preview.box": STATUS_BAR_FG_HINT,
+    "queue-preview.header": "#f1fa8c bold",
+    "queue-preview.item": STATUS_BAR_FG_HINT,
     # Slash-command autocomplete popup. ``bg:default`` blends into the
     # terminal palette; ``noreverse`` strips prompt_toolkit's default
     # reverse-video highlight so the selection is conveyed by bright

--- a/datus/cli/execution_state.py
+++ b/datus/cli/execution_state.py
@@ -65,13 +65,16 @@ class PendingInputQueue:
     """
 
     MAX_DRAIN_PER_TURN = 3
+    MAX_PENDING_ITEMS = 200
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._items: "deque[str]" = deque()
+        self._items: "deque[str]" = deque(maxlen=self.MAX_PENDING_ITEMS)
 
     def push(self, text: str) -> None:
         with self._lock:
+            if len(self._items) == self.MAX_PENDING_ITEMS:
+                logger.warning("PendingInputQueue overflow; dropping oldest staged input.")
             self._items.append(text)
 
     def drain(self) -> List[str]:

--- a/datus/cli/execution_state.py
+++ b/datus/cli/execution_state.py
@@ -8,6 +8,7 @@
 import asyncio
 import threading
 import uuid
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional
@@ -50,6 +51,56 @@ class InterruptController:
     def reset(self):
         """Clear the interrupt signal for a new execution cycle."""
         self._interrupted.clear()
+
+
+class PendingInputQueue:
+    """Thread-safe FIFO of free-text user messages staged during an agent run.
+
+    Producer side (TUI Enter handler, API ``/insert`` route) calls
+    :meth:`push`. Consumer side (``call_model_input_filter`` closure,
+    chat-layer auto-continuation) calls :meth:`drain`. The queue is
+    bounded per-turn by :attr:`MAX_DRAIN_PER_TURN`; overflow naturally
+    flushes on subsequent turns so spammed input cannot blow the
+    context window in a single LLM call.
+    """
+
+    MAX_DRAIN_PER_TURN = 3
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._items: "deque[str]" = deque()
+
+    def push(self, text: str) -> None:
+        with self._lock:
+            self._items.append(text)
+
+    def drain(self) -> List[str]:
+        """Pop up to ``MAX_DRAIN_PER_TURN`` items in FIFO order."""
+        result: List[str] = []
+        with self._lock:
+            while self._items and len(result) < self.MAX_DRAIN_PER_TURN:
+                result.append(self._items.popleft())
+        return result
+
+    def drain_all(self) -> List[str]:
+        """Pop every queued item. Used by final-turn auto-continuation."""
+        with self._lock:
+            result = list(self._items)
+            self._items.clear()
+        return result
+
+    def snapshot(self) -> List[str]:
+        """Return a read-only copy of the current queue without consuming."""
+        with self._lock:
+            return list(self._items)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._items.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
 
 
 @dataclass
@@ -134,6 +185,32 @@ class InteractionBroker:
                 except RuntimeError:
                     pass
         self._output_queue.put_nowait(self._STOP_SENTINEL)
+
+    def emit_user_insert(self, text: str) -> None:
+        """Push a USER ``ActionHistory`` representing a mid-run insertion.
+
+        Called from the model layer's ``call_model_input_filter`` the moment
+        a queued mid-run message is actually being flushed into the next
+        LLM turn. Surfacing the action through the broker's output queue
+        makes it visible both to the TUI (which renders the merged action
+        stream) and to the API SSE stream (which serialises the same
+        merged stream via :func:`action_to_sse_event`). The action is
+        synchronous because the producer side is the SDK's asyncio loop —
+        we only need to enqueue, not await a response.
+        """
+        if self._closed:
+            logger.debug("InteractionBroker.emit_user_insert called after close(); ignored")
+            return
+        action = ActionHistory(
+            action_id=str(uuid.uuid4()),
+            role=ActionRole.USER,
+            status=ActionStatus.SUCCESS,
+            action_type="user_insert",
+            messages=text,
+            input={"user_message": text, "source": "mid_run_insert"},
+            output={"user_message": text},
+        )
+        self._output_queue.put_nowait(action)
 
     async def send(
         self,

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -536,6 +536,17 @@ class DatusCLI:
             logger.debug(f"todo sidebar line_count failed: {e}")
             return 0
 
+    def _active_pending_input_queue(self):
+        """Return the active chat node's :class:`PendingInputQueue` or None.
+
+        Consulted by the TUI Enter handler and the pinned queue-preview
+        ``ConditionalContainer`` while the agent is streaming. Defensive
+        getattr chain because ``chat_commands`` is only created lazily.
+        """
+        chat_commands = getattr(self, "chat_commands", None)
+        current_node = getattr(chat_commands, "current_node", None) if chat_commands else None
+        return getattr(current_node, "pending_input_queue", None) if current_node else None
+
     def _interrupt_agent(self) -> None:
         chat_commands = getattr(self, "chat_commands", None)
         current_node = getattr(chat_commands, "current_node", None) if chat_commands else None
@@ -690,6 +701,11 @@ class DatusCLI:
             # inside the viewport. This keeps type-latency flat even when the
             # verbose-mode scrollback grows into thousands of lines.
             output_buffer=self._tui_output_buffer,
+            # Mid-run user-insert path. The TUI's Enter handler consults
+            # this provider while the agent is streaming so typed messages
+            # are queued for the next LLM turn (via the OpenAI Agents SDK
+            # ``call_model_input_filter`` hook) instead of being dropped.
+            pending_input_provider=self._active_pending_input_queue,
         )
 
         # Now that the Application exists, wire the buffer's ``on_change``

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -544,7 +544,9 @@ class DatusCLI:
         getattr chain because ``chat_commands`` is only created lazily.
         """
         chat_commands = getattr(self, "chat_commands", None)
-        current_node = getattr(chat_commands, "current_node", None) if chat_commands else None
+        if chat_commands is None or getattr(chat_commands, "current_streaming_ctx", None) is None:
+            return None
+        current_node = getattr(chat_commands, "current_node", None)
         return getattr(current_node, "pending_input_queue", None) if current_node else None
 
     def _interrupt_agent(self) -> None:

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -165,9 +165,16 @@ class DatusApp:
         output_tokens_fn: Optional[Callable[[], List[Tuple[str, str]]]] = None,
         output_line_count_fn: Optional[Callable[[], int]] = None,
         output_buffer: Optional["TUIOutputBuffer"] = None,
+        pending_input_provider: Optional[Callable[[], Any]] = None,
     ) -> None:
         self._status_tokens_fn = status_tokens_fn
         self._dispatch_fn = dispatch_fn
+        # Returns the active :class:`PendingInputQueue` (or ``None``) for
+        # the running chat session. Consulted by the Enter handler when
+        # ``_agent_running`` is set so the user can stage messages
+        # mid-stream, and by the queue-preview ``ConditionalContainer``
+        # pinned above the status bar.
+        self._pending_input_provider = pending_input_provider
         self._placeholder_fn = placeholder_fn or (lambda: "")
         self._input_prompt_fn = input_prompt_fn or (lambda: "> ")
         self._live_state = live_display_state
@@ -411,8 +418,10 @@ class DatusApp:
         # takes the slot instead, hiding status + input and pushing the
         # output row upward as much as the wizard needs. See
         # ``datus/cli/tui/wizard_host.py`` for the embedding contract.
+        self._queue_preview = self._build_queue_preview()
         self._normal_bottom_section = HSplit(
             [
+                self._queue_preview,
                 self._make_separator(),
                 self._status_window,
                 self._make_separator(),
@@ -484,6 +493,64 @@ class DatusApp:
     # be readable (20% of 60 columns ≈ 12, with a 1-col rule on its
     # left). Below this threshold the entire right column is hidden.
     _SIDEBAR_MIN_TERMINAL_COLS = 60
+
+    # Max number of pending lines rendered in the queue preview before
+    # the trailing items are collapsed into an "(+N more)" line. The
+    # preview's job is just to confirm "your text is queued" — it is
+    # not a transcript and should never push the layout around.
+    _QUEUE_PREVIEW_MAX_LINES = 5
+
+    def _build_queue_preview(self) -> ConditionalContainer:
+        """Build the pinned queue-preview box rendered above the status bar.
+
+        Visibility is driven by :class:`Condition` so the entire container
+        collapses to zero rows when the queue is empty — no layout churn,
+        no manual show/hide. When :attr:`_pending_input_provider` is not
+        wired (non-chat dispatch), the filter never reports visible.
+        """
+
+        def _visible() -> bool:
+            if self._pending_input_provider is None:
+                return False
+            queue = self._pending_input_provider()
+            if queue is None:
+                return False
+            try:
+                return len(queue) > 0
+            except TypeError:
+                return False
+
+        def _tokens() -> List[Tuple[str, str]]:
+            if self._pending_input_provider is None:
+                return []
+            queue = self._pending_input_provider()
+            if queue is None:
+                return []
+            try:
+                items = queue.snapshot()
+            except AttributeError:
+                return []
+            if not items:
+                return []
+            lines: List[Tuple[str, str]] = [
+                ("class:queue-preview.header", f"⏎ queued for agent ({len(items)}):\n"),
+            ]
+            visible_items = items[: self._QUEUE_PREVIEW_MAX_LINES]
+            for idx, text in enumerate(visible_items, 1):
+                preview = text if len(text) <= 80 else text[:77] + "..."
+                lines.append(("class:queue-preview.item", f"  {idx}. {preview}\n"))
+            overflow = len(items) - len(visible_items)
+            if overflow > 0:
+                lines.append(("class:queue-preview.item", f"  (+{overflow} more)\n"))
+            return lines
+
+        window = Window(
+            content=FormattedTextControl(_tokens),
+            height=Dimension(min=1, max=self._QUEUE_PREVIEW_MAX_LINES + 2),
+            style="class:queue-preview.box",
+            always_hide_cursor=True,
+        )
+        return ConditionalContainer(content=window, filter=Condition(_visible))
 
     def _build_todo_sidebar(self) -> ConditionalContainer:
         """Construct the TodoList sidebar column pinned above the status bar.
@@ -1743,6 +1810,31 @@ class DatusApp:
                     buffer.cancel_completion()
 
             if self._agent_running.is_set():
+                # Mid-run user-insert path. The OpenAI Agents SDK caches
+                # ``_model_input_items`` for the lifetime of a streamed run,
+                # so we cannot drop text into the session and expect the
+                # model to pick it up. Instead, push into the
+                # :class:`PendingInputQueue` carried by the running node;
+                # the model layer's ``call_model_input_filter`` drains it
+                # before the next LLM turn. When no queue is wired (e.g.
+                # the dispatch surface is not chat), fall through to a
+                # no-op as before.
+                queue = self._pending_input_provider() if self._pending_input_provider else None
+                if queue is None:
+                    return
+                text = buffer.text
+                if self._stored_paste:
+                    placeholder = self._paste_placeholder(self._stored_paste.count("\n") + 1)
+                    if placeholder in text:
+                        text = text.replace(placeholder, self._stored_paste, 1)
+                    self._stored_paste = None
+                    self._paste_collapsed = False
+                stripped = text.strip()
+                if not stripped:
+                    return
+                queue.push(stripped)
+                buffer.reset()
+                event.app.invalidate()
                 return
 
             text = buffer.text

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -509,48 +509,79 @@ class DatusApp:
         wired (non-chat dispatch), the filter never reports visible.
         """
 
-        def _visible() -> bool:
-            if self._pending_input_provider is None:
-                return False
-            queue = self._pending_input_provider()
-            if queue is None:
-                return False
-            try:
-                return len(queue) > 0
-            except TypeError:
-                return False
-
-        def _tokens() -> List[Tuple[str, str]]:
-            if self._pending_input_provider is None:
-                return []
-            queue = self._pending_input_provider()
-            if queue is None:
-                return []
-            try:
-                items = queue.snapshot()
-            except AttributeError:
-                return []
-            if not items:
-                return []
-            lines: List[Tuple[str, str]] = [
-                ("class:queue-preview.header", f"⏎ queued for agent ({len(items)}):\n"),
-            ]
-            visible_items = items[: self._QUEUE_PREVIEW_MAX_LINES]
-            for idx, text in enumerate(visible_items, 1):
-                preview = text if len(text) <= 80 else text[:77] + "..."
-                lines.append(("class:queue-preview.item", f"  {idx}. {preview}\n"))
-            overflow = len(items) - len(visible_items)
-            if overflow > 0:
-                lines.append(("class:queue-preview.item", f"  (+{overflow} more)\n"))
-            return lines
-
         window = Window(
-            content=FormattedTextControl(_tokens),
+            content=FormattedTextControl(self._queue_preview_tokens),
             height=Dimension(min=1, max=self._QUEUE_PREVIEW_MAX_LINES + 2),
             style="class:queue-preview.box",
             always_hide_cursor=True,
         )
-        return ConditionalContainer(content=window, filter=Condition(_visible))
+        return ConditionalContainer(content=window, filter=Condition(self._queue_preview_visible))
+
+    def _enqueue_pending_input(self, buffer, app) -> bool:
+        """Push the input-buffer text into the running agent's pending queue.
+
+        Returns ``True`` when the text was successfully queued, ``False``
+        otherwise (no queue wired, blank text). The OpenAI Agents SDK
+        caches ``_model_input_items`` for the lifetime of a streamed run,
+        so dropping text into the session mid-stream is invisible to the
+        model. The queue is drained by the model layer's
+        ``call_model_input_filter`` before the next LLM turn.
+        """
+        queue = self._pending_input_provider() if self._pending_input_provider else None
+        if queue is None:
+            return False
+        text = buffer.text
+        if self._stored_paste:
+            placeholder = self._paste_placeholder(self._stored_paste.count("\n") + 1)
+            if placeholder in text:
+                text = text.replace(placeholder, self._stored_paste, 1)
+            self._stored_paste = None
+            self._paste_collapsed = False
+        stripped = text.strip()
+        if not stripped:
+            return False
+        queue.push(stripped)
+        buffer.reset()
+        if app is not None:
+            app.invalidate()
+        return True
+
+    def _queue_preview_visible(self) -> bool:
+        """Visibility predicate for the pinned queue-preview container."""
+        if self._pending_input_provider is None:
+            return False
+        queue = self._pending_input_provider()
+        if queue is None:
+            return False
+        try:
+            return len(queue) > 0
+        except TypeError:
+            return False
+
+    def _queue_preview_tokens(self) -> List[Tuple[str, str]]:
+        """Render the formatted-text rows for the queue-preview container."""
+        if self._pending_input_provider is None:
+            return []
+        queue = self._pending_input_provider()
+        if queue is None:
+            return []
+        try:
+            items = queue.snapshot()
+        except AttributeError:
+            return []
+        if not items:
+            return []
+        lines: List[Tuple[str, str]] = [
+            ("class:queue-preview.header", f"⏎ queued for agent ({len(items)}):\n"),
+        ]
+        visible_items = items[: self._QUEUE_PREVIEW_MAX_LINES]
+        for idx, text in enumerate(visible_items, 1):
+            preview = text if len(text) <= 80 else text[:77] + "..."
+            lines.append(("class:queue-preview.item", f"  {idx}. {preview}\n"))
+        overflow = len(items) - len(visible_items)
+        if overflow > 0:
+            lines.append(("class:queue-preview.item", f"  (+{overflow} more)\n"))
+        return lines
 
     def _build_todo_sidebar(self) -> ConditionalContainer:
         """Construct the TodoList sidebar column pinned above the status bar.
@@ -1810,31 +1841,7 @@ class DatusApp:
                     buffer.cancel_completion()
 
             if self._agent_running.is_set():
-                # Mid-run user-insert path. The OpenAI Agents SDK caches
-                # ``_model_input_items`` for the lifetime of a streamed run,
-                # so we cannot drop text into the session and expect the
-                # model to pick it up. Instead, push into the
-                # :class:`PendingInputQueue` carried by the running node;
-                # the model layer's ``call_model_input_filter`` drains it
-                # before the next LLM turn. When no queue is wired (e.g.
-                # the dispatch surface is not chat), fall through to a
-                # no-op as before.
-                queue = self._pending_input_provider() if self._pending_input_provider else None
-                if queue is None:
-                    return
-                text = buffer.text
-                if self._stored_paste:
-                    placeholder = self._paste_placeholder(self._stored_paste.count("\n") + 1)
-                    if placeholder in text:
-                        text = text.replace(placeholder, self._stored_paste, 1)
-                    self._stored_paste = None
-                    self._paste_collapsed = False
-                stripped = text.strip()
-                if not stripped:
-                    return
-                queue.push(stripped)
-                buffer.reset()
-                event.app.invalidate()
+                self._enqueue_pending_input(buffer, event.app)
                 return
 
             text = buffer.text

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -20,6 +20,7 @@ from agents import Agent, ModelSettings, Runner, Tool
 from agents.exceptions import MaxTurnsExceeded, ModelBehaviorError
 from agents.extensions.memory import AdvancedSQLiteSession
 from agents.mcp import MCPServerStdio
+from agents.run import CallModelData, ModelInputData, RunConfig
 from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 from openai.types.shared.reasoning import Reasoning
 from pydantic import AnyUrl
@@ -715,6 +716,8 @@ class OpenAICompatibleModel(LLMBaseModel):
         action_history_manager: Optional[ActionHistoryManager] = None,
         hooks=None,
         interrupt_controller=None,
+        pending_input_queue=None,
+        interaction_broker=None,
         **kwargs,
     ) -> AsyncGenerator[ActionHistory, None]:
         """
@@ -750,9 +753,74 @@ class OpenAICompatibleModel(LLMBaseModel):
             action_history_manager,
             hooks,
             interrupt_controller=interrupt_controller,
+            pending_input_queue=pending_input_queue,
+            interaction_broker=interaction_broker,
             **kwargs,
         ):
             yield action
+
+    def _build_run_config(
+        self,
+        pending_input_queue=None,
+        session: Optional[AdvancedSQLiteSession] = None,
+        interrupt_controller=None,
+        interaction_broker=None,
+    ) -> Optional[RunConfig]:
+        """Build a :class:`RunConfig` carrying our mid-run input filter.
+
+        Returns ``None`` when no ``pending_input_queue`` is wired in — the
+        SDK then runs with its default config and behavior is unchanged.
+
+        The filter is invoked by the SDK before every LLM turn within a
+        ``Runner.run_streamed`` invocation (``agents/run.py`` ~1483). It
+        drains the queue (up to ``MAX_DRAIN_PER_TURN`` items) and appends
+        each as a structured Responses-API user message, also persisting
+        them onto the session so future runs see them.
+
+        When ``interaction_broker`` is provided, each drained item is also
+        emitted as a USER ``ActionHistory`` via
+        :meth:`InteractionBroker.emit_user_insert`. That makes the
+        injection visible to the TUI's streaming display and to the API
+        SSE consumer at the exact moment it's being flushed to the model.
+
+        All exceptions in the filter body are swallowed: the SDK re-raises
+        uncaught filter errors and aborts the entire run, which we must
+        never let a queue or sqlite hiccup do.
+        """
+        if pending_input_queue is None:
+            return None
+
+        async def _filter(data: CallModelData) -> ModelInputData:
+            try:
+                if interrupt_controller is not None and getattr(interrupt_controller, "is_interrupted", False):
+                    return data.model_data
+                pending = pending_input_queue.drain()
+                if not pending:
+                    return data.model_data
+                new_items = list(data.model_data.input)
+                for text in pending:
+                    user_item = {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": text}],
+                    }
+                    new_items.append(user_item)
+                    if session is not None:
+                        try:
+                            await session.add_items([user_item])
+                        except Exception:  # noqa: BLE001 — never abort the run on a session write
+                            logger.exception("Failed to persist injected user item; in-memory only.")
+                    if interaction_broker is not None:
+                        try:
+                            interaction_broker.emit_user_insert(text)
+                        except Exception:  # noqa: BLE001 — broker emission is best-effort
+                            logger.exception("Failed to emit user_insert ActionHistory; model still sees the text.")
+                return ModelInputData(input=new_items, instructions=data.model_data.instructions)
+            except Exception:  # noqa: BLE001 — filter exceptions abort the SDK run
+                logger.exception("call_model_input_filter raised; returning original input unchanged.")
+                return data.model_data
+
+        return RunConfig(call_model_input_filter=_filter)
 
     def _build_agent(
         self,
@@ -963,6 +1031,8 @@ class OpenAICompatibleModel(LLMBaseModel):
         action_history_manager: ActionHistoryManager,
         hooks=None,
         interrupt_controller=None,
+        pending_input_queue=None,
+        interaction_broker=None,
         **kwargs,
     ) -> AsyncGenerator[ActionHistory, None]:
         """Internal method for tool streaming execution with error handling.
@@ -988,8 +1058,20 @@ class OpenAICompatibleModel(LLMBaseModel):
                     agent_name=kwargs.pop("agent_name", "Tools_Agent"),
                 )
 
+                run_config = self._build_run_config(
+                    pending_input_queue=pending_input_queue,
+                    session=session,
+                    interrupt_controller=interrupt_controller,
+                    interaction_broker=interaction_broker,
+                )
                 try:
-                    result = Runner.run_streamed(agent, input=prompt, max_turns=max_turns, session=session)
+                    result = Runner.run_streamed(
+                        agent,
+                        input=prompt,
+                        max_turns=max_turns,
+                        session=session,
+                        run_config=run_config,
+                    )
                 except MaxTurnsExceeded as e:
                     logger.error(f"Max turns exceeded in streaming: {str(e)}")
                     raise DatusException(

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -252,3 +252,126 @@ class TestChatRouteAcceptance:
         assert isinstance(response, StreamingResponse)
         assert response.status_code == 200
         assert response.media_type == "text/event-stream"
+
+
+# ===========================================================================
+# /api/v1/chat/insert — mid-run user-text injection
+# ===========================================================================
+
+
+class TestInsertMessageEndpoint:
+    """Behavioural contract for the ``/insert`` endpoint.
+
+    The endpoint is the API equivalent of typing in the TUI while the
+    agent is streaming: it appends a free-text user message to the
+    pending-input queue carried by the running node, so the model sees
+    it before its next LLM turn.
+    """
+
+    @staticmethod
+    def _make_request(message: str = "describe customers", session_id: str = "s1"):
+        from datus.api.models.chat_models import InsertMessageInput
+
+        return InsertMessageInput(session_id=session_id, message=message)
+
+    @staticmethod
+    def _make_task_with_queue(queue=None):
+        from datus.cli.execution_state import PendingInputQueue
+
+        task = MagicMock()
+        task.node.pending_input_queue = queue if queue is not None else PendingInputQueue()
+        return task
+
+    @pytest.mark.asyncio
+    async def test_push_success_returns_queued_count(self):
+        from datus.api.routes.chat_routes import insert_message
+
+        task = self._make_task_with_queue()
+        svc = _mock_svc(task=task)
+
+        result = await insert_message(self._make_request("hello"), svc)
+
+        assert result.success is True
+        assert result.data.session_id == "s1"
+        assert result.data.queued_count == 1
+        assert task.node.pending_input_queue.snapshot() == ["hello"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_pushes_accumulate(self):
+        from datus.api.routes.chat_routes import insert_message
+
+        task = self._make_task_with_queue()
+        svc = _mock_svc(task=task)
+
+        await insert_message(self._make_request("first"), svc)
+        result = await insert_message(self._make_request("second"), svc)
+
+        assert result.success is True
+        assert result.data.queued_count == 2
+        assert task.node.pending_input_queue.snapshot() == ["first", "second"]
+
+    @pytest.mark.asyncio
+    async def test_missing_task_returns_session_not_running(self):
+        from datus.api.routes.chat_routes import insert_message
+
+        svc = _mock_svc(task=None)
+
+        result = await insert_message(self._make_request("anything"), svc)
+
+        assert result.success is False
+        assert result.errorCode == "SESSION_NOT_RUNNING"
+
+    @pytest.mark.asyncio
+    async def test_task_without_node_returns_session_not_running(self):
+        from datus.api.routes.chat_routes import insert_message
+
+        task = MagicMock()
+        task.node = None
+        svc = _mock_svc(task=task)
+
+        result = await insert_message(self._make_request("anything"), svc)
+
+        assert result.success is False
+        assert result.errorCode == "SESSION_NOT_RUNNING"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_message_returns_invalid_input(self):
+        from datus.api.routes.chat_routes import insert_message
+
+        task = self._make_task_with_queue()
+        svc = _mock_svc(task=task)
+
+        result = await insert_message(self._make_request("   \t  "), svc)
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_INPUT"
+        # Queue untouched.
+        assert len(task.node.pending_input_queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_node_without_queue_returns_queue_unavailable(self):
+        """Node exists but caller never initialised pending_input_queue —
+        the route must surface that as a distinct error rather than
+        silently pushing nowhere."""
+        from datus.api.routes.chat_routes import insert_message
+
+        task = MagicMock()
+        task.node.pending_input_queue = None
+        svc = _mock_svc(task=task)
+
+        result = await insert_message(self._make_request("hello"), svc)
+
+        assert result.success is False
+        assert result.errorCode == "QUEUE_UNAVAILABLE"
+
+    @pytest.mark.asyncio
+    async def test_message_is_stripped_before_push(self):
+        from datus.api.routes.chat_routes import insert_message
+
+        task = self._make_task_with_queue()
+        svc = _mock_svc(task=task)
+
+        await insert_message(self._make_request("  padded  "), svc)
+
+        # Stripped form lands in the queue.
+        assert task.node.pending_input_queue.snapshot() == ["padded"]

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -870,6 +870,25 @@ class TestActionToSSEEvent:
         assert event.data.payload.role == "user"
         assert event.data.payload.content[0].type == "markdown"
 
+    def test_user_insert_action_always_emitted(self):
+        """``user_insert`` actions represent text the user typed mid-run
+        (TUI / API ``/insert``) and must reach the SSE client regardless
+        of ``include_user_message`` — that flag gates the initial-request
+        echo, which is unrelated to live mid-run injections."""
+        action = _make_action(
+            role=ActionRole.USER,
+            action_type="user_insert",
+            status=ActionStatus.SUCCESS,
+            input={"user_message": "顺便统计行数", "source": "mid_run_insert"},
+            output={"user_message": "顺便统计行数"},
+        )
+        # No include_user_message flag — default False; must still emit.
+        event = action_to_sse_event(action, event_id=6, message_id="msg-6")
+        event = _assert_sse_event(event)
+        assert event.data.payload.role == "user"
+        assert event.data.payload.content[0].type == "markdown"
+        assert event.data.payload.content[0].payload["content"] == "顺便统计行数"
+
     def test_visual_report_response_emits_artifact_without_final_response_flag(self):
         """gen_visual_report completion fires an artifact event even when include_final_response=False.
 

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -571,6 +571,61 @@ class TestUnifiedReprint:
         assert "Previous question" in output
         assert "Current question" in output
 
+    def test_reprint_preserves_user_insert_actions(self):
+        """Ctrl+O verbose toggle reprints history from ``self.actions``.
+
+        The initial USER request (depth=0, original action_type) is
+        dropped because it's already echoed by the user-header at the top
+        of the turn. But ``user_insert`` actions — text the user typed
+        mid-run via TUI / API — must survive the reprint, otherwise the
+        verbose snapshot would silently lose the user's own mid-stream
+        contributions.
+        """
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        display = ActionHistoryDisplay(console)
+
+        actions = [
+            # 1) Initial request — should NOT appear in reprint body
+            # (the user-header at the top already shows it).
+            _make_action(
+                ActionRole.USER,
+                ActionStatus.PROCESSING,
+                action_type="chat_agentic_node_request",
+                messages="User: original question",
+                input_data={"user_message": "original question"},
+            ),
+            # 2) A tool call mid-turn.
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                messages="ok",
+                input_data={"function_name": "list_tables"},
+            ),
+            # 3) The mid-run user injection that must survive Ctrl+O.
+            _make_action(
+                ActionRole.USER,
+                ActionStatus.SUCCESS,
+                action_type="user_insert",
+                messages="also count the rows",
+                input_data={"user_message": "also count the rows", "source": "mid_run_insert"},
+                output_data={"user_message": "also count the rows"},
+            ),
+        ]
+
+        ctx = InlineStreamingContext(actions, display, current_user_message="original question")
+        ctx._processed_index = len(actions)
+        ctx._verbose = True
+
+        ctx._reprint_history(verbose=True)
+
+        output = buf.getvalue()
+        # The verbose reprint must include the mid-run injection ...
+        assert "also count the rows" in output
+        # ... but not echo the initial request twice (its text only shows
+        # up once, in the user header at the top — which we also emit).
+        assert output.count("original question") == 1
+
     def test_reprint_verbose_mode_with_active_groups(self):
         """Reprint in verbose mode shows active groups with in-progress indicator."""
         buf = StringIO()

--- a/tests/unit_tests/cli/test_execution_state.py
+++ b/tests/unit_tests/cli/test_execution_state.py
@@ -1016,7 +1016,10 @@ class TestPendingInputQueue:
 
         q = PendingInputQueue()
         n_threads = 8
-        per_thread = 50
+        # Stay strictly below MAX_PENDING_ITEMS so the contention test
+        # asserts thread-safety, not overflow behaviour.
+        per_thread = PendingInputQueue.MAX_PENDING_ITEMS // n_threads
+        assert n_threads * per_thread <= PendingInputQueue.MAX_PENDING_ITEMS
         producers = []
         barrier = threading.Barrier(n_threads)
 
@@ -1036,6 +1039,23 @@ class TestPendingInputQueue:
         # producer's pushes is preserved by the underlying deque.
         items = q.drain_all()
         assert len(items) == n_threads * per_thread
+
+    def test_push_beyond_cap_drops_oldest_and_warns(self, caplog):
+        q = PendingInputQueue()
+        cap = PendingInputQueue.MAX_PENDING_ITEMS
+        for i in range(cap):
+            q.push(f"old-{i}")
+        assert len(q) == cap
+
+        with caplog.at_level("WARNING", logger="datus.cli.execution_state"):
+            q.push("new")
+
+        assert len(q) == cap
+        snapshot = q.snapshot()
+        # Oldest entry was dropped, newest is at the tail.
+        assert snapshot[0] == "old-1"
+        assert snapshot[-1] == "new"
+        assert any("PendingInputQueue overflow" in rec.message for rec in caplog.records)
 
 
 class TestEmitUserInsert:

--- a/tests/unit_tests/cli/test_execution_state.py
+++ b/tests/unit_tests/cli/test_execution_state.py
@@ -24,6 +24,7 @@ from datus.cli.execution_state import (
     InteractionBroker,
     InteractionCancelled,
     InterruptController,
+    PendingInputQueue,
     PendingInteraction,
     auto_submit_interaction,
     merge_interaction_stream,
@@ -940,3 +941,156 @@ class TestInteractionBrokerAllowFreeText:
         action = broker._output_queue.get_nowait()
         events = action.input.get("events", []) if isinstance(action.input, dict) else []
         assert events and events[0].get("allow_free_text") is True
+
+
+class TestPendingInputQueue:
+    """Behavioural contract for the mid-run user-insert queue."""
+
+    def test_push_and_drain_preserves_fifo_order(self):
+        q = PendingInputQueue()
+        q.push("first")
+        q.push("second")
+        q.push("third")
+
+        # __len__ reflects pending count.
+        assert len(q) == 3
+
+        drained = q.drain()
+        # MAX_DRAIN_PER_TURN caps per-turn drain at 3 — all three fit.
+        assert drained == ["first", "second", "third"]
+        assert len(q) == 0
+
+    def test_drain_respects_max_per_turn_cap(self):
+        q = PendingInputQueue()
+        for i in range(PendingInputQueue.MAX_DRAIN_PER_TURN + 2):
+            q.push(f"msg-{i}")
+
+        first = q.drain()
+        assert len(first) == PendingInputQueue.MAX_DRAIN_PER_TURN
+        # Remaining items stay in the queue and flush on the next drain.
+        assert len(q) == 2
+        second = q.drain()
+        assert second == ["msg-3", "msg-4"]
+        assert len(q) == 0
+
+    def test_snapshot_does_not_consume(self):
+        q = PendingInputQueue()
+        q.push("alpha")
+        q.push("beta")
+
+        snap1 = q.snapshot()
+        snap2 = q.snapshot()
+
+        assert snap1 == ["alpha", "beta"]
+        assert snap2 == ["alpha", "beta"]
+        # Snapshot returns a copy, not the internal deque view.
+        snap1.clear()
+        assert q.snapshot() == ["alpha", "beta"]
+        # Items still available for actual drain afterwards.
+        assert q.drain() == ["alpha", "beta"]
+
+    def test_drain_all_pops_everything(self):
+        q = PendingInputQueue()
+        for i in range(7):
+            q.push(f"m{i}")
+        all_items = q.drain_all()
+        assert len(all_items) == 7
+        assert len(q) == 0
+
+    def test_clear_drops_pending_items(self):
+        q = PendingInputQueue()
+        q.push("x")
+        q.push("y")
+        q.clear()
+        assert len(q) == 0
+        assert q.snapshot() == []
+        assert q.drain() == []
+
+    def test_drain_on_empty_returns_empty_list(self):
+        q = PendingInputQueue()
+        assert q.drain() == []
+        assert q.drain_all() == []
+
+    def test_concurrent_push_from_multiple_threads_preserves_count(self):
+        import threading
+
+        q = PendingInputQueue()
+        n_threads = 8
+        per_thread = 50
+        producers = []
+        barrier = threading.Barrier(n_threads)
+
+        def producer(tid):
+            barrier.wait()
+            for i in range(per_thread):
+                q.push(f"t{tid}-i{i}")
+
+        for tid in range(n_threads):
+            t = threading.Thread(target=producer, args=(tid,))
+            producers.append(t)
+            t.start()
+        for t in producers:
+            t.join()
+
+        # No items lost under contention; FIFO order within a single
+        # producer's pushes is preserved by the underlying deque.
+        items = q.drain_all()
+        assert len(items) == n_threads * per_thread
+
+
+class TestEmitUserInsert:
+    """``InteractionBroker.emit_user_insert`` enqueues a USER ActionHistory
+    visible to both the TUI and the API SSE consumers."""
+
+    @pytest.mark.asyncio
+    async def test_emit_pushes_user_action_with_user_insert_type(self):
+        broker = InteractionBroker()
+        broker.reset_queue()  # bind the queue to the running loop
+
+        broker.emit_user_insert("追加：还要顺便统计行数")
+
+        # The action lands in the broker's output queue, where
+        # ``broker.fetch()`` (and thus the merged action stream) consumes it.
+        action = broker._output_queue.get_nowait()
+        assert action.role == ActionRole.USER
+        assert action.action_type == "user_insert"
+        assert action.status == ActionStatus.SUCCESS
+        assert action.messages == "追加：还要顺便统计行数"
+        # ``_build_user_content`` reads ``input["user_message"]`` — emit
+        # must produce that shape so the SSE converter renders correctly.
+        assert action.input["user_message"] == "追加：还要顺便统计行数"
+        assert action.input.get("source") == "mid_run_insert"
+        assert action.output["user_message"] == "追加：还要顺便统计行数"
+
+    @pytest.mark.asyncio
+    async def test_emit_after_close_is_noop(self):
+        """A broker that has already closed must drop the emission rather
+        than raise — the filter is best-effort and the run might be tearing
+        down."""
+        broker = InteractionBroker()
+        broker.reset_queue()
+        broker.close()
+
+        # Drain the close sentinel so we can observe that nothing else lands.
+        sentinel = broker._output_queue.get_nowait()
+        assert sentinel is broker._STOP_SENTINEL
+
+        broker.emit_user_insert("ignored")
+
+        # No further item after the sentinel.
+        assert broker._output_queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_multiple_emits_preserve_order(self):
+        broker = InteractionBroker()
+        broker.reset_queue()
+
+        broker.emit_user_insert("first")
+        broker.emit_user_insert("second")
+        broker.emit_user_insert("third")
+
+        actions = [broker._output_queue.get_nowait() for _ in range(3)]
+        assert [a.messages for a in actions] == ["first", "second", "third"]
+        for a in actions:
+            assert a.role == ActionRole.USER
+            assert a.action_type == "user_insert"

--- a/tests/unit_tests/cli/test_mid_run_insert.py
+++ b/tests/unit_tests/cli/test_mid_run_insert.py
@@ -1,0 +1,406 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the mid-run user-insert surface.
+
+Covers the small-but-load-bearing CLI / TUI pieces that bridge the
+in-memory :class:`PendingInputQueue` to the running agent: the
+auto-continuation loop in :meth:`ChatCommands.execute_chat_command`, the
+``_active_pending_input_queue`` accessor wired into ``DatusApp``, and the
+``DatusApp`` queue-preview + Enter helpers that drive the pinned
+preview box above the status bar.
+
+CI tier: zero external dependencies — these tests construct lightweight
+stubs (no real prompt_toolkit Application, no real CLI bootstrap)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.cli.execution_state import InterruptController, PendingInputQueue
+
+# ---------------------------------------------------------------------------
+# ChatCommands.execute_chat_command — auto-continuation loop
+# ---------------------------------------------------------------------------
+
+
+class _StubChatCommands:
+    """Subset of :class:`ChatCommands` needed to drive the loop.
+
+    We instantiate the real class is overkill here — the loop only reads
+    ``self.current_node`` / ``self.console`` and calls ``_execute_chat``.
+    A minimal stub keeps the test focused on the loop logic itself.
+    """
+
+    # Mirror the cap on the real class so the test stays aligned even
+    # if the production constant moves.
+    from datus.cli.chat_commands import ChatCommands as _Real
+
+    MAX_AUTO_CONTINUATIONS = _Real.MAX_AUTO_CONTINUATIONS
+    execute_chat_command = _Real.execute_chat_command
+
+    def __init__(self, queue_residuals):
+        """``queue_residuals`` is a list of lists: residuals[i] is the
+        contents of the queue *after* the i-th ``_execute_chat`` call."""
+        self.console = MagicMock()
+        self.current_node = SimpleNamespace(
+            pending_input_queue=PendingInputQueue(),
+            interrupt_controller=InterruptController(),
+        )
+        self._residuals = list(queue_residuals)
+        self._calls = []
+
+    def _execute_chat(self, message, plan_mode=False, subagent_name=None, interactive=True):
+        self._calls.append(message)
+        # Refresh the queue contents to simulate what would have been
+        # pushed by the TUI / API while the previous call was running.
+        next_residual = self._residuals.pop(0) if self._residuals else []
+        # The production code drains the queue between iterations, so the
+        # stub fully resets here and re-pushes whatever the scenario
+        # wants the next iteration to see.
+        self.current_node.pending_input_queue.clear()
+        for text in next_residual:
+            self.current_node.pending_input_queue.push(text)
+
+
+class TestExecuteChatCommandAutoContinuation:
+    """Behavioural contract for the final-turn auto-continuation loop."""
+
+    def test_single_turn_when_queue_stays_empty(self):
+        """Happy path: no mid-run insertions → exactly one ``_execute_chat`` call."""
+        cc = _StubChatCommands(queue_residuals=[[]])
+
+        cc.execute_chat_command("first prompt")
+
+        assert cc._calls == ["first prompt"]
+
+    def test_residual_after_run_triggers_one_extra_call(self):
+        """Queue with content after the run → loop drains and runs again."""
+        cc = _StubChatCommands(queue_residuals=[["also stats"], []])
+
+        cc.execute_chat_command("first prompt")
+
+        # First call uses the original message, second call uses the
+        # drained residual — order preserved verbatim.
+        assert cc._calls == ["first prompt", "also stats"]
+
+    def test_multiple_residual_items_are_joined_with_double_newline(self):
+        """Several queued lines collapse into a single follow-up message."""
+        cc = _StubChatCommands(queue_residuals=[["one", "two", "three"], []])
+
+        cc.execute_chat_command("orig")
+
+        assert cc._calls == ["orig", "one\n\ntwo\n\nthree"]
+
+    def test_continuation_cap_stops_loop(self):
+        """``MAX_AUTO_CONTINUATIONS`` prevents a perpetual loop. After the
+        cap is reached we warn the user and leave the queue intact."""
+        # Always-non-empty residual — without the cap the loop would
+        # never terminate.
+        residuals = [[f"msg-{i}"] for i in range(_StubChatCommands.MAX_AUTO_CONTINUATIONS + 4)]
+        cc = _StubChatCommands(queue_residuals=residuals)
+
+        cc.execute_chat_command("orig")
+
+        # 1 initial + MAX_AUTO_CONTINUATIONS auto-continuations.
+        assert len(cc._calls) == 1 + _StubChatCommands.MAX_AUTO_CONTINUATIONS
+        # Warning printed to the console.
+        cc.console.print.assert_called_once()
+        warning_text = cc.console.print.call_args[0][0]
+        assert "auto-continuation cap reached" in warning_text
+
+    def test_interrupt_clears_queue_and_stops_loop(self):
+        """An interrupted run drains the queue and breaks the loop —
+        residual mid-run text is dropped because the user explicitly
+        cancelled."""
+        cc = _StubChatCommands(queue_residuals=[["should-be-cleared"]])
+
+        # Simulate ESC during the first call.
+        def _execute_with_interrupt(message, **_kw):
+            cc._calls.append(message)
+            cc.current_node.pending_input_queue.clear()
+            for text in ["should-be-cleared"]:
+                cc.current_node.pending_input_queue.push(text)
+            cc.current_node.interrupt_controller.interrupt()
+
+        cc._execute_chat = _execute_with_interrupt
+        cc.execute_chat_command("orig")
+
+        assert cc._calls == ["orig"]
+        assert len(cc.current_node.pending_input_queue) == 0
+
+    def test_no_current_node_breaks_loop_immediately(self):
+        """If the implementation never created a node (degenerate path)
+        the loop must still terminate after the first call."""
+        cc = _StubChatCommands(queue_residuals=[[]])
+        # Wipe the node after the call to simulate the no-node case.
+        original_execute = cc._execute_chat
+
+        def _execute_then_clear(message, **kw):
+            original_execute(message, **kw)
+            cc.current_node = None
+
+        cc._execute_chat = _execute_then_clear
+        cc.execute_chat_command("orig")
+
+        assert cc._calls == ["orig"]
+
+
+# ---------------------------------------------------------------------------
+# DatusCLI._active_pending_input_queue accessor
+# ---------------------------------------------------------------------------
+
+
+class TestActivePendingInputQueueAccessor:
+    """``DatusCLI._active_pending_input_queue`` exposes the running node's
+    queue to the TUI without pulling the whole CLI graph into the
+    keybinding closure."""
+
+    @staticmethod
+    def _call(cli):
+        from datus.cli.repl import DatusCLI
+
+        # Methods are descriptors that yield plain functions on class
+        # access. Invoke directly with our stub bound as ``self``.
+        return DatusCLI._active_pending_input_queue(cli)
+
+    def test_returns_queue_when_node_has_one(self):
+        queue = PendingInputQueue()
+        chat_commands = SimpleNamespace(current_node=SimpleNamespace(pending_input_queue=queue))
+        cli = SimpleNamespace(chat_commands=chat_commands)
+
+        assert self._call(cli) is queue
+
+    def test_returns_none_when_no_chat_commands(self):
+        cli = SimpleNamespace()
+        assert self._call(cli) is None
+
+    def test_returns_none_when_no_current_node(self):
+        cli = SimpleNamespace(chat_commands=SimpleNamespace(current_node=None))
+        assert self._call(cli) is None
+
+    def test_returns_none_when_node_has_no_queue_attribute(self):
+        chat_commands = SimpleNamespace(current_node=SimpleNamespace())
+        cli = SimpleNamespace(chat_commands=chat_commands)
+        assert self._call(cli) is None
+
+
+# ---------------------------------------------------------------------------
+# DatusApp helpers — queue preview + Enter enqueue
+# ---------------------------------------------------------------------------
+
+
+def _build_app(pending_input_provider=None):
+    from datus.cli.tui.app import DatusApp
+
+    return DatusApp(
+        status_tokens_fn=lambda: [],
+        dispatch_fn=lambda _: None,
+        pending_input_provider=pending_input_provider,
+    )
+
+
+class TestQueuePreviewVisible:
+    """``DatusApp._queue_preview_visible`` drives the
+    ``ConditionalContainer`` that owns the preview rows. When it returns
+    False the box collapses to zero rows; when True the user sees their
+    pending mid-run injections above the status bar."""
+
+    def test_no_provider_hides_box(self):
+        app = _build_app(pending_input_provider=None)
+        assert app._queue_preview_visible() is False
+
+    def test_provider_returning_none_hides_box(self):
+        app = _build_app(pending_input_provider=lambda: None)
+        assert app._queue_preview_visible() is False
+
+    def test_empty_queue_hides_box(self):
+        queue = PendingInputQueue()
+        app = _build_app(pending_input_provider=lambda: queue)
+        assert app._queue_preview_visible() is False
+
+    def test_non_empty_queue_shows_box(self):
+        queue = PendingInputQueue()
+        queue.push("追加一条")
+        app = _build_app(pending_input_provider=lambda: queue)
+        assert app._queue_preview_visible() is True
+
+    def test_object_without_len_hides_box(self):
+        """Defensive: if the provider returns something that does not
+        support ``len()`` (e.g. a half-built stub during a hot reload),
+        we hide rather than crash the layout."""
+        app = _build_app(pending_input_provider=lambda: object())
+        assert app._queue_preview_visible() is False
+
+
+class TestQueuePreviewTokens:
+    """``DatusApp._queue_preview_tokens`` renders the formatted rows."""
+
+    def test_no_provider_returns_empty(self):
+        app = _build_app(pending_input_provider=None)
+        assert app._queue_preview_tokens() == []
+
+    def test_provider_returning_none_returns_empty(self):
+        app = _build_app(pending_input_provider=lambda: None)
+        assert app._queue_preview_tokens() == []
+
+    def test_empty_queue_returns_empty(self):
+        queue = PendingInputQueue()
+        app = _build_app(pending_input_provider=lambda: queue)
+        assert app._queue_preview_tokens() == []
+
+    def test_renders_header_and_items_in_order(self):
+        queue = PendingInputQueue()
+        queue.push("first")
+        queue.push("second")
+        app = _build_app(pending_input_provider=lambda: queue)
+
+        tokens = app._queue_preview_tokens()
+
+        # First token is the header carrying the count.
+        assert tokens[0][0] == "class:queue-preview.header"
+        assert "queued for agent (2)" in tokens[0][1]
+        # Then one item row per queued message, in FIFO order.
+        item_texts = [text for cls, text in tokens[1:] if cls == "class:queue-preview.item"]
+        assert len(item_texts) == 2
+        assert "1. first" in item_texts[0]
+        assert "2. second" in item_texts[1]
+
+    def test_long_text_is_truncated(self):
+        queue = PendingInputQueue()
+        long_text = "x" * 200
+        queue.push(long_text)
+        app = _build_app(pending_input_provider=lambda: queue)
+
+        tokens = app._queue_preview_tokens()
+        item_row = next(text for cls, text in tokens if cls == "class:queue-preview.item")
+        # Hard cap (77 chars + ellipsis) keeps the box at a predictable width.
+        assert "..." in item_row
+        assert len(item_row) < 90
+
+    def test_overflow_collapses_to_more_row(self):
+        queue = PendingInputQueue()
+        from datus.cli.tui.app import DatusApp
+
+        for i in range(DatusApp._QUEUE_PREVIEW_MAX_LINES + 3):
+            queue.push(f"item-{i}")
+        app = _build_app(pending_input_provider=lambda: queue)
+
+        tokens = app._queue_preview_tokens()
+        # MAX rendered rows + 1 header + 1 overflow row.
+        item_rows = [text for cls, text in tokens if cls == "class:queue-preview.item"]
+        assert len(item_rows) == DatusApp._QUEUE_PREVIEW_MAX_LINES + 1
+        assert "(+3 more)" in item_rows[-1]
+
+    def test_snapshot_attribute_error_returns_empty(self):
+        """Defensive: a stub provider that returns something without
+        ``snapshot()`` must not crash the renderer."""
+        app = _build_app(pending_input_provider=lambda: object())
+        assert app._queue_preview_tokens() == []
+
+
+class TestEnqueuePendingInput:
+    """``DatusApp._enqueue_pending_input`` is the production code-path
+    exercised by the TUI Enter key while ``_agent_running`` is set."""
+
+    @staticmethod
+    def _make_buffer(text=""):
+        # prompt_toolkit's Buffer is heavy; a small stub with the two
+        # attributes the helper touches is sufficient.
+        return SimpleNamespace(text=text, reset=MagicMock())
+
+    def test_returns_false_when_no_provider(self):
+        app = _build_app(pending_input_provider=None)
+        buf = self._make_buffer("hello")
+        fake_app = SimpleNamespace(invalidate=MagicMock())
+
+        assert app._enqueue_pending_input(buf, fake_app) is False
+        # Buffer untouched; no invalidate call.
+        buf.reset.assert_not_called()
+        fake_app.invalidate.assert_not_called()
+
+    def test_returns_false_when_provider_returns_none(self):
+        app = _build_app(pending_input_provider=lambda: None)
+        buf = self._make_buffer("hello")
+        fake_app = SimpleNamespace(invalidate=MagicMock())
+
+        assert app._enqueue_pending_input(buf, fake_app) is False
+
+    def test_blank_text_is_not_queued(self):
+        queue = PendingInputQueue()
+        app = _build_app(pending_input_provider=lambda: queue)
+        buf = self._make_buffer("   \t  ")
+        fake_app = SimpleNamespace(invalidate=MagicMock())
+
+        assert app._enqueue_pending_input(buf, fake_app) is False
+        assert len(queue) == 0
+        buf.reset.assert_not_called()
+
+    def test_happy_path_pushes_stripped_text_and_resets_buffer(self):
+        queue = PendingInputQueue()
+        app = _build_app(pending_input_provider=lambda: queue)
+        buf = self._make_buffer("  also stats  ")
+        fake_app = SimpleNamespace(invalidate=MagicMock())
+
+        assert app._enqueue_pending_input(buf, fake_app) is True
+
+        # Pushed in stripped form so the model isn't fed ragged whitespace.
+        assert queue.snapshot() == ["also stats"]
+        buf.reset.assert_called_once()
+        fake_app.invalidate.assert_called_once()
+
+    def test_handles_missing_app_for_invalidate(self):
+        """The helper is also called from contexts where the
+        :class:`Application` reference is not yet wired (early tests,
+        bare construction). It must not raise."""
+        queue = PendingInputQueue()
+        app = _build_app(pending_input_provider=lambda: queue)
+        buf = self._make_buffer("real text")
+
+        assert app._enqueue_pending_input(buf, None) is True
+        assert queue.snapshot() == ["real text"]
+
+
+# ---------------------------------------------------------------------------
+# Broker emission exception path inside the model-layer input filter
+# ---------------------------------------------------------------------------
+
+
+class TestFilterBrokerEmissionFailure:
+    """When ``broker.emit_user_insert`` raises, the filter must still
+    return the augmented :class:`ModelInputData` — broker emission is
+    best-effort, the model layer of the run is the contract that has to
+    survive a misbehaving display side."""
+
+    @pytest.mark.asyncio
+    async def test_broker_emit_exception_does_not_drop_model_input(self):
+        from agents.run import CallModelData, ModelInputData
+
+        # _make_model lives in the openai_compatible test module.
+        from tests.unit_tests.models.test_openai_compatible import _make_model
+
+        model = _make_model()
+        queue = PendingInputQueue()
+        queue.push("追加：see this anyway")
+
+        bad_broker = MagicMock()
+        bad_broker.emit_user_insert = MagicMock(side_effect=RuntimeError("display down"))
+
+        rc = model._build_run_config(pending_input_queue=queue, session=None, interaction_broker=bad_broker)
+        baseline = ModelInputData(
+            input=[{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+            instructions="be brief",
+        )
+        data = CallModelData(model_data=baseline, agent=MagicMock(), context=None)
+
+        result = await rc.call_model_input_filter(data)
+
+        # Filter still injected the queued message into the model input.
+        assert len(result.input) == 2
+        assert result.input[-1]["content"][0]["text"] == "追加：see this anyway"
+        # Emission was attempted exactly once.
+        bad_broker.emit_user_insert.assert_called_once_with("追加：see this anyway")

--- a/tests/unit_tests/cli/test_mid_run_insert.py
+++ b/tests/unit_tests/cli/test_mid_run_insert.py
@@ -170,7 +170,10 @@ class TestActivePendingInputQueueAccessor:
 
     def test_returns_queue_when_node_has_one(self):
         queue = PendingInputQueue()
-        chat_commands = SimpleNamespace(current_node=SimpleNamespace(pending_input_queue=queue))
+        chat_commands = SimpleNamespace(
+            current_node=SimpleNamespace(pending_input_queue=queue),
+            current_streaming_ctx=object(),
+        )
         cli = SimpleNamespace(chat_commands=chat_commands)
 
         assert self._call(cli) is queue
@@ -180,11 +183,26 @@ class TestActivePendingInputQueueAccessor:
         assert self._call(cli) is None
 
     def test_returns_none_when_no_current_node(self):
-        cli = SimpleNamespace(chat_commands=SimpleNamespace(current_node=None))
+        cli = SimpleNamespace(chat_commands=SimpleNamespace(current_node=None, current_streaming_ctx=object()))
         assert self._call(cli) is None
 
     def test_returns_none_when_node_has_no_queue_attribute(self):
-        chat_commands = SimpleNamespace(current_node=SimpleNamespace())
+        chat_commands = SimpleNamespace(current_node=SimpleNamespace(), current_streaming_ctx=object())
+        cli = SimpleNamespace(chat_commands=chat_commands)
+        assert self._call(cli) is None
+
+    def test_returns_none_when_not_streaming(self):
+        """Stale ``current_node`` between chat turns must not leak its queue.
+
+        Without an active streamed turn (``current_streaming_ctx is None``),
+        a slash command or other worker task could otherwise push input into
+        a queue that the next chat run would surprisingly flush.
+        """
+        queue = PendingInputQueue()
+        chat_commands = SimpleNamespace(
+            current_node=SimpleNamespace(pending_input_queue=queue),
+            current_streaming_ctx=None,
+        )
         cli = SimpleNamespace(chat_commands=chat_commands)
         assert self._call(cli) is None
 

--- a/tests/unit_tests/cli/test_tui_layout.py
+++ b/tests/unit_tests/cli/test_tui_layout.py
@@ -13,6 +13,9 @@ catch that class of regression without needing an interactive terminal.
 
 from __future__ import annotations
 
+import os
+
+import pytest
 from prompt_toolkit.layout.containers import ConditionalContainer, Window
 from prompt_toolkit.layout.menus import CompletionsMenuControl
 
@@ -82,6 +85,10 @@ class TestCompletionsMenuWired:
         assert bottom_children[5] is app._completions_menu
         assert bottom_children[6] is app._search_bar
 
+    @pytest.mark.skipif(
+        os.environ.get("TERMINAL_EMULATOR", "").strip().lower() == "jetbrains-jediterm",
+        reason="JediTerm forces mouse_support off; see datus/cli/tui/app.py:_resolve_mouse_support",
+    )
     def test_app_runs_in_full_screen_with_mouse_support(self):
         """Sidebar can only sit "next to" the output history when the
         Application owns the entire terminal — assert the two flags

--- a/tests/unit_tests/cli/test_tui_layout.py
+++ b/tests/unit_tests/cli/test_tui_layout.py
@@ -69,16 +69,18 @@ class TestCompletionsMenuWired:
         bottom = children[1].get_container()
         assert isinstance(bottom, HSplit), "no wizard active → bottom is the normal HSplit"
         bottom_children = list(bottom.get_children())
-        # Expected order in normal bottom: top_sep, status, mid_sep, input,
-        # menu, search_bar, bottom_sep, hint. The search bar is a
-        # ConditionalContainer that consumes zero rows when ``_search_active``
-        # is False, so it doesn't affect the steady-state layout.
-        assert len(bottom_children) == 8, f"unexpected bottom HSplit child count: {len(bottom_children)}"
-        assert bottom_children[1] is app._status_window, "status bar must follow the leading separator"
-        # Menu (index 4) sits immediately after the input (index 3; the TextArea
+        # Expected order in normal bottom: queue_preview, top_sep, status,
+        # mid_sep, input, menu, search_bar, bottom_sep, hint. The queue
+        # preview and search bar are both ``ConditionalContainer``s that
+        # consume zero rows when their filter is False, so they don't
+        # affect the steady-state layout.
+        assert len(bottom_children) == 9, f"unexpected bottom HSplit child count: {len(bottom_children)}"
+        assert bottom_children[0] is app._queue_preview, "queue preview pinned above the status bar"
+        assert bottom_children[2] is app._status_window, "status bar must follow the leading separator"
+        # Menu (index 5) sits immediately after the input (index 4; the TextArea
         # is flattened into its wrapping Window by prompt_toolkit).
-        assert bottom_children[4] is app._completions_menu
-        assert bottom_children[5] is app._search_bar
+        assert bottom_children[5] is app._completions_menu
+        assert bottom_children[6] is app._search_bar
 
     def test_app_runs_in_full_screen_with_mouse_support(self):
         """Sidebar can only sit "next to" the output history when the

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -1960,3 +1960,166 @@ class TestExtractUsageInfo:
             info = model._extract_usage_info(usage)
 
         assert info["last_call_input_tokens"] == 0
+
+
+# ===========================================================================
+# Mid-run input filter (call_model_input_filter) tests
+# ===========================================================================
+
+
+class TestBuildRunConfigInputFilter:
+    """Behavioural contract for :meth:`OpenAICompatibleModel._build_run_config`.
+
+    The filter is the load-bearing piece of the mid-run user-insert
+    feature: when the user types into the TUI or POSTs to the API while
+    the agent is streaming, the filter is what injects that text into the
+    next LLM turn within the running ``Runner.run_streamed`` invocation.
+    """
+
+    @staticmethod
+    def _make_call_data():
+        """Build a CallModelData stand-in mirroring what the SDK passes."""
+        from agents.run import CallModelData, ModelInputData
+
+        baseline = ModelInputData(
+            input=[{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            instructions="be helpful",
+        )
+        # CallModelData also carries agent + context; the filter does not
+        # read them, so MagicMocks are sufficient.
+        return CallModelData(model_data=baseline, agent=MagicMock(), context=None)
+
+    def test_returns_none_when_no_queue(self):
+        """Without a queue wired in, no RunConfig is constructed — SDK
+        runs with default behavior and the run is unchanged."""
+        model = _make_model()
+        assert model._build_run_config(pending_input_queue=None) is None
+
+    @pytest.mark.asyncio
+    async def test_filter_appends_queued_items_and_persists_to_session(self):
+        """When the queue has pending text, the filter appends each as a
+        structured Responses user message AND calls ``session.add_items``
+        once per item so future runs see them. With a broker plumbed in,
+        each drained item also flows out as a USER ``user_insert``
+        ActionHistory so the TUI and API SSE see the injection live."""
+        from datus.cli.execution_state import InteractionBroker, PendingInputQueue
+        from datus.schemas.action_history import ActionRole
+
+        model = _make_model()
+        queue = PendingInputQueue()
+        queue.push("追加 1")
+        queue.push("追加 2")
+        session = MagicMock()
+        session.add_items = AsyncMock()
+        broker = InteractionBroker()
+        broker.reset_queue()
+
+        rc = model._build_run_config(pending_input_queue=queue, session=session, interaction_broker=broker)
+        assert rc is not None and rc.call_model_input_filter is not None
+
+        result = await rc.call_model_input_filter(self._make_call_data())
+
+        # Original message preserved; two structured user items appended.
+        assert len(result.input) == 3
+        for injected, expected in zip(result.input[1:], ["追加 1", "追加 2"]):
+            assert injected["type"] == "message"
+            assert injected["role"] == "user"
+            assert injected["content"][0]["type"] == "input_text"
+            assert injected["content"][0]["text"] == expected
+
+        # Session persistence: once per drained item.
+        assert session.add_items.await_count == 2
+        # Queue drained.
+        assert len(queue) == 0
+        # Instructions passed through untouched.
+        assert result.instructions == "be helpful"
+
+        # Broker emission: each drained item becomes a USER user_insert
+        # ActionHistory in the broker's output queue, in original order.
+        emitted = [broker._output_queue.get_nowait() for _ in range(2)]
+        assert [a.messages for a in emitted] == ["追加 1", "追加 2"]
+        for action in emitted:
+            assert action.role == ActionRole.USER
+            assert action.action_type == "user_insert"
+
+    @pytest.mark.asyncio
+    async def test_filter_returns_unchanged_when_queue_empty(self):
+        """Empty queue → filter returns the original model_data verbatim."""
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = _make_model()
+        queue = PendingInputQueue()
+        rc = model._build_run_config(pending_input_queue=queue, session=MagicMock())
+
+        data = self._make_call_data()
+        result = await rc.call_model_input_filter(data)
+
+        assert result is data.model_data
+        assert len(result.input) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_short_circuits_when_interrupted(self):
+        """An interrupted run must not inject pending text — the user
+        explicitly cancelled, so leaking the queue into the model would
+        contradict intent. ESC also clears the queue elsewhere, but this
+        is the safety net inside the filter itself."""
+        from datus.cli.execution_state import InterruptController, PendingInputQueue
+
+        model = _make_model()
+        queue = PendingInputQueue()
+        queue.push("should-not-be-sent")
+        controller = InterruptController()
+        controller.interrupt()
+        session = MagicMock()
+        session.add_items = AsyncMock()
+
+        rc = model._build_run_config(
+            pending_input_queue=queue,
+            session=session,
+            interrupt_controller=controller,
+        )
+        result = await rc.call_model_input_filter(self._make_call_data())
+
+        # Original input unchanged, queue NOT drained, session NOT written.
+        assert len(result.input) == 1
+        assert len(queue) == 1
+        session.add_items.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_filter_session_write_failure_does_not_abort_run(self):
+        """If ``session.add_items`` raises, the filter logs and continues
+        — a sqlite hiccup must never kill the entire agent run. The
+        in-memory injection still lands so the model sees the message."""
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = _make_model()
+        queue = PendingInputQueue()
+        queue.push("persist me")
+        session = MagicMock()
+        session.add_items = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        rc = model._build_run_config(pending_input_queue=queue, session=session)
+        result = await rc.call_model_input_filter(self._make_call_data())
+
+        # Message still reached the model layer despite session failure.
+        assert len(result.input) == 2
+        assert result.input[-1]["content"][0]["text"] == "persist me"
+
+    @pytest.mark.asyncio
+    async def test_filter_top_level_exception_returns_original(self):
+        """A bug inside the filter body must never propagate out of the
+        callback — the SDK re-raises filter exceptions and aborts the
+        run. We catch-and-return the original model_data so the agent
+        continues."""
+        model = _make_model()
+        # A queue stub whose drain() raises will trigger the outer
+        # except, exercising the safety net without monkey-patching the
+        # real class.
+        broken_queue = MagicMock()
+        broken_queue.drain.side_effect = RuntimeError("queue corrupted")
+
+        rc = model._build_run_config(pending_input_queue=broken_queue, session=MagicMock())
+        data = self._make_call_data()
+        result = await rc.call_model_input_filter(data)
+
+        assert result is data.model_data


### PR DESCRIPTION
Adds a mid-run injection path so users can type into the TUI or POST to the API while ``Runner.run_streamed`` is still executing, and have the text seen by the model on its very next LLM turn.

Mechanism:
- ``PendingInputQueue`` (thread-safe FIFO, per-turn drain cap of 3).
- A ``call_model_input_filter`` closure attached via ``RunConfig`` to every streamed run. Drains the queue before each LLM turn, appends structured Responses user items, persists them to the session, and emits a USER ``user_insert`` ``ActionHistory`` via the interaction broker so TUI and API SSE both render the injection live.
- Auto-continuation in ``chat_commands`` for final-turn residue: when a run ends with the queue non-empty, drain and feed into a fresh run (capped at 3 consecutive continuations).

Surfaces:
- TUI: Enter while the agent is running pushes into the queue; a pinned ``ConditionalContainer`` above the status bar previews the pending items and collapses to zero rows when drained.
- API: new ``POST /api/v1/chat/insert`` route mirrors the ``/user_interaction`` pattern; CLI and API share the same queue instance per session.

Display fixes:
- ``user_insert`` actions are exempted from the existing USER-skip filters in ``chat_commands``, ``streaming._reprint_history`` and ``display.render_history_with_user_headers`` so they survive Ctrl+O verbose toggles.
- ``action_to_sse_event`` USER branch emits ``user_insert`` regardless of ``include_user_message``.

Tests:
- ``PendingInputQueue`` push/drain/snapshot/cap/clear/concurrency.
- ``_build_run_config`` filter: append, persist, broker emission, empty-queue passthrough, interrupt short-circuit, session-write failure recovery, top-level exception safety net.
- ``InteractionBroker.emit_user_insert`` ordering and post-close noop.
- ``/api/v1/chat/insert`` happy path, missing task, missing node, whitespace, missing queue, accumulation, strip-before-push.
- ``action_to_sse_event``: ``user_insert`` always emitted.
- ``_reprint_history``: ``user_insert`` preserved across Ctrl+O verbose toggle reprints.
- ``test_tui_layout``: bottom HSplit child-count + index assertions updated for the new pinned queue preview.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mid-run queuing: enqueue messages into active chats (POST /chat/insert) and drain them into upcoming model turns; TUI Enter can queue mid-run messages and shows a queue preview; auto-continuation processes queued items (cap: 3).

* **Bug Fixes / UX**
  * Mid-run injected messages are preserved in history, reprints, and reliably emitted to SSE clients.

* **Tests**
  * Added extensive tests covering the insert API, queue contract/overflow, TUI preview/enqueue, streaming injection, and SSE emission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->