### PR TITLE
[Enhancement] Raise default max_turns for visual artifact nodes to 80

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -119,11 +119,11 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         self.execution_mode = execution_mode
         self.configured_node_name = node_name
 
-        self.max_turns = 40
+        self.max_turns = 80
         if agent_config and hasattr(agent_config, "agentic_nodes") and node_name in agent_config.agentic_nodes:
             cfg = agent_config.agentic_nodes[node_name]
             if isinstance(cfg, dict):
-                self.max_turns = cfg.get("max_turns", 40)
+                self.max_turns = cfg.get("max_turns", 80)
 
         # Tool attributes must exist before the parent constructor calls
         # ``_get_system_prompt`` indirectly via skill setup.


### PR DESCRIPTION
## Why

`BaseVisualArtifactAgenticNode` defaults `max_turns` to 40, which is too tight for complex dashboards/reports. Each chart typically consumes ~3 turns (`read_query` for SQL validation → `save_query_template` → `write_file` for JSX render), so anything over ~10 charts cannot reach the finalize step within 40 turns.

A real failure in dev (trace `857904260282feffc71b70c365cba0a5`, image `dev-20260520161541-910bbc1`) on a 13-chart `jeff_shop` dashboard hit the cap after ~5 minutes of successful work. The agent had already validated SQL, saved ~11 templates, and started writing JSX render files when it ran out of turns. Because finalize never ran, the response came back with `render_file_count=0`, `template_count=0`, `tokens_used=0` and the user saw `"Sorry, I encountered an error while generating the visual dashboard."` despite ~80% of the work being done on disk.

## Solution

Raise the default `max_turns` in `BaseVisualArtifactAgenticNode.__init__` from 40 to 80. This affects both subclasses that inherit it: `GenVisualDashboardAgenticNode` and `GenVisualReportAgenticNode`.

The per-node override path is unchanged: users who want a different budget can still set `agentic_nodes.<node_name>.max_turns` in `agent.yml`, and the new default only kicks in when no override is provided.

No new config knobs, no behavior change for users who already set an explicit `max_turns`. Cost impact is bounded — `max_turns` only caps the worst case, it does not affect typical-case turn count.

## Test Cases

No new tests added. The existing visual-artifact unit-test suite (`test_gen_visual_dashboard_agentic_node.py`, `test_gen_visual_report_agentic_node.py`, `test_visual_artifact_finalize.py`, `test_ask_artifact_agentic_node.py`, 179 tests) does not assert against the previous 40 default — all tests pass unchanged with the new default. A dedicated "default is N" assertion would just hardcode the literal and fight future tuning; the existing override-path tests (which pass an explicit `max_turns` and assert it is honored) already cover the contract that matters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Default maximum turns limit for visual artifact generation has been increased from 40 to 80 iterations. Configuration handling has been updated such that when using configuration overrides without explicitly specifying a maximum turns value, the system now defaults to 80 turns, ensuring more consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->