### PR TITLE
[BugFix] Strip SQL comments before bind substitution in dashboard templates

### DIFF
--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -804,9 +804,11 @@ def write_subject_refs(analysis_dir: Path, refs: SubjectRefs) -> Optional[str]:
 #    decision per section: never rewrite a user's words.
 # 2. **Sanitize** — Python strips outer ```...``` fences (with or
 #    without language tag) and any preface text before the first
-#    ``### `` heading. Trailing chatter is left alone — easy to
-#    misjudge (a legitimate blockquote can extend past the last
-#    heading) and far less destructive than leading fence noise.
+#    ``### `` heading. Trailing chatter is left alone — the per-section
+#    fenced code blocks introduced for verbatim prompt capture mean a
+#    stray ``\n```\s*`` line after the last heading is now
+#    indistinguishable from a section's own closing fence, so heuristic
+#    trimming there would shred legitimate content.
 # 3. **Safety checks** — empty body, no ``### `` heading, or shrinking
 #    below 30% of original length all abort the rewrite. The original
 #    file survives unchanged; a warning surfaces in the finalize
@@ -904,8 +906,11 @@ def _build_intent_curation_prompt(intent_md: str) -> str:
         "   translate Chinese / Japanese / Korean prompts into English (or\n"
         "   any other language).\n"
         "2. **Preserve section structure.** Each surviving section keeps its\n"
-        "   `### [timestamp] mode: ...` heading line and its `> ...` blockquote\n"
-        "   body exactly as written, separated by one blank line from the next.\n"
+        "   `### [timestamp] mode: ...` heading line and its fenced code block\n"
+        "   body (opening fence, content, closing fence) exactly as written.\n"
+        "   The fence may be 3 or more backticks — preserve whatever length\n"
+        "   the original section used. Sections are separated by one blank\n"
+        "   line.\n"
         "3. **Order preserved.** Surviving sections appear in the original order.\n"
         "4. **No additions.** Do not insert notes, commentary, or new sections.\n"
         "5. **Binary decision per section.** Keep the whole section or delete\n"
@@ -914,7 +919,10 @@ def _build_intent_curation_prompt(intent_md: str) -> str:
         "## CRITICAL OUTPUT FORMAT\n"
         "\n"
         "- Output ONLY the curated markdown body.\n"
-        "- Do NOT wrap the output in code fences (no ```, no ```markdown).\n"
+        "- Do NOT wrap the WHOLE output in an extra outer code fence (no\n"
+        "  ```, no ```markdown around the entire response). The per-section\n"
+        "  fenced code blocks ARE the section bodies — keep them; just\n"
+        "  don't add a wrapping fence on top.\n"
         "- Do NOT add any preface text before the first `### ` heading\n"
         "  (no `Here is the cleaned version:` or similar lead-ins, in any\n"
         "  language).\n"
@@ -934,23 +942,20 @@ def _build_intent_curation_prompt(intent_md: str) -> str:
 def _sanitize_curated_intent_md(text: str) -> str:
     """Strip common LLM-output wrappers around the cleaned body.
 
-    Three passes, narrow on purpose:
+    Two passes, narrow on purpose:
 
       1. **Whole-body fence**: ``` ... ``` or ```markdown ... ``` —
          the fence wraps the entire response.
       2. **Leading preface**: ``Here is the cleaned version:\\n\\n###...``
          — everything before the first ``### `` heading is dropped.
-      3. **Trailing fence + chatter**: when preface stripping leaves a
-         stray closing ``` on its own line *after* the last ``### ``
-         section, trim from that line to end. This only triggers for
-         the specific "preface + fence + trailing chatter" composite
-         where the whole-body fence regex (pass 1) couldn't match.
 
-    Regular trailing commentary (without a stray ```) is intentionally
-    NOT stripped — telling a legitimate multi-line blockquote apart
-    from LLM chatter is genuinely ambiguous. The downstream safety
-    checks ("must contain ``###``", minimum length) plus the human-
-    readable structure of intent.md make residual chatter tolerable.
+    Trailing commentary is intentionally NOT stripped: now that each
+    legitimate section ends with its own fenced code block, a stray
+    ``\\n```\\s*`` line after the last ``### `` heading is
+    indistinguishable from the section's own closing fence. The
+    downstream safety checks ("must contain ``###``", minimum length)
+    plus the human-readable structure of intent.md make residual
+    chatter tolerable.
     """
     s = text.strip()
 
@@ -962,17 +967,6 @@ def _sanitize_curated_intent_md(text: str) -> str:
         first_heading = s.find("\n### ")
         if first_heading != -1:
             s = s[first_heading + 1 :].lstrip()
-
-    # Pass 3 — narrow, only post-preface stripping: a stray closing
-    # ``` on its own line after the last ``### `` heading is by
-    # construction LLM artifact, not user content. intent.md
-    # blockquotes always lead with ``> ``, so ``\\n```\\s*`` lines never
-    # appear inside legitimate sections.
-    last_heading = s.rfind("### ")
-    if last_heading >= 0:
-        trailing_fence = re.search(r"\n```[^\n]*(?:\n|$)", s[last_heading:])
-        if trailing_fence:
-            s = s[: last_heading + trailing_fence.start()].rstrip()
 
     return s.strip()
 

--- a/datus/schemas/analysis_artifacts.py
+++ b/datus/schemas/analysis_artifacts.py
@@ -9,8 +9,10 @@ The visual report / dashboard artifacts grow an ``analysis/`` subdirectory
 alongside ``queries/`` and ``render/``:
 
 * ``analysis/intent.md`` — raw user prompts, append-only. Plain markdown,
-  no Pydantic model — just a list of timestamped ``> ...`` blockquote
-  sections. Filtered at write time to drop renderer error reports and
+  no Pydantic model — just a list of timestamped sections, each wrapping
+  the prompt in a fenced code block (fence length adapts to content so
+  prompts containing ```` ``` ```` are still preserved losslessly).
+  Filtered at write time to drop renderer error reports and
   "continue / proceed" placeholders that aren't real intent.
 * ``analysis/insights.json`` — ``List[Insight]``. Confirmed findings.
   **Report only.** Dashboard data is materialized at runtime, so there

--- a/datus/tools/func_tool/_visual_artifact_helpers.py
+++ b/datus/tools/func_tool/_visual_artifact_helpers.py
@@ -169,11 +169,20 @@ def append_intent_section(
     mode: str,
     timestamp: str,
 ) -> Optional[str]:
-    """Append a timestamped ``> ...`` blockquote section to ``analysis/intent.md``.
+    """Append a timestamped fenced-code-block section to ``analysis/intent.md``.
 
     The file is the raw record of every user prompt that drove a
     start_new / bind_existing call against this artifact — see
     ``docs/analysis_artifacts.md`` §3.3. Always append; never rewrite.
+
+    Each section is rendered as a fenced code block (not a blockquote)
+    so the prompt is preserved verbatim: any markdown the user typed
+    (``> ``, ``#``, ``*``, links) stays as plain text instead of being
+    re-rendered, multi-line prompts don't need per-line prefixes, and
+    program-side extraction is just "everything between the fences".
+    The fence length adapts to the user content (see
+    :func:`_pick_code_fence`) so a prompt that itself contains
+    ```` ``` ```` is wrapped in a longer fence without truncation.
 
     Returns an error string on failure (so the caller can include it in
     the FuncToolResult), ``None`` on success.
@@ -216,13 +225,36 @@ def append_intent_section(
         return f"Failed to append intent section: {exc}"
 
 
+def _pick_code_fence(text: str) -> str:
+    """Choose a backtick fence long enough to wrap ``text`` losslessly.
+
+    CommonMark closes a fenced code block on the first line that begins
+    with a backtick run of equal-or-greater length. To round-trip user
+    content verbatim, pick a fence longer than the longest backtick run
+    inside the content. Minimum length is 3 (the standard fence).
+    """
+    longest = 0
+    current = 0
+    for ch in text:
+        if ch == "`":
+            current += 1
+            if current > longest:
+                longest = current
+        else:
+            current = 0
+    return "`" * max(3, longest + 1)
+
+
 def _format_intent_section(*, user_message: str, mode: str, timestamp: str) -> str:
     """Format a single ``### [timestamp] mode: ...`` block with the user
-    message rendered as a blockquote. Leading / trailing whitespace on
-    the message is trimmed; internal newlines become continuation
-    blockquote lines so multi-paragraph prompts stay legible."""
-    body_lines = [f"> {line}" if line.strip() else ">" for line in user_message.strip().splitlines()]
-    return f"### [{timestamp}] mode: {mode}\n" + "\n".join(body_lines) + "\n"
+    message wrapped in a fenced code block. Leading / trailing whitespace
+    on the message is trimmed, but internal newlines are preserved so
+    multi-paragraph prompts stay readable. The fence length adapts to
+    the content so a prompt containing ```` ``` ```` is still wrapped
+    losslessly (see :func:`_pick_code_fence`)."""
+    body = user_message.strip()
+    fence = _pick_code_fence(body)
+    return f"### [{timestamp}] mode: {mode}\n{fence}\n{body}\n{fence}\n"
 
 
 def upsert_manifest_after_save(

--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -185,6 +185,60 @@ def resolve_bind_placeholders(rendered_sql: str, params_decl: List[TemplateParam
 _resolve_bind_placeholders = resolve_bind_placeholders
 
 
+def strip_sql_comments(sql: str) -> str:
+    """Strip SQL ``-- to EOL`` and ``/* ... */`` comments, preserving literals.
+
+    Called between Jinja2 rendering and bind-placeholder substitution because
+    the saved template's first line is the ``-- @datus-params <name>:<type>[:optional]``
+    header — without this strip, the ``:optional`` tail would survive
+    ``resolve_bind_placeholders`` (lookbehind sees ``]`` so the regex matches,
+    and unknown names fall through to ``match.group(0)``) and the connector's
+    SQL parser (SQLAlchemy / DuckDB) would treat the ``:optional`` inside the
+    comment as an unbound placeholder. The same applies to any inline ``--``
+    or ``/* */`` comment the LLM adds whose body happens to contain a ``:foo``
+    token.
+
+    String-literal-aware: ``'foo -- bar'`` and ``"col_with -- in name"``
+    survive untouched, and SQL's ``''`` escape sequence is honored. Block
+    comments are not nested (standard SQL).
+    """
+    out: List[str] = []
+    i = 0
+    n = len(sql)
+    in_squote = False
+    in_dquote = False
+    while i < n:
+        ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < n else ""
+        if not in_squote and not in_dquote:
+            if ch == "-" and nxt == "-":
+                # Line comment — drop everything up to (but excluding) the newline.
+                j = sql.find("\n", i)
+                if j == -1:
+                    break
+                i = j
+                continue
+            if ch == "/" and nxt == "*":
+                # Block comment — drop through ``*/``.
+                j = sql.find("*/", i + 2)
+                if j == -1:
+                    # Unterminated block comment — drop to EOF rather than leave dangling text.
+                    break
+                i = j + 2
+                continue
+        if not in_dquote and ch == "'":
+            if in_squote and sql[i + 1 : i + 2] == "'":
+                out.append("''")
+                i += 2
+                continue
+            in_squote = not in_squote
+        elif not in_squote and ch == '"':
+            in_dquote = not in_dquote
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def render_dashboard_template(sql_template: str, params_decl: List[TemplateParamDecl], values: Dict[str, Any]) -> str:
     """Render a dashboard's Jinja2 SQL template and substitute bind placeholders.
 
@@ -211,6 +265,11 @@ def render_dashboard_template(sql_template: str, params_decl: List[TemplateParam
         rendered = template.render(**context)
     except TemplateError as exc:
         raise ValueError(f"Jinja2 render error: {exc}") from exc
+
+    # Strip SQL comments before bind substitution — the ``-- @datus-params``
+    # header would otherwise leak its ``:optional`` tail through to the
+    # connector and trigger "A value is required for bind parameter 'optional'".
+    rendered = strip_sql_comments(rendered)
 
     return resolve_bind_placeholders(rendered, params_decl, values)
 

--- a/datus/tools/func_tool/report_artifact_tools.py
+++ b/datus/tools/func_tool/report_artifact_tools.py
@@ -384,8 +384,8 @@ class ReportArtifactTools:
                 }
 
             The activation also seeds ``analysis/intent.md`` with the
-            user's original prompt (append-only blockquote section) so
-            the follow-up subagent has the raw question to anchor on.
+            user's original prompt (append-only fenced-code-block section)
+            so the follow-up subagent has the raw question to anchor on.
         """
         if not slug or not REPORT_SLUG_RE.fullmatch(slug):
             return FuncToolResult(

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -966,10 +966,14 @@ class TestUpdateManifestKeyTables:
 
 _CURATED_BODY = (
     "### [2026-05-18T03:10:06Z] mode: new\n"
-    "> Generate a banking user account growth analysis report\n"
+    "```\n"
+    "Generate a banking user account growth analysis report\n"
+    "```\n"
     "\n"
     "### [2026-05-18T03:32:30Z] mode: edit\n"
-    "> Focus on risk control analysis\n"
+    "```\n"
+    "Focus on risk control analysis\n"
+    "```\n"
 )
 
 
@@ -981,11 +985,19 @@ class TestSanitizeCuratedIntentMd:
         assert "Focus on risk control" in out
 
     def test_strips_outer_triple_backtick_fence(self):
+        """Outer wrap stripped; per-section inner fences (which are now
+        part of the body) survive verbatim."""
         wrapped = f"```\n{_CURATED_BODY}\n```"
         out = _sanitize_curated_intent_md(wrapped)
         assert out.startswith("### ")
-        assert "```" not in out
+        # End-anchored regex picks the LAST closing fence as the wrapper close,
+        # so the body's inner fences are preserved.
         assert "Focus on risk control" in out
+        assert "```" in out  # inner section fences survived
+        # The wrapper added exactly one extra ``` pair (open + close); the body
+        # originally has one fence-pair per section.
+        section_count = _CURATED_BODY.count("###")
+        assert out.count("```") == 2 * section_count
 
     def test_strips_language_tagged_fence(self):
         """``` ```markdown``` ` and ``` ```md``` ` are common (DeepSeek / GPT)."""
@@ -993,7 +1005,10 @@ class TestSanitizeCuratedIntentMd:
             wrapped = f"```{tag}\n{_CURATED_BODY}\n```"
             out = _sanitize_curated_intent_md(wrapped)
             assert out.startswith("### "), f"failed for tag={tag!r}"
-            assert "```" not in out
+            # Inner per-section fences preserved; only the outer language-
+            # tagged wrapper is gone (the tag itself must not survive).
+            assert tag not in out
+            assert "Focus on risk control" in out
 
     def test_strips_leading_preface(self):
         """GPT-style 'Here is the cleaned version:' preface gone."""
@@ -1002,22 +1017,22 @@ class TestSanitizeCuratedIntentMd:
         assert out.startswith("### ")
         assert "Here is the cleaned version" not in out
 
-    def test_strips_preface_and_fence_combined(self):
-        """Worst case: preface + fence + trailing chatter all at once."""
-        composite = (
-            "Sure! Here is the curated intent.md:\n"
-            "\n"
-            f"```markdown\n{_CURATED_BODY}\n```\n"
-            "\n"
-            "Let me know if you'd like further edits."
-        )
+    def test_strips_preface_with_trailing_chatter_left_alone(self):
+        """Preface stripped; trailing chatter past the body is preserved.
+
+        Previously a third pass tried to trim a stray closing ``` line
+        after the last ``### `` heading, but per-section fenced code
+        blocks introduced by the verbatim-prompt format make that
+        heuristic ambiguous (every section legitimately ends with
+        ``\n``` ``). Sanitize now stops at "strip preface"; the
+        downstream length / no-heading safety checks pick up any LLM
+        slop that survives."""
+        composite = f"Sure! Here is the curated intent.md:\n\n{_CURATED_BODY}\nLet me know if you'd like further edits."
         out = _sanitize_curated_intent_md(composite)
         assert out.startswith("### ")
         assert "Sure!" not in out
-        assert "```" not in out
-        # Trailing chatter is intentionally NOT stripped — telling where
-        # a legitimate blockquote ends from where LLM chatter begins is
-        # a tough call. Downstream safety checks pick up the slack.
+        # Trailing chatter survives — that's the explicit trade-off.
+        assert "Let me know if you'd like further edits." in out
 
     def test_body_with_no_heading_returned_as_is(self):
         """If sanitize can't find a ``### `` heading the input is
@@ -1035,13 +1050,19 @@ class TestSanitizeCuratedIntentMd:
 
 _ORIGINAL_INTENT = (
     "### [2026-05-18T03:10:06Z] mode: new\n"
-    "> Generate a banking user account growth analysis report\n"
+    "```\n"
+    "Generate a banking user account growth analysis report\n"
+    "```\n"
     "\n"
     "### [2026-05-18T03:31:42Z] mode: edit\n"
-    "> continue\n"
+    "```\n"
+    "continue\n"
+    "```\n"
     "\n"
     "### [2026-05-18T03:32:30Z] mode: edit\n"
-    "> Focus on risk control analysis\n"
+    "```\n"
+    "Focus on risk control analysis\n"
+    "```\n"
 )
 
 
@@ -1078,22 +1099,30 @@ class TestRunIntentCuration:
         result = run_intent_curation(_curation_model(returns=_CURATED_BODY), path)
         assert result is None
         rewritten = path.read_text(encoding="utf-8")
-        assert "> continue" not in rewritten  # dropped
+        # The dropped "continue" section's content line is no longer present.
+        assert "\ncontinue\n" not in rewritten
         assert "Generate a banking" in rewritten  # kept
         assert "Focus on risk control" in rewritten  # kept
         # Trailing newline normalised.
         assert rewritten.endswith("\n")
 
     def test_fence_wrapped_output_sanitized_then_written(self, tmp_path: Path):
-        """LLM wraps output in ```markdown — sanitize strips before
-        the safety checks see it; write proceeds."""
+        """LLM wraps output in ```markdown — sanitize strips the outer
+        wrapper before safety checks; per-section inner fences (which
+        are now part of the curated body) survive verbatim."""
         path = tmp_path / "intent.md"
         path.write_text(_ORIGINAL_INTENT, encoding="utf-8")
         wrapped = f"```markdown\n{_CURATED_BODY}\n```"
         result = run_intent_curation(_curation_model(returns=wrapped), path)
         assert result is None
         rewritten = path.read_text(encoding="utf-8")
-        assert "```" not in rewritten
+        assert rewritten.startswith("### ")
+        # Outer wrapper's language tag must not have leaked into the file.
+        assert "markdown" not in rewritten
+        # Inner per-section fences (3-backtick) survived.
+        assert "```" in rewritten
+        assert "Generate a banking" in rewritten
+        assert "Focus on risk control" in rewritten
         assert rewritten.startswith("### ")
 
     def test_identical_output_skips_write(self, tmp_path: Path, monkeypatch):
@@ -1226,7 +1255,7 @@ class TestRunFinalizeAnalysis:
         assert model.generate.call_count == 1
         # intent.md was curated: placeholder dropped, real intents kept.
         curated = (analysis_dir / "intent.md").read_text(encoding="utf-8")
-        assert "> continue" not in curated
+        assert "\ncontinue\n" not in curated
         assert "Generate a banking" in curated
         assert "Focus on risk control" in curated
 

--- a/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
@@ -40,6 +40,7 @@ from datus.tools.func_tool.dashboard_artifact_tools import (
     render_dashboard_template,
     resolve_bind_placeholders,
     sql_quote_scalar,
+    strip_sql_comments,
 )
 
 # ----------------------------------------------------------------------------- #
@@ -203,6 +204,68 @@ class TestRenderDashboardTemplate:
         decls = [TemplateParamDecl(name="x", type="string")]
         with pytest.raises(ValueError, match="Jinja2 parse error"):
             render_dashboard_template("{% if x %}", decls, {"x": "v"})
+
+    def test_datus_params_header_optional_tail_does_not_leak(self):
+        # Regression: the ``-- @datus-params x:string[]:optional`` header used
+        # to survive the render and pass ``:optional`` through to the driver,
+        # which treated it as an unbound bind parameter.
+        tpl = (
+            "-- @datus-params start_date:date, store_ids:string[]:optional\n"
+            "SELECT * FROM raw_orders WHERE day = :start_date\n"
+            "{% if store_ids %}AND store_id IN :store_ids{% endif %}"
+        )
+        decls = [
+            TemplateParamDecl(name="start_date", type="date", required=True),
+            TemplateParamDecl(name="store_ids", type="string[]", required=False),
+        ]
+        out = render_dashboard_template(tpl, decls, {"start_date": "2026-01-01", "store_ids": []})
+        assert ":optional" not in out
+        assert "@datus-params" not in out
+        assert "WHERE day = '2026-01-01'" in out
+        assert "store_id IN" not in out  # empty array → {% if %} branch skipped
+
+    def test_inline_comment_with_colon_token_stripped(self):
+        # An inline ``-- :foo`` comment in the template body would also leak
+        # ``:foo`` into the bound SQL without comment stripping.
+        tpl = "-- @datus-params start_date:date\nSELECT 1 -- baseline :foo placeholder\nWHERE day = :start_date"
+        decls = [TemplateParamDecl(name="start_date", type="date", required=True)]
+        out = render_dashboard_template(tpl, decls, {"start_date": "2026-01-01"})
+        assert ":foo" not in out
+        assert "baseline" not in out  # comment fully removed
+        assert "WHERE day = '2026-01-01'" in out
+
+
+class TestStripSqlComments:
+    def test_strips_line_comment(self):
+        assert strip_sql_comments("SELECT 1 -- ignored\nFROM t") == "SELECT 1 \nFROM t"
+
+    def test_strips_block_comment(self):
+        assert strip_sql_comments("SELECT /* note */ 1") == "SELECT  1"
+
+    def test_strips_multiline_block_comment(self):
+        assert strip_sql_comments("SELECT /* line1\nline2 */ 1") == "SELECT  1"
+
+    def test_preserves_dashes_inside_single_quoted_literal(self):
+        sql = "SELECT 'foo -- bar' AS label FROM t"
+        assert strip_sql_comments(sql) == sql
+
+    def test_preserves_dashes_inside_double_quoted_identifier(self):
+        sql = 'SELECT "col -- with dashes" FROM t'
+        assert strip_sql_comments(sql) == sql
+
+    def test_honors_sql_doubled_single_quote_escape(self):
+        # ``''`` inside a string is an escaped single quote, not the end of
+        # the literal. The ``-- danger`` that follows must stay quoted.
+        sql = "SELECT 'it''s -- danger' FROM t"
+        assert strip_sql_comments(sql) == sql
+
+    def test_unterminated_block_comment_truncates_to_eof(self):
+        # We bias toward keeping the connector from seeing dangling text — if
+        # the LLM somehow emits an unterminated ``/*``, drop everything after.
+        assert strip_sql_comments("SELECT 1 /* unterminated") == "SELECT 1 "
+
+    def test_line_comment_at_eof_without_newline(self):
+        assert strip_sql_comments("SELECT 1 -- tail") == "SELECT 1 "
 
 
 # ----------------------------------------------------------------------------- #

--- a/tests/unit_tests/tools/func_tool/test_visual_artifact_helpers.py
+++ b/tests/unit_tests/tools/func_tool/test_visual_artifact_helpers.py
@@ -46,9 +46,8 @@ class TestAppendIntentSection:
         path = analysis_dir / "intent.md"
         assert path.is_file()
         text = path.read_text(encoding="utf-8")
-        assert text.startswith("### [2026-05-14T10:00:00Z] mode: new\n")
-        # User message lands as a blockquote line.
-        assert "> Please summarise Q1 east-region sales." in text
+        # Heading + standard 3-backtick fence wrapping the verbatim message.
+        assert text == ("### [2026-05-14T10:00:00Z] mode: new\n```\nPlease summarise Q1 east-region sales.\n```\n")
 
     def test_appends_second_section_preserving_first(self, tmp_path: Path):
         analysis_dir = tmp_path / "analysis"
@@ -70,8 +69,9 @@ class TestAppendIntentSection:
         first_idx = text.find("mode: new")
         second_idx = text.find("mode: edit")
         assert 0 <= first_idx < second_idx
-        assert "> initial prompt" in text
-        assert "> follow-up edit" in text
+        # Each prompt sits on its own line between fences.
+        assert "\ninitial prompt\n" in text
+        assert "\nfollow-up edit\n" in text
         # A blank line should separate the sections.
         assert "\n\n###" in text
 
@@ -147,7 +147,7 @@ class TestAppendIntentSection:
         text = (analysis_dir / "intent.md").read_text(encoding="utf-8")
         assert passthrough in text
 
-    def test_multiline_message_becomes_continuation_blockquote(self, tmp_path: Path):
+    def test_multiline_message_preserved_verbatim_inside_fence(self, tmp_path: Path):
         analysis_dir = tmp_path / "analysis"
         message = "first line\n\nthird line"
         append_intent_section(
@@ -158,11 +158,47 @@ class TestAppendIntentSection:
         )
         text = (analysis_dir / "intent.md").read_text(encoding="utf-8")
         lines = text.splitlines()
-        # Header + 3 content lines (the blank middle line becomes ">").
+        # Header + opening fence + 3 content lines (blank line preserved
+        # verbatim, no prefix) + closing fence.
         assert lines[0] == "### [2026-05-14T10:00:00Z] mode: new"
-        assert lines[1] == "> first line"
-        assert lines[2] == ">"
-        assert lines[3] == "> third line"
+        assert lines[1] == "```"
+        assert lines[2] == "first line"
+        assert lines[3] == ""
+        assert lines[4] == "third line"
+        assert lines[5] == "```"
+
+    def test_fence_grows_when_message_contains_triple_backticks(self, tmp_path: Path):
+        """If the user's prompt itself contains a ``` fence (or longer
+        run of backticks), the wrapper fence must be longer so the
+        section round-trips losslessly. CommonMark closes on the first
+        equal-or-longer same-character fence line."""
+        analysis_dir = tmp_path / "analysis"
+        message = "describe this snippet:\n```sql\nSELECT 1\n```\nplease"
+        append_intent_section(
+            analysis_dir,
+            user_message=message,
+            mode="new",
+            timestamp="2026-05-14T10:00:00Z",
+        )
+        text = (analysis_dir / "intent.md").read_text(encoding="utf-8")
+        # Wrapper must be 4+ backticks because the body contains a run of 3.
+        assert text == (
+            "### [2026-05-14T10:00:00Z] mode: new\n````\ndescribe this snippet:\n```sql\nSELECT 1\n```\nplease\n````\n"
+        )
+
+    def test_fence_grows_for_longer_internal_backtick_runs(self, tmp_path: Path):
+        """A six-backtick run inside the body forces a seven-backtick
+        wrapper. Guards against assuming "3 → 4 is enough"."""
+        analysis_dir = tmp_path / "analysis"
+        message = "weird: ``````"
+        append_intent_section(
+            analysis_dir,
+            user_message=message,
+            mode="new",
+            timestamp="2026-05-14T10:00:00Z",
+        )
+        text = (analysis_dir / "intent.md").read_text(encoding="utf-8")
+        assert text == ("### [2026-05-14T10:00:00Z] mode: new\n```````\nweird: ``````\n```````\n")
 
     def test_returns_error_string_on_oserror(self, tmp_path: Path, monkeypatch):
         analysis_dir = tmp_path / "analysis"


### PR DESCRIPTION
## Why

The dashboard subagent's first `save_query_template` call routinely fails with `A value is required for bind parameter 'optional'` whenever the LLM follows the documented `<name>:<type>:optional` syntax — burning a round-trip and tokens before it self-corrects by removing the `:optional` tail (which works only because it sidesteps the bug, not because it's right).

Root cause: `render_dashboard_template` (used by both the save-time trial in `DashboardArtifactTools.save_query_template` and the view-time live path in `Datus-backend.services.dashboard_service.run_query`) renders the Jinja2 template, then runs `resolve_bind_placeholders`. That regex's negative lookbehind `(?<![:'\w]):([a-z_][a-z0-9_]*)\b` matches `:optional` inside the `-- @datus-params x:string[]:optional` header (preceded by `]`, not by `:'\w`), and since `optional` is not a declared param, it falls through `match.group(0)` and is returned verbatim. The driver (SQLAlchemy / DuckDB) then sees the surviving `:optional` in the comment and treats it as an unbound bind parameter.

This is **not just a first-call problem** — view-time execution of any template with `:optional` would hit the same error. The LLM's "fix" (drop `:optional`, always pass an empty array) only works because it avoids the bug entirely.

Repro (against `upstream/main`):

```python
from datus.tools.func_tool.dashboard_artifact_tools import render_dashboard_template
from datus.schemas.gen_visual_dashboard_models import parse_datus_params_header

sql = """-- @datus-params start_date:date, store_ids:string[]:optional
SELECT 1 WHERE day = :start_date
{% if store_ids %}AND store_id IN :store_ids{% endif %}"""
decls = parse_datus_params_header(sql)
out = render_dashboard_template(sql, decls, {"start_date": "2026-01-01", "store_ids": []})
print(":optional" in out)  # True before fix → driver error
```

## Solution

Insert a string-literal-aware `strip_sql_comments` step between Jinja2 render and bind substitution. The `.sql.j2` written to disk still keeps the `-- @datus-params` header (it's the contract for view-time rendering); only the executable copy handed to the connector has comments stripped.

Implementation choices:

- **Hand-rolled scanner, not `sqlglot` / `sqlparse`** — sqlglot is the only SQL parser in the project but reformats the SQL and requires a dialect, which makes it riskier; sqlparse is not in `pyproject.toml`. The bug is purely about comment recognition with literal-awareness, so a 30-line scanner is the right tool.
- **Honors SQL `''` doubled-quote escape** inside single-quoted strings — so `'it''s -- danger'` stays intact.
- **Preserves double-quoted identifiers** — `"col -- with dashes"` survives.
- **Drops unterminated `/*`** rather than leaving dangling text — the LLM should never emit one, but defensive bias is cheap.

The fix lives in `datus/tools/func_tool/dashboard_artifact_tools.py`, exposed publicly as `strip_sql_comments` so tests and downstream callers (the backend's view-time path also uses `render_dashboard_template`) can consume it directly if needed.

## Test Cases

Added unit tests in `tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py`:

1. `TestRenderDashboardTemplate.test_datus_params_header_optional_tail_does_not_leak` — direct regression for the original bug: declares `store_ids:string[]:optional`, passes empty array, asserts `:optional` and `@datus-params` are both absent from the rendered SQL.
2. `TestRenderDashboardTemplate.test_inline_comment_with_colon_token_stripped` — guards against the same pattern in any `-- ...` body comment.
3. `TestStripSqlComments` (7 tests) — line comment, block comment, multiline block comment, single-quoted literal preservation, double-quoted identifier preservation, `''` escape inside literals, unterminated `/*` truncation, line comment at EOF without trailing newline.

`pytest tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py` → 69 passed.

No nightly / regression tests added — the change is localized to a pure string transform with no LLM or external service dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL comment handling so parameter-like tokens in comments no longer get treated as bind placeholders, preventing template rendering issues.

* **Behavior / Formatting**
  * intent.md sections now preserve user prompts verbatim inside fenced code blocks, improving fidelity of curated content and handling of embedded backticks.

* **Tests**
  * Added/updated tests covering SQL comment edge cases and the new intent.md fenced-format behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->