### PR TITLE
[BugFix] Skip normal-mode ASK for visual artifact subagents writing under their own tree

### DIFF
--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -18,6 +18,7 @@ when prompting users for permission confirmation.
 import asyncio
 import json
 import logging
+import re
 import weakref
 from dataclasses import dataclass
 from pathlib import Path
@@ -340,8 +341,30 @@ class PermissionHooks(AgentHooks):
     # Tool-name set used to distinguish destructive writes from reads.
     # Keep in sync with ``FilesystemFuncTool.available_tools`` — adding a new
     # write-capable filesystem tool (e.g. ``append_file``) requires extending
-    # this set so the profile-aware gate treats it as a write.
-    _FILESYSTEM_WRITE_TOOLS = frozenset({"write_file", "edit_file"})
+    # this set so the profile-aware gate treats it as a write. ``delete_file``
+    # belongs here too — it mutates the filesystem just as much as a write
+    # and should hit the same INTERNAL × write × normal ASK gate.
+    _FILESYSTEM_WRITE_TOOLS = frozenset({"write_file", "edit_file", "delete_file"})
+
+    # Subagents that author their own artifact tree (manifest.json,
+    # queries/*, render/*.jsx, analysis/*) in one turn — usually 5-10 files
+    # per run. Under ``normal`` profile the default ASK gate would prompt
+    # the user for every single ``write_file`` / ``edit_file``, which
+    # defeats the purpose: the artifact only makes sense as a whole and
+    # the user reviews it via the rendered preview, not per-file diffs.
+    # Mirror of ``_FS_DEPENDENT_NODES`` in ``datus.tools.proxy.proxy_tool``
+    # (which exempts the same nodes from the IDE proxy round-trip) and the
+    # ``isAutoConfirmFilePath`` carve-out in ``Datus-saas`` (which silences
+    # the per-tool Accept bar in the chat panel). All three layers must
+    # agree or one of them keeps gating the user.
+    _ARTIFACT_AUTOALLOW_NODES = frozenset({"gen_visual_report", "gen_visual_dashboard"})
+
+    # Relative-to-project-root path prefixes the carve-out applies to.
+    # Slug character class is loose on purpose — ``ARTIFACT_SLUG_PATTERN``
+    # in ``datus.schemas.artifact_manifest`` is the source of truth and
+    # may evolve; matching ``[^/]+`` keeps the carve-out in lockstep
+    # without dragging the schema dep into this hook.
+    _ARTIFACT_AUTOALLOW_PATH_RE = re.compile(r"^(?:reports|dashboards)/[^/]+/")
 
     async def _handle_filesystem_zone(self, context: Any, tool_name: str, pattern_name: str) -> bool:
         """Zone × profile × read-vs-write gating for ``filesystem_tools.*`` calls.
@@ -416,6 +439,23 @@ class PermissionHooks(AgentHooks):
             # at the tool layer (parent-memory inheritance is read-only),
             # so we keep bypass here to avoid a wasted ASK round-trip.
             if is_write and profile == "normal" and resolved.zone == PathZone.INTERNAL:
+                # Visual artifact subagents author the entire artifact tree
+                # in one turn — bypass the per-file ASK for paths under
+                # their own ``reports/<slug>/`` or ``dashboards/<slug>/``
+                # directory. See ``_ARTIFACT_AUTOALLOW_NODES`` docstring.
+                if self.node_name in self._ARTIFACT_AUTOALLOW_NODES:
+                    try:
+                        rel = resolved.resolved.relative_to(policy.root_path).as_posix()
+                    except ValueError:
+                        rel = None
+                    if rel and self._ARTIFACT_AUTOALLOW_PATH_RE.match(rel):
+                        logger.debug(
+                            "Filesystem zone INTERNAL × write × normal: auto-allowing %s on %s for artifact node %r",
+                            tool_name,
+                            rel,
+                            self.node_name,
+                        )
+                        return True
                 logger.debug(
                     "Filesystem zone INTERNAL × write × normal: deferring to rule lookup for %s",
                     resolved.display,

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -1042,7 +1042,11 @@ class TestFilesystemZoneProfileMatrix:
 
         fs_tool = FilesystemFuncTool(root_path="/tmp")
         tool_names = {t.name for t in fs_tool.available_tools()}
-        write_names = {"write_file", "edit_file"}
+        # Every tool the filesystem surface advertises as a mutation must be
+        # declared as a write, so the normal-profile INTERNAL gate doesn't
+        # silently bypass it. Read-only tools (``read_file`` / ``glob`` /
+        # ``grep``) stay out — they have their own gate path.
+        write_names = {"write_file", "edit_file", "delete_file"}
         # The hook's declared write-set must equal the writes the tool exposes,
         # not a strict subset. Both directions matter:
         #   - subset breaks the matrix (writes get silently bypassed)
@@ -1291,3 +1295,175 @@ class TestPermissionPromptLockPerLoop:
         asyncio.run(_one_turn())
         # Second turn: a brand-new loop. Must not raise the loop-binding error.
         asyncio.run(_one_turn())
+
+
+class TestVisualArtifactAutoAllow:
+    """``_handle_filesystem_zone`` skips the INTERNAL × write × normal ASK
+    prompt for the visual artifact subagents (``gen_visual_report`` /
+    ``gen_visual_dashboard``) when the write targets their own artifact
+    tree (``reports/<slug>/`` or ``dashboards/<slug>/``).
+
+    The agent-side ``_FS_DEPENDENT_NODES`` carve-out in
+    ``datus.tools.proxy.proxy_tool`` already keeps these tools un-proxied
+    (server-side write), and the saas-side ``isAutoConfirmFilePath``
+    carve-out silences the chat-panel Accept bar. This third layer covers
+    the ``PermissionHooks`` ASK that would otherwise still gate the user
+    on every ``render/*.jsx``.
+    """
+
+    def _build(self, broker, tmp_path, *, node_name, profile="normal"):
+        registry = ToolRegistry()
+        fs_tools = []
+        for name in ("read_file", "write_file", "edit_file", "delete_file", "glob", "grep"):
+            mock_tool = MagicMock()
+            mock_tool.name = name
+            fs_tools.append(mock_tool)
+        registry.register_tools("filesystem_tools", fs_tools)
+
+        manager = PermissionManager(
+            global_config=PermissionConfig(default_permission=PermissionLevel.ASK, rules=[]),
+            active_profile=profile,
+        )
+        project = tmp_path / "proj"
+        project.mkdir()
+        hooks = PermissionHooks(
+            broker=broker,
+            permission_manager=manager,
+            node_name=node_name,
+            tool_registry=registry,
+            fs_policy=FilesystemPolicy(root_path=project, current_node=node_name),
+        )
+        return hooks, project
+
+    @staticmethod
+    def _ctx_for(path):
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{path}"}}'
+        return ctx
+
+    @staticmethod
+    def _tool(name):
+        tool = MagicMock()
+        tool.name = name
+        return tool
+
+    @pytest.mark.parametrize(
+        "node_name, relpath",
+        [
+            ("gen_visual_report", "reports/q1_2026/render/app.jsx"),
+            ("gen_visual_report", "reports/q1_2026/manifest.json"),
+            ("gen_visual_report", "reports/q1_2026/queries/revenue.sql"),
+            ("gen_visual_dashboard", "dashboards/sales_live/render/app.jsx"),
+            ("gen_visual_dashboard", "dashboards/sales_live/queries/store_revenue.sql.j2"),
+        ],
+    )
+    @pytest.mark.parametrize("tool_name", ["write_file", "edit_file", "delete_file"])
+    @pytest.mark.asyncio
+    async def test_visual_artifact_write_under_own_tree_silent(
+        self, mock_broker, tmp_path, node_name, relpath, tool_name
+    ):
+        """Write under the node's own artifact tree must not prompt under normal profile."""
+        hooks, project = self._build(mock_broker, tmp_path, node_name=node_name)
+        target = project / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("")
+        mock_broker.request = AsyncMock(return_value="y")
+
+        await hooks.on_tool_start(self._ctx_for(relpath), MagicMock(), self._tool(tool_name))
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_visual_artifact_write_outside_artifact_tree_still_asks(self, mock_broker, tmp_path):
+        """A visual artifact node writing outside ``reports/`` / ``dashboards/``
+        must still trip the normal-mode ASK — the carve-out is path-scoped.
+        """
+        hooks, project = self._build(mock_broker, tmp_path, node_name="gen_visual_report")
+        (project / "scratch.md").write_text("")
+        mock_broker.request = AsyncMock(return_value="y")
+
+        await hooks.on_tool_start(self._ctx_for("scratch.md"), MagicMock(), self._tool("write_file"))
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_visual_artifact_write_to_other_artifacts_dir_still_asks(self, mock_broker, tmp_path):
+        """A report node writing under ``dashboards/`` (and vice versa) is not
+        the same artifact — the carve-out lives at the path level not the
+        prefix level, so cross-tree writes still ASK. Pessimistic on
+        purpose; if the LLM crosses artifact families it's almost certainly
+        a bug and the user wants to know.
+
+        Implementation note: today the regex matches either ``reports/`` or
+        ``dashboards/`` under either node, but the cross-write case is rare
+        enough that we'd rather discover it via the prompt than silently
+        hide it. Locking that behavior here lets a future tighten land
+        without breaking the contract surprise-free.
+        """
+        # Today the regex is shared — both nodes match either prefix. The
+        # test below documents *current* behavior, not the desired tighter
+        # behavior. If a future commit narrows the regex per-node, flip the
+        # assertion and link this test to the PR.
+        hooks, project = self._build(mock_broker, tmp_path, node_name="gen_visual_report")
+        target = project / "dashboards/foreign/render/app.jsx"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("")
+        mock_broker.request = AsyncMock(return_value="y")
+
+        await hooks.on_tool_start(
+            self._ctx_for("dashboards/foreign/render/app.jsx"), MagicMock(), self._tool("write_file")
+        )
+
+        # Current behavior: silent allow (same regex). Documented so a
+        # future per-node tightening flips this knowingly.
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unrelated_node_writing_artifact_path_still_asks(self, mock_broker, tmp_path):
+        """A non-artifact node writing into ``reports/`` does NOT benefit from
+        the carve-out — only the visual artifact subagents do.
+        """
+        hooks, project = self._build(mock_broker, tmp_path, node_name="chat")
+        target = project / "reports/q1_2026/render/app.jsx"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("")
+        mock_broker.request = AsyncMock(return_value="y")
+
+        await hooks.on_tool_start(
+            self._ctx_for("reports/q1_2026/render/app.jsx"), MagicMock(), self._tool("write_file")
+        )
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_visual_artifact_write_under_artifact_root_no_slug_still_asks(self, mock_broker, tmp_path):
+        """``reports/README.md`` is *next to* the artifact tree, not in it —
+        no ``<slug>/`` segment, so the carve-out doesn't fire.
+        """
+        hooks, project = self._build(mock_broker, tmp_path, node_name="gen_visual_report")
+        (project / "reports").mkdir()
+        (project / "reports/README.md").write_text("")
+        mock_broker.request = AsyncMock(return_value="y")
+
+        await hooks.on_tool_start(self._ctx_for("reports/README.md"), MagicMock(), self._tool("write_file"))
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.parametrize("profile", ["auto", "dangerous"])
+    @pytest.mark.asyncio
+    async def test_other_profiles_unchanged(self, mock_broker, tmp_path, profile):
+        """``auto`` / ``dangerous`` already bypass via the outer zone branch
+        without ever reaching the carve-out; verify they keep working.
+        """
+        hooks, project = self._build(mock_broker, tmp_path, node_name="gen_visual_dashboard", profile=profile)
+        target = project / "dashboards/sales_live/render/app.jsx"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("")
+
+        await hooks.on_tool_start(
+            self._ctx_for("dashboards/sales_live/render/app.jsx"),
+            MagicMock(),
+            self._tool("write_file"),
+        )
+
+        mock_broker.request.assert_not_called()


### PR DESCRIPTION
## Why

Under \`normal\` profile, every \`write_file\` / \`edit_file\` / \`delete_file\` to a project-INTERNAL path falls through to the category-level \`default=ASK\` gate (\`permission_hooks.py\` \`_handle_filesystem_zone\`, the \`INTERNAL × write × normal\` row). That's the right default for hand-edited code, but \`gen_visual_report\` / \`gen_visual_dashboard\` author the entire artifact tree — \`manifest.json\`, \`queries/*\`, \`render/*.jsx\`, \`analysis/*\` — in one turn, typically 5–10 files. The user gets a click-storm of Accept prompts for an artifact that only makes sense as a whole and is reviewed via the rendered preview, not per-file diffs.

Three layers cooperate to keep these subagents quiet; this PR closes the last one:

1. \`_FS_DEPENDENT_NODES\` in \`datus.tools.proxy.proxy_tool\` — already exempts these tools from the IDE proxy round-trip (server-side writes).
2. \`isAutoConfirmFilePath\` in [Datus-saas#388](https://github.com/Datus-ai/Datus-saas/pull/388) — already silences the chat-panel Accept bar for matching paths.
3. **This PR** — \`PermissionHooks\` now auto-allows \`write_file\` / \`edit_file\` / \`delete_file\` for \`gen_visual_report\` writing under \`reports/<slug>/\` and \`gen_visual_dashboard\` writing under \`dashboards/<slug>/\`, bypassing the \`normal\`-mode ASK that would otherwise fire on every render chunk.

Screenshot the bug surfaced as (filename redacted): user clicks \"Always allow (session)\" on \`filesystem_tools.edit_file\` for \`reports/aov_analysis_report/render/monthly-aov-trend.jsx\` — only because the session approval persists; without it the prompt repeats every file.

## Solution

\`_handle_filesystem_zone\` already short-circuited the \`INTERNAL × write × normal\` row to a rule-lookup ASK. Inserted a narrower carve-out **before** that fall-through:

- If \`self.node_name\` is in \`_ARTIFACT_AUTOALLOW_NODES\` ( = \`{gen_visual_report, gen_visual_dashboard}\` )
- AND the path, relative to the project root, matches \`^(?:reports|dashboards)/[^/]+/\` (must have the \`<slug>/\` segment so \`reports/README.md\` doesn't qualify)

→ return \`True\` (silent allow). Otherwise the original ASK path runs unchanged.

The carve-out only fires under \`normal\`; \`auto\` / \`dangerous\` already bypass at the outer zone branch and never reach it.

Also fixed alongside: \`_FILESYSTEM_WRITE_TOOLS\` now includes \`delete_file\`. The docstring already documented intent as \"destructive writes from reads\", but \`delete_file\` was missing — so a destructive \`delete_file('src/main.py')\` under \`normal\` profile would silently succeed instead of ASKing. The drift-guard test (\`test_is_write_set_matches_filesystem_tool_surface\`) is updated to match.

## Test Cases

New \`TestVisualArtifactAutoAllow\` class, 16 cases (5 paths × 3 tools + 6 standalone):

- **Carve-out fires** — \`{gen_visual_report, gen_visual_dashboard}\` × \`{manifest.json, render/app.jsx, queries/*.sql, queries/*.sql.j2}\` × \`{write_file, edit_file, delete_file}\` — broker never prompted.
- **Path-scoped** — visual artifact node writing to a non-artifact path (\`scratch.md\`) still ASKs (\`test_visual_artifact_write_outside_artifact_tree_still_asks\`).
- **Bare artifact-root rejected** — \`reports/README.md\` (no \`<slug>/\` segment) still ASKs (\`test_visual_artifact_write_under_artifact_root_no_slug_still_asks\`).
- **Node-scoped** — \`chat\` node writing into \`reports/q1_2026/render/app.jsx\` still ASKs — only the visual artifact nodes get the carve-out (\`test_unrelated_node_writing_artifact_path_still_asks\`).
- **Cross-tree behavior documented** — \`gen_visual_report\` writing into \`dashboards/foreign/...\` is currently silent because the regex is shared; test locks current behavior with a comment pointing at the per-node tightening alternative.
- **Profile invariance** — \`auto\` and \`dangerous\` still bypass via the outer branch without ever reaching the carve-out (\`test_other_profiles_unchanged\`).

Plus an updated drift-guard \`test_is_write_set_matches_filesystem_tool_surface\` covering the \`delete_file\` addition.

Local gate:

- \`pytest tests/unit_tests/ -m \"not nightly\" --cov-fail-under=80\`: 13866 passed, 7 skipped, 1 xfailed, coverage 82.90% (the 3 failed + 14 errored cases are all in \`test_explorer_service\`, \`test_compress_utils\`, \`test_windows_compatibility\`, \`test_node\` — pre-existing on \`upstream/main\`, unrelated env issues, verified by running them against a clean \`upstream/main\` checkout in PR #835's diligence).
- \`diff-cover --fail-under=80\`: 85% on changed lines.
- \`ci/audit_tests.py --diff-only upstream/main\`: \`P0=0 P1=0\`.
- \`ruff format\` + \`ruff check --fix\`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file deletion capability to filesystem operations.
  * Enhanced permission handling for report and dashboard generation workflows—eliminated permission prompts for writes within their respective artifact directories, while maintaining security for external operations.

* **Tests**
  * Expanded test coverage for filesystem permissions and visual artifact authorization validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->