### PR TITLE
[BugFix] Backport bootstrap BI semantic validation scope to 0.3.1

### DIFF
--- a/datus/cli/bootstrap_bi_streams.py
+++ b/datus/cli/bootstrap_bi_streams.py
@@ -247,12 +247,14 @@ async def stream_bi_reference_sql(
 # ─────────────────────────────────────────────────────────────────────
 
 
-def _validate_semantic_model_sync(agent_config: AgentConfig) -> tuple[bool, Optional[str]]:
+def _validate_semantic_model_sync(agent_config: AgentConfig, *, scope: str = "all") -> tuple[bool, Optional[str]]:
     """Run :class:`SemanticTools.validate_semantic` synchronously.
 
     Returns ``(ok, error_message)``. Adapter-loading or runtime errors are
     captured and surfaced as ``error_message`` rather than propagating, so
     the coordinator can yield a single failure message and gate metrics.
+    Use ``scope="semantic_model"`` before metric generation so the expected
+    no-metrics validation issue does not block the metrics step.
     """
     try:
         from datus.tools.func_tool.semantic_tools import SemanticTools
@@ -270,7 +272,7 @@ def _validate_semantic_model_sync(agent_config: AgentConfig) -> tuple[bool, Opti
         tools = SemanticTools(agent_config=agent_config, adapter_type=adapter_type)
         if not tools.adapter:
             return False, "Semantic adapter not available. Install with: pip install datus-semantic-metricflow"
-        result = tools.validate_semantic()
+        result = tools.validate_semantic(scope=scope)
         if not result.success:
             return False, result.error or "Semantic validation failed"
         return True, None
@@ -326,7 +328,7 @@ async def stream_bi_semantic_model(
     ):
         yield action
 
-    ok, err = await asyncio.to_thread(_validate_semantic_model_sync, agent_config)
+    ok, err = await asyncio.to_thread(_validate_semantic_model_sync, agent_config, scope="semantic_model")
     state.semantic_ok = ok
     if ok:
         yield message_action("Semantic model validated.")

--- a/tests/unit_tests/cli/test_bootstrap_bi_streams.py
+++ b/tests/unit_tests/cli/test_bootstrap_bi_streams.py
@@ -25,6 +25,7 @@ from datus.cli.bootstrap_bi_streams import (
     BiBuildState,
     _collect_metrics_from_semantic_models,
     _collect_ref_sqls_from_summary_files,
+    _validate_semantic_model_sync,
     stream_bi_metadata,
     stream_bi_metrics,
     stream_bi_reference_sql,
@@ -238,6 +239,12 @@ async def test_stream_bi_semantic_model_sets_semantic_ok_on_validation_success(a
     async def _ok_async(*_a, **_k):
         return True, ""
 
+    validation_scopes: list[str] = []
+
+    def _validate(_agent_config, *, scope: str = "all"):
+        validation_scopes.append(scope)
+        return True, None
+
     with (
         patch(
             "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
@@ -245,7 +252,7 @@ async def test_stream_bi_semantic_model_sets_semantic_ok_on_validation_success(a
         ),
         patch(
             "datus.cli.bootstrap_bi_streams._validate_semantic_model_sync",
-            return_value=(True, None),
+            side_effect=_validate,
         ),
     ):
         actions = await _consume(
@@ -259,6 +266,7 @@ async def test_stream_bi_semantic_model_sets_semantic_ok_on_validation_success(a
         )
 
     assert state.semantic_ok is True
+    assert validation_scopes == ["semantic_model"]
     assert any("validated" in a.messages.lower() for a in actions)
 
 
@@ -331,6 +339,12 @@ async def test_stream_bi_metrics_collects_metric_identifiers(agent_config, state
     async def _ok_metrics(*_a, **_k):
         return True, "", {"semantic_models": ["semantic_models/metrics/orders.yml"]}
 
+    validation_scopes: list[str] = []
+
+    def _validate(_agent_config, *, scope: str = "all"):
+        validation_scopes.append(scope)
+        return True, None
+
     with (
         patch(
             "datus.storage.metric.metric_init.init_success_story_metrics_async",
@@ -338,7 +352,7 @@ async def test_stream_bi_metrics_collects_metric_identifiers(agent_config, state
         ),
         patch(
             "datus.cli.bootstrap_bi_streams._validate_semantic_model_sync",
-            return_value=(True, None),
+            side_effect=_validate,
         ),
         patch(
             "datus.cli.generation_hooks.resolve_kb_sandbox_path",
@@ -356,7 +370,28 @@ async def test_stream_bi_metrics_collects_metric_identifiers(agent_config, state
         )
 
     assert state.metrics == ["superset.sales.total_orders"]
+    assert validation_scopes == ["all"]
     assert any("Collected 1 metric" in a.messages for a in actions)
+
+
+def test_validate_semantic_model_sync_passes_requested_scope(agent_config, monkeypatch) -> None:
+    validation_scopes: list[str] = []
+
+    class FakeSemanticTools:
+        def __init__(self, *_a, **_k):
+            self.adapter = object()
+
+        def validate_semantic(self, scope: str = "all"):
+            validation_scopes.append(scope)
+            return SimpleNamespace(success=1, error=None)
+
+    monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
+
+    ok, err = _validate_semantic_model_sync(agent_config, scope="semantic_model")
+
+    assert ok is True
+    assert err is None
+    assert validation_scopes == ["semantic_model"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
- Backport #850 to release/0.3.1.
- Validate bootstrap-bi semantic model generation with semantic_model scope before metrics exist.
- Keep full semantic validation after metrics generation.

Validation
- uv run ruff check datus/cli/bootstrap_bi_streams.py tests/unit_tests/cli/test_bootstrap_bi_streams.py tests/unit_tests/cli/test_bootstrap_bi_commands.py
- uv run pytest tests/unit_tests/cli/test_bootstrap_bi_streams.py tests/unit_tests/cli/test_bootstrap_bi_commands.py -q

Source
- Cherry-picked main commit 75beccae99c24af56531e4c1441c7978c8c7d3f8 from PR #850.