### PR TITLE
[Tool] Backport prepare release tooling to 0.3.1

### DIFF
--- a/ci/prepare_release.py
+++ b/ci/prepare_release.py
@@ -36,9 +36,11 @@ def parse_canonical_version(raw_version: str) -> Version:
     return version
 
 
-def ensure_version_can_advance(repo_root: Path, target_version: Version) -> None:
+def ensure_version_can_advance(
+    repo_root: Path, target_version: Version, *, allow_current_version: bool = False
+) -> None:
     current_version = read_pyproject_version(repo_root)
-    if target_version <= current_version:
+    if target_version < current_version or (target_version == current_version and not allow_current_version):
         raise ValueError(f"Release version must advance current version {current_version}; got {target_version}")
 
     tag_errors = check_tag_available(repo_root, target_version)
@@ -148,6 +150,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Allow prerelease adapter versions when updating adapter core lower bounds",
     )
+    parser.add_argument(
+        "--allow-current-version",
+        action="store_true",
+        help="Allow preparing a release branch that already has the target version",
+    )
+    parser.add_argument(
+        "--allow-no-changes",
+        action="store_true",
+        help="Exit successfully when release metadata is already prepared",
+    )
     parser.add_argument("--pypi-timeout", type=float, default=10.0, help="PyPI request timeout in seconds")
     return parser
 
@@ -157,7 +169,7 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = args.repo_root.resolve()
     try:
         version = parse_canonical_version(args.version)
-        ensure_version_can_advance(repo_root, version)
+        ensure_version_can_advance(repo_root, version, allow_current_version=args.allow_current_version)
         changed = prepare_release(
             repo_root,
             version,
@@ -170,6 +182,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if not changed or not git_has_diff(repo_root):
+        if args.allow_no_changes:
+            print(f"Release metadata is already prepared for datus-agent {version}")
+            return 0
         print(f"Release preparation produced no changes for {version}", file=sys.stderr)
         return 1
 

--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -461,7 +461,11 @@ def _resolve_explicit_compare_ref(base_ref: str) -> str | None:
     elif ref.startswith("refs/remotes/"):
         add(ref.removeprefix("refs/remotes/"))
         add(ref)
+    elif ref.startswith(("origin/", "upstream/")):
+        add(ref)
     elif "/" in ref:
+        add(f"origin/{ref}")
+        add(f"upstream/{ref}")
         add(ref)
     else:
         add(f"origin/{ref}")

--- a/tests/unit_tests/ci/test_prepare_release.py
+++ b/tests/unit_tests/ci/test_prepare_release.py
@@ -94,6 +94,14 @@ def test_ensure_version_can_advance_rejects_same_or_lower_version(tmp_path, prep
         prepare_release.ensure_version_can_advance(repo_root, Version("0.2.6"))
 
 
+def test_ensure_version_can_advance_can_allow_current_version(tmp_path, prepare_release):
+    repo_root = _write_release_repo(tmp_path)
+
+    assert prepare_release.ensure_version_can_advance(repo_root, Version("0.2.6"), allow_current_version=True) is None
+    with pytest.raises(ValueError, match="must advance current version"):
+        prepare_release.ensure_version_can_advance(repo_root, Version("0.2.5"), allow_current_version=True)
+
+
 def test_prepare_release_updates_version_and_adapter_bounds(tmp_path, monkeypatch, prepare_release):
     repo_root = _write_release_repo(tmp_path)
     monkeypatch.setattr(
@@ -145,3 +153,21 @@ def test_prepare_release_can_leave_adapter_bounds_unchanged(tmp_path, monkeypatc
         "pyproject.toml",
     }
     assert '"datus-db-core>=0.1.3"' in (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_main_can_treat_already_prepared_release_as_success(tmp_path, prepare_release):
+    repo_root = _write_release_repo(tmp_path)
+
+    result = prepare_release.main(
+        [
+            "--repo-root",
+            str(repo_root),
+            "--version",
+            "0.2.6",
+            "--allow-current-version",
+            "--allow-no-changes",
+            "--no-update-adapter-bounds",
+        ]
+    )
+
+    assert result == 0

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -210,6 +210,12 @@ def test_resolve_explicit_compare_ref_prefers_origin_for_branch_name(monkeypatch
     assert run_pr_tests._resolve_explicit_compare_ref("main") == "origin/main"
 
 
+def test_resolve_explicit_compare_ref_prefers_origin_for_slash_branch(monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "_git_ref_exists", lambda ref: ref == "origin/release/0.3.1")
+
+    assert run_pr_tests._resolve_explicit_compare_ref("release/0.3.1") == "origin/release/0.3.1"
+
+
 def test_resolve_explicit_compare_ref_accepts_remote_ref(monkeypatch):
     monkeypatch.setattr(run_pr_tests, "_git_ref_exists", lambda ref: ref == "upstream/main")
 


### PR DESCRIPTION
## Summary

- Backport prepare-release script support for `--allow-current-version` and `--allow-no-changes` to `release/0.3.1`.
- Backport the unit coverage that verifies already-prepared release metadata can be treated as a successful no-op.

## Why

The current `Prepare Release` workflow is dispatched from `main` but checks out `release/0.3.1` before running `ci/prepare_release.py`. The workflow passes the new idempotency flags, so the release branch needs the matching script support before preparing `0.3.1rc2`.

## Validation

- `python3 ci/prepare_release.py --help | rg -n "allow-current-version|allow-no-changes"`
- `uv run ruff check ci/prepare_release.py tests/unit_tests/ci/test_prepare_release.py`
- `uv run pytest tests/unit_tests/ci/test_prepare_release.py -q`
- `git diff --check`
