### PR TITLE
[Enhancement] Add runtime trace context grouping

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -39,6 +39,11 @@ from datus.utils.json_utils import to_str
 from datus.utils.loggings import get_logger
 from datus.utils.path_utils import safe_rmtree
 from datus.utils.time_utils import format_duration_human
+from datus.utils.trace_context import (
+    build_benchmark_trace_context,
+    build_bootstrap_trace_context_from_agent,
+    trace_context,
+)
 from datus.utils.traceable_utils import optional_traceable
 
 logger = get_logger(__name__)
@@ -337,7 +342,7 @@ class Agent:
             logger.info("Metrics item success")
             return
 
-    @optional_traceable(name="bootstrap_kb")
+    @optional_traceable(name="bootstrap_kb", context_builder=build_bootstrap_trace_context_from_agent)
     def bootstrap_kb(self):
         """Initialize knowledge base storage components."""
         logger.info("Initializing knowledge base components")
@@ -711,26 +716,40 @@ class Agent:
             # Use hierarchical save directory structure
             output_dir = self.global_config.get_save_run_dir(run_id) if run_id else self.global_config.output_dir
 
-            result = self.run(
-                SqlTask(
-                    id=task_id,
-                    database_type=conn.dialect,
-                    task=task,
-                    database_name=database_name,
-                    output_dir=output_dir,
-                    current_date=self.args.current_date,
-                    tables=use_tables,
-                    external_knowledge=(
-                        ""
-                        if not benchmark_config.ext_knowledge_key
-                        else task_item.get(benchmark_config.ext_knowledge_key, "")
-                    ),
-                    schema_linking_type="full",
-                ),
-                check_storage=False,
-                check_db=False,
-                run_id=run_id,
+            trace_ctx = build_benchmark_trace_context(
+                benchmark=benchmark_platform,
+                run_id=run_id or "",
+                task_id=task_id,
+                workflow=getattr(self.args, "workflow", None),
+                context_type=getattr(self.args, "context_type", None),
+                datasource=self.global_config.current_datasource,
+                agent_home=self.global_config.home,
+                extra={
+                    "max_steps": getattr(self.args, "max_steps", None),
+                    "max_workers": getattr(self.args, "max_workers", None),
+                },
             )
+            with trace_context(trace_ctx, replace=True):
+                result = self.run(
+                    SqlTask(
+                        id=task_id,
+                        database_type=conn.dialect,
+                        task=task,
+                        database_name=database_name,
+                        output_dir=output_dir,
+                        current_date=self.args.current_date,
+                        tables=use_tables,
+                        external_knowledge=(
+                            ""
+                            if not benchmark_config.ext_knowledge_key
+                            else task_item.get(benchmark_config.ext_knowledge_key, "")
+                        ),
+                        schema_linking_type="full",
+                    ),
+                    check_storage=False,
+                    check_db=False,
+                    run_id=run_id,
+                )
             logger.info(f"Finish benchmark with {task_id}, file saved in {output_dir}/{task_id}.csv.")
             return task_id, result
 

--- a/datus/agent/workflow_runner.py
+++ b/datus/agent/workflow_runner.py
@@ -12,6 +12,7 @@ from datus.schemas.action_history import ActionHistory, ActionHistoryManager, Ac
 from datus.schemas.base import BaseResult
 from datus.schemas.node_models import SqlTask
 from datus.utils.loggings import get_logger
+from datus.utils.trace_context import build_workflow_trace_context_from_runner
 from datus.utils.traceable_utils import get_trace_url, optional_traceable
 
 logger = get_logger(__name__)
@@ -165,7 +166,7 @@ class WorkflowRunner:
             if output_data:
                 action.output.update(output_data)
 
-    @optional_traceable(name="agent")
+    @optional_traceable(name="agent", context_builder=build_workflow_trace_context_from_runner)
     def run(self, sql_task: Optional[SqlTask] = None, check_storage: bool = False) -> Dict:
         """Execute the workflow synchronously."""
         logger.info("Starting agent execution")
@@ -223,7 +224,7 @@ class WorkflowRunner:
         metadata = self._finalize_workflow(step_count)
         return metadata.get("final_result", {})
 
-    @optional_traceable(name="agent_stream")
+    @optional_traceable(name="agent_stream", context_builder=build_workflow_trace_context_from_runner)
     async def run_stream(
         self,
         sql_task: Optional[SqlTask] = None,

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -33,6 +33,7 @@ from datus.tools.proxy.proxy_tool import apply_proxy_tools
 from datus.utils.loggings import get_logger
 from datus.utils.path_manager import set_current_path_manager
 from datus.utils.time_utils import now_utc_iso
+from datus.utils.trace_context import build_chat_trace_context, reset_trace_context, set_trace_context
 
 logger = get_logger(__name__)
 
@@ -443,6 +444,7 @@ class ChatTaskManager:
         """Execute the full agentic loop, pushing SSE events to the task buffer."""
         session_id = task.session_id
         event_id = 0
+        trace_token = None
 
         # Pin the path manager into this task's context. Required when the caller
         # dispatched us from a thread that never inherited AgentConfig's ContextVar
@@ -487,6 +489,20 @@ class ChatTaskManager:
 
             node = await asyncio.to_thread(_init_node)
             task.node = node
+            trace_token = set_trace_context(
+                build_chat_trace_context(
+                    session_id=session_id,
+                    llm_session_id=node.session_id,
+                    node_name=node.get_node_name() if hasattr(node, "get_node_name") else None,
+                    subagent_id=sub_agent_id,
+                    user_id=user_id,
+                    datasource=agent_config.current_datasource,
+                    source_session_id=request.source_session_id,
+                    source=request.source or self._default_source,
+                    model=request.model,
+                    agent_home=agent_config.home,
+                )
+            )
 
             # Per-request permission profile override. We deliberately do
             # NOT mutate ``agent_config.active_profile_name`` here because
@@ -659,6 +675,8 @@ class ChatTaskManager:
             event_id += 1
 
         finally:
+            if trace_token is not None:
+                reset_trace_context(trace_token)
             async with task.condition:
                 task.condition.notify_all()
             self._tasks.pop(session_id, None)

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -31,6 +31,7 @@ from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
 from datus.utils.time_utils import now_utc_iso, to_utc_iso
+from datus.utils.trace_context import build_bootstrap_trace_context, trace_context
 
 logger = get_logger(__name__)
 
@@ -72,16 +73,21 @@ class KbService:
                 break
             # Run the sync init in a background thread.
             # Stream BatchEvents from the queue in real-time while the thread runs.
-            future = loop.run_in_executor(
-                None,
-                self._run_component,
-                request,
-                comp_name,
-                queue,
-                loop,
-                cancel_event,
-                project_root,
+            trace_component = comp_name.value if hasattr(comp_name, "value") else str(comp_name)
+            trace_ctx = build_bootstrap_trace_context(
+                datasource=self.agent_config.current_datasource,
+                components=[trace_component],
+                strategy=request.strategy,
+                stream_id=stream_id,
+                agent_home=self.agent_config.home,
+                extra={"source": "api"},
             )
+
+            def _run_component_with_trace(trace_ctx=trace_ctx, comp_name=comp_name):
+                with trace_context(trace_ctx, replace=True):
+                    return self._run_component(request, comp_name, queue, loop, cancel_event, project_root)
+
+            future = loop.run_in_executor(None, _run_component_with_trace)
 
             # Consume events as they arrive until the thread signals completion
             result = None

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -11,6 +11,7 @@ from agents import Agent, ModelSettings, Runner, SQLiteSession, Tool
 from agents.exceptions import MaxTurnsExceeded
 from agents.mcp import MCPServerStdio
 from agents.models.openai_responses import OpenAIResponsesModel
+from agents.run import RunConfig
 
 from datus.auth.oauth_config import CODEX_API_BASE_URL
 from datus.auth.oauth_manager import OAuthManager
@@ -21,6 +22,7 @@ from datus.models.mcp_utils import multiple_mcp_servers
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
+from datus.utils.trace_context import build_agents_run_config_kwargs
 
 logger = get_logger(__name__)
 
@@ -312,9 +314,12 @@ class CodexModel(LLMBaseModel):
 
             agent = Agent(**agent_kwargs)
 
+            run_config_kwargs = build_agents_run_config_kwargs(agent_name=agent_kwargs["name"])
+            run_config = RunConfig(**run_config_kwargs) if run_config_kwargs else None
+
             async def _run_streamed_to_completion(a, p):
                 """Run agent via streaming (Codex API requires stream=True) and return the result."""
-                result = Runner.run_streamed(a, input=p, max_turns=max_turns, session=session)
+                result = Runner.run_streamed(a, input=p, max_turns=max_turns, session=session, run_config=run_config)
                 while not result.is_complete:
                     async for _ in result.stream_events():
                         pass
@@ -393,7 +398,11 @@ class CodexModel(LLMBaseModel):
 
             agent = Agent(**agent_kwargs)
 
-            result = Runner.run_streamed(agent, input=prompt, max_turns=max_turns, session=session)
+            run_config_kwargs = build_agents_run_config_kwargs(agent_name=agent_kwargs["name"])
+            run_config = RunConfig(**run_config_kwargs) if run_config_kwargs else None
+            result = Runner.run_streamed(
+                agent, input=prompt, max_turns=max_turns, session=session, run_config=run_config
+            )
 
             # Stream events and yield ActionHistory objects
             temp_tool_calls = {}  # {call_id: {"tool_name": ..., "arguments": ...}}

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -962,7 +962,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         async def _tools_operation():
             # Use multiple_mcp_servers context manager with empty dict if no MCP servers
             async with multiple_mcp_servers(mcp_servers or {}) as connected_servers:
-                agent_name = kwargs.pop("agent_name", "default_agent")
+                agent_name = kwargs.get("agent_name", "default_agent")
                 agent = self._build_agent(
                     instruction=instruction,
                     output_type=output_type,
@@ -1063,7 +1063,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         async def _stream_operation():
             # Use multiple_mcp_servers context manager with empty dict if no MCP servers
             async with multiple_mcp_servers(mcp_servers or {}) as connected_servers:
-                agent_name = kwargs.pop("agent_name", "Tools_Agent")
+                agent_name = kwargs.get("agent_name", "Tools_Agent")
                 agent = self._build_agent(
                     instruction=instruction,
                     output_type=output_type,

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -38,6 +38,7 @@ from datus.utils.json_utils import to_str
 from datus.utils.loggings import get_logger
 from datus.utils.resource_utils import read_data_file_text
 from datus.utils.text_utils import LitellmPlaceholderStreamFilter, strip_litellm_placeholder
+from datus.utils.trace_context import build_agents_run_config_kwargs
 from datus.utils.traceable_utils import setup_tracing
 
 logger = get_logger(__name__)
@@ -765,11 +766,13 @@ class OpenAICompatibleModel(LLMBaseModel):
         session: Optional[AdvancedSQLiteSession] = None,
         interrupt_controller=None,
         interaction_broker=None,
+        agent_name: Optional[str] = None,
     ) -> Optional[RunConfig]:
         """Build a :class:`RunConfig` carrying our mid-run input filter.
 
-        Returns ``None`` when no ``pending_input_queue`` is wired in — the
-        SDK then runs with its default config and behavior is unchanged.
+        Returns ``None`` when neither tracing context nor ``pending_input_queue``
+        is wired in — the SDK then runs with its default config and behavior is
+        unchanged.
 
         The filter is invoked by the SDK before every LLM turn within a
         ``Runner.run_streamed`` invocation (``agents/run.py`` ~1483). It
@@ -787,7 +790,8 @@ class OpenAICompatibleModel(LLMBaseModel):
         uncaught filter errors and aborts the entire run, which we must
         never let a queue or sqlite hiccup do.
         """
-        if pending_input_queue is None:
+        trace_kwargs = build_agents_run_config_kwargs(agent_name=agent_name)
+        if pending_input_queue is None and not trace_kwargs:
             return None
 
         async def _filter(data: CallModelData) -> ModelInputData:
@@ -820,7 +824,10 @@ class OpenAICompatibleModel(LLMBaseModel):
                 logger.exception("call_model_input_filter raised; returning original input unchanged.")
                 return data.model_data
 
-        return RunConfig(call_model_input_filter=_filter)
+        if pending_input_queue is None:
+            return RunConfig(**trace_kwargs)
+
+        return RunConfig(call_model_input_filter=_filter, **trace_kwargs)
 
     def _build_agent(
         self,
@@ -955,6 +962,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         async def _tools_operation():
             # Use multiple_mcp_servers context manager with empty dict if no MCP servers
             async with multiple_mcp_servers(mcp_servers or {}) as connected_servers:
+                agent_name = kwargs.pop("agent_name", "default_agent")
                 agent = self._build_agent(
                     instruction=instruction,
                     output_type=output_type,
@@ -962,13 +970,20 @@ class OpenAICompatibleModel(LLMBaseModel):
                     connected_servers=connected_servers,
                     tools=tools,
                     hooks=hooks,
-                    agent_name=kwargs.pop("agent_name", "default_agent"),
+                    agent_name=agent_name,
                 )
+                run_config = self._build_run_config(agent_name=agent_name)
 
                 # Run agent with LangSmith tracing via OpenAIAgentsTracingProcessor
                 # (configured at module level, captures all SDK traces automatically)
                 try:
-                    result = await Runner.run(agent, input=prompt, max_turns=max_turns, session=session)
+                    result = await Runner.run(
+                        agent,
+                        input=prompt,
+                        max_turns=max_turns,
+                        session=session,
+                        run_config=run_config,
+                    )
                 except MaxTurnsExceeded as e:
                     logger.error(f"Max turns exceeded: {str(e)}")
                     raise DatusException(
@@ -1048,6 +1063,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         async def _stream_operation():
             # Use multiple_mcp_servers context manager with empty dict if no MCP servers
             async with multiple_mcp_servers(mcp_servers or {}) as connected_servers:
+                agent_name = kwargs.pop("agent_name", "Tools_Agent")
                 agent = self._build_agent(
                     instruction=instruction,
                     output_type=output_type,
@@ -1055,7 +1071,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                     connected_servers=connected_servers,
                     tools=tools,
                     hooks=hooks,
-                    agent_name=kwargs.pop("agent_name", "Tools_Agent"),
+                    agent_name=agent_name,
                 )
 
                 run_config = self._build_run_config(
@@ -1063,6 +1079,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                     session=session,
                     interrupt_controller=interrupt_controller,
                     interaction_broker=interaction_broker,
+                    agent_name=agent_name,
                 )
                 try:
                     result = Runner.run_streamed(

--- a/datus/utils/trace_context.py
+++ b/datus/utils/trace_context.py
@@ -1,0 +1,362 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Runtime trace identity shared by Datus workflow, chat, and benchmark paths."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterator, Mapping, Optional, Sequence
+
+_CURRENT_TRACE_CONTEXT: contextvars.ContextVar[Optional["TraceContext"]] = contextvars.ContextVar(
+    "datus_trace_context",
+    default=None,
+)
+
+
+def _compact_slug(value: Any, fallback: str = "unknown") -> str:
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    text = text.replace("/", "_")
+    text = re.sub(r"\s+", "_", text)
+    text = re.sub(r"[^A-Za-z0-9_.:-]+", "_", text)
+    return text.strip("_") or fallback
+
+
+def _as_list(values: Any) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        return [values]
+    if isinstance(values, Sequence):
+        return [str(item) for item in values if item is not None and str(item) != ""]
+    return [str(values)]
+
+
+def _string_metadata_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list, tuple)):
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    else:
+        text = str(value)
+    return text[:200]
+
+
+def _timestamped_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}:{uuid.uuid4().hex[:8]}"
+
+
+def create_cli_run_id(action: str) -> str:
+    return f"cli:{_compact_slug(action)}:{_timestamped_id()}"
+
+
+@dataclass(frozen=True)
+class TraceContext:
+    """Stable trace identity for one logical Datus operation."""
+
+    name: str
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
+    tags: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def langfuse_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"trace_name": self.name}
+        if self.session_id:
+            kwargs["session_id"] = self.session_id
+        if self.user_id:
+            kwargs["user_id"] = self.user_id
+        if self.tags:
+            kwargs["tags"] = list(dict.fromkeys(self.tags))
+        if self.metadata:
+            kwargs["metadata"] = {
+                str(key): _string_metadata_value(value) for key, value in self.metadata.items() if value is not None
+            }
+        return kwargs
+
+    def agents_run_config_kwargs(self, agent_name: Optional[str] = None) -> dict[str, Any]:
+        child_name = self.name
+        if agent_name:
+            child_name = f"{self.name}/{_compact_slug(agent_name)}"
+
+        metadata = dict(self.metadata)
+        metadata.setdefault("trace_name", self.name)
+        if self.session_id:
+            metadata.setdefault("trace_session_id", self.session_id)
+        if self.tags:
+            metadata.setdefault("trace_tags", list(dict.fromkeys(self.tags)))
+        if agent_name:
+            metadata.setdefault("agent_name", agent_name)
+
+        kwargs: dict[str, Any] = {
+            "workflow_name": child_name,
+            "trace_metadata": metadata,
+        }
+        if self.session_id:
+            kwargs["group_id"] = self.session_id
+        return kwargs
+
+
+def get_trace_context() -> Optional[TraceContext]:
+    return _CURRENT_TRACE_CONTEXT.get()
+
+
+def set_trace_context(ctx: TraceContext) -> contextvars.Token[Optional[TraceContext]]:
+    return _CURRENT_TRACE_CONTEXT.set(ctx)
+
+
+def reset_trace_context(token: contextvars.Token[Optional[TraceContext]]) -> None:
+    _CURRENT_TRACE_CONTEXT.reset(token)
+
+
+@contextlib.contextmanager
+def trace_context(ctx: Optional[TraceContext], *, replace: bool = False) -> Iterator[None]:
+    if ctx is None or (get_trace_context() is not None and not replace):
+        yield
+        return
+
+    token = set_trace_context(ctx)
+    try:
+        yield
+    finally:
+        reset_trace_context(token)
+
+
+def build_agents_run_config_kwargs(agent_name: Optional[str] = None) -> dict[str, Any]:
+    ctx = get_trace_context()
+    if ctx is None:
+        return {}
+    return ctx.agents_run_config_kwargs(agent_name=agent_name)
+
+
+def _metadata_base(
+    *,
+    component: str,
+    datasource: Optional[str] = None,
+    workflow: Optional[str] = None,
+    run_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    agent_home: Optional[str] = None,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"datus_component": component}
+    if datasource:
+        metadata["datasource"] = datasource
+    if workflow:
+        metadata["workflow"] = workflow
+    if run_id:
+        metadata["run_id"] = run_id
+    if task_id:
+        metadata["task_id"] = task_id
+    if agent_home:
+        metadata["agent_home"] = agent_home
+    if extra:
+        metadata.update({key: value for key, value in extra.items() if value is not None})
+    return metadata
+
+
+def build_workflow_trace_context_from_runner(runner: Any, *args: Any, **kwargs: Any) -> TraceContext:
+    sql_task = kwargs.get("sql_task")
+    if sql_task is None and args:
+        sql_task = args[0]
+
+    runner_args = getattr(runner, "args", None)
+    config = getattr(runner, "global_config", None)
+    workflow = getattr(runner_args, "workflow", None) or "workflow"
+    datasource = getattr(config, "current_datasource", None) or getattr(runner_args, "datasource", None)
+    run_id = getattr(runner, "run_id", None) or getattr(runner_args, "run_id", None)
+    task_id = getattr(sql_task, "id", None)
+    session_id = f"cli:run:{run_id}" if run_id else create_cli_run_id("run")
+    workflow_slug = _compact_slug(workflow)
+
+    tags = ["cli", "run", f"workflow:{workflow_slug}"]
+    if datasource:
+        tags.append(f"datasource:{_compact_slug(datasource)}")
+
+    return TraceContext(
+        name=f"cli/run/{workflow_slug}",
+        session_id=session_id,
+        tags=tuple(tags),
+        metadata=_metadata_base(
+            component="cli_run",
+            datasource=datasource,
+            workflow=workflow,
+            run_id=run_id,
+            task_id=str(task_id) if task_id else None,
+            agent_home=getattr(config, "home", None),
+        ),
+    )
+
+
+def _infer_context_type(benchmark: Optional[str], workflow: Optional[str], run_id: Optional[str]) -> Optional[str]:
+    if benchmark and workflow and workflow.startswith(f"{benchmark}_"):
+        return workflow[len(benchmark) + 1 :]
+    if run_id:
+        match = re.match(r"(.+)_\d{8}_\d{6}$", run_id)
+        if match:
+            value = match.group(1)
+            return value.rsplit("_", 1)[-1] if value.startswith("default_") else value
+    return None
+
+
+def build_benchmark_trace_context(
+    *,
+    benchmark: str,
+    run_id: str,
+    task_id: str,
+    workflow: Optional[str] = None,
+    context_type: Optional[str] = None,
+    datasource: Optional[str] = None,
+    agent_home: Optional[str] = None,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> TraceContext:
+    run_id = run_id or _timestamped_id()
+    context = context_type or _infer_context_type(benchmark, workflow, run_id) or "default"
+    benchmark_slug = _compact_slug(benchmark)
+    context_slug = _compact_slug(context)
+    task_slug = _compact_slug(task_id)
+    tags = [
+        "benchmark",
+        benchmark_slug,
+        context_slug,
+        f"task:{task_slug}",
+    ]
+    if datasource:
+        tags.append(f"datasource:{_compact_slug(datasource)}")
+
+    metadata = _metadata_base(
+        component="benchmark",
+        datasource=datasource,
+        workflow=workflow,
+        run_id=run_id,
+        task_id=task_id,
+        agent_home=agent_home,
+        extra={
+            "benchmark": benchmark,
+            "benchmark_run_id": run_id,
+            "context_type": context,
+            **(dict(extra) if extra else {}),
+        },
+    )
+    return TraceContext(
+        name=f"benchmark/{benchmark_slug}/{context_slug}/task-{task_slug}",
+        session_id=f"benchmark:{run_id}",
+        tags=tuple(tags),
+        metadata=metadata,
+    )
+
+
+def build_bootstrap_trace_context(
+    *,
+    datasource: Optional[str],
+    components: Sequence[str],
+    strategy: Optional[str] = None,
+    run_id: Optional[str] = None,
+    stream_id: Optional[str] = None,
+    agent_home: Optional[str] = None,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> TraceContext:
+    component_values = _as_list(components) or ["metadata"]
+    component_slug = "+".join(_compact_slug(component) for component in component_values)
+    datasource_slug = _compact_slug(datasource, "default")
+    raw_session_id = stream_id or run_id or _timestamped_id()
+    session_id = raw_session_id if str(raw_session_id).startswith("bootstrap:") else f"bootstrap:{raw_session_id}"
+    tags = [
+        "bootstrap-kb",
+        f"datasource:{datasource_slug}",
+        *(f"component:{_compact_slug(c)}" for c in component_values),
+    ]
+    if strategy:
+        tags.append(f"strategy:{_compact_slug(strategy)}")
+
+    metadata = _metadata_base(
+        component="bootstrap_kb",
+        datasource=datasource,
+        run_id=run_id,
+        agent_home=agent_home,
+        extra={
+            "components": component_values,
+            "strategy": strategy,
+            "stream_id": stream_id,
+            **(dict(extra) if extra else {}),
+        },
+    )
+    return TraceContext(
+        name=f"bootstrap-kb/{datasource_slug}/{component_slug}",
+        session_id=session_id,
+        tags=tuple(tags),
+        metadata=metadata,
+    )
+
+
+def build_bootstrap_trace_context_from_agent(agent: Any, *_args: Any, **_kwargs: Any) -> TraceContext:
+    agent_args = getattr(agent, "args", None)
+    config = getattr(agent, "global_config", None)
+    return build_bootstrap_trace_context(
+        datasource=getattr(config, "current_datasource", None) or getattr(agent_args, "datasource", None),
+        components=_as_list(getattr(agent_args, "components", None)),
+        strategy=getattr(agent_args, "kb_update_strategy", None),
+        run_id=getattr(agent_args, "run_id", None),
+        agent_home=getattr(config, "home", None),
+        extra={
+            "catalog": getattr(agent_args, "catalog", None),
+            "database_name": getattr(agent_args, "database_name", None),
+            "subject_path": getattr(agent_args, "subject_path", None),
+        },
+    )
+
+
+def build_chat_trace_context(
+    *,
+    session_id: str,
+    node_name: Optional[str] = None,
+    subagent_id: Optional[str] = None,
+    llm_session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    datasource: Optional[str] = None,
+    source_session_id: Optional[str] = None,
+    source: Optional[str] = None,
+    model: Optional[str] = None,
+    agent_home: Optional[str] = None,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> TraceContext:
+    display_name = node_name or subagent_id or "chat"
+    display_slug = _compact_slug(display_name, "chat")
+    tags = ["chat", f"agent:{display_slug}"]
+    if datasource:
+        tags.append(f"datasource:{_compact_slug(datasource)}")
+    if source:
+        tags.append(f"source:{_compact_slug(source)}")
+
+    metadata = _metadata_base(
+        component="chat",
+        datasource=datasource,
+        agent_home=agent_home,
+        extra={
+            "service_session_id": session_id,
+            "llm_session_id": llm_session_id,
+            "subagent_id": subagent_id,
+            "node_name": node_name,
+            "source_session_id": source_session_id,
+            "source": source,
+            "model": model,
+            **(dict(extra) if extra else {}),
+        },
+    )
+    return TraceContext(
+        name=f"chat/{display_slug}",
+        session_id=session_id,
+        user_id=user_id,
+        tags=tuple(tags),
+        metadata=metadata,
+    )

--- a/datus/utils/traceable_utils.py
+++ b/datus/utils/traceable_utils.py
@@ -38,7 +38,7 @@ _LANGFUSE_TYPE_MAP = {
 _langfuse_enabled = False
 
 
-def optional_traceable(name: str = "", run_type: RUN_TYPE_T = "chain"):
+def optional_traceable(name: str = "", run_type: RUN_TYPE_T = "chain", context_builder=None):
     """
     Optional traceable decorator that wraps functions with LangSmith and/or Langfuse tracing.
 
@@ -64,21 +64,53 @@ def optional_traceable(name: str = "", run_type: RUN_TYPE_T = "chain"):
             except ImportError:
                 pass
 
-        if HAS_LANGFUSE:
+        if HAS_LANGFUSE or context_builder is not None:
             _inner = wrapped
             _observed = None
 
             @functools.wraps(_inner)
             def _langfuse_lazy(*args, **kwargs):
                 nonlocal _observed
-                if _langfuse_enabled:
-                    if _observed is None:
-                        from langfuse import observe
+                token = None
+                try:
+                    from datus.utils.trace_context import get_trace_context, set_trace_context
 
-                        t = name or getattr(func, "__name__", "agent_operation")
-                        _observed = observe(name=t, as_type=_LANGFUSE_TYPE_MAP.get(run_type, "span"))(_inner)
-                    return _observed(*args, **kwargs)
-                return _inner(*args, **kwargs)
+                    trace_ctx = get_trace_context()
+                    if trace_ctx is None and context_builder is not None:
+                        trace_ctx = context_builder(*args, **kwargs)
+                        if trace_ctx is not None:
+                            token = set_trace_context(trace_ctx)
+                except Exception as e:
+                    logger.debug(f"Failed to prepare trace context: {e}")
+                    trace_ctx = None
+
+                try:
+                    if _langfuse_enabled and HAS_LANGFUSE:
+                        if _observed is None:
+                            from langfuse import observe
+
+                            t = name or getattr(func, "__name__", "agent_operation")
+                            _observed = observe(name=t, as_type=_LANGFUSE_TYPE_MAP.get(run_type, "span"))(_inner)
+
+                        if trace_ctx is not None:
+                            try:
+                                from langfuse import propagate_attributes
+
+                                with propagate_attributes(**trace_ctx.langfuse_kwargs()):
+                                    return _observed(*args, **kwargs)
+                            except Exception as e:
+                                logger.debug(f"Langfuse propagate_attributes unavailable or failed: {e}")
+                        return _observed(*args, **kwargs)
+
+                    return _inner(*args, **kwargs)
+                finally:
+                    if token is not None:
+                        try:
+                            from datus.utils.trace_context import reset_trace_context
+
+                            reset_trace_context(token)
+                        except Exception as e:
+                            logger.debug(f"Failed to reset trace context: {e}")
 
             wrapped = _langfuse_lazy
 

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -312,11 +312,18 @@ class TestChatTaskManagerBehavior:
         """The web stream must surface chat_response when the model only produced tool cards."""
         from datus.api.models.cli_models import StreamChatInput
         from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+        from datus.utils.trace_context import get_trace_context
+
+        captured = {}
 
         class FakeNode:
             session_id = "s-final"
 
+            def get_node_name(self):
+                return "chat"
+
             async def execute_stream_with_interactions(self, action_history_manager):
+                captured["trace_context"] = get_trace_context()
                 yield ActionHistory(
                     action_id="final",
                     role=ActionRole.ASSISTANT,
@@ -336,6 +343,8 @@ class TestChatTaskManagerBehavior:
 
         await manager._run_loop(task, real_agent_config, StreamChatInput(message="tables", session_id="s-final"))
 
+        assert captured["trace_context"].name == "chat/chat"
+        assert captured["trace_context"].session_id == "s-final"
         message_events = [event for event in task.events if event.event == "message"]
         assert len(message_events) == 1
         content = message_events[0].data.payload.content[0]

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -22,6 +22,7 @@ from datus.models.openai_compatible import (
 )
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.trace_context import TraceContext, trace_context
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1994,6 +1995,25 @@ class TestBuildRunConfigInputFilter:
         runs with default behavior and the run is unchanged."""
         model = _make_model()
         assert model._build_run_config(pending_input_queue=None) is None
+
+    def test_returns_trace_config_when_trace_context_is_active(self):
+        """TraceContext should turn into Agents SDK workflow/group metadata."""
+        model = _make_model()
+        ctx = TraceContext(
+            name="benchmark/baisheng/semantic_model/task-1",
+            session_id="benchmark:semantic_model_20260520_054027",
+            tags=("benchmark", "task:1"),
+            metadata={"task_id": "1"},
+        )
+
+        with trace_context(ctx, replace=True):
+            rc = model._build_run_config(pending_input_queue=None, agent_name="gen_sql")
+
+        assert rc is not None
+        assert rc.workflow_name == "benchmark/baisheng/semantic_model/task-1/gen_sql"
+        assert rc.group_id == "benchmark:semantic_model_20260520_054027"
+        assert rc.trace_metadata["task_id"] == "1"
+        assert rc.trace_metadata["agent_name"] == "gen_sql"
 
     @pytest.mark.asyncio
     async def test_filter_appends_queued_items_and_persists_to_session(self):

--- a/tests/unit_tests/utils/test_trace_context.py
+++ b/tests/unit_tests/utils/test_trace_context.py
@@ -1,0 +1,70 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from datus.utils.trace_context import (
+    build_benchmark_trace_context,
+    build_bootstrap_trace_context,
+    build_chat_trace_context,
+)
+
+
+def test_benchmark_context_uses_run_id_as_session_group():
+    ctx = build_benchmark_trace_context(
+        benchmark="baisheng",
+        run_id="semantic_model_20260520_054027",
+        task_id="1",
+        workflow="baisheng_semantic_model",
+        datasource="starrocks",
+    )
+
+    assert ctx.name == "benchmark/baisheng/semantic_model/task-1"
+    assert ctx.session_id == "benchmark:semantic_model_20260520_054027"
+    assert "task:1" in ctx.tags
+    assert ctx.metadata["benchmark_run_id"] == "semantic_model_20260520_054027"
+    assert ctx.metadata["context_type"] == "semantic_model"
+
+
+def test_bootstrap_context_names_datasource_and_components():
+    ctx = build_bootstrap_trace_context(
+        datasource="starrocks",
+        components=["metadata", "semantic_model"],
+        strategy="incremental",
+        stream_id="stream-1",
+    )
+
+    assert ctx.name == "bootstrap-kb/starrocks/metadata+semantic_model"
+    assert ctx.session_id == "bootstrap:stream-1"
+    assert "component:metadata" in ctx.tags
+    assert ctx.metadata["components"] == ["metadata", "semantic_model"]
+
+
+def test_generated_session_ids_keep_operation_prefixes():
+    benchmark_ctx = build_benchmark_trace_context(
+        benchmark="baisheng",
+        run_id="",
+        task_id="1",
+    )
+    bootstrap_ctx = build_bootstrap_trace_context(
+        datasource="starrocks",
+        components=["metadata"],
+    )
+
+    assert benchmark_ctx.session_id.startswith("benchmark:20")
+    assert not benchmark_ctx.session_id.startswith("benchmark:cli:")
+    assert bootstrap_ctx.session_id.startswith("bootstrap:20")
+    assert not bootstrap_ctx.session_id.startswith("bootstrap:cli:")
+
+
+def test_chat_context_uses_chat_session_as_group_not_name():
+    ctx = build_chat_trace_context(
+        session_id="gen_sql_summary_session_ab12cd34",
+        llm_session_id="gen_sql_summary_session_ab12cd34",
+        node_name="gen_sql_summary",
+        datasource="starrocks",
+    )
+
+    assert ctx.name == "chat/gen_sql_summary"
+    assert ctx.session_id == "gen_sql_summary_session_ab12cd34"
+    assert "gen_sql_summary_session_ab12cd34" not in ctx.name
+    assert ctx.metadata["service_session_id"] == "gen_sql_summary_session_ab12cd34"

--- a/tests/unit_tests/utils/test_traceable_utils.py
+++ b/tests/unit_tests/utils/test_traceable_utils.py
@@ -7,6 +7,7 @@
 import sys
 from unittest.mock import MagicMock, patch
 
+from datus.utils.trace_context import TraceContext, get_trace_context
 from datus.utils.traceable_utils import (
     _disable_sdk_tracing,
     _get_langfuse_trace_url,
@@ -479,6 +480,71 @@ class TestOptionalTraceableLangfuse:
 
                 assert add(1, 2) == 3
                 mock_observe.assert_not_called()
+        finally:
+            _restore_langfuse_module(saved)
+
+    def test_context_builder_scopes_context_without_langfuse(self, monkeypatch):
+        """A context_builder still scopes TraceContext when Langfuse export is disabled."""
+        import datus.utils.traceable_utils as module
+
+        monkeypatch.setattr(module, "HAS_LANGFUSE", False)
+        monkeypatch.setattr(module, "_langfuse_enabled", False)
+        seen = {}
+
+        @optional_traceable(
+            name="test_op",
+            context_builder=lambda *_args, **_kwargs: TraceContext(
+                name="cli/run/test",
+                session_id="cli:run:test",
+                tags=("cli", "run"),
+                metadata={"workflow": "test"},
+            ),
+        )
+        def op():
+            seen["ctx"] = get_trace_context()
+            return "ok"
+
+        assert op() == "ok"
+        assert seen["ctx"].name == "cli/run/test"
+        assert get_trace_context() is None
+
+    def test_langfuse_propagates_runtime_attributes(self, monkeypatch):
+        """Langfuse observe receives runtime trace name/session/tags/metadata."""
+        import datus.utils.traceable_utils as module
+
+        monkeypatch.setattr(module, "HAS_LANGFUSE", True)
+        monkeypatch.setattr(module, "_langfuse_enabled", True)
+
+        saved = _ensure_langfuse_module()
+        try:
+            mock_observe = MagicMock(side_effect=lambda *a, **kw: lambda fn: fn)
+            mock_propagate = MagicMock()
+            mock_propagate.return_value.__enter__.return_value = None
+            mock_propagate.return_value.__exit__.return_value = None
+            with (
+                patch("langfuse.observe", mock_observe),
+                patch("langfuse.propagate_attributes", mock_propagate),
+            ):
+
+                @optional_traceable(
+                    name="test_langfuse_op",
+                    context_builder=lambda *_args, **_kwargs: TraceContext(
+                        name="benchmark/baisheng/semantic_model/task-1",
+                        session_id="benchmark:semantic_model_20260520_054027",
+                        tags=("benchmark", "task:1"),
+                        metadata={"task_id": "1", "benchmark_run_id": "semantic_model_20260520_054027"},
+                    ),
+                )
+                def op():
+                    return "ok"
+
+                assert op() == "ok"
+                mock_propagate.assert_called_once()
+                kwargs = mock_propagate.call_args.kwargs
+                assert kwargs["trace_name"] == "benchmark/baisheng/semantic_model/task-1"
+                assert kwargs["session_id"] == "benchmark:semantic_model_20260520_054027"
+                assert kwargs["tags"] == ["benchmark", "task:1"]
+                assert kwargs["metadata"]["task_id"] == "1"
         finally:
             _restore_langfuse_module(saved)
 


### PR DESCRIPTION
## Why

Langfuse traces from benchmark, bootstrap-kb, CLI, and SaaS chat flows were hard to correlate back to the logical Datus operation. Benchmark runs in particular could collapse into a single generic agent workflow trace instead of exposing task/run identity that can be filtered in Langfuse.

## Solution

- Add a shared `TraceContext` runtime helper for trace name, session/group id, tags, and metadata.
- Propagate trace attributes through Langfuse `propagate_attributes` when tracing is enabled.
- Pass the active trace context into OpenAI Agents SDK `RunConfig` as `workflow_name`, `group_id`, and `trace_metadata`.
- Scope trace identities for benchmark tasks, bootstrap-kb components, regular CLI workflow runs, and SaaS chat sessions.
- Add unit coverage for trace naming, grouping, metadata propagation, and RunConfig injection.

## Test Cases

- `uv run ruff check datus/utils/trace_context.py datus/utils/traceable_utils.py datus/agent/workflow_runner.py datus/agent/agent.py datus/api/services/kb_service.py datus/api/services/chat_task_manager.py datus/models/openai_compatible.py datus/models/codex_model.py tests/unit_tests/utils/test_trace_context.py tests/unit_tests/utils/test_traceable_utils.py tests/unit_tests/models/test_openai_compatible.py tests/unit_tests/api/services/test_chat_task_manager.py`
- `uv run pytest tests/unit_tests/utils/test_trace_context.py tests/unit_tests/utils/test_traceable_utils.py tests/unit_tests/models/test_openai_compatible.py::TestBuildRunConfigInputFilter tests/unit_tests/api/services/test_chat_task_manager.py::TestChatTaskManagerBehavior::test_run_loop_emits_final_response_when_no_plain_assistant_response -q`
- `uv run pytest tests/unit_tests/agent/test_agent.py tests/unit_tests/api/services/test_kb_service.py tests/unit_tests/api/services/test_chat_task_manager.py tests/unit_tests/models/test_openai_compatible.py tests/unit_tests/utils/test_trace_context.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system-wide tracing/observability across agents, workflows, benchmarks, knowledge-base bootstrapping, chat sessions, and model/tool runs to improve end-to-end tracking and diagnostics.

* **Tests**
  * Added and updated unit tests to validate trace-context behavior and ensure tracing is correctly applied and cleaned up during operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->