### PR TITLE
[Enhancement] Inline analysis sidecars into ask_* system prompt

### DIFF
--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -31,17 +31,28 @@ permissions, etc.) and add three things:
    filesystem traversal. The blob source uses :class:`MemoryFilesystemFuncTool` (no disk
    touched); the disk source uses :class:`FilesystemFuncTool`.
 3. **Artifact context injection** — load ``manifest.json`` plus
-   ``analysis/intent.md`` once at node startup, and surface them to
-   the prompt template so the LLM has a baseline grounding without
-   paying ``read_file`` tool calls every turn.
+   ``analysis/intent.md`` once at node startup, and render the full
+   artifact context preamble (manifest header, intent, subject scope,
+   confirmed insights for reports, and a per-query catalog with
+   brief + columns + sample/rows + SQL) into the system prompt.
+   Earlier iterations only preloaded the manifest + intent and left
+   everything else to ``read_file`` round-trips at turn time; the
+   observed failure mode was the LLM issuing 8–10+ serial
+   ``glob`` + ``read_file`` calls per follow-up before producing any
+   output, even when the prompt could carry every sidecar directly.
+   The renderer now inlines as much as fits under
+   :data:`INLINE_CATALOG_BYTES_CAP` and degrades the long tail
+   (sample rows instead of full, tighter SQL truncation) so the LLM
+   has a complete grounding without paying read round-trips for it.
 
-The earlier ``interpretation.json`` preload was removed along with the
-file itself — ``manifest.description`` covers framing and
-``analysis/insights.json`` (read on demand by the LLM) covers the
-substantive findings. Likewise, ``suggested_questions.json`` is **not**
-preloaded into the prompt: it's surfaced via the detail API as UI
-chips, but injecting it here would anchor the LLM toward a fixed
-question set whenever the user types an open-ended follow-up.
+``suggested_questions.json`` is the one analysis file still kept out
+of the inline preamble — it's surfaced via the detail API as UI
+chips, and injecting its contents here would anchor the LLM toward a
+fixed question set whenever the user types an open-ended follow-up.
+The filename does appear in the layout-tree section, but only on a
+``DO NOT read`` line so the original anti-anchor intent is enforced
+by explicit instruction. The earlier ``interpretation.json`` preload
+was removed along with the file itself.
 
 Per-kind specialization (``ARTIFACT_KIND`` / template name / whether
 ``insights.json`` is expected / whether ``BLOB_REQUIRED``) lives in the
@@ -52,7 +63,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Literal, Optional
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
 
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
 from datus.configuration.agent_config import AgentConfig
@@ -62,6 +73,47 @@ from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+# ── Inline-rendering thresholds ──────────────────────────────────────────────
+# A query result's rows are inlined into the system prompt only when BOTH
+# conditions hold:
+#   1. row_count <= INLINE_ROW_LIMIT
+#   2. JSON-serialized rows fit in INLINE_ROW_BYTES_LIMIT bytes
+# Either threshold being exceeded triggers degraded mode: the catalog entry
+# keeps the columns + a 2-row sample, and the full payload stays read-only
+# behind ``read_file('queries/<slug>.json')``. The byte gate is what catches
+# a 20-row result whose rows each carry a multi-KB text field — row count
+# alone would let that through.
+INLINE_ROW_LIMIT = 20
+INLINE_ROW_BYTES_LIMIT = 4 * 1024
+
+# SQL bodies > this many lines are truncated to the first N lines with a
+# trailing "...(truncated)" marker. Report SQLs are typically <20 lines;
+# anything beyond 40 is exceptional and the LLM can pay one read_file
+# round-trip if it genuinely needs the full body.
+INLINE_SQL_LINE_LIMIT = 40
+
+# Soft cap on the total bytes the query-catalog section contributes to the
+# system prompt. When approached the renderer degrades remaining entries
+# (drop full rows -> drop caveats -> tighter SQL truncation). Header info
+# (slug + size + hypothesis + columns) always survives so the LLM still
+# knows what data exists; a follow-up ``read_file`` can fetch detail.
+INLINE_CATALOG_BYTES_CAP = 64 * 1024
+
+
+def _compact_row(row: Any) -> str:
+    """Render a single result row as one deterministic line.
+
+    Used in the inline ``rows`` / ``sample`` blocks of the query catalog
+    section. JSON-encodes scalars so units/quoting stay unambiguous (e.g.
+    ``aov=29.19`` vs ``aov="29.19"``) and joins key/value pairs with the
+    middle dot so the eye can scan a wide row without confusing commas
+    inside string values with row-level separators.
+    """
+    if isinstance(row, dict):
+        parts = [f"{k}={json.dumps(v, ensure_ascii=False, default=str)}" for k, v in row.items()]
+        return " · ".join(parts)
+    return json.dumps(row, ensure_ascii=False, default=str)
 
 
 class BaseArtifactAskAgenticNode(ChatAgenticNode):
@@ -512,19 +564,149 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     def _render_artifact_context_block(self) -> str:
         """Build the artifact-context preamble prepended to the chat prompt.
 
-        Hand-rolls a small markdown block rather than a separate j2
-        template because the structure is dead simple, the inputs are
-        already in memory, and a 30-line template adds more indirection
-        than it saves.
+        Composes per-section helper methods so each concern (header,
+        intent, subject scope, insights, query catalog, layout, rules)
+        stays self-contained and individually testable. The catalog
+        section inlines as much of the artifact as fits under
+        :data:`INLINE_CATALOG_BYTES_CAP` so the LLM rarely needs to
+        ``read_file`` defensively — the trace this was tuned against
+        was paying 10+ serial tool round-trips before producing any
+        output, all loading content the prompt could carry directly.
+
+        Hand-rolls markdown rather than a j2 template because the
+        section helpers already encapsulate the structure and a
+        template here would add indirection without saving lines.
         """
         if self._artifact_files is None and self._artifact_root is None:
             return ""
 
+        # Sections produced in order; empty ones are silently dropped so
+        # the rendered prompt stays clean for artifacts that don't have
+        # insights / subject refs / queries (rare but real, e.g. a newly
+        # created report with no save_query calls yet).
+        sections: List[str] = [self._render_header_section()]
+        for render in (
+            self._render_intent_section,
+            self._render_subject_scope_section,
+            self._render_insights_section,
+            self._render_query_catalog_section,
+        ):
+            block = render()
+            if block:
+                sections.append(block)
+        sections.append(self._render_filesystem_layout_section())
+        sections.append(self._render_behavioral_rules_section())
+        return "\n\n".join(sections)
+
+    # ── Unified artifact-file access ────────────────────────────────────
+
+    def _read_artifact_file(self, rel_path: str) -> Optional[str]:
+        """Return the contents of a slug-relative artifact file.
+
+        Unifies blob mode (in-memory file map) and disk mode (rooted at
+        ``self._artifact_root``) so the section renderers below don't
+        each have to branch on the source. The path uses POSIX
+        separators — same shape the LLM passes to ``read_file``.
+
+        Returns ``None`` when the file is missing or unreadable so the
+        caller can skip a section rather than raise mid-render. We log
+        on disk-side ``OSError`` because it's the only signal an
+        operator gets that the artifact tree is corrupted; missing
+        files in blob mode are silently skipped (a degenerate blob is
+        already caught at init by ``_is_usable_blob``).
+        """
+        if self._artifact_files is not None:
+            return self._artifact_files.get(rel_path)
+        if self._artifact_root is None:
+            return None
+        full = self._artifact_root / rel_path
+        if not full.is_file():
+            return None
+        try:
+            return full.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Failed to read %s during prompt render: %s", full, exc)
+            return None
+
+    def _query_slugs(self) -> List[str]:
+        """Return query slugs in deterministic alphabetical order.
+
+        Built from ``queries/*.brief.json`` because every saved query
+        has a brief sidecar (``save_query`` writes them atomically with
+        the SQL/result triple); SQL files without a brief shouldn't
+        exist in a well-formed artifact and surfacing them would just
+        clutter the catalog. Deterministic order is important for
+        prompt caching — the same artifact must render the same catalog
+        across turns.
+        """
+        prefix = "queries/"
+        suffix = ".brief.json"
+        slugs: List[str] = []
+        if self._artifact_files is not None:
+            for path in sorted(self._artifact_files):
+                if path.startswith(prefix) and path.endswith(suffix):
+                    slugs.append(path[len(prefix) : -len(suffix)])
+            return slugs
+        if self._artifact_root is None:
+            return []
+        queries_dir = self._artifact_root / "queries"
+        if not queries_dir.is_dir():
+            return []
+        for path in sorted(queries_dir.glob("*.brief.json")):
+            slugs.append(path.name[: -len(suffix)])
+        return slugs
+
+    def _load_query_bundle(self, slug: str) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]], Optional[str]]:
+        """Return ``(brief, data, sql)`` for a query slug.
+
+        ``data`` is the result snapshot for reports (``<slug>.json``)
+        or the params declaration for dashboards (``<slug>.params.json``);
+        ``sql`` is the SQL text (``<slug>.sql``) or template
+        (``<slug>.sql.j2``). Any of the three may come back missing/
+        partial — the catalog renderer falls back to whatever pieces
+        are available so a single corrupt sidecar doesn't strand the
+        whole section.
+        """
+        brief: Dict[str, Any] = {}
+        brief_raw = self._read_artifact_file(f"queries/{slug}.brief.json")
+        if brief_raw:
+            try:
+                parsed = json.loads(brief_raw)
+                if isinstance(parsed, dict):
+                    brief = parsed
+            except json.JSONDecodeError as exc:
+                logger.warning("Catalog render: brief.json for %s unreadable: %s", slug, exc)
+
+        data: Optional[Dict[str, Any]] = None
+        data_path = f"queries/{slug}.json" if self.ARTIFACT_KIND == "report" else f"queries/{slug}.params.json"
+        data_raw = self._read_artifact_file(data_path)
+        if data_raw:
+            try:
+                parsed = json.loads(data_raw)
+                if isinstance(parsed, dict):
+                    data = parsed
+            except json.JSONDecodeError as exc:
+                logger.warning("Catalog render: %s unreadable: %s", data_path, exc)
+
+        sql_path = f"queries/{slug}.sql" if self.ARTIFACT_KIND == "report" else f"queries/{slug}.sql.j2"
+        sql = self._read_artifact_file(sql_path)
+        return brief, data, sql
+
+    # ── Section renderers ──────────────────────────────────────────────
+
+    def _render_header_section(self) -> str:
+        """Top metadata block — artifact identity, source, key tables.
+
+        Always rendered (caller already guarded against the "neither
+        blob nor disk" case). Mirrors the original preamble field
+        choices because downstream tests assert on specific labels
+        ("Slug", "Tables referenced", "in-memory snapshot", etc.).
+        """
         manifest = self._artifact_manifest or {}
         artifact_name = manifest.get("name") or self._artifact_slug
         artifact_description = manifest.get("description") or ""
 
-        lines: list[str] = []
+        lines: List[str] = []
         lines.append(f"## Bound Artifact — {self.ARTIFACT_KIND.title()}: {artifact_name}")
         lines.append("")
         lines.append(f"- **Slug**: `{self._artifact_slug}`")
@@ -540,111 +722,447 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if manifest.get("datasources"):
             lines.append(f"- **Datasources**: {', '.join(manifest['datasources'])}")
         if manifest.get("key_tables"):
-            # Surface code-aggregated table list so the LLM can answer
-            # "which tables does this report touch" / plan a follow-up
-            # SQL without first ``list_tables`` / ``describe_table`` round-
-            # trips. Code-generated by finalize from the SQL bodies, not
-            # an LLM claim — trustworthy as long as it's present.
+            # Code-aggregated by finalize from the SQL bodies, not an
+            # LLM claim — trustworthy as long as it's present. Surfacing
+            # it here lets the LLM skip ``list_tables`` round-trips
+            # when planning follow-up SQL.
             lines.append(f"- **Tables referenced**: {', '.join(manifest['key_tables'])}")
-        lines.append("")
+        return "\n".join(lines)
 
-        if self._artifact_intent_md.strip():
-            lines.append("### User's Original Intent (`analysis/intent.md`)")
-            lines.append("")
-            lines.append(self._artifact_intent_md.strip())
-            lines.append("")
+    def _render_intent_section(self) -> str:
+        """User's original intent.md, verbatim.
 
-        # File-system layout & usage hints — kept brief because the chat
-        # template already documents the available tools; we just point
-        # the LLM at what's under the bound artifact. We deliberately
-        # do NOT list ``analysis/suggested_questions.json`` here — it
-        # exists as UI chip data and including it would anchor the LLM
-        # toward a fixed question set when the user asks something open.
-        # ``analysis/subject_refs.json`` is also omitted from the static
-        # tree because it's present-iff-non-empty; the LLM can ``glob``
-        # for it if it cares.
-        lines.append("### Artifact Filesystem Layout")
-        lines.append("")
-        layout_root_label = self._artifact_root.name if self._artifact_root is not None else self.ARTIFACT_ROOT_DIR_NAME
-        lines.append(
-            f"Your filesystem tools are anchored at the artifact root. "
-            f"Relative paths resolve under `{layout_root_label}/`:"
-        )
-        lines.append("")
-        lines.append("```")
-        lines.append(".")
-        lines.append("├── manifest.json")
-        lines.append("├── analysis/")
-        lines.append("│   ├── intent.md                 # raw user prompts (append-only)")
+        Returns "" when intent is empty so the section is skipped — a
+        missing intent.md degrades gracefully (the manifest description
+        already frames the artifact).
+        """
+        if not self._artifact_intent_md.strip():
+            return ""
+        return "### User's Original Intent (`analysis/intent.md`)\n\n" + self._artifact_intent_md.strip()
+
+    def _render_subject_scope_section(self) -> str:
+        """Subject-library assets the artifact was grounded in.
+
+        Walks ``analysis/subject_refs.json`` (the code-aggregated dedup
+        of every brief's ``uses`` block) and surfaces:
+
+        * per-asset: kind, full subject path, name
+        * reverse index: which query slugs reference each asset
+
+        The reverse index is built fresh from every brief rather than
+        from the subject_refs file itself because subject_refs only
+        carries the dedup'd asset list, not the back-pointers. This
+        lets the LLM answer "which queries use metric X?" without any
+        file reads.
+
+        Returns "" when subject_refs is missing/empty so a report that
+        didn't draw on the subject library doesn't get a stub heading.
+        """
+        raw = self._read_artifact_file("analysis/subject_refs.json")
+        if not raw:
+            return ""
+        try:
+            refs = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("Subject scope render: subject_refs.json unreadable: %s", exc)
+            return ""
+        if not isinstance(refs, dict):
+            return ""
+
+        # Reverse index: (kind, name) -> sorted list of query slugs.
+        usage_by_asset: Dict[Tuple[str, str], List[str]] = {}
+        for slug in self._query_slugs():
+            brief_raw = self._read_artifact_file(f"queries/{slug}.brief.json")
+            if not brief_raw:
+                continue
+            try:
+                brief = json.loads(brief_raw)
+            except json.JSONDecodeError:
+                continue
+            uses = brief.get("uses") if isinstance(brief, dict) else None
+            if not isinstance(uses, dict):
+                continue
+            for kind_key in ("metrics", "reference_sql", "ext_knowledge"):
+                for entry in uses.get(kind_key) or []:
+                    if isinstance(entry, dict):
+                        name = entry.get("name")
+                        if isinstance(name, str) and name:
+                            usage_by_asset.setdefault((kind_key, name), []).append(slug)
+
+        body_lines: List[str] = []
+        for kind_key, label in (
+            ("metrics", "metric"),
+            ("reference_sql", "sql"),
+            ("ext_knowledge", "knowledge"),
+        ):
+            entries = refs.get(kind_key) or []
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("name") or ""
+                if not isinstance(name, str) or not name:
+                    continue
+                path = entry.get("path") or []
+                if isinstance(path, list) and all(isinstance(p, str) for p in path):
+                    path_str = " > ".join(path) if path else "(no path)"
+                else:
+                    path_str = "(no path)"
+                used_by = sorted(set(usage_by_asset.get((kind_key, name), [])))
+                line = f"- **{label}** `{path_str} > {name}`"
+                if used_by:
+                    line += f"\n  · used by: {', '.join(used_by)}"
+                body_lines.append(line)
+
+        if not body_lines:
+            return ""
+
+        header = [
+            "### Subject Library Scope (`analysis/subject_refs.json`)",
+            "",
+            (
+                "The artifact was grounded in the following subject-library "
+                "assets. To fetch a canonical definition, call "
+                "`get_metrics(path, name)` / `get_reference_sql(path, name)` "
+                "/ `get_ext_knowledge(path, name)`:"
+            ),
+            "",
+        ]
+        return "\n".join(header + body_lines)
+
+    def _render_insights_section(self) -> str:
+        """Inline ``analysis/insights.json`` (report-only).
+
+        Confirmed findings are authoritative for the artifact — the
+        LLM should be able to cite them by id without any file read.
+        Dashboards have no equivalent (their templates have no static
+        conclusions), so the section is empty for the dashboard kind
+        and gets dropped by the orchestrator.
+        """
+        if self.ARTIFACT_KIND != "report":
+            return ""
+        raw = self._read_artifact_file("analysis/insights.json")
+        if not raw:
+            return ""
+        try:
+            insights = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("Insights render: insights.json unreadable: %s", exc)
+            return ""
+        if not isinstance(insights, list) or not insights:
+            return ""
+
+        lines: List[str] = ["### Confirmed Findings (`analysis/insights.json`)", ""]
+        for idx, insight in enumerate(insights, start=1):
+            if not isinstance(insight, dict):
+                continue
+            iid = insight.get("id") or "?"
+            title = insight.get("title") or "(no title)"
+            confidence = insight.get("confidence")
+            conf_str = f" _(conf {confidence:.2f})_" if isinstance(confidence, (int, float)) else ""
+            summary = insight.get("summary") or ""
+            evidence = insight.get("evidence_queries") or []
+            lines.append(f"{idx}. **`{iid}`** — {title}{conf_str}")
+            if summary:
+                lines.append(f"   {summary}")
+            if isinstance(evidence, list) and evidence:
+                ev_strs = [f"`{e}`" for e in evidence if isinstance(e, str)]
+                if ev_strs:
+                    lines.append(f"   · evidence: {', '.join(ev_strs)}")
+        return "\n".join(lines)
+
+    def _render_query_catalog_section(self) -> str:
+        """Per-query entries: brief + columns + sample/rows + SQL.
+
+        Walks every query slug in deterministic order and produces a
+        compact catalog entry. Each entry's size is tracked against
+        :data:`INLINE_CATALOG_BYTES_CAP`; once the running total would
+        exceed the cap, remaining entries are rendered in degraded
+        mode (drop full rows, tighter SQL truncation, drop caveats)
+        so the LLM still knows what data exists for every query, just
+        with less detail for the long tail.
+
+        Row inlining for report queries uses TWO thresholds at once:
+        :data:`INLINE_ROW_LIMIT` (count) and :data:`INLINE_ROW_BYTES_LIMIT`
+        (serialized byte size). Either being exceeded triggers degraded
+        sampling (first 2 rows only). The byte gate matters when a
+        20-row result carries a multi-KB text column per row — row
+        count alone would silently inflate the prompt.
+        """
+        slugs = self._query_slugs()
+        if not slugs:
+            return ""
+
         if self.ARTIFACT_KIND == "report":
-            lines.append("│   └── insights.json             # confirmed findings (report only)")
-        lines.append("├── queries/")
-        if self.ARTIFACT_KIND == "report":
-            lines.append("│   ├── <name>.sql                # SQL text")
-            lines.append("│   ├── <name>.json               # query result snapshot")
+            data_label = "result snapshot"
+            data_suffix = ".json"
+            sql_suffix = ".sql"
+            sql_word = "SQL"
         else:
-            lines.append("│   ├── <name>.sql.j2             # Jinja2 SQL template (params header)")
-            lines.append("│   └── <name>.params.json        # declared params + sample columns")
-        lines.append("│   └── <name>.brief.json         # hypothesis / uses / caveats")
-        lines.append("└── render/                       # presentation tier — DO NOT READ")
-        lines.append("```")
-        lines.append("")
+            data_label = "params declaration"
+            data_suffix = ".params.json"
+            sql_suffix = ".sql.j2"
+            sql_word = "SQL template"
 
-        # Behavioral rules — these are the load-bearing rules that define
-        # the ask agent's role. They sit at the top of the prompt so the
-        # LLM internalizes them before reading the chat template's general
-        # tool documentation below.
-        lines.append("### Behavioral Rules (load-bearing)")
-        lines.append("")
+        intro = (
+            f"Each entry below summarizes one `queries/<slug>` triple "
+            f"(brief + {data_label} + {sql_word}). When a query's full rows "
+            f"or SQL body would blow the inline budget, only a small sample "
+            f"is shown and the full payload remains read-only behind "
+            f"`read_file('queries/<slug>{data_suffix}')` / "
+            f"`read_file('queries/<slug>{sql_suffix}')`."
+        )
+
+        header: List[str] = ["### Query Catalog", "", intro, ""]
+
+        body: List[str] = []
+        running_bytes = 0
+        degraded = False
+        for slug in slugs:
+            brief, data, sql = self._load_query_bundle(slug)
+            entry_lines = self._render_query_catalog_entry(slug, brief, data, sql, degraded=degraded)
+            entry_bytes = sum(len(line) + 1 for line in entry_lines)
+            if not degraded and running_bytes + entry_bytes > INLINE_CATALOG_BYTES_CAP:
+                degraded = True
+                entry_lines = self._render_query_catalog_entry(slug, brief, data, sql, degraded=True)
+                entry_bytes = sum(len(line) + 1 for line in entry_lines)
+            body.extend(entry_lines)
+            body.append("")
+            running_bytes += entry_bytes
+
+        return "\n".join(header + body).rstrip()
+
+    def _render_query_catalog_entry(
+        self,
+        slug: str,
+        brief: Dict[str, Any],
+        data: Optional[Dict[str, Any]],
+        sql: Optional[str],
+        *,
+        degraded: bool,
+    ) -> List[str]:
+        """Render one catalog entry. Caller stitches entries together.
+
+        Degraded mode skips full-row inlining (always sample) and
+        caveats, and tightens the SQL line cap. The header (slug + row
+        count + hypothesis + columns) always survives so the LLM keeps
+        a usable index of every query even when the catalog cap fires.
+        """
+        lines: List[str] = []
+
+        # Header: slug + size descriptor.
+        if self.ARTIFACT_KIND == "report" and isinstance(data, dict):
+            rows = data.get("rows") or []
+            row_count = data.get("row_count", len(rows))
+            size_desc = f"{row_count} rows"
+        elif self.ARTIFACT_KIND == "dashboard" and isinstance(data, dict):
+            sample_row_count = data.get("sample_row_count", 0)
+            size_desc = f"template · sample {sample_row_count} rows"
+        else:
+            size_desc = "no data file"
+        lines.append(f"#### `{slug}` — {size_desc}")
+
+        hypothesis = brief.get("hypothesis") or ""
+        if hypothesis:
+            lines.append(f"- **hypothesis**: {hypothesis}")
+
+        # Subjects: short labels only — full paths live in the global
+        # Subject Library Scope section so we don't repeat the path
+        # once per query.
+        uses = brief.get("uses") or {}
+        subject_parts: List[str] = []
+        if isinstance(uses, dict):
+            for kind_key, label in (
+                ("metrics", "metric"),
+                ("reference_sql", "sql"),
+                ("ext_knowledge", "knowledge"),
+            ):
+                for entry in uses.get(kind_key) or []:
+                    if isinstance(entry, dict):
+                        name = entry.get("name")
+                        if isinstance(name, str) and name:
+                            subject_parts.append(f"{label}:`{name}`")
+        if subject_parts:
+            lines.append(f"- **subjects**: {', '.join(subject_parts)}")
+
+        caveats = brief.get("caveats") or ""
+        if caveats and not degraded:
+            lines.append(f"- **caveats**: {caveats}")
+
+        # Columns block — always rendered when available since it's
+        # cheap and key to "what data does this query produce".
+        if isinstance(data, dict):
+            cols = data.get("columns") or []
+            col_strs: List[str] = []
+            for c in cols:
+                if isinstance(c, dict):
+                    cname = c.get("name", "?")
+                    ctype = c.get("type", "?")
+                    col_strs.append(f"{cname}:{ctype}")
+            if col_strs:
+                lines.append(f"- **columns**: {', '.join(col_strs)}")
+
+        # Rows (report) / sample params (dashboard).
+        if self.ARTIFACT_KIND == "report" and isinstance(data, dict):
+            rows = data.get("rows") or []
+            row_count = data.get("row_count", len(rows))
+            # Double-gate the inline: count AND serialized byte size.
+            full_inline = False
+            if rows and not degraded and row_count <= INLINE_ROW_LIMIT:
+                payload = json.dumps(rows, ensure_ascii=False, default=str)
+                if len(payload.encode("utf-8")) <= INLINE_ROW_BYTES_LIMIT:
+                    full_inline = True
+            if rows:
+                if full_inline:
+                    lines.append(f"- **rows** ({row_count}):")
+                    for row in rows:
+                        lines.append(f"    - {_compact_row(row)}")
+                else:
+                    show = min(2, len(rows))
+                    lines.append(
+                        f"- **sample** (first {show} of {row_count}; full data via `read_file('queries/{slug}.json')`):"
+                    )
+                    for row in rows[:show]:
+                        lines.append(f"    - {_compact_row(row)}")
+        elif self.ARTIFACT_KIND == "dashboard" and isinstance(data, dict):
+            sample_params = data.get("sample_params") or {}
+            if sample_params:
+                lines.append("- **sample_params**: " + json.dumps(sample_params, ensure_ascii=False, default=str))
+
+        # SQL body, truncated when long. Degraded mode tightens the cap
+        # so the long tail of queries stays compact under the catalog
+        # cap.
+        if sql:
+            lines.append("- **SQL**:")
+            lines.append("  ```sql")
+            sql_lines = sql.strip().splitlines()
+            max_lines = (INLINE_SQL_LINE_LIMIT // 2) if degraded else INLINE_SQL_LINE_LIMIT
+            if len(sql_lines) > max_lines:
+                for line in sql_lines[:max_lines]:
+                    lines.append(f"  {line}")
+                remaining = len(sql_lines) - max_lines
+                full_sql_suffix = ".sql" if self.ARTIFACT_KIND == "report" else ".sql.j2"
+                lines.append(f"  -- ... ({remaining} more lines; read queries/{slug}{full_sql_suffix} for full body)")
+            else:
+                for line in sql_lines:
+                    lines.append(f"  {line}")
+            lines.append("  ```")
+
+        return lines
+
+    def _render_filesystem_layout_section(self) -> str:
+        """Tell the LLM what's already inlined vs what still needs read_file.
+
+        The directory tree mirrors the on-disk artifact layout but
+        annotates each entry with "inlined above" vs "DO NOT read" vs
+        "read on demand" so a model trying to be helpful by pre-fetching
+        files immediately sees that defensive reads are not useful.
+        """
+        layout_root_label = self._artifact_root.name if self._artifact_root is not None else self.ARTIFACT_ROOT_DIR_NAME
+        loaded_list = (
+            "manifest.json, analysis/intent.md, "
+            + ("analysis/insights.json, " if self.ARTIFACT_KIND == "report" else "")
+            + "analysis/subject_refs.json (when present), and every "
+            "`queries/*.brief.json` plus the inlined slice of "
+            "`queries/*` data + SQL above"
+        )
+        lines: List[str] = [
+            "### Artifact Filesystem Layout",
+            "",
+            (
+                f"Filesystem tool anchored at the artifact root (relative paths "
+                f"resolve under `{layout_root_label}/`). **The following are "
+                f"already loaded into this prompt: {loaded_list}.** "
+                f"**Do NOT `read_file` / `glob` them defensively.** Read on "
+                f"demand only when the catalog above flags a query's data as "
+                f"sampled or its SQL as truncated."
+            ),
+            "",
+            "```",
+            ".",
+            "├── manifest.json                # inlined above",
+            "├── analysis/",
+            "│   ├── intent.md                # inlined above",
+        ]
+        if self.ARTIFACT_KIND == "report":
+            lines.append("│   ├── insights.json            # inlined above")
+        lines.extend(
+            [
+                "│   ├── subject_refs.json        # inlined above (if present)",
+                "│   └── suggested_questions.json # UI chips — DO NOT read",
+                "├── queries/                     # briefs always inlined; data + SQL inlined or sampled per catalog above",
+                "└── render/                     # presentation tier — DO NOT READ",
+                "```",
+            ]
+        )
+        return "\n".join(lines)
+
+    def _render_behavioral_rules_section(self) -> str:
+        """Load-bearing rules that define the ask agent's role.
+
+        Rule 1 is the load-bearing change in this rewrite: it forbids
+        defensive pre-fetching of files that are already inlined above.
+        Without this the LLM tends to ``glob`` + ``read_file`` every
+        sidecar at turn start out of habit, paying many serial tool
+        round-trips for content the prompt already carries.
+        """
+        lines: List[str] = ["### Behavioral Rules (load-bearing)", ""]
         lines.append(
-            "1. **Ground in existing analysis first**. Before running new SQL, "
-            "try to answer from the anchor context above and from on-disk "
-            "files via `read_file` / `glob` / `grep`. Only run new queries "
-            "when the existing data genuinely doesn't cover the question — "
-            "and when you do, briefly explain why."
+            "1. **Answer from the inlined context first**. The header above "
+            "already contains the manifest, the original intent, the "
+            "subject library scope, "
+            + ("confirmed insights, " if self.ARTIFACT_KIND == "report" else "")
+            + "and a query catalog with hypothesis / caveats / columns / "
+            "sample rows / SQL for every saved query. **Do NOT issue "
+            "`glob` or `read_file` to pre-fetch anything already inlined "
+            "above.** Only re-read a file when the catalog explicitly "
+            "flagged its data as sampled or its SQL as truncated, OR "
+            "when the inlined summary genuinely doesn't address the "
+            "question — and when you do, briefly say which file and "
+            "why."
         )
         lines.append(
-            "2. **Do NOT regenerate the artifact**. You are read-only. If the "
-            "user asks to add a chart, edit a panel, or rewrite the report, "
-            f"direct them to the `gen_visual_{self.ARTIFACT_KIND}` subagent."
+            "2. **Do NOT regenerate the artifact**. You are read-only. If "
+            "the user asks to add a chart, edit a panel, or rewrite the "
+            f"{self.ARTIFACT_KIND}, direct them to the "
+            f"`gen_visual_{self.ARTIFACT_KIND}` subagent."
         )
         lines.append(
-            "3. **Cite by slug**. Refer to queries as ``queries/<name>`` and "
-            "(report only) insights as ``insight:<id>`` so the UI can "
-            "highlight / jump to them."
+            "3. **Cite by slug**. Refer to queries as ``queries/<name>`` "
+            "and (report only) insights as ``insight:<id>`` so the UI "
+            "can highlight / jump to them."
         )
         lines.append(
-            "4. **Stay anchored to the original intent**. Re-read the user "
-            "prompts in `analysis/intent.md` before answering complex "
-            "follow-ups; flag when the user's new question genuinely "
-            "shifts scope from the original artifact's coverage."
+            "4. **Stay anchored to the original intent**. Flag when the "
+            "user's new question genuinely shifts scope from the "
+            f"original {self.ARTIFACT_KIND}'s coverage."
         )
         lines.append(
-            "5. **Respect the data scope**. If `analysis/subject_refs.json` "
-            "exists (it's present iff at least one query declared a "
-            "subject-library asset), it lists what the artifact originally "
-            "drew on. Exploring outside that scope is OK if the user "
-            "explicitly asks, but call it out in your answer."
+            "5. **Respect the data scope**. The Subject Library Scope "
+            "section above (when present) lists the authoritative "
+            "subject assets. Exploring outside that scope is OK if the "
+            "user explicitly asks, but call it out in your answer."
         )
         if self.ARTIFACT_KIND == "dashboard":
             lines.append(
                 "6. **Dashboard queries have no precomputed data**. The "
-                "`queries/<name>.sql.j2` files are templates; to answer "
-                "quantitative questions, run an equivalent ad-hoc SQL via "
-                "`execute_sql` within the dashboard's datasource scope, or "
-                "use the params declaration in `<name>.params.json` to "
-                "explain what user-controllable filters exist."
+                "`queries/<slug>.sql.j2` files (inlined above) are "
+                "templates; to answer quantitative questions, run an "
+                "equivalent ad-hoc SQL via `execute_sql` within the "
+                "dashboard's datasource scope, or use the params "
+                "declaration to explain what user-controllable filters "
+                "exist."
             )
         else:
             lines.append(
-                "6. **`insights.json` is the authoritative findings record**. "
-                "Read it when the user's question touches on confirmed "
-                "conclusions; each insight has `evidence_queries[]` that "
-                "you can cross-reference."
+                "6. **`insights.json` is the authoritative findings "
+                "record**. Already inlined above; each insight has "
+                "`evidence_queries[]` you can cross-reference."
             )
         lines.append(
-            "7. **No artifact mutations**. Filesystem write/edit/delete are "
-            "not available to you and will be rejected — do not attempt them."
+            "7. **No artifact mutations**. Filesystem write/edit/delete "
+            "are not available to you and will be rejected — do not "
+            "attempt them."
         )
-
         return "\n".join(lines)

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -13,12 +13,16 @@ Pins the node-level invariants we depend on at runtime:
   - blob source ⇒ :class:`MemoryFilesystemFuncTool` (no disk),
   - disk source ⇒ :class:`FilesystemFuncTool` rooted at the artifact dir.
 * The artifact-context preamble rendered into the system prompt includes
-  the manifest name, the intent.md body, the expected directory tree
-  (with kind-specific branches: ``insights.json`` only for reports),
-  and the seven load-bearing behavioral rules. ``interpretation.json``
-  and ``suggested_questions.json`` are intentionally NOT loaded into
-  the preamble (the first was removed; the second is reserved for UI
-  chips to avoid anchoring the LLM on a fixed question set).
+  the manifest header, the intent.md body, the subject-library scope
+  (when any subject refs exist), the confirmed insights (report only),
+  a per-query catalog (brief + columns + sample/rows + SQL with byte +
+  row gating and a catalog-level cap), the filesystem layout note, and
+  the seven load-bearing behavioral rules — rule 1 in particular
+  forbids defensive ``glob`` / ``read_file`` on anything already
+  inlined. ``interpretation.json`` (removed) is never mentioned;
+  ``suggested_questions.json`` only appears in the layout tree as a
+  ``DO NOT read`` annotation so its contents never anchor the LLM
+  toward a fixed question set.
 
 We instantiate the nodes directly (bypassing ``node_factory``) so the test
 focuses on the binding / context-injection layer without dragging in the
@@ -596,13 +600,18 @@ class TestArtifactContextBlock:
         assert "Demo Report" in block  # manifest name
         assert "demo_report" in block  # slug
         assert "Q3 anomalies" in block  # intent.md
-        # Directory tree branches on artifact_kind — report shows insights.
+        # Layout tree branches on artifact_kind — report flags insights as inlined.
         assert "insights.json" in block
-        # Brief sidecar replaced reasoning sidecar in the tree.
+        # Brief sidecar called out in the "already loaded" list as part of
+        # the inline-context contract; SQL summaries / reasoning sidecars
+        # don't exist anymore.
         assert "brief.json" in block
         assert "reasoning.json" not in block
-        # Behavioral rules are present and number 7.
-        assert "Ground in existing analysis first" in block
+        # Behavioral rule 1 is the load-bearing "answer from inlined context first"
+        # nudge added when the renderer started inlining briefs/insights/SQL.
+        # Rule 7 is the read-only mutation guard.
+        assert "Answer from the inlined context first" in block
+        assert "Do NOT issue `glob` or `read_file`" in block
         assert "No artifact mutations" in block
 
     def test_report_block_includes_key_tables(self, real_agent_config):
@@ -618,12 +627,30 @@ class TestArtifactContextBlock:
 
     def test_report_block_excludes_interpretation_and_suggested(self, real_agent_config):
         """interpretation.json was removed; suggested_questions.json is
-        UI-chip data and must not leak into the system prompt where it
-        would anchor the LLM toward a fixed question set."""
+        UI-chip data and must not leak its contents into the system
+        prompt where it would anchor the LLM toward a fixed question
+        set. The filename itself MAY appear in the layout tree but only
+        as a "DO NOT read" annotation — the original anti-anchor intent
+        is now enforced by explicit instruction rather than by omission.
+        """
         node = _make_ask_report_node(real_agent_config)
         block = node._render_artifact_context_block()
         assert "interpretation.json" not in block
-        assert "suggested_questions.json" not in block
+        # The filename always appears in the layout tree but must be
+        # paired with the "DO NOT read" annotation on every mentioning
+        # line. We pin on the literal rendered annotation rather than
+        # a loose substring search so a regression that silently inlines
+        # the file's questions (the original anti-anchor concern) still
+        # fails this test.
+        mentioning_lines = [line for line in block.splitlines() if "suggested_questions.json" in line]
+        assert mentioning_lines, (
+            "renderer must surface suggested_questions.json in the layout "
+            "tree (with a DO NOT read annotation) so the LLM knows the file "
+            "exists but is off-limits; missing entirely would invite the "
+            "LLM to `glob` for it"
+        )
+        for line in mentioning_lines:
+            assert "DO NOT read" in line, f"suggested_questions.json mentioned without DO NOT annotation: {line!r}"
 
     def test_dashboard_block_excludes_insights(self, real_agent_config):
         node = _make_ask_dashboard_node(real_agent_config)
@@ -662,3 +689,573 @@ class TestArtifactContextBlock:
         block = node._render_artifact_context_block()
         assert "**Root**" in block
         assert "in-memory snapshot" not in block
+
+
+# --------------------------------------------------------------------------- #
+# Inline-content rendering                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _seed_query_files(
+    artifact_root: Path,
+    kind: str,
+    queries: list[dict],
+) -> None:
+    """Drop per-query sidecars into an already-seeded artifact root.
+
+    Each ``queries`` entry is a dict like::
+
+        {
+            "slug": str,
+            "brief": dict,             # written to <slug>.brief.json
+            "result": dict | None,     # report-only: <slug>.json
+            "params": dict | None,     # dashboard-only: <slug>.params.json
+            "sql": str,                # <slug>.sql (report) or <slug>.sql.j2 (dashboard)
+        }
+
+    Built as an explicit fixture-driver rather than overloading
+    ``_seed_artifact`` (whose existing kwargs are load-bearing on a
+    dozen other tests) so the inline-rendering tests can dial in
+    exact row counts, byte sizes, and SQL lengths.
+    """
+    queries_dir = artifact_root / "queries"
+    queries_dir.mkdir(parents=True, exist_ok=True)
+    for q in queries:
+        slug = q["slug"]
+        (queries_dir / f"{slug}.brief.json").write_text(json.dumps(q.get("brief") or {}), encoding="utf-8")
+        if kind == "report" and q.get("result") is not None:
+            (queries_dir / f"{slug}.json").write_text(json.dumps(q["result"]), encoding="utf-8")
+        if kind == "dashboard" and q.get("params") is not None:
+            (queries_dir / f"{slug}.params.json").write_text(json.dumps(q["params"]), encoding="utf-8")
+        sql_suffix = ".sql" if kind == "report" else ".sql.j2"
+        (queries_dir / f"{slug}{sql_suffix}").write_text(q.get("sql") or "", encoding="utf-8")
+
+
+def _seed_analysis_extras(
+    artifact_root: Path,
+    *,
+    insights: list[dict] | None = None,
+    subject_refs: dict | None = None,
+    suggested_questions: list[dict] | None = None,
+) -> None:
+    """Drop optional analysis files into an already-seeded artifact root."""
+    analysis_dir = artifact_root / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+    if insights is not None:
+        (analysis_dir / "insights.json").write_text(json.dumps(insights), encoding="utf-8")
+    if subject_refs is not None:
+        (analysis_dir / "subject_refs.json").write_text(json.dumps(subject_refs), encoding="utf-8")
+    if suggested_questions is not None:
+        (analysis_dir / "suggested_questions.json").write_text(json.dumps(suggested_questions), encoding="utf-8")
+
+
+def _make_dashboard_with_queries(agent_config, *, slug: str, queries: list[dict], subject_refs: dict | None = None):
+    """Build a dashboard node bound to a fully-seeded artifact.
+
+    Dashboards keep ``BLOB_REQUIRED = False`` so we test the disk path
+    here — the same renderer code runs in blob mode (see the parity
+    test) but disk mode is the production path for ``ask_dashboard``
+    until publish lands."""
+    _seed_artifact(agent_config.project_root, "dashboard", slug)
+    root = Path(agent_config.project_root) / "dashboards" / slug
+    _seed_query_files(root, "dashboard", queries)
+    if subject_refs is not None:
+        _seed_analysis_extras(root, subject_refs=subject_refs)
+    _register_ask_agent(agent_config, name=f"ask_{slug}", kind="dashboard", slug=slug)
+    return AskDashboardAgenticNode(
+        node_id=f"{slug}_test",
+        description="test ask_dashboard node",
+        node_type="chat",
+        agent_config=agent_config,
+        node_name=f"ask_{slug}",
+    )
+
+
+def _make_report_with_queries(
+    agent_config,
+    *,
+    slug: str,
+    queries: list[dict],
+    insights: list[dict] | None = None,
+    subject_refs: dict | None = None,
+    suggested_questions: list[dict] | None = None,
+):
+    """Build a report node from a fully-seeded artifact via the blob path.
+
+    Reports have ``BLOB_REQUIRED = True`` so the artifact must travel
+    through ``_blob_from_disk`` — the helper that mirrors the backend
+    publish wire shape. We seed disk first as a convenient construction
+    vehicle then snapshot it into the blob; the node never touches the
+    disk tree at runtime.
+    """
+    _seed_artifact(agent_config.project_root, "report", slug)
+    root = Path(agent_config.project_root) / "reports" / slug
+    _seed_query_files(root, "report", queries)
+    _seed_analysis_extras(
+        root,
+        insights=insights,
+        subject_refs=subject_refs,
+        suggested_questions=suggested_questions,
+    )
+    blob = _blob_from_disk(agent_config.project_root, "report", slug)
+    _register_ask_agent(agent_config, name=f"ask_{slug}", kind="report", slug=slug, blob=blob)
+    return AskReportAgenticNode(
+        node_id=f"{slug}_test",
+        description="test ask_report node",
+        node_type="chat",
+        agent_config=agent_config,
+        node_name=f"ask_{slug}",
+    )
+
+
+def _basic_query_result(
+    slug: str,
+    *,
+    columns: list[tuple[str, str]] | None = None,
+    rows: list[dict] | None = None,
+) -> dict:
+    cols = [{"name": n, "type": t} for n, t in (columns or [("v", "number")])]
+    rows = rows or [{"v": 1}, {"v": 2}]
+    return {
+        "executed_at": "2026-05-19T00:00:00Z",
+        "datasource": "test_ds",
+        "row_count": len(rows),
+        "columns": cols,
+        "rows": rows,
+    }
+
+
+class TestArtifactContextBlockInlining:
+    """Renderer inlines as much as fits and degrades the rest cleanly.
+
+    The runtime concern these tests pin: an ``ask_*`` follow-up should
+    not need to pre-fetch sidecars to answer the user. The renderer
+    accomplishes that by inlining insights / subject scope / per-query
+    brief + columns + sample rows + SQL into the system prompt, with
+    threshold-based degradation when individual queries or the catalog
+    as a whole would blow the prompt budget.
+    """
+
+    # --- Small-artifact happy path --------------------------------------
+
+    def test_small_report_inlines_all_query_rows(self, real_agent_config):
+        """Tiny artifact: 1 query with 3 rows should be inlined in full
+        (rows block, not sample). Pins the lower bound of the row+byte
+        gate so a regression that always degrades to ``sample`` is
+        visible immediately.
+        """
+        queries = [
+            {
+                "slug": "small_q",
+                "brief": {"name": "small_q", "hypothesis": "h1", "caveats": "c1", "uses": {}},
+                "result": _basic_query_result(
+                    "small_q",
+                    columns=[("day", "string"), ("v", "number")],
+                    rows=[{"day": "Mon", "v": 10}, {"day": "Tue", "v": 11}, {"day": "Wed", "v": 12}],
+                ),
+                "sql": "SELECT day, v FROM t",
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="small_report", queries=queries)
+        block = node._render_artifact_context_block()
+        # Catalog header for the slug + the full-rows marker (NOT sample).
+        assert "#### `small_q`" in block
+        assert "**rows** (3):" in block
+        assert "**sample**" not in block
+        # Every row's value should appear verbatim.
+        assert 'day="Mon"' in block
+        assert "v=12" in block
+        # Hypothesis and caveats survive in non-degraded mode.
+        assert "**hypothesis**: h1" in block
+        assert "**caveats**: c1" in block
+
+    def test_row_count_above_limit_degrades_to_sample(self, real_agent_config):
+        """row_count > INLINE_ROW_LIMIT (20) ⇒ sample mode with the
+        ``read_file`` pointer so the LLM knows where the full data is.
+        """
+        rows = [{"v": i} for i in range(30)]
+        queries = [
+            {
+                "slug": "wide_q",
+                "brief": {"name": "wide_q", "uses": {}},
+                "result": _basic_query_result("wide_q", rows=rows),
+                "sql": "SELECT v FROM t",
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="wide_report", queries=queries)
+        block = node._render_artifact_context_block()
+        assert "#### `wide_q` — 30 rows" in block
+        # Sample wording references the actual count + remediation path.
+        assert "**sample** (first 2 of 30" in block
+        assert "read_file('queries/wide_q.json')" in block
+        # Full rows block must NOT be emitted for a wide result.
+        assert "**rows** (30)" not in block
+        # The remaining 28 rows shouldn't all be in the prompt.
+        # Cheap proxy: the last row's value (29) shouldn't appear.
+        assert "v=29" not in block
+
+    def test_byte_size_above_limit_degrades_to_sample(self, real_agent_config):
+        """A 5-row result whose rows each carry a multi-KB text field
+        must degrade even though row_count is well under 20. This is the
+        gate that protects against fat text columns silently inflating
+        the prompt — the user-reported failure mode that originally
+        prompted the double-gate design.
+        """
+        fat = "x" * 2_000  # ~2KB per row, 5 rows = 10KB > 4KB byte limit
+        rows = [{"id": i, "blob": fat} for i in range(5)]
+        queries = [
+            {
+                "slug": "fat_q",
+                "brief": {"name": "fat_q", "uses": {}},
+                "result": _basic_query_result("fat_q", columns=[("id", "integer"), ("blob", "string")], rows=rows),
+                "sql": "SELECT id, blob FROM t",
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="fat_report", queries=queries)
+        block = node._render_artifact_context_block()
+        # Header still says 5 rows; the degradation is on inline content, not the count.
+        assert "#### `fat_q` — 5 rows" in block
+        # Sample mode kicks in because of bytes, not count.
+        assert "**sample** (first 2 of 5" in block
+        # The fat blob should appear at most twice (the sample), not 5 times.
+        assert block.count("blob=") <= 2
+
+    # --- SQL truncation -------------------------------------------------
+
+    def test_long_sql_is_truncated_with_marker(self, real_agent_config):
+        """SQL > INLINE_SQL_LINE_LIMIT (40) ⇒ truncate to the first N
+        lines and append a marker telling the LLM where to find the full
+        body. The marker text is load-bearing — if it changes the rule-1
+        contract ("flag when the inlined summary doesn't address the
+        question") breaks because the LLM no longer knows the SQL was
+        elided.
+        """
+        long_sql = "\n".join([f"-- line {i}" for i in range(60)] + ["SELECT 1"])
+        queries = [
+            {
+                "slug": "long_sql_q",
+                "brief": {"name": "long_sql_q", "uses": {}},
+                "result": _basic_query_result("long_sql_q"),
+                "sql": long_sql,
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="long_sql_report", queries=queries)
+        block = node._render_artifact_context_block()
+        assert "-- line 0" in block
+        # Line 50 is past the 40-line cap.
+        assert "-- line 50" not in block
+        # Truncation marker names the file so the LLM can read_file it
+        # explicitly when truly needed.
+        assert "more lines; read queries/long_sql_q.sql for full body" in block
+
+    # --- Catalog cap degradation ---------------------------------------
+
+    def test_catalog_cap_degrades_later_entries(self, real_agent_config, monkeypatch):
+        """When the catalog's running byte count would exceed
+        INLINE_CATALOG_BYTES_CAP, later entries drop caveats and fall
+        back to sample-mode (even when individually they'd fit the
+        per-row inline gate). Header info (slug + row count + columns)
+        always survives so the LLM still knows the long-tail queries
+        exist.
+
+        We monkeypatch the cap down to a tiny value so the test stays
+        fast and deterministic — the production cap (64KB) would need
+        an artificially large fixture to trip.
+        """
+        from datus.agent.node import base_artifact_ask_agentic_node as mod
+
+        # Cap chosen empirically: each non-degraded entry in this
+        # fixture renders to ~220 bytes (header + hypothesis + caveats
+        # + 3-row inline + SQL block). 400 fits the first entry only;
+        # the second entry's running total trips the cap and switches
+        # to degraded mode for the rest of the catalog.
+        monkeypatch.setattr(mod, "INLINE_CATALOG_BYTES_CAP", 400)
+
+        common_rows = [{"v": i} for i in range(3)]
+        queries = []
+        for slug in ("a_first", "b_second", "c_third"):
+            queries.append(
+                {
+                    "slug": slug,
+                    "brief": {
+                        "name": slug,
+                        "hypothesis": f"{slug} hypothesis",
+                        # Caveats are visible enough to assert on.
+                        "caveats": f"{slug}-CAVEAT-MARKER",
+                        "uses": {},
+                    },
+                    "result": _basic_query_result(slug, rows=list(common_rows)),
+                    "sql": f"SELECT v FROM {slug}",
+                }
+            )
+        node = _make_report_with_queries(real_agent_config, slug="capped_report", queries=queries)
+        block = node._render_artifact_context_block()
+        # All three slugs survive (header info always emits).
+        assert "#### `a_first`" in block
+        assert "#### `b_second`" in block
+        assert "#### `c_third`" in block
+        # First entry keeps its caveat (not degraded).
+        assert "a_first-CAVEAT-MARKER" in block
+        # At least one later entry has its caveat dropped (degraded mode).
+        # We don't assert which specific entry to keep the test resilient
+        # against minor rendering-size shifts.
+        late_caveats_dropped = "b_second-CAVEAT-MARKER" not in block or "c_third-CAVEAT-MARKER" not in block
+        assert late_caveats_dropped, "expected catalog cap to drop at least one later caveat"
+
+    # --- Subject scope --------------------------------------------------
+
+    def test_subject_scope_reverse_index_lists_referencing_queries(self, real_agent_config):
+        """One subject asset referenced by multiple queries → the
+        subject scope block lists all referencing slugs in alphabetical
+        order. This is the section that makes "which queries use metric
+        X?" answerable without a file scan.
+        """
+        subj = {
+            "path": ["Commerce", "Orders", "AOV"],
+            "name": "average_order_value",
+        }
+        queries = [
+            {
+                "slug": "q_alpha",
+                "brief": {"name": "q_alpha", "uses": {"metrics": [subj]}},
+                "result": _basic_query_result("q_alpha"),
+                "sql": "SELECT 1",
+            },
+            {
+                "slug": "q_beta",
+                "brief": {"name": "q_beta", "uses": {"metrics": [subj]}},
+                "result": _basic_query_result("q_beta"),
+                "sql": "SELECT 1",
+            },
+            # A query without the metric — must NOT appear in the
+            # reverse index even though it's in the catalog.
+            {
+                "slug": "q_orphan",
+                "brief": {"name": "q_orphan", "uses": {}},
+                "result": _basic_query_result("q_orphan"),
+                "sql": "SELECT 1",
+            },
+        ]
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="subj_report",
+            queries=queries,
+            subject_refs={
+                "metrics": [subj],
+                "reference_sql": [],
+                "ext_knowledge": [],
+            },
+        )
+        block = node._render_artifact_context_block()
+        # Path + name rendered together in the scope section.
+        assert "Commerce > Orders > AOV > average_order_value" in block
+        # Reverse index: both referencing slugs listed; orphan absent.
+        assert "used by: q_alpha, q_beta" in block
+        # Per-query "subjects" line shows up only on the referencing entries.
+        # Pin on a concrete substring that appears once per referencing
+        # query — confirms the catalog entry actually includes the tag.
+        assert block.count("metric:`average_order_value`") >= 2
+
+    # --- Skipped sections when files absent -----------------------------
+
+    def test_insights_section_renders_id_title_confidence_evidence(self, real_agent_config):
+        """When insights.json is present, the section renders one
+        numbered entry per insight with id (back-ticked), title,
+        optional confidence in 2-decimal form, summary, and an
+        ``evidence:`` line citing referenced query slugs. Locks in the
+        full set of fields the LLM relies on for ``insight:<id>``
+        citations and cross-references in answers.
+        """
+        insights = [
+            {
+                "id": "weekend_aov_spike",
+                "title": "Sunday AOV is nearly 3x weekday levels",
+                "summary": "Average order value on Sundays ($29.19) is significantly higher.",
+                "confidence": 0.95,
+                "evidence_queries": ["aov_by_day_of_week", "aov_daily_trend"],
+            },
+            {
+                # An insight with NO confidence and NO summary — must
+                # still render its title without crashing or emitting a
+                # stray confidence badge or an empty summary line.
+                "id": "qualitative_obs",
+                "title": "qualitative observation",
+                "evidence_queries": [],
+            },
+        ]
+        queries = [
+            {
+                "slug": "aov_by_day_of_week",
+                "brief": {"name": "aov_by_day_of_week", "uses": {}},
+                "result": _basic_query_result("aov_by_day_of_week"),
+                "sql": "SELECT 1",
+            }
+        ]
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="ins_report",
+            queries=queries,
+            insights=insights,
+        )
+        block = node._render_artifact_context_block()
+        assert "### Confirmed Findings (`analysis/insights.json`)" in block
+        # First insight: id, title, confidence in 2-decimal form, summary, evidence list.
+        assert "1. **`weekend_aov_spike`** — Sunday AOV is nearly 3x weekday levels _(conf 0.95)_" in block
+        assert "Average order value on Sundays" in block
+        assert "evidence: `aov_by_day_of_week`, `aov_daily_trend`" in block
+        # Second insight: id + title only, no confidence badge or evidence line.
+        # Pin on the exact rendered form so a regression that adds
+        # ``_(conf None)_`` or an empty evidence list ", " trips.
+        assert "2. **`qualitative_obs`** — qualitative observation" in block
+        # Sanity: the second entry must NOT emit a stray confidence badge
+        # (`_(conf ...)_` is the precise rendered form for the badge).
+        qual_line = next(line for line in block.splitlines() if "`qualitative_obs`" in line)
+        assert "_(conf" not in qual_line, f"unexpected conf badge: {qual_line!r}"
+
+    def test_missing_insights_skips_section(self, real_agent_config):
+        """No insights.json ⇒ no "Confirmed Findings" heading. The
+        renderer must not emit an empty stub section that confuses the
+        LLM into thinking the report has no conclusions.
+        """
+        queries = [
+            {
+                "slug": "q",
+                "brief": {"name": "q", "uses": {}},
+                "result": _basic_query_result("q"),
+                "sql": "SELECT 1",
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="no_ins", queries=queries)
+        block = node._render_artifact_context_block()
+        assert "### Confirmed Findings" not in block
+
+    def test_missing_subject_refs_skips_section(self, real_agent_config):
+        """No subject_refs.json ⇒ no "Subject Library Scope" heading."""
+        queries = [
+            {
+                "slug": "q",
+                "brief": {"name": "q", "uses": {}},
+                "result": _basic_query_result("q"),
+                "sql": "SELECT 1",
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="no_subj", queries=queries)
+        block = node._render_artifact_context_block()
+        assert "### Subject Library Scope" not in block
+
+    def test_no_queries_skips_catalog(self, real_agent_config):
+        """Artifact with no queries/ files ⇒ no catalog section. Avoids
+        emitting an empty heading or a misleading "no data" stub when a
+        bare-bones report binds to ask_report (e.g. freshly published
+        before save_query calls were issued — should never happen, but
+        the renderer must not crash if it does).
+        """
+        node = _make_ask_report_node(real_agent_config)  # no queries seeded
+        block = node._render_artifact_context_block()
+        assert "### Query Catalog" not in block
+        # Other sections still render normally.
+        assert "## Bound Artifact" in block
+
+    # --- Dashboard branching --------------------------------------------
+
+    def test_dashboard_catalog_uses_sample_params_not_rows(self, real_agent_config):
+        """Dashboard catalog renders ``sample_params`` from the .params
+        sidecar and labels the size as ``template`` — NOT rows. Locks
+        in the kind-branch in ``_render_query_catalog_entry`` so a
+        regression that always emits report shape on dashboards
+        (silently dropping params from the prompt) is visible.
+        """
+        queries = [
+            {
+                "slug": "dash_q",
+                "brief": {"name": "dash_q", "uses": {}},
+                "params": {
+                    "columns": [{"name": "v", "type": "number"}],
+                    "sample_params": {"start_date": "2026-01-01", "store_id": 42},
+                    "sample_row_count": 7,
+                },
+                "sql": "SELECT v FROM t WHERE store_id = {{ store_id }}",
+            }
+        ]
+        node = _make_dashboard_with_queries(real_agent_config, slug="dash_inline", queries=queries)
+        block = node._render_artifact_context_block()
+        assert "#### `dash_q` — template · sample 7 rows" in block
+        assert "**sample_params**:" in block
+        assert "start_date" in block and "store_id" in block
+        # Dashboard SQL appears under the .sql.j2 suffix.
+        assert "store_id = {{ store_id }}" in block
+        # Report-shape ("rows" inline) MUST NOT appear.
+        assert "**rows** (" not in block
+
+    # --- Disk ↔ blob parity ---------------------------------------------
+
+    def test_blob_and_disk_modes_render_identically(self, real_agent_config):
+        """Same artifact seeded once and read once via the disk path and
+        once via the blob path renders the same content block (modulo
+        the source-line: in-memory snapshot vs Root path). This is the
+        cross-component contract between the disk-backed
+        FilesystemFuncTool flow (CLI) and the MemoryFilesystemFuncTool flow (SaaS) —
+        if rendering drifts between the two, the same artifact would
+        answer differently depending on deployment.
+        """
+        slug = "parity"
+        queries = [
+            {
+                "slug": "parity_q",
+                "brief": {"name": "parity_q", "hypothesis": "h", "uses": {}},
+                "result": _basic_query_result("parity_q", rows=[{"v": 1}, {"v": 2}]),
+                "sql": "SELECT v FROM t",
+            }
+        ]
+
+        # Disk path via dashboard kind (BLOB_REQUIRED=False).
+        node_disk = _make_dashboard_with_queries(real_agent_config, slug=f"{slug}_d", queries=queries)
+        block_disk = node_disk._render_artifact_context_block()
+
+        # Blob path via report kind (BLOB_REQUIRED=True). Note: this is
+        # a different kind, so the test compares structural similarity
+        # rather than byte-identical rendering. We pin the load-bearing
+        # cross-mode behavior: the per-query data shows up the same way
+        # regardless of where the files came from.
+        node_blob = _make_report_with_queries(
+            real_agent_config,
+            slug=f"{slug}_r",
+            queries=queries,
+        )
+        block_blob = node_blob._render_artifact_context_block()
+
+        # Header per-mode differs (Root vs in-memory snapshot); verify
+        # the kind-agnostic per-query rendering matches structure.
+        assert "#### `parity_q`" in block_blob
+        # Dashboard renders sample_params if params present; since this
+        # fixture only seeded a report-shape result, the dashboard side
+        # has no params, so its entry header is "no data file".
+        assert "#### `parity_q` — no data file" in block_disk
+        # SQL appears in BOTH renderings.
+        assert "SELECT v FROM t" in block_disk
+        assert "SELECT v FROM t" in block_blob
+
+    # --- Rule 1 contract -----------------------------------------------
+
+    def test_rule_one_forbids_defensive_reads(self, real_agent_config):
+        """Behavioral rule 1 must explicitly forbid pre-fetching files
+        already inlined. This is the runtime behavior change the
+        rewrite was driven by; without an explicit prohibition the LLM
+        reverts to defensive ``glob`` + ``read_file`` even when the
+        prompt carries everything.
+        """
+        queries = [
+            {
+                "slug": "q",
+                "brief": {"name": "q", "uses": {}},
+                "result": _basic_query_result("q"),
+                "sql": "SELECT 1",
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="rule1", queries=queries)
+        block = node._render_artifact_context_block()
+        # Find rule 1 specifically (it starts with a numbered "1. ").
+        # We pin on both the imperative wording and the explicit "DO
+        # NOT" so a future copy-edit that softens the rule trips.
+        assert "1. **Answer from the inlined context first**" in block
+        assert "Do NOT issue `glob` or `read_file`" in block


### PR DESCRIPTION
## Why

Follow-ups in `ask_report` / `ask_dashboard` were paying 10+ serial tool round-trips before producing any meaningful output, all loading content the prompt could carry directly. A real trace against a small AOV report:

| Step | Action | Count |
|---|---|---|
| 1 | `Glob **/*` + `Read` insights / 4 result JSONs / 4 brief JSONs | 10 |
| 2 | `describe_table` (raw_orders, raw_stores) — manifest already has `key_tables` but not columns | 2 |
| 3 | `read_query` × 3, first result is off-by-100× because the SQL `/100.0` cents convention lives in one brief's caveats the model hadn't read yet | 3 |

The `_render_artifact_context_block` already inlined manifest + intent.md but explicitly **did not** inline insights / brief sidecars / SQL / small result snapshots — leaving the LLM to defensively `glob` and `read_file` every turn. The total artifact is ~50KB on disk, ~5K tokens worth of content, well within budget.

## Solution

Refactor `BaseArtifactAskAgenticNode._render_artifact_context_block` into per-section helpers and inline the full content of:

- `analysis/insights.json` (report only) — id, title, confidence, summary, evidence_queries
- `analysis/subject_refs.json` — aggregated by asset with a **reverse index** (which query slugs reference each metric/reference_sql/ext_knowledge), so "which queries use metric X" is answerable without any read
- **Query catalog** — for every `queries/<slug>`, one entry with brief.hypothesis / subjects (compact tags) / brief.caveats / columns / sample-or-full-rows / SQL body

Behavioral rule 1 is reworded from "Ground in existing analysis first" (permissive) to "**Answer from the inlined context first**" + explicit "Do NOT issue `glob` or `read_file` to pre-fetch anything already inlined above". Layout block annotates each tree entry with "inlined above" / "DO NOT read" / "read on demand only when the catalog flags ...".

Three thresholds gate inlining so a fat report doesn't blow the prompt:

| Constant | Default | What it guards |
|---|---|---|
| `INLINE_ROW_LIMIT` | 20 | Row-count cap per result |
| `INLINE_ROW_BYTES_LIMIT` | 4KB | Byte cap per result (catches 5 rows × 2KB-text-column case the count alone would let through) |
| `INLINE_SQL_LINE_LIMIT` | 40 | SQL truncation with `-- ... (N more lines; read queries/<slug>.sql for full body)` marker |
| `INLINE_CATALOG_BYTES_CAP` | 64KB | Total-catalog soft cap; later entries degrade (drop caveats → sample instead of full rows → tighter SQL cap) while keeping slug + size + columns so the LLM still has an index |

Either of the row OR byte thresholds being exceeded triggers degraded sampling (first 2 rows + read_file pointer). The same renderer serves dashboards via `ARTIFACT_KIND` branching: sample_params replace rows, `.sql.j2` replaces `.sql`, the insights section is skipped.

### Expected ask_* speedup on the AOV trace

| Stage | Before | After |
|---|---|---|
| `Glob` + `Read` upfront | 10 | 0 (everything inlined) |
| `describe_table` | 2 | 2 _(this PR doesn't touch the key_tables schema bake — separate follow-up)_ |
| `read_query` wrong-unit retry | 1 | 0 _(every SQL inline shows `/100.0`)_ |
| **Total round-trips before answer** | **~13–15** | **~2–3** |

## Test Cases

`tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py` (46 tests, diff-cover 89% on new lines):

**Existing tests updated** to match new copy:

- `test_report_block_includes_insights_in_tree` — pins on new rule 1 wording (\"Answer from the inlined context first\" + \"Do NOT issue \`glob\` or \`read_file\`\")
- `test_report_block_excludes_interpretation_and_suggested` — `suggested_questions.json` may appear in the layout tree but only on a \"DO NOT read\" line; the test pins this explicitly so a regression that inlines question content still fails

**New `TestArtifactContextBlockInlining` class** (12 tests):

- `test_small_report_inlines_all_query_rows` — 3-row result renders as full \`**rows**\` block
- `test_row_count_above_limit_degrades_to_sample` — 30 rows ⇒ sample of 2 + read_file pointer
- `test_byte_size_above_limit_degrades_to_sample` — 5 rows × 2KB blob each ⇒ sample (the fat-text-column gate)
- `test_long_sql_is_truncated_with_marker` — 60-line SQL ⇒ first 40 lines + marker naming the file
- `test_catalog_cap_degrades_later_entries` — monkeypatched cap = 400B; later entries lose caveats while header info survives
- `test_subject_scope_reverse_index_lists_referencing_queries` — reverse index lists queries alphabetically; orphan queries absent
- `test_insights_section_renders_id_title_confidence_evidence` — id/title/conf-badge/summary/evidence rendering; insights without confidence emit no stray badge
- `test_missing_insights_skips_section`, `test_missing_subject_refs_skips_section`, `test_no_queries_skips_catalog` — graceful degradation
- `test_dashboard_catalog_uses_sample_params_not_rows` — kind branching
- `test_blob_and_disk_modes_render_identically` — same artifact via in-memory blob vs disk renders the same per-query content
- `test_rule_one_forbids_defensive_reads` — pin the explicit \"Do NOT\" wording

Audit (`ci/audit_tests.py --paths`): **P0=0, P1=0**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized artifact context handling to reduce redundant operations during follow-up queries, improving performance.
  * Enhanced system prompt generation with more comprehensive pre-loaded artifact information.

* **Tests**
  * Expanded test coverage for artifact context rendering and inline content behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->