### PR TITLE
[Tool] Sync main release metadata to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Project basic information configuration, required.
 [project]
 name = "datus-agent"
-version = "0.3.0"
+version = "0.3.1"
 description = "AI-powered SQL Agent for data engineering (Compiled Version)"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "datus-db-core>=0.1.3",
+    "datus-db-core>=0.1.4",
     "datus-storage-base>=0.1.2,<0.2.0",
     "python-dotenv==1.0.0",
     "pandas==2.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ lxml>=5.0.0
 markdown-it-py>=3.0.0
 tabulate>=0.9.0
 datus-storage-base==0.1.2rc2
-datus-db-core>=0.1.3
+datus-db-core>=0.1.4
 datus-semantic-core>=0.2.0
 datus-bi-core>=0.1.2
 datus-scheduler-core>=0.1.1


### PR DESCRIPTION
## Summary

- Update main source metadata to `datus-agent` 0.3.1 after the 0.3.1 release tag.
- Align the `datus-db-core` lower bound with the release branch metadata.

## Validation

- `python3 ci/check_release_readiness.py --expected-version 0.3.1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.3.1
  * Updated core database dependency requirement to version 0.1.4 or higher

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->