### PR TITLE
[BugFix] Write repaired tool call arguments back to session history

### DIFF
--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -12,6 +12,7 @@ import uuid
 from contextlib import nullcontext
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
+import json_repair
 from agents import Agent, ModelSettings, Runner, SQLiteSession, Tool
 from agents.exceptions import MaxTurnsExceeded
 from agents.mcp import MCPServerStdio
@@ -649,7 +650,33 @@ class CodexModel(LLMBaseModel):
                                     arguments = getattr(raw_item, "arguments", "{}")
                                 if not call_id:
                                     call_id = f"tool_{uuid.uuid4().hex[:8]}"
-                                args_str = str(arguments)[:80]
+
+                                # Validate and repair malformed JSON arguments
+                                try:
+                                    json.loads(arguments)
+                                    args_str = str(arguments)[:80]
+                                except (json.JSONDecodeError, TypeError, ValueError):
+                                    try:
+                                        repaired = json_repair.loads(arguments)
+                                        repaired_str = json.dumps(repaired, ensure_ascii=False)
+                                        logger.warning(
+                                            f"Repaired malformed tool call arguments for '{tool_name}' "
+                                            f"in session history: {arguments[:200]}"
+                                        )
+                                        if isinstance(raw_item, dict):
+                                            raw_item["arguments"] = repaired_str
+                                        else:
+                                            event.item.raw_item = raw_item.model_copy(
+                                                update={"arguments": repaired_str}
+                                            )
+                                            raw_item = event.item.raw_item
+                                        arguments = repaired_str
+                                        args_str = repaired_str[:80]
+                                    except Exception:
+                                        logger.error(
+                                            f"Cannot repair tool call arguments for '{tool_name}': {arguments[:200]}"
+                                        )
+                                        args_str = str(arguments)[:80]
 
                                 temp_tool_calls[call_id] = {
                                     "tool_name": tool_name,

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -12,7 +12,6 @@ import uuid
 from contextlib import nullcontext
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
-import json_repair
 from agents import Agent, ModelSettings, Runner, SQLiteSession, Tool
 from agents.exceptions import MaxTurnsExceeded
 from agents.mcp import MCPServerStdio
@@ -28,6 +27,7 @@ from datus.models.mcp_utils import multiple_mcp_servers
 from datus.observability.manager import get_observability_manager
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.json_utils import repair_tool_call_arguments
 from datus.utils.loggings import get_logger
 from datus.utils.trace_context import build_agents_run_config_kwargs, build_trace_span_attributes
 
@@ -349,7 +349,6 @@ class CodexModel(LLMBaseModel):
         Returns:
             Parsed JSON response as a dictionary
         """
-        import json
 
         self._refresh_client_token()
         input_data = self._convert_prompt_to_input(prompt)
@@ -651,32 +650,19 @@ class CodexModel(LLMBaseModel):
                                 if not call_id:
                                     call_id = f"tool_{uuid.uuid4().hex[:8]}"
 
-                                # Validate and repair malformed JSON arguments
-                                try:
-                                    json.loads(arguments)
-                                    args_str = str(arguments)[:80]
-                                except (json.JSONDecodeError, TypeError, ValueError):
-                                    try:
-                                        repaired = json_repair.loads(arguments)
-                                        repaired_str = json.dumps(repaired, ensure_ascii=False)
-                                        logger.warning(
-                                            f"Repaired malformed tool call arguments for '{tool_name}' "
-                                            f"in session history: {arguments[:200]}"
-                                        )
-                                        if isinstance(raw_item, dict):
-                                            raw_item["arguments"] = repaired_str
-                                        else:
-                                            event.item.raw_item = raw_item.model_copy(
-                                                update={"arguments": repaired_str}
-                                            )
-                                            raw_item = event.item.raw_item
-                                        arguments = repaired_str
-                                        args_str = repaired_str[:80]
-                                    except Exception:
-                                        logger.error(
-                                            f"Cannot repair tool call arguments for '{tool_name}': {arguments[:200]}"
-                                        )
-                                        args_str = str(arguments)[:80]
+                                repaired_args, was_repaired = repair_tool_call_arguments(arguments)
+                                if was_repaired:
+                                    logger.warning(
+                                        f"Repaired malformed tool call arguments for '{tool_name}' "
+                                        f"in session history: {arguments[:200]}"
+                                    )
+                                    if isinstance(raw_item, dict):
+                                        raw_item["arguments"] = repaired_args
+                                    else:
+                                        event.item.raw_item = raw_item.model_copy(update={"arguments": repaired_args})
+                                        raw_item = event.item.raw_item
+                                    arguments = repaired_args
+                                args_str = str(arguments)[:80]
 
                                 temp_tool_calls[call_id] = {
                                     "tool_name": tool_name,

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 import httpx
+import json_repair
 import litellm
 import yaml
 from agents import Agent, ModelSettings, Runner, Tool
@@ -1338,7 +1339,22 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     args_dict = json.loads(arguments) if arguments else {}
                                     args_str = to_str(args_dict)[:80]
                                 except Exception:
-                                    args_str = str(arguments)[:80]
+                                    try:
+                                        repaired = json_repair.loads(arguments)
+                                        repaired_str = json.dumps(repaired, ensure_ascii=False)
+                                        logger.warning(
+                                            f"Repaired malformed tool call arguments for '{tool_name}' "
+                                            f"in session history: {arguments[:200]}"
+                                        )
+                                        event.item.raw_item = raw_item.model_copy(update={"arguments": repaired_str})
+                                        raw_item = event.item.raw_item
+                                        arguments = repaired_str
+                                        args_str = repaired_str[:80]
+                                    except Exception:
+                                        logger.error(
+                                            f"Cannot repair tool call arguments for '{tool_name}': {arguments[:200]}"
+                                        )
+                                        args_str = str(arguments)[:80]
 
                                 # Store tool call info for matching with result
                                 temp_tool_calls[call_id] = {

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -1320,13 +1320,16 @@ class OpenAICompatibleModel(LLMBaseModel):
                             final_assistant_yielded = False
                             raw_item = getattr(event.item, "raw_item", None)
                             if raw_item:
-                                tool_name = getattr(raw_item, "name", None)
-                                if not tool_name:
+                                if isinstance(raw_item, dict):
+                                    tool_name = raw_item.get("name") or "unknown"
+                                    arguments = raw_item.get("arguments", "{}")
+                                    call_id = raw_item.get("call_id")
+                                else:
+                                    tool_name = getattr(raw_item, "name", None) or "unknown"
+                                    arguments = getattr(raw_item, "arguments", "{}")
+                                    call_id = getattr(raw_item, "call_id", None)
+                                if not tool_name or tool_name == "unknown":
                                     logger.warning(f"Tool call has no name field: {type(raw_item)}, {dir(raw_item)}")
-                                    tool_name = "unknown"
-
-                                arguments = getattr(raw_item, "arguments", "{}")
-                                call_id = getattr(raw_item, "call_id", None)
 
                                 # Generate call_id if missing
                                 if not call_id:
@@ -1339,8 +1342,11 @@ class OpenAICompatibleModel(LLMBaseModel):
                                         f"Repaired malformed tool call arguments for '{tool_name}' "
                                         f"in session history: {arguments[:200]}"
                                     )
-                                    event.item.raw_item = raw_item.model_copy(update={"arguments": repaired_args})
-                                    raw_item = event.item.raw_item
+                                    if isinstance(raw_item, dict):
+                                        raw_item["arguments"] = repaired_args
+                                    else:
+                                        event.item.raw_item = raw_item.model_copy(update={"arguments": repaired_args})
+                                        raw_item = event.item.raw_item
                                     arguments = repaired_args
                                 try:
                                     args_str = to_str(json.loads(arguments))[:80]

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 import httpx
-import json_repair
 import litellm
 import yaml
 from agents import Agent, ModelSettings, Runner, Tool
@@ -37,7 +36,7 @@ from datus.schemas.action_history import ActionHistory, ActionHistoryManager
 from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY, looks_like_failure
 from datus.utils.constants import LLMProvider
 from datus.utils.exceptions import DatusException, ErrorCode
-from datus.utils.json_utils import to_str
+from datus.utils.json_utils import repair_tool_call_arguments, to_str
 from datus.utils.loggings import get_logger
 from datus.utils.resource_utils import read_data_file_text
 from datus.utils.text_utils import LitellmPlaceholderStreamFilter, strip_litellm_placeholder
@@ -1334,27 +1333,19 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     call_id = f"tool_{uuid.uuid4().hex[:8]}"
                                     logger.warning(f"Tool call missing call_id, generated: {call_id}")
 
-                                # Try to format arguments
+                                repaired_args, was_repaired = repair_tool_call_arguments(arguments)
+                                if was_repaired:
+                                    logger.warning(
+                                        f"Repaired malformed tool call arguments for '{tool_name}' "
+                                        f"in session history: {arguments[:200]}"
+                                    )
+                                    event.item.raw_item = raw_item.model_copy(update={"arguments": repaired_args})
+                                    raw_item = event.item.raw_item
+                                    arguments = repaired_args
                                 try:
-                                    args_dict = json.loads(arguments) if arguments else {}
-                                    args_str = to_str(args_dict)[:80]
+                                    args_str = to_str(json.loads(arguments))[:80]
                                 except Exception:
-                                    try:
-                                        repaired = json_repair.loads(arguments)
-                                        repaired_str = json.dumps(repaired, ensure_ascii=False)
-                                        logger.warning(
-                                            f"Repaired malformed tool call arguments for '{tool_name}' "
-                                            f"in session history: {arguments[:200]}"
-                                        )
-                                        event.item.raw_item = raw_item.model_copy(update={"arguments": repaired_str})
-                                        raw_item = event.item.raw_item
-                                        arguments = repaired_str
-                                        args_str = repaired_str[:80]
-                                    except Exception:
-                                        logger.error(
-                                            f"Cannot repair tool call arguments for '{tool_name}': {arguments[:200]}"
-                                        )
-                                        args_str = str(arguments)[:80]
+                                    args_str = str(arguments)[:80]
 
                                 # Store tool call info for matching with result
                                 temp_tool_calls[call_id] = {

--- a/datus/utils/json_utils.py
+++ b/datus/utils/json_utils.py
@@ -592,3 +592,24 @@ def to_str(json_data: Any) -> Optional[str]:
     if json_data is None:
         return None
     return _dump_json(json_data)
+
+
+def repair_tool_call_arguments(arguments: str) -> tuple[str, bool]:
+    """Parse tool-call arguments; repair malformed JSON when possible.
+
+    Returns (json_str, was_repaired).
+    """
+    if not arguments or not arguments.strip():
+        return "{}", False
+    try:
+        json.loads(arguments)
+        return arguments, False
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+    try:
+        repaired = json_repair.loads(arguments)
+        repaired_str = json.dumps(repaired, ensure_ascii=False)
+        json.loads(repaired_str)
+        return repaired_str, True
+    except Exception:
+        return arguments, False

--- a/datus/utils/json_utils.py
+++ b/datus/utils/json_utils.py
@@ -600,7 +600,7 @@ def repair_tool_call_arguments(arguments: str) -> tuple[str, bool]:
     Returns (json_str, was_repaired).
     """
     if not arguments or not arguments.strip():
-        return "{}", False
+        return "", False
     try:
         json.loads(arguments)
         return arguments, False
@@ -608,6 +608,9 @@ def repair_tool_call_arguments(arguments: str) -> tuple[str, bool]:
         pass
     try:
         repaired = json_repair.loads(arguments)
+        # Repair is best-effort: semantics may change (e.g. unquoted value → string literal)
+        if not isinstance(repaired, dict):
+            return arguments, False
         repaired_str = json.dumps(repaired, ensure_ascii=False)
         json.loads(repaired_str)
         return repaired_str, True

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -570,6 +570,134 @@ class TestCodexModelGenerateWithToolsStream:
     @patch("datus.models.codex_model.Runner")
     @patch("datus.models.codex_model.Agent")
     @patch("datus.models.codex_model.extract_sql_contexts")
+    async def test_stream_repairs_malformed_tool_call_arguments_dict(
+        self, mock_extract, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
+    ):
+        """Cover the dict-based raw_item repair branch (lines 659-660)."""
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth = MagicMock()
+        mock_oauth.get_access_token.return_value = "tok"
+        mock_oauth_cls.return_value = mock_oauth
+
+        model = CodexModel(model_config=model_config)
+        model._async_client = MagicMock()
+
+        with patch("agents.models.openai_responses.OpenAIResponsesModel"):
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            # Dict-based raw_item with malformed arguments
+            tool_call_event = MagicMock()
+            tool_call_event.type = "run_item_stream_event"
+            tool_call_event.item.type = "tool_call_item"
+            tool_call_event.item.raw_item = {
+                "name": "execute_sql",
+                "call_id": "call_repair_dict",
+                "arguments": '{"sql": SELECT * FROM users}',
+            }
+
+            tool_output_event = MagicMock()
+            tool_output_event.type = "run_item_stream_event"
+            tool_output_event.item.type = "tool_call_output_item"
+            tool_output_event.item.output = "repaired"
+            tool_output_event.item.raw_item = {"call_id": "call_repair_dict"}
+
+            mock_result = MagicMock()
+            mock_result.final_output = "Done"
+            is_complete_values = iter([False, True])
+            type(mock_result).is_complete = property(lambda self: next(is_complete_values))
+
+            async def stream_events():
+                yield tool_call_event
+                yield tool_output_event
+
+            mock_result.stream_events = stream_events
+            mock_runner.run_streamed.return_value = mock_result
+            mock_extract.return_value = []
+
+            actions = []
+            async for action in model.generate_with_tools_stream(prompt="test"):
+                actions.append(action)
+
+            assert len(actions) == 3
+            # Verify the dict raw_item was repaired in place
+            assert json.loads(tool_call_event.item.raw_item["arguments"])["sql"] is not None
+
+    @pytest.mark.asyncio
+    @patch("datus.models.codex_model.OAuthManager")
+    @patch("datus.models.codex_model.multiple_mcp_servers")
+    @patch("datus.models.codex_model.Runner")
+    @patch("datus.models.codex_model.Agent")
+    @patch("datus.models.codex_model.extract_sql_contexts")
+    async def test_stream_repairs_malformed_tool_call_arguments_pydantic(
+        self, mock_extract, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
+    ):
+        """Cover the Pydantic model_copy repair branch (lines 662-664)."""
+        from pydantic import BaseModel
+
+        from datus.models.codex_model import CodexModel
+
+        class FakeToolCallRawItem(BaseModel):
+            name: str = "execute_sql"
+            call_id: str = "call_repair_pydantic"
+            arguments: str = '{"sql": SELECT count(*) FROM orders}'
+
+            class Config:
+                extra = "allow"
+
+        mock_oauth = MagicMock()
+        mock_oauth.get_access_token.return_value = "tok"
+        mock_oauth_cls.return_value = mock_oauth
+
+        model = CodexModel(model_config=model_config)
+        model._async_client = MagicMock()
+
+        with patch("agents.models.openai_responses.OpenAIResponsesModel"):
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            raw_item = FakeToolCallRawItem()
+            tool_call_event = MagicMock()
+            tool_call_event.type = "run_item_stream_event"
+            tool_call_event.item.type = "tool_call_item"
+            tool_call_event.item.raw_item = raw_item
+
+            tool_output_event = MagicMock()
+            tool_output_event.type = "run_item_stream_event"
+            tool_output_event.item.type = "tool_call_output_item"
+            tool_output_event.item.output = "repaired"
+            tool_output_event.item.raw_item = {"call_id": "call_repair_pydantic"}
+
+            mock_result = MagicMock()
+            mock_result.final_output = "Done"
+            is_complete_values = iter([False, True])
+            type(mock_result).is_complete = property(lambda self: next(is_complete_values))
+
+            async def stream_events():
+                yield tool_call_event
+                yield tool_output_event
+
+            mock_result.stream_events = stream_events
+            mock_runner.run_streamed.return_value = mock_result
+            mock_extract.return_value = []
+
+            actions = []
+            async for action in model.generate_with_tools_stream(prompt="test"):
+                actions.append(action)
+
+            assert len(actions) == 3
+            # Verify model_copy was used — the event's raw_item should have repaired arguments
+            repaired_raw = tool_call_event.item.raw_item
+            parsed = json.loads(repaired_raw.arguments)
+            assert "sql" in parsed
+
+    @pytest.mark.asyncio
+    @patch("datus.models.codex_model.OAuthManager")
+    @patch("datus.models.codex_model.multiple_mcp_servers")
+    @patch("datus.models.codex_model.Runner")
+    @patch("datus.models.codex_model.Agent")
+    @patch("datus.models.codex_model.extract_sql_contexts")
     async def test_stream_with_raw_response_text(
         self, mock_extract, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
     ):

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -572,7 +572,7 @@ class TestCodexModelGenerateWithToolsStream:
     @patch("datus.models.codex_model.extract_sql_contexts")
     async def test_stream_repairs_malformed_tool_call_arguments_dict(
         self, mock_extract, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
-    ):
+    ) -> None:
         """Cover the dict-based raw_item repair branch (lines 659-660)."""
         from datus.models.codex_model import CodexModel
 
@@ -621,8 +621,15 @@ class TestCodexModelGenerateWithToolsStream:
                 actions.append(action)
 
             assert len(actions) == 3
-            # Verify the dict raw_item was repaired in place
-            assert json.loads(tool_call_event.item.raw_item["arguments"])["sql"] is not None
+            repaired_raw = tool_call_event.item.raw_item
+            parsed = json.loads(repaired_raw["arguments"])
+            assert parsed["sql"] == "SELECT * FROM users"
+            assert repaired_raw["name"] == "execute_sql"
+            assert repaired_raw["call_id"] == "call_repair_dict"
+            # Contract: to_input_item() must serialize valid JSON into session history
+            tool_call_event.item.to_input_item.return_value = repaired_raw
+            input_item = tool_call_event.item.to_input_item()
+            json.loads(input_item["arguments"])
 
     @pytest.mark.asyncio
     @patch("datus.models.codex_model.OAuthManager")
@@ -632,7 +639,7 @@ class TestCodexModelGenerateWithToolsStream:
     @patch("datus.models.codex_model.extract_sql_contexts")
     async def test_stream_repairs_malformed_tool_call_arguments_pydantic(
         self, mock_extract, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
-    ):
+    ) -> None:
         """Cover the Pydantic model_copy repair branch (lines 662-664)."""
         from pydantic import BaseModel
 
@@ -687,10 +694,15 @@ class TestCodexModelGenerateWithToolsStream:
                 actions.append(action)
 
             assert len(actions) == 3
-            # Verify model_copy was used — the event's raw_item should have repaired arguments
             repaired_raw = tool_call_event.item.raw_item
             parsed = json.loads(repaired_raw.arguments)
-            assert "sql" in parsed
+            assert parsed["sql"] == "SELECT count(*) FROM orders"
+            assert repaired_raw.name == "execute_sql"
+            assert repaired_raw.call_id == "call_repair_pydantic"
+            # Contract: to_input_item() must serialize valid JSON into session history
+            tool_call_event.item.to_input_item.return_value = {"arguments": repaired_raw.arguments}
+            input_item = tool_call_event.item.to_input_item()
+            json.loads(input_item["arguments"])
 
     @pytest.mark.asyncio
     @patch("datus.models.codex_model.OAuthManager")

--- a/tests/unit_tests/models/test_openai_compatible_json_repair.py
+++ b/tests/unit_tests/models/test_openai_compatible_json_repair.py
@@ -35,14 +35,14 @@ class TestRepairToolCallArguments:
         assert result == args
         assert was_repaired is False
 
-    def test_empty_string_returns_empty_dict(self):
+    def test_empty_string_not_repaired(self):
         result, was_repaired = repair_tool_call_arguments("")
-        assert result == "{}"
+        assert result == ""
         assert was_repaired is False
 
-    def test_whitespace_only_returns_empty_dict(self):
+    def test_whitespace_only_not_repaired(self):
         result, was_repaired = repair_tool_call_arguments("   \t\n  ")
-        assert result == "{}"
+        assert result == ""
         assert was_repaired is False
 
     def test_malformed_json_is_repaired(self):
@@ -62,13 +62,15 @@ class TestRepairToolCallArguments:
         assert parsed["question"] == "请问您想查询哪个数据库的信息？"
         assert parsed["options"] == ["StarRocks", "MySQL"]
 
-    def test_garbage_input_still_returns_valid_json(self):
+    def test_garbage_input_fallback(self):
         garbage = "not json at all {{{{[[[["
         result, was_repaired = repair_tool_call_arguments(garbage)
-        # json_repair may produce something from garbage; either way the result must be valid JSON
-        json.loads(result)
-        # If repair failed, original is returned unchanged
-        assert was_repaired is True or result == garbage
+        # repair either produced a valid JSON object, or fell back to the original unchanged
+        if was_repaired:
+            parsed = json.loads(result)
+            assert isinstance(parsed, dict)
+        else:
+            assert result == garbage
 
     @pytest.mark.parametrize(
         "valid_args",
@@ -144,9 +146,9 @@ class TestDictRawItemRepair:
 class TestRepairEdgeCases:
     """Cover edge cases and exception paths in repair_tool_call_arguments."""
 
-    def test_none_like_string_treated_as_empty(self):
+    def test_whitespace_string_not_repaired(self):
         result, was_repaired = repair_tool_call_arguments("  ")
-        assert result == "{}"
+        assert result == ""
         assert was_repaired is False
 
     def test_truncated_json_repaired(self):
@@ -236,3 +238,40 @@ class TestStreamingRepairIntegration:
         parsed = json.loads(arguments)
         assert parsed["table"] == "users"
         assert parsed["limit"] == 10
+
+
+class TestToInputItemContract:
+    """Regression: repaired arguments must survive to_input_item() serialization."""
+
+    def test_pydantic_raw_item_to_input_item_contains_valid_json(self):
+        """model_copy(update=...) keeps 'arguments' in model_fields_set so to_input_item works."""
+        from unittest.mock import MagicMock
+
+        malformed = '{"sql": SELECT * FROM orders}'
+        raw_item = FakeRawItem(name="execute_sql", call_id="call_contract_pydantic", arguments=malformed)
+        repaired_args, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
+
+        new_raw_item = raw_item.model_copy(update={"arguments": repaired_args})
+        event_item = MagicMock()
+        event_item.raw_item = new_raw_item
+        event_item.to_input_item.return_value = {"arguments": new_raw_item.arguments, "name": new_raw_item.name}
+
+        input_item = event_item.to_input_item()
+        assert json.loads(input_item["arguments"]) == json.loads(repaired_args)
+
+    def test_dict_raw_item_to_input_item_contains_valid_json(self):
+        from unittest.mock import MagicMock
+
+        malformed = '{"sql": SELECT count(*) FROM users}'
+        raw_item = {"name": "execute_sql", "call_id": "call_contract_dict", "arguments": malformed}
+        repaired_args, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
+
+        raw_item["arguments"] = repaired_args
+        event_item = MagicMock()
+        event_item.raw_item = raw_item
+        event_item.to_input_item.return_value = raw_item
+
+        input_item = event_item.to_input_item()
+        assert json.loads(input_item["arguments"]) == json.loads(repaired_args)

--- a/tests/unit_tests/models/test_openai_compatible_json_repair.py
+++ b/tests/unit_tests/models/test_openai_compatible_json_repair.py
@@ -1,0 +1,125 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Unit tests for malformed JSON repair in tool call arguments during streaming.
+
+Verifies that openai_compatible.py repairs malformed arguments in raw_item
+before they are stored in session history, preventing cascading API failures.
+"""
+
+import json
+
+from pydantic import BaseModel
+
+from datus.models.openai_compatible import json_repair
+
+
+class FakeRawItem(BaseModel):
+    name: str = "ask_user"
+    call_id: str = "call_abc123"
+    arguments: str = "{}"
+
+    class Config:
+        extra = "allow"
+
+
+class TestToolCallArgumentsRepair:
+    """Test JSON repair of tool call arguments in streaming layer."""
+
+    def test_valid_json_passes_through_unchanged(self):
+        raw_item = FakeRawItem(arguments='{"question": "hello", "options": ["a", "b"]}')
+        original_arguments = raw_item.arguments
+
+        try:
+            json.loads(raw_item.arguments)
+            repaired = False
+        except (json.JSONDecodeError, TypeError, ValueError):
+            repaired = True
+
+        assert not repaired
+        assert raw_item.arguments == original_arguments
+
+    def test_malformed_json_is_repaired(self):
+        malformed = '{"keywords": PERCENTILE function, "platform": "starrocks"}'
+        raw_item = FakeRawItem(arguments=malformed)
+
+        try:
+            json.loads(raw_item.arguments)
+            needs_repair = False
+        except (json.JSONDecodeError, TypeError, ValueError):
+            needs_repair = True
+
+        assert needs_repair
+
+        repaired = json_repair.loads(malformed)
+        repaired_str = json.dumps(repaired, ensure_ascii=False)
+        new_raw_item = raw_item.model_copy(update={"arguments": repaired_str})
+
+        assert json.loads(new_raw_item.arguments) is not None
+        assert new_raw_item.name == "ask_user"
+        assert new_raw_item.call_id == "call_abc123"
+
+    def test_model_copy_preserves_other_fields(self):
+        raw_item = FakeRawItem(
+            name="execute_sql",
+            call_id="call_xyz789",
+            arguments='{"sql": SELECT * FROM t}',
+        )
+
+        repaired = json_repair.loads(raw_item.arguments)
+        repaired_str = json.dumps(repaired, ensure_ascii=False)
+        new_raw_item = raw_item.model_copy(update={"arguments": repaired_str})
+
+        assert new_raw_item.name == "execute_sql"
+        assert new_raw_item.call_id == "call_xyz789"
+        assert json.loads(new_raw_item.arguments) is not None
+
+    def test_unrepairable_json_left_unchanged(self):
+        garbage = "not json at all {{{{[[[["
+        raw_item = FakeRawItem(arguments=garbage)
+
+        try:
+            json.loads(raw_item.arguments)
+            needs_repair = False
+        except (json.JSONDecodeError, TypeError, ValueError):
+            needs_repair = True
+
+        assert needs_repair
+
+        # json_repair may still produce something from garbage;
+        # the key point is the original raw_item is unchanged if we don't write back
+        assert raw_item.arguments == garbage
+
+    def test_empty_arguments_not_repaired(self):
+        raw_item = FakeRawItem(arguments="")
+
+        try:
+            json.loads(raw_item.arguments) if raw_item.arguments else {}
+            needs_repair = False
+        except (json.JSONDecodeError, TypeError, ValueError):
+            needs_repair = True
+
+        assert not needs_repair
+
+    def test_glm_style_unquoted_values_repaired(self):
+        """Simulate real GLM output: unquoted string values in JSON."""
+        malformed = '{"question": 请问您想查询哪个数据库的信息？, "options": [StarRocks, MySQL]}'
+        raw_item = FakeRawItem(arguments=malformed)
+
+        try:
+            json.loads(raw_item.arguments)
+            needs_repair = False
+        except (json.JSONDecodeError, TypeError, ValueError):
+            needs_repair = True
+
+        assert needs_repair
+
+        repaired = json_repair.loads(malformed)
+        repaired_str = json.dumps(repaired, ensure_ascii=False)
+        new_raw_item = raw_item.model_copy(update={"arguments": repaired_str})
+
+        parsed = json.loads(new_raw_item.arguments)
+        assert "question" in parsed
+        assert isinstance(parsed.get("options"), list)

--- a/tests/unit_tests/models/test_openai_compatible_json_repair.py
+++ b/tests/unit_tests/models/test_openai_compatible_json_repair.py
@@ -3,17 +3,18 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 """
-Unit tests for malformed JSON repair in tool call arguments during streaming.
+Unit tests for malformed JSON repair in tool call arguments.
 
-Verifies that openai_compatible.py repairs malformed arguments in raw_item
-before they are stored in session history, preventing cascading API failures.
+Tests the shared repair_tool_call_arguments() utility and verifies
+that Pydantic model_copy correctly propagates repaired arguments.
 """
 
 import json
 
+import pytest
 from pydantic import BaseModel
 
-from datus.models.openai_compatible import json_repair
+from datus.utils.json_utils import repair_tool_call_arguments
 
 
 class FakeRawItem(BaseModel):
@@ -25,101 +26,213 @@ class FakeRawItem(BaseModel):
         extra = "allow"
 
 
-class TestToolCallArgumentsRepair:
-    """Test JSON repair of tool call arguments in streaming layer."""
+class TestRepairToolCallArguments:
+    """Test the repair_tool_call_arguments utility function."""
 
     def test_valid_json_passes_through_unchanged(self):
-        raw_item = FakeRawItem(arguments='{"question": "hello", "options": ["a", "b"]}')
-        original_arguments = raw_item.arguments
+        args = '{"question": "hello", "options": ["a", "b"]}'
+        result, was_repaired = repair_tool_call_arguments(args)
+        assert result == args
+        assert was_repaired is False
 
-        try:
-            json.loads(raw_item.arguments)
-            repaired = False
-        except (json.JSONDecodeError, TypeError, ValueError):
-            repaired = True
+    def test_empty_string_returns_empty_dict(self):
+        result, was_repaired = repair_tool_call_arguments("")
+        assert result == "{}"
+        assert was_repaired is False
 
-        assert not repaired
-        assert raw_item.arguments == original_arguments
+    def test_whitespace_only_returns_empty_dict(self):
+        result, was_repaired = repair_tool_call_arguments("   \t\n  ")
+        assert result == "{}"
+        assert was_repaired is False
 
     def test_malformed_json_is_repaired(self):
         malformed = '{"keywords": PERCENTILE function, "platform": "starrocks"}'
-        raw_item = FakeRawItem(arguments=malformed)
+        result, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
+        parsed = json.loads(result)
+        assert "keywords" in parsed
+        assert "platform" in parsed
+        assert parsed["platform"] == "starrocks"
 
-        try:
-            json.loads(raw_item.arguments)
-            needs_repair = False
-        except (json.JSONDecodeError, TypeError, ValueError):
-            needs_repair = True
+    def test_glm_style_unquoted_values_repaired(self):
+        malformed = '{"question": 请问您想查询哪个数据库的信息？, "options": [StarRocks, MySQL]}'
+        result, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
+        parsed = json.loads(result)
+        assert parsed["question"] == "请问您想查询哪个数据库的信息？"
+        assert parsed["options"] == ["StarRocks", "MySQL"]
 
-        assert needs_repair
+    def test_garbage_input_still_returns_valid_json(self):
+        garbage = "not json at all {{{{[[[["
+        result, was_repaired = repair_tool_call_arguments(garbage)
+        # json_repair may produce something from garbage; either way the result must be valid JSON
+        json.loads(result)
+        # If repair failed, original is returned unchanged
+        assert was_repaired is True or result == garbage
 
-        repaired = json_repair.loads(malformed)
-        repaired_str = json.dumps(repaired, ensure_ascii=False)
-        new_raw_item = raw_item.model_copy(update={"arguments": repaired_str})
+    @pytest.mark.parametrize(
+        "valid_args",
+        [
+            "{}",
+            '{"key": "value"}',
+            '{"nested": {"a": 1}, "list": [1, 2, 3]}',
+            "[]",
+            '{"unicode": "中文值"}',
+        ],
+    )
+    def test_various_valid_json_not_repaired(self, valid_args):
+        result, was_repaired = repair_tool_call_arguments(valid_args)
+        assert was_repaired is False
+        assert result == valid_args
 
-        assert json.loads(new_raw_item.arguments) is not None
-        assert new_raw_item.name == "ask_user"
-        assert new_raw_item.call_id == "call_abc123"
 
-    def test_model_copy_preserves_other_fields(self):
+class TestModelCopyIntegration:
+    """Verify that model_copy correctly propagates repaired arguments."""
+
+    def test_model_copy_updates_arguments(self):
+        malformed = '{"sql": SELECT * FROM t}'
         raw_item = FakeRawItem(
             name="execute_sql",
             call_id="call_xyz789",
-            arguments='{"sql": SELECT * FROM t}',
+            arguments=malformed,
         )
 
-        repaired = json_repair.loads(raw_item.arguments)
-        repaired_str = json.dumps(repaired, ensure_ascii=False)
-        new_raw_item = raw_item.model_copy(update={"arguments": repaired_str})
+        repaired_args, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
 
+        new_raw_item = raw_item.model_copy(update={"arguments": repaired_args})
+        parsed = json.loads(new_raw_item.arguments)
+        assert "sql" in parsed
         assert new_raw_item.name == "execute_sql"
         assert new_raw_item.call_id == "call_xyz789"
-        assert json.loads(new_raw_item.arguments) is not None
 
-    def test_unrepairable_json_left_unchanged(self):
-        garbage = "not json at all {{{{[[[["
-        raw_item = FakeRawItem(arguments=garbage)
+    def test_model_copy_not_needed_for_valid_json(self):
+        valid = '{"question": "hello"}'
+        raw_item = FakeRawItem(arguments=valid)
 
-        try:
-            json.loads(raw_item.arguments)
-            needs_repair = False
-        except (json.JSONDecodeError, TypeError, ValueError):
-            needs_repair = True
+        result, was_repaired = repair_tool_call_arguments(valid)
+        assert was_repaired is False
+        assert raw_item.arguments == valid
 
-        assert needs_repair
 
-        # json_repair may still produce something from garbage;
-        # the key point is the original raw_item is unchanged if we don't write back
-        assert raw_item.arguments == garbage
+class TestDictRawItemRepair:
+    """Verify repair integration with dict-based raw_item (CodexModel path)."""
 
-    def test_empty_arguments_not_repaired(self):
-        raw_item = FakeRawItem(arguments="")
+    def test_dict_raw_item_updated_in_place(self):
+        malformed = '{"sql": SELECT * FROM users WHERE id = 1}'
+        raw_item = {"name": "execute_sql", "call_id": "call_001", "arguments": malformed}
 
-        try:
-            json.loads(raw_item.arguments) if raw_item.arguments else {}
-            needs_repair = False
-        except (json.JSONDecodeError, TypeError, ValueError):
-            needs_repair = True
+        repaired_args, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
 
-        assert not needs_repair
+        if isinstance(raw_item, dict):
+            raw_item["arguments"] = repaired_args
 
-    def test_glm_style_unquoted_values_repaired(self):
-        """Simulate real GLM output: unquoted string values in JSON."""
-        malformed = '{"question": 请问您想查询哪个数据库的信息？, "options": [StarRocks, MySQL]}'
-        raw_item = FakeRawItem(arguments=malformed)
+        parsed = json.loads(raw_item["arguments"])
+        assert "sql" in parsed
+        assert raw_item["name"] == "execute_sql"
 
-        try:
-            json.loads(raw_item.arguments)
-            needs_repair = False
-        except (json.JSONDecodeError, TypeError, ValueError):
-            needs_repair = True
+    def test_dict_raw_item_unchanged_for_valid_json(self):
+        valid = '{"query": "SELECT 1"}'
+        raw_item = {"name": "execute_sql", "call_id": "call_002", "arguments": valid}
 
-        assert needs_repair
+        repaired_args, was_repaired = repair_tool_call_arguments(valid)
+        assert was_repaired is False
+        assert raw_item["arguments"] == valid
 
-        repaired = json_repair.loads(malformed)
-        repaired_str = json.dumps(repaired, ensure_ascii=False)
-        new_raw_item = raw_item.model_copy(update={"arguments": repaired_str})
 
-        parsed = json.loads(new_raw_item.arguments)
-        assert "question" in parsed
-        assert isinstance(parsed.get("options"), list)
+class TestRepairEdgeCases:
+    """Cover edge cases and exception paths in repair_tool_call_arguments."""
+
+    def test_none_like_string_treated_as_empty(self):
+        result, was_repaired = repair_tool_call_arguments("  ")
+        assert result == "{}"
+        assert was_repaired is False
+
+    def test_truncated_json_repaired(self):
+        truncated = '{"key": "value", "nested": {"a":'
+        result, was_repaired = repair_tool_call_arguments(truncated)
+        assert was_repaired is True
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+    def test_trailing_comma_repaired(self):
+        trailing = '{"a": 1, "b": 2,}'
+        result, was_repaired = repair_tool_call_arguments(trailing)
+        assert was_repaired is True
+        parsed = json.loads(result)
+        assert parsed == {"a": 1, "b": 2}
+
+    def test_single_quotes_repaired(self):
+        single_quotes = "{'key': 'value'}"
+        result, was_repaired = repair_tool_call_arguments(single_quotes)
+        assert was_repaired is True
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+    def test_repair_fallback_when_json_repair_raises(self):
+        """Cover the exception fallback path (lines 614-615) when json_repair itself fails."""
+        from unittest.mock import patch
+
+        malformed = '{"broken": !!!}'
+        with patch("datus.utils.json_utils.json_repair.loads", side_effect=Exception("repair failed")):
+            result, was_repaired = repair_tool_call_arguments(malformed)
+        assert result == malformed
+        assert was_repaired is False
+
+
+class TestStreamingRepairIntegration:
+    """Cover the repair branch inside model streaming event handlers."""
+
+    def test_openai_compatible_repair_branch_with_pydantic_raw_item(self):
+        """Simulate the repair path in OpenAICompatibleModel streaming."""
+        malformed = '{"sql": SELECT * FROM t WHERE id = 1}'
+        raw_item = FakeRawItem(name="execute_sql", call_id="call_001", arguments=malformed)
+
+        repaired_args, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
+
+        # Simulate the model code path: event.item.raw_item = raw_item.model_copy(...)
+        new_raw_item = raw_item.model_copy(update={"arguments": repaired_args})
+        raw_item = new_raw_item
+        arguments = repaired_args
+
+        parsed = json.loads(arguments)
+        assert "sql" in parsed
+        assert raw_item.arguments == repaired_args
+
+    def test_codex_repair_branch_with_dict_raw_item(self):
+        """Simulate the dict-based repair path in CodexModel streaming."""
+        malformed = '{"query": SELECT count(*) FROM orders}'
+        raw_item = {"name": "execute_sql", "call_id": "call_002", "arguments": malformed}
+
+        repaired_args, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
+
+        # Simulate the CodexModel code path: if isinstance(raw_item, dict)
+        if isinstance(raw_item, dict):
+            raw_item["arguments"] = repaired_args
+        arguments = repaired_args
+
+        parsed = json.loads(arguments)
+        assert "query" in parsed
+        assert raw_item["arguments"] == repaired_args
+
+    def test_codex_repair_branch_with_pydantic_raw_item(self):
+        """Simulate the else branch in CodexModel (Pydantic raw_item)."""
+        malformed = '{"table": users, "limit": 10}'
+        raw_item = FakeRawItem(name="read_table", call_id="call_003", arguments=malformed)
+
+        repaired_args, was_repaired = repair_tool_call_arguments(malformed)
+        assert was_repaired is True
+
+        # Simulate: not isinstance(raw_item, dict) → model_copy path
+        if not isinstance(raw_item, dict):
+            new_raw_item = raw_item.model_copy(update={"arguments": repaired_args})
+            raw_item = new_raw_item
+        arguments = repaired_args
+
+        assert raw_item.arguments == repaired_args
+        parsed = json.loads(arguments)
+        assert parsed["table"] == "users"
+        assert parsed["limit"] == 10


### PR DESCRIPTION
## Why

When an LLM (e.g. GLM) returns malformed JSON in tool call arguments, the `json_repair` fallback (PR #685) successfully parses them for tool execution, but **the original malformed string stays in `raw_item.arguments`**. The Agents SDK later serializes this via `to_input_item()` → `model_dump()` into session history. On subsequent turns, the corrupted history is replayed to the API, causing permanent `BadRequestError` for the entire session.

Closes #862

## Solution

In the streaming layer (`openai_compatible.py` and `codex_model.py`), reuse the existing `json.loads(arguments)` try/except block. When parsing fails, repair via `json_repair` and replace `raw_item` with a corrected Pydantic model copy (`model_copy(update={"arguments": repaired_str})`). This ensures `to_input_item()` serializes valid JSON into session storage.

- **Zero overhead for valid JSON** — repair only triggers in the existing `except` branch
- **Covers both model backends** — `OpenAICompatibleModel` (Pydantic raw_item) and `CodexModel` (dict or Pydantic raw_item)

## Test Cases

- `tests/unit_tests/models/test_openai_compatible_json_repair.py` — 6 new tests:
  - `test_valid_json_passes_through_unchanged`
  - `test_malformed_json_is_repaired` — GLM-style `PERCENTILE function` unquoted value
  - `test_model_copy_preserves_other_fields` — name/call_id unchanged after repair
  - `test_unrepairable_json_left_unchanged`
  - `test_empty_arguments_not_repaired`
  - `test_glm_style_unquoted_values_repaired` — Chinese unquoted values + array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of malformed JSON in streamed tool-call arguments: attempts automatic repair, updates stored/displayed arguments when repaired, and falls back to original on failure.

* **New Features**
  * Added a JSON repair utility that normalizes and validates tool-call arguments and reports when repair occurred; streaming paths now apply it.

* **Tests**
  * Added extensive unit and integration tests for valid, malformed, edge-case, and model-vs-dict repair scenarios.

* **Chores**
  * Removed a redundant local import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
