### PR TITLE
[Enhancement] Register gen_visual_dashboard alongside gen_visual_report

### DIFF
--- a/datus/cli/sub_agent_wizard.py
+++ b/datus/cli/sub_agent_wizard.py
@@ -520,12 +520,16 @@ class SubAgentWizard:
         self.name_buffer.on_text_changed += self._update_previews
         self.description_area = TextArea(text="", multiline=True, wrap_lines=True, style="class:textarea")
         self.description_area.buffer.on_text_changed += self._update_previews
-        # Node class selection (gen_sql / gen_report / gen_visual_report)
+        # Node class selection (gen_sql / gen_report / gen_visual_report / gen_visual_dashboard)
         self.node_class_radio = RadioList(
             values=[
                 ("gen_sql", "gen_sql - SQL generation (default)"),
                 ("gen_report", "gen_report - Report/analysis generation"),
                 ("gen_visual_report", "gen_visual_report - Structured report artifact (manifest + queries)"),
+                (
+                    "gen_visual_dashboard",
+                    "gen_visual_dashboard - Parameterized dashboard artifact (Jinja2 SQL templates)",
+                ),
             ],
             default="gen_sql",
         )
@@ -1705,6 +1709,8 @@ class SubAgentWizard:
             fallback_template = "gen_report_system"
         elif node_class == "gen_visual_report":
             fallback_template = "gen_visual_report_system"
+        elif node_class == "gen_visual_dashboard":
+            fallback_template = "gen_visual_dashboard_system"
         else:
             fallback_template = "sql_system"
         try:
@@ -1735,6 +1741,8 @@ class SubAgentWizard:
             default_template = "gen_report_system"
         elif node_class == "gen_visual_report":
             default_template = "gen_visual_report_system"
+        elif node_class == "gen_visual_dashboard":
+            default_template = "gen_visual_dashboard_system"
         else:
             default_template = "sql_system"
         if (

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -51,6 +51,7 @@ NODE_CLASS_MAP = {
     "chat": NodeType.TYPE_CHAT,
     "gen_report": NodeType.TYPE_GEN_REPORT,
     "gen_visual_report": NodeType.TYPE_GEN_VISUAL_REPORT,
+    "gen_visual_dashboard": NodeType.TYPE_GEN_VISUAL_DASHBOARD,
     "ext_knowledge": NodeType.TYPE_EXT_KNOWLEDGE,
     "semantic": NodeType.TYPE_SEMANTIC,
     "sql_summary": NodeType.TYPE_SQL_SUMMARY,
@@ -110,6 +111,24 @@ BUILTIN_SUBAGENT_DESCRIPTIONS = {
         "write_file the render/*.jsx components, then finalize with validate_render. "
         "Returns JSON with {response, report_id, app_jsx_path, render_file_count, "
         "html_path, query_count, tokens_used}."
+    ),
+    "gen_visual_dashboard": (
+        "Produce a parameterized visual dashboard artifact under "
+        "<project_root>/dashboards/<slug>/ (render/*.jsx + queries/<slug>.sql.j2 + "
+        "queries/<slug>.params.json + manifest.json). Unlike gen_visual_report, "
+        "queries are persisted as Jinja2 SQL templates with declared parameter "
+        "metadata; at view time the backend renders the template with user-selected "
+        "filter values and executes it live against the bound datasource. "
+        "Use this whenever the user asks for an interactive dashboard with filters "
+        "(date range, region, segment, etc.) that should re-query data on demand, "
+        "instead of a one-shot pre-baked report. The subagent picks a fresh slug "
+        "via start_new_dashboard (or reuses one via bind_existing_dashboard), "
+        "persists each query via save_query_template, write_file's the render/*.jsx "
+        "components, then finalizes with validate_render. "
+        "Prompt: provide the dashboard question/topic plus the filter dimensions "
+        "the user wants exposed; the agent will discover data, build templates, and "
+        "wire them to the JSX filter state. Returns JSON with {response, "
+        "dashboard_slug, app_jsx_path, render_file_count, template_count, tokens_used}."
     ),
     "gen_semantic_model": (
         "Generate MetricFlow semantic model YAML files from database table structures. "
@@ -444,6 +463,20 @@ class SubAgentTaskTool:
                 execution_mode=self._resolve_execution_mode(),
                 is_subagent=True,
             )
+        elif subagent_type == "gen_visual_dashboard":
+            from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
+
+            return GenVisualDashboardAgenticNode(
+                node_id=f"task_gen_visual_dashboard_{uuid.uuid4().hex[:8]}",
+                description="Visual dashboard generation node for gen_visual_dashboard",
+                node_type="gen_visual_dashboard",
+                input_data=None,
+                agent_config=self.agent_config,
+                tools=None,
+                node_name="gen_visual_dashboard",
+                execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
+            )
         elif subagent_type == "gen_table":
             from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
 
@@ -528,6 +561,10 @@ class SubAgentTaskTool:
         # Built-in gen_visual_report type
         if subagent_type == "gen_visual_report":
             return NodeType.TYPE_GEN_VISUAL_REPORT, "gen_visual_report"
+
+        # Built-in gen_visual_dashboard type
+        if subagent_type == "gen_visual_dashboard":
+            return NodeType.TYPE_GEN_VISUAL_DASHBOARD, "gen_visual_dashboard"
 
         # Built-in system subagents (SYS_SUB_AGENTS)
         builtin_type_map = {
@@ -947,6 +984,16 @@ class SubAgentTaskTool:
             from datus.schemas.gen_visual_report_models import GenVisualReportNodeInput
 
             return GenVisualReportNodeInput(
+                user_message=prompt,
+                database=self.agent_config.current_datasource,
+            )
+
+        from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
+
+        if isinstance(node, GenVisualDashboardAgenticNode):
+            from datus.schemas.gen_visual_dashboard_models import GenVisualDashboardNodeInput
+
+            return GenVisualDashboardNodeInput(
                 user_message=prompt,
                 database=self.agent_config.current_datasource,
             )

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -464,6 +464,23 @@ class SubAgentTaskTool:
                 is_subagent=True,
             )
         elif subagent_type == "gen_visual_dashboard":
+            # ``GenVisualDashboardAgenticNode`` inherits from
+            # ``BaseVisualArtifactAgenticNode`` whose ``__init__`` does
+            # NOT accept ``session_id`` (no resume flow yet — the
+            # artifact directory + manifest itself is the persistence
+            # boundary). Silently dropping a caller-supplied session_id
+            # the way other visual subagents do would let resume loops
+            # spawn a fresh session every turn while the LLM thinks it
+            # picked up an existing one. Fail loud instead so the
+            # caller can either drop the kwarg or wait for a
+            # constructor-level resume API.
+            if session_id is not None:
+                raise ValueError(
+                    "gen_visual_dashboard does not support session resume "
+                    "(BaseVisualArtifactAgenticNode constructor has no "
+                    "session_id parameter). Drop the session_id kwarg, "
+                    "or use a resumable subagent type."
+                )
             from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
 
             return GenVisualDashboardAgenticNode(

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -1175,6 +1175,32 @@ class SubAgentTaskTool:
                 }
             )
 
+        # Visual dashboard result (new artifact-based subagent). The
+        # legacy ``dashboard_result`` envelope above is from
+        # ``gen_dashboard_agentic_node.py``; the new
+        # ``GenVisualDashboardNodeResult`` carries the documented fields
+        # (``dashboard_slug``, ``app_jsx_path``, ``render_file_count``,
+        # ``template_count``) flat at the top level. Without this branch
+        # the conversion falls through to the generic envelope and drops
+        # everything the parent LLM was told (via
+        # ``BUILTIN_SUBAGENT_DESCRIPTIONS["gen_visual_dashboard"]``) to
+        # expect. Match on the slug key's presence rather than tool name
+        # so the branch also fires for legitimate model_dump output
+        # where ``dashboard_slug`` is None (run failed before binding) —
+        # preserving the explicit None is more honest than silently
+        # collapsing into the generic envelope.
+        if "dashboard_slug" in output:
+            return _wrap(
+                {
+                    "response": response,
+                    "dashboard_slug": output.get("dashboard_slug"),
+                    "app_jsx_path": output.get("app_jsx_path"),
+                    "render_file_count": output.get("render_file_count", 0),
+                    "template_count": output.get("template_count", 0),
+                    "tokens_used": tokens,
+                }
+            )
+
         # Scheduler result: has 'scheduler_result' key
         scheduler_result = output.get("scheduler_result")
         if scheduler_result is not None:

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -450,6 +450,18 @@ class SubAgentTaskTool:
                 session_id=session_id,
             )
         elif subagent_type == "gen_visual_report":
+            # Same session_id contract as gen_visual_dashboard below —
+            # ``BaseVisualArtifactAgenticNode.__init__`` doesn't accept
+            # ``session_id``, so silently dropping it would let resume
+            # loops spawn a fresh session per turn while the LLM
+            # thinks it picked up an existing one. Fail loud.
+            if session_id is not None:
+                raise ValueError(
+                    "gen_visual_report does not support session resume "
+                    "(BaseVisualArtifactAgenticNode constructor has no "
+                    "session_id parameter). Drop the session_id kwarg, "
+                    "or use a resumable subagent type."
+                )
             from datus.agent.node.gen_visual_report_agentic_node import GenVisualReportAgenticNode
 
             return GenVisualReportAgenticNode(

--- a/datus/utils/constants.py
+++ b/datus/utils/constants.py
@@ -52,6 +52,7 @@ SYS_SUB_AGENTS = {
     "gen_sql",
     "gen_report",
     "gen_visual_report",
+    "gen_visual_dashboard",
     "gen_table",
     "gen_job",
     "gen_skill",

--- a/datus/utils/sub_agent_manager.py
+++ b/datus/utils/sub_agent_manager.py
@@ -109,6 +109,8 @@ class SubAgentManager:
             source_template = "gen_report_system"
         elif node_class == "gen_visual_report":
             source_template = "gen_visual_report_system"
+        elif node_class == "gen_visual_dashboard":
+            source_template = "gen_visual_dashboard_system"
         else:
             source_template = "sql_system"
 

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -604,6 +604,74 @@ class TestConvertToFuncResult:
         assert result.success == 1
         assert result.result["response"] == "Some content"
 
+    def test_visual_dashboard_result_preserves_documented_fields(self, task_tool):
+        """``GenVisualDashboardNodeResult.model_dump()`` carries
+        ``dashboard_slug``, ``app_jsx_path``, ``render_file_count``,
+        ``template_count`` flat at the top level (no
+        ``dashboard_result`` envelope — that key belongs to the legacy
+        ``gen_dashboard`` node). The conversion must preserve every
+        field the parent LLM is told to expect via
+        ``BUILTIN_SUBAGENT_DESCRIPTIONS["gen_visual_dashboard"]``.
+        """
+        # Shape mirrors ``GenVisualDashboardNodeResult(...).model_dump()``
+        # — only the documented + load-bearing fields are inlined here
+        # so a regression that adds a new field to the model doesn't
+        # spuriously fail this test.
+        output = {
+            "success": True,
+            "response": "Dashboard built.",
+            "dashboard_slug": "aov_weekly",
+            "app_jsx_path": "dashboards/aov_weekly/render/app.jsx",
+            "render_file_count": 4,
+            "template_count": 3,
+            "tokens_used": 12345,
+            "artifact_kind": "dashboard",
+            "artifact_mode": "new",
+            "name": "AOV Weekly Trend",
+        }
+        result = task_tool._convert_to_func_result(output)
+        assert result.success == 1
+        # Every documented field present + non-discarded.
+        assert result.result["response"] == "Dashboard built."
+        assert result.result["dashboard_slug"] == "aov_weekly"
+        assert result.result["app_jsx_path"] == "dashboards/aov_weekly/render/app.jsx"
+        assert result.result["render_file_count"] == 4
+        assert result.result["template_count"] == 3
+        assert result.result["tokens_used"] == 12345
+
+    def test_visual_dashboard_result_preserves_none_slug_on_partial_run(self, task_tool):
+        """When the dashboard run failed before binding, the model
+        emits ``dashboard_slug=None`` (still a populated key). The
+        conversion must keep that explicit None rather than fall
+        through to the generic envelope — otherwise the parent LLM
+        can't tell "the subagent kind ran but didn't bind" apart from
+        "the subagent kind wasn't even invoked"."""
+        output = {
+            "success": False,
+            "response": "Failed before binding an artifact.",
+            "dashboard_slug": None,
+            "app_jsx_path": None,
+            "render_file_count": 0,
+            "template_count": 0,
+            "tokens_used": 42,
+        }
+        # The branch fires regardless of the ``success`` flag because
+        # the early ``output.get("success") is False`` check intercepts
+        # explicit failures. For partial-runs where the result model
+        # was constructed with ``success=True`` but bindings still
+        # None, the same branch handles it.
+        # We simulate the partial-success case by removing the
+        # explicit-failure signal.
+        partial = dict(output, success=True)
+        result = task_tool._convert_to_func_result(partial)
+        assert result.success == 1
+        # ``dashboard_slug`` key present with None — operators / parent
+        # LLM can disambiguate "ran but no artifact" from missing-key.
+        assert "dashboard_slug" in result.result
+        assert result.result["dashboard_slug"] is None
+        assert result.result["render_file_count"] == 0
+        assert result.result["template_count"] == 0
+
 
 @pytest.mark.acceptance
 class TestSubAgentTaskAcceptance:

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -250,6 +250,67 @@ class TestResolveNodeType:
         assert NODE_CLASS_MAP["gen_visual_dashboard"] == NodeType.TYPE_GEN_VISUAL_DASHBOARD
         assert "gen_visual_dashboard" in BUILTIN_SUBAGENT_DESCRIPTIONS
 
+    def test_gen_visual_dashboard_constructs_and_builds_input(self, task_tool, tmp_path):
+        """``_create_builtin_node`` and ``_build_node_input`` must wire
+        together for gen_visual_dashboard the same way they do for
+        every other builtin subagent. The mapping-level assertions in
+        :meth:`test_gen_visual_dashboard_resolves` cover registration
+        but won't catch a constructor signature drift or an input-
+        builder branch that returns the wrong dataclass — both would
+        only surface at runtime when the LLM actually invokes the
+        subagent.
+        """
+        from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
+        from datus.schemas.gen_visual_dashboard_models import GenVisualDashboardNodeInput
+
+        # ``_setup_filesystem_tools`` reaches for the workspace root;
+        # the fixture's bare Mock would otherwise emit a TypeError-noise
+        # log line during construction. Setting it to a real path keeps
+        # the captured-log output clean for future log-based tests.
+        task_tool.agent_config.workspace_root = str(tmp_path)
+
+        node = task_tool._create_builtin_node("gen_visual_dashboard")
+        assert isinstance(node, GenVisualDashboardAgenticNode), f"factory returned wrong type: {type(node).__name__}"
+        # Both the configured name (used for node_config lookup) and
+        # the class-level NODE_NAME / ARTIFACT_KIND constants are
+        # load-bearing for the prompt template / artifact dir routing.
+        assert node.configured_node_name == "gen_visual_dashboard"
+        assert node.NODE_NAME == "gen_visual_dashboard"
+        assert node.ARTIFACT_KIND == "dashboard"
+        assert node.execution_mode == "interactive"
+
+        # Cross-component contract: feeding the same prompt into
+        # ``_build_node_input`` must yield the dashboard-specific
+        # input dataclass with the user_message + scoped datasource
+        # populated. Hits the ``isinstance(node, GenVisualDashboardAgenticNode)``
+        # branch on the input builder side — without this assertion a
+        # branch that's only registered but not wired to build input
+        # would slip through.
+        prompt = "build a dashboard for daily AOV by store"
+        node_input = task_tool._build_node_input(node, prompt)
+        assert isinstance(node_input, GenVisualDashboardNodeInput), (
+            f"input builder returned wrong type: {type(node_input).__name__}"
+        )
+        assert node_input.user_message == prompt
+        # ``database`` is sourced from ``agent_config.current_datasource``
+        # which the fixture pins to "test_db".
+        assert node_input.database == "test_db"
+
+    def test_gen_visual_dashboard_rejects_session_id(self, task_tool):
+        """``_create_builtin_node`` for gen_visual_dashboard MUST fail
+        loud when a session_id is passed — the underlying
+        ``BaseVisualArtifactAgenticNode`` constructor has no
+        ``session_id`` parameter so silently dropping it (the prior
+        behaviour) would let resume loops spawn a fresh session per
+        turn while the LLM thinks it picked up an existing one. Pin
+        on ValueError + a substring that names both the subagent type
+        and the load-bearing reason ("does not support session
+        resume") so a regression to silent-drop or to a different
+        error class trips here.
+        """
+        with pytest.raises(ValueError, match="gen_visual_dashboard.*session resume"):
+            task_tool._create_builtin_node("gen_visual_dashboard", session_id="some-prior-session")
+
     def test_resolve_effective_inherits_parent_when_child_empty(self, task_tool):
         parent = MagicMock()
         parent.node_config = {"scoped_context": {"tables": "public.users"}}

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -236,6 +236,44 @@ class TestResolveNodeType:
         assert NODE_CLASS_MAP["gen_visual_report"] == NodeType.TYPE_GEN_VISUAL_REPORT
         assert "gen_visual_report" in BUILTIN_SUBAGENT_DESCRIPTIONS
 
+    def test_gen_visual_report_constructs_and_builds_input(self, task_tool, tmp_path):
+        """Mirror of ``test_gen_visual_dashboard_constructs_and_builds_input``
+        for the report subagent — ``_create_builtin_node`` + the
+        matching ``_build_node_input`` branch must produce the right
+        node class and input dataclass. The mapping-level
+        ``test_gen_visual_report_resolves`` check above won't catch
+        constructor signature drift or an input-builder branch
+        returning the wrong type.
+        """
+        from datus.agent.node.gen_visual_report_agentic_node import GenVisualReportAgenticNode
+        from datus.schemas.gen_visual_report_models import GenVisualReportNodeInput
+
+        task_tool.agent_config.workspace_root = str(tmp_path)
+
+        node = task_tool._create_builtin_node("gen_visual_report")
+        assert isinstance(node, GenVisualReportAgenticNode), f"factory returned wrong type: {type(node).__name__}"
+        assert node.configured_node_name == "gen_visual_report"
+        assert node.NODE_NAME == "gen_visual_report"
+        assert node.ARTIFACT_KIND == "report"
+        assert node.execution_mode == "interactive"
+
+        prompt = "produce a quarterly revenue report"
+        node_input = task_tool._build_node_input(node, prompt)
+        assert isinstance(node_input, GenVisualReportNodeInput), (
+            f"input builder returned wrong type: {type(node_input).__name__}"
+        )
+        assert node_input.user_message == prompt
+        assert node_input.database == "test_db"
+
+    def test_gen_visual_report_rejects_session_id(self, task_tool):
+        """gen_visual_report has the same no-resume contract as
+        gen_visual_dashboard — both inherit from
+        ``BaseVisualArtifactAgenticNode`` which doesn't accept
+        ``session_id``. Pin ValueError + the load-bearing substring
+        so a regression to silent-drop trips here."""
+        with pytest.raises(ValueError, match="gen_visual_report.*session resume"):
+            task_tool._create_builtin_node("gen_visual_report", session_id="some-prior-session")
+
     def test_gen_visual_dashboard_resolves(self, task_tool):
         """gen_visual_dashboard must be registered alongside the other visual subagent.
 

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -236,6 +236,20 @@ class TestResolveNodeType:
         assert NODE_CLASS_MAP["gen_visual_report"] == NodeType.TYPE_GEN_VISUAL_REPORT
         assert "gen_visual_report" in BUILTIN_SUBAGENT_DESCRIPTIONS
 
+    def test_gen_visual_dashboard_resolves(self, task_tool):
+        """gen_visual_dashboard must be registered alongside the other visual subagent.
+
+        Mirrors :meth:`test_gen_visual_report_resolves` — the dashboard subagent
+        is enumerated in ``SYS_SUB_AGENTS`` and exposed via the chat agent's
+        task tool, so missing entries in NODE_CLASS_MAP / descriptions /
+        factory cause the LLM to report it as 'unavailable'.
+        """
+        node_type, node_name = task_tool._resolve_node_type("gen_visual_dashboard")
+        assert node_type == NodeType.TYPE_GEN_VISUAL_DASHBOARD
+        assert node_name == "gen_visual_dashboard"
+        assert NODE_CLASS_MAP["gen_visual_dashboard"] == NodeType.TYPE_GEN_VISUAL_DASHBOARD
+        assert "gen_visual_dashboard" in BUILTIN_SUBAGENT_DESCRIPTIONS
+
     def test_resolve_effective_inherits_parent_when_child_empty(self, task_tool):
         parent = MagicMock()
         parent.node_config = {"scoped_context": {"tables": "public.users"}}
@@ -329,6 +343,7 @@ class TestResolveNodeType:
             "chat": NodeType.TYPE_CHAT,
             "gen_report": NodeType.TYPE_GEN_REPORT,
             "gen_visual_report": NodeType.TYPE_GEN_VISUAL_REPORT,
+            "gen_visual_dashboard": NodeType.TYPE_GEN_VISUAL_DASHBOARD,
             "ext_knowledge": NodeType.TYPE_EXT_KNOWLEDGE,
             "semantic": NodeType.TYPE_SEMANTIC,
             "sql_summary": NodeType.TYPE_SQL_SUMMARY,


### PR DESCRIPTION
## Why

`GenVisualDashboardAgenticNode` (the parameterized-dashboard sibling of
`GenVisualReportAgenticNode`) was already implemented, ships its own
prompt template (`gen_visual_dashboard_system_1.0.j2`), schemas
(`GenVisualDashboardNodeInput` / `Result`), filesystem-tool subclass
(`DashboardFilesystemFuncTool`), artifact tools
(`DashboardArtifactTools`), and `NodeType` enum
(`TYPE_GEN_VISUAL_DASHBOARD`), plus is wired into the proxy-tool
allowlist and `node_factory`.

What was missing is the cross-cutting wiring that lets the chat agent
actually delegate to it through the task tool — every other
`SYS_SUB_AGENTS` member registers itself in a handful of dispatch tables
(`NODE_CLASS_MAP`, `BUILTIN_SUBAGENT_DESCRIPTIONS`,
`_create_builtin_node`, `_resolve_node_type`, `_build_node_input`,
`SubAgentManager._write_prompt_template`, the `sub_agent_wizard`
RadioList / fallback-template branches). Without those entries, the
type is reachable only via `Node.new_instance` — the chat agent's
LLM-facing `task(type="gen_visual_dashboard", ...)` call would resolve
to "unknown subagent type".

## Solution

Mirror the dispatch entries that `gen_visual_report` already has, point
them at the dashboard's existing pieces:

- `constants.SYS_SUB_AGENTS` — add `gen_visual_dashboard`.
- `sub_agent_task_tool.NODE_CLASS_MAP` — `gen_visual_dashboard →
  NodeType.TYPE_GEN_VISUAL_DASHBOARD`.
- `sub_agent_task_tool.BUILTIN_SUBAGENT_DESCRIPTIONS` — author the LLM
  description (calls out the Jinja2 templates + live-runtime distinction
  vs. `gen_visual_report`'s pre-baked JSON, lists the typical save /
  validate_render lifecycle, and the result shape).
- `sub_agent_task_tool._create_builtin_node` — instantiate
  `GenVisualDashboardAgenticNode` with the same kwargs as the report
  branch (no `session_id` — matches report-mode behavior).
- `sub_agent_task_tool._resolve_node_type` — explicit short-circuit so
  the type resolves without consulting `agent.yml`.
- `sub_agent_task_tool._build_node_input` — route prompts to
  `GenVisualDashboardNodeInput`.
- `sub_agent_manager._write_prompt_template` — pick
  `gen_visual_dashboard_system` as the source template when a custom
  subagent declares `node_class=gen_visual_dashboard`.
- `sub_agent_wizard` — add a `gen_visual_dashboard` radio option and
  wire the fallback / default template branches in `_update_previews` and
  `_parse_template_name`.

## Test Cases

- `tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py`:
  - `TestResolveNodeType.test_gen_visual_dashboard_resolves` — new
    regression mirroring `test_gen_visual_report_resolves`, asserts
    `NODE_CLASS_MAP` / `BUILTIN_SUBAGENT_DESCRIPTIONS` /
    `_resolve_node_type` all expose `gen_visual_dashboard`.
  - `TestResolveNodeType.test_node_class_map_coverage` — `expected_map`
    extended with the new key so the contract assertion stays exact.
- Re-ran the targeted scope (sub_agent_task_tool, gen_visual_*
  agentic-node tests, dashboard_artifact_tools, dashboard schemas,
  action_sse_converter, cli/) — 3562 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visual dashboard subagent type across the UI/CLI/tooling, including system template selection and prompt-preview behavior for dashboards; toolchains now produce dedicated dashboard outputs (slug, render counts, artifacts) instead of a generic envelope.

* **Bug Fixes / Validation**
  * Enforced session-resume validation for visual artifact subagents (rejecting supplied session IDs).

* **Tests**
  * Added tests for dashboard registration, construction, input wiring, template resolution, conversion output shape, and session-resume behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->