### PR TITLE
[BugFix] Backport semantic bootstrap fixes to 0.3.1

### DIFF
--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -434,7 +434,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 raise RuntimeError(
                     "Semantic model generation produced semantic_model_files, but validate_semantic is unavailable."
                 )
-            validation_result = self.semantic_func_tool.validate_semantic()
+            validation_result = self.semantic_func_tool.validate_semantic(scope="semantic_model")
             self.generation_evidence.record_validation_result(validation_result)
             if not self._tool_succeeded(validation_result):
                 raise RuntimeError(

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
@@ -66,6 +66,7 @@ Please strictly follow the instructions below:
    - Create a semantic model following the specification below.
    - A semantic model generation file should define `data_source:` document(s). Do not add a top-level `metrics:` list to the same YAML document.
    - If explicit metric definitions are required later, generate them in the metrics workflow as separate `metric:` YAML documents. MetricFlow requires each YAML document to have exactly one top-level object type.
+   - Do not define the same column/name under both `identifiers` and `dimensions`. Use identifiers for primary/join keys and dimensions for grouping/filtering fields.
    - **CRITICAL**: Populate `description` fields for ALL measures, dimensions, and identifiers by **COMBINING ALL** available information:
      - Start with DDL comments (preserve original language)
      - Append usage patterns and **filter examples** from `analyze_column_usage_patterns`
@@ -87,16 +88,17 @@ Please strictly follow the instructions below:
    - If semantic model already exists, update it with `edit_file` if anything changed
 
 6. **Validate configuration** (MANDATORY - DO NOT SKIP):
-   - Use `validate_semantic` tool to validate the semantic model
+   - Use `validate_semantic(scope="semantic_model")` tool to validate the semantic model
    - **CRITICAL**: If validation fails:
      1. Analyze the error message carefully
      2. Use `edit_file` tool to fix the YAML file (do NOT just describe the fix - actually execute the fix)
-     3. Call `validate_semantic` again to verify the fix
+     3. Call `validate_semantic(scope="semantic_model")` again to verify the fix
      4. Repeat until validation passes
    - **ABSOLUTE RULE**: You MUST NOT return the final JSON response until `validate_semantic` returns success
    - Common validation errors and fixes:
      - PostgreSQL column case sensitivity: wrap uppercase column names in double quotes (e.g., `expr: '"SP_POP_TOTL"'`)
      - Column not found: check column names match exactly with DDL
+     - Duplicate semantic element name: remove a column from either `identifiers` or `dimensions`; do not keep the same `name` in both lists
      - Invalid YAML syntax: check indentation and quoting
 
 7. **Complete generation** (ONLY AFTER VALIDATION PASSES):
@@ -176,11 +178,11 @@ data_source:
 ```
 
 ### Step 6: Validate All Files Together (MANDATORY)
-- Call `validate_semantic` tool
+- Call `validate_semantic(scope="semantic_model")` tool
 - **CRITICAL**: If validation fails:
   1. Analyze the error message (e.g., "column xxx does not exist")
   2. Use `edit_file` tool to fix the YAML file - actually execute the fix, don't just describe it
-  3. Call `validate_semantic` again
+  3. Call `validate_semantic(scope="semantic_model")` again
   4. Repeat until ALL validations pass
 - **ABSOLUTE RULE**: Do NOT proceed to Step 7 until validation succeeds
 

--- a/datus/resources/skills/gen-semantic-model/SKILL.md
+++ b/datus/resources/skills/gen-semantic-model/SKILL.md
@@ -28,6 +28,8 @@ Create production-ready MetricFlow semantic model YAML for one or more database 
    - Define identifiers for primary keys and join keys.
    - Define measures only for reusable aggregations.
    - Define dimensions for grouping/filtering fields.
+   - Do not define the same column/name under both `identifiers` and `dimensions`. Use identifiers for
+     primary/join keys and dimensions for grouping/filtering fields.
    - Use `expr: "1"` for row-count measures with `agg: COUNT`.
    - For measures, use `agg` for the aggregation type; do not add a `type` field to measure entries.
 
@@ -40,7 +42,7 @@ Create production-ready MetricFlow semantic model YAML for one or more database 
    - If explicit metric definitions are needed, write them through the metrics generation workflow as separate `metric:` documents.
 
 4. **Validate and fix**
-   - Call `validate_semantic`.
+   - Call `validate_semantic(scope="semantic_model")`.
    - If validation fails, use `edit_file` to fix the YAML and call `validate_semantic` again.
    - Repeat until `validate_semantic` succeeds.
 

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -35,6 +35,7 @@ def _action_status_value(action: Any) -> Optional[str]:
 
 
 DEFAULT_METRICS_BATCH_SIZE = 1
+METRICS_RESPONSE_ACTION_TYPE = f"{GenMetricsAgenticNode.NODE_NAME}_response"
 
 
 async def _generate_metrics_batch(
@@ -98,7 +99,11 @@ async def _generate_metrics_batch(
                 terminal_error = action.messages or "Metrics extraction failed"
                 logger.error(terminal_error)
                 continue
-            if action.status == ActionStatus.SUCCESS and action_type == "metrics_response" and action.output:
+            if action.status == ActionStatus.FAILED and action_type == METRICS_RESPONSE_ACTION_TYPE:
+                terminal_error = action.messages or "Metrics extraction failed"
+                logger.error(terminal_error)
+                continue
+            if action.status == ActionStatus.SUCCESS and action_type == METRICS_RESPONSE_ACTION_TYPE and action.output:
                 final_result = action.output
                 logger.debug(f"Metrics generation action (batch {batch_idx}): {action.messages}")
         if terminal_error:

--- a/datus/storage/reference_sql/reference_sql_init.py
+++ b/datus/storage/reference_sql/reference_sql_init.py
@@ -3,6 +3,8 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import asyncio
+import os
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
@@ -27,6 +29,33 @@ def _action_status_value(action: Any) -> Optional[str]:
     if status is None:
         return None
     return status.value if hasattr(status, "value") else str(status)
+
+
+def _resolve_generated_summary_file_path(
+    agent_config: AgentConfig,
+    node: SqlSummaryAgenticNode,
+    sql_summary_file: str,
+) -> Optional[Path]:
+    """Resolve a generated SQL summary path reported by the workflow node."""
+    knowledge_base_dir = getattr(node, "knowledge_base_dir", None)
+    if isinstance(knowledge_base_dir, (str, os.PathLike)) and not hasattr(knowledge_base_dir, "mock_calls"):
+        from datus.cli.generation_hooks import resolve_kb_sandbox_path
+
+        resolved = resolve_kb_sandbox_path(sql_summary_file, "sql_summary", str(knowledge_base_dir))
+        return Path(resolved) if resolved else None
+
+    reported_path = Path(sql_summary_file)
+    if reported_path.is_absolute():
+        return reported_path
+
+    parts = reported_path.parts
+    if "sql_summaries" in parts:
+        summary_dir_index = parts.index("sql_summaries")
+        summary_relative_parts = parts[summary_dir_index + 1 :]
+        if summary_relative_parts:
+            return Path(agent_config.path_manager.sql_summary_path()).joinpath(*summary_relative_parts)
+
+    return Path(agent_config.path_manager.sql_summary_path()) / reported_path
 
 
 async def process_sql_item(
@@ -105,11 +134,14 @@ async def process_sql_item(
 
         logger.info(f"Generated SQL summary: {sql_summary_file}")
 
-        file_path = agent_config.path_manager.sql_summary_path() / sql_summary_file
+        file_path = _resolve_generated_summary_file_path(agent_config, node, sql_summary_file)
         import yaml
 
         try:
             # Load YAML file to get name and subject_tree
+            if not file_path:
+                logger.warning(f"SQL summary file rejected by sandbox check: {sql_summary_file!r}")
+                return None
             with open(file_path, "r", encoding="utf-8") as f:
                 doc = yaml.safe_load(f)
                 if not item.get("name"):

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -19,6 +19,8 @@ from datus.utils.terminal_utils import suppress_keyboard_input
 
 logger = get_logger(__name__)
 
+SEMANTIC_MODEL_RESPONSE_ACTION_TYPE = f"{GenSemanticModelAgenticNode.NODE_NAME}_response"
+
 
 async def init_success_story_semantic_model_async(
     agent_config: AgentConfig,
@@ -150,7 +152,11 @@ async def init_success_story_semantic_model_async(
                 )
 
             action_type = getattr(action, "action_type", "")
-            if action.status == ActionStatus.SUCCESS and action_type == "semantic_response" and action.output:
+            if (
+                action.status == ActionStatus.SUCCESS
+                and action_type == SEMANTIC_MODEL_RESPONSE_ACTION_TYPE
+                and action.output
+            ):
                 if isinstance(action.output, dict):
                     # Check for semantic_models field (from SemanticNodeResult)
                     if "semantic_models" in action.output:
@@ -159,7 +165,7 @@ async def init_success_story_semantic_model_async(
                             generated_files.extend(models)
                         elif models:  # Single file as string
                             generated_files.append(models)
-            elif action.status == ActionStatus.FAILED and action_type == "error":
+            elif action.status == ActionStatus.FAILED and action_type in {"error", SEMANTIC_MODEL_RESPONSE_ACTION_TYPE}:
                 terminal_error = action.messages or "Semantic model generation failed"
                 logger.error(terminal_error)
                 continue

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -9,8 +9,9 @@ Provides unified interface to semantic layer services through adapters.
 Tools delegate to registered semantic adapters while leveraging unified storage for performance.
 """
 
+import inspect
 import json
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from agents import Tool
 
@@ -27,6 +28,8 @@ from datus.utils.compress_utils import DataCompressor
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+NO_METRICS_PRESENT_MESSAGE = "No metrics present in the model."
 
 
 def _normalize_dimension_rows(raw) -> list:
@@ -74,6 +77,45 @@ def _normalize_name_list(value) -> List[str]:
         if text:
             names.append(text)
     return names
+
+
+def _serialize_validation_issue(issue) -> dict:
+    if hasattr(issue, "model_dump"):
+        issue_data = issue.model_dump(mode="json")
+    else:
+        issue_data = {"severity": "error", "message": str(issue)}
+
+    severity = issue_data.get("severity")
+    if severity is not None:
+        issue_data["severity"] = str(severity).lower()
+    return issue_data
+
+
+def _is_no_metrics_present_issue(issue: dict) -> bool:
+    message = str(issue.get("message") or "")
+    return NO_METRICS_PRESENT_MESSAGE in message
+
+
+def _validation_has_errors(issues: List[dict]) -> bool:
+    return any(str(issue.get("severity") or "").lower() == "error" for issue in issues)
+
+
+def _format_validation_error(issues: List[dict]) -> str:
+    count = len(issues)
+    if count == 0:
+        return "0 validation errors"
+
+    messages = []
+    for issue in issues[:3]:
+        message = str(issue.get("message") or "").strip()
+        if message:
+            messages.append(message)
+
+    if not messages:
+        return f"{count} validation errors"
+
+    suffix = f"; ... {count - len(messages)} more" if count > len(messages) else ""
+    return f"{count} validation errors: {'; '.join(messages)}{suffix}"
 
 
 def _run_async(coro):
@@ -596,7 +638,7 @@ class SemanticTools:
                 error=f"Failed to query metrics: {str(e)}",
             )
 
-    def validate_semantic(self) -> FuncToolResult:
+    def validate_semantic(self, scope: Literal["all", "semantic_model"] = "all") -> FuncToolResult:
         """
         Validate semantic layer configuration (requires adapter).
 
@@ -604,10 +646,24 @@ class SemanticTools:
         metrics or semantic model changes. This ensures that subsequent calls to
         query_metrics can find newly created metrics.
 
+        Args:
+            scope: Validation scope. Use "all" for full semantic-layer validation,
+                including metrics. Use "semantic_model" when generating semantic
+                models before metric definitions exist; this still fails on real
+                semantic model errors but ignores the expected no-metrics issue.
+
         Returns:
             FuncToolResult with validation status and issues
         """
-        logger.info("validate_semantic called")
+        scope = normalize_null(scope) or "all"
+        if scope not in ("all", "semantic_model"):
+            return FuncToolResult(
+                success=0,
+                error="scope must be one of: all, semantic_model",
+                result=None,
+            )
+
+        logger.info(f"validate_semantic called scope={scope}")
         adapter = self.adapter
         if not adapter:
             if self._adapter_load_error:
@@ -623,23 +679,57 @@ class SemanticTools:
             )
 
         try:
-            validation_result = _run_async(adapter.validate_semantic())
+            validate_semantic = adapter.validate_semantic
+            validation_kwargs = {}
+            if scope != "all":
+                try:
+                    signature = inspect.signature(validate_semantic)
+                    if "scope" in signature.parameters:
+                        validation_kwargs["scope"] = scope
+                    elif "validation_scope" in signature.parameters:
+                        validation_kwargs["validation_scope"] = scope
+                except (TypeError, ValueError):
+                    validation_kwargs = {}
+
+            validation_result = _run_async(validate_semantic(**validation_kwargs))
 
             # Serialize ValidationIssue objects to dicts
-            issues_data = [
-                issue.model_dump() if hasattr(issue, "model_dump") else {"severity": "error", "message": str(issue)}
-                for issue in validation_result.issues
-            ]
+            issues_data = [_serialize_validation_issue(issue) for issue in validation_result.issues]
+
+            ignored_issues = []
+            effective_issues = issues_data
+            if scope == "semantic_model":
+                ignored_issues = [issue for issue in issues_data if _is_no_metrics_present_issue(issue)]
+                effective_issues = [issue for issue in issues_data if not _is_no_metrics_present_issue(issue)]
+
+            effective_valid = validation_result.valid or (
+                scope == "semantic_model" and not _validation_has_errors(effective_issues)
+            )
+
+            if issues_data:
+                logger.warning(
+                    "Semantic validation issues scope=%s valid=%s effective_valid=%s issues=%s ignored=%s",
+                    scope,
+                    validation_result.valid,
+                    effective_valid,
+                    json.dumps(effective_issues, ensure_ascii=False),
+                    json.dumps(ignored_issues, ensure_ascii=False),
+                )
 
             # If validation succeeded, reload the adapter to pick up new metrics
-            if validation_result.valid:
+            if effective_valid:
                 logger.info("Validation succeeded, reloading adapter to pick up new metrics...")
                 self._reload_adapter()
 
             tool_result = FuncToolResult(
-                success=1 if validation_result.valid else 0,
-                result={"valid": validation_result.valid, "issues": issues_data},
-                error=None if validation_result.valid else f"{len(validation_result.issues)} validation errors",
+                success=1 if effective_valid else 0,
+                result={
+                    "valid": effective_valid,
+                    "issues": effective_issues,
+                    "scope": scope,
+                    "ignored_issues": ignored_issues,
+                },
+                error=None if effective_valid else _format_validation_error(effective_issues),
             )
             if self.generation_evidence:
                 self.generation_evidence.record_validation_result(tool_result)

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -617,7 +617,7 @@ class TestExecuteStreamGenSemanticModelError:
 
         assert actions[-1].status == ActionStatus.SUCCESS
         assert actions[-1].action_type == "gen_semantic_model_response"
-        node.semantic_func_tool.validate_semantic.assert_called_once()
+        node.semantic_func_tool.validate_semantic.assert_called_once_with(scope="semantic_model")
         sync_mock.assert_called_once()
 
     @pytest.mark.asyncio
@@ -664,6 +664,7 @@ class TestExecuteStreamGenSemanticModelError:
         assert actions[-1].status == ActionStatus.FAILED
         assert actions[-1].action_type == "error"
         assert "validate_semantic failed before publishing semantic models" in actions[-1].output["error"]
+        node.semantic_func_tool.validate_semantic.assert_called_once_with(scope="semantic_model")
         sync_mock.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -182,7 +182,7 @@ class TestInitSuccessStoryMetricsAsync:
             captured_input["input"] = mock_node.input
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"response": "done"}
             action.messages = "ok"
             yield action
@@ -284,7 +284,7 @@ class TestInitSuccessStoryMetricsAsync:
 
             final_action = MagicMock()
             final_action.status = ActionStatus.SUCCESS
-            final_action.action_type = "metrics_response"
+            final_action.action_type = "gen_metrics_response"
             final_action.output = {"response": "done"}
             final_action.messages = "ok"
             yield final_action
@@ -427,7 +427,7 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
         async def fake_execute_stream(_action_manager):
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"response": "done"}
             action.messages = "ok"
             yield action
@@ -481,7 +481,7 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
         async def fake_execute_stream(_action_manager):
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"response": "done"}
             action.messages = "ok"
             yield action
@@ -549,7 +549,7 @@ class TestGenerateMetricsBatch:
         async def fake_stream(_ahm):
             action = MagicMock()
             action.status = ActionStatus.SUCCESS
-            action.action_type = "metrics_response"
+            action.action_type = "gen_metrics_response"
             action.output = {"metrics": ["revenue"]}
             action.messages = "ok"
             yield action
@@ -619,6 +619,48 @@ class TestGenerateMetricsBatch:
 
         assert ok is False
         assert "Max turns" in err
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_failed_final_response_returns_failure(self):
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.schemas.batch_events import BatchEventHelper
+
+        mock_node = MagicMock()
+
+        async def fake_stream(_ahm):
+            action = MagicMock()
+            action.status = ActionStatus.FAILED
+            action.action_type = "gen_metrics_response"
+            action.output = {"error": "publish failed"}
+            action.messages = "publish failed"
+            yield action
+
+        mock_node.execute_stream = fake_stream
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
+        ):
+            ok, err, result = await _generate_metrics_batch(
+                ["Query 1:\nQuestion: q?\nSQL:\nSELECT 1"],
+                0,
+                mock_config,
+                None,
+                None,
+                BatchEventHelper("test", None),
+                None,
+            )
+
+        assert ok is False
+        assert "publish failed" in err
         assert result is None
 
     @pytest.mark.asyncio
@@ -695,7 +737,7 @@ class TestBatchSplitting:
                 else:
                     action = MagicMock()
                     action.status = ActionStatus.SUCCESS
-                    action.action_type = "metrics_response"
+                    action.action_type = "gen_metrics_response"
                     action.output = {"metrics": [f"m{self._batch_idx}"]}
                     action.messages = "ok"
                     yield action

--- a/tests/unit_tests/storage/reference_sql/test_reference_sql_init.py
+++ b/tests/unit_tests/storage/reference_sql/test_reference_sql_init.py
@@ -5,7 +5,7 @@
 """Unit tests for datus.storage.reference_sql.reference_sql_init."""
 
 from enum import Enum
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -72,6 +72,99 @@ class TestBizNameConstant:
     def test_biz_name_value(self):
         """BIZ_NAME is reference_sql_init."""
         assert BIZ_NAME == "reference_sql_init"
+
+
+# ---------------------------------------------------------------------------
+# process_sql_item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestProcessSqlItem:
+    """Tests for process_sql_item summary-path handling."""
+
+    def test_fallback_summary_path_strips_generated_sql_summaries_prefix(self, tmp_path):
+        """Fallback path resolution accepts generated paths that already include sql_summaries."""
+        from datus.storage.reference_sql.reference_sql_init import _resolve_generated_summary_file_path
+
+        summary_dir = tmp_path / "subject" / "sql_summaries"
+        mock_config = MagicMock()
+        mock_config.path_manager.sql_summary_path.return_value = summary_dir
+        mock_node = MagicMock()
+
+        result = _resolve_generated_summary_file_path(
+            mock_config,
+            mock_node,
+            "subject/sql_summaries/ref_001.yaml",
+        )
+
+        assert result == summary_dir / "ref_001.yaml"
+
+    def test_fallback_summary_path_allows_absolute_path(self, tmp_path):
+        """Fallback path resolution preserves absolute paths when no KB root is available."""
+        from datus.storage.reference_sql.reference_sql_init import _resolve_generated_summary_file_path
+
+        summary_file = tmp_path / "subject" / "sql_summaries" / "ref_001.yaml"
+        mock_config = MagicMock()
+        mock_node = MagicMock()
+
+        result = _resolve_generated_summary_file_path(mock_config, mock_node, str(summary_file))
+
+        assert result == summary_file
+
+    @pytest.mark.asyncio
+    async def test_success_with_subject_prefixed_summary_path(self, tmp_path):
+        """LLM may report subject/sql_summaries/...; resolver should not duplicate prefixes."""
+        import yaml
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.reference_sql.reference_sql_init import process_sql_item
+
+        kb_dir = tmp_path / "subject"
+        summary_dir = kb_dir / "sql_summaries"
+        summary_dir.mkdir(parents=True)
+        summary_file = summary_dir / "ref_001.yaml"
+        summary_file.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "new_product_activity_query",
+                    "subject_tree": "运营/活动/类别",
+                },
+                allow_unicode=True,
+            ),
+            encoding="utf-8",
+        )
+
+        success_action = MagicMock()
+        success_action.status = ActionStatus.SUCCESS
+        success_action.output = {"sql_summary_file": "subject/sql_summaries/ref_001.yaml"}
+        success_action.messages = []
+
+        async def mock_execute_stream(*args, **kwargs):
+            yield success_action
+
+        mock_node = MagicMock()
+        mock_node.knowledge_base_dir = str(kb_dir)
+        mock_node.execute_stream = mock_execute_stream
+
+        mock_config = MagicMock()
+        mock_config.path_manager.sql_summary_path.return_value = summary_dir
+
+        item = {
+            "sql": "SELECT * FROM v_udata_ac_info",
+            "filepath": "/tmp/ref.sql",
+            "comment": "",
+        }
+
+        with patch(
+            "datus.storage.reference_sql.reference_sql_init.SqlSummaryAgenticNode",
+            return_value=mock_node,
+        ):
+            result = await process_sql_item(item, mock_config, build_mode="overwrite")
+
+        assert result == "subject/sql_summaries/ref_001.yaml"
+        assert item["name"] == "new_product_activity_query"
+        assert item["subject_tree"] == "运营/活动/类别"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/semantic_model/test_auto_create.py
+++ b/tests/unit_tests/storage/semantic_model/test_auto_create.py
@@ -339,7 +339,9 @@ class TestCreateSemanticModelForTable:
                     action_type="tool_call",
                     messages="Tool call: validate_semantic('{}...')",
                 )
-                yield SimpleNamespace(status=ActionStatus.SUCCESS, action_type="semantic_response", messages="ok")
+                yield SimpleNamespace(
+                    status=ActionStatus.SUCCESS, action_type="gen_semantic_model_response", messages="ok"
+                )
 
         with (
             patch(

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -360,7 +360,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["model1.yaml", "model2.yaml"]},
                     messages="Generated models",
                 )
@@ -402,7 +402,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["model.yaml"]},
                     messages="Generated model",
                 )
@@ -450,7 +450,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
                 # single string instead of list
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": "single_model.yaml"},
                     messages="Generated",
                 )
@@ -497,7 +497,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
                 )
                 yield SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["model.yaml"]},
                     messages="Generated",
                 )
@@ -553,6 +553,46 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
         assert "did not publish" in error
 
     @pytest.mark.asyncio
+    async def test_failed_final_response_action_returns_failure(self, tmp_path, monkeypatch):
+        """A failed final response action still fails the batch."""
+        from types import SimpleNamespace
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT 1,Q?\n")
+
+        mock_config = MagicMock()
+        mock_db_config = MagicMock()
+        mock_db_config.catalog = ""
+        mock_db_config.database = "db"
+        mock_db_config.schema = ""
+        mock_config.current_db_config.return_value = mock_db_config
+
+        class MockSemanticNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+
+            async def execute_stream(self, action_history_manager):
+                yield SimpleNamespace(
+                    status=ActionStatus.FAILED,
+                    action_type="gen_semantic_model_response",
+                    output={"error": "failed final response"},
+                    messages="failed final response",
+                )
+
+        monkeypatch.setattr(
+            "datus.storage.semantic_model.semantic_model_init.GenSemanticModelAgenticNode",
+            MockSemanticNode,
+        )
+
+        success, error = await init_success_story_semantic_model_async(mock_config, str(csv_path))
+
+        assert success is False
+        assert "failed final response" in error
+
+    @pytest.mark.asyncio
     async def test_empty_result_path_returns_false(self, tmp_path, monkeypatch):
         """Empty result path: no generated files → returns (False, error)."""
         from types import SimpleNamespace
@@ -578,7 +618,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
                 # Yields an action with SUCCESS but no semantic_models key
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"other_key": "value"},
                     messages="Nothing useful",
                 )
@@ -620,7 +660,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={},
                     messages="",
                 )
@@ -738,7 +778,7 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
             async def execute_stream(self, action_history_manager):
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output=None,
                     messages="",
                 )
@@ -793,7 +833,7 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
             async def execute_stream(self, action_history_manager):
                 yield SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["m.yaml"]},
                     messages="ok",
                 )
@@ -840,7 +880,7 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
             async def execute_stream(self, action_history_manager):
                 yield SimpleNamespace(
                     status=ActionStatus.SUCCESS,
-                    action_type="semantic_response",
+                    action_type="gen_semantic_model_response",
                     output={"semantic_models": ["m.yaml"]},
                     messages="ok",
                 )

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -2,6 +2,7 @@
 Test cases for SemanticTools utility functions and query_metrics compression.
 """
 
+from enum import Enum
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,6 +11,10 @@ from datus.tools.func_tool.base import FuncToolResult, normalize_null
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.semantic_tools import _run_async
 from datus.tools.semantic_tools.models import QueryResult
+
+
+class _Severity(Enum):
+    ERROR = "error"
 
 
 class TestGenerationEvidence:
@@ -795,7 +800,122 @@ class TestValidateSemantic:
         assert result.result["valid"] is False
         assert len(result.result["issues"]) == 1
         assert "1 validation errors" in result.error
+        assert "bad config" in result.error
         assert evidence.validation_passed is False
+
+    def test_all_scope_keeps_no_metrics_validation_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        mock_issue = Mock()
+        mock_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "No metrics present in the model.",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [mock_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            result = tool.validate_semantic()
+
+        assert result.success == 0
+        assert result.result["valid"] is False
+        assert result.result["issues"] == [{"severity": "error", "message": "No metrics present in the model."}]
+        assert result.result["ignored_issues"] == []
+        assert evidence.validation_passed is False
+
+    def test_semantic_model_scope_ignores_no_metrics_validation_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        mock_issue = Mock()
+        mock_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "No metrics present in the model.",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [mock_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            with patch.object(tool, "_reload_adapter", return_value=True):
+                result = tool.validate_semantic(scope="semantic_model")
+
+        assert result.success == 1
+        assert result.result["valid"] is True
+        assert result.result["issues"] == []
+        assert result.result["ignored_issues"] == [{"severity": "error", "message": "No metrics present in the model."}]
+        assert result.result["scope"] == "semantic_model"
+        assert evidence.validation_passed is True
+
+    def test_semantic_model_scope_keeps_real_validation_errors(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        no_metrics_issue = Mock()
+        no_metrics_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "No metrics present in the model.",
+        }
+        duplicate_issue = Mock()
+        duplicate_issue.model_dump.return_value = {
+            "severity": "error",
+            "message": "Element ac_code has already been used as Dimension",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [no_metrics_issue, duplicate_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            result = tool.validate_semantic(scope="semantic_model")
+
+        assert result.success == 0
+        assert result.result["valid"] is False
+        assert result.result["issues"] == [
+            {"severity": "error", "message": "Element ac_code has already been used as Dimension"}
+        ]
+        assert result.result["ignored_issues"] == [{"severity": "error", "message": "No metrics present in the model."}]
+        assert "1 validation errors" in result.error
+        assert "Element ac_code" in result.error
+        assert evidence.validation_passed is False
+
+    def test_semantic_model_scope_treats_enum_severity_as_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        mock_issue = Mock()
+        mock_issue.model_dump.return_value = {
+            "severity": _Severity.ERROR,
+            "message": "bad enum severity",
+        }
+        mock_issue.model_dump.side_effect = lambda mode=None: {
+            "severity": _Severity.ERROR.value if mode == "json" else _Severity.ERROR,
+            "message": "bad enum severity",
+        }
+        mock_validation = Mock()
+        mock_validation.valid = False
+        mock_validation.issues = [mock_issue]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_validation):
+            result = tool.validate_semantic(scope="semantic_model")
+
+        assert result.success == 0
+        assert result.result["issues"] == [{"severity": "error", "message": "bad enum severity"}]
+        assert result.result["ignored_issues"] == []
+        assert evidence.validation_passed is False
+
+    def test_invalid_scope_returns_error(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+
+        result = tool.validate_semantic(scope="unknown")
+
+        assert result.success == 0
+        assert "scope must be one of" in result.error
 
     def test_exception_returns_failure(self, semantic_tools_with_adapter):
         tool, mock_adapter = semantic_tools_with_adapter


### PR DESCRIPTION
## Summary

- Backport #827 to scope semantic-model validation during gen-semantic-model bootstrap.
- Backport #831 to recognize framework response action names for semantic model and metric bootstrap.
- Backport #840 to resolve reference SQL summary paths consistently under subject/sandbox paths.

## Why

These bug fixes protect the 0.3.1 release branch bootstrap, semantic generation, metrics generation, and reference SQL summary initialization paths without merging unrelated main-branch feature work into the release branch.

## Validation

- `uv run pytest tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestValidateSemantic tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/storage/semantic_model/test_semantic_model_init.py tests/unit_tests/storage/metric/test_metric_init.py tests/unit_tests/storage/semantic_model/test_auto_create.py tests/unit_tests/storage/reference_sql/test_reference_sql_init.py -q`
- `uv run ruff check datus/tools/func_tool/semantic_tools.py datus/agent/node/gen_semantic_model_agentic_node.py datus/storage/semantic_model/semantic_model_init.py datus/storage/metric/metric_init.py datus/storage/reference_sql/reference_sql_init.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/storage/semantic_model/test_semantic_model_init.py tests/unit_tests/storage/semantic_model/test_auto_create.py tests/unit_tests/storage/metric/test_metric_init.py tests/unit_tests/storage/reference_sql/test_reference_sql_init.py`
- `git diff --check upstream/release/0.3.1..HEAD`
