### PR TITLE
[BugFix] gen_visual: forward session_id so multi-turn history persists

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -117,6 +117,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         execution_mode: Literal["interactive", "workflow"] = "interactive",
         scope: Optional[str] = None,
         is_subagent: bool = False,
+        session_id: Optional[str] = None,
     ):
         self.execution_mode = execution_mode
         self.configured_node_name = node_name
@@ -153,6 +154,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             mcp_servers={},
             scope=scope,
             is_subagent=is_subagent,
+            session_id=session_id,
         )
 
         self.setup_tools()

--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -128,6 +128,7 @@ def create_interactive_node(
                 node_name=subagent_name,
                 scope=scope,
                 execution_mode=execution_mode,
+                session_id=session_id,
             )
 
         elif subagent_name == "gen_visual_dashboard" or node_class_type == "gen_visual_dashboard":
@@ -143,6 +144,7 @@ def create_interactive_node(
                 node_name=subagent_name,
                 scope=scope,
                 execution_mode=execution_mode,
+                session_id=session_id,
             )
 
         elif subagent_name == "explore" or node_class_type == "explore":

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -84,6 +84,14 @@ class TestGenVisualDashboardInit:
         assert node.dashboard_artifact_tools is None
         assert node._active_dashboard_slug is None
 
+    def test_session_id_is_honored(self, real_agent_config, mock_llm_create):
+        # Regression: BaseVisualArtifactAgenticNode must accept session_id and
+        # forward it to the base node. When dropped, the node mints a fresh
+        # random session id each turn, so the SQLite history never matches the
+        # chat session and multi-turn context is silently lost.
+        node = _make_node(real_agent_config, session_id="vd_session_fixed")
+        assert node.session_id == "vd_session_fixed"
+
     def test_tools_include_filesystem_and_db(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config)
         tool_names = {t.name for t in node.tools}
@@ -369,6 +377,32 @@ class TestNodeFactoryDashboardBranch:
         )
         assert isinstance(node, GenVisualReportAgenticNode)
         assert node.get_node_name() == "gen_visual_report"
+
+    def test_factory_forwards_session_id_to_dashboard(self, real_agent_config, mock_llm_create):
+        # Regression: the API path passes the HTTP session id as both node_id
+        # and session_id so the node's SQLite history matches the chat session.
+        # The gen_visual_* branches previously dropped session_id, breaking
+        # multi-turn history for dashboards/reports.
+        from datus.agent.node.node_factory import create_interactive_node
+
+        node = create_interactive_node(
+            subagent_name="gen_visual_dashboard",
+            agent_config=real_agent_config,
+            node_id="api_session_42",
+            session_id="api_session_42",
+        )
+        assert node.session_id == "api_session_42"
+
+    def test_factory_forwards_session_id_to_report(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.node_factory import create_interactive_node
+
+        node = create_interactive_node(
+            subagent_name="gen_visual_report",
+            agent_config=real_agent_config,
+            node_id="api_session_99",
+            session_id="api_session_99",
+        )
+        assert node.session_id == "api_session_99"
 
     def test_create_node_input_returns_dashboard_input(self, real_agent_config, mock_llm_create):
         from datus.agent.node.node_factory import create_node_input


### PR DESCRIPTION
## Problem

Multi-turn chat through `/api/v1/chat/stream` with `subagent_id=gen_visual_dashboard` (and `gen_visual_report`) loses all history. Re-sending the same `session_id` has no effect: the model starts every turn blind and cannot recall prior edits or the conversation.

The tell is in the stream-start payload — `session_id` and `llm_session_id` differ, when they should be equal:

```
session_id     = gen_visual_dashboard_session_111ec269   # task-level id (== node_id, what the client echoes back)
llm_session_id = gen_visual_dashboard_session_d8c7d291   # node.session_id (the actual SQLite history file)
```

## Root cause

The `gen_visual_*` nodes drop `session_id` on construction, in two places:

1. `BaseVisualArtifactAgenticNode.__init__` has no `session_id` parameter and never forwards one to `AgenticNode.__init__`.
2. The `gen_visual_dashboard` / `gen_visual_report` branches in `node_factory.create_interactive_node` are the only branches that don't pass `session_id=session_id` (every other node type does).

So `AgenticNode.__init__` receives `session_id=None` → `self.session_id = ""` → `_generate_session_id()` mints a **fresh random id each turn**. The `AdvancedSQLiteSession` history therefore lands in a new, empty `.db` every request, and the client-supplied `session_id` is only used as the task-level `node_id`, never to locate history.

Knock-on effect: with no history, the model falls back to `glob('dashboards/*')` to recover context, finds nothing, finishes without binding a dashboard, and trips the `_missing_binding_error()` guard.

## Fix

- Add `session_id` to `BaseVisualArtifactAgenticNode.__init__` and forward it to the base node (matching `GenReportAgenticNode`).
- Pass `session_id=session_id` through both `gen_visual_*` factory branches.

After this, `node.session_id == node_id == client session_id`, so re-using a `session_id` reopens the same SQLite history and multi-turn context works.

## Tests

- `test_session_id_is_honored` — direct construction sets `node.session_id` (covers the base `__init__`).
- `test_factory_forwards_session_id_to_dashboard` / `..._to_report` — `create_interactive_node` forwards `session_id` for both node types (covers the factory).

`56 passed` in `test_node_factory.py` + `test_gen_visual_dashboard_agentic_node.py`; `ruff format --check` and `ruff check` clean.

## Impact

Affects only `gen_visual_dashboard` and `gen_visual_report` multi-turn context. `gen_report` / `gen_metrics` / `gen_table` / `chat` / `gen_sql` were already correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Resolved session state propagation issues for visual reports and dashboards to ensure consistent session persistence during interactive operations and artifact generation.

**Tests**
- Added comprehensive test coverage for session ID handling in visual dashboard and report generation workflows, including regression tests to verify proper state preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->