### PR TITLE
[BugFix] Scope semantic-model validation

### DIFF
--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -434,7 +434,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 raise RuntimeError(
                     "Semantic model generation produced semantic_model_files, but validate_semantic is unavailable."
                 )
-            validation_result = self.semantic_func_tool.validate_semantic()
+            validation_result = self.semantic_func_tool.validate_semantic(scope="semantic_model")
             self.generation_evidence.record_validation_result(validation_result)
             if not self._tool_succeeded(validation_result):
                 raise RuntimeError(

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
@@ -66,6 +66,7 @@ Please strictly follow the instructions below:
    - Create a semantic model following the specification below.
    - A semantic model generation file should define `data_source:` document(s). Do not add a top-level `metrics:` list to the same YAML document.
    - If explicit metric definitions are required later, generate them in the metrics workflow as separate `metric:` YAML documents. MetricFlow requires each YAML document to have exactly one top-level object type.
+   - Do not define the same column/name under both `identifiers` and `dimensions`. Use identifiers for primary/join keys and dimensions for grouping/filtering fields.
    - **CRITICAL**: Populate `description` fields for ALL measures, dimensions, and identifiers by **COMBINING ALL** available information:
      - Start with DDL comments (preserve original language)
      - Append usage patterns and **filter examples** from `analyze_column_usage_patterns`
@@ -87,16 +88,17 @@ Please strictly follow the instructions below:
    - If semantic model already exists, update it with `edit_file` if anything changed
 
 6. **Validate configuration** (MANDATORY - DO NOT SKIP):
-   - Use `validate_semantic` tool to validate the semantic model
+   - Use `validate_semantic(scope="semantic_model")` tool to validate the semantic model
    - **CRITICAL**: If validation fails:
      1. Analyze the error message carefully
      2. Use `edit_file` tool to fix the YAML file (do NOT just describe the fix - actually execute the fix)
-     3. Call `validate_semantic` again to verify the fix
+     3. Call `validate_semantic(scope="semantic_model")` again to verify the fix
      4. Repeat until validation passes
    - **ABSOLUTE RULE**: You MUST NOT return the final JSON response until `validate_semantic` returns success
    - Common validation errors and fixes:
      - PostgreSQL column case sensitivity: wrap uppercase column names in double quotes (e.g., `expr: '"SP_POP_TOTL"'`)
      - Column not found: check column names match exactly with DDL
+     - Duplicate semantic element name: remove a column from either `identifiers` or `dimensions`; do not keep the same `name` in both lists
      - Invalid YAML syntax: check indentation and quoting
 
 7. **Complete generation** (ONLY AFTER VALIDATION PASSES):
@@ -176,11 +178,11 @@ data_source:
 ```
 
 ### Step 6: Validate All Files Together (MANDATORY)
-- Call `validate_semantic` tool
+- Call `validate_semantic(scope="semantic_model")` tool
 - **CRITICAL**: If validation fails:
   1. Analyze the error message (e.g., "column xxx does not exist")
   2. Use `edit_file` tool to fix the YAML file - actually execute the fix, don't just describe it
-  3. Call `validate_semantic` again
+  3. Call `validate_semantic(scope="semantic_model")` again
   4. Repeat until ALL validations pass
 - **ABSOLUTE RULE**: Do NOT proceed to Step 7 until validation succeeds
 

--- a/datus/resources/skills/gen-semantic-model/SKILL.md
+++ b/datus/resources/skills/gen-semantic-model/SKILL.md
@@ -28,6 +28,8 @@ Create production-ready MetricFlow semantic model YAML for one or more database 
    - Define identifiers for primary keys and join keys.
    - Define measures only for reusable aggregations.
    - Define dimensions for grouping/filtering fields.
+   - Do not define the same column/name under both `identifiers` and `dimensions`. Use identifiers for
+     primary/join keys and dimensions for grouping/filtering fields.
    - Use `expr: "1"` for row-count measures with `agg: COUNT`.
    - For measures, use `agg` for the aggregation type; do not add a `type` field to measure entries.
 
@@ -40,7 +42,7 @@ Create production-ready MetricFlow semantic model YAML for one or more database 
    - If explicit metric definitions are needed, write them through the metrics generation workflow as separate `metric:` documents.
 
 4. **Validate and fix**
-   - Call `validate_semantic`.
+   - Call `validate_semantic(scope="semantic_model")`.
    - If validation fails, use `edit_file` to fix the YAML and call `validate_semantic` again.
    - Repeat until `validate_semantic` succeeds.
 

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -9,8 +9,9 @@ Provides unified interface to semantic layer services through adapters.
 Tools delegate to registered semantic adapters while leveraging unified storage for performance.
 """
 
+import inspect
 import json
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from agents import Tool
 
@@ -27,6 +28,8 @@ from datus.utils.compress_utils import DataCompressor
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+NO_METRICS_PRESENT_MESSAGE = "No metrics present in the model."
 
 
 def _normalize_dimension_rows(raw) -> list:
@@ -74,6 +77,39 @@ def _normalize_name_list(value) -> List[str]:
         if text:
             names.append(text)
     return names
+
+
+def _serialize_validation_issue(issue) -> dict:
+    if hasattr(issue, "model_dump"):
+        return issue.model_dump()
+    return {"severity": "error", "message": str(issue)}
+
+
+def _is_no_metrics_present_issue(issue: dict) -> bool:
+    message = str(issue.get("message") or "")
+    return NO_METRICS_PRESENT_MESSAGE in message
+
+
+def _validation_has_errors(issues: List[dict]) -> bool:
+    return any(issue.get("severity") == "error" for issue in issues)
+
+
+def _format_validation_error(issues: List[dict]) -> str:
+    count = len(issues)
+    if count == 0:
+        return "0 validation errors"
+
+    messages = []
+    for issue in issues[:3]:
+        message = str(issue.get("message") or "").strip()
+        if message:
+            messages.append(message)
+
+    if not messages:
+        return f"{count} validation errors"
+
+    suffix = f"; ... {count - len(messages)} more" if count > len(messages) else ""
+    return f"{count} validation errors: {'; '.join(messages)}{suffix}"
 
 
 def _run_async(coro):
@@ -596,7 +632,7 @@ class SemanticTools:
                 error=f"Failed to query metrics: {str(e)}",
             )
 
-    def validate_semantic(self) -> FuncToolResult:
+    def validate_semantic(self, scope: Literal["all", "semantic_model"] = "all") -> FuncToolResult:
         """
         Validate semantic layer configuration (requires adapter).
 
@@ -604,10 +640,24 @@ class SemanticTools:
         metrics or semantic model changes. This ensures that subsequent calls to
         query_metrics can find newly created metrics.
 
+        Args:
+            scope: Validation scope. Use "all" for full semantic-layer validation,
+                including metrics. Use "semantic_model" when generating semantic
+                models before metric definitions exist; this still fails on real
+                semantic model errors but ignores the expected no-metrics issue.
+
         Returns:
             FuncToolResult with validation status and issues
         """
-        logger.info("validate_semantic called")
+        scope = normalize_null(scope) or "all"
+        if scope not in ("all", "semantic_model"):
+            return FuncToolResult(
+                success=0,
+                error="scope must be one of: all, semantic_model",
+                result=None,
+            )
+
+        logger.info(f"validate_semantic called scope={scope}")
         adapter = self.adapter
         if not adapter:
             if self._adapter_load_error:
@@ -623,23 +673,57 @@ class SemanticTools:
             )
 
         try:
-            validation_result = _run_async(adapter.validate_semantic())
+            validate_semantic = adapter.validate_semantic
+            validation_kwargs = {}
+            if scope != "all":
+                try:
+                    signature = inspect.signature(validate_semantic)
+                    if "scope" in signature.parameters:
+                        validation_kwargs["scope"] = scope
+                    elif "validation_scope" in signature.parameters:
+                        validation_kwargs["validation_scope"] = scope
+                except (TypeError, ValueError):
+                    validation_kwargs = {}
+
+            validation_result = _run_async(validate_semantic(**validation_kwargs))
 
             # Serialize ValidationIssue objects to dicts
-            issues_data = [
-                issue.model_dump() if hasattr(issue, "model_dump") else {"severity": "error", "message": str(issue)}
-                for issue in validation_result.issues
-            ]
+            issues_data = [_serialize_validation_issue(issue) for issue in validation_result.issues]
+
+            ignored_issues = []
+            effective_issues = issues_data
+            if scope == "semantic_model":
+                ignored_issues = [issue for issue in issues_data if _is_no_metrics_present_issue(issue)]
+                effective_issues = [issue for issue in issues_data if not _is_no_metrics_present_issue(issue)]
+
+            effective_valid = validation_result.valid or (
+                scope == "semantic_model" and not _validation_has_errors(effective_issues)
+            )
+
+            if issues_data:
+                logger.warning(
+                    "Semantic validation issues scope=%s valid=%s effective_valid=%s issues=%s ignored=%s",
+                    scope,
+                    validation_result.valid,
+                    effective_valid,
+                    json.dumps(effective_issues, ensure_ascii=False),
+                    json.dumps(ignored_issues, ensure_ascii=False),
+                )
 
             # If validation succeeded, reload the adapter to pick up new metrics
-            if validation_result.valid:
+            if effective_valid:
                 logger.info("Validation succeeded, reloading adapter to pick up new metrics...")
                 self._reload_adapter()
 
             tool_result = FuncToolResult(
-                success=1 if validation_result.valid else 0,
-                result={"valid": validation_result.valid, "issues": issues_data},
-                error=None if validation_result.valid else f"{len(validation_result.issues)} validation errors",
+                success=1 if effective_valid else 0,
+                result={
+                    "valid": effective_valid,
+                    "issues": effective_issues,
+                    "scope": scope,
+                    "ignored_issues": ignored_issues,
+                },
+                error=None if effective_valid else _format_validation_error(effective_issues),
             )
             if self.generation_evidence:
                 self.generation_evidence.record_validation_result(tool_result)

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -81,8 +81,14 @@ def _normalize_name_list(value) -> List[str]:
 
 def _serialize_validation_issue(issue) -> dict:
     if hasattr(issue, "model_dump"):
-        return issue.model_dump()
-    return {"severity": "error", "message": str(issue)}
+        issue_data = issue.model_dump(mode="json")
+    else:
+        issue_data = {"severity": "error", "message": str(issue)}
+
+    severity = issue_data.get("severity")
+    if severity is not None:
+        issue_data["severity"] = str(severity).lower()
+    return issue_data
 
 
 def _is_no_metrics_present_issue(issue: dict) -> bool:
@@ -91,7 +97,7 @@ def _is_no_metrics_present_issue(issue: dict) -> bool:
 
 
 def _validation_has_errors(issues: List[dict]) -> bool:
-    return any(issue.get("severity") == "error" for issue in issues)
+    return any(str(issue.get("severity") or "").lower() == "error" for issue in issues)
 
 
 def _format_validation_error(issues: List[dict]) -> str:

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -617,7 +617,7 @@ class TestExecuteStreamGenSemanticModelError:
 
         assert actions[-1].status == ActionStatus.SUCCESS
         assert actions[-1].action_type == "gen_semantic_model_response"
-        node.semantic_func_tool.validate_semantic.assert_called_once()
+        node.semantic_func_tool.validate_semantic.assert_called_once_with(scope="semantic_model")
         sync_mock.assert_called_once()
 
     @pytest.mark.asyncio
@@ -664,6 +664,7 @@ class TestExecuteStreamGenSemanticModelError:
         assert actions[-1].status == ActionStatus.FAILED
         assert actions[-1].action_type == "error"
         assert "validate_semantic failed before publishing semantic models" in actions[-1].output["error"]
+        node.semantic_func_tool.validate_semantic.assert_called_once_with(scope="semantic_model")
         sync_mock.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -795,7 +795,96 @@ class TestValidateSemantic:
         assert result.result["valid"] is False
         assert len(result.result["issues"]) == 1
         assert "1 validation errors" in result.error
+        assert "bad config" in result.error
         assert evidence.validation_passed is False
+
+    def test_all_scope_keeps_no_metrics_validation_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        mock_issue = Mock()
+        mock_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "No metrics present in the model.",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [mock_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            result = tool.validate_semantic()
+
+        assert result.success == 0
+        assert result.result["valid"] is False
+        assert result.result["issues"] == [{"severity": "error", "message": "No metrics present in the model."}]
+        assert result.result["ignored_issues"] == []
+        assert evidence.validation_passed is False
+
+    def test_semantic_model_scope_ignores_no_metrics_validation_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        mock_issue = Mock()
+        mock_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "No metrics present in the model.",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [mock_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            with patch.object(tool, "_reload_adapter", return_value=True):
+                result = tool.validate_semantic(scope="semantic_model")
+
+        assert result.success == 1
+        assert result.result["valid"] is True
+        assert result.result["issues"] == []
+        assert result.result["ignored_issues"] == [{"severity": "error", "message": "No metrics present in the model."}]
+        assert result.result["scope"] == "semantic_model"
+        assert evidence.validation_passed is True
+
+    def test_semantic_model_scope_keeps_real_validation_errors(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        no_metrics_issue = Mock()
+        no_metrics_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "No metrics present in the model.",
+        }
+        duplicate_issue = Mock()
+        duplicate_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "Element ac_code has already been used as Dimension",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [no_metrics_issue, duplicate_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            result = tool.validate_semantic(scope="semantic_model")
+
+        assert result.success == 0
+        assert result.result["valid"] is False
+        assert result.result["issues"] == [
+            {"severity": "error", "message": "Element ac_code has already been used as Dimension"}
+        ]
+        assert result.result["ignored_issues"] == [{"severity": "error", "message": "No metrics present in the model."}]
+        assert "1 validation errors" in result.error
+        assert "Element ac_code" in result.error
+        assert evidence.validation_passed is False
+
+    def test_invalid_scope_returns_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+
+        result = tool.validate_semantic(scope="unknown")
+
+        assert result.success == 0
+        assert "scope must be one of" in result.error
 
     def test_exception_returns_failure(self, semantic_tools_with_adapter):
         tool, mock_adapter = semantic_tools_with_adapter

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -2,6 +2,7 @@
 Test cases for SemanticTools utility functions and query_metrics compression.
 """
 
+from enum import Enum
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,6 +11,10 @@ from datus.tools.func_tool.base import FuncToolResult, normalize_null
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.semantic_tools import _run_async
 from datus.tools.semantic_tools.models import QueryResult
+
+
+class _Severity(Enum):
+    ERROR = "error"
 
 
 class TestGenerationEvidence:
@@ -876,6 +881,32 @@ class TestValidateSemantic:
         assert result.result["ignored_issues"] == [{"severity": "error", "message": "No metrics present in the model."}]
         assert "1 validation errors" in result.error
         assert "Element ac_code" in result.error
+        assert evidence.validation_passed is False
+
+    def test_semantic_model_scope_treats_enum_severity_as_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        mock_issue = Mock()
+        mock_issue.model_dump.return_value = {
+            "severity": _Severity.ERROR,
+            "message": "bad enum severity",
+        }
+        mock_issue.model_dump.side_effect = lambda mode=None: {
+            "severity": _Severity.ERROR.value if mode == "json" else _Severity.ERROR,
+            "message": "bad enum severity",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [mock_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            result = tool.validate_semantic(scope="semantic_model")
+
+        assert result.success == 0
+        assert result.result["issues"] == [{"severity": "error", "message": "bad enum severity"}]
+        assert result.result["ignored_issues"] == []
         assert evidence.validation_passed is False
 
     def test_invalid_scope_returns_error(self, semantic_tools_with_adapter):


### PR DESCRIPTION
Summary
- Add a semantic_model validation scope so semantic-model generation can validate data_source YAML before metric definitions exist.
- Keep full metric validation as the default all scope, and surface concrete validation issue messages in tool errors/logs.
- Update gen-semantic-model prompt/skill guidance to use semantic_model scope and avoid duplicate identifier/dimension names.

Validation
- uv run ruff check datus/tools/func_tool/semantic_tools.py datus/agent/node/gen_semantic_model_agentic_node.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
- uv run pytest tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestValidateSemantic tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced semantic model validation workflow with clearer error-analysis/fix loops and a scope-specific validation mode for semantic models.
  * Added modeling constraint: columns/names cannot be defined in both identifiers and dimensions.
  * Validation for semantic-model scope now treats "no metrics present" as ignorable so valid semantic models without metrics can pass.

* **Documentation**
  * Updated semantic model guide and skill docs with the new validation workflow and YAML modeling constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->