### PR TITLE
[Enhancement] move Skeleton/ErrorBlock to @datus/web-artifact + use refetch

### DIFF
--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -216,11 +216,15 @@ Treat each output as a polished deliverable — a small **branded analytics prod
 `Skeleton` and `ErrorBlock` are runtime-provided primitives — **import them directly from `@datus/web-artifact`**. Do not re-implement them in `render/shared/card.jsx`; every artifact shares one canonical look and gets free upgrades when the runtime ships new versions, exactly like `AnimateOnVisible` and `ChartEntryMore`.
 
 ```jsx
-import { Skeleton, ErrorBlock } from '@datus/web-artifact';
+import { useDatusArtifact, Skeleton, ErrorBlock } from '@datus/web-artifact';
 
-const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/foo', params);
-if (isLoading) return <Skeleton minHeight={300} />;
-if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={refetch} />;
+function RevenueCard({ params }) {
+  const { useQuerySql } = useDatusArtifact();
+  const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/foo', params);
+  if (isLoading) return <Skeleton minHeight={300} />;
+  if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={refetch} />;
+  // ... chart JSX
+}
 ```
 
 Props:

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -47,7 +47,7 @@ The optional `/** @datus-title ... */` annotation at the top is used by the stan
 | Module | Notes |
 |---|---|
 | `react` | `useState`, `useEffect`, `useRef`, `useMemo`, `useCallback`, `useContext`, `createContext`, plus the default `React` namespace |
-| `@datus/web-artifact` | `useDatusArtifact`, `AnimateOnVisible` (see "Motion & animation"), `ChartEntryMore` (see "Chart action menu") |
+| `@datus/web-artifact` | `useDatusArtifact`, `AnimateOnVisible` (see "Motion & animation"), `ChartEntryMore` (see "Chart action menu"), `Skeleton`, `ErrorBlock` (see "Loading & error placeholders") |
 | `recharts` | any named export (`AreaChart`, `LineChart`, `BarChart`, `RadarChart`, `PieChart`, `ResponsiveContainer`, `Tooltip`, `XAxis`, `YAxis`, `CartesianGrid`, `Area`, `Line`, `Bar`, `Radar`, `Pie`, `Cell`, etc.) |
 | `lucide-react` | any icon component (`User`, `TrendingUp`, `Banknote`, `Globe`, `Landmark`, …). **Use these instead of emoji** — see the "Iconography & emoji" section below. |
 | `d3-format` | `format` — build numeric / currency / percent / SI-prefix formatters |
@@ -64,9 +64,9 @@ Every chart / table / KPI component in `render/` follows the same five-section s
 
 ```jsx
 import { useMemo, useRef } from 'react';
-import { useDatusArtifact, AnimateOnVisible, ChartEntryMore } from '@datus/web-artifact';
+import { useDatusArtifact, AnimateOnVisible, ChartEntryMore, Skeleton, ErrorBlock } from '@datus/web-artifact';
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
-import Card, { Skeleton, ErrorBlock } from './shared/card';
+import Card from './shared/card';
 import { N } from './shared/formatters';
 
 function RevenueTrendCard() {
@@ -213,115 +213,31 @@ Treat each output as a polished deliverable — a small **branded analytics prod
 
 ### Loading & error placeholders — `Skeleton` / `ErrorBlock`
 
-`Skeleton` and `ErrorBlock` live alongside `Card` in `render/shared/card.jsx` and every component imports them as `import Card, { Skeleton, ErrorBlock } from './shared/card'`. They are the **first thing the reader sees** while a query resolves or when it fails — treat them as part of the visual system, not as throwaway placeholders. The default LLM versions (one centered pulsing dot, one red text line) read as cheap and unfinished. Use the reference implementation below as a starting point and adapt the palette/copy to the artifact.
+`Skeleton` and `ErrorBlock` are runtime-provided primitives — **import them directly from `@datus/web-artifact`**. Do not re-implement them in `render/shared/card.jsx`; every artifact shares one canonical look and gets free upgrades when the runtime ships new versions, exactly like `AnimateOnVisible` and `ChartEntryMore`.
 
 ```jsx
-// render/shared/card.jsx
-import { AlertCircle, RotateCcw } from 'lucide-react';
-import { COLORS } from './colors';
+import { Skeleton, ErrorBlock } from '@datus/web-artifact';
 
-const PLACEHOLDER_KEYFRAMES = `
-  @keyframes datus-shimmer { 0% { background-position: 200% 0 } 100% { background-position: -200% 0 } }
-`;
-
-export function Skeleton({ minHeight = 200, bars = 3 }) {
-  // Three stacked shimmer bars at 60% / 80% / 40% width — reads as "data is
-  // loading" without committing to a chart shape that would flash and
-  // re-arrange when real data arrives.
-  const widths = ['60%', '80%', '40%'];
-  return (
-    <div
-      style={{
-        minHeight,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        gap: 12,
-        padding: 20,
-      }}
-    >
-      <style>{PLACEHOLDER_KEYFRAMES}</style>
-      {Array.from({ length: bars }).map((_, i) => (
-        <div
-          key={i}
-          style={{
-            height: 12,
-            width: widths[i % widths.length],
-            borderRadius: 6,
-            background:
-              'linear-gradient(90deg, #F3F4F6 0%, #E5E7EB 50%, #F3F4F6 100%)',
-            backgroundSize: '200% 100%',
-            animation: 'datus-shimmer 1.4s ease-in-out infinite',
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
-export function ErrorBlock({ msg, onRetry }) {
-  const handleRetry = onRetry ?? (() => window.location.reload());
-  return (
-    <div
-      style={{
-        minHeight: 140,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: 10,
-        padding: 20,
-        background: '#FEF2F2',
-        border: '1px solid #FECACA',
-        borderRadius: 12,
-        textAlign: 'center',
-      }}
-    >
-      <AlertCircle size={24} strokeWidth={2} style={{ color: COLORS.negative }} />
-      <span style={{ fontSize: 13, color: COLORS.negative, maxWidth: 360, lineHeight: 1.5 }}>
-        {msg}
-      </span>
-      <button
-        type="button"
-        onClick={handleRetry}
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 6,
-          padding: '6px 12px',
-          marginTop: 4,
-          borderRadius: 6,
-          border: `1px solid ${COLORS.negative}`,
-          background: 'transparent',
-          color: COLORS.negative,
-          fontSize: 12,
-          fontWeight: 500,
-          cursor: 'pointer',
-        }}
-      >
-        <RotateCcw size={14} strokeWidth={2} />
-        Retry
-      </button>
-    </div>
-  );
-}
+const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/foo', params);
+if (isLoading) return <Skeleton minHeight={300} />;
+if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={refetch} />;
 ```
+
+Props:
+
+| Component | Prop | Default | Notes |
+|---|---|---|---|
+| `Skeleton` | `minHeight` | `200` | Match the chart's expected height so the layout doesn't shift when real content mounts. |
+| `Skeleton` | `bars` | `3` | Number of shimmer bars (60% / 80% / 40% width cycle). Bump to 4–5 for taller cards. |
+| `ErrorBlock` | `msg` | — (required) | The `errorMessage` field from `useQuerySql`. |
+| `ErrorBlock` | `onRetry` | `window.location.reload` | Pass `refetch` from `useQuerySql` so the Retry button re-runs just the failed query instead of reloading the whole iframe. |
+| `ErrorBlock` | `minHeight` | `140` | Override only when the surrounding layout demands a specific height. |
 
 Rules:
 
-- **Always import `{ Skeleton, ErrorBlock }` from `./shared/card`** — never inline a one-off placeholder per component. The whole point of the shared module is consistent loading/error UX across the artifact.
-- **Skeleton uses a shimmering bar stack**, not a single pulsing dot. Three stacked bars at 60% / 80% / 40% widths read as "a card whose contents haven't loaded yet"; a centered dot reads as "spinner in an empty box". Skeletons live on the card's own background — do **not** add a separate filled rectangle behind the bars.
-- **ErrorBlock always shows a Retry control**, even on errors the user can't directly fix. The action gives the reader an obvious recovery affordance instead of a dead-end red box. Use Lucide `AlertCircle` (24×24, `COLORS.negative`) above the message and Lucide `RotateCcw` (14×14) inside the button — these are an explicit exception to the "icons sparingly" rule below because the placeholders are functional UI.
-- **`onRetry` is optional but should always be wired up** in components that use `useQuerySql`. The hook exposes a stable `refetch()` action — pass it straight through. When `onRetry` is omitted (e.g. a placeholder rendered outside the data-hooks flow), the button falls back to `window.location.reload()` so every artifact still has a working recovery path.
-- **Component usage** matches the canonical-component-shape early returns:
-
-  ```jsx
-  const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/foo', params);
-  if (isLoading) return <Skeleton minHeight={300} />;
-  if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={refetch} />;
-  ```
-
-  `refetch` re-runs the same `(sqlId, params)` pair against the provider without remounting the component — preferred over `window.location.reload()`, which reloads the entire artifact iframe.
+- **Always wire `onRetry={refetch}`** in components that use `useQuerySql`. The fallback (`window.location.reload()`) re-mounts the entire artifact iframe and loses any local UI state (filters, page numbers, scroll position) — fine as a last resort but not the preferred path.
+- **The placeholders use a fixed neutral palette** (gray-100/200 shimmer for `Skeleton`; red-50 / red-200 / red-700 for `ErrorBlock`) so error UX is consistent across every artifact. Do not try to override their colors via wrapper divs — if a future palette knob is needed, it will land as an explicit prop.
+- **Lucide icons inside the runtime placeholders** (`AlertCircle`, `RotateCcw`) are part of the component, not something you import — they are an exception to the "icons sparingly" rule below because the placeholders are functional UI.
 
 ### Iconography & emoji (read this twice)
 

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -77,7 +77,7 @@ function RevenueTrendCard() {
 
   // 2. Data hooks — every `useQuerySql` at the top, before any early return.
   const { useQuerySql } = useDatusArtifact();
-  const { isLoading, errorMessage, data } = useQuerySql('queries/revenue_by_month');
+  const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/revenue_by_month');
 
   // 3. Derived data — `useMemo` with stable deps; coerce numerics with N().
   const rows = useMemo(
@@ -88,7 +88,7 @@ function RevenueTrendCard() {
   // 4. Early returns — only AFTER every hook above. Render loading / error
   //    placeholders here; never inline a hook into the skeleton below.
   if (isLoading) return <Skeleton minHeight={300} />;
-  if (errorMessage) return <ErrorBlock msg={errorMessage} />;
+  if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={refetch} />;
 
   // 5. JSX — wrapper `<div ref={cardRef}>` is the screenshot root for
   //    ChartEntryMore. `titleRight` hosts the action menu so `<Card>` itself
@@ -133,13 +133,14 @@ All data access goes through one hook:
 import { useDatusArtifact } from '@datus/web-artifact';
 
 const { useQuerySql } = useDatusArtifact();
-const { isLoading, errorMessage, data } = useQuerySql('queries/account_activity_by_city');
+const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/account_activity_by_city');
 ```
 
 Returns:
 - `isLoading: boolean` — true until the artifact resolves.
 - `errorMessage: string | null` — non-null when the sqlId is unpublished or the JSON is malformed.
 - `data: ISqlQueryResult | null` — null until ready.
+- `refetch: () => void` — re-runs the query against the underlying provider, ignoring any in-memory cache. Pass into `<ErrorBlock onRetry={refetch}>` to wire up the placeholder's Retry button.
 
 ```ts
 type ColumnSemanticType = 'string' | 'integer' | 'number' | 'date' | 'boolean';
@@ -311,17 +312,16 @@ Rules:
 - **Always import `{ Skeleton, ErrorBlock }` from `./shared/card`** — never inline a one-off placeholder per component. The whole point of the shared module is consistent loading/error UX across the artifact.
 - **Skeleton uses a shimmering bar stack**, not a single pulsing dot. Three stacked bars at 60% / 80% / 40% widths read as "a card whose contents haven't loaded yet"; a centered dot reads as "spinner in an empty box". Skeletons live on the card's own background — do **not** add a separate filled rectangle behind the bars.
 - **ErrorBlock always shows a Retry control**, even on errors the user can't directly fix. The action gives the reader an obvious recovery affordance instead of a dead-end red box. Use Lucide `AlertCircle` (24×24, `COLORS.negative`) above the message and Lucide `RotateCcw` (14×14) inside the button — these are an explicit exception to the "icons sparingly" rule below because the placeholders are functional UI.
-- **`onRetry` is optional**. Pass a callback when the caller knows how to re-trigger the query (typically: a `retryKey` from `useState` that you increment, used in the component's own re-mount key); when omitted, the button falls back to `window.location.reload()` so the artifact always has a working recovery path.
+- **`onRetry` is optional but should always be wired up** in components that use `useQuerySql`. The hook exposes a stable `refetch()` action — pass it straight through. When `onRetry` is omitted (e.g. a placeholder rendered outside the data-hooks flow), the button falls back to `window.location.reload()` so every artifact still has a working recovery path.
 - **Component usage** matches the canonical-component-shape early returns:
 
   ```jsx
-  const [retryKey, setRetryKey] = useState(0);
-  const { isLoading, errorMessage, data } = useQuerySql('queries/foo', { ...params, _retry: retryKey });
+  const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/foo', params);
   if (isLoading) return <Skeleton minHeight={300} />;
-  if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={() => setRetryKey(k => k + 1)} />;
+  if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={refetch} />;
   ```
 
-  The `_retry` key trick is only needed when you want the retry to re-run the *same* query without a full page reload; if a page reload is acceptable, omit `onRetry` entirely and let the default kick in.
+  `refetch` re-runs the same `(sqlId, params)` pair against the provider without remounting the component — preferred over `window.location.reload()`, which reloads the entire artifact iframe.
 
 ### Iconography & emoji (read this twice)
 

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -97,7 +97,7 @@ function RevenueTrendCard() {
     <div ref={cardRef}>
       <Card
         title="Revenue trend"
-        titleRight={<ChartEntryMore sqlId="queries/revenue_by_month" cardRef={cardRef} />}
+        titleRight={<ChartEntryMore sqlId="queries/revenue_by_month" data={data} cardRef={cardRef} />}
       >
         <AnimateOnVisible minHeight={300}>
           <ResponsiveContainer width="100%" height={300}>
@@ -361,15 +361,17 @@ Every visualization backed by a `useQuerySql(...)` call gets a `<ChartEntryMore>
 1. **Always wrap the card in `<div ref={cardRef}>`.** The wrapper div is the screenshot root for PNG export. Mandatory; don't skip even if your `<Card>` primitive looks like it could host the ref.
 2. **Never pass `ref` directly to `<Card>`.** React 18 strips `ref` from props on function components, so `cardRef.current` stays null and PNG export throws. The wrapper-div pattern in rule 1 sidesteps this entirely.
 3. **Always pass `cardRef` to `<ChartEntryMore>`.** Don't rely on the `cardSelector` fallback below.
-4. **Render `<ChartEntryMore>` in the card's `titleRight` slot** when it exists (every shared `card.jsx` should expose one). Otherwise lay it out inline with `display: 'flex'` + `justifyContent: 'space-between'` in the card header row.
-5. **One `<ChartEntryMore>` per card.** Don't add multiple for different sub-charts inside one card — combine them into one card per query, or pick the most-prominent sqlId.
-6. **Add `<ChartEntryMore>` to every `useQuerySql`-backed visualization** — line / bar / area / pie / scatter / radar charts, KPI cards, KPI sparklines, custom inline SVG visualizations, **and data tables** (trigger in the header strip above `<table>`, not inside `<thead>`). The "View SQL" action is the single best credibility move for an analytical deliverable; don't gate it on whether the chart "looks important enough".
+4. **Always pass `data` to `<ChartEntryMore>`** — feed it the `data` field from the matching `useQuerySql(sqlId, params)` call. `ChartEntryMore` no longer fetches on its own; without `data` the View SQL / Export SQL / Export CSV / Export JSON actions are disabled (PNG actions still work). This is **mandatory in dashboard mode** because the menu has no way to know what `params` the parent applied — passing `data` is the only way to keep menu and chart in sync.
+5. **Render `<ChartEntryMore>` in the card's `titleRight` slot** when it exists (every shared `card.jsx` should expose one). Otherwise lay it out inline with `display: 'flex'` + `justifyContent: 'space-between'` in the card header row.
+6. **One `<ChartEntryMore>` per card.** Don't add multiple for different sub-charts inside one card — combine them into one card per query, or pick the most-prominent sqlId.
+7. **Add `<ChartEntryMore>` to every `useQuerySql`-backed visualization** — line / bar / area / pie / scatter / radar charts, KPI cards, KPI sparklines, custom inline SVG visualizations, **and data tables** (trigger in the header strip above `<table>`, not inside `<thead>`). The "View SQL" action is the single best credibility move for an analytical deliverable; don't gate it on whether the chart "looks important enough".
 
 #### Props
 
 | Prop | Required | Notes |
 |---|---|---|
-| `sqlId` | yes | Same literal you passed to `useQuerySql`. The component looks up the cached query result and the raw `.sql` text by this id. |
+| `sqlId` | yes | The same literal you passed to `useQuerySql`. Used only for the View SQL modal title and as the default download filename — the component does **not** re-fetch by this id. |
+| `data` | yes (per rule 4) | Pass through the `data` field from the matching `useQuerySql(sqlId, params)` call. Provides the rows / columns for CSV+JSON export and `data.sql` for the SQL actions. |
 | `cardRef` | yes (per rule 3) | Ref on the **outer wrapper div** — the screenshot root for "Export PNG" / "Copy PNG". |
 | `cardSelector` | no (fallback only) | Used when `cardRef` is omitted; do not rely on this. Defaults to `'[data-datus-chart-card]'` — if you skip `cardRef`, mark the card root with that attribute. |
 | `filenameBase` | no | Override the downloaded basename (default: the slug). Extensions are added automatically. |

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -210,6 +210,119 @@ Treat each output as a polished deliverable — a small **branded analytics prod
 - **Figure captions** (report mode): every chart gets a caption beneath the `<ResponsiveContainer>` in the form `Figure N. <one-line description>. Source: <sqlId>, executed <date>`. Captions in 11px italic muted text.
 - **Data tables**: zebra-striped rows, right-aligned numeric columns, left-aligned string columns, sticky header within the table card. When the dataset has **more than 15 rows, paginate** at 15 rows/page. Render a small pagination footer beneath the table — `‹ Prev`, `<current> / <total>` indicator, `Next ›` laid out in a single row and **right-aligned within the card** (`display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 8`). Never center the footer in the card or stretch it edge-to-edge — flex-end is mandatory so multiple tables on the same page align visually. Keep the current page in component-local `useState`; disable the boundary button at page 1 / last page. Don't use a "show more" toggle and don't render all rows at once; paginating is the cleaner read for the user and keeps the rendered DOM small.
 
+### Loading & error placeholders — `Skeleton` / `ErrorBlock`
+
+`Skeleton` and `ErrorBlock` live alongside `Card` in `render/shared/card.jsx` and every component imports them as `import Card, { Skeleton, ErrorBlock } from './shared/card'`. They are the **first thing the reader sees** while a query resolves or when it fails — treat them as part of the visual system, not as throwaway placeholders. The default LLM versions (one centered pulsing dot, one red text line) read as cheap and unfinished. Use the reference implementation below as a starting point and adapt the palette/copy to the artifact.
+
+```jsx
+// render/shared/card.jsx
+import { AlertCircle, RotateCcw } from 'lucide-react';
+import { COLORS } from './colors';
+
+const PLACEHOLDER_KEYFRAMES = `
+  @keyframes datus-shimmer { 0% { background-position: 200% 0 } 100% { background-position: -200% 0 } }
+`;
+
+export function Skeleton({ minHeight = 200, bars = 3 }) {
+  // Three stacked shimmer bars at 60% / 80% / 40% width — reads as "data is
+  // loading" without committing to a chart shape that would flash and
+  // re-arrange when real data arrives.
+  const widths = ['60%', '80%', '40%'];
+  return (
+    <div
+      style={{
+        minHeight,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        gap: 12,
+        padding: 20,
+      }}
+    >
+      <style>{PLACEHOLDER_KEYFRAMES}</style>
+      {Array.from({ length: bars }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            height: 12,
+            width: widths[i % widths.length],
+            borderRadius: 6,
+            background:
+              'linear-gradient(90deg, #F3F4F6 0%, #E5E7EB 50%, #F3F4F6 100%)',
+            backgroundSize: '200% 100%',
+            animation: 'datus-shimmer 1.4s ease-in-out infinite',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ErrorBlock({ msg, onRetry }) {
+  const handleRetry = onRetry ?? (() => window.location.reload());
+  return (
+    <div
+      style={{
+        minHeight: 140,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+        padding: 20,
+        background: '#FEF2F2',
+        border: '1px solid #FECACA',
+        borderRadius: 12,
+        textAlign: 'center',
+      }}
+    >
+      <AlertCircle size={24} strokeWidth={2} style={{ color: COLORS.negative }} />
+      <span style={{ fontSize: 13, color: COLORS.negative, maxWidth: 360, lineHeight: 1.5 }}>
+        {msg}
+      </span>
+      <button
+        type="button"
+        onClick={handleRetry}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '6px 12px',
+          marginTop: 4,
+          borderRadius: 6,
+          border: `1px solid ${COLORS.negative}`,
+          background: 'transparent',
+          color: COLORS.negative,
+          fontSize: 12,
+          fontWeight: 500,
+          cursor: 'pointer',
+        }}
+      >
+        <RotateCcw size={14} strokeWidth={2} />
+        Retry
+      </button>
+    </div>
+  );
+}
+```
+
+Rules:
+
+- **Always import `{ Skeleton, ErrorBlock }` from `./shared/card`** — never inline a one-off placeholder per component. The whole point of the shared module is consistent loading/error UX across the artifact.
+- **Skeleton uses a shimmering bar stack**, not a single pulsing dot. Three stacked bars at 60% / 80% / 40% widths read as "a card whose contents haven't loaded yet"; a centered dot reads as "spinner in an empty box". Skeletons live on the card's own background — do **not** add a separate filled rectangle behind the bars.
+- **ErrorBlock always shows a Retry control**, even on errors the user can't directly fix. The action gives the reader an obvious recovery affordance instead of a dead-end red box. Use Lucide `AlertCircle` (24×24, `COLORS.negative`) above the message and Lucide `RotateCcw` (14×14) inside the button — these are an explicit exception to the "icons sparingly" rule below because the placeholders are functional UI.
+- **`onRetry` is optional**. Pass a callback when the caller knows how to re-trigger the query (typically: a `retryKey` from `useState` that you increment, used in the component's own re-mount key); when omitted, the button falls back to `window.location.reload()` so the artifact always has a working recovery path.
+- **Component usage** matches the canonical-component-shape early returns:
+
+  ```jsx
+  const [retryKey, setRetryKey] = useState(0);
+  const { isLoading, errorMessage, data } = useQuerySql('queries/foo', { ...params, _retry: retryKey });
+  if (isLoading) return <Skeleton minHeight={300} />;
+  if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={() => setRetryKey(k => k + 1)} />;
+  ```
+
+  The `_retry` key trick is only needed when you want the retry to re-run the *same* query without a full page reload; if a page reload is acceptable, omit `onRetry` entirely and let the default kick in.
+
 ### Iconography & emoji (read this twice)
 
 The default LLM instinct is to pepper an artifact with 📊 📈 🌍 💰 🏦 📱 — **don't**. Emoji read as consumer / casual / cheap and undercut the analytical credibility a BI deliverable needs. They render at different sizes across platforms, can't be color-coordinated with the palette, and turn a research-grade deliverable into something that looks like a Slack post.
@@ -318,7 +431,7 @@ Rules of thumb when wiring this in:
 #### Other motion concerns
 
 - **Custom inline SVG** (treemaps, gauges, score sliders): also wrap in `AnimateOnVisible` (imported from `@datus/web-artifact`). Inside, animate with CSS transitions on `transform` / `opacity` / `stroke-dashoffset`, driven by `useState` + a `useEffect(() => setMounted(true), [])` toggle on mount. Same easing language: `transition: 'transform 800ms ease-out'`.
-- **Loading skeletons** should pulse, not animate full charts. A subtle `@keyframes pulse { 0%, 100% { opacity: 0.6 } 50% { opacity: 1 } }` on the skeleton block is enough — defined via an inline `<style>` tag at the top of the file or in a shared `card.jsx`.
+- **Loading skeletons** animate at the card boundary, never at the chart-primitive boundary — see the "Loading & error placeholders" section above for the canonical `Skeleton` (shimmering bar stack) and `ErrorBlock` (Lucide icon + retry) implementations to copy into `render/shared/card.jsx`.
 - **Respect reduced motion.** Compute `window.matchMedia('(prefers-reduced-motion: reduce)').matches` once at the top of `app.jsx` (via `useState` + `useEffect`) and pass `animationDuration={prefersReducedMotion ? 0 : 1500}` to Recharts primitives. `AnimateOnVisible` itself is fine to keep on — it only delays mount, never adds motion.
 
 Animation is part of the visual polish — the same way you'd pick a palette and a card primitive. An artifact whose charts pop in *as the reader reaches them* feels alive; one whose charts have already finished by the time they're seen feels like a screenshot.


### PR DESCRIPTION
## Why

The `Skeleton` / `ErrorBlock` placeholders the `gen_visual_report` and `gen_visual_dashboard` subagents emit have two long-standing problems:

1. **Cheap default look.** Generated per artifact, they end up as a single pulsing dot and a bare red text line — the first thing a reader sees while a query resolves or fails.
2. **No retry affordance.** ErrorBlock dead-ends the reader; the only "fix" was reloading the entire iframe.

Worse, both are LLM-emitted (~70 lines of JSX in every generated `render/shared/card.jsx`), so quality varies across runs and fixing the look means regenerating every existing artifact.

## Solution

This PR lands alongside [Datus-saas#390](https://github.com/Datus-ai/Datus-saas/pull/390), which moves `Skeleton` / `ErrorBlock` into `@datus/web-artifact` as first-class runtime primitives (mirroring `AnimateOnVisible` / `ChartEntryMore`) and adds `refetch` to the `useQuerySql` return value.

Prompt changes:

- **Allowed-imports table** lists `Skeleton` / `ErrorBlock` alongside the other `@datus/web-artifact` exports.
- **Canonical component shape** imports the placeholders from the runtime; `./shared/card` is left holding only `Card`.
- **New "Loading & error placeholders" section** drops the reference jsx (now ~70 lines lighter) and keeps just the prop table + wiring rules.
- **`useQuerySql` Returns doc** adds `refetch: () => void` and tells the subagent to pass it as `onRetry={refetch}` — the placeholder's `onRetry` falls back to `window.location.reload()` so the artifact still has a working recovery path if a component omits it.
- **Canonical examples and the Data-layer intro** destructure `refetch` from the hook and wire `<ErrorBlock onRetry={refetch} />` in early returns.

Net effect on the rendered prompt: **-2.6 KB / -70 lines**, plus a consistent placeholder look across every artifact (existing and future) and a per-card Retry button that doesn't reload the iframe.

### Ordering

This PR is safe to merge before #390 ships:

- If the prompt lands first, generated code imports `Skeleton` / `ErrorBlock` from `@datus/web-artifact`. The validator's allow-list already permits that bare specifier, so static validation passes; runtime resolution fails until #390 ships, which surfaces as a per-card error — not a hard crash. Practically you'd want #390 to land first.
- If #390 lands first, nothing changes for already-generated artifacts; new generations pick up the new pattern only after this PR lands.

## Test Cases

No new tests — pure prompt change. Verification:

- `jinja2` rendering of `_visual_artifact_common.j2` succeeds; the new section appears in the output and the old reference jsx (`PLACEHOLDER_KEYFRAMES`, `datus-shimmer` keyframe definitions) is gone.
- `pytest tests/unit_tests/agent/node/test_gen_visual_{dashboard,report}_agentic_node.py` — 29/29 pass (these exercise prompt loading).
- End-to-end behavior (the Retry button actually re-running the query) is covered by nightly visual-artifact regression once #390 ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart action menu now requires query results (data) for certain actions; those actions are disabled when data isn't provided.
  * Error states include standardized retry wiring (uses provided retry handler; falls back to page reload).

* **Documentation**
  * Updated guidance for loading/error placeholders and mandated direct imports for them.
  * Loading skeleton animation moved to card boundaries for consistent UX.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->