### PR TITLE
[Enhancement] Skip permission hook for proxied tools and unify chat hook path

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -15,7 +15,7 @@ import asyncio
 import os
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional, Set
 
 from agents import Tool
 from agents.extensions.memory import AdvancedSQLiteSession
@@ -198,6 +198,15 @@ class AgenticNode(Node):
 
         # Proxy tool patterns - stored when apply_proxy_tools() is called, inherited by sub-agents
         self.proxy_tool_patterns: Optional[List[str]] = None
+
+        # Names of tools that ``apply_proxy_tools`` actually replaced with proxy
+        # wrappers. ``PermissionHooks`` consults this set to short-circuit the
+        # permission check for proxied tools — the external caller (e.g.
+        # ``print_mode`` stdin protocol) is responsible for any secondary
+        # confirmation, so the agent must not double-prompt. Held as a stable
+        # reference so PermissionHooks can be built before the first proxy call
+        # and still observe later updates without rebuilding.
+        self.proxied_tool_names: Set[str] = set()
 
         # Shared tool_name -> category registry (used by PermissionHooks & proxy_tool)
         from datus.tools.registry.tool_registry import ToolRegistry
@@ -2427,6 +2436,7 @@ class AgenticNode(Node):
                 tool_registry=self.tool_registry,
                 fs_policy=self._make_filesystem_policy(),
                 non_interactive=non_interactive,
+                proxied_tool_names=self.proxied_tool_names,
             )
             logger.debug(
                 f"PermissionHooks attached to node '{self.get_node_name()}' "

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -10,7 +10,7 @@ chat interactions with markdown output, database/filesystem tool support,
 skills, and permissions. This node is fully independent from GenSQLAgenticNode.
 """
 
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.gen_sql_agentic_node import prepare_template_context
@@ -22,7 +22,6 @@ from datus.schemas.chat_agentic_node_models import ChatNodeInput, ChatNodeResult
 from datus.tools.func_tool import ContextSearchTools, DBFuncTool, FilesystemFuncTool, PlatformDocSearchTool
 from datus.tools.func_tool.date_parsing_tools import DateParsingTools
 from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
-from datus.tools.permission.permission_hooks import PermissionHooks
 from datus.tools.permission.permission_manager import PermissionManager
 from datus.tools.skill_tools.skill_func_tool import SkillFuncTool
 from datus.tools.skill_tools.skill_manager import SkillManager
@@ -93,9 +92,6 @@ class ChatAgenticNode(AgenticNode):
         self._platform_doc_tool: Optional[PlatformDocSearchTool] = None
         self.reference_template_tools: Optional[ReferenceTemplateTools] = None
 
-        # Chat-specific: permission hooks
-        self.permission_hooks: Optional[PermissionHooks] = None
-
         # Call parent constructor
         super().__init__(
             node_id=node_id,
@@ -148,8 +144,12 @@ class ChatAgenticNode(AgenticNode):
         self._rebuild_tools()
         self._setup_platform_doc_tools()
 
-        # Setup permission hooks after all tools are initialized
-        self._setup_permission_hooks()
+        # Populate the shared tool_registry eagerly so consumers that inspect
+        # categories before the first LLM turn (tests, ``apply_proxy_tools``'
+        # FS-dependent exclusion, etc.) see a populated mapping. The actual
+        # ``PermissionHooks`` is still built lazily by
+        # ``_ensure_permission_hooks`` via ``_compose_hooks``.
+        self._populate_tool_registry()
 
     def _setup_date_parsing_tools(self):
         """Setup date parsing tools."""
@@ -220,54 +220,38 @@ class ChatAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup skill tools: {e}")
 
-    def _setup_permission_hooks(self):
-        """Setup permission hooks and register all tool categories."""
-        if not self.permission_manager:
-            logger.debug("No permission manager available, skipping permission hooks setup")
-            return
+    def _tool_category_map(self) -> Dict[str, List[Any]]:
+        """Declare chat-specific tool categories for permission registration.
 
-        try:
-            # 1. Populate the node-level tool_registry
-            if self.db_func_tool:
-                self.tool_registry.register_tools("db_tools", self.db_func_tool.available_tools())
-            if self.context_search_tools:
-                self.tool_registry.register_tools("context_search_tools", self.context_search_tools.available_tools())
-            if self.reference_template_tools:
-                self.tool_registry.register_tools(
-                    "reference_template_tools", self.reference_template_tools.available_tools()
-                )
-            if self.date_parsing_tools:
-                self.tool_registry.register_tools("date_parsing_tools", self.date_parsing_tools.available_tools())
-            if self.filesystem_func_tool:
-                self.tool_registry.register_tools("filesystem_tools", self.filesystem_func_tool.available_tools())
-            if self.bash_tool:
-                self.tool_registry.register_tools("bash_tools", self.bash_tool.available_tools())
-            if self.skill_func_tool:
-                self.tool_registry.register_tools("skills", self.skill_func_tool.available_tools())
-            if self.sub_agent_task_tool:
-                self.tool_registry.register_tools("sub_agent_tools", self.sub_agent_task_tool.available_tools())
-            if self.ask_user_tool:
-                self.tool_registry.register_tools("tools", self.ask_user_tool.available_tools())
-            if self._platform_doc_tool:
-                self.tool_registry.register_tools("tools", self._platform_doc_tool.available_tools())
-            # 2. Create PermissionHooks sharing the same tool_registry instance
-            broker = self._get_or_create_broker()
-            # ``workflow`` runs have no UI listener; ASK / EXTERNAL fs checks
-            # must fail closed instead of awaiting the broker forever.
-            non_interactive = getattr(self, "execution_mode", None) == "workflow"
-            self.permission_hooks = PermissionHooks(
-                broker=broker,
-                permission_manager=self.permission_manager,
-                node_name=self.get_node_name(),
-                tool_registry=self.tool_registry,
-                fs_policy=self._make_filesystem_policy(),
-                non_interactive=non_interactive,
-            )
-
-            logger.debug(f"Permission hooks setup with {len(self.tool_registry)} registered tools")
-        except Exception as e:
-            logger.error(f"Failed to setup permission hooks: {e}")
-            self.permission_hooks = None
+        Picked up by ``AgenticNode._populate_tool_registry`` so the base
+        ``_ensure_permission_hooks`` can build ``PermissionHooks`` with the
+        full registry. The base implementation already covers ``skills`` and
+        ``bash_tools``; this override extends with chat's own tool surface.
+        Tools that aren't tied to a profile category (``ask_user_tool``,
+        ``_platform_doc_tool``) land in the ``tools`` catch-all so explicit
+        ``tools.*`` rules can still match them.
+        """
+        mapping = super()._tool_category_map()
+        if self.db_func_tool:
+            mapping["db_tools"] = list(self.db_func_tool.available_tools())
+        if self.context_search_tools:
+            mapping["context_search_tools"] = list(self.context_search_tools.available_tools())
+        if self.reference_template_tools:
+            mapping["reference_template_tools"] = list(self.reference_template_tools.available_tools())
+        if self.date_parsing_tools:
+            mapping["date_parsing_tools"] = list(self.date_parsing_tools.available_tools())
+        if self.filesystem_func_tool:
+            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
+        if self.sub_agent_task_tool:
+            mapping["sub_agent_tools"] = list(self.sub_agent_task_tool.available_tools())
+        catch_all: List[Any] = []
+        if self.ask_user_tool:
+            catch_all.extend(self.ask_user_tool.available_tools())
+        if self._platform_doc_tool:
+            catch_all.extend(self._platform_doc_tool.available_tools())
+        if catch_all:
+            mapping["tools"] = catch_all
+        return mapping
 
     def _rebuild_tools(self):
         """Rebuild the tools list with current tool instances including skills."""

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -21,7 +21,7 @@ import logging
 import weakref
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
 
 from agents.lifecycle import AgentHooks
 
@@ -169,6 +169,7 @@ class PermissionHooks(AgentHooks):
         *,
         fs_policy: Optional[FilesystemPolicy] = None,
         non_interactive: bool = False,
+        proxied_tool_names: Optional[Set[str]] = None,
     ):
         """Initialize the permission hooks.
 
@@ -191,6 +192,15 @@ class PermissionHooks(AgentHooks):
                 subagents, etc.) where there is no human in the loop and any
                 ASK/EXTERNAL hit means the tool is outside the active profile's
                 scope. ``DENY`` continues to raise as before.
+            proxied_tool_names: Optional set of tool names that
+                :func:`datus.tools.proxy.proxy_tool.apply_proxy_tools` wrapped
+                with stdin-driven proxies. When provided, ``on_tool_start``
+                skips ALL permission checks (DENY/ASK/zone) for these tools —
+                the external caller (e.g. ``print_mode`` stdin protocol) owns
+                secondary confirmation, so the agent must not double-prompt or
+                block proxied calls. Passing the same set reference held by the
+                node lets late ``apply_proxy_tools`` invocations be observed
+                without rebuilding the hook.
         """
         self.broker = broker
         self.permission_manager = permission_manager
@@ -198,6 +208,7 @@ class PermissionHooks(AgentHooks):
         self.tool_registry = tool_registry
         self.fs_policy = fs_policy
         self.non_interactive = non_interactive
+        self.proxied_tool_names = proxied_tool_names
 
     # Plan-mode tooling is always allowed regardless of permission profile:
     # ``confirm_plan`` already runs its own user interaction, and ``todo_*``
@@ -227,6 +238,14 @@ class PermissionHooks(AgentHooks):
         # Short-circuit plan-mode helpers: they carry their own UX and have
         # no external side effects, so skip the permission profile entirely.
         if tool_name in self._PLAN_MODE_BYPASS_TOOLS:
+            return
+
+        # Short-circuit proxied tools: their execution is delegated to the
+        # external caller via the stdin proxy channel, which owns secondary
+        # confirmation. Re-checking the profile here would either double-prompt
+        # (ASK) or block calls the caller already authorised (DENY).
+        if self.proxied_tool_names and tool_name in self.proxied_tool_names:
+            logger.debug("Tool '%s' is proxied; skipping permission check", tool_name)
             return
 
         # Get tool category and pattern name for permission checking

--- a/datus/tools/proxy/proxy_tool.py
+++ b/datus/tools/proxy/proxy_tool.py
@@ -95,6 +95,7 @@ def apply_proxy_tools(
         exclude_categories = {"filesystem_tools"}
 
     new_tools = []
+    proxied_names: Set[str] = set()
     for tool in node.tools:
         if isinstance(tool, FunctionTool) and _matches(tool.name, registry, parsed):
             if exclude_categories and registry.get(tool.name) in exclude_categories:
@@ -103,9 +104,21 @@ def apply_proxy_tools(
             else:
                 logger.info(f"Proxying tool: {tool.name}")
                 new_tools.append(create_proxy_tool(tool, target_channel))
+                proxied_names.add(tool.name)
         else:
             new_tools.append(tool)
     node.tools = new_tools
+    # ``PermissionHooks`` consults this set in ``on_tool_start`` to skip the
+    # ALLOW/ASK/DENY check for proxied tools — the external caller (e.g.
+    # ``print_mode`` stdin protocol) owns secondary confirmation. Mutate in
+    # place so existing PermissionHooks instances built earlier still see the
+    # latest snapshot via the shared reference held on the node.
+    existing = getattr(node, "proxied_tool_names", None)
+    if isinstance(existing, set):
+        existing.clear()
+        existing.update(proxied_names)
+    else:
+        node.proxied_tool_names = proxied_names
 
 
 # ── Internal helpers ─────────────────────────────────────────────────

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1728,3 +1728,50 @@ class TestInjectResponseLanguage:
             mgr.return_value.render_template.side_effect = RuntimeError("boom")
             result = node._inject_response_language("BASE")
         assert result == "BASE"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_permission_hooks: proxied_tool_names wiring
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePermissionHooksProxyWiring:
+    """The shared ``proxied_tool_names`` set must flow into ``PermissionHooks``."""
+
+    def _prepare_node(self, proxied_tool_names):
+        from datus.tools.registry.tool_registry import ToolRegistry
+
+        node = _make_simple_node()
+        node.permission_manager = MagicMock()
+        node.permission_hooks = None
+        node.tool_registry = ToolRegistry()
+        node.execution_mode = None
+        node.proxied_tool_names = proxied_tool_names
+        # ``_make_filesystem_policy`` looks at agent_config / root path; stub.
+        node._make_filesystem_policy = MagicMock(return_value=None)
+        node._populate_tool_registry = MagicMock()
+        return node
+
+    def test_passes_shared_set_reference(self):
+        """Constructor receives the *same* set object the node holds."""
+        proxied = {"read_file"}
+        node = self._prepare_node(proxied)
+
+        with patch("datus.tools.permission.permission_hooks.PermissionHooks") as ph_cls:
+            node._ensure_permission_hooks()
+
+        ph_cls.assert_called_once()
+        kwargs = ph_cls.call_args.kwargs
+        # Must be the same set instance, not a copy — late ``apply_proxy_tools``
+        # invocations mutate this set in place.
+        assert kwargs["proxied_tool_names"] is proxied
+
+    def test_default_empty_set_is_passed(self):
+        """A freshly-built node with no proxied tools still passes an empty set."""
+        node = self._prepare_node(set())
+
+        with patch("datus.tools.permission.permission_hooks.PermissionHooks") as ph_cls:
+            node._ensure_permission_hooks()
+
+        kwargs = ph_cls.call_args.kwargs
+        assert kwargs["proxied_tool_names"] == set()

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -198,6 +198,10 @@ class TestChatAgenticNodeToolSetup:
             # Contract is mandatory: strict mode must reach the hook policy,
             # otherwise EXTERNAL paths would still trigger broker prompts in
             # non-interactive bootstraps (the whole point of strict mode).
+            # PermissionHooks is built lazily by ``_ensure_permission_hooks``
+            # (called from ``_compose_hooks`` on the first LLM turn); trigger
+            # it explicitly here to inspect the constructed policy.
+            node._ensure_permission_hooks()
             assert node.permission_hooks.fs_policy.strict is True
         finally:
             real_agent_config.filesystem_strict = previous_strict

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -325,6 +325,172 @@ class TestPermissionHooks:
         assert "run /profile to open the profile picker" in str(exc_info.value)
         assert "arrow keys" in str(exc_info.value)
 
+    def test_initialization_default_proxied_tool_names_is_none(self, mock_broker):
+        """``proxied_tool_names`` defaults to ``None`` for back-compat callers."""
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=PermissionManager(),
+            node_name="chat",
+            tool_registry=ToolRegistry(),
+        )
+        assert hooks.proxied_tool_names is None
+
+    @pytest.mark.asyncio
+    async def test_on_tool_start_skips_check_for_proxied_tool(self, mock_broker):
+        """Proxied tools bypass permission checking even when DENY would normally fire.
+
+        The external caller (e.g. ``print_mode`` stdin protocol) is responsible
+        for secondary confirmation, so the agent must not double-check.
+        """
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ALLOW,
+            rules=[
+                PermissionRule(tool="db_tools", pattern="*", permission=PermissionLevel.DENY),
+            ],
+        )
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "execute_sql"
+        registry.register_tools("db_tools", [tool_mock])
+
+        proxied = {"execute_sql"}
+        manager = PermissionManager(global_config=config)
+        check_spy = MagicMock(wraps=manager.check_permission)
+        manager.check_permission = check_spy  # type: ignore[assignment]
+
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            proxied_tool_names=proxied,
+        )
+
+        context = MagicMock()
+        context.tool_arguments = "{}"
+        agent = MagicMock()
+        tool = MagicMock()
+        tool.name = "execute_sql"
+
+        # No exception even though the profile says DENY for db_tools.*.
+        await hooks.on_tool_start(context, agent, tool)
+
+        # Permission lookup must not happen at all for proxied tools.
+        check_spy.assert_not_called()
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_tool_start_skips_check_for_proxied_ask_without_broker(self, mock_broker):
+        """An ASK-rule proxied tool also bypasses — broker must not be touched."""
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ALLOW,
+            rules=[
+                PermissionRule(tool="db_tools", pattern="*", permission=PermissionLevel.ASK),
+            ],
+        )
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "execute_sql"
+        registry.register_tools("db_tools", [tool_mock])
+
+        manager = PermissionManager(global_config=config)
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            proxied_tool_names={"execute_sql"},
+        )
+
+        context = MagicMock()
+        context.tool_arguments = "{}"
+        agent = MagicMock()
+        tool = MagicMock()
+        tool.name = "execute_sql"
+
+        await hooks.on_tool_start(context, agent, tool)
+
+        # No broker prompt despite the ASK rule.
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_tool_start_observes_late_proxied_set_mutation(self, mock_broker):
+        """When the hook holds a shared set reference, names added AFTER
+        construction also bypass permission — this is the wiring used by
+        ``ChatAgenticNode._setup_permission_hooks`` together with
+        ``apply_proxy_tools`` running later in ``chat_task_manager``.
+        """
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ALLOW,
+            rules=[
+                PermissionRule(tool="db_tools", pattern="*", permission=PermissionLevel.DENY),
+            ],
+        )
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "execute_sql"
+        registry.register_tools("db_tools", [tool_mock])
+
+        shared: set = set()
+        manager = PermissionManager(global_config=config)
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            proxied_tool_names=shared,
+        )
+
+        # Empty set at construction → DENY still applies.
+        context = MagicMock()
+        context.tool_arguments = "{}"
+        agent = MagicMock()
+        tool = MagicMock()
+        tool.name = "execute_sql"
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(context, agent, tool)
+
+        # Simulate ``apply_proxy_tools`` running later and mutating the shared set.
+        shared.add("execute_sql")
+
+        # Now the same hook observes the name and skips permission checking.
+        await hooks.on_tool_start(context, agent, tool)
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_tool_start_non_proxied_tool_still_checked(self, mock_broker):
+        """Tools outside ``proxied_tool_names`` follow the normal DENY behaviour."""
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ALLOW,
+            rules=[
+                PermissionRule(tool="db_tools", pattern="*", permission=PermissionLevel.DENY),
+            ],
+        )
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "execute_sql"
+        registry.register_tools("db_tools", [tool_mock])
+
+        manager = PermissionManager(global_config=config)
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            # Different tool name → execute_sql should still be denied.
+            proxied_tool_names={"read_file"},
+        )
+
+        context = MagicMock()
+        context.tool_arguments = "{}"
+        agent = MagicMock()
+        tool = MagicMock()
+        tool.name = "execute_sql"
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(context, agent, tool)
+
     @pytest.mark.asyncio
     async def test_on_tool_start_ask_with_session_approval(self, mock_broker):
         """Test on_tool_start uses session cache for ASK permission."""

--- a/tests/unit_tests/tools/proxy/test_proxy_tool.py
+++ b/tests/unit_tests/tools/proxy/test_proxy_tool.py
@@ -453,3 +453,150 @@ class TestFsDependentNodeExclusion:
 
         # Should be proxied since node has no get_node_name
         assert node.tools[0].on_invoke_tool is not original_invoke
+
+
+# ---------------------------------------------------------------------------
+# Tests: proxied_tool_names exposure for PermissionHooks bypass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestProxiedToolNames:
+    """``apply_proxy_tools`` records actually-wrapped tool names on the node."""
+
+    def _make_node(self, tools, registry=None, node_name=None, proxied_attr="missing"):
+        kwargs = {
+            "tools": tools,
+            "tool_channel": ToolResultChannel(),
+            "tool_registry": registry or ToolRegistry(),
+            "proxy_tool_patterns": None,
+        }
+        if node_name is not None:
+            kwargs["get_node_name"] = lambda: node_name
+        if proxied_attr == "set":
+            kwargs["proxied_tool_names"] = set()
+        node = SimpleNamespace(**kwargs)
+        return node
+
+    def test_records_wrapped_tool_names(self):
+        original_invoke = MagicMock()
+        read_file = FunctionTool(
+            name="read_file",
+            description="Read",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=original_invoke,
+        )
+        execute_sql = FunctionTool(
+            name="execute_sql",
+            description="SQL",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=original_invoke,
+        )
+
+        node = self._make_node(
+            [read_file, execute_sql],
+            registry=ToolRegistry({"read_file": "filesystem_tools", "execute_sql": "db_tools"}),
+        )
+
+        apply_proxy_tools(node, ["filesystem_tools.*"])
+
+        # Only the wrapped tool's name is recorded.
+        assert node.proxied_tool_names == {"read_file"}
+
+    def test_excludes_fs_dependent_skipped_tools(self):
+        original_invoke = MagicMock()
+        write_file = FunctionTool(
+            name="write_file",
+            description="Write",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=original_invoke,
+        )
+        execute_sql = FunctionTool(
+            name="execute_sql",
+            description="SQL",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=original_invoke,
+        )
+
+        # gen_semantic_model is in _FS_DEPENDENT_NODES — write_file must NOT be
+        # proxied or recorded, but execute_sql still is.
+        node = self._make_node(
+            [write_file, execute_sql],
+            registry=ToolRegistry({"write_file": "filesystem_tools", "execute_sql": "db_tools"}),
+            node_name="gen_semantic_model",
+        )
+
+        apply_proxy_tools(node, ["*"])
+
+        assert node.proxied_tool_names == {"execute_sql"}
+
+    def test_excludes_non_function_tools(self):
+        non_func_tool = MagicMock(spec=["name"])
+        non_func_tool.name = "mcp_tool"
+        read_file = FunctionTool(
+            name="read_file",
+            description="Read",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=MagicMock(),
+        )
+
+        node = self._make_node(
+            [non_func_tool, read_file],
+            registry=ToolRegistry({"read_file": "filesystem_tools"}),
+        )
+
+        apply_proxy_tools(node, ["*"])
+
+        # Non-FunctionTool instances are kept as-is and therefore NOT recorded.
+        assert node.proxied_tool_names == {"read_file"}
+
+    def test_subsequent_calls_overwrite(self):
+        original_invoke = MagicMock()
+        read_file = FunctionTool(
+            name="read_file",
+            description="Read",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=original_invoke,
+        )
+        execute_sql = FunctionTool(
+            name="execute_sql",
+            description="SQL",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=original_invoke,
+        )
+
+        node = self._make_node(
+            [read_file, execute_sql],
+            registry=ToolRegistry({"read_file": "filesystem_tools", "execute_sql": "db_tools"}),
+        )
+
+        apply_proxy_tools(node, ["filesystem_tools.*"])
+        assert node.proxied_tool_names == {"read_file"}
+
+        apply_proxy_tools(node, ["db_tools.*"])
+        # The second call resets the set: only db_tools matches now.
+        assert node.proxied_tool_names == {"execute_sql"}
+
+    def test_mutates_existing_set_reference(self):
+        """When node already exposes a set, ``apply_proxy_tools`` updates it in
+        place so PermissionHooks built earlier still observes the latest names.
+        """
+        original_invoke = MagicMock()
+        read_file = FunctionTool(
+            name="read_file",
+            description="Read",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=original_invoke,
+        )
+
+        node = self._make_node(
+            [read_file],
+            registry=ToolRegistry({"read_file": "filesystem_tools"}),
+            proxied_attr="set",
+        )
+        held_reference = node.proxied_tool_names
+
+        apply_proxy_tools(node, ["filesystem_tools.*"])
+
+        assert node.proxied_tool_names is held_reference
+        assert held_reference == {"read_file"}


### PR DESCRIPTION

Proxied tools (apply_proxy_tools) now bypass PermissionHooks on the agent side: the external caller (print_mode stdin, vscode/web chat_task_manager) already owns secondary confirmation, so re-checking the profile would either double-prompt on ASK or block calls the caller authorised on DENY. ``apply_proxy_tools`` records wrapped tool names on the node and shares the set reference with PermissionHooks, so late proxy installation is observed without rebuilding the hook.

ChatAgenticNode previously built PermissionHooks eagerly in ``_setup_permission_hooks`` and missed the new ``proxied_tool_names`` wiring because ``_ensure_permission_hooks`` short-circuited on the pre-built hook. Collapsed the chat path into the shared lazy builder: chat now declares its 9 tool categories via ``_tool_category_map`` and relies on the base ``_ensure_permission_hooks`` to construct the hook on the first LLM turn.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Proxied tools now bypass redundant permission checks, eliminating duplicate prompts when tools are delegated to external execution flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->