### PR TITLE
[Tool] Extend PyPI visibility wait for release publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -197,19 +197,38 @@ jobs:
           repository = os.environ["TARGET_REPOSITORY"]
           host = "test.pypi.org" if repository == "testpypi" else "pypi.org"
           url = f"https://{host}/pypi/datus-agent/{version}/json"
+          wait_seconds = 300
+          sleep_seconds = 10
+          max_attempts = wait_seconds // sleep_seconds
+          last_error = None
 
-          for attempt in range(1, 11):
+          for attempt in range(1, max_attempts + 1):
               try:
                   with urllib.request.urlopen(url, timeout=20) as response:
                       payload = json.load(response)
                   if payload.get("info", {}).get("version") == version:
-                      print(f"datus-agent {version} is visible on {repository}")
+                      print(
+                          f"datus-agent {version} is visible on {repository} "
+                          f"after {attempt} attempt(s)"
+                      )
                       raise SystemExit(0)
+                  last_error = (
+                      "Package index returned version "
+                      f"{payload.get('info', {}).get('version')!r}"
+                  )
               except (urllib.error.URLError, TimeoutError) as exc:
-                  print(f"Package visibility check attempt {attempt} failed: {exc}")
-              time.sleep(6)
+                  last_error = str(exc)
+              print(
+                  "Package visibility check attempt "
+                  f"{attempt}/{max_attempts} failed for {url}: {last_error}"
+              )
+              if attempt < max_attempts:
+                  time.sleep(sleep_seconds)
 
-          raise SystemExit(f"datus-agent {version} is not visible on {repository} after upload")
+          raise SystemExit(
+              f"datus-agent {version} is not visible on {repository} "
+              f"after waiting {wait_seconds} seconds. Last error: {last_error}"
+          )
           PY
 
       - name: Record published commit SHA


### PR DESCRIPTION
Summary
- Extend post-upload PyPI visibility polling from 60 seconds to 5 minutes.
- Include attempt count, package JSON URL, and final error in visibility-check logs.

Validation
- actionlint .github/workflows/publish-release.yml
- Manual visibility probe for datus-agent 0.3.1rc2 against PyPI JSON API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release publishing workflow with enhanced verification logic to ensure more reliable and transparent distribution of releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->