### PR TITLE
[Enhancement] Tag suggested_questions as quick vs deep_dive

### DIFF
--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -123,8 +123,10 @@ def build_finalize_prompt(
         "`evidence_queries` (string[]), `informed_by_knowledge` "
         "(string[]). 3–8 entries typical.\n"
         "  - `suggested_questions`: array of objects with `question`, "
-        "`related_queries` (string[]), `related_insight` (string or "
-        "null), `priority` (0..1). Aim for exactly 5 entries."
+        "`kind` (`'quick'` or `'deep_dive'` — see SUGGESTED QUESTIONS "
+        "CONTRACT below), `related_queries` (string[]), `related_insight` "
+        "(string or null), `priority` (0..1). EXACTLY 5 entries, split as "
+        "3 quick + 2 deep_dive."
     )
     if is_dashboard:
         sections.append(
@@ -132,8 +134,56 @@ def build_finalize_prompt(
             "templates with no statically-known results. You MUST return "
             "`insights: []` (empty array). Suggested questions should focus "
             "on `how to use the dashboard` and `which filters/dimensions to "
-            "explore`, NOT on data conclusions."
+            "explore`, NOT on data conclusions. The quick / deep_dive split "
+            "still applies: `quick` = answerable from the inlined template "
+            "metadata + sample params + columns (e.g. 'which filters does "
+            "this dashboard expose'); `deep_dive` = needs a real query run "
+            "(e.g. 'what trend does dimension X show under filter Y')."
         )
+
+    sections.append("## SUGGESTED QUESTIONS CONTRACT (3 quick + 2 deep_dive)")
+    sections.append(
+        "Generate EXACTLY 5 follow-up questions. They are surfaced to the "
+        "user as chips in the artifact detail view; clicking a chip launches "
+        "the ask-agent against this artifact's pre-loaded context. The split "
+        "matters because the artifact already inlines insights, query briefs, "
+        "preview rows, and key-table schemas into the ask prompt — chips that "
+        "match that inlined context answer in ~0 tool calls; chips that go "
+        "beyond it trigger a full new analysis loop.\n\n"
+        '### 3 × `kind="quick"` — answerable from the inlined artifact\n'
+        "The answer must be fully derivable from the QUERIES (briefs) and "
+        "QUERY RESULT PREVIEWS shown above (plus the report's insights for "
+        "report mode). A user clicking the chip must get an answer the "
+        "ask-agent can write WITHOUT calling any tools.\n"
+        '  - Frame as descriptive / lookup questions: "which months had X", '
+        '"how does Y compare between A and B", "what share of Z falls '
+        'above N", "which insight has the highest confidence".\n'
+        "  - MUST cite at least one `related_queries` slug whose preview "
+        "rows contain the answer, OR one `related_insight` whose `summary` "
+        "already states the answer.\n"
+        '  - AVOID "why" / "what caused" / "can we replicate" / "what '
+        'factors contribute" — those require decomposition the artifact '
+        "didn't pre-compute and belong in deep_dive.\n"
+        "  - Self-check: before tagging a question quick, draft a one-sentence "
+        "answer from the preview rows alone. If you cannot, it is deep_dive.\n\n"
+        '### 2 × `kind="deep_dive"` — requires new analysis\n'
+        "The question legitimately needs new SQL, new tables, customer / "
+        "product / segment joins, or counterfactual analysis the existing "
+        "queries didn't cover. The UI will warn the user that this takes "
+        "longer (~5–10 tool calls expected).\n"
+        '  - These are the "why" / "what factors" / "can we forecast" / '
+        '"what segments drive" questions a sharp analyst would ask after '
+        "reading the report.\n"
+        "  - `related_queries` and `related_insight` are OPTIONAL but "
+        "encouraged — point at the closest existing query as a starting "
+        "hint so the consultant knows where to begin extending.\n"
+        "  - Use this tag honestly: a question that needs columns NOT in the "
+        "existing query previews is deep_dive even if the topic feels "
+        "related to an existing insight.\n\n"
+        "Distribution: aim for EXACTLY 3 quick + 2 deep_dive in the 5-entry "
+        "output. The schema rejects quick questions with no grounding, and a "
+        "post-validation check warns when the distribution drifts off-target."
+    )
 
     sections.append("## RAW USER PROMPTS (intent.md)")
     sections.append(intent_md.strip() or "(empty)")
@@ -180,6 +230,11 @@ def build_finalize_prompt(
         "## CONSTRAINTS RECAP\n"
         f"  - artifact_kind = {artifact_kind!r}\n"
         f"  - `insights` MUST be {'an empty array' if is_dashboard else '3–8 entries'}.\n"
+        "  - `suggested_questions` MUST contain exactly 5 entries split as "
+        "3 `kind='quick'` + 2 `kind='deep_dive'`.\n"
+        "  - Every `kind='quick'` entry MUST cite a non-empty "
+        "`related_queries` slug OR a non-null `related_insight` so the "
+        "consultant has explicit grounding in the inlined artifact context.\n"
         "  - Every `evidence_queries` / `related_queries` entry MUST be a "
         "query name that appears in the reasoning steps above.\n"
         "  - Every `related_insight` MUST reference an `id` you declare in "
@@ -1074,6 +1129,36 @@ def consistency_check(
                 warnings.append(f"suggested_question references missing query {q!r}")
         if sq.related_insight is not None and sq.related_insight not in insight_ids:
             warnings.append(f"suggested_question.related_insight {sq.related_insight!r} not in insights")
+        # ``kind='quick'`` already had schema-level validation that at least
+        # one of related_queries / related_insight is set. We re-check here
+        # against the *resolved* world: a quick chip whose grounding points
+        # at slugs that don't exist on disk (or an insight id this same
+        # finalize call didn't declare) can't be answered from the inlined
+        # context either — the schema validator only sees field presence,
+        # not whether the referenced names resolve.
+        if sq.kind == "quick":
+            valid_query_refs = [q for q in sq.related_queries if q in existing_query_slugs]
+            valid_insight_ref = sq.related_insight is not None and sq.related_insight in insight_ids
+            if not valid_query_refs and not valid_insight_ref:
+                warnings.append(
+                    f"suggested_question {sq.question[:60]!r} kind='quick' has no "
+                    "resolvable grounding (related_queries point to missing slugs "
+                    "and related_insight is null/unknown); ask-agent will be unable "
+                    "to answer from the inlined artifact"
+                )
+
+    # Distribution check — the contract asks for exactly 3 quick + 2 deep_dive
+    # out of 5. The schema keeps the count range 1..8 forgiving (so a single
+    # off-by-one doesn't strand the whole finalize), so we surface drift as
+    # a warning here for ops visibility instead of as a hard failure.
+    quick_count = sum(1 for sq in output.suggested_questions if sq.kind == "quick")
+    deep_count = sum(1 for sq in output.suggested_questions if sq.kind == "deep_dive")
+    total = len(output.suggested_questions)
+    if total != 5 or quick_count != 3 or deep_count != 2:
+        warnings.append(
+            f"suggested_questions distribution off-target: total={total} "
+            f"quick={quick_count} deep_dive={deep_count} (expected 5 / 3 / 2)"
+        )
 
     for w in warnings:
         logger.warning("finalize consistency: %s", w)

--- a/datus/schemas/analysis_artifacts.py
+++ b/datus/schemas/analysis_artifacts.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 import re
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # Same character set as ``REPORT_SLUG_RE`` / ``QUERY_SLUG_RE`` so insight
 # ids stay filesystem-friendly and easy to ``grep`` from compiled HTML
@@ -60,6 +60,8 @@ ANALYSIS_SLUG_PATTERN = r"^[a-z0-9_]{1,64}$"
 ANALYSIS_SLUG_RE = re.compile(ANALYSIS_SLUG_PATTERN)
 
 SubjectAssetKind = Literal["metric", "reference_sql", "ext_knowledge"]
+
+SuggestionKind = Literal["quick", "deep_dive"]
 
 
 class SubjectAssetRef(BaseModel):
@@ -247,6 +249,32 @@ class SuggestedQuestion(BaseModel):
     ``analysis/suggested_questions.json``. Both report and dashboard
     produce these — dashboards just keep ``related_insight=None``
     (there are no insights to anchor to).
+
+    Each suggestion declares a ``kind`` so the UI can set user
+    expectations on latency:
+
+    * ``"quick"`` — answer is fully derivable from what the artifact
+      already pre-loaded into the ask-agent prompt
+      (``insights[]`` + per-query ``brief.json`` + preview rows + key
+      tables schema). A user clicking the chip should get an answer
+      with ~0 new tool calls. **Must** cite at least one
+      ``related_queries`` slug or one ``related_insight`` so the
+      consultant has an explicit grounding pointer.
+    * ``"deep_dive"`` — legitimately requires new SQL, new tables, or
+      decomposition the artifact didn't pre-compute (e.g. "why does
+      Philly's AOV beat Brooklyn's" needs item-level / product-mix
+      data that the headline AOV-by-store query doesn't have). UI
+      surfaces a chip badge so users know ~5–10 tool calls are
+      expected. ``related_queries`` / ``related_insight`` are
+      optional starting hints.
+
+    The split matters because the artifact-inlining work in the
+    ask-agent prompt (insights / subject scope / query catalog /
+    key-table schemas) only pays off when suggested chips actually
+    point at questions the inlined context can answer. Without the
+    tag, the LLM tended to emit aspirational "why" questions that
+    triggered a full new analysis loop on every click — defeating the
+    inlining contract.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -257,15 +285,31 @@ class SuggestedQuestion(BaseModel):
         max_length=300,
         description="Single-sentence follow-up. Same language as the user's prompts where possible.",
     )
+    kind: SuggestionKind = Field(
+        ...,
+        description=(
+            "``'quick'`` if the answer is fully derivable from the inlined "
+            "artifact context (insights / briefs / preview rows / key-table "
+            "schemas); ``'deep_dive'`` if it requires new SQL or tables the "
+            "artifact didn't pre-compute. Frontend renders this as a chip tag "
+            "to set latency expectations."
+        ),
+    )
     related_queries: List[str] = Field(
         default_factory=list,
-        description="Query slugs the suggestion would build on.",
+        description=(
+            "Query slugs the suggestion would build on. **Required** (non-empty "
+            "or paired with ``related_insight``) when ``kind='quick'`` — the "
+            "consultant needs an explicit grounding pointer to answer from the "
+            "inlined preview rows."
+        ),
     )
     related_insight: Optional[str] = Field(
         default=None,
         description=(
             "Insight slug this follow-up extends. Report-only; dashboards always set "
-            "this to ``None`` since there are no insights for them."
+            "this to ``None`` since there are no insights for them. Counts as "
+            "grounding for ``kind='quick'`` when ``related_queries`` is empty."
         ),
     )
     priority: float = Field(
@@ -274,6 +318,31 @@ class SuggestedQuestion(BaseModel):
         le=1.0,
         description="LLM-assigned priority in [0,1]; frontend uses it for display order when more than one suggestion competes for the same slot.",
     )
+
+    @model_validator(mode="after")
+    def _quick_requires_grounding(self) -> "SuggestedQuestion":
+        """``kind='quick'`` must declare at least one grounding pointer.
+
+        Quick questions promise an answer with no new tool calls. The
+        ask-agent only achieves that when it can cite a specific
+        inlined source (``related_queries`` slug → preview rows / SQL;
+        ``related_insight`` → insights.json entry). A quick question
+        with no grounding either becomes a hallucinated answer or
+        forces the LLM to fall back to ``glob`` / ``read_file``,
+        defeating the whole point of the chip.
+
+        ``deep_dive`` is exempt because by definition the data isn't
+        in the artifact yet — pointing at a "closest existing query"
+        is encouraged but not required.
+        """
+        if self.kind == "quick" and not self.related_queries and self.related_insight is None:
+            raise ValueError(
+                "SuggestedQuestion with kind='quick' must cite at least one "
+                "related_queries slug or one related_insight so the consultant "
+                "can answer from the inlined artifact. Use kind='deep_dive' for "
+                "questions that legitimately require new SQL or tables."
+            )
+        return self
 
 
 class FinalizeAnalysisOutput(BaseModel):

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -30,6 +30,7 @@ from datus.agent.node._visual_artifact_finalize import (
     aggregate_referenced_tables,
     aggregate_subject_refs,
     bake_key_tables_schema,
+    build_finalize_prompt,
     collect_query_briefs,
     collect_query_previews,
     consistency_check,
@@ -63,7 +64,13 @@ def _write_brief(queries_dir: Path, name: str, *, uses: Dict[str, List[str]] | N
 
 
 def _full_finalize_response(*, insights: list | None = None, suggested_questions: list | None = None) -> Dict[str, Any]:
-    """Build a ``FinalizeAnalysisOutput``-compatible dict the LLM mock will return."""
+    """Build a ``FinalizeAnalysisOutput``-compatible dict the LLM mock will return.
+
+    Suggested questions default to a single ``kind='quick'`` entry that
+    satisfies the schema's grounding rule (cites ``related_queries`` and
+    ``related_insight``). Tests exercising the 3-quick + 2-deep_dive
+    distribution / consistency_check assemble their own lists.
+    """
     return {
         "insights": insights
         if insights is not None
@@ -82,12 +89,37 @@ def _full_finalize_response(*, insights: list | None = None, suggested_questions
         else [
             {
                 "question": "Which regions drove the dip?",
+                "kind": "quick",
                 "related_queries": ["rev_by_region"],
                 "related_insight": "revenue_dip",
                 "priority": 0.6,
             }
         ],
     }
+
+
+def _sq(
+    *,
+    question: str = "q?",
+    kind: str = "deep_dive",
+    related_queries: list[str] | None = None,
+    related_insight: str | None = None,
+    priority: float = 0.5,
+) -> SuggestedQuestion:
+    """Build a SuggestedQuestion with sensible defaults for tests.
+
+    Defaults to ``kind='deep_dive'`` so tests that don't care about the
+    quick-grounding contract get a schema-valid object without having to
+    set ``related_queries`` / ``related_insight``. Override ``kind`` when
+    exercising the quick path.
+    """
+    return SuggestedQuestion(
+        question=question,
+        kind=kind,
+        related_queries=related_queries or [],
+        related_insight=related_insight,
+        priority=priority,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -317,9 +349,24 @@ class TestParseFinalizeOutput:
 def _make_output(*, insights=None, suggested_questions=None) -> FinalizeAnalysisOutput:
     return FinalizeAnalysisOutput(
         insights=insights or [],
-        suggested_questions=suggested_questions
-        or [SuggestedQuestion(question="q?", related_queries=[], related_insight=None, priority=0.5)],
+        suggested_questions=suggested_questions or [_sq()],
     )
+
+
+def _balanced_suggestions(*, quick_query_slug: str = "alpha", quick_insight_id: str = "i1") -> list[SuggestedQuestion]:
+    """A schema-valid 3 quick + 2 deep_dive list for distribution tests.
+
+    Quick chips ground on ``quick_query_slug`` (and ``quick_insight_id`` on
+    the third) so consistency_check's resolved-grounding check passes when
+    the caller materializes the matching SQL file + insight on disk.
+    """
+    return [
+        _sq(question="quick A?", kind="quick", related_queries=[quick_query_slug]),
+        _sq(question="quick B?", kind="quick", related_queries=[quick_query_slug]),
+        _sq(question="quick C?", kind="quick", related_insight=quick_insight_id),
+        _sq(question="deep A?", kind="deep_dive"),
+        _sq(question="deep B?", kind="deep_dive", related_queries=[quick_query_slug]),
+    ]
 
 
 class TestConsistencyCheck:
@@ -337,9 +384,7 @@ class TestConsistencyCheck:
                     evidence_queries=["alpha"],
                 )
             ],
-            suggested_questions=[
-                SuggestedQuestion(question="q?", related_queries=["alpha"], related_insight="i1", priority=0.5)
-            ],
+            suggested_questions=_balanced_suggestions(),
         )
         warnings = consistency_check(queries_dir=queries_dir, output=output)
         assert warnings == []
@@ -367,12 +412,190 @@ class TestConsistencyCheck:
         queries_dir.mkdir()
         output = _make_output(
             insights=[],
-            suggested_questions=[
-                SuggestedQuestion(question="q?", related_queries=[], related_insight="unknown", priority=0.5)
-            ],
+            suggested_questions=[_sq(kind="deep_dive", related_insight="unknown")],
         )
         warnings = consistency_check(queries_dir=queries_dir, output=output)
         assert any("unknown" in w for w in warnings)
+
+
+class TestConsistencyCheckDistribution:
+    """The 3 quick + 2 deep_dive split is the contract every artifact ships
+    under. The schema keeps the total range 1..8 forgiving so a marginal
+    LLM run isn't outright rejected; consistency_check surfaces drift as a
+    warning so ops can spot finalize regressions in the trace log without
+    blocking the artifact.
+    """
+
+    def test_no_distribution_warning_on_3_quick_2_deep(self, tmp_path: Path):
+        queries_dir = tmp_path / "queries"
+        queries_dir.mkdir()
+        (queries_dir / "alpha.sql").write_text("SELECT 1", encoding="utf-8")
+        output = _make_output(
+            insights=[
+                Insight(id="i1", title="t", summary="s", confidence=0.5, evidence_queries=["alpha"]),
+            ],
+            suggested_questions=_balanced_suggestions(),
+        )
+        warnings = consistency_check(queries_dir=queries_dir, output=output)
+        assert not any("distribution off-target" in w for w in warnings)
+
+    def test_distribution_warning_when_all_quick(self, tmp_path: Path):
+        queries_dir = tmp_path / "queries"
+        queries_dir.mkdir()
+        (queries_dir / "alpha.sql").write_text("SELECT 1", encoding="utf-8")
+        five_quick = [_sq(question=f"q{i}", kind="quick", related_queries=["alpha"]) for i in range(5)]
+        output = _make_output(suggested_questions=five_quick)
+        warnings = consistency_check(queries_dir=queries_dir, output=output)
+        assert any("distribution off-target" in w and "quick=5" in w for w in warnings)
+
+    def test_distribution_warning_when_wrong_total(self, tmp_path: Path):
+        queries_dir = tmp_path / "queries"
+        queries_dir.mkdir()
+        (queries_dir / "alpha.sql").write_text("SELECT 1", encoding="utf-8")
+        # 4 entries instead of 5 — schema allows 1..8 but contract is 5.
+        four = [
+            _sq(question="q1", kind="quick", related_queries=["alpha"]),
+            _sq(question="q2", kind="quick", related_queries=["alpha"]),
+            _sq(question="q3", kind="quick", related_queries=["alpha"]),
+            _sq(question="q4", kind="deep_dive"),
+        ]
+        output = _make_output(suggested_questions=four)
+        warnings = consistency_check(queries_dir=queries_dir, output=output)
+        assert any("distribution off-target" in w and "total=4" in w for w in warnings)
+
+
+class TestConsistencyCheckQuickGrounding:
+    """The schema validator only sees that quick has *some* grounding pointer
+    (non-empty related_queries OR non-null related_insight). It can't tell
+    whether those pointers actually resolve to artifacts on disk. The
+    consistency check closes that gap so a quick chip whose only grounding
+    is a typo'd slug surfaces as a warning instead of silently failing the
+    ask-agent at click time.
+    """
+
+    def test_warns_when_quick_grounding_does_not_resolve(self, tmp_path: Path):
+        queries_dir = tmp_path / "queries"
+        queries_dir.mkdir()
+        # Real SQL on disk; the quick chip cites a different (missing) slug.
+        (queries_dir / "alpha.sql").write_text("SELECT 1", encoding="utf-8")
+        output = _make_output(
+            insights=[],
+            suggested_questions=[_sq(kind="quick", related_queries=["ghost_query"])],
+        )
+        warnings = consistency_check(queries_dir=queries_dir, output=output)
+        assert any("no resolvable grounding" in w for w in warnings)
+
+    def test_no_quick_grounding_warning_when_insight_resolves(self, tmp_path: Path):
+        queries_dir = tmp_path / "queries"
+        queries_dir.mkdir()
+        output = _make_output(
+            insights=[
+                Insight(id="i1", title="t", summary="s", confidence=0.5, evidence_queries=["alpha"]),
+            ],
+            suggested_questions=[_sq(kind="quick", related_insight="i1")],
+        )
+        # SQL "alpha" exists too so the insight's evidence resolves.
+        (queries_dir / "alpha.sql").write_text("SELECT 1", encoding="utf-8")
+        warnings = consistency_check(queries_dir=queries_dir, output=output)
+        assert not any("no resolvable grounding" in w for w in warnings)
+
+    def test_deep_dive_without_grounding_does_not_warn(self, tmp_path: Path):
+        queries_dir = tmp_path / "queries"
+        queries_dir.mkdir()
+        output = _make_output(
+            suggested_questions=[_sq(kind="deep_dive", related_queries=[], related_insight=None)],
+        )
+        warnings = consistency_check(queries_dir=queries_dir, output=output)
+        # deep_dive is exempt — data isn't in the artifact yet, by design.
+        assert not any("no resolvable grounding" in w for w in warnings)
+
+
+class TestBuildFinalizePrompt:
+    """Pin the SUGGESTED QUESTIONS CONTRACT section of the finalize prompt.
+
+    The prompt is the only place we communicate the 3-quick + 2-deep_dive
+    split to the LLM, so a regression that drops or muddies the wording
+    will silently let the finalize step revert to the pre-split behavior
+    (all-aspirational chips that trigger a full new analysis loop on
+    every click).
+    """
+
+    @pytest.fixture
+    def report_prompt(self) -> str:
+        return build_finalize_prompt(
+            artifact_kind="report",
+            intent_md="user wanted an AOV report",
+            query_briefs=[{"name": "alpha", "hypothesis": "h"}],
+            query_previews=[{"name": "alpha", "kind": "report_result", "preview_rows": []}],
+            action_history_hints=[],
+            existing_insights=None,
+            existing_suggested_questions=None,
+        )
+
+    def test_prompt_announces_kind_field_in_schema(self, report_prompt: str):
+        # Schema section must mention the kind field by name so the LLM
+        # actually emits it.
+        assert "`kind`" in report_prompt
+        assert "'quick'" in report_prompt
+        assert "'deep_dive'" in report_prompt
+
+    def test_prompt_pins_3_quick_2_deep_split(self, report_prompt: str):
+        # OUTPUT SCHEMA section spells the split in plain prose; the
+        # CONTRACT section spells it in code-block form. Both must be
+        # present so the LLM has the rule reinforced.
+        assert "3 quick + 2 deep_dive" in report_prompt
+        assert '3 × `kind="quick"`' in report_prompt
+        assert '2 × `kind="deep_dive"`' in report_prompt
+
+    def test_prompt_states_quick_grounding_rule(self, report_prompt: str):
+        # The "quick MUST cite grounding" invariant has to be visible in
+        # the prompt — the schema validator catches violations, but the
+        # prompt is what gets the LLM to produce valid output in the
+        # first place.
+        assert "MUST cite" in report_prompt
+        assert "related_queries" in report_prompt
+        assert "related_insight" in report_prompt
+
+    def test_prompt_calls_out_avoid_aspirational_quick(self, report_prompt: str):
+        # The single biggest failure mode the contract guards against:
+        # "why" / "what factors" questions tagged as quick because the
+        # LLM sees them as obvious follow-ups. The prompt must call this
+        # out explicitly or the LLM regresses to the old behavior.
+        assert '"why"' in report_prompt
+        assert "deep_dive" in report_prompt
+
+    def test_prompt_calls_out_self_check(self, report_prompt: str):
+        # The "draft a one-sentence answer from preview rows alone"
+        # heuristic is the operational version of the quick contract —
+        # pinning the exact wording so a future prose-tweak that drops
+        # the imperative ("could try drafting…") still fails this test.
+        assert "Self-check: before tagging a question quick" in report_prompt
+
+    def test_dashboard_prompt_keeps_kind_split(self):
+        prompt = build_finalize_prompt(
+            artifact_kind="dashboard",
+            intent_md="dashboard intent",
+            query_briefs=[],
+            query_previews=[],
+            action_history_hints=[],
+            existing_insights=None,
+            existing_suggested_questions=None,
+        )
+        # Dashboards skip insights but the quick/deep_dive split still
+        # applies — quick chips describe the template metadata, deep_dive
+        # chips trigger a real query run.
+        assert "DASHBOARD MODE" in prompt
+        assert "quick" in prompt
+        assert "deep_dive" in prompt
+
+    def test_constraints_recap_pins_distribution(self, report_prompt: str):
+        # The "CONSTRAINTS RECAP" block is the prompt's TL;DR. The exact
+        # "5 entries split as 3 ... + 2 ..." wording must surface here so
+        # an LLM that skims past the long-form CONTRACT section still
+        # gets the distribution rule.
+        assert "5 entries split as" in report_prompt
+        assert "kind='quick'" in report_prompt
+        assert "kind='deep_dive'" in report_prompt
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit_tests/schemas/test_analysis_artifacts.py
+++ b/tests/unit_tests/schemas/test_analysis_artifacts.py
@@ -250,6 +250,7 @@ class TestInsight:
 def _full_suggested_question_payload(**overrides):
     base = {
         "question": "Which regions drove the March dip?",
+        "kind": "quick",
         "related_queries": ["rev_by_region_monthly"],
         "related_insight": "revenue_dipped_in_eu",
         "priority": 0.6,
@@ -265,11 +266,13 @@ class TestSuggestedQuestion:
         assert restored == sq
 
     def test_related_insight_none_accepted(self):
+        # ``quick`` still satisfied by non-empty related_queries alone.
         sq = SuggestedQuestion.model_validate(_full_suggested_question_payload(related_insight=None))
         assert sq.related_insight is None
 
     def test_related_queries_default_empty(self):
-        payload = _full_suggested_question_payload()
+        # Default empty list is fine for deep_dive (no grounding required).
+        payload = _full_suggested_question_payload(kind="deep_dive", related_insight=None)
         payload.pop("related_queries")
         sq = SuggestedQuestion.model_validate(payload)
         assert sq.related_queries == []
@@ -282,6 +285,75 @@ class TestSuggestedQuestion:
     def test_empty_question_rejected(self):
         with pytest.raises(ValidationError):
             SuggestedQuestion.model_validate(_full_suggested_question_payload(question=""))
+
+
+class TestSuggestedQuestionKind:
+    """Pins the ``kind`` field contract: required, restricted to
+    ``quick`` / ``deep_dive``, and the quick-grounding model validator.
+
+    The split exists so the ask-agent's inlined artifact context (insights,
+    briefs, preview rows, key-table schemas) actually pays off — quick
+    chips MUST be answerable from that context, otherwise clicking one
+    forces a full new analysis loop and defeats the inlining contract
+    set up by the prior round of optimizations.
+    """
+
+    def test_kind_required(self):
+        # No default — finalize LLM must explicitly classify every chip.
+        payload = _full_suggested_question_payload()
+        payload.pop("kind")
+        with pytest.raises(ValidationError):
+            SuggestedQuestion.model_validate(payload)
+
+    @pytest.mark.parametrize("bad_kind", ["medium", "Quick", "", "follow_up", None])
+    def test_invalid_kind_rejected(self, bad_kind):
+        with pytest.raises(ValidationError):
+            SuggestedQuestion.model_validate(_full_suggested_question_payload(kind=bad_kind))
+
+    def test_quick_with_only_related_queries_accepted(self):
+        sq = SuggestedQuestion.model_validate(
+            _full_suggested_question_payload(
+                kind="quick", related_queries=["rev_by_region_monthly"], related_insight=None
+            )
+        )
+        assert sq.kind == "quick"
+
+    def test_quick_with_only_related_insight_accepted(self):
+        sq = SuggestedQuestion.model_validate(
+            _full_suggested_question_payload(kind="quick", related_queries=[], related_insight="revenue_dipped_in_eu")
+        )
+        assert sq.kind == "quick"
+
+    def test_quick_without_any_grounding_rejected(self):
+        # The whole point of "quick": it MUST cite where the answer lives.
+        # Bare quick with no grounding becomes a hallucination invitation.
+        with pytest.raises(ValidationError, match="kind='quick'"):
+            SuggestedQuestion.model_validate(
+                _full_suggested_question_payload(kind="quick", related_queries=[], related_insight=None)
+            )
+
+    def test_deep_dive_without_grounding_accepted(self):
+        # deep_dive is exempt — by definition the data isn't in the artifact
+        # yet, so pointing at a "closest existing query" is encouraged but
+        # not required.
+        sq = SuggestedQuestion.model_validate(
+            _full_suggested_question_payload(kind="deep_dive", related_queries=[], related_insight=None)
+        )
+        assert sq.kind == "deep_dive"
+        assert sq.related_queries == []
+        assert sq.related_insight is None
+
+    def test_deep_dive_with_partial_grounding_accepted(self):
+        # Pointing at the closest existing query as a starting hint is the
+        # encouraged shape for deep_dive.
+        sq = SuggestedQuestion.model_validate(
+            _full_suggested_question_payload(
+                kind="deep_dive",
+                related_queries=["aov_by_store"],
+                related_insight="philly_dominates",
+            )
+        )
+        assert sq.kind == "deep_dive"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Why

The artifact-inlining work in [#830](https://github.com/Datus-ai/Datus-agent/pull/830) + [#832](https://github.com/Datus-ai/Datus-agent/pull/832) pre-loads insights, query briefs, preview rows, and key-table schemas into the ``ask_*`` system prompt so follow-ups answer in ~2 tool calls instead of ~15. That promise only holds when the chip the user actually clicks points at a question the inlined context can answer.

Today's chips don't. A real session on the AOV report (click ``What specific factors contribute to Philadelphia's higher AOV?``):

| Step | Action |
|---|---|
| 1 | ``list_tables`` (find ``raw_items`` / ``raw_products``) |
| 2 | ``describe_table`` × 3 — none of the new tables are in ``manifest.key_tables`` |
| 3 | ``read_query`` × 7 — items_per_order / product mix / basket / zero-AOV / counterfactual |
| 4 | Final answer |

Every one of those 11 tool calls is **legitimate new analysis** — the artifact has no item-level / product-mix data, the chip just asks for it. PR #830 / #832 protect against pre-fetching content the prompt already carries; they cannot help when the chip itself routes the user out of inlined-context land.

Inspecting ``suggested_questions.json`` for the report, 4½ of the 5 chips are like this — aspirational "why" / "what factors" / "can we replicate" questions whose answers are not in any saved query. So the finalize generator is silently shipping false promises.

## Solution

Tag every chip as either ``quick`` (answerable from the inlined artifact, ~0 tool calls) or ``deep_dive`` (needs new SQL / new tables, ~5–10 tool calls) and force a 3 + 2 split. The front-end surfaces the tag as a chip badge plus a quick-first sort so users see at a glance which click costs them latency.

### Schema (``datus/schemas/analysis_artifacts.py``)

- New ``SuggestionKind = Literal['quick', 'deep_dive']``.
- ``SuggestedQuestion.kind`` is **required**.
- ``model_validator`` rejects ``kind='quick'`` chips that have neither ``related_queries`` non-empty nor ``related_insight`` set — a quick chip must cite *where* its answer lives, otherwise it's a hallucination invitation. ``deep_dive`` is exempt (by design the data isn't in the artifact yet).
- ``FinalizeAnalysisOutput.suggested_questions`` keeps the existing ``min=1, max=8`` range so a marginal LLM run isn't outright rejected; the 5 / 3 / 2 target lives in the prompt and consistency_check.

### Finalize prompt (``datus/agent/node/_visual_artifact_finalize.py::build_finalize_prompt``)

Adds a dedicated ``## SUGGESTED QUESTIONS CONTRACT (3 quick + 2 deep_dive)`` section:

- Explicit examples of what counts as quick ("which months had X", "how does Y compare", "which insight has the highest confidence") vs what doesn't ("why" / "what factors" / "can we replicate").
- Self-check: "before tagging quick, draft a one-sentence answer from preview rows alone. If you cannot, it is deep_dive."
- Dashboard branch keeps the split (quick = answerable from template metadata + sample params + columns; deep_dive = needs a real query run).
- CONSTRAINTS RECAP at the tail pins the schema-level "quick MUST cite grounding" rule + the 5 / 3 / 2 distribution.

### Consistency check (``consistency_check``)

Two new soft warnings:

- ``kind='quick'`` with no *resolvable* grounding (slugs that don't exist on disk, insight id this same finalize call didn't declare). Schema only catches field presence — this catches typo'd / stale references.
- Distribution drift: any run that isn't exactly 5 total / 3 quick / 2 deep_dive surfaces ``suggested_questions distribution off-target: total=N quick=N deep_dive=N (expected 5 / 3 / 2)`` so ops can spot finalize regressions in the result trace.

## Test Cases

``tests/unit_tests/schemas/test_analysis_artifacts.py`` — new ``TestSuggestedQuestionKind`` (7 tests):

- ``test_kind_required`` — missing ``kind`` rejected
- ``test_invalid_kind_rejected`` — parametrized over ``medium`` / ``Quick`` / ``""`` / ``follow_up`` / ``None``
- ``test_quick_with_only_related_queries_accepted`` / ``test_quick_with_only_related_insight_accepted`` — either grounding form alone is enough
- ``test_quick_without_any_grounding_rejected`` — the central invariant (asserts on the validator error message)
- ``test_deep_dive_without_grounding_accepted`` / ``test_deep_dive_with_partial_grounding_accepted`` — exemption pin

Existing ``TestSuggestedQuestion`` payload fixture gains a default ``kind='quick'`` so unrelated tests still pass.

``tests/unit_tests/agent/node/test_visual_artifact_finalize.py``:

- ``_sq`` helper + ``_balanced_suggestions()`` give every old test a schema-valid 3 quick + 2 deep_dive list to assert against.
- New ``TestConsistencyCheckDistribution`` (3 tests): no warning on 3+2; warning when all-quick; warning when total != 5.
- New ``TestConsistencyCheckQuickGrounding`` (3 tests): quick-with-typo'd-slug surfaces "no resolvable grounding"; quick with valid insight id is silent; deep_dive without grounding is exempt.
- New ``TestBuildFinalizePrompt`` (6 tests): pins ``kind`` field in OUTPUT SCHEMA; pins ``3 × kind="quick"`` + ``2 × kind="deep_dive"`` wording; pins MUST-cite grounding rule; pins the ``"why"`` failure-mode call-out; pins the self-check imperative; dashboard branch still carries the split; CONSTRAINTS RECAP pins the 5 / 3 / 2 distribution.

Audit: ``P0=0`` on diff. Diff coverage 100% on ``datus/schemas/analysis_artifacts.py`` and 91.9% on ``_visual_artifact_finalize.py`` (the 3 uncovered lines are sub-spans of a multi-line string literal exercised by the prompt-content tests — false negative from diff-cover's line attribution).

Suite: 227 / 227 passed across the three touched test files.

Stacks naturally on the artifact-inlining work in #830 / #832 — those gave us the inlined context that makes "quick" possible; this PR makes sure the chips users see route to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Suggested questions now categorized as "quick" or "deep_dive" to clarify expected latency and depth.
  * Enhanced dashboard mode guidance for suggested questions and insights validation.

* **Bug Fixes**
  * Added validation to ensure quick suggestions include resolvable grounding pointers.
  * Distribution warnings now emitted when suggested questions deviate from expected 5-total split (3 quick/2 deep_dive).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->