### PR TITLE
[BugFix] Resolve reference SQL summary paths

### DIFF
--- a/datus/storage/reference_sql/reference_sql_init.py
+++ b/datus/storage/reference_sql/reference_sql_init.py
@@ -3,6 +3,8 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import asyncio
+import os
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
@@ -27,6 +29,22 @@ def _action_status_value(action: Any) -> Optional[str]:
     if status is None:
         return None
     return status.value if hasattr(status, "value") else str(status)
+
+
+def _resolve_generated_summary_file_path(
+    agent_config: AgentConfig,
+    node: SqlSummaryAgenticNode,
+    sql_summary_file: str,
+) -> Optional[Path]:
+    """Resolve a generated SQL summary path reported by the workflow node."""
+    knowledge_base_dir = getattr(node, "knowledge_base_dir", None)
+    if isinstance(knowledge_base_dir, (str, os.PathLike)) and not hasattr(knowledge_base_dir, "mock_calls"):
+        from datus.cli.generation_hooks import resolve_kb_sandbox_path
+
+        resolved = resolve_kb_sandbox_path(sql_summary_file, "sql_summary", str(knowledge_base_dir))
+        return Path(resolved) if resolved else None
+
+    return Path(agent_config.path_manager.sql_summary_path()) / sql_summary_file
 
 
 async def process_sql_item(
@@ -105,11 +123,14 @@ async def process_sql_item(
 
         logger.info(f"Generated SQL summary: {sql_summary_file}")
 
-        file_path = agent_config.path_manager.sql_summary_path() / sql_summary_file
+        file_path = _resolve_generated_summary_file_path(agent_config, node, sql_summary_file)
         import yaml
 
         try:
             # Load YAML file to get name and subject_tree
+            if not file_path:
+                logger.warning(f"SQL summary file rejected by sandbox check: {sql_summary_file!r}")
+                return None
             with open(file_path, "r", encoding="utf-8") as f:
                 doc = yaml.safe_load(f)
                 if not item.get("name"):

--- a/datus/storage/reference_sql/reference_sql_init.py
+++ b/datus/storage/reference_sql/reference_sql_init.py
@@ -44,7 +44,18 @@ def _resolve_generated_summary_file_path(
         resolved = resolve_kb_sandbox_path(sql_summary_file, "sql_summary", str(knowledge_base_dir))
         return Path(resolved) if resolved else None
 
-    return Path(agent_config.path_manager.sql_summary_path()) / sql_summary_file
+    reported_path = Path(sql_summary_file)
+    if reported_path.is_absolute():
+        return reported_path
+
+    parts = reported_path.parts
+    if "sql_summaries" in parts:
+        summary_dir_index = parts.index("sql_summaries")
+        summary_relative_parts = parts[summary_dir_index + 1 :]
+        if summary_relative_parts:
+            return Path(agent_config.path_manager.sql_summary_path()).joinpath(*summary_relative_parts)
+
+    return Path(agent_config.path_manager.sql_summary_path()) / reported_path
 
 
 async def process_sql_item(

--- a/tests/unit_tests/storage/reference_sql/test_reference_sql_init.py
+++ b/tests/unit_tests/storage/reference_sql/test_reference_sql_init.py
@@ -5,7 +5,7 @@
 """Unit tests for datus.storage.reference_sql.reference_sql_init."""
 
 from enum import Enum
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -72,6 +72,70 @@ class TestBizNameConstant:
     def test_biz_name_value(self):
         """BIZ_NAME is reference_sql_init."""
         assert BIZ_NAME == "reference_sql_init"
+
+
+# ---------------------------------------------------------------------------
+# process_sql_item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestProcessSqlItem:
+    """Tests for process_sql_item summary-path handling."""
+
+    @pytest.mark.asyncio
+    async def test_success_with_subject_prefixed_summary_path(self, tmp_path):
+        """LLM may report subject/sql_summaries/...; resolver should not duplicate prefixes."""
+        import yaml
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.reference_sql.reference_sql_init import process_sql_item
+
+        kb_dir = tmp_path / "subject"
+        summary_dir = kb_dir / "sql_summaries"
+        summary_dir.mkdir(parents=True)
+        summary_file = summary_dir / "ref_001.yaml"
+        summary_file.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "new_product_activity_query",
+                    "subject_tree": "运营/活动/类别",
+                },
+                allow_unicode=True,
+            ),
+            encoding="utf-8",
+        )
+
+        success_action = MagicMock()
+        success_action.status = ActionStatus.SUCCESS
+        success_action.output = {"sql_summary_file": "subject/sql_summaries/ref_001.yaml"}
+        success_action.messages = []
+
+        async def mock_execute_stream(*args, **kwargs):
+            yield success_action
+
+        mock_node = MagicMock()
+        mock_node.knowledge_base_dir = str(kb_dir)
+        mock_node.execute_stream = mock_execute_stream
+
+        mock_config = MagicMock()
+        mock_config.path_manager.sql_summary_path.return_value = summary_dir
+
+        item = {
+            "sql": "SELECT * FROM v_udata_ac_info",
+            "filepath": "/tmp/ref.sql",
+            "comment": "",
+        }
+
+        with patch(
+            "datus.storage.reference_sql.reference_sql_init.SqlSummaryAgenticNode",
+            return_value=mock_node,
+        ):
+            result = await process_sql_item(item, mock_config, build_mode="overwrite")
+
+        assert result == "subject/sql_summaries/ref_001.yaml"
+        assert item["name"] == "new_product_activity_query"
+        assert item["subject_tree"] == "运营/活动/类别"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/reference_sql/test_reference_sql_init.py
+++ b/tests/unit_tests/storage/reference_sql/test_reference_sql_init.py
@@ -83,6 +83,35 @@ class TestBizNameConstant:
 class TestProcessSqlItem:
     """Tests for process_sql_item summary-path handling."""
 
+    def test_fallback_summary_path_strips_generated_sql_summaries_prefix(self, tmp_path):
+        """Fallback path resolution accepts generated paths that already include sql_summaries."""
+        from datus.storage.reference_sql.reference_sql_init import _resolve_generated_summary_file_path
+
+        summary_dir = tmp_path / "subject" / "sql_summaries"
+        mock_config = MagicMock()
+        mock_config.path_manager.sql_summary_path.return_value = summary_dir
+        mock_node = MagicMock()
+
+        result = _resolve_generated_summary_file_path(
+            mock_config,
+            mock_node,
+            "subject/sql_summaries/ref_001.yaml",
+        )
+
+        assert result == summary_dir / "ref_001.yaml"
+
+    def test_fallback_summary_path_allows_absolute_path(self, tmp_path):
+        """Fallback path resolution preserves absolute paths when no KB root is available."""
+        from datus.storage.reference_sql.reference_sql_init import _resolve_generated_summary_file_path
+
+        summary_file = tmp_path / "subject" / "sql_summaries" / "ref_001.yaml"
+        mock_config = MagicMock()
+        mock_node = MagicMock()
+
+        result = _resolve_generated_summary_file_path(mock_config, mock_node, str(summary_file))
+
+        assert result == summary_file
+
     @pytest.mark.asyncio
     async def test_success_with_subject_prefixed_summary_path(self, tmp_path):
         """LLM may report subject/sql_summaries/...; resolver should not duplicate prefixes."""


### PR DESCRIPTION
## Summary
- resolve generated reference SQL summary YAML paths with the same sandbox resolver used by workflow-mode DB sync
- prevent subject/sql_summaries paths from being prefixed twice during metadata backfill
- add coverage for subject-prefixed summary paths

## Tests
- uv run pytest tests/unit_tests/storage/reference_sql/test_reference_sql_init.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SQL summary file path resolution to respect sandbox and subject-relative locations
  * Added validation to detect and warn when generated summary paths are invalid to avoid misreads

* **Tests**
  * Added tests covering path-resolution behavior, including subject-prefixed paths and sandbox/unavailable-root scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->