### PR TITLE
[BugFix] Recognize bootstrap response actions

### DIFF
--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -35,6 +35,7 @@ def _action_status_value(action: Any) -> Optional[str]:
 
 
 DEFAULT_METRICS_BATCH_SIZE = 1
+METRICS_RESPONSE_ACTION_TYPE = f"{GenMetricsAgenticNode.NODE_NAME}_response"
 
 
 async def _generate_metrics_batch(
@@ -98,7 +99,11 @@ async def _generate_metrics_batch(
                 terminal_error = action.messages or "Metrics extraction failed"
                 logger.error(terminal_error)
                 continue
-            if action.status == ActionStatus.SUCCESS and action_type == "metrics_response" and action.output:
+            if action.status == ActionStatus.FAILED and action_type == METRICS_RESPONSE_ACTION_TYPE:
+                terminal_error = action.messages or "Metrics extraction failed"
+                logger.error(terminal_error)
+                continue
+            if action.status == ActionStatus.SUCCESS and action_type == METRICS_RESPONSE_ACTION_TYPE and action.output:
                 final_result = action.output
                 logger.debug(f"Metrics generation action (batch {batch_idx}): {action.messages}")
         if terminal_error:

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -19,6 +19,8 @@ from datus.utils.terminal_utils import suppress_keyboard_input
 
 logger = get_logger(__name__)
 
+SEMANTIC_MODEL_RESPONSE_ACTION_TYPE = f"{GenSemanticModelAgenticNode.NODE_NAME}_response"
+
 
 async def init_success_story_semantic_model_async(
     agent_config: AgentConfig,
@@ -150,7 +152,11 @@ async def init_success_story_semantic_model_async(
                 )
 
             action_type = getattr(action, "action_type", "")
-            if action.status == ActionStatus.SUCCESS and action_type == "semantic_response" and action.output:
+            if (
+                action.status == ActionStatus.SUCCESS
+                and action_type == SEMANTIC_MODEL_RESPONSE_ACTION_TYPE
+                and action.output
+            ):
                 if isinstance(action.output, dict):
                     # Check for semantic_models field (from SemanticNodeResult)
                     if "semantic_models" in action.output:
@@ -159,7 +165,7 @@ async def init_success_story_semantic_model_async(
                             generated_files.extend(models)
                         elif models:  # Single file as string
                             generated_files.append(models)
-            elif action.status == ActionStatus.FAILED and action_type == "error":
+            elif action.status == ActionStatus.FAILED and action_type in {"error", SEMANTIC_MODEL_RESPONSE_ACTION_TYPE}:
                 terminal_error = action.messages or "Semantic model generation failed"
                 logger.error(terminal_error)
                 continue

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -182,7 +182,7 @@ class TestInitSuccessStoryMetricsAsync:
             captured_input["input"] = mock_node.input
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"response": "done"}
             action.messages = "ok"
             yield action
@@ -284,7 +284,7 @@ class TestInitSuccessStoryMetricsAsync:
 
             final_action = MagicMock()
             final_action.status = ActionStatus.SUCCESS
-            final_action.action_type = "metrics_response"
+            final_action.action_type = "gen_metrics_response"
             final_action.output = {"response": "done"}
             final_action.messages = "ok"
             yield final_action
@@ -427,7 +427,7 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
         async def fake_execute_stream(_action_manager):
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"response": "done"}
             action.messages = "ok"
             yield action
@@ -481,7 +481,7 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
         async def fake_execute_stream(_action_manager):
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"response": "done"}
             action.messages = "ok"
             yield action
@@ -549,7 +549,7 @@ class TestGenerateMetricsBatch:
         async def fake_stream(_ahm):
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"metrics": ["revenue"]}
             action.messages = "ok"
             yield action
@@ -695,7 +695,7 @@ class TestBatchSplitting:
                 else:
                     action = MagicMock()
                     action.status = ActionStatus.SUCCESS
-                    action.action_type = "metrics_response"
+                    action.action_type = "gen_metrics_response"
                     action.output = {"metrics": [f"m{self._batch_idx}"]}
                     action.messages = "ok"
                     yield action

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -622,6 +622,48 @@ class TestGenerateMetricsBatch:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_failed_final_response_returns_failure(self):
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.schemas.batch_events import BatchEventHelper
+
+        mock_node = MagicMock()
+
+        async def fake_stream(_ahm):
+            action = MagicMock()
+            action.status = ActionStatus.FAILED
+            action.action_type = "gen_metrics_response"
+            action.output = {"error": "publish failed"}
+            action.messages = "publish failed"
+            yield action
+
+        mock_node.execute_stream = fake_stream
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
+        ):
+            ok, err, result = await _generate_metrics_batch(
+                ["Query 1:\nQuestion: q?\nSQL:\nSELECT 1"],
+                0,
+                mock_config,
+                None,
+                None,
+                BatchEventHelper("test", None),
+                None,
+            )
+
+        assert ok is False
+        assert "publish failed" in err
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_exception_returns_failure(self):
         from unittest.mock import patch
 

--- a/tests/unit_tests/storage/semantic_model/test_auto_create.py
+++ b/tests/unit_tests/storage/semantic_model/test_auto_create.py
@@ -339,7 +339,9 @@ class TestCreateSemanticModelForTable:
                     action_type="tool_call",
                     messages="Tool call: validate_semantic('{}...')",
                 )
-                yield SimpleNamespace(status=ActionStatus.SUCCESS, action_type="semantic_response", messages="ok")
+                yield SimpleNamespace(
+                    status=ActionStatus.SUCCESS, action_type="gen_semantic_model_response", messages="ok"
+                )
 
         with (
             patch(

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -360,7 +360,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["model1.yaml", "model2.yaml"]},
                     messages="Generated models",
                 )
@@ -402,7 +402,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["model.yaml"]},
                     messages="Generated model",
                 )
@@ -450,7 +450,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
                 # single string instead of list
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": "single_model.yaml"},
                     messages="Generated",
                 )
@@ -497,7 +497,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
                 )
                 yield SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["model.yaml"]},
                     messages="Generated",
                 )
@@ -578,7 +578,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
                 # Yields an action with SUCCESS but no semantic_models key
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"other_key": "value"},
                     messages="Nothing useful",
                 )
@@ -620,7 +620,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={},
                     messages="",
                 )
@@ -738,7 +738,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output=None,
                     messages="",
                 )
@@ -793,7 +793,7 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
             async def execute_stream(self, action_history_manager):
                 yield SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["m.yaml"]},
                     messages="ok",
                 )
@@ -840,7 +840,7 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
             async def execute_stream(self, action_history_manager):
                 yield SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["m.yaml"]},
                     messages="ok",
                 )

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -553,6 +553,46 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
         assert "did not publish" in error
 
     @pytest.mark.asyncio
+    async def test_failed_final_response_action_returns_failure(self, tmp_path, monkeypatch):
+        """A failed final response action still fails the batch."""
+        from types import SimpleNamespace
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT 1,Q?\n")
+
+        mock_config = MagicMock()
+        mock_db_config = MagicMock()
+        mock_db_config.catalog = ""
+        mock_db_config.database = "db"
+        mock_db_config.schema = ""
+        mock_config.current_db_config.return_value = mock_db_config
+
+        class MockSemanticNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+
+            async def execute_stream(self, action_history_manager):
+                yield SimpleNamespace(
+                    status=ActionStatus.FAILED,
+                    action_type="gen_semantic_model_response",
+                    output={"error": "failed final response"},
+                    messages="failed final response",
+                )
+
+        monkeypatch.setattr(
+            "datus.storage.semantic_model.semantic_model_init.GenSemanticModelAgenticNode",
+            MockSemanticNode,
+        )
+
+        success, error = await init_success_story_semantic_model_async(mock_config, str(csv_path))
+
+        assert success is False
+        assert "failed final response" in error
+
+    @pytest.mark.asyncio
     async def test_empty_result_path_returns_false(self, tmp_path, monkeypatch):
         """Empty result path: no generated files → returns (False, error)."""
         from types import SimpleNamespace


### PR DESCRIPTION
## Summary
- Match semantic model bootstrap against the standard gen_semantic_model_response action.
- Match metrics bootstrap against the standard gen_metrics_response action, including failed final responses.
- Update storage bootstrap tests to mock the framework-produced response action names.

## Validation
- uv run pytest tests/unit_tests/storage/semantic_model/test_semantic_model_init.py tests/unit_tests/storage/metric/test_metric_init.py tests/unit_tests/storage/semantic_model/test_auto_create.py
- uv run ruff check datus/storage/semantic_model/semantic_model_init.py datus/storage/metric/metric_init.py tests/unit_tests/storage/semantic_model/test_semantic_model_init.py tests/unit_tests/storage/semantic_model/test_auto_create.py tests/unit_tests/storage/metric/test_metric_init.py
- PYTHONPATH=/Users/kangxue/work/datus/agent-1 uv --project /Users/kangxue/work/datus/agent-1 run python scripts/generate_context.py --benchmark baisheng --datasource starrocks --context-type semantic_model --force --task-ids 1 11 21 --datus-home /tmp/datus-benchmark-semantic-local-fixed/.datus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized action-type handling for metrics and semantic model generation to improve consistency.

* **Tests**
  * Updated and expanded tests to reflect the refined action-type behavior and to cover new failure/success scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->