### PR TITLE
[BugFix] Whitelist .j2 in FilesystemFuncTool's default extension list

### DIFF
--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -46,6 +46,7 @@ class FilesystemConfig:
             ".yml",
             ".csv",
             ".sql",
+            ".j2",
             ".html",
             ".css",
             ".xml",

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -41,6 +41,9 @@ class TestFilesystemConfig:
         assert ".py" in cfg.allowed_extensions
         assert ".txt" in cfg.allowed_extensions
         assert ".json" in cfg.allowed_extensions
+        # Dashboard artifact templates land as ``<slug>.sql.j2`` — Path.suffix
+        # returns ``.j2`` only, so the bare ``.j2`` entry is what gates them.
+        assert ".j2" in cfg.allowed_extensions
 
     def test_custom_allowed_extensions(self):
         cfg = FilesystemConfig(allowed_extensions=[".py"])


### PR DESCRIPTION
## Why

Dashboard artifacts persist parameterised SQL as ``<slug>.sql.j2``, but `read_file` rejected those paths with `File type not allowed: dashboards/jeff_shop_overview/queries/product_type_mix.sql.j2`. The LLM couldn't read its own saved templates back during edits.

The check is `file_path.suffix.lower() in allowed_extensions`. `Path("foo.sql.j2").suffix` returns `.j2`, which the default list didn't cover.

## Solution

Add `.j2` to `FilesystemConfig.allowed_extensions` default list. Single-entry whitelist extension; no behaviour change for callers that pass their own `allowed_extensions` (subclasses like `ReportFilesystemFuncTool` / `DashboardArtifactFilesystemFuncTool` already gate by path zone separately).

## Test Cases

Extended `TestFilesystemConfig.test_default_allowed_extensions` to assert `.j2 in cfg.allowed_extensions`. Full `tests/unit_tests/tools/func_tool/test_filesystem_tools.py` suite (78 cases) stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filesystem tools now support .j2 (Jinja2 template) files, enabling read, write, edit, and delete operations on these template files alongside other supported file types.

* **Tests**
  * Test suite expanded to validate .j2 template file support in filesystem operations, including proper file extension handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->