### PR TITLE
[Enhancement] Bake key_tables column schema and inline into ask_* prompt

### DIFF
--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -646,6 +646,19 @@ def bake_key_tables_schema(
     tables were unavailable.
     """
     if db_func_tool is None or not key_tables:
+        # Present-iff-bakeable semantics: if a prior finalize wrote a
+        # schema sidecar but the current run has nothing to bake
+        # (key_tables emptied after an edit-mode rerun, or this run has
+        # no db tool), the stale file would lie to the follow-up
+        # consultant. Proactively unlink so the "absent" signal stays
+        # accurate. Mirrors what ``write_subject_refs`` does for
+        # subject_refs.json.
+        stale = analysis_dir / "key_tables_schema.json"
+        if stale.is_file():
+            try:
+                stale.unlink()
+            except OSError as exc:
+                logger.warning("Failed to remove stale %s: %s", stale, exc)
         return None
 
     # Lazy import keeps the schema module out of the dependency graph

--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -611,6 +611,128 @@ def update_manifest_key_tables(manifest_path: Path, key_tables: List[str]) -> Op
         return f"failed to write key_tables: {exc}"
 
 
+def bake_key_tables_schema(
+    *,
+    db_func_tool: Optional[Any],
+    key_tables: List[str],
+    analysis_dir: Path,
+) -> Optional[str]:
+    """Snapshot ``describe_table`` output for every ``manifest.key_tables``
+    entry into ``analysis/key_tables_schema.json``.
+
+    The follow-up ``ask_*`` consultant inlines this file into the system
+    prompt so SQL planning on the listed tables skips
+    ``describe_table`` round-trips. Companion file to
+    ``manifest.key_tables`` (names only) — that field stays a small
+    list of strings for list-page consumers; the schema detail lives
+    in this sidecar instead.
+
+    Best-effort:
+
+    * ``db_func_tool is None`` → silently skip (CLI tests, dry runs).
+    * Empty ``key_tables`` → skip (no schema to bake).
+    * ``describe_table`` per-table failure → record the error string
+      on the table entry rather than aborting the whole bake — the
+      LLM gets a partial schema plus a "schema unavailable" hint per
+      missing table, and can re-fetch via ``describe_table`` for the
+      blanks if the user asks.
+    * Write OSError → returned as a warning string for the caller to
+      surface; the artifact's primary contract (queries/, render/,
+      manifest.json) is already on disk by the time this runs.
+
+    Returns ``None`` on success / skip; a warning string on write
+    failure. Per-table errors are NOT propagated as warnings — they
+    travel with the sidecar so the prompt can be specific about which
+    tables were unavailable.
+    """
+    if db_func_tool is None or not key_tables:
+        return None
+
+    # Lazy import keeps the schema module out of the dependency graph
+    # for callers that only run the LLM-authored side of finalize.
+    from datus.schemas.key_tables_schema import KeyTableColumn, KeyTableSchema, KeyTablesSchemaFile
+
+    tables_out: List[KeyTableSchema] = []
+    for table_name in key_tables:
+        try:
+            result = db_func_tool.describe_table(table_name=table_name)
+        except Exception as exc:
+            # Broad except: connector implementations raise their own
+            # exception types and we don't want to enumerate them. The
+            # bake is best-effort; a single misbehaving connector
+            # shouldn't strand the whole sidecar.
+            logger.warning("describe_table raised for %s during key_tables bake: %s", table_name, exc)
+            tables_out.append(KeyTableSchema(name=table_name, error=f"describe_table raised: {exc}"))
+            continue
+
+        if result is None or getattr(result, "success", 1) == 0:
+            err = (
+                (getattr(result, "error", None) or "describe_table returned no usable result")
+                if result
+                else "describe_table returned None"
+            )
+            tables_out.append(KeyTableSchema(name=table_name, error=str(err)))
+            continue
+
+        payload = getattr(result, "result", None)
+        if not isinstance(payload, dict):
+            tables_out.append(
+                KeyTableSchema(
+                    name=table_name,
+                    error=f"describe_table returned unexpected payload type: {type(payload).__name__}",
+                )
+            )
+            continue
+
+        raw_columns = payload.get("columns") or []
+        if not isinstance(raw_columns, list):
+            tables_out.append(
+                KeyTableSchema(
+                    name=table_name,
+                    error=f"describe_table returned non-list columns: {type(raw_columns).__name__}",
+                )
+            )
+            continue
+
+        cols: List[KeyTableColumn] = []
+        for raw_col in raw_columns:
+            if not isinstance(raw_col, dict):
+                continue
+            cname = raw_col.get("name")
+            if not isinstance(cname, str) or not cname:
+                continue
+            # ``is_dimension`` may legitimately be missing (no semantic
+            # model). Distinguish "absent" from "False" via None.
+            is_dimension = raw_col.get("is_dimension")
+            if not isinstance(is_dimension, bool):
+                is_dimension = None
+            cols.append(
+                KeyTableColumn(
+                    name=cname,
+                    type=str(raw_col.get("type") or ""),
+                    comment=str(raw_col.get("comment") or ""),
+                    is_dimension=is_dimension,
+                )
+            )
+
+        table_meta = payload.get("table") if isinstance(payload.get("table"), dict) else {}
+        description = str(table_meta.get("description") or "") if table_meta else ""
+
+        tables_out.append(KeyTableSchema(name=table_name, description=description, columns=cols))
+
+    schema_file = KeyTablesSchemaFile(tables=tables_out)
+    out_path = analysis_dir / "key_tables_schema.json"
+    try:
+        _atomic_write_text(
+            out_path,
+            json.dumps(schema_file.model_dump(), ensure_ascii=False, indent=2) + "\n",
+        )
+    except OSError as exc:
+        logger.warning("Failed to write %s: %s", out_path, exc)
+        return f"failed to write key_tables_schema.json: {exc}"
+    return None
+
+
 def write_subject_refs(analysis_dir: Path, refs: SubjectRefs) -> Optional[str]:
     """Write ``subject_refs.json`` iff any bucket is non-empty.
 
@@ -955,6 +1077,7 @@ def run_finalize_analysis(
     queries_dir: Path,
     analysis_dir: Path,
     actions: Iterable[ActionHistory],
+    db_func_tool: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """Top-level orchestrator. Returns a result dict::
 
@@ -1062,6 +1185,20 @@ def run_finalize_analysis(
     kt_err = update_manifest_key_tables(artifact_dir / "manifest.json", key_tables)
     if kt_err:
         warnings.append(kt_err)
+
+    # Snapshot column metadata for every key_table into
+    # ``analysis/key_tables_schema.json``. ask_* inlines this so SQL
+    # planning skips ``describe_table`` round-trips on tables the
+    # artifact already touched. Best-effort: per-table errors travel
+    # with the sidecar (so the prompt can be specific about gaps);
+    # only a write OSError surfaces as a warning here.
+    schema_err = bake_key_tables_schema(
+        db_func_tool=db_func_tool,
+        key_tables=key_tables,
+        analysis_dir=analysis_dir,
+    )
+    if schema_err:
+        warnings.append(schema_err)
 
     subject_refs_count = {
         "metrics": len(refs.metrics),

--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -658,7 +658,16 @@ def bake_key_tables_schema(
             try:
                 stale.unlink()
             except OSError as exc:
+                # Surface to the caller's ``warnings`` list — silently
+                # dropping the failure would let the next ask_* session
+                # serve a snapshot the renderer believes is fresh.
+                # ``run_finalize_analysis`` already appends the
+                # write-side warnings from this function to the same
+                # list; the unlink-side warning uses the same string
+                # shape so consumers parsing warnings don't need a new
+                # branch.
                 logger.warning("Failed to remove stale %s: %s", stale, exc)
+                return f"failed to remove stale key_tables_schema.json at {stale}: {exc}"
         return None
 
     # Lazy import keeps the schema module out of the dependency graph

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -805,8 +805,15 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if not isinstance(refs, dict):
             return ""
 
-        # Reverse index: (kind, name) -> sorted list of query slugs.
-        usage_by_asset: Dict[Tuple[str, str], List[str]] = {}
+        # Reverse index: (kind, tuple(path), name) -> sorted list of
+        # referencing query slugs. The path is part of the key because
+        # ``get_metrics(path, name)`` / ``get_reference_sql(path, name)``
+        # both take (path, name) and two different assets can legitimately
+        # share a leaf ``name`` under different folders (e.g.
+        # ``Commerce/Orders/aov`` vs ``Finance/Reporting/aov``). Keying
+        # on name alone would conflate them and the "used by" list would
+        # falsely show queries from the wrong asset.
+        usage_by_asset: Dict[Tuple[str, Tuple[str, ...], str], List[str]] = {}
         for slug in self._query_slugs():
             brief_raw = self._read_artifact_file(f"queries/{slug}.brief.json")
             if not brief_raw:
@@ -820,10 +827,20 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                 continue
             for kind_key in ("metrics", "reference_sql", "ext_knowledge"):
                 for entry in uses.get(kind_key) or []:
-                    if isinstance(entry, dict):
-                        name = entry.get("name")
-                        if isinstance(name, str) and name:
-                            usage_by_asset.setdefault((kind_key, name), []).append(slug)
+                    if not isinstance(entry, dict):
+                        continue
+                    name = entry.get("name")
+                    raw_path = entry.get("path")
+                    if not isinstance(name, str) or not name:
+                        continue
+                    if not isinstance(raw_path, list) or not all(isinstance(p, str) for p in raw_path):
+                        # Drop malformed brief entries entirely rather
+                        # than fall back to a path-less key — letting
+                        # one bad entry coalesce with valid ones would
+                        # silently re-introduce the conflation we're
+                        # fixing.
+                        continue
+                    usage_by_asset.setdefault((kind_key, tuple(raw_path), name), []).append(slug)
 
         body_lines: List[str] = []
         for kind_key, label in (
@@ -840,12 +857,14 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                 name = entry.get("name") or ""
                 if not isinstance(name, str) or not name:
                     continue
-                path = entry.get("path") or []
-                if isinstance(path, list) and all(isinstance(p, str) for p in path):
-                    path_str = " > ".join(path) if path else "(no path)"
+                raw_path = entry.get("path") or []
+                if isinstance(raw_path, list) and all(isinstance(p, str) for p in raw_path):
+                    path_tuple = tuple(raw_path)
+                    path_str = " > ".join(raw_path) if raw_path else "(no path)"
                 else:
+                    path_tuple = ()
                     path_str = "(no path)"
-                used_by = sorted(set(usage_by_asset.get((kind_key, name), [])))
+                used_by = sorted(set(usage_by_asset.get((kind_key, path_tuple, name), [])))
                 line = f"- **{label}** `{path_str} > {name}`"
                 if used_by:
                     line += f"\n  · used by: {', '.join(used_by)}"
@@ -913,13 +932,19 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         )
 
         lines: List[str] = ["### Table Schemas (`analysis/key_tables_schema.json`)", "", intro, ""]
-        running_bytes = sum(len(line) + 1 for line in lines)
+        # Measure in UTF-8 bytes (not code points) since the cap is
+        # phrased in bytes; a Chinese-heavy description (each CJK
+        # codepoint ≈ 3 UTF-8 bytes) would otherwise silently fit
+        # ~3× more content than INLINE_SCHEMA_BYTES_CAP intends. The
+        # ``+1`` per line accounts for the joining newline appended at
+        # render time by ``"\n".join(...)``.
+        running_bytes = sum(len(line.encode("utf-8")) + 1 for line in lines)
         cap_reached = False
         for tbl in tables:
             if not isinstance(tbl, dict):
                 continue
             entry_lines = self._render_table_schema_entry(tbl)
-            entry_bytes = sum(len(line) + 1 for line in entry_lines)
+            entry_bytes = sum(len(line.encode("utf-8")) + 1 for line in entry_lines)
             if running_bytes + entry_bytes > INLINE_SCHEMA_BYTES_CAP:
                 cap_reached = True
                 break
@@ -1065,16 +1090,22 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         header: List[str] = ["### Query Catalog", "", intro, ""]
 
         body: List[str] = []
-        running_bytes = 0
+        # Cap is phrased in bytes (UTF-8) and the cap covers the whole
+        # section, not just the body — count the header upfront so a
+        # large intro doesn't silently leak past the cap, and use
+        # ``.encode("utf-8")`` length on every line so non-ASCII content
+        # (Chinese caveats, emoji in SQL comments, etc.) is sized
+        # honestly.
+        running_bytes = sum(len(line.encode("utf-8")) + 1 for line in header)
         degraded = False
         for slug in slugs:
             brief, data, sql = self._load_query_bundle(slug)
             entry_lines = self._render_query_catalog_entry(slug, brief, data, sql, degraded=degraded)
-            entry_bytes = sum(len(line) + 1 for line in entry_lines)
+            entry_bytes = sum(len(line.encode("utf-8")) + 1 for line in entry_lines)
             if not degraded and running_bytes + entry_bytes > INLINE_CATALOG_BYTES_CAP:
                 degraded = True
                 entry_lines = self._render_query_catalog_entry(slug, brief, data, sql, degraded=True)
-                entry_bytes = sum(len(line) + 1 for line in entry_lines)
+                entry_bytes = sum(len(line.encode("utf-8")) + 1 for line in entry_lines)
             body.extend(entry_lines)
             body.append("")
             running_bytes += entry_bytes
@@ -1199,6 +1230,28 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
 
         return lines
 
+    def _artifact_has_insights(self) -> bool:
+        """Same emptiness check ``_render_insights_section`` uses.
+
+        The layout-tree and ``loaded_list`` are claims to the LLM that
+        a file is already in the prompt. If we unconditionally said so
+        for every report — even those whose finalize LLM failed and
+        never wrote ``insights.json`` — the LLM would believe the file
+        is loaded and skip a legitimate ``read_file``. Mirror the
+        renderer's exact gate so the tree only advertises insights
+        when the section actually rendered them.
+        """
+        if self.ARTIFACT_KIND != "report":
+            return False
+        raw = self._read_artifact_file("analysis/insights.json")
+        if not raw:
+            return False
+        try:
+            insights = json.loads(raw)
+        except json.JSONDecodeError:
+            return False
+        return isinstance(insights, list) and bool(insights)
+
     def _render_filesystem_layout_section(self) -> str:
         """Tell the LLM what's already inlined vs what still needs read_file.
 
@@ -1208,9 +1261,10 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         files immediately sees that defensive reads are not useful.
         """
         layout_root_label = self._artifact_root.name if self._artifact_root is not None else self.ARTIFACT_ROOT_DIR_NAME
+        has_insights = self._artifact_has_insights()
         loaded_list = (
             "manifest.json, analysis/intent.md, "
-            + ("analysis/insights.json, " if self.ARTIFACT_KIND == "report" else "")
+            + ("analysis/insights.json, " if has_insights else "")
             + "analysis/subject_refs.json (when present), "
             "analysis/key_tables_schema.json (when present), and every "
             "`queries/*.brief.json` plus the inlined slice of "
@@ -1234,7 +1288,11 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "├── analysis/",
             "│   ├── intent.md                # inlined above",
         ]
-        if self.ARTIFACT_KIND == "report":
+        # Only advertise insights when there's actually a populated
+        # insights.json on disk / in the blob — see
+        # :meth:`_artifact_has_insights`. Dashboards skip the line
+        # unconditionally (no insights file by design).
+        if has_insights:
             lines.append("│   ├── insights.json            # inlined above")
         lines.extend(
             [
@@ -1257,12 +1315,21 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         sidecar at turn start out of habit, paying many serial tool
         round-trips for content the prompt already carries.
         """
+        # Same presence check the layout-tree uses (see
+        # ``_artifact_has_insights``). Drives both rule 1's preamble
+        # (which lists what was actually inlined) and rule 6's
+        # report-only branch — without this, a report whose finalize
+        # produced no insights would still have rule 6 claim
+        # "insights.json is the authoritative findings record" and
+        # rule 1 claim "confirmed insights" are inlined, both of
+        # which would mislead the LLM.
+        has_insights = self._artifact_has_insights()
         lines: List[str] = ["### Behavioral Rules (load-bearing)", ""]
         lines.append(
             "1. **Answer from the inlined context first**. The header above "
             "already contains the manifest, the original intent, the "
             "subject library scope, the table schemas snapshot, "
-            + ("confirmed insights, " if self.ARTIFACT_KIND == "report" else "")
+            + ("confirmed insights, " if has_insights else "")
             + "and a query catalog with hypothesis / caveats / columns / "
             "sample rows / SQL for every saved query. **Do NOT issue "
             "`glob` or `read_file` to pre-fetch anything already inlined "
@@ -1307,11 +1374,26 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                 "declaration to explain what user-controllable filters "
                 "exist."
             )
-        else:
+        elif has_insights:
             lines.append(
                 "6. **`insights.json` is the authoritative findings "
                 "record**. Already inlined above; each insight has "
                 "`evidence_queries[]` you can cross-reference."
+            )
+        else:
+            # Report whose finalize LLM crashed (or whose insights list
+            # was empty). Emit rule 6 in its insights-absent form so
+            # the numbering stays 1–7 across kinds AND the LLM knows
+            # not to claim non-existent findings as if it had read
+            # them. Without this branch the rule is silently dropped
+            # and the LLM sees rules 1..5,7 (jumping over 6) — a small
+            # but persistent prompt-quality regression.
+            lines.append(
+                "6. **No confirmed-findings record for this report**. "
+                "Finalize did not produce a populated `insights.json`. "
+                "Ground answers in the query catalog above and cite "
+                "individual queries by slug; do NOT claim insights "
+                "that aren't in the prompt."
             )
         lines.append(
             "7. **No artifact mutations**. Filesystem write/edit/delete "

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -571,9 +571,30 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # base class untouched.
         base_prompt = super()._get_system_prompt(conversation_summary, prompt_version)
         artifact_header = self._render_artifact_context_block()
-        if artifact_header:
-            return artifact_header + "\n\n" + base_prompt
-        return base_prompt
+        final_prompt = (artifact_header + "\n\n" + base_prompt) if artifact_header else base_prompt
+        # Observability hook: real-world prompt growth after the
+        # inline-rendering rework is hard to predict per artifact (varies
+        # with insight count, query catalog size, table schema width).
+        # Single grep-friendly line per turn so operators can spot
+        # outliers without dragging through trace logs. Key=value form
+        # makes ad-hoc parsing trivial.
+        header_bytes = len(artifact_header.encode("utf-8")) if artifact_header else 0
+        base_bytes = len(base_prompt.encode("utf-8"))
+        final_bytes = len(final_prompt.encode("utf-8"))
+        # ``count('\n') + 1`` matches what an LLM would see as "the
+        # number of lines"; cheaper than splitting and we don't need
+        # accuracy on trailing newlines.
+        logger.info(
+            "ask_artifact prompt assembled: node=%s kind=%s slug=%s lines=%d bytes=%d header_bytes=%d base_bytes=%d",
+            self._configured_subagent_name,
+            self.ARTIFACT_KIND,
+            self._artifact_slug,
+            final_prompt.count("\n") + 1,
+            final_bytes,
+            header_bytes,
+            base_bytes,
+        )
+        return final_prompt
 
     def _render_artifact_context_block(self) -> str:
         """Build the artifact-context preamble prepended to the chat prompt.

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -100,6 +100,20 @@ INLINE_SQL_LINE_LIMIT = 40
 # knows what data exists; a follow-up ``read_file`` can fetch detail.
 INLINE_CATALOG_BYTES_CAP = 64 * 1024
 
+# Per-table column cap for the Table Schemas section. A wide fact table
+# (200+ columns) inlined whole would dominate the prompt without payoff —
+# the LLM only references a handful per follow-up. We truncate to the
+# first N and tell the LLM to call ``describe_table()`` for the full list
+# when it needs more.
+INLINE_SCHEMA_COLS_PER_TABLE = 50
+
+# Soft cap on the Table Schemas section as a whole. Sized so a typical
+# report (2–5 tables × ~10–30 columns each) fits comfortably; a report
+# referencing 20+ tables hits the cap and the renderer drops trailing
+# tables with a "remaining omitted" marker so the LLM knows to fall back
+# to ``describe_table``.
+INLINE_SCHEMA_BYTES_CAP = 8 * 1024
+
 
 def _compact_row(row: Any) -> str:
     """Render a single result row as one deterministic line.
@@ -588,6 +602,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         for render in (
             self._render_intent_section,
             self._render_subject_scope_section,
+            self._render_table_schemas_section,
             self._render_insights_section,
             self._render_query_catalog_section,
         ):
@@ -831,6 +846,118 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         ]
         return "\n".join(header + body_lines)
 
+    def _render_table_schemas_section(self) -> str:
+        """Inline ``analysis/key_tables_schema.json`` — snapshot of
+        ``describe_table`` output for every ``manifest.key_tables`` entry.
+
+        The snapshot lets the LLM plan follow-up SQL on the listed
+        tables without paying ``describe_table`` round-trips. Critical
+        prompt design choice: the intro **explicitly carves out** the
+        cases where the LLM MUST still call ``describe_table`` — live
+        schema drift (user asking about "current" / "latest" state),
+        column names not in this list (typos / post-finalize
+        additions), and tables outside ``manifest.key_tables``. Without
+        the carve-out the LLM would treat the snapshot as authoritative
+        forever and answer stale-schema questions confidently.
+
+        Returns "" when the file is missing or empty so reports
+        without a baked schema (older artifacts, dry runs) skip the
+        section silently.
+        """
+        raw = self._read_artifact_file("analysis/key_tables_schema.json")
+        if not raw:
+            return ""
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("Table schemas render: key_tables_schema.json unreadable: %s", exc)
+            return ""
+        if not isinstance(data, dict):
+            return ""
+        tables = data.get("tables")
+        if not isinstance(tables, list) or not tables:
+            return ""
+
+        intro = (
+            "Columns of every table in `manifest.key_tables` at the time "
+            "the artifact was finalized. **This is a SNAPSHOT — call "
+            "`describe_table('<table>')` instead when the user explicitly "
+            "asks about the LATEST / CURRENT schema, when they reference "
+            "a column NOT in this list (could be a typo or a post-"
+            "finalize addition), or when they ask about tables NOT in "
+            "`manifest.key_tables`.** For everything else (writing "
+            "follow-up SQL on the listed tables, explaining a column, "
+            "planning a join between listed tables), use this snapshot "
+            "directly — no `describe_table` round-trip needed."
+        )
+
+        lines: List[str] = ["### Table Schemas (`analysis/key_tables_schema.json`)", "", intro, ""]
+        running_bytes = sum(len(line) + 1 for line in lines)
+        cap_reached = False
+        for tbl in tables:
+            if not isinstance(tbl, dict):
+                continue
+            entry_lines = self._render_table_schema_entry(tbl)
+            entry_bytes = sum(len(line) + 1 for line in entry_lines)
+            if running_bytes + entry_bytes > INLINE_SCHEMA_BYTES_CAP:
+                cap_reached = True
+                break
+            lines.extend(entry_lines)
+            lines.append("")
+            running_bytes += entry_bytes
+        if cap_reached:
+            lines.append(
+                "_(schema section cap reached — remaining tables omitted; "
+                "call `describe_table('<table>')` for any name in "
+                "`manifest.key_tables` not shown above.)_"
+            )
+        return "\n".join(lines).rstrip()
+
+    def _render_table_schema_entry(self, tbl: Dict[str, Any]) -> List[str]:
+        """Render one table block: header + optional description + columns.
+
+        Per-table ``error`` (populated when ``describe_table`` failed
+        at finalize) surfaces as a "schema unavailable" hint with the
+        exact remediation (call ``describe_table('<name>')``) so the
+        LLM has a clear next step rather than guessing.
+        """
+        name = tbl.get("name") or "?"
+        if not isinstance(name, str):
+            name = str(name)
+        description = tbl.get("description") or ""
+        columns = tbl.get("columns") or []
+        error = tbl.get("error")
+
+        lines: List[str] = [f"#### `{name}`"]
+        if description:
+            lines.append(f"_(description: {description})_")
+        if error:
+            lines.append(f"_(schema unavailable: {error}; call `describe_table('{name}')` to fetch live schema.)_")
+            return lines
+        if not isinstance(columns, list):
+            return lines
+
+        # Truncate wide tables: keep the first N columns + a marker
+        # pointing the LLM at ``describe_table`` for the rest.
+        truncated = len(columns) > INLINE_SCHEMA_COLS_PER_TABLE
+        cols_to_render = columns[:INLINE_SCHEMA_COLS_PER_TABLE] if truncated else columns
+        for c in cols_to_render:
+            if not isinstance(c, dict):
+                continue
+            cname = c.get("name")
+            if not isinstance(cname, str) or not cname:
+                continue
+            ctype = c.get("type") or "?"
+            comment = c.get("comment") or ""
+            line = f"- `{cname}`: {ctype}"
+            if comment:
+                line += f"  -- {comment}"
+            lines.append(line)
+        if truncated:
+            remaining = len(columns) - INLINE_SCHEMA_COLS_PER_TABLE
+            lines.append(f"- _(... {remaining} more columns; call `describe_table('{name}')` for the full list.)_")
+        return lines
+
     def _render_insights_section(self) -> str:
         """Inline ``analysis/insights.json`` (report-only).
 
@@ -1063,7 +1190,8 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         loaded_list = (
             "manifest.json, analysis/intent.md, "
             + ("analysis/insights.json, " if self.ARTIFACT_KIND == "report" else "")
-            + "analysis/subject_refs.json (when present), and every "
+            + "analysis/subject_refs.json (when present), "
+            "analysis/key_tables_schema.json (when present), and every "
             "`queries/*.brief.json` plus the inlined slice of "
             "`queries/*` data + SQL above"
         )
@@ -1090,6 +1218,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         lines.extend(
             [
                 "│   ├── subject_refs.json        # inlined above (if present)",
+                "│   ├── key_tables_schema.json   # inlined above (if present); snapshot only — describe_table() for live",
                 "│   └── suggested_questions.json # UI chips — DO NOT read",
                 "├── queries/                     # briefs always inlined; data + SQL inlined or sampled per catalog above",
                 "└── render/                     # presentation tier — DO NOT READ",
@@ -1111,16 +1240,19 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         lines.append(
             "1. **Answer from the inlined context first**. The header above "
             "already contains the manifest, the original intent, the "
-            "subject library scope, "
+            "subject library scope, the table schemas snapshot, "
             + ("confirmed insights, " if self.ARTIFACT_KIND == "report" else "")
             + "and a query catalog with hypothesis / caveats / columns / "
             "sample rows / SQL for every saved query. **Do NOT issue "
             "`glob` or `read_file` to pre-fetch anything already inlined "
-            "above.** Only re-read a file when the catalog explicitly "
-            "flagged its data as sampled or its SQL as truncated, OR "
-            "when the inlined summary genuinely doesn't address the "
-            "question — and when you do, briefly say which file and "
-            "why."
+            "above.** Re-read or re-fetch only when (a) the catalog "
+            "explicitly flagged a query's data as sampled or its SQL as "
+            "truncated, (b) the user asks about LIVE / CURRENT state "
+            "the snapshot can't answer — fresh schema after a DDL "
+            "change, live row counts, today's data (call "
+            "`describe_table` / `execute_sql` for those), or (c) the "
+            "inlined summary genuinely doesn't address the question. "
+            "When you do, briefly say which file or tool and why."
         )
         lines.append(
             "2. **Do NOT regenerate the artifact**. You are read-only. If "

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -476,6 +476,13 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
                 queries_dir=queries_dir,
                 analysis_dir=analysis_dir,
                 actions=actions,
+                # ``db_func_tool`` is wired by ``setup_tools`` early in
+                # the run. Passing it through enables the finalize-time
+                # ``key_tables_schema.json`` bake (describe_table snapshot
+                # per manifest.key_tables entry). The bake is best-effort
+                # so finalize still runs when this is None (e.g. node was
+                # configured without db tools — unusual but supported).
+                db_func_tool=self.db_func_tool,
             )
         except Exception as exc:
             logger.warning("Finalize stage crashed for %s/%s: %s", self.ARTIFACT_KIND, artifact_slug, exc)

--- a/datus/schemas/key_tables_schema.py
+++ b/datus/schemas/key_tables_schema.py
@@ -1,0 +1,84 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""On-disk schema snapshot for an artifact's ``manifest.key_tables``.
+
+Written once at finalize time (after ``manifest.key_tables`` is
+code-aggregated from the saved SQL bodies) to
+``<root>/<slug>/analysis/key_tables_schema.json``. The companion
+``ask_*`` consultant inlines the snapshot into its system prompt so
+follow-up SQL planning skips ``describe_table`` round-trips for the
+tables the artifact already touched.
+
+Contract — snapshot only:
+
+* Captures the columns that existed when the artifact was finalized.
+  Live DDL drift is **expected** to happen; the prompt instructs the
+  LLM to re-fetch via ``describe_table('<table>')`` whenever the user
+  asks about the current/latest state, or about a column not in this
+  list, or about tables outside ``manifest.key_tables``.
+* Best-effort. ``describe_table`` may fail for individual tables
+  (permission revoked, table renamed/dropped post-creation). Per-table
+  ``error`` field carries the failure reason instead of stranding the
+  whole sidecar.
+* Mirrors :func:`datus.tools.func_tool.database.DBFuncTool.describe_table`
+  return shape so the bake step is a thin pass-through and the prompt
+  rendering knows exactly which fields can be present.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class KeyTableColumn(BaseModel):
+    """One column of a snapshotted key_table.
+
+    Fields mirror ``DBFuncTool.describe_table()`` output. ``is_dimension``
+    is only populated when a semantic model existed for the table at
+    finalize time — its absence is meaningful (no semantic info), so
+    we distinguish ``None`` (unknown / no model) from ``False``
+    (model exists but column is a measure / metric, not a dimension).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: str = ""
+    comment: str = ""
+    is_dimension: Optional[bool] = None
+
+
+class KeyTableSchema(BaseModel):
+    """Snapshot of one entry from ``manifest.key_tables``.
+
+    ``name`` mirrors the manifest entry verbatim (fully qualified per
+    SQL convention, e.g. ``jeff_shop.raw_orders``). ``error`` is
+    populated iff ``describe_table`` failed for this table; when set,
+    ``columns`` is empty and the prompt renderer surfaces a "schema
+    unavailable; call describe_table()" hint instead of a column list.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str = ""
+    columns: List[KeyTableColumn] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class KeyTablesSchemaFile(BaseModel):
+    """Top-level wrapper for ``analysis/key_tables_schema.json``.
+
+    Single-field wrapper rather than a bare list so the file shape is
+    forward-compatible — e.g. adding ``generated_at`` or
+    ``connector_version`` later is a non-breaking change for any
+    consumer that already validates against this model.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    tables: List[KeyTableSchema] = Field(default_factory=list)

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -1531,6 +1531,53 @@ class TestTableSchemasSection:
         # minor sizing shifts in the intro string.
         assert any(f"#### `tbl_{i}`" not in block for i in (3, 4))
 
+    def test_get_system_prompt_logs_size_for_observability(self, real_agent_config, caplog):
+        """One INFO log per system-prompt assembly with kind / slug /
+        lines / bytes / header_bytes / base_bytes. Operators grep for
+        ``ask_artifact prompt assembled`` to monitor real-world prompt
+        growth — pin the prefix + key names so a refactor that drops
+        keys (and breaks the grep) trips."""
+        import logging
+
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="size_log",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+        )
+        with caplog.at_level(logging.INFO, logger="datus.agent.node.base_artifact_ask_agentic_node"):
+            prompt = node._get_system_prompt()
+
+        # structlog wraps the formatted message with ANSI/timestamp prefixes,
+        # so the assembled record's text doesn't ``startswith`` the literal
+        # prefix — match the unique substring instead (same idiom the
+        # existing caplog tests use, e.g. test_agent_config_permissions).
+        size_logs = [
+            rec
+            for rec in caplog.records
+            if rec.name == "datus.agent.node.base_artifact_ask_agentic_node"
+            and "ask_artifact prompt assembled" in rec.getMessage()
+        ]
+        assert len(size_logs) == 1, (
+            f"expected exactly one prompt-size log line, got {len(size_logs)}: {[r.getMessage() for r in size_logs]}"
+        )
+        msg = size_logs[0].getMessage()
+        # All the keys an operator needs to grep / parse a real trace.
+        for key in ("node=", "kind=report", "slug=size_log", "lines=", "bytes=", "header_bytes=", "base_bytes="):
+            assert key in msg, f"size log missing {key!r} key: {msg}"
+        # Sanity-check the byte count against the actual prompt — if the
+        # log drifts from the real prompt size the value loses meaning.
+        expected_bytes = len(prompt.encode("utf-8"))
+        assert f"bytes={expected_bytes}" in msg, (
+            f"logged bytes don't match actual prompt size (expected {expected_bytes}): {msg}"
+        )
+
     def test_layout_tree_mentions_schema_file(self, real_agent_config):
         """The filesystem layout tree should explicitly list
         ``key_tables_schema.json`` so a model that ``glob``s the

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -969,12 +969,14 @@ class TestArtifactContextBlockInlining:
         """
         from datus.agent.node import base_artifact_ask_agentic_node as mod
 
-        # Cap chosen empirically: each non-degraded entry in this
-        # fixture renders to ~220 bytes (header + hypothesis + caveats
-        # + 3-row inline + SQL block). 400 fits the first entry only;
-        # the second entry's running total trips the cap and switches
-        # to degraded mode for the rest of the catalog.
-        monkeypatch.setattr(mod, "INLINE_CATALOG_BYTES_CAP", 400)
+        # Cap chosen empirically. After the UTF-8 byte-counting fix
+        # the cap now includes the section header (~380B for the
+        # intro paragraph) plus each non-degraded entry (~220B). Cap
+        # of 700 lets the first entry land non-degraded (intro 380 +
+        # entry 220 ≈ 600 < 700) but the second entry's running total
+        # (600 + 220 = 820 > 700) trips the cap and switches the rest
+        # of the catalog to degraded mode.
+        monkeypatch.setattr(mod, "INLINE_CATALOG_BYTES_CAP", 700)
 
         common_rows = [{"v": i} for i in range(3)]
         queries = []
@@ -1006,6 +1008,93 @@ class TestArtifactContextBlockInlining:
         # against minor rendering-size shifts.
         late_caveats_dropped = "b_second-CAVEAT-MARKER" not in block or "c_third-CAVEAT-MARKER" not in block
         assert late_caveats_dropped, "expected catalog cap to drop at least one later caveat"
+
+    def test_catalog_cap_uses_utf8_bytes_not_codepoints(self, real_agent_config, monkeypatch):
+        """The catalog cap is phrased in BYTES — a single CJK code-point
+        takes 3 UTF-8 bytes. Without ``.encode("utf-8")`` the cap would
+        let ~3× more content through on a Chinese-heavy artifact than
+        intended. We construct an entry where the codepoint count is
+        well under the cap but the UTF-8 byte count blows past it,
+        and verify the cap fires (catalog degrades).
+        """
+        from datus.agent.node import base_artifact_ask_agentic_node as mod
+
+        # 300 CJK chars = 300 codepoints = 900 UTF-8 bytes.
+        chinese_caveat = "测" * 300
+        monkeypatch.setattr(mod, "INLINE_CATALOG_BYTES_CAP", 700)
+        queries = []
+        for slug in ("a_first", "b_second"):
+            queries.append(
+                {
+                    "slug": slug,
+                    "brief": {"name": slug, "hypothesis": "h", "caveats": chinese_caveat, "uses": {}},
+                    "result": _basic_query_result(slug, rows=[{"v": 1}, {"v": 2}]),
+                    "sql": "SELECT v FROM t",
+                }
+            )
+        node = _make_report_with_queries(real_agent_config, slug="utf8_cap", queries=queries)
+        block = node._render_artifact_context_block()
+        # First entry's caveat (CJK) lands intact — single ~900-byte
+        # caveat per-entry is still under-counted as 300 if we used
+        # codepoint length, so this is a load-bearing pre-condition.
+        # Cap of 700 bytes < intro (~380) + entry1 (~1200 incl. CJK) so
+        # entry1 itself triggers degraded mode and the caveat is dropped
+        # from entry1 as well. Pin the visible outcome: NO caveat
+        # appears anywhere in the block. With the buggy codepoint
+        # accounting all caveats would have been kept.
+        assert chinese_caveat not in block, (
+            "CJK caveat survived the catalog cap — byte counting regressed to code-point length"
+        )
+
+    def test_subject_scope_section_uses_utf8_bytes_in_byte_cap(self, real_agent_config, monkeypatch):
+        """Companion to the schema-section cap test — the schema section
+        cap MUST also count UTF-8 bytes so a Chinese description
+        doesn't silently let the section grow past
+        ``INLINE_SCHEMA_BYTES_CAP``. We feed an oversized description
+        that fits under the byte cap as codepoints but exceeds it as
+        UTF-8 bytes and verify the cap reaches in for the byte
+        counting branch (later tables omitted).
+        """
+        from datus.agent.node import base_artifact_ask_agentic_node as mod
+
+        # 200 CJK ≈ 600 UTF-8 bytes; well over 500-byte cap.
+        chinese_desc = "字" * 200
+        monkeypatch.setattr(mod, "INLINE_SCHEMA_BYTES_CAP", 500)
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="utf8_schema_cap",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema={
+                "tables": [
+                    {
+                        "name": "tbl_with_cjk",
+                        "description": chinese_desc,
+                        "columns": [{"name": "id", "type": "int", "comment": ""}],
+                    },
+                    {
+                        "name": "tbl_after",
+                        "description": "",
+                        "columns": [{"name": "id", "type": "int", "comment": ""}],
+                    },
+                ]
+            },
+        )
+        block = node._render_artifact_context_block()
+        # Either the section never starts (intro itself blows the cap)
+        # OR the first table fits + cap marker hits before tbl_after.
+        # Both outcomes prove byte-aware counting is in effect; the
+        # codepoint-counting bug would let BOTH tables through.
+        assert "tbl_after" not in block, (
+            "second table appeared despite CJK description blowing the "
+            "byte cap — schema cap regressed to code-point counting"
+        )
 
     # --- Subject scope --------------------------------------------------
 
@@ -1060,6 +1149,68 @@ class TestArtifactContextBlockInlining:
         # Pin on a concrete substring that appears once per referencing
         # query — confirms the catalog entry actually includes the tag.
         assert block.count("metric:`average_order_value`") >= 2
+
+    def test_subject_scope_distinguishes_same_name_under_different_paths(self, real_agent_config):
+        """Two metrics that happen to share a leaf name (``aov`` under
+        ``Commerce`` vs ``Finance``) are independent assets — the
+        reverse index must NOT conflate the queries that use one with
+        the queries that use the other. Without the path-aware key,
+        the prompt would falsely tell the LLM that a Finance-team
+        query references the Commerce metric (or vice versa) and a
+        ``get_metrics(path, name)`` lookup would resolve to the wrong
+        asset.
+        """
+        commerce_aov = {"path": ["Commerce", "Orders"], "name": "aov"}
+        finance_aov = {"path": ["Finance", "Reporting"], "name": "aov"}
+        queries = [
+            {
+                "slug": "q_commerce",
+                "brief": {"name": "q_commerce", "uses": {"metrics": [commerce_aov]}},
+                "result": _basic_query_result("q_commerce"),
+                "sql": "SELECT 1",
+            },
+            {
+                "slug": "q_finance",
+                "brief": {"name": "q_finance", "uses": {"metrics": [finance_aov]}},
+                "result": _basic_query_result("q_finance"),
+                "sql": "SELECT 1",
+            },
+        ]
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="subj_same_name",
+            queries=queries,
+            subject_refs={
+                "metrics": [commerce_aov, finance_aov],
+                "reference_sql": [],
+                "ext_knowledge": [],
+            },
+        )
+        block = node._render_artifact_context_block()
+        # Both assets rendered with their full path so the LLM can
+        # disambiguate visually.
+        assert "Commerce > Orders > aov" in block
+        assert "Finance > Reporting > aov" in block
+        # Each "used by" line names ONLY the query that actually
+        # referenced THAT path — no cross-talk.
+        commerce_line = next(line for line in block.splitlines() if "Commerce > Orders > aov" in line)
+        finance_line = next(line for line in block.splitlines() if "Finance > Reporting > aov" in line)
+        # Slice the "used by" section that immediately follows each
+        # asset header. Block format places it on the next line.
+        block_lines = block.splitlines()
+        commerce_idx = block_lines.index(commerce_line)
+        finance_idx = block_lines.index(finance_line)
+        commerce_used_by = block_lines[commerce_idx + 1]
+        finance_used_by = block_lines[finance_idx + 1]
+        assert "used by:" in commerce_used_by
+        assert "q_commerce" in commerce_used_by
+        assert "q_finance" not in commerce_used_by, (
+            f"path-aware reverse index regressed; finance query bled into "
+            f"the commerce asset's used-by list: {commerce_used_by!r}"
+        )
+        assert "used by:" in finance_used_by
+        assert "q_finance" in finance_used_by
+        assert "q_commerce" not in finance_used_by
 
     # --- Skipped sections when files absent -----------------------------
 
@@ -1133,6 +1284,78 @@ class TestArtifactContextBlockInlining:
         node = _make_report_with_queries(real_agent_config, slug="no_ins", queries=queries)
         block = node._render_artifact_context_block()
         assert "### Confirmed Findings" not in block
+
+    def test_missing_insights_drops_from_layout_tree_and_loaded_list(self, real_agent_config):
+        """When a report has no insights.json (finalize LLM failed or
+        produced an empty list), the layout tree and the
+        "already loaded into this prompt" sentence in the layout intro
+        must NOT advertise insights.json — otherwise the LLM trusts the
+        claim and skips a legitimate ``read_file`` (or worse, hallucinates
+        insights it thinks are inlined). Mirrors the same gate
+        ``_render_insights_section`` already applies."""
+        queries = [
+            {
+                "slug": "q",
+                "brief": {"name": "q", "uses": {}},
+                "result": _basic_query_result("q"),
+                "sql": "SELECT 1",
+            }
+        ]
+        node = _make_report_with_queries(real_agent_config, slug="no_ins_layout", queries=queries)
+        block = node._render_artifact_context_block()
+        # Section absent (already covered by the prior test, but locking
+        # the precondition here keeps this test self-contained).
+        assert "### Confirmed Findings" not in block
+        # Layout tree line absent — the file isn't claimed as a
+        # top-level entry alongside intent.md / subject_refs.json.
+        assert "├── insights.json" not in block
+        # Loaded_list sentence absent — pin the exact substring used in
+        # the layout intro paragraph.
+        assert "analysis/insights.json, " not in block, (
+            "layout intro advertised insights.json as already-loaded even though no insights section rendered"
+        )
+        # Rule 1 preamble dropped the "confirmed insights" mention.
+        assert "confirmed insights" not in block
+        # Rule 6's POSITIVE form is absent (the "authoritative findings
+        # record" claim). The NEGATIVE form ("no confirmed-findings
+        # record for this report") IS allowed and is the load-bearing
+        # honesty signal — assert it positively so a refactor that
+        # silently drops rule 6 entirely (breaking numbering) trips.
+        assert "authoritative findings record" not in block
+        assert "No confirmed-findings record for this report" in block, (
+            "rule 6 must explicitly tell the LLM that no insights "
+            "exist for this report instead of being silently dropped"
+        )
+
+    def test_insights_present_keeps_layout_tree_entry(self, real_agent_config):
+        """Symmetric to the prior test — when insights ARE inlined the
+        layout entry must reappear, so a contract regression that
+        always-drops the line trips here."""
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="ins_layout",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            insights=[
+                {
+                    "id": "x",
+                    "title": "t",
+                    "summary": "s",
+                    "confidence": 0.5,
+                    "evidence_queries": ["q"],
+                }
+            ],
+        )
+        block = node._render_artifact_context_block()
+        # Layout entry IS present (annotated with "inlined above").
+        layout_lines = [line for line in block.splitlines() if "insights.json" in line and "inlined above" in line]
+        assert layout_lines, "insights.json should be in the layout tree when actually inlined"
 
     def test_missing_subject_refs_skips_section(self, real_agent_config):
         """No subject_refs.json ⇒ no "Subject Library Scope" heading."""
@@ -1530,53 +1753,6 @@ class TestTableSchemasSection:
         # we don't pin which specifically to stay resilient against
         # minor sizing shifts in the intro string.
         assert any(f"#### `tbl_{i}`" not in block for i in (3, 4))
-
-    def test_get_system_prompt_logs_size_for_observability(self, real_agent_config, caplog):
-        """One INFO log per system-prompt assembly with kind / slug /
-        lines / bytes / header_bytes / base_bytes. Operators grep for
-        ``ask_artifact prompt assembled`` to monitor real-world prompt
-        growth — pin the prefix + key names so a refactor that drops
-        keys (and breaks the grep) trips."""
-        import logging
-
-        node = _make_report_with_queries(
-            real_agent_config,
-            slug="size_log",
-            queries=[
-                {
-                    "slug": "q",
-                    "brief": {"name": "q", "uses": {}},
-                    "result": _basic_query_result("q"),
-                    "sql": "SELECT 1",
-                }
-            ],
-        )
-        with caplog.at_level(logging.INFO, logger="datus.agent.node.base_artifact_ask_agentic_node"):
-            prompt = node._get_system_prompt()
-
-        # structlog wraps the formatted message with ANSI/timestamp prefixes,
-        # so the assembled record's text doesn't ``startswith`` the literal
-        # prefix — match the unique substring instead (same idiom the
-        # existing caplog tests use, e.g. test_agent_config_permissions).
-        size_logs = [
-            rec
-            for rec in caplog.records
-            if rec.name == "datus.agent.node.base_artifact_ask_agentic_node"
-            and "ask_artifact prompt assembled" in rec.getMessage()
-        ]
-        assert len(size_logs) == 1, (
-            f"expected exactly one prompt-size log line, got {len(size_logs)}: {[r.getMessage() for r in size_logs]}"
-        )
-        msg = size_logs[0].getMessage()
-        # All the keys an operator needs to grep / parse a real trace.
-        for key in ("node=", "kind=report", "slug=size_log", "lines=", "bytes=", "header_bytes=", "base_bytes="):
-            assert key in msg, f"size log missing {key!r} key: {msg}"
-        # Sanity-check the byte count against the actual prompt — if the
-        # log drifts from the real prompt size the value loses meaning.
-        expected_bytes = len(prompt.encode("utf-8"))
-        assert f"bytes={expected_bytes}" in msg, (
-            f"logged bytes don't match actual prompt size (expected {expected_bytes}): {msg}"
-        )
 
     def test_layout_tree_mentions_schema_file(self, real_agent_config):
         """The filesystem layout tree should explicitly list

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -737,6 +737,7 @@ def _seed_analysis_extras(
     insights: list[dict] | None = None,
     subject_refs: dict | None = None,
     suggested_questions: list[dict] | None = None,
+    key_tables_schema: dict | None = None,
 ) -> None:
     """Drop optional analysis files into an already-seeded artifact root."""
     analysis_dir = artifact_root / "analysis"
@@ -747,6 +748,8 @@ def _seed_analysis_extras(
         (analysis_dir / "subject_refs.json").write_text(json.dumps(subject_refs), encoding="utf-8")
     if suggested_questions is not None:
         (analysis_dir / "suggested_questions.json").write_text(json.dumps(suggested_questions), encoding="utf-8")
+    if key_tables_schema is not None:
+        (analysis_dir / "key_tables_schema.json").write_text(json.dumps(key_tables_schema), encoding="utf-8")
 
 
 def _make_dashboard_with_queries(agent_config, *, slug: str, queries: list[dict], subject_refs: dict | None = None):
@@ -779,6 +782,7 @@ def _make_report_with_queries(
     insights: list[dict] | None = None,
     subject_refs: dict | None = None,
     suggested_questions: list[dict] | None = None,
+    key_tables_schema: dict | None = None,
 ):
     """Build a report node from a fully-seeded artifact via the blob path.
 
@@ -796,6 +800,7 @@ def _make_report_with_queries(
         insights=insights,
         subject_refs=subject_refs,
         suggested_questions=suggested_questions,
+        key_tables_schema=key_tables_schema,
     )
     blob = _blob_from_disk(agent_config.project_root, "report", slug)
     _register_ask_agent(agent_config, name=f"ask_{slug}", kind="report", slug=slug, blob=blob)
@@ -1259,3 +1264,299 @@ class TestArtifactContextBlockInlining:
         # NOT" so a future copy-edit that softens the rule trips.
         assert "1. **Answer from the inlined context first**" in block
         assert "Do NOT issue `glob` or `read_file`" in block
+
+
+# --------------------------------------------------------------------------- #
+# Table Schemas section                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestTableSchemasSection:
+    """Inline ``analysis/key_tables_schema.json`` so the LLM plans
+    follow-up SQL without ``describe_table`` round-trips for tables
+    already in ``manifest.key_tables``.
+
+    The section's intro is load-bearing: it explicitly carves out the
+    cases where the LLM MUST still call ``describe_table`` (live
+    schema state, unknown columns, tables outside key_tables). These
+    tests pin both the inlining behavior AND the carve-out wording.
+    """
+
+    def _basic_schema(self) -> dict:
+        return {
+            "tables": [
+                {
+                    "name": "jeff_shop.raw_orders",
+                    "description": "canonical orders fact table",
+                    "columns": [
+                        {"name": "order_id", "type": "bigint", "comment": "primary key"},
+                        {
+                            "name": "order_total",
+                            "type": "int",
+                            "comment": "stored in cents",
+                            "is_dimension": False,
+                        },
+                        {"name": "store_id", "type": "int", "comment": "FK to raw_stores.id"},
+                    ],
+                },
+                {
+                    "name": "jeff_shop.raw_stores",
+                    "description": "",
+                    "columns": [
+                        {"name": "id", "type": "int", "comment": ""},
+                        {"name": "name", "type": "varchar", "comment": ""},
+                    ],
+                },
+            ]
+        }
+
+    def test_section_renders_tables_and_columns(self, real_agent_config):
+        """Happy path: schema sidecar present ⇒ section renders both
+        tables with columns + types + comments. The catalog and rule
+        sections still follow."""
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="schema_basic",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema=self._basic_schema(),
+        )
+        block = node._render_artifact_context_block()
+        assert "### Table Schemas (`analysis/key_tables_schema.json`)" in block
+        # Both table headers present.
+        assert "#### `jeff_shop.raw_orders`" in block
+        assert "#### `jeff_shop.raw_stores`" in block
+        # Description from semantic model only on the first table.
+        assert "_(description: canonical orders fact table)_" in block
+        # Per-column rendering: type + comment via ``--``.
+        assert "- `order_id`: bigint  -- primary key" in block
+        assert "- `order_total`: int  -- stored in cents" in block
+        # Comment-less columns just show name + type.
+        assert "- `id`: int" in block
+        assert "- `name`: varchar" in block
+
+    def test_section_intro_carves_out_live_state_call_describe(self, real_agent_config):
+        """The intro MUST explicitly tell the LLM to fall back to
+        ``describe_table`` for live schema / unknown columns / non-
+        key_tables. Without this carve-out the LLM would treat the
+        snapshot as authoritative forever and answer stale-schema
+        questions confidently. Pin on substrings that survive minor
+        copy-edits but trip if the safety guidance gets weakened."""
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="schema_carveout",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema=self._basic_schema(),
+        )
+        block = node._render_artifact_context_block()
+        assert "SNAPSHOT" in block
+        assert "describe_table" in block
+        # Specific carve-out scenarios are named in the intro.
+        assert "LATEST / CURRENT schema" in block
+        assert "column NOT in this list" in block
+        assert "tables NOT in `manifest.key_tables`" in block
+
+    def test_rule_one_includes_live_state_exception(self, real_agent_config):
+        """Behavioral rule 1 (already pins the "no defensive read"
+        contract) must also carry the LIVE/CURRENT exception clause
+        so the LLM knows when re-fetching IS expected."""
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="rule_live",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema=self._basic_schema(),
+        )
+        block = node._render_artifact_context_block()
+        # Find the line starting rule 1 and verify it mentions the
+        # LIVE / CURRENT exception.
+        rule1_idx = block.find("1. **Answer from the inlined context first**")
+        rule2_idx = block.find("2. **Do NOT regenerate the artifact**")
+        assert rule1_idx > 0 and rule2_idx > rule1_idx
+        rule1_text = block[rule1_idx:rule2_idx]
+        assert "LIVE / CURRENT" in rule1_text
+        assert "describe_table" in rule1_text
+
+    def test_missing_schema_skips_section(self, real_agent_config):
+        """No sidecar (older artifacts, dry runs, finalize without a
+        db tool) ⇒ section absent. The other inlined sections must
+        still render."""
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="schema_missing",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            # No key_tables_schema kwarg ⇒ file not seeded.
+        )
+        block = node._render_artifact_context_block()
+        assert "### Table Schemas" not in block
+        # But rule 1 still mentions LIVE/CURRENT (it's a static
+        # behavioral rule, independent of whether the schema sidecar
+        # exists for THIS artifact).
+        assert "LIVE / CURRENT" in block
+
+    def test_per_table_error_renders_describe_hint(self, real_agent_config):
+        """When the bake captured an error for a specific table
+        (permission denied, table dropped, etc.), the renderer
+        surfaces the failure with the exact remediation rather than
+        silently dropping the entry. Without this hint the LLM might
+        assume the table doesn't exist."""
+        schema = {
+            "tables": [
+                {"name": "ok_tbl", "columns": [{"name": "id", "type": "int", "comment": ""}]},
+                {"name": "denied_tbl", "columns": [], "error": "access denied"},
+            ]
+        }
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="schema_partial",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema=schema,
+        )
+        block = node._render_artifact_context_block()
+        # Good table still shows columns.
+        assert "#### `ok_tbl`" in block
+        assert "- `id`: int" in block
+        # Failed table: header + "schema unavailable" hint + specific
+        # remediation call. Pin the literal remediation form so a
+        # regression that drops the call hint trips.
+        assert "#### `denied_tbl`" in block
+        assert "schema unavailable: access denied" in block
+        assert "describe_table('denied_tbl')" in block
+
+    def test_wide_table_truncated_with_remediation_hint(self, real_agent_config):
+        """A table with > INLINE_SCHEMA_COLS_PER_TABLE columns must
+        truncate the column list with a marker telling the LLM how
+        to get the rest. Without this the LLM might write SQL against
+        a column that exists but wasn't shown."""
+        wide_cols = [{"name": f"col_{i}", "type": "varchar", "comment": ""} for i in range(80)]
+        schema = {"tables": [{"name": "wide_tbl", "columns": wide_cols}]}
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="schema_wide",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema=schema,
+        )
+        block = node._render_artifact_context_block()
+        # First 50 columns present.
+        assert "- `col_0`: varchar" in block
+        assert "- `col_49`: varchar" in block
+        # 50 onwards absent.
+        assert "- `col_50`:" not in block
+        # Truncation marker mentions the remaining count + describe_table.
+        assert "30 more columns" in block
+        assert "describe_table('wide_tbl')" in block
+
+    def test_section_byte_cap_drops_trailing_tables(self, real_agent_config, monkeypatch):
+        """When many tables collectively blow the section cap, later
+        tables are omitted with a "cap reached" footer. Each table
+        keeps its column block intact (no half-rendered entries) so
+        the LLM never sees a misleading partial schema. We
+        monkeypatch the cap to ~720B — the section intro alone is
+        ~640B (the carve-out paragraph), so only 1–2 small table
+        entries fit before the cap fires."""
+        from datus.agent.node import base_artifact_ask_agentic_node as mod
+
+        monkeypatch.setattr(mod, "INLINE_SCHEMA_BYTES_CAP", 720)
+        many_tables = []
+        for i in range(5):
+            many_tables.append(
+                {
+                    "name": f"tbl_{i}",
+                    "columns": [
+                        {"name": "id", "type": "int", "comment": ""},
+                        {"name": "name", "type": "varchar", "comment": ""},
+                    ],
+                }
+            )
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="schema_capped",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema={"tables": many_tables},
+        )
+        block = node._render_artifact_context_block()
+        # First table survives.
+        assert "#### `tbl_0`" in block
+        # Some later table is dropped + cap marker present.
+        assert "schema section cap reached" in block
+        # At least one of the last tables must NOT be in the block —
+        # we don't pin which specifically to stay resilient against
+        # minor sizing shifts in the intro string.
+        assert any(f"#### `tbl_{i}`" not in block for i in (3, 4))
+
+    def test_layout_tree_mentions_schema_file(self, real_agent_config):
+        """The filesystem layout tree should explicitly list
+        ``key_tables_schema.json`` so a model that ``glob``s the
+        analysis directory finds the file by name and knows it's
+        already inlined. Without this entry the LLM might assume the
+        sidecar is absent and skip the schema section."""
+        node = _make_report_with_queries(
+            real_agent_config,
+            slug="schema_tree",
+            queries=[
+                {
+                    "slug": "q",
+                    "brief": {"name": "q", "uses": {}},
+                    "result": _basic_query_result("q"),
+                    "sql": "SELECT 1",
+                }
+            ],
+            key_tables_schema=self._basic_schema(),
+        )
+        block = node._render_artifact_context_block()
+        # File appears in the tree with the "inlined above" annotation
+        # AND the describe_table fallback hint on the same line.
+        tree_lines = [line for line in block.splitlines() if "key_tables_schema.json" in line]
+        assert tree_lines, "key_tables_schema.json missing from layout tree"
+        # At least one mention is in the tree (has the # comment style),
+        # and at least one mention contains describe_table to make the
+        # "snapshot only" contract visible from the tree itself.
+        assert any("inlined above" in line for line in tree_lines)
+        assert any("describe_table" in line for line in tree_lines)

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -29,6 +29,7 @@ from datus.agent.node._visual_artifact_finalize import (
     _sanitize_curated_intent_md,
     aggregate_referenced_tables,
     aggregate_subject_refs,
+    bake_key_tables_schema,
     collect_query_briefs,
     collect_query_previews,
     consistency_check,
@@ -433,6 +434,249 @@ def _make_artifact_layout(
             encoding="utf-8",
         )
     return artifact_dir, queries_dir, analysis_dir
+
+
+# --------------------------------------------------------------------------- #
+# bake_key_tables_schema                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _mock_describe_table_tool(per_table_payload: Dict[str, Any]) -> Mock:
+    """Build a mock ``db_func_tool`` whose ``describe_table`` returns
+    a pre-canned payload per table name.
+
+    Each entry in ``per_table_payload`` is either:
+    * ``{"result": {...}}`` for a successful describe
+    * ``{"success": 0, "error": "..."}`` for a connector-side failure
+    * an ``Exception`` instance to raise
+
+    Builds a FuncToolResult-shaped Mock object (``success``, ``result``,
+    ``error`` attrs) so the bake function's duck-typed access path
+    works the same way it does against the real tool.
+    """
+    tool = Mock()
+
+    def describe(*, table_name: str, **_kwargs: Any) -> Any:
+        spec = per_table_payload.get(table_name)
+        if isinstance(spec, Exception):
+            raise spec
+        if spec is None:
+            return None
+        result_mock = Mock()
+        result_mock.success = spec.get("success", 1)
+        result_mock.result = spec.get("result")
+        result_mock.error = spec.get("error")
+        return result_mock
+
+    tool.describe_table = Mock(side_effect=describe)
+    return tool
+
+
+class TestBakeKeyTablesSchema:
+    """Snapshot ``describe_table`` output per key_table into the sidecar.
+
+    The bake is best-effort: per-table failures get captured inline so
+    a single broken connector / dropped table doesn't strand the whole
+    schema sidecar.
+    """
+
+    def test_no_db_func_tool_skips_silently(self, tmp_path: Path):
+        """A node without a DB tool (rare, but supported in tests / dry
+        runs) must skip the bake without writing a misleading empty
+        sidecar."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        warning = bake_key_tables_schema(
+            db_func_tool=None,
+            key_tables=["jeff_shop.raw_orders"],
+            analysis_dir=analysis_dir,
+        )
+        assert warning is None
+        assert not (analysis_dir / "key_tables_schema.json").exists()
+
+    def test_empty_key_tables_skips_silently(self, tmp_path: Path):
+        """Manifest has no key_tables (e.g. an artifact with only
+        literal/constant SQL) ⇒ no schema to bake, no sidecar file."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        tool = _mock_describe_table_tool({})
+        warning = bake_key_tables_schema(
+            db_func_tool=tool,
+            key_tables=[],
+            analysis_dir=analysis_dir,
+        )
+        assert warning is None
+        assert not (analysis_dir / "key_tables_schema.json").exists()
+        # describe_table must not be called when there's nothing to describe.
+        tool.describe_table.assert_not_called()
+
+    def test_writes_schema_when_describe_succeeds(self, tmp_path: Path):
+        """Happy path: one table, describe_table returns columns + an
+        optional semantic-model description; the sidecar carries
+        name/description/columns shape verbatim."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        tool = _mock_describe_table_tool(
+            {
+                "jeff_shop.raw_orders": {
+                    "result": {
+                        "columns": [
+                            {"name": "order_id", "type": "bigint", "comment": "primary key"},
+                            {"name": "order_total", "type": "int", "comment": "stored in cents"},
+                        ],
+                        "table": {
+                            "name": "raw_orders",
+                            "description": "canonical orders fact table",
+                        },
+                    }
+                }
+            }
+        )
+        warning = bake_key_tables_schema(
+            db_func_tool=tool,
+            key_tables=["jeff_shop.raw_orders"],
+            analysis_dir=analysis_dir,
+        )
+        assert warning is None
+        out = json.loads((analysis_dir / "key_tables_schema.json").read_text())
+        # Exact shape pinned so consumers can rely on this contract.
+        assert out == {
+            "tables": [
+                {
+                    "name": "jeff_shop.raw_orders",
+                    "description": "canonical orders fact table",
+                    "columns": [
+                        {
+                            "name": "order_id",
+                            "type": "bigint",
+                            "comment": "primary key",
+                            "is_dimension": None,
+                        },
+                        {
+                            "name": "order_total",
+                            "type": "int",
+                            "comment": "stored in cents",
+                            "is_dimension": None,
+                        },
+                    ],
+                    "error": None,
+                }
+            ]
+        }
+
+    def test_is_dimension_propagates_when_semantic_model_present(self, tmp_path: Path):
+        """When describe_table found a semantic model, the per-column
+        ``is_dimension`` flag is preserved through to the sidecar so
+        the LLM can tell measures from dimensions without a semantic
+        lookup.
+        """
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        tool = _mock_describe_table_tool(
+            {
+                "tbl_a": {
+                    "result": {
+                        "columns": [
+                            {"name": "id", "type": "int", "comment": "", "is_dimension": True},
+                            {"name": "amount", "type": "decimal", "comment": "", "is_dimension": False},
+                        ],
+                        "table": {"name": "tbl_a", "description": ""},
+                    }
+                }
+            }
+        )
+        bake_key_tables_schema(
+            db_func_tool=tool,
+            key_tables=["tbl_a"],
+            analysis_dir=analysis_dir,
+        )
+        out = json.loads((analysis_dir / "key_tables_schema.json").read_text())
+        cols_by_name = {c["name"]: c for c in out["tables"][0]["columns"]}
+        assert cols_by_name["id"]["is_dimension"] is True
+        assert cols_by_name["amount"]["is_dimension"] is False
+
+    def test_per_table_describe_failure_captured_inline(self, tmp_path: Path):
+        """Mixed success: one table works, one returns ``success=0``,
+        one raises. All three appear in the sidecar — the failing two
+        with their error strings so the prompt can render a per-table
+        "schema unavailable" hint instead of dropping them."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        tool = _mock_describe_table_tool(
+            {
+                "good_tbl": {
+                    "result": {
+                        "columns": [{"name": "c", "type": "int", "comment": ""}],
+                    }
+                },
+                "permission_denied_tbl": {"success": 0, "error": "access denied"},
+                "raising_tbl": RuntimeError("connection reset"),
+            }
+        )
+        warning = bake_key_tables_schema(
+            db_func_tool=tool,
+            key_tables=["good_tbl", "permission_denied_tbl", "raising_tbl"],
+            analysis_dir=analysis_dir,
+        )
+        assert warning is None
+        out = json.loads((analysis_dir / "key_tables_schema.json").read_text())
+        by_name = {t["name"]: t for t in out["tables"]}
+        assert by_name["good_tbl"]["error"] is None
+        assert len(by_name["good_tbl"]["columns"]) == 1
+        # Connector-side failure: error string from the tool surfaces verbatim.
+        assert by_name["permission_denied_tbl"]["columns"] == []
+        assert "access denied" in by_name["permission_denied_tbl"]["error"]
+        # Exception: bake catches and records the message.
+        assert by_name["raising_tbl"]["columns"] == []
+        assert "connection reset" in by_name["raising_tbl"]["error"]
+
+    def test_non_dict_payload_captured_as_error(self, tmp_path: Path):
+        """A connector that returns the wrong shape (string, list,
+        None) gets caught at validation time so the LLM never sees a
+        half-populated entry that looks valid."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        tool = _mock_describe_table_tool({"weird_tbl": {"result": "not a dict"}})
+        bake_key_tables_schema(
+            db_func_tool=tool,
+            key_tables=["weird_tbl"],
+            analysis_dir=analysis_dir,
+        )
+        out = json.loads((analysis_dir / "key_tables_schema.json").read_text())
+        assert out["tables"][0]["columns"] == []
+        # Pin the substring rather than the exact wording — error
+        # message is constructed at the bake site and may be tuned.
+        assert "unexpected payload type" in out["tables"][0]["error"]
+
+    def test_columns_without_name_silently_skipped(self, tmp_path: Path):
+        """Malformed column entries (non-dict, missing/blank name) are
+        skipped at the column level so one bad row doesn't strand the
+        rest of the table's schema."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        tool = _mock_describe_table_tool(
+            {
+                "tbl": {
+                    "result": {
+                        "columns": [
+                            {"name": "good", "type": "int", "comment": ""},
+                            "not a dict",
+                            {"name": "", "type": "int"},
+                            {"type": "bigint"},  # no name
+                            {"name": "also_good", "type": "varchar"},
+                        ],
+                    }
+                }
+            }
+        )
+        bake_key_tables_schema(
+            db_func_tool=tool,
+            key_tables=["tbl"],
+            analysis_dir=analysis_dir,
+        )
+        out = json.loads((analysis_dir / "key_tables_schema.json").read_text())
+        names = [c["name"] for c in out["tables"][0]["columns"]]
+        assert names == ["good", "also_good"]
 
 
 # --------------------------------------------------------------------------- #
@@ -950,6 +1194,82 @@ class TestRunFinalizeAnalysis:
         assert result["key_tables"] == ["Account", "PersonOwnAccount"]
         manifest = json.loads((artifact_dir / "manifest.json").read_text(encoding="utf-8"))
         assert manifest["key_tables"] == ["Account", "PersonOwnAccount"]
+
+    def test_end_to_end_bakes_key_tables_schema_when_db_tool_passed(self, tmp_path: Path):
+        """When the orchestrator is given a ``db_func_tool`` (the
+        production wiring), it bakes ``analysis/key_tables_schema.json``
+        from the same key_tables it wrote to the manifest. ask_* reads
+        this sidecar so SQL planning on the listed tables skips
+        ``describe_table`` round-trips."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(
+            tmp_path,
+            sql_body="SELECT * FROM Account",
+        )
+        model = Mock(spec=["generate_with_json_output"])
+        model.generate_with_json_output.return_value = _full_finalize_response()
+
+        db_tool = _mock_describe_table_tool(
+            {
+                "Account": {
+                    "result": {
+                        "columns": [
+                            {"name": "id", "type": "int", "comment": "primary key"},
+                            {"name": "name", "type": "varchar", "comment": ""},
+                        ],
+                        "table": {"name": "Account", "description": ""},
+                    }
+                }
+            }
+        )
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            db_func_tool=db_tool,
+        )
+
+        assert result["ok"] is True
+        schema_path = analysis_dir / "key_tables_schema.json"
+        assert schema_path.is_file()
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        # The bake walks ``key_tables`` (already populated by the
+        # update_manifest_key_tables step in the same orchestrator pass)
+        # so the sidecar tables list mirrors the manifest entries.
+        assert [t["name"] for t in schema["tables"]] == ["Account"]
+        assert {c["name"] for c in schema["tables"][0]["columns"]} == {"id", "name"}
+
+    def test_end_to_end_skips_schema_bake_without_db_tool(self, tmp_path: Path):
+        """Backwards-compatible default: no ``db_func_tool`` ⇒ no schema
+        sidecar. Existing finalize call sites (and the older
+        BaseVisualArtifactAgenticNode signature before this PR) keep
+        working unchanged."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(
+            tmp_path,
+            sql_body="SELECT * FROM Account",
+        )
+        model = Mock(spec=["generate_with_json_output"])
+        model.generate_with_json_output.return_value = _full_finalize_response()
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            # No db_func_tool — explicit None to make the default-
+            # behaviour assertion clear.
+            db_func_tool=None,
+        )
+
+        assert result["ok"] is True
+        assert result["key_tables"] == ["Account"]
+        # Sidecar absent — only the deterministic manifest update fired.
+        assert not (analysis_dir / "key_tables_schema.json").exists()
 
     def test_end_to_end_preserves_qualified_table_references(self, tmp_path: Path):
         """Real-world SQL is usually fully qualified (``finbench.main.Account``);

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -494,6 +494,56 @@ class TestBakeKeyTablesSchema:
         assert warning is None
         assert not (analysis_dir / "key_tables_schema.json").exists()
 
+    def test_early_return_removes_stale_schema_file(self, tmp_path: Path):
+        """Edit-mode rerun where the new SQL set produces no
+        ``key_tables`` (or finalize runs without a db tool this time)
+        MUST proactively delete any prior ``key_tables_schema.json`` —
+        otherwise ask_* would serve the previous artifact's schema
+        snapshot indefinitely. Mirrors the present-iff-non-empty
+        semantics already used by ``write_subject_refs`` for
+        ``subject_refs.json``."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        stale_path = analysis_dir / "key_tables_schema.json"
+        stale_path.write_text(
+            json.dumps({"tables": [{"name": "old_tbl", "columns": []}]}),
+            encoding="utf-8",
+        )
+        assert stale_path.is_file()
+
+        warning = bake_key_tables_schema(
+            db_func_tool=None,
+            key_tables=["some_tbl_that_would_have_been_baked"],
+            analysis_dir=analysis_dir,
+        )
+        assert warning is None
+        # Stale file gone — the absent signal is now truthful.
+        assert not stale_path.exists()
+
+    def test_early_return_with_empty_key_tables_also_clears_stale(self, tmp_path: Path):
+        """Same cleanup applies when ``key_tables`` is empty — finalize
+        re-aggregated the SQL set and there are no tables anymore, so
+        the prior snapshot is wrong by definition."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        stale_path = analysis_dir / "key_tables_schema.json"
+        stale_path.write_text(
+            json.dumps({"tables": [{"name": "obsolete", "columns": []}]}),
+            encoding="utf-8",
+        )
+
+        tool = _mock_describe_table_tool({})
+        warning = bake_key_tables_schema(
+            db_func_tool=tool,
+            key_tables=[],
+            analysis_dir=analysis_dir,
+        )
+        assert warning is None
+        assert not stale_path.exists()
+        # And describe_table was NOT called — empty key_tables is a
+        # short-circuit, not "ask the connector about nothing".
+        tool.describe_table.assert_not_called()
+
     def test_empty_key_tables_skips_silently(self, tmp_path: Path):
         """Manifest has no key_tables (e.g. an artifact with only
         literal/constant SQL) ⇒ no schema to bake, no sidecar file."""

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -520,6 +520,46 @@ class TestBakeKeyTablesSchema:
         # Stale file gone — the absent signal is now truthful.
         assert not stale_path.exists()
 
+    def test_stale_cleanup_unlink_failure_surfaces_as_warning(self, tmp_path: Path, monkeypatch):
+        """When ``stale.unlink()`` fails (read-only filesystem, immutable
+        flag, racing process), the bake must return a warning string so
+        ``run_finalize_analysis`` collects it into its ``warnings``
+        list. Silently logging would leave the next ask_* turn serving
+        a snapshot the consumer treats as fresh — the exact lying-
+        snapshot scenario the stale-cleanup was added to prevent."""
+        analysis_dir = tmp_path / "analysis"
+        analysis_dir.mkdir()
+        stale_path = analysis_dir / "key_tables_schema.json"
+        stale_path.write_text(json.dumps({"tables": []}), encoding="utf-8")
+
+        # Patch ``Path.unlink`` so only the stale-cleanup call raises —
+        # other Path operations stay live and the test doesn't trip on
+        # incidental mkdir / is_file etc.
+        original_unlink = Path.unlink
+
+        def boom(self, *args, **kwargs):  # noqa: ARG001 — match Path.unlink signature
+            if self == stale_path:
+                raise OSError("read-only filesystem")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", boom)
+
+        warning = bake_key_tables_schema(
+            db_func_tool=None,
+            key_tables=["bake-would-have-happened"],
+            analysis_dir=analysis_dir,
+        )
+        assert isinstance(warning, str), f"expected a warning string, got {warning!r}"
+        # The warning must include both the filename (consumer-facing
+        # identifier) and the underlying OSError message (actionable
+        # detail) — pin both so a refactor that swallows one trips.
+        assert "key_tables_schema.json" in warning
+        assert "read-only filesystem" in warning
+        # File still on disk (unlink failed) — proves the warning is
+        # actually correlated with the lying-snapshot risk, not just
+        # a phantom error string.
+        assert stale_path.is_file()
+
     def test_early_return_with_empty_key_tables_also_clears_stale(self, tmp_path: Path):
         """Same cleanup applies when ``key_tables`` is empty — finalize
         re-aggregated the SQL set and there are no tables anymore, so


### PR DESCRIPTION
## Why

**Stacks on #830** (ask_* inline analysis sidecars). Merge that first.

After #830 a typical follow-up against the AOV report dropped from ~13 to ~3 round-trips, but the remaining 2 are still ``describe_table`` calls on ``manifest.key_tables`` — the LLM has the table names but no columns, so it has to look them up before writing any new SQL. This PR closes that gap.

| Stage | Pre-#830 | After #830 | After this PR |
|---|---|---|---|
| Glob/Read sidecars | 10 | 0 | 0 |
| ``describe_table`` | 2 | 2 | **0** |
| ``read_query`` wrong-unit retry | 1 | 0 | 0 |
| Actual SQL probes | 2-3 | 1-2 | 1-2 |
| **Total** | **~15** | **~3** | **~2** (= unavoidable floor) |

## Solution

Two-sided change. Producer side (gen_visual_*) bakes a schema snapshot at finalize; consumer side (ask_*) inlines it with explicit live-state fallback guidance.

### Producer: ``bake_key_tables_schema()`` at finalize

New ``analysis/key_tables_schema.json`` sidecar written by ``_visual_artifact_finalize.run_finalize_analysis`` after the ``update_manifest_key_tables`` step. For every entry in ``manifest.key_tables``:

- Call ``DBFuncTool.describe_table(table_name=tn)``.
- On success: persist ``{name, description, columns:[{name, type, comment, is_dimension?}]}``. ``is_dimension`` is preserved from the connector's semantic-model enrichment when present (None → no semantic model; True/False → measure vs dimension).
- On per-table failure (permission denied, exception, malformed payload): record ``{name, columns:[], error: <reason>}`` inline. The bake does NOT abort — partial schemas are useful and the prompt renders a "schema unavailable; call describe_table()" hint per failed entry.
- Best-effort: missing ``db_func_tool`` (CLI / dry runs) silently skips; only write OSError surfaces as a finalize warning.

Wired through:
- New ``db_func_tool: Optional[Any]=None`` kwarg on ``run_finalize_analysis`` (back-compat default).
- ``BaseVisualArtifactAgenticNode._run_finalize`` passes ``self.db_func_tool``.

Schema lives in a new dedicated module ``datus/schemas/key_tables_schema.py`` (``KeyTableColumn`` / ``KeyTableSchema`` / ``KeyTablesSchemaFile``).

### Consumer: Table Schemas section in ask_* prompt

New ``_render_table_schemas_section`` inserted between subject scope and insights. Per-table block: header, optional description, one column per line (``\`name\`: type  -- comment``), optional ``is_dimension`` not currently surfaced (LLM-inferable from columns + briefs).

Caps:
- ``INLINE_SCHEMA_COLS_PER_TABLE = 50`` — wide table truncates with ``... N more columns; call describe_table()`` marker
- ``INLINE_SCHEMA_BYTES_CAP = 8KB`` — many-table report truncates trailing tables with section-level marker

**Critical prompt design: live-state carve-out.** The section intro and behavioral rule 1 explicitly tell the LLM to fall back to ``describe_table`` for:
1. User asking about LIVE / CURRENT schema (post-DDL state)
2. User referencing a column NOT in the snapshot list (typo or post-finalize addition)
3. User asking about tables NOT in ``manifest.key_tables``

Without these carve-outs the LLM treats the snapshot as authoritative forever and confidently answers stale-schema questions.

### Layout tree

Adds ``key_tables_schema.json`` with both ``inlined above`` and ``snapshot only — describe_table() for live`` annotations on the same line so a model scanning the tree sees the contract immediately.

## Test Cases

``tests/unit_tests/agent/node/test_visual_artifact_finalize.py`` — ``TestBakeKeyTablesSchema`` + orchestrator integration (8 new tests):
- ``test_no_db_func_tool_skips_silently`` — None tool ⇒ no file written
- ``test_empty_key_tables_skips_silently`` — empty list ⇒ describe_table never called
- ``test_writes_schema_when_describe_succeeds`` — happy path, exact shape pinned
- ``test_is_dimension_propagates_when_semantic_model_present`` — semantic enrichment flows through
- ``test_per_table_describe_failure_captured_inline`` — mixed success: connector error + exception + happy table all surface
- ``test_non_dict_payload_captured_as_error`` — malformed connector return caught
- ``test_columns_without_name_silently_skipped`` — bad per-column entries don't strand the table
- ``test_end_to_end_bakes_key_tables_schema_when_db_tool_passed`` — orchestrator wiring fires the bake
- ``test_end_to_end_skips_schema_bake_without_db_tool`` — backwards compat

``tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py`` — ``TestTableSchemasSection`` (8 new tests):
- ``test_section_renders_tables_and_columns`` — happy path
- ``test_section_intro_carves_out_live_state_call_describe`` — pins the LIVE/CURRENT/NOT-in-list/NOT-in-key_tables carve-out
- ``test_rule_one_includes_live_state_exception`` — pins LIVE / CURRENT + describe_table in rule 1
- ``test_missing_schema_skips_section`` — graceful degradation
- ``test_per_table_error_renders_describe_hint`` — surfaces ``describe_table('<name>')`` remediation
- ``test_wide_table_truncated_with_remediation_hint`` — col cap fires with marker
- ``test_section_byte_cap_drops_trailing_tables`` — section cap fires with footer
- ``test_layout_tree_mentions_schema_file`` — tree entry + describe_table annotation

Full suite: 129 passed (existing 75 finalize + new 8 + existing 46 ask + new 8). Audit P0=0. Diff-cover 86% on new code vs the stacked base branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Best-effort key-tables schema snapshotting: writes per-table column metadata to analysis sidecars, removes stale snapshots when not applicable, and surfaces bake/write/unlink failures as warnings.

* **Improvements**
  * Richer artifact-context prompts: inline table schemas, confirmed-insights handling, subject-scope disambiguation, per-query row/byte caps with degraded fallbacks, SQL truncation markers, UTF-8-aware sizing, and prompt-size observability.

* **Tests**
  * Expanded unit tests covering schema baking/removal, prompt inlining/degradation, error handling, and end-to-end finalize behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->