### PR TITLE
[Enhancement] Add version column to visual artifact allowed imports

### DIFF
--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -48,7 +48,7 @@ The optional `/** @datus-title ... */` annotation at the top is used by the stan
 |---|---|---|
 | `react` | `^18.2.0` | `useState`, `useEffect`, `useRef`, `useMemo`, `useCallback`, `useContext`, `createContext`, plus the default `React` namespace |
 | `@datus/web-artifact` | runtime-provided | `useDatusArtifact`, `AnimateOnVisible` (see "Motion & animation"), `ChartCard` (see "Canonical component shape" + "Card props"), `ChartEntryMore` (escape hatch — `ChartCard` already embeds it), `Skeleton`, `ErrorBlock` (see "Loading & error placeholders") |
-| `recharts` | `^3.8.1` | any named export (`AreaChart`, `LineChart`, `BarChart`, `RadarChart`, `PieChart`, `ResponsiveContainer`, `Tooltip`, `XAxis`, `YAxis`, `CartesianGrid`, `Area`, `Line`, `Bar`, `Radar`, `Pie`, `Cell`, etc.). **v3 API** — not v2. |
+| `recharts` | `^3.8.1` | any named export (`AreaChart`, `LineChart`, `BarChart`, `RadarChart`, `PieChart`, `ResponsiveContainer`, `Tooltip`, `XAxis`, `YAxis`, `CartesianGrid`, `Area`, `Line`, `Bar`, `Radar`, `Pie`, `Cell`, etc.). **v3, not v2** — see the v3 notes below. |
 | `lucide-react` | `^0.563.0` | any icon component (`User`, `TrendingUp`, `Banknote`, `Globe`, `Landmark`, …). **Use these instead of emoji** — see the "Iconography & emoji" section below. |
 | `d3-format` | `^3.1.2` | `format` — build numeric / currency / percent / SI-prefix formatters |
 | `dayjs` | `^1.11.20` | default `dayjs` factory + `.format(pattern)` |
@@ -57,6 +57,12 @@ The optional `/** @datus-title ... */` annotation at the top is used by the stan
 Do **not** import from: `react-dom`, `next/*`, `react-router*`, state-management (`zustand`, `redux`, `jotai`), CSS-in-JS (`styled-components`, `emotion`), data-fetching (`swr`, `react-query`), or utility libraries (`lodash`, `date-fns`, `moment`). Reimplement what you need inline. The validator rejects every other bare specifier; the iframe runtime would also throw.
 
 Relative paths must stay under `render/` — `../../../escape` is rejected.
+
+**recharts is v3, not v2** — avoid these v2-only patterns the model tends to reach for:
+
+- No `activeIndex` / `activeShape` on `<Pie>` / `<Bar>` / `<Scatter>` (removed in v3). To emphasize a slice/bar, drive its color from data via `<Cell fill>` instead.
+- `<Pie blendStroke>` removed → use `stroke="none"`.
+- SVG has no z-index; paint order follows JSX order. Put `<Tooltip>` **after** `<Legend>` in JSX so the tooltip renders on top.
 
 ### Import every name you reference
 

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -44,15 +44,15 @@ The optional `/** @datus-title ... */` annotation at the top is used by the stan
 
 ### Allowed imports
 
-| Module | Notes |
-|---|---|
-| `react` | `useState`, `useEffect`, `useRef`, `useMemo`, `useCallback`, `useContext`, `createContext`, plus the default `React` namespace |
-| `@datus/web-artifact` | `useDatusArtifact`, `AnimateOnVisible` (see "Motion & animation"), `ChartCard` (see "Canonical component shape" + "Card props"), `ChartEntryMore` (escape hatch — `ChartCard` already embeds it), `Skeleton`, `ErrorBlock` (see "Loading & error placeholders") |
-| `recharts` | any named export (`AreaChart`, `LineChart`, `BarChart`, `RadarChart`, `PieChart`, `ResponsiveContainer`, `Tooltip`, `XAxis`, `YAxis`, `CartesianGrid`, `Area`, `Line`, `Bar`, `Radar`, `Pie`, `Cell`, etc.) |
-| `lucide-react` | any icon component (`User`, `TrendingUp`, `Banknote`, `Globe`, `Landmark`, …). **Use these instead of emoji** — see the "Iconography & emoji" section below. |
-| `d3-format` | `format` — build numeric / currency / percent / SI-prefix formatters |
-| `dayjs` | default `dayjs` factory + `.format(pattern)` |
-| `'./<sibling>'` or `'../<path>'` | resolves to a file under `render/`. `./kpi-banner` → `render/kpi-banner.jsx`; `./charts/trend` → `render/charts/trend.jsx`. Extensions optional; `/index.jsx` fallback supported. |
+| Module | Version | Notes |
+|---|---|---|
+| `react` | `^18.2.0` | `useState`, `useEffect`, `useRef`, `useMemo`, `useCallback`, `useContext`, `createContext`, plus the default `React` namespace |
+| `@datus/web-artifact` | runtime-provided | `useDatusArtifact`, `AnimateOnVisible` (see "Motion & animation"), `ChartCard` (see "Canonical component shape" + "Card props"), `ChartEntryMore` (escape hatch — `ChartCard` already embeds it), `Skeleton`, `ErrorBlock` (see "Loading & error placeholders") |
+| `recharts` | `^3.8.1` | any named export (`AreaChart`, `LineChart`, `BarChart`, `RadarChart`, `PieChart`, `ResponsiveContainer`, `Tooltip`, `XAxis`, `YAxis`, `CartesianGrid`, `Area`, `Line`, `Bar`, `Radar`, `Pie`, `Cell`, etc.). **v3 API** — not v2. |
+| `lucide-react` | `^0.563.0` | any icon component (`User`, `TrendingUp`, `Banknote`, `Globe`, `Landmark`, …). **Use these instead of emoji** — see the "Iconography & emoji" section below. |
+| `d3-format` | `^3.1.2` | `format` — build numeric / currency / percent / SI-prefix formatters |
+| `dayjs` | `^1.11.20` | default `dayjs` factory + `.format(pattern)` |
+| `'./<sibling>'` or `'../<path>'` | — | resolves to a file under `render/`. `./kpi-banner` → `render/kpi-banner.jsx`; `./charts/trend` → `render/charts/trend.jsx`. Extensions optional; `/index.jsx` fallback supported. |
 
 Do **not** import from: `react-dom`, `next/*`, `react-router*`, state-management (`zustand`, `redux`, `jotai`), CSS-in-JS (`styled-components`, `emotion`), data-fetching (`swr`, `react-query`), or utility libraries (`lodash`, `date-fns`, `moment`). Reimplement what you need inline. The validator rejects every other bare specifier; the iframe runtime would also throw.
 


### PR DESCRIPTION
## Why

The visual-artifact prompt (`_visual_artifact_common.j2`) lists the allowed
imports for LLM-authored artifacts but pins no versions. The runtime is served
by `Datus-saas/packages/web-artifact`, whose `package.json` pins specific major
versions — most importantly `recharts ^3.8.1`, whose API differs significantly
from v2. Without a version hint the LLM can emit code against the wrong major
(e.g. recharts v2 props), which fails at render time.

## Solution

Add a `Version` column to the "Allowed imports" table, sourced from
`Datus-saas/packages/web-artifact/package.json`:

- `react` → `^18.2.0`
- `recharts` → `^3.8.1` (flagged as **v3 API, not v2**)
- `lucide-react` → `^0.563.0`
- `d3-format` → `^3.1.2`
- `dayjs` → `^1.11.20`
- `@datus/web-artifact` → runtime-provided
- relative paths → n/a

## Test Cases

None. Documentation-only change to a prompt template (`.j2`); no Python code or
behavior is affected, so no unit/integration tests apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Version column and explicit version constraints for key libraries (React, charting, icons, date/formatting) to improve consistency in generated artifacts.
  * Kept one runtime-provided package unchanged.
  * Expanded charting guidance to discourage outdated v2 patterns and clarified relative-import guidance for render-time modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->