### PR TITLE
[BugFix] validate_render: accept ES6 shorthand keys in useQuerySql params

### DIFF
--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -104,6 +104,21 @@ _PARAMS_KEY_RE = re.compile(
     re.VERBOSE | re.IGNORECASE,
 )
 
+# ES6 shorthand property names: { foo, bar } ≡ { foo: foo, bar: bar }. The
+# boundary intentionally excludes whitespace and the lookahead excludes `:`,
+# so identifiers sitting in value position (e.g. `bar` in `{ foo: bar }`) are
+# not captured.
+_PARAMS_SHORTHAND_KEY_RE = re.compile(
+    r"""
+    (?:^|[,{])                       # boundary: open brace or comma only
+    \s*
+    ([a-z_][a-z0-9_]*)               # 1: bare identifier
+    \s*
+    (?=[,}])                         # lookahead: , or } (never :)
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
 
 # --------------------------------------------------------------------------- #
 # Jinja2 sandbox + bind-value resolution                                      #
@@ -1017,6 +1032,8 @@ class DashboardArtifactTools:
                 literal_keys: Set[str] = set()
                 for key_match in _PARAMS_KEY_RE.finditer(params_literal):
                     literal_keys.add((key_match.group(1) or key_match.group(2)).lower())
+                for key_match in _PARAMS_SHORTHAND_KEY_RE.finditer(params_literal):
+                    literal_keys.add(key_match.group(1).lower())
 
                 # Spread / computed keys appear in the source but not in our
                 # capture group. Detect them so we can warn (and skip the

--- a/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
@@ -697,6 +697,56 @@ class TestValidateRender:
         result = dashboard_tools.validate_render()
         assert result.success == 1, result.error
 
+    def test_accepts_multiline_shorthand_param_object(
+        self, dashboard_tools: DashboardArtifactTools, project_root: Path
+    ):
+        # The subagent often emits the params object across multiple lines.
+        # `\s*` in both `_PARAMS_KEY_RE` and `_PARAMS_SHORTHAND_KEY_RE` is
+        # expected to absorb the newline + indentation between keys.
+        _seed_template(dashboard_tools)
+        app_multiline_shorthand = (
+            "import React from 'react';\n"
+            "import { useDatusArtifact } from '@datus/web-artifact';\n"
+            "export default function App() {\n"
+            "  const month_floor = '2026-01';\n"
+            "  const regions = ['NA', 'EU'];\n"
+            "  const { useQuerySql } = useDatusArtifact();\n"
+            "  const { data } = useQuerySql('queries/revenue_by_region', {\n"
+            "    month_floor,\n"
+            "    regions,\n"
+            "  });\n"
+            "  return React.createElement('pre', null, JSON.stringify(data?.rows ?? []));\n"
+            "}\n"
+        )
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app_multiline_shorthand})
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+        assert "queries/revenue_by_region" in result.result["query_refs"]
+
+    def test_accepts_multiline_mixed_shorthand_and_explicit(
+        self, dashboard_tools: DashboardArtifactTools, project_root: Path
+    ):
+        # Mixed form across lines: one key uses shorthand, the other uses
+        # explicit `key: value` syntax. Neither side may be misclassified.
+        _seed_template(dashboard_tools)
+        app_multiline_mixed = (
+            "import React from 'react';\n"
+            "import { useDatusArtifact } from '@datus/web-artifact';\n"
+            "export default function App() {\n"
+            "  const sd = '2026-01';\n"
+            "  const regions = ['NA', 'EU'];\n"
+            "  const { useQuerySql } = useDatusArtifact();\n"
+            "  const { data } = useQuerySql('queries/revenue_by_region', {\n"
+            "    month_floor: sd,\n"
+            "    regions,\n"
+            "  });\n"
+            "  return React.createElement('pre', null, JSON.stringify(data?.rows ?? []));\n"
+            "}\n"
+        )
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app_multiline_mixed})
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+
     def test_rejects_unknown_param_key(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
         _seed_template(dashboard_tools)
         app_extra_key = (

--- a/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
@@ -660,6 +660,43 @@ class TestValidateRender:
         assert "missing required" in (result.error or "")
         assert "month_floor" in (result.error or "")
 
+    def test_accepts_shorthand_param_keys(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        _seed_template(dashboard_tools)
+        app_shorthand = (
+            "import React from 'react';\n"
+            "import { useDatusArtifact } from '@datus/web-artifact';\n"
+            "export default function App() {\n"
+            "  const month_floor = '2026-01';\n"
+            "  const { useQuerySql } = useDatusArtifact();\n"
+            "  const { data } = useQuerySql('queries/revenue_by_region', { month_floor });\n"
+            "  return React.createElement('pre', null, JSON.stringify(data?.rows ?? []));\n"
+            "}\n"
+        )
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app_shorthand})
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+        assert "queries/revenue_by_region" in result.result["query_refs"]
+
+    def test_shorthand_does_not_capture_value_position_identifiers(
+        self, dashboard_tools: DashboardArtifactTools, project_root: Path
+    ):
+        # Regression: the shorthand handling must not treat the value side of
+        # `{ month_floor: someVar }` as a separate (unknown) key.
+        _seed_template(dashboard_tools)
+        app_explicit = (
+            "import React from 'react';\n"
+            "import { useDatusArtifact } from '@datus/web-artifact';\n"
+            "export default function App() {\n"
+            "  const some_var = '2026-01';\n"
+            "  const { useQuerySql } = useDatusArtifact();\n"
+            "  const { data } = useQuerySql('queries/revenue_by_region', { month_floor: some_var });\n"
+            "  return React.createElement('pre', null, JSON.stringify(data?.rows ?? []));\n"
+            "}\n"
+        )
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app_explicit})
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+
     def test_rejects_unknown_param_key(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
         _seed_template(dashboard_tools)
         app_extra_key = (


### PR DESCRIPTION
## Why

`gen_visual_dashboard` subagent's `validate_render` falsely reports `useQuerySql('queries/foo', { start_date, end_date })` as missing required params:

```
render/store-bar-chart.jsx: useQuerySql('queries/revenue_by_store', ...) is missing required params: ['end_date', 'start_date']. Template declares ['end_date', 'start_date']; literal has [].
```

ES6 shorthand property syntax (`{ foo, bar }` ≡ `{ foo: foo, bar: bar }`) is legal JSX and a natural form for the subagent to emit, but `_PARAMS_KEY_RE` in `dashboard_artifact_tools.py` required a trailing `:` and therefore never captured shorthand keys, collapsing `literal_keys` to `set()`.

## Solution

Add a sibling regex `_PARAMS_SHORTHAND_KEY_RE` that:

- Bounds the identifier with `{` or `,` (no whitespace — whitespace alone is ambiguous between key-position and value-position).
- Uses a lookahead requiring `,` or `}` (never `:`).

These two constraints make the regex match only true shorthand positions; identifiers sitting in value position (e.g. `bar` in `{ foo: bar }`) are not captured, so the existing `{ key: value }` form keeps working.

The existing `_PARAMS_KEY_RE` is unchanged; the new regex's results are unioned into `literal_keys`.

The bare-variable form (`useQuerySql(slug, params)`) is intentionally not handled in this patch — it continues to fall through `_USE_QUERY_SQL_LITERAL_RE` silently as before.

## Test Cases

Added two `TestValidateRender` cases under `tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py`:

- `test_accepts_shorthand_param_keys` — `{ month_floor }` passes validation.
- `test_shorthand_does_not_capture_value_position_identifiers` — regression guard for `{ month_floor: some_var }` to ensure the value-side identifier is not misclassified as an unknown param.

Local gates:
- `pytest tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py::TestValidateRender` — 10/10 pass.
- Full unit-test suite with coverage: total 82.94% (preexisting unrelated failures in `test_explorer_service`, `test_compress_utils`, `test_windows_compatibility`, `test_node`; none touch the dashboard validator).
- `diff-cover` vs `upstream/main`: 100% diff coverage on the new lines.
- `ci/audit_tests.py --diff-only upstream/main`: P0=0, P1=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard queries now recognize ES6 object shorthand for parameter declarations, letting you declare params more concisely (e.g., { month }) without validation errors.

* **Tests**
  * Added unit tests covering shorthand, mixed, and multiline params objects to ensure parameter detection and validation behave correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->