### PR TITLE
[BugFix] gen_visual: require imports for every JSX-referenced name

### DIFF
--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -58,6 +58,12 @@ Do **not** import from: `react-dom`, `next/*`, `react-router*`, state-management
 
 Relative paths must stay under `render/` — `../../../escape` is rejected.
 
+### Import every name you reference
+
+Every JSX component (`<Cell>`, `<Legend>`, `<Coffee>`) and every helper (`useMemo`, `formatCurrency`, `N`) used in a file must appear in a named import at the top of *that same file*. `recharts`, `lucide-react`, and `@datus/web-artifact` do not register globals — a missing import surfaces at render time as `ReferenceError: <name> is not defined` and crashes the whole artifact. `validate_render` only checks that the import *paths* resolve; it does not check that every JSX identifier is imported, so the burden is on you.
+
+Before saving a file, scan its body and JSX for every capitalized component (Recharts primitives like `<Cell>`, Lucide icons like `<Coffee>`) plus every helper call (`N`, `formatCurrency`, …) and confirm each one is in one of the file's `import { ... }` lines. The most common miss: adding `<Cell>` inside `<Bar>` / `<Pie>` for per-row coloring while leaving `Cell` out of the existing `recharts` import.
+
 ### Canonical component shape
 
 Every chart / table / KPI component in `render/` follows the same five-section shape. **Copy this skeleton when you author a new component.** Data flow, hook ordering, ref handling, AnimateOnVisible wiring, and the ChartEntryMore action menu are all here — if your component structurally matches this shape, you cannot trip the most common rendering errors.


### PR DESCRIPTION
## Why

Dashboards generated by `gen_visual_dashboard` occasionally crash at render with `ReferenceError: <Name> is not defined`. The pattern observed in dev (trace `4c50db081795d2fd829c17c72d3631f7`, dashboard slug `jeff_shop_business_analysis`):

```
ReferenceError: Cell is not defined
  at ProductTypeCompare (render/product-type-compare.jsx:59)
```

The model added `<Cell>` inside a `<Bar>` for per-row coloring but did not add `Cell` to the existing `recharts` import. `validate_render` only checks that import *paths* resolve — it does not check that every identifier used in JSX has been imported — so the broken file passed validation and shipped. The agent then re-edited the file in a second round and validate_render passed again, but the whole loop wasted a 15-minute SSE round-trip and surfaced a confusing render error to the user.

## Solution

Add a short, explicit subsection `### Import every name you reference` to `datus/prompts/prompt_templates/_visual_artifact_common.j2`, immediately after the "Allowed imports" table. It:

- States the rule: every JSX component and helper used in a file must appear in a named import at the top of that same file.
- Names the failure mode: `ReferenceError` at render time, crashes the artifact.
- Calls out the canonical miss (`<Cell>` inside `<Bar>` / `<Pie>` while leaving `Cell` out of the existing `recharts` import).
- Notes that `validate_render` cannot catch this, so the model has to self-check.

Because `_visual_artifact_common.j2` is included by both `gen_visual_dashboard_system_1.0.j2` and `gen_visual_report_system_1.0.j2`, the new rule applies to both subagents with no other changes.

Tradeoff considered: adding a static check inside `validate_render` would be more robust than a prompt rule, but requires a JSX parser to enumerate referenced identifiers vs imported ones — out of scope for this fix. The prompt rule is cheap and covers the observed failure today; a stronger validator can land later.

## Test Cases

No code changes — this is a 6-line addition to a Jinja prompt template. No existing unit/integration tests cover the contents of model system prompts, and adding a regression test would require an end-to-end LLM run (nightly tier) to be meaningful. Will rely on nightly visual-artifact regression runs to confirm the rule shows up in the rendered prompt and that future dashboard generations do not repeat the import-omission pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal template instructions to improve code generation guidelines for component and function imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->