### PR TITLE
[Enhancement] ClaudeModel: stream text deltas via native Anthropic API

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -171,10 +171,15 @@ class ClaudeModel(OpenAICompatibleModel):
         # Optional proxy configuration
         proxy_url = os.environ.get("HTTP_PROXY") or os.environ.get("HTTPS_PROXY")
         self.proxy_client = None
+        self.async_proxy_client = None
 
         if proxy_url:
             self.proxy_client = httpx.Client(
                 transport=httpx.HTTPTransport(proxy=httpx.Proxy(url=proxy_url)),
+                timeout=60.0,
+            )
+            self.async_proxy_client = httpx.AsyncClient(
+                transport=httpx.AsyncHTTPTransport(proxy=httpx.Proxy(url=proxy_url)),
                 timeout=60.0,
             )
 
@@ -194,11 +199,24 @@ class ClaudeModel(OpenAICompatibleModel):
                 http_client=self.proxy_client,
                 default_headers=extra_headers or None,
             )
+            self.async_anthropic_client = anthropic.AsyncAnthropic(
+                auth_token=self.api_key,
+                api_key=None,
+                base_url=self.base_url if self.base_url else None,
+                http_client=self.async_proxy_client,
+                default_headers=extra_headers or None,
+            )
         else:
             self.anthropic_client = anthropic.Anthropic(
                 api_key=self.api_key,
                 base_url=self.base_url if self.base_url else None,
                 http_client=self.proxy_client,
+                default_headers=extra_headers or None,
+            )
+            self.async_anthropic_client = anthropic.AsyncAnthropic(
+                api_key=self.api_key,
+                base_url=self.base_url if self.base_url else None,
+                http_client=self.async_proxy_client,
                 default_headers=extra_headers or None,
             )
 
@@ -207,6 +225,7 @@ class ClaudeModel(OpenAICompatibleModel):
             from langsmith.wrappers import wrap_anthropic
 
             self.anthropic_client = wrap_anthropic(self.anthropic_client)
+            self.async_anthropic_client = wrap_anthropic(self.async_anthropic_client)
         except ImportError:
             logger.debug("No langsmith wrapper available")
 
@@ -250,6 +269,23 @@ class ClaudeModel(OpenAICompatibleModel):
         if self._is_oauth_token:
             return self.anthropic_client.beta.messages.create(**kwargs)
         return self.anthropic_client.messages.create(**kwargs)
+
+    def _anthropic_messages_stream(self, **kwargs):
+        """Return an async context manager that streams Anthropic Messages events.
+
+        Routes to ``beta.messages.stream`` for OAuth subscription tokens (which
+        require the OAuth beta headers and Bearer auth) and to
+        ``messages.stream`` for standard API-key auth. Caller enters via
+        ``async with self._anthropic_messages_stream(...) as stream:``.
+        """
+        if self.async_anthropic_client is None:
+            raise DatusException(
+                ErrorCode.MODEL_AUTHENTICATION_ERROR,
+                "Async Anthropic client is not initialized; streaming unavailable",
+            )
+        if self._is_oauth_token:
+            return self.async_anthropic_client.beta.messages.stream(**kwargs)
+        return self.async_anthropic_client.messages.stream(**kwargs)
 
     def _diagnose_oauth_401(self, original_error: Exception) -> None:
         """Diagnose a 401 error for OAuth subscription tokens and raise a specific exception.
@@ -472,7 +508,7 @@ class ClaudeModel(OpenAICompatibleModel):
 
                     logger.debug(f"Turn {turn + 1}/{max_turns}")
 
-                    response = self._anthropic_messages_create(
+                    request_kwargs = dict(
                         model=self.model_name,
                         system=self._build_system_param(instruction),
                         messages=wrap_prompt_cache(messages),
@@ -480,6 +516,79 @@ class ClaudeModel(OpenAICompatibleModel):
                         max_tokens=kwargs.get("max_tokens") or self.max_tokens() or 20480,
                         temperature=kwargs.get("temperature", anthropic.NOT_GIVEN),
                     )
+
+                    if self.async_anthropic_client is not None:
+                        # Streaming path: yield text deltas as ``thinking_delta``
+                        # ActionHistory in real time (parity with
+                        # OpenAICompatibleModel.generate_with_tools_stream), then
+                        # rehydrate the final ``Message`` to reuse the existing
+                        # tool-use / usage / session logic below unchanged.
+                        thinking_stream_id: Optional[str] = None
+                        thinking_accumulated = ""
+                        async with self._anthropic_messages_stream(**request_kwargs) as stream:
+                            async for event in stream:
+                                if interrupt_controller and interrupt_controller.is_interrupted:
+                                    from datus.cli.execution_state import ExecutionInterrupted
+
+                                    raise ExecutionInterrupted("Interrupted by user")
+
+                                event_type = getattr(event, "type", None)
+                                if event_type == "content_block_start":
+                                    block_start = getattr(event, "content_block", None)
+                                    if block_start is not None and getattr(block_start, "type", None) == "text":
+                                        thinking_stream_id = f"thinking_stream_{uuid.uuid4().hex[:8]}"
+                                        thinking_accumulated = ""
+                                elif event_type == "content_block_delta":
+                                    delta = getattr(event, "delta", None)
+                                    if delta is None or getattr(delta, "type", None) != "text_delta":
+                                        continue
+                                    delta_text = getattr(delta, "text", "") or ""
+                                    if not delta_text:
+                                        continue
+                                    if thinking_stream_id is None:
+                                        thinking_stream_id = f"thinking_stream_{uuid.uuid4().hex[:8]}"
+                                    thinking_accumulated += delta_text
+                                    delta_action = ActionHistory(
+                                        action_id=thinking_stream_id,
+                                        role=ActionRole.ASSISTANT,
+                                        messages="",
+                                        action_type="thinking_delta",
+                                        input={},
+                                        output={"delta": delta_text, "accumulated": thinking_accumulated},
+                                        status=ActionStatus.PROCESSING,
+                                    )
+                                    yield delta_action
+                                elif event_type == "content_block_stop":
+                                    # Mirror OpenAICompatibleModel / codex_model: when
+                                    # a text block ends, emit a paired terminal
+                                    # ``response`` SUCCESS action sharing the delta
+                                    # stream id. Without it the CLI's
+                                    # ``_print_completed_action`` dedup path never
+                                    # runs, so ``_finalize_markdown_stream`` never
+                                    # clears the pinned live region — the last
+                                    # paragraph stays visible while ``__exit__``
+                                    # also flushes it to scrollback, producing a
+                                    # visible duplicate of the closing paragraph.
+                                    if thinking_accumulated.strip():
+                                        full_text = thinking_accumulated.strip()
+                                        text_preview = full_text if len(full_text) <= 200 else f"{full_text[:200]}..."
+                                        yield ActionHistory(
+                                            action_id=thinking_stream_id or f"assistant_{uuid.uuid4().hex[:8]}",
+                                            role=ActionRole.ASSISTANT,
+                                            messages=f"Thinking: {text_preview}",
+                                            action_type="response",
+                                            input={},
+                                            output={"raw_output": full_text, "is_thinking": False},
+                                            status=ActionStatus.SUCCESS,
+                                        )
+                                    thinking_stream_id = None
+                                    thinking_accumulated = ""
+                            response = await stream.get_final_message()
+                    else:
+                        # Fallback non-streaming path (kept so existing tests that
+                        # mock ``anthropic_client.messages.create`` still work, and
+                        # for environments where the async client failed to init).
+                        response = self._anthropic_messages_create(**request_kwargs)
 
                     # Track token usage from this turn
                     if hasattr(response, "usage") and response.usage:
@@ -876,12 +985,26 @@ class ClaudeModel(OpenAICompatibleModel):
             except Exception as e:
                 logger.warning(f"Error closing proxy client: {e}")
 
+        if hasattr(self, "async_proxy_client") and self.async_proxy_client:
+            try:
+                await self.async_proxy_client.aclose()
+                logger.debug("Async proxy client closed successfully")
+            except Exception as e:
+                logger.warning(f"Error closing async proxy client: {e}")
+
         if hasattr(self, "anthropic_client") and hasattr(self.anthropic_client, "close"):
             try:
                 self.anthropic_client.close()
                 logger.debug("Anthropic client closed successfully")
             except Exception as e:
                 logger.warning(f"Error closing anthropic client: {e}")
+
+        if hasattr(self, "async_anthropic_client") and self.async_anthropic_client is not None:
+            try:
+                await self.async_anthropic_client.close()
+                logger.debug("Async anthropic client closed successfully")
+            except Exception as e:
+                logger.warning(f"Error closing async anthropic client: {e}")
 
     def close(self):
         """Synchronous close for backward compatibility."""

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -220,14 +220,22 @@ class ClaudeModel(OpenAICompatibleModel):
                 default_headers=extra_headers or None,
             )
 
-        # Wrap with LangSmith if available
+        # Wrap with LangSmith if available. Wrap sync and async clients
+        # independently so a failure on the async wrap (e.g. older langsmith
+        # without AsyncAnthropic support) does not also drop sync tracing.
         try:
             from langsmith.wrappers import wrap_anthropic
-
-            self.anthropic_client = wrap_anthropic(self.anthropic_client)
-            self.async_anthropic_client = wrap_anthropic(self.async_anthropic_client)
         except ImportError:
             logger.debug("No langsmith wrapper available")
+        else:
+            try:
+                self.anthropic_client = wrap_anthropic(self.anthropic_client)
+            except Exception as e:
+                logger.warning(f"Failed to wrap sync anthropic client with langsmith: {e}")
+            try:
+                self.async_anthropic_client = wrap_anthropic(self.async_anthropic_client)
+            except Exception as e:
+                logger.warning(f"Failed to wrap async anthropic client with langsmith: {e}")
 
         logger.debug(f"Initialized Claude model: {self.model_name}, use_native_api={self.use_native_api}")
 
@@ -270,6 +278,7 @@ class ClaudeModel(OpenAICompatibleModel):
             return self.anthropic_client.beta.messages.create(**kwargs)
         return self.anthropic_client.messages.create(**kwargs)
 
+    @optional_traceable(name="anthropic_messages_stream", run_type="llm")
     def _anthropic_messages_stream(self, **kwargs):
         """Return an async context manager that streams Anthropic Messages events.
 
@@ -277,6 +286,12 @@ class ClaudeModel(OpenAICompatibleModel):
         require the OAuth beta headers and Bearer auth) and to
         ``messages.stream`` for standard API-key auth. Caller enters via
         ``async with self._anthropic_messages_stream(...) as stream:``.
+
+        Note: ``optional_traceable`` here records the call returning the
+        context manager. For ``messages.stream`` langsmith's ``wrap_anthropic``
+        additionally instruments per-event iteration; ``beta.messages.stream``
+        is not wrapped upstream, so this decorator is the only tracing the
+        OAuth path gets.
         """
         if self.async_anthropic_client is None:
             raise DatusException(
@@ -1019,6 +1034,11 @@ class ClaudeModel(OpenAICompatibleModel):
                 self.anthropic_client.close()
             except Exception as e:
                 logger.warning(f"Error closing anthropic client: {e}")
+
+        # Async resources can't be awaited from sync ``close()``; warn so callers
+        # know to invoke ``aclose()`` instead of leaking connections/threads.
+        if getattr(self, "async_anthropic_client", None) is not None or getattr(self, "async_proxy_client", None):
+            logger.debug("Async anthropic/proxy clients require aclose(); sync close() cannot release them")
 
     def __del__(self):
         """Destructor to ensure cleanup on garbage collection."""

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -1044,7 +1044,17 @@ class SessionManager:
                                 item_type = item.get("type", "")
                                 text = item.get("text", "")
 
-                                if item_type == "output_text" and text:
+                                # Accept both OpenAI-style ``output_text`` and
+                                # Anthropic-style ``text`` blocks. ClaudeModel's
+                                # native OAuth path persists assistant turns as
+                                # ``[{"type": "text", "text": ...}]`` (Anthropic's
+                                # wire format, needed so ``session.get_items()``
+                                # replays back into the API verbatim). Without
+                                # ``"text"`` here, Claude assistant turns are
+                                # silently skipped on resume — no group gets
+                                # initialised, no content lands in ``messages``,
+                                # and the user sees only their own input.
+                                if item_type in ("output_text", "text") and text:
                                     # Initialize assistant group if needed
                                     if not current_assistant_group:
                                         current_assistant_group = {

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -72,6 +72,12 @@ def _make_claude_model(model_config=None):
         model = ClaudeModel(model_config)
         model.litellm_adapter = mock_litellm_adapter
         model.anthropic_client = mock_anthropic_client
+        # Existing tests mock the sync ``anthropic_client.messages.create`` API.
+        # Disabling the async streaming client routes those tests through the
+        # non-streaming fallback in ``_generate_with_mcp_stream`` so they keep
+        # working without rewriting every mock; the streaming code path has
+        # dedicated tests in ``TestGenerateWithMcpStreamTextDeltas``.
+        model.async_anthropic_client = None
         return model
 
 
@@ -1463,3 +1469,140 @@ class TestGenerateWithMcpToolRouting:
         passed_args = call_args[1]["arguments"]
         assert passed_args == {"query": "SELECT 1"}
         assert passed_args is not original_input  # must be a different object
+
+
+# ---------------------------------------------------------------------------
+# Streaming text deltas (native Anthropic ``messages.stream`` path)
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamEvent:
+    """Lightweight stand-in for the SDK's stream event objects."""
+
+    def __init__(self, type_, delta=None, content_block=None):
+        self.type = type_
+        if delta is not None:
+            self.delta = delta
+        if content_block is not None:
+            self.content_block = content_block
+
+
+class _FakeAsyncStreamManager:
+    """Async context manager that replays a fixed sequence of stream events.
+
+    Mirrors the shape of ``anthropic.lib.streaming._messages.AsyncMessageStreamManager``
+    just enough for ``_generate_with_mcp_stream``: ``async with`` enters, the
+    body iterates via ``async for event in stream``, then awaits
+    ``stream.get_final_message()`` to retrieve the assembled ``Message``.
+    """
+
+    def __init__(self, events, final_message):
+        self._events = events
+        self._final_message = final_message
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def __aiter__(self):
+        events = list(self._events)
+
+        async def gen():
+            for ev in events:
+                yield ev
+
+        return gen()
+
+    async def get_final_message(self):
+        return self._final_message
+
+
+class TestGenerateWithMcpStreamTextDeltas:
+    @pytest.mark.asyncio
+    async def test_streams_text_deltas_as_thinking_delta_actions(self):
+        """When async_anthropic_client is set, yield thinking_delta per text_delta event."""
+        from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        # Build a fake stream: start text block, two text deltas, stop text block.
+        text_block_start = MagicMock()
+        text_block_start.type = "text"
+        delta1 = MagicMock()
+        delta1.type = "text_delta"
+        delta1.text = "Hello, "
+        delta2 = MagicMock()
+        delta2.type = "text_delta"
+        delta2.text = "world!"
+        events = [
+            _FakeStreamEvent("content_block_start", content_block=text_block_start),
+            _FakeStreamEvent("content_block_delta", delta=delta1),
+            _FakeStreamEvent("content_block_delta", delta=delta2),
+            _FakeStreamEvent("content_block_stop"),
+        ]
+        final_msg = _make_response([_make_text_block("Hello, world!")])
+
+        stream_manager = _FakeAsyncStreamManager(events, final_msg)
+
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        ahm = ActionHistoryManager()
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for action in model._generate_with_mcp_stream(
+                prompt="test",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+            ):
+                actions.append(action)
+
+        # Stream invoked once
+        async_client.messages.stream.assert_called_once()
+
+        # Exactly two thinking_delta events with incremental accumulation, both transient.
+        delta_actions = [a for a in actions if a.action_type == "thinking_delta"]
+        assert len(delta_actions) == 2
+        assert all(a.role == ActionRole.ASSISTANT for a in delta_actions)
+        assert all(a.status == ActionStatus.PROCESSING for a in delta_actions)
+        assert delta_actions[0].output == {"delta": "Hello, ", "accumulated": "Hello, "}
+        assert delta_actions[1].output == {"delta": "world!", "accumulated": "Hello, world!"}
+        # Delta actions share one stream id (incremental display in CLI groups them).
+        assert delta_actions[0].action_id == delta_actions[1].action_id
+
+        # Paired terminal ``response`` SUCCESS emitted at content_block_stop —
+        # CLI ``_print_completed_action`` consumes this to finalize the
+        # markdown stream and clear the pinned live region. Without it the
+        # tail paragraph stays visible AND gets reflushed via ``__exit__``,
+        # producing a visible duplicate.
+        responses = [a for a in actions if a.action_type == "response"]
+        assert len(responses) == 1
+        assert responses[0].role == ActionRole.ASSISTANT
+        assert responses[0].status == ActionStatus.SUCCESS
+        assert responses[0].output["raw_output"] == "Hello, world!"
+        # Shares stream id with deltas so CLI dedup matches the paired turn.
+        assert responses[0].action_id == delta_actions[0].action_id
+        assert responses[0].output["is_thinking"] is False
+
+        # Final assistant action carries the assembled text.
+        finals = [a for a in actions if a.action_type == "final_response"]
+        assert len(finals) == 1
+        assert finals[0].output["raw_output"] == "Hello, world!"
+        assert finals[0].status == ActionStatus.SUCCESS
+
+        # Transient deltas are NOT persisted into the action history manager;
+        # only the final_response should land there. The paired ``response``
+        # action is also transient (yield-only, like delta) so it should not
+        # land in the manager either.
+        persisted_types = {a.action_type for a in ahm.actions}
+        assert "thinking_delta" not in persisted_types
+        assert "response" not in persisted_types
+        assert "final_response" in persisted_types

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -1606,3 +1606,350 @@ class TestGenerateWithMcpStreamTextDeltas:
         assert "thinking_delta" not in persisted_types
         assert "response" not in persisted_types
         assert "final_response" in persisted_types
+
+    @pytest.mark.asyncio
+    async def test_interrupt_during_stream_raises_execution_interrupted(self):
+        """When ``interrupt_controller.is_interrupted`` is True during the stream
+        loop, the generator must raise ``ExecutionInterrupted`` so the caller can
+        unwind cleanly instead of yielding more delta events.
+        """
+        from datus.cli.execution_state import ExecutionInterrupted
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        delta = MagicMock()
+        delta.type = "text_delta"
+        delta.text = "ignored"
+        events = [_FakeStreamEvent("content_block_delta", delta=delta)]
+        final_msg = _make_response([_make_text_block("ignored")])
+        stream_manager = _FakeAsyncStreamManager(events, final_msg)
+
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        interrupt_ctrl = MagicMock()
+        interrupt_ctrl.is_interrupted = True
+
+        ahm = ActionHistoryManager()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(ExecutionInterrupted):
+                async for _ in model._generate_with_mcp_stream(
+                    prompt="test",
+                    mcp_servers={},
+                    instruction="sys",
+                    output_type={},
+                    action_history_manager=ahm,
+                    interrupt_controller=interrupt_ctrl,
+                ):
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_non_text_delta_event_is_skipped(self):
+        """A ``content_block_delta`` whose ``delta.type`` is not ``text_delta``
+        (e.g. ``input_json_delta`` from tool argument streaming) must be ignored
+        — no ``thinking_delta`` should be emitted for it.
+        """
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        text_block_start = MagicMock()
+        text_block_start.type = "text"
+        json_delta = MagicMock()
+        json_delta.type = "input_json_delta"
+        json_delta.text = "{should-be-ignored}"
+        real_delta = MagicMock()
+        real_delta.type = "text_delta"
+        real_delta.text = "kept"
+        events = [
+            _FakeStreamEvent("content_block_start", content_block=text_block_start),
+            _FakeStreamEvent("content_block_delta", delta=json_delta),
+            _FakeStreamEvent("content_block_delta", delta=real_delta),
+            _FakeStreamEvent("content_block_stop"),
+        ]
+        final_msg = _make_response([_make_text_block("kept")])
+        stream_manager = _FakeAsyncStreamManager(events, final_msg)
+
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        ahm = ActionHistoryManager()
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for action in model._generate_with_mcp_stream(
+                prompt="test",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+            ):
+                actions.append(action)
+
+        delta_actions = [a for a in actions if a.action_type == "thinking_delta"]
+        assert len(delta_actions) == 1
+        assert delta_actions[0].output["delta"] == "kept"
+
+    @pytest.mark.asyncio
+    async def test_empty_text_delta_is_skipped(self):
+        """A ``text_delta`` event with an empty ``text`` field carries no payload
+        and must be silently skipped so the CLI never receives a no-op delta.
+        """
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        text_block_start = MagicMock()
+        text_block_start.type = "text"
+        empty_delta = MagicMock()
+        empty_delta.type = "text_delta"
+        empty_delta.text = ""
+        real_delta = MagicMock()
+        real_delta.type = "text_delta"
+        real_delta.text = "real"
+        events = [
+            _FakeStreamEvent("content_block_start", content_block=text_block_start),
+            _FakeStreamEvent("content_block_delta", delta=empty_delta),
+            _FakeStreamEvent("content_block_delta", delta=real_delta),
+            _FakeStreamEvent("content_block_stop"),
+        ]
+        final_msg = _make_response([_make_text_block("real")])
+        stream_manager = _FakeAsyncStreamManager(events, final_msg)
+
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        ahm = ActionHistoryManager()
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for action in model._generate_with_mcp_stream(
+                prompt="test",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+            ):
+                actions.append(action)
+
+        delta_actions = [a for a in actions if a.action_type == "thinking_delta"]
+        assert len(delta_actions) == 1
+        assert delta_actions[0].output["delta"] == "real"
+
+    @pytest.mark.asyncio
+    async def test_text_delta_without_prior_block_start_gets_fresh_stream_id(self):
+        """If a ``text_delta`` arrives before any ``content_block_start`` is seen,
+        a stream id must be created inline so the CLI can still pair the deltas.
+        """
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        delta = MagicMock()
+        delta.type = "text_delta"
+        delta.text = "orphan"
+        events = [_FakeStreamEvent("content_block_delta", delta=delta)]
+        final_msg = _make_response([_make_text_block("orphan")])
+        stream_manager = _FakeAsyncStreamManager(events, final_msg)
+
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        ahm = ActionHistoryManager()
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for action in model._generate_with_mcp_stream(
+                prompt="test",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ahm,
+            ):
+                actions.append(action)
+
+        delta_actions = [a for a in actions if a.action_type == "thinking_delta"]
+        assert len(delta_actions) == 1
+        # The stream id was minted on the delta path (no prior content_block_start
+        # set one), proving the fallback at line 549 fired.
+        assert delta_actions[0].action_id.startswith("thinking_stream_")
+
+
+# ---------------------------------------------------------------------------
+# Proxy client init via HTTP_PROXY / HTTPS_PROXY env vars
+# ---------------------------------------------------------------------------
+
+
+class TestProxyClientInit:
+    def test_async_proxy_client_created_when_http_proxy_env_set(self):
+        """When ``HTTP_PROXY`` is set, both sync and async proxy clients must be
+        wired up — the async client backs the streaming code path, which would
+        otherwise bypass the proxy and leak traffic.
+        """
+        cfg = _make_model_config(api_key="sk-ant-test")
+        with (
+            patch("datus.models.openai_compatible.setup_tracing"),
+            patch("datus.models.openai_compatible.LiteLLMAdapter") as mock_adapter_cls,
+            patch("anthropic.Anthropic"),
+            patch("anthropic.AsyncAnthropic"),
+            patch("langsmith.wrappers.wrap_anthropic", side_effect=lambda c: c),
+            patch.dict(
+                "os.environ",
+                {"HTTP_PROXY": "http://proxy.example.com:8080", "ANTHROPIC_API_KEY": "sk-ant-test"},
+                clear=True,
+            ),
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.litellm_model_name = "anthropic/claude-sonnet-4-5"
+            mock_adapter.provider = "anthropic"
+            mock_adapter.is_thinking_model = False
+            mock_adapter.get_agents_sdk_model.return_value = MagicMock()
+            mock_adapter_cls.return_value = mock_adapter
+
+            model = ClaudeModel(cfg)
+
+        import httpx
+
+        # Both sides of the client pair must be the matching httpx flavour —
+        # an async-only or sync-only setup would still pass ``is not None`` but
+        # would break the streaming path the test is meant to protect.
+        assert isinstance(model.proxy_client, httpx.Client)
+        assert isinstance(model.async_proxy_client, httpx.AsyncClient)
+
+
+# ---------------------------------------------------------------------------
+# _anthropic_messages_stream routing
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicMessagesStream:
+    def test_raises_when_async_client_is_none(self):
+        """Streaming without an initialised async client must raise
+        ``MODEL_AUTHENTICATION_ERROR`` so callers can fall back to the
+        non-streaming path instead of silently hanging.
+        """
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        model = _make_claude_model()
+        model.async_anthropic_client = None
+
+        with pytest.raises(DatusException) as exc_info:
+            model._anthropic_messages_stream(model="test", messages=[])
+        assert exc_info.value.code == ErrorCode.MODEL_AUTHENTICATION_ERROR
+
+    def test_routes_to_beta_stream_for_oauth_token(self):
+        """OAuth subscription tokens require the OAuth beta endpoint —
+        ``beta.messages.stream`` — because the standard endpoint rejects Bearer auth.
+        """
+        cfg = _make_model_config(api_key="sk-ant-oat01-token", auth_type="subscription")
+        model = _make_claude_model(cfg)
+
+        async_client = MagicMock()
+        async_client.beta.messages.stream.return_value = "beta-stream-ctx"
+        async_client.messages.stream.return_value = "standard-stream-ctx"
+        model.async_anthropic_client = async_client
+
+        result = model._anthropic_messages_stream(model="m", messages=[])
+
+        assert result == "beta-stream-ctx"
+        async_client.beta.messages.stream.assert_called_once()
+        async_client.messages.stream.assert_not_called()
+
+    def test_routes_to_standard_stream_for_api_key(self):
+        """Standard ``x-api-key`` auth must route to ``messages.stream`` —
+        the beta endpoint is reserved for OAuth and would reject the request.
+        """
+        cfg = _make_model_config(api_key="sk-ant-regular", auth_type="api_key")
+        model = _make_claude_model(cfg)
+
+        async_client = MagicMock()
+        async_client.beta.messages.stream.return_value = "beta-stream-ctx"
+        async_client.messages.stream.return_value = "standard-stream-ctx"
+        model.async_anthropic_client = async_client
+
+        result = model._anthropic_messages_stream(model="m", messages=[])
+
+        assert result == "standard-stream-ctx"
+        async_client.messages.stream.assert_called_once()
+        async_client.beta.messages.stream.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# aclose: async proxy + async anthropic client cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestAcloseAsyncClients:
+    @pytest.mark.asyncio
+    async def test_aclose_closes_async_proxy_client(self):
+        """A configured ``async_proxy_client`` must be awaited-closed on aclose."""
+        model = _make_claude_model()
+        async_proxy = MagicMock()
+        async_proxy.aclose = AsyncMock()
+        model.async_proxy_client = async_proxy
+
+        await model.aclose()
+
+        async_proxy.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_aclose_logs_warning_on_async_proxy_close_failure(self):
+        """Exceptions from ``async_proxy_client.aclose()`` must be swallowed and
+        logged as a warning — cleanup failures must not propagate and abort shutdown.
+        """
+        model = _make_claude_model()
+        async_proxy = MagicMock()
+        async_proxy.aclose = AsyncMock(side_effect=RuntimeError("net error"))
+        model.async_proxy_client = async_proxy
+
+        with patch("datus.models.claude_model.logger") as mock_logger:
+            await model.aclose()
+
+        warned = [str(c.args[0]) for c in mock_logger.warning.call_args_list]
+        assert any("async proxy client" in w.lower() and "net error" in w for w in warned), (
+            f"Expected warning naming 'async proxy client' with the underlying error, got: {warned}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_aclose_closes_async_anthropic_client(self):
+        """A configured ``async_anthropic_client`` must be awaited-closed on aclose."""
+        model = _make_claude_model()
+        async_client = MagicMock()
+        async_client.close = AsyncMock()
+        model.async_anthropic_client = async_client
+
+        await model.aclose()
+
+        async_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_aclose_logs_warning_on_async_anthropic_close_failure(self):
+        """Exceptions from ``async_anthropic_client.close()`` must be swallowed
+        and logged as a warning — keeping shutdown best-effort.
+        """
+        model = _make_claude_model()
+        async_client = MagicMock()
+        async_client.close = AsyncMock(side_effect=RuntimeError("already closed"))
+        model.async_anthropic_client = async_client
+
+        with patch("datus.models.claude_model.logger") as mock_logger:
+            await model.aclose()
+
+        warned = [str(c.args[0]) for c in mock_logger.warning.call_args_list]
+        assert any("async anthropic client" in w.lower() and "already closed" in w for w in warned), (
+            f"Expected warning naming 'async anthropic client' with the underlying error, got: {warned}"
+        )

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1292,6 +1292,40 @@ class TestGetSessionMessages:
         assert success_by_call_id[call_id_a].input["arguments"] == args_a
         assert success_by_call_id[call_id_b].input["arguments"] == args_b
 
+    def test_anthropic_native_text_blocks_resume_show_content(self, sm):
+        """Claude OAuth/native path persists assistant turns as ``type=text``.
+
+        Regression: ``get_session_messages`` previously only matched
+        ``type=output_text`` for assistant content. Anthropic-format text
+        blocks were silently skipped, so resuming a Claude OAuth chat showed
+        only the user's own messages — the assistant's reply was invisible.
+        """
+        session_id = f"test_anthropic_resume_{uuid.uuid4().hex[:8]}"
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (session_id,))
+            user_msg = {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+            assistant_msg = {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hi! 👋 Welcome to Datus."}],
+            }
+            conn.execute(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                (session_id, json.dumps(user_msg), "2026-05-21T00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                (session_id, json.dumps(assistant_msg), "2026-05-21T00:00:01"),
+            )
+            conn.commit()
+
+        messages = sm.get_session_messages(session_id)
+        assistant_groups = [m for m in messages if m["role"] == "assistant"]
+        assert assistant_groups, "Anthropic-format assistant turn missing from resume payload"
+        assert assistant_groups[0]["content"] == "Hi! 👋 Welcome to Datus."
+
 
 # ===========================================================================
 # TestParseOutputFromAction (migrated from test_session_loader.py)


### PR DESCRIPTION
Mirror OpenAICompatibleModel's streaming contract on the native Anthropic
path: yield ``thinking_delta`` PROCESSING actions per ``text_delta`` event
and a paired ``response`` SUCCESS action at each ``content_block_stop`` so
the CLI's ``_print_completed_action`` finalizes the markdown stream and
clears the pinned live region. Without the paired terminal the tail
paragraph stayed live AND got reflushed in ``__exit__``, producing a
visible duplicate of the last paragraph.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native async streaming for Claude models with real-time text-delta events and incremental assistant updates

* **Bug Fixes**
  * Session resumption now recognizes and includes Claude/Anthropic-style assistant message blocks
  * Proper async client shutdown handling to ensure clean resource cleanup

* **Tests**
  * Added comprehensive streaming and client lifecycle tests covering deltas, terminal responses, routing, and interruption handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->