### PR TITLE
[Enhancement] Degrade gracefully when embeddings are unavailable

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -142,6 +142,8 @@ class AgenticNode(Node):
         self.scope = scope
         self.mcp_servers = mcp_servers or {}
         self.actions: List[ActionHistory] = []
+        if not hasattr(self, "degraded_capabilities"):
+            self.degraded_capabilities: Dict[str, str] = {}
         # Resume target (or freshly generated id when caller passes ``None``).
         # ``session_id`` is set once below — after ``get_node_name()`` is wired
         # up — and is treated as immutable for the node's lifetime: resume /
@@ -326,6 +328,17 @@ class AgenticNode(Node):
         self._status_dirty_callback: Optional[Callable[[], None]] = None
         # Lazy single-instance handle — see ``_get_or_create_token_usage_hook``.
         self._token_usage_hook_instance: Optional[Any] = None
+
+    def _record_degraded_capability(self, key: str, message: str) -> None:
+        """Record a non-fatal capability degradation for API/CLI surfaces."""
+        self.degraded_capabilities[key] = message
+
+    def _record_context_search_degraded(self, error: BaseException | str) -> str:
+        from datus.storage.embedding_diagnostics import format_context_degraded_warning
+
+        message = format_context_degraded_warning(error)
+        self._record_degraded_capability("context_search_tools", message)
+        return message
 
     @property
     def model(self) -> Optional[LLMBaseModel]:

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -130,7 +130,7 @@ class ChatAgenticNode(AgenticNode):
         node_name = self.get_node_name()
         self.db_func_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=node_name)
         self._setup_context_search_tools()
-        self.reference_template_tools = ReferenceTemplateTools(self.agent_config, db_func_tool=self.db_func_tool)
+        self._setup_reference_template_tools()
         self._setup_date_parsing_tools()
         self._setup_filesystem_tools()
         # self.bash_tool was created in AgenticNode.__init__; just surface its
@@ -160,6 +160,23 @@ class ChatAgenticNode(AgenticNode):
             self.context_search_tools = None
             warning = self._record_context_search_degraded(exc)
             logger.warning("Failed to setup context search tools, continuing without: %s", warning)
+
+    def _setup_reference_template_tools(self):
+        """Setup reference-template tools without blocking DB/chat capabilities."""
+        try:
+            self.reference_template_tools = ReferenceTemplateTools(
+                self.agent_config,
+                sub_agent_name=self.get_node_name(),
+                db_func_tool=self.db_func_tool,
+            )
+        except Exception as exc:
+            self.reference_template_tools = None
+            message = (
+                "Reference template tools are disabled because the embedding-backed "
+                f"template store is unavailable. Details: {exc}"
+            )
+            self._record_degraded_capability("reference_template_tools", message)
+            logger.warning("Failed to setup reference template tools, continuing without: %s", message)
 
     def _setup_date_parsing_tools(self):
         """Setup date parsing tools."""

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -87,6 +87,7 @@ class ChatAgenticNode(AgenticNode):
         # Initialize tool attributes BEFORE calling parent constructor
         self.db_func_tool: Optional[DBFuncTool] = None
         self.context_search_tools: Optional[ContextSearchTools] = None
+        self.degraded_capabilities: Dict[str, str] = {}
         self.date_parsing_tools: Optional[DateParsingTools] = None
         self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
         self._platform_doc_tool: Optional[PlatformDocSearchTool] = None
@@ -128,7 +129,7 @@ class ChatAgenticNode(AgenticNode):
         """Initialize all tools with default database connection."""
         node_name = self.get_node_name()
         self.db_func_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=node_name)
-        self.context_search_tools = ContextSearchTools(self.agent_config, sub_agent_name=node_name)
+        self._setup_context_search_tools()
         self.reference_template_tools = ReferenceTemplateTools(self.agent_config, db_func_tool=self.db_func_tool)
         self._setup_date_parsing_tools()
         self._setup_filesystem_tools()
@@ -150,6 +151,15 @@ class ChatAgenticNode(AgenticNode):
         # ``PermissionHooks`` is still built lazily by
         # ``_ensure_permission_hooks`` via ``_compose_hooks``.
         self._populate_tool_registry()
+
+    def _setup_context_search_tools(self):
+        """Setup context search tools without blocking DB/chat capabilities."""
+        try:
+            self.context_search_tools = ContextSearchTools(self.agent_config, sub_agent_name=self.get_node_name())
+        except Exception as exc:
+            self.context_search_tools = None
+            warning = self._record_context_search_degraded(exc)
+            logger.warning("Failed to setup context search tools, continuing without: %s", warning)
 
     def _setup_date_parsing_tools(self):
         """Setup date parsing tools."""

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -15,11 +15,13 @@ from typing import AsyncGenerator, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.api.models.cli_models import (
+    IMessageContent,
     SSEDataType,
     SSEEndData,
     SSEErrorData,
     SSEEvent,
     SSEMessageData,
+    SSEMessagePayload,
     SSEPingData,
     SSESessionData,
     SSEUsageData,
@@ -544,6 +546,7 @@ class ChatTaskManager:
                 ),
             )
             event_id += 1
+            event_id = await self._push_degraded_capability_warnings(task, node, event_id)
 
             # 3. Resolve @-references
             at_tables, at_metrics, at_sqls = self._resolve_at_context(
@@ -928,6 +931,35 @@ class ChatTaskManager:
     # @ reference resolution
     # ------------------------------------------------------------------
 
+    async def _push_degraded_capability_warnings(self, task: ChatTask, node: AgenticNode, event_id: int) -> int:
+        degraded = getattr(node, "degraded_capabilities", {}) or {}
+        context_warning = degraded.get("context_search_tools")
+        if not context_warning:
+            return event_id
+
+        await self._push_event(
+            task,
+            SSEEvent(
+                id=event_id,
+                event="message",
+                data=SSEMessageData(
+                    type=SSEDataType.CREATE_MESSAGE,
+                    payload=SSEMessagePayload(
+                        message_id=f"context-degraded-{uuid.uuid4().hex[:8]}",
+                        role="assistant",
+                        content=[
+                            IMessageContent(
+                                type="markdown",
+                                payload={"content": context_warning},
+                            )
+                        ],
+                    ),
+                ),
+                timestamp=now_utc_iso(),
+            ),
+        )
+        return event_id + 1
+
     def _resolve_at_context(
         self,
         agent_config: AgentConfig,
@@ -936,8 +968,12 @@ class ChatTaskManager:
         sql_paths: Optional[List[str]],
     ) -> tuple[List[TableSchema], List[Metric], List[ReferenceSql]]:
         """Resolve @-reference paths to typed objects using a fresh completer."""
-        completer = AtReferenceCompleter(agent_config)
-        completer.reload_data()
+        try:
+            completer = AtReferenceCompleter(agent_config)
+            completer.reload_data()
+        except Exception as exc:
+            logger.warning("Failed to resolve @ references; continuing without context references: %s", exc)
+            return [], [], []
 
         tables: List[TableSchema] = []
         for path in table_paths or []:

--- a/datus/api/services/tool_service.py
+++ b/datus/api/services/tool_service.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict
 from datus.api.models.base_models import Result
 from datus.api.models.config_models import ErrorCode
 from datus.configuration.agent_config import AgentConfig
+from datus.storage.embedding_diagnostics import format_context_degraded_warning
 from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.utils.loggings import get_logger
@@ -16,9 +17,26 @@ logger = get_logger(__name__)
 class ToolService:
     """Registry-based tool dispatch: tool_name -> bound method."""
 
+    CONTEXT_TOOL_NAMES = {
+        "list_subject_tree",
+        "search_metrics",
+        "get_metrics",
+        "search_reference_sql",
+        "get_reference_sql",
+        "search_semantic_objects",
+        "search_knowledge",
+        "get_knowledge",
+    }
+
     def __init__(self, agent_config: AgentConfig):
         self._agent_config = agent_config
-        self._context_search_tools = ContextSearchTools(agent_config)
+        self.context_warning = ""
+        try:
+            self._context_search_tools = ContextSearchTools(agent_config)
+        except Exception as exc:
+            self._context_search_tools = None
+            self.context_warning = format_context_degraded_warning(exc)
+            logger.warning("Context search tool registry disabled: %s", self.context_warning)
         self._registry: Dict[str, Callable[..., FuncToolResult]] = self._build_registry()
 
     def _build_registry(self) -> Dict[str, Callable[..., FuncToolResult]]:
@@ -26,17 +44,10 @@ class ToolService:
         registry: Dict[str, Callable[..., FuncToolResult]] = {}
 
         # ContextSearchTools methods
-        context_tool_names = [
-            "list_subject_tree",
-            "search_metrics",
-            "get_metrics",
-            "search_reference_sql",
-            "get_reference_sql",
-            "search_semantic_objects",
-            "search_knowledge",
-            "get_knowledge",
-        ]
-        for name in context_tool_names:
+        if self._context_search_tools is None:
+            return registry
+
+        for name in self.CONTEXT_TOOL_NAMES:
             method = getattr(self._context_search_tools, name, None)
             if method and callable(method):
                 registry[name] = method
@@ -52,6 +63,12 @@ class ToolService:
         """Dispatch tool_name with params and return wrapped Result."""
         method = self._registry.get(tool_name)
         if method is None:
+            if self.context_warning and tool_name in self.CONTEXT_TOOL_NAMES:
+                return Result(
+                    success=False,
+                    errorCode=ErrorCode.TOOL_EXECUTION_ERROR,
+                    errorMessage=self.context_warning,
+                )
             return Result(
                 success=False,
                 errorCode=ErrorCode.TOOL_NOT_FOUND,

--- a/datus/cli/agent_commands.py
+++ b/datus/cli/agent_commands.py
@@ -72,59 +72,15 @@ class AgentCommands:
                 logger.warning("Context search tools disabled: %s", self._context_search_warning)
         return self._context_search_tools
 
-    def _embedding_ready_for_search(self, model: Any, search_name: str) -> tuple[bool, str]:
-        if model is None:
-            return True, ""
-
-        try:
-            if not model.has_local_fastembed_snapshot():
-                return False, format_context_degraded_warning(f"FastEmbed cache is missing for {search_name}")
-        except Exception as exc:
-            return False, format_context_degraded_warning(exc)
-        return True, ""
-
-    def _embedding_store_ready_for_search(self, store: Any, search_name: str) -> tuple[bool, str]:
-        if store is None:
-            return True, ""
-
-        count_rows = getattr(store, "_count_rows", None)
-        if callable(count_rows):
-            try:
-                if count_rows() == 0:
-                    return True, ""
-            except Exception:
-                pass
-        return self._embedding_ready_for_search(getattr(store, "model", None), search_name)
-
-    def _metric_embedding_ready_for_search(self) -> tuple[bool, str]:
-        tools = self.context_search_tools
-        if tools is None:
-            return False, self._context_search_warning
-
-        store = getattr(getattr(tools, "metric_rag", None), "storage", None)
-        return self._embedding_store_ready_for_search(store, "metric search")
-
-    def _reference_sql_embedding_ready_for_search(self) -> tuple[bool, str]:
-        tools = self.context_search_tools
-        if tools is None:
-            return False, self._context_search_warning
-
-        store = getattr(getattr(tools, "reference_sql_store", None), "reference_sql_storage", None)
-        return self._embedding_store_ready_for_search(store, "reference SQL search")
-
-    def _schema_embedding_ready_for_search(self, schema_rag: Any) -> tuple[bool, str]:
-        for store_name, search_name in (
-            ("schema_store", "schema linking"),
-            ("value_store", "schema value linking"),
-        ):
-            ready, warning = self._embedding_store_ready_for_search(getattr(schema_rag, store_name, None), search_name)
-            if not ready:
-                return ready, warning
-        return True, ""
-
     def update_agent_reference(self):
         """Update the agent reference if it has changed in the CLI."""
         self.agent = self.cli.agent
+
+    def _print_embedding_aware_error(self, action: str, error: BaseException | str | None) -> None:
+        if is_embedding_unavailable_error(error):
+            print_warning(self.console, format_context_degraded_warning(error))
+        else:
+            print_error(self.console, f"{action}: {error}")
 
     def create_node_input(self, node_type: str, task_text: str = None) -> BaseInput:
         """Create input for a specific node type with console prompts."""
@@ -446,10 +402,6 @@ class AgentCommands:
         from datus.storage.schema_metadata import SchemaWithValueRAG
 
         schema_rag = SchemaWithValueRAG(self.cli.agent_config)
-        ready, warning = self._schema_embedding_ready_for_search(schema_rag)
-        if not ready:
-            print_warning(self.console, warning)
-            return
 
         try:
             with self.console.status("[green]Searching for relevant tables...[/]"):
@@ -461,10 +413,7 @@ class AgentCommands:
                     top_n=int(top_n.strip()),
                 )
         except Exception as exc:
-            if is_embedding_unavailable_error(exc):
-                print_warning(self.console, format_context_degraded_warning(exc))
-            else:
-                print_error(self.console, f"schema linking: {exc}")
+            self._print_embedding_aware_error("schema linking", exc)
             return
 
         if metadata.num_rows > 0 or sample_data.num_rows > 0:
@@ -542,10 +491,6 @@ class AgentCommands:
             return
         subject_path = self._prompt_subject_path()
         top_n = self.cli.prompt_input("Enter top_n to match", default="5")
-        ready, warning = self._metric_embedding_ready_for_search()
-        if not ready:
-            print_warning(self.console, warning)
-            return
 
         with self.console.status("[green]Searching for metrics...[/]"):
             result = self.context_search_tools.search_metrics(
@@ -573,10 +518,7 @@ class AgentCommands:
                 )
             self.console.print(table)
         elif not result.success:
-            if is_embedding_unavailable_error(result.error):
-                print_warning(self.console, format_context_degraded_warning(result.error))
-            else:
-                print_error(self.console, f"searching metrics: {result.error}")
+            self._print_embedding_aware_error("searching metrics", result.error)
         else:
             print_warning(self.console, "No metrics found.")
 
@@ -608,10 +550,6 @@ class AgentCommands:
 
         subject_path = self._prompt_subject_path()
         top_n = self.cli.prompt_input("Enter top_n to match", default="5")
-        ready, warning = self._reference_sql_embedding_ready_for_search()
-        if not ready:
-            print_warning(self.console, warning)
-            return
 
         with self.console.status("[green]Searching reference SQL...[/]"):
             result = self.context_search_tools.search_reference_sql(
@@ -652,10 +590,7 @@ class AgentCommands:
                 )
             self.console.print(table)
         elif not result.success:
-            if is_embedding_unavailable_error(result.error):
-                print_warning(self.console, format_context_degraded_warning(result.error))
-            else:
-                print_error(self.console, f"searching reference SQL: {result.error}")
+            self._print_embedding_aware_error("searching reference SQL", result.error)
         else:
             print_warning(self.console, "No reference SQL queries found.")
 
@@ -690,11 +625,6 @@ class AgentCommands:
         from datus.tools.search_tools.search_tool import SearchTool
 
         search_tool = SearchTool(agent_config=self.cli.agent_config)
-        store = search_tool._get_document_store(platform)
-        ready, warning = self._embedding_store_ready_for_search(store, "document search")
-        if not ready:
-            print_warning(self.console, warning)
-            return
 
         with self.console.status("[green]Searching documentation...[/]"):
             result = search_tool.search_document(
@@ -741,10 +671,7 @@ class AgentCommands:
                     )
                 self.console.print(table)
         elif not result.success:
-            if is_embedding_unavailable_error(result.error):
-                print_warning(self.console, format_context_degraded_warning(result.error))
-            else:
-                print_error(self.console, f"searching documents: {result.error}")
+            self._print_embedding_aware_error("searching documents", result.error)
         else:
             print_warning(self.console, "No documents found.")
 

--- a/datus/cli/agent_commands.py
+++ b/datus/cli/agent_commands.py
@@ -47,6 +47,21 @@ if TYPE_CHECKING:
     from datus.cli.repl import DatusCLI
 
 
+def _is_embedding_unavailable_error(error: str | None) -> bool:
+    """Return True for embedding-cache/provider failures that should degrade search."""
+    if not error:
+        return False
+    return any(
+        marker in error
+        for marker in (
+            "MODEL_EMBEDDING_ERROR",
+            "error_code=300019",
+            "Embedding model cache is missing",
+            "embedding model is unavailable",
+        )
+    )
+
+
 class AgentCommands:
     """Handles all agent, workflow, and node-related commands."""
 
@@ -507,7 +522,10 @@ class AgentCommands:
                 )
             self.console.print(table)
         elif not result.success:
-            print_error(self.console, f"searching metrics: {result.error}")
+            if _is_embedding_unavailable_error(result.error):
+                print_warning(self.console, format_context_degraded_warning(result.error))
+            else:
+                print_error(self.console, f"searching metrics: {result.error}")
         else:
             print_warning(self.console, "No metrics found.")
 

--- a/datus/cli/agent_commands.py
+++ b/datus/cli/agent_commands.py
@@ -33,6 +33,7 @@ from datus.schemas.compare_node_models import CompareInput
 from datus.schemas.node_models import ExecuteSQLInput, GenerateSQLInput, OutputInput, SqlTask
 from datus.schemas.reason_sql_node_models import ReasoningInput
 from datus.schemas.schema_linking_node_models import SchemaLinkingInput
+from datus.storage.embedding_diagnostics import format_context_degraded_warning
 from datus.tools.db_tools import connector_registry
 from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.tools.output_tools import OutputTool
@@ -58,12 +59,17 @@ class AgentCommands:
         self.darun_is_running = False
         self.agent_thread = None
         self._context_search_tools: ContextSearchTools | None = None
+        self._context_search_warning: str = ""
         self.output_tool: OutputTool | None = None
 
     @property
-    def context_search_tools(self):
-        if not self._context_search_tools:
-            self._context_search_tools = ContextSearchTools(self.cli.agent_config)
+    def context_search_tools(self) -> ContextSearchTools | None:
+        if self._context_search_tools is None and not self._context_search_warning:
+            try:
+                self._context_search_tools = ContextSearchTools(self.cli.agent_config)
+            except Exception as exc:
+                self._context_search_warning = format_context_degraded_warning(exc)
+                logger.warning("Context search tools disabled: %s", self._context_search_warning)
         return self._context_search_tools
 
     def update_agent_reference(self):
@@ -469,6 +475,9 @@ class AgentCommands:
         if not input_text:
             print_error(self.console, "Input text cannot be empty.")
             return
+        if self.context_search_tools is None:
+            print_warning(self.console, self._context_search_warning)
+            return
         subject_path = self._prompt_subject_path()
         top_n = self.cli.prompt_input("Enter top_n to match", default="5")
 
@@ -523,6 +532,9 @@ class AgentCommands:
         input_text = args.strip() or self.cli.prompt_input("Enter search text for reference SQL")
         if not input_text:
             print_error(self.console, "Input text cannot be empty.")
+            return
+        if self.context_search_tools is None:
+            print_warning(self.console, self._context_search_warning)
             return
 
         subject_path = self._prompt_subject_path()

--- a/datus/cli/agent_commands.py
+++ b/datus/cli/agent_commands.py
@@ -87,6 +87,22 @@ class AgentCommands:
                 logger.warning("Context search tools disabled: %s", self._context_search_warning)
         return self._context_search_tools
 
+    def _metric_embedding_ready_for_search(self) -> tuple[bool, str]:
+        tools = self.context_search_tools
+        if tools is None:
+            return False, self._context_search_warning
+
+        model = getattr(getattr(getattr(tools, "metric_rag", None), "storage", None), "model", None)
+        if model is None:
+            return True, ""
+
+        try:
+            if not model.has_local_fastembed_snapshot():
+                return False, format_context_degraded_warning("FastEmbed cache is missing for metric search")
+        except Exception as exc:
+            return False, format_context_degraded_warning(exc)
+        return True, ""
+
     def update_agent_reference(self):
         """Update the agent reference if it has changed in the CLI."""
         self.agent = self.cli.agent
@@ -495,6 +511,10 @@ class AgentCommands:
             return
         subject_path = self._prompt_subject_path()
         top_n = self.cli.prompt_input("Enter top_n to match", default="5")
+        ready, warning = self._metric_embedding_ready_for_search()
+        if not ready:
+            print_warning(self.console, warning)
+            return
 
         with self.console.status("[green]Searching for metrics...[/]"):
             result = self.context_search_tools.search_metrics(

--- a/datus/cli/agent_commands.py
+++ b/datus/cli/agent_commands.py
@@ -33,7 +33,7 @@ from datus.schemas.compare_node_models import CompareInput
 from datus.schemas.node_models import ExecuteSQLInput, GenerateSQLInput, OutputInput, SqlTask
 from datus.schemas.reason_sql_node_models import ReasoningInput
 from datus.schemas.schema_linking_node_models import SchemaLinkingInput
-from datus.storage.embedding_diagnostics import format_context_degraded_warning
+from datus.storage.embedding_diagnostics import format_context_degraded_warning, is_embedding_unavailable_error
 from datus.tools.db_tools import connector_registry
 from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.tools.output_tools import OutputTool
@@ -45,21 +45,6 @@ logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from datus.cli.repl import DatusCLI
-
-
-def _is_embedding_unavailable_error(error: str | None) -> bool:
-    """Return True for embedding-cache/provider failures that should degrade search."""
-    if not error:
-        return False
-    return any(
-        marker in error
-        for marker in (
-            "MODEL_EMBEDDING_ERROR",
-            "error_code=300019",
-            "Embedding model cache is missing",
-            "embedding model is unavailable",
-        )
-    )
 
 
 class AgentCommands:
@@ -87,20 +72,54 @@ class AgentCommands:
                 logger.warning("Context search tools disabled: %s", self._context_search_warning)
         return self._context_search_tools
 
-    def _metric_embedding_ready_for_search(self) -> tuple[bool, str]:
-        tools = self.context_search_tools
-        if tools is None:
-            return False, self._context_search_warning
-
-        model = getattr(getattr(getattr(tools, "metric_rag", None), "storage", None), "model", None)
+    def _embedding_ready_for_search(self, model: Any, search_name: str) -> tuple[bool, str]:
         if model is None:
             return True, ""
 
         try:
             if not model.has_local_fastembed_snapshot():
-                return False, format_context_degraded_warning("FastEmbed cache is missing for metric search")
+                return False, format_context_degraded_warning(f"FastEmbed cache is missing for {search_name}")
         except Exception as exc:
             return False, format_context_degraded_warning(exc)
+        return True, ""
+
+    def _embedding_store_ready_for_search(self, store: Any, search_name: str) -> tuple[bool, str]:
+        if store is None:
+            return True, ""
+
+        count_rows = getattr(store, "_count_rows", None)
+        if callable(count_rows):
+            try:
+                if count_rows() == 0:
+                    return True, ""
+            except Exception:
+                pass
+        return self._embedding_ready_for_search(getattr(store, "model", None), search_name)
+
+    def _metric_embedding_ready_for_search(self) -> tuple[bool, str]:
+        tools = self.context_search_tools
+        if tools is None:
+            return False, self._context_search_warning
+
+        store = getattr(getattr(tools, "metric_rag", None), "storage", None)
+        return self._embedding_store_ready_for_search(store, "metric search")
+
+    def _reference_sql_embedding_ready_for_search(self) -> tuple[bool, str]:
+        tools = self.context_search_tools
+        if tools is None:
+            return False, self._context_search_warning
+
+        store = getattr(getattr(tools, "reference_sql_store", None), "reference_sql_storage", None)
+        return self._embedding_store_ready_for_search(store, "reference SQL search")
+
+    def _schema_embedding_ready_for_search(self, schema_rag: Any) -> tuple[bool, str]:
+        for store_name, search_name in (
+            ("schema_store", "schema linking"),
+            ("value_store", "schema value linking"),
+        ):
+            ready, warning = self._embedding_store_ready_for_search(getattr(schema_rag, store_name, None), search_name)
+            if not ready:
+                return ready, warning
         return True, ""
 
     def update_agent_reference(self):
@@ -424,17 +443,29 @@ class AgentCommands:
         # The PDF mentions table_type, but the tool implementation has it fixed to "full".
         # I will omit prompting for it as it won't be used.
 
-        with self.console.status("[green]Searching for relevant tables...[/]"):
-            from datus.storage.schema_metadata import SchemaWithValueRAG
+        from datus.storage.schema_metadata import SchemaWithValueRAG
 
-            schema_rag = SchemaWithValueRAG(self.cli.agent_config)
-            metadata, sample_data = schema_rag.search_similar(
-                query_text=input_text,
-                catalog_name=catalog_name,
-                database_name=database_name,
-                schema_name=schema_name,
-                top_n=int(top_n.strip()),
-            )
+        schema_rag = SchemaWithValueRAG(self.cli.agent_config)
+        ready, warning = self._schema_embedding_ready_for_search(schema_rag)
+        if not ready:
+            print_warning(self.console, warning)
+            return
+
+        try:
+            with self.console.status("[green]Searching for relevant tables...[/]"):
+                metadata, sample_data = schema_rag.search_similar(
+                    query_text=input_text,
+                    catalog_name=catalog_name,
+                    database_name=database_name,
+                    schema_name=schema_name,
+                    top_n=int(top_n.strip()),
+                )
+        except Exception as exc:
+            if is_embedding_unavailable_error(exc):
+                print_warning(self.console, format_context_degraded_warning(exc))
+            else:
+                print_error(self.console, f"schema linking: {exc}")
+            return
 
         if metadata.num_rows > 0 or sample_data.num_rows > 0:
             self.console.print(
@@ -542,7 +573,7 @@ class AgentCommands:
                 )
             self.console.print(table)
         elif not result.success:
-            if _is_embedding_unavailable_error(result.error):
+            if is_embedding_unavailable_error(result.error):
                 print_warning(self.console, format_context_degraded_warning(result.error))
             else:
                 print_error(self.console, f"searching metrics: {result.error}")
@@ -577,6 +608,11 @@ class AgentCommands:
 
         subject_path = self._prompt_subject_path()
         top_n = self.cli.prompt_input("Enter top_n to match", default="5")
+        ready, warning = self._reference_sql_embedding_ready_for_search()
+        if not ready:
+            print_warning(self.console, warning)
+            return
+
         with self.console.status("[green]Searching reference SQL...[/]"):
             result = self.context_search_tools.search_reference_sql(
                 query_text=input_text, subject_path=subject_path, top_n=int(top_n.strip())
@@ -616,7 +652,10 @@ class AgentCommands:
                 )
             self.console.print(table)
         elif not result.success:
-            print_error(self.console, f"searching reference SQL: {result.error}")
+            if is_embedding_unavailable_error(result.error):
+                print_warning(self.console, format_context_degraded_warning(result.error))
+            else:
+                print_error(self.console, f"searching reference SQL: {result.error}")
         else:
             print_warning(self.console, "No reference SQL queries found.")
 
@@ -648,10 +687,16 @@ class AgentCommands:
             print_error(self.console, "top_n must be an integer.")
             return
 
-        with self.console.status("[green]Searching documentation...[/]"):
-            from datus.tools.search_tools.search_tool import SearchTool
+        from datus.tools.search_tools.search_tool import SearchTool
 
-            search_tool = SearchTool(agent_config=self.cli.agent_config)
+        search_tool = SearchTool(agent_config=self.cli.agent_config)
+        store = search_tool._get_document_store(platform)
+        ready, warning = self._embedding_store_ready_for_search(store, "document search")
+        if not ready:
+            print_warning(self.console, warning)
+            return
+
+        with self.console.status("[green]Searching documentation...[/]"):
             result = search_tool.search_document(
                 platform=platform,
                 keywords=keywords,
@@ -696,7 +741,10 @@ class AgentCommands:
                     )
                 self.console.print(table)
         elif not result.success:
-            print_error(self.console, f"searching documents: {result.error}")
+            if is_embedding_unavailable_error(result.error):
+                print_warning(self.console, format_context_degraded_warning(result.error))
+            else:
+                print_error(self.console, f"searching documents: {result.error}")
         else:
             print_warning(self.console, "No documents found.")
 

--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -428,6 +428,7 @@ class DynamicAtReferenceCompleter(Completer):
         self.max_completions = max_completions
         self.quote_leaf = quote_leaf
         self._loaded = False
+        self.last_error: Optional[str] = None
         # Serializes atomic swaps between reader threads (prompt_toolkit main
         # thread calling get_completions / fuzzy_match) and writer threads
         # (BackgroundSchemaSyncManager invoking reload_data on the bg event
@@ -440,18 +441,43 @@ class DynamicAtReferenceCompleter(Completer):
             self.flatten_data = {}
             self._loaded = False
             self.max_level = 0
+            self.last_error = None
 
-    def _ensure_loaded(self):
-        if self._loaded:
-            return
-        data, flatten, max_level = self._build_snapshot()
+    def _mark_unavailable(self, exc: Exception) -> None:
+        error = str(exc)
+        logger.warning("Autocomplete data unavailable for %s: %s", type(self).__name__, error)
         with self._lock:
-            if self._loaded:
-                return
+            self._data = {}
+            self.flatten_data = {}
+            self.max_level = 0
+            self._loaded = True
+            self.last_error = error
+
+    def _apply_snapshot(
+        self,
+        data: Union[List[str], Dict[str, Any]],
+        flatten: Dict[str, Any],
+        max_level: int,
+    ) -> None:
+        with self._lock:
             self._data = data
             self.flatten_data = flatten
             self.max_level = max_level
             self._loaded = True
+            self.last_error = None
+
+    def _ensure_loaded(self):
+        if self._loaded:
+            return
+        try:
+            data, flatten, max_level = self._build_snapshot()
+        except Exception as exc:
+            self._mark_unavailable(exc)
+            return
+        with self._lock:
+            if self._loaded:
+                return
+        self._apply_snapshot(data, flatten, max_level)
 
     def fuzzy_match(self, text: str, limit: Optional[int] = None) -> List[str]:
         """Return flatten-path keys whose lower-cased form contains ``text``.
@@ -488,22 +514,23 @@ class DynamicAtReferenceCompleter(Completer):
         """Back-compat shim: delegate to :meth:`_build_snapshot` and apply the
         result in-place.
         """
-        data, flatten, max_level = self._build_snapshot()
-        with self._lock:
-            self._data = data
-            self.flatten_data = flatten
-            self.max_level = max_level
+        try:
+            data, flatten, max_level = self._build_snapshot()
+        except Exception as exc:
+            self._mark_unavailable(exc)
+            return {}
+        self._apply_snapshot(data, flatten, max_level)
         return data
 
     def reload_data(self):
         # Build outside the lock so readers are only blocked for the atomic
         # reference swap, not the heavy LanceDB scan.
-        data, flatten, max_level = self._build_snapshot()
-        with self._lock:
-            self._data = data
-            self.flatten_data = flatten
-            self.max_level = max_level
-            self._loaded = True
+        try:
+            data, flatten, max_level = self._build_snapshot()
+        except Exception as exc:
+            self._mark_unavailable(exc)
+            return
+        self._apply_snapshot(data, flatten, max_level)
 
     def get_data(self):
         self._ensure_loaded()
@@ -1116,9 +1143,15 @@ class AtReferenceCompleter(Completer):
         self.sql_completer.clear()
 
     def reload_data(self):
-        self.table_completer.reload_data()
-        self.metric_completer.reload_data()
-        self.sql_completer.reload_data()
+        for name, completer in (
+            ("Table", self.table_completer),
+            ("Metrics", self.metric_completer),
+            ("Sql", self.sql_completer),
+        ):
+            try:
+                completer.reload_data()
+            except Exception as exc:  # pragma: no cover - defensive; DynamicAtReferenceCompleter catches
+                logger.warning("Failed to reload @%s autocomplete data: %s", name, exc)
 
     def parse_at_context(
         self, user_input: str
@@ -1130,9 +1163,6 @@ class AtReferenceCompleter(Completer):
         flips routing. Subsequent ``@Agent`` mentions are ignored on purpose
         to keep the dispatch hint deterministic.
         """
-        self.table_completer._ensure_loaded()
-        self.metric_completer._ensure_loaded()
-        self.sql_completer._ensure_loaded()
         user_input = user_input.strip()
         if not user_input:
             return ([], [], [], None)
@@ -1141,15 +1171,18 @@ class AtReferenceCompleter(Completer):
         metrics = []
         sqls = []
         if parse_result["tables"]:
+            self.table_completer._ensure_loaded()
             for key in parse_result["tables"]:
                 if key in self.table_completer.flatten_data:
                     tables.append(TableSchema.from_dict(self.table_completer.flatten_data[key]))
 
         if parse_result["metrics"]:
+            self.metric_completer._ensure_loaded()
             for key in parse_result["metrics"]:
                 if key in self.metric_completer.flatten_data:
                     metrics.append(Metric.from_dict(self.metric_completer.flatten_data[key]))
         if parse_result["sqls"]:
+            self.sql_completer._ensure_loaded()
             for key in parse_result["sqls"]:
                 if key in self.sql_completer.flatten_data:
                     sqls.append(ReferenceSql.from_dict(self.sql_completer.flatten_data[key]))

--- a/datus/cli/background_sync.py
+++ b/datus/cli/background_sync.py
@@ -155,6 +155,17 @@ class BackgroundSchemaSyncManager:
                 return
 
             store = SchemaWithValueRAG(cli.agent_config)
+            if reason == "startup":
+                cache_ready, reason_message = self._embedding_cache_ready_for_noncritical_sync(store)
+                if not cache_ready:
+                    logger.warning(
+                        "background sync skipped for %s (reason=%s): %s",
+                        datasource,
+                        reason,
+                        reason_message,
+                    )
+                    return
+
             await init_local_schema_async(
                 store,
                 cli.agent_config,
@@ -178,6 +189,27 @@ class BackgroundSchemaSyncManager:
             raise
         except Exception as exc:
             logger.warning("background sync failed for %s: %s", datasource, exc)
+
+    @staticmethod
+    def _embedding_cache_ready_for_noncritical_sync(store) -> tuple[bool, str]:
+        """Check embedding cache readiness without triggering downloads."""
+        for store_name in ("schema_store", "value_store"):
+            embedding_store = getattr(store, store_name, None)
+            model = getattr(embedding_store, "model", None)
+            if model is None:
+                continue
+            try:
+                if not model.has_local_fastembed_snapshot():
+                    return (
+                        False,
+                        (
+                            f"FastEmbed cache is missing for {store_name}; "
+                            "metadata sync will retry when cache is available"
+                        ),
+                    )
+            except Exception as exc:
+                return False, f"embedding cache check failed for {store_name}: {exc}"
+        return True, ""
 
     def _on_done(self, future: concurrent.futures.Future) -> None:
         with self._lock:

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -74,6 +74,7 @@ from datus.cli.tui.live_display_state import LiveDisplayState
 from datus.configuration.agent_config_loader import configuration_manager, load_agent_config
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
+from datus.storage.embedding_diagnostics import format_context_degraded_warning
 from datus.tools.db_tools.db_manager import db_manager_instance
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS, DBType, SQLType
 from datus.utils.exceptions import setup_exception_handler
@@ -153,6 +154,7 @@ class DatusCLI:
         self.agent_initializing = False
         self.agent_ready = False
         self._workflow_runner: WorkflowRunner | None = None
+        self.startup_warnings: List[str] = []
 
         # Plan mode support
         self.plan_mode_active = False
@@ -1144,7 +1146,27 @@ class DatusCLI:
     def _pre_load_storage(self):
         """Preload rag to avoid unnecessary printing"""
         if self.at_completer:
-            self.at_completer.reload_data()
+            try:
+                self.at_completer.reload_data()
+                errors = [
+                    error
+                    for error in (
+                        getattr(self.at_completer.table_completer, "last_error", None),
+                        getattr(self.at_completer.metric_completer, "last_error", None),
+                        getattr(self.at_completer.sql_completer, "last_error", None),
+                    )
+                    if error
+                ]
+                if errors:
+                    warning = format_context_degraded_warning("; ".join(errors))
+                    self.startup_warnings.append(warning)
+                    logger.warning("REPL context autocomplete preload degraded: %s", warning)
+                    print_warning(self.console, warning)
+            except Exception as exc:
+                warning = format_context_degraded_warning(exc)
+                self.startup_warnings.append(warning)
+                logger.warning("REPL context autocomplete preload failed: %s", warning)
+                print_warning(self.console, warning)
 
     def _maybe_schedule_startup_sync(self) -> None:
         """Kick off a one-shot background metadata sync for the default

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -178,10 +178,12 @@ class BaseEmbeddingStore(StorageBase):
         table = self._open_existing_table_for_read()
         if table is None:
             return self._empty_result(select_fields)
-        if limit:
+        if limit is not None:
             row_limit = limit
         else:
             row_limit = table.count_rows(where) if where else table.count_rows()
+        if row_limit == 0:
+            return self._empty_result(select_fields)
         result = table.search_all(where=where, select_fields=select_fields, limit=row_limit)
         if self.vector_column_name in result.column_names:
             result = result.drop([self.vector_column_name])

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -136,6 +136,33 @@ class BaseEmbeddingStore(StorageBase):
                 self._create_scalar_index(col)
             logger.debug(f"Table {self.table_name} initialized successfully with embedding function")
 
+    def _open_existing_table_for_read(self) -> Optional[VectorTable]:
+        """Open an existing vector table for read-only access without embeddings."""
+        if self.table is not None:
+            return self.table
+        if not self.db.table_exists(self.table_name):
+            return None
+        self.table = self.db.open_table(self.table_name)
+        return self.table
+
+    def _empty_result(self, select_fields: Optional[List[str]] = None) -> pa.Table:
+        """Return an empty result table shaped like this store's schema."""
+        schema = self._schema or pa.schema([])
+        if select_fields is None:
+            fields = [field for field in schema if field.name != self.vector_column_name]
+        else:
+            fields = []
+            for field_name in select_fields:
+                if field_name == self.vector_column_name:
+                    continue
+                if field_name in schema.names:
+                    fields.append(schema.field(field_name))
+                else:
+                    fields.append(pa.field(field_name, pa.null()))
+        result_schema = pa.schema(fields)
+        arrays = [pa.array([], type=field.type) for field in fields]
+        return pa.Table.from_arrays(arrays, schema=result_schema)
+
     def _apply_default_values(self, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Fill in default values for rows that are missing them."""
         if not self._default_values:
@@ -148,12 +175,14 @@ class BaseEmbeddingStore(StorageBase):
     def _search_all(
         self, where: WhereExpr = None, select_fields: Optional[List[str]] = None, limit: Optional[int] = None
     ) -> pa.Table:
-        self._ensure_table_ready()
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return self._empty_result(select_fields)
         if limit:
             row_limit = limit
         else:
-            row_limit = self.table.count_rows(where) if where else self.table.count_rows()
-        result = self.table.search_all(where=where, select_fields=select_fields, limit=row_limit)
+            row_limit = table.count_rows(where) if where else table.count_rows()
+        result = table.search_all(where=where, select_fields=select_fields, limit=row_limit)
         if self.vector_column_name in result.column_names:
             result = result.drop([self.vector_column_name])
         return result
@@ -171,7 +200,12 @@ class BaseEmbeddingStore(StorageBase):
 
         # Try to access the model (this will trigger lazy loading)
         try:
-            _ = self.model.model
+            model = self.model.model
+            if model is None:
+                raise DatusException(
+                    ErrorCode.MODEL_EMBEDDING_ERROR,
+                    message=f"Embedding model '{self.model.model_name}' initialization produced no model",
+                )
         except DatusException as e:
             # Re-raise DatusException directly to avoid nesting
             raise e
@@ -512,8 +546,7 @@ class BaseEmbeddingStore(StorageBase):
             ) from e
 
     def table_size(self) -> int:
-        self._ensure_table_ready()
-        return self.table.count_rows()
+        return self._count_rows()
 
     def update(self, where: WhereExpr, update_values: Dict[str, Any], unique_filter: Optional[WhereExpr] = None):
         self._ensure_table_ready()
@@ -577,8 +610,10 @@ class BaseEmbeddingStore(StorageBase):
 
     def _count_rows(self, where: WhereExpr = None) -> int:
         """Count rows with optional filter."""
-        self._ensure_table_ready()
-        return self.table.count_rows(where)
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return 0
+        return table.count_rows(where)
 
     def query_with_filter(
         self,
@@ -587,10 +622,12 @@ class BaseEmbeddingStore(StorageBase):
         limit: Optional[int] = None,
     ) -> pa.Table:
         """Query rows with filter, field selection, and optional limit."""
-        self._ensure_table_ready()
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return self._empty_result(select_fields)
         if limit is None:
-            limit = self.table.count_rows(where)
-        return self.table.search_all(
+            limit = table.count_rows(where)
+        return table.search_all(
             where=where,
             select_fields=select_fields,
             limit=limit,

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -217,6 +217,24 @@ class BaseEmbeddingStore(StorageBase):
                 message=f"Embedding model '{self.model.model_name}' initialization failed: {str(e)}",
             ) from e
 
+    def _ensure_embedding_cache_ready_for_search(self):
+        """Avoid on-demand downloads for read-time vector search."""
+        try:
+            has_snapshot = self.model.has_local_fastembed_snapshot()
+        except DatusException:
+            raise
+        except Exception as e:
+            raise DatusException(
+                ErrorCode.MODEL_EMBEDDING_ERROR,
+                message=f"Embedding cache readiness check failed for '{self.table_name}': {e}",
+            ) from e
+
+        if not has_snapshot:
+            raise DatusException(
+                ErrorCode.MODEL_EMBEDDING_ERROR,
+                message=f"Embedding model cache is missing for vector search on '{self.table_name}'",
+            )
+
     def truncate(self) -> None:
         """Drop the entire table and reset state (admin operation)."""
         with self._table_lock:
@@ -485,6 +503,14 @@ class BaseEmbeddingStore(StorageBase):
         where: WhereExpr = None,
         query_type: str = "vector",
     ) -> pa.Table:
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return self._empty_result(select_fields)
+        row_count = table.count_rows(where) if where else table.count_rows()
+        if row_count == 0:
+            return self._empty_result(select_fields)
+
+        self._ensure_embedding_cache_ready_for_search()
         self._ensure_table_ready()
 
         if query_type == "hybrid":

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -629,6 +629,8 @@ class BaseEmbeddingStore(StorageBase):
             return self._empty_result(select_fields)
         if limit is None:
             limit = table.count_rows(where)
+        if limit == 0:
+            return self._empty_result(select_fields)
         return table.search_all(
             where=where,
             select_fields=select_fields,

--- a/datus/storage/document/store.py
+++ b/datus/storage/document/store.py
@@ -221,8 +221,6 @@ class DocumentStore(BaseEmbeddingStore):
         Returns:
             List of dicts with version and chunk_count
         """
-        self._ensure_table_ready()
-
         all_data = self._search_all(
             select_fields=["version"],
         )
@@ -240,8 +238,6 @@ class DocumentStore(BaseEmbeddingStore):
         Returns:
             Dict with versions, total_chunks, doc_count, etc.
         """
-        self._ensure_table_ready()
-
         all_data = self._search_all(
             select_fields=["version", "doc_path", "created_at"],
         )
@@ -379,7 +375,6 @@ class DocumentStore(BaseEmbeddingStore):
         Returns:
             List of matching rows as dictionaries
         """
-        self._ensure_table_ready()
         results = self._search_all(where=where, select_fields=select_fields)
         return results.to_pylist()
 

--- a/datus/storage/embedding_diagnostics.py
+++ b/datus/storage/embedding_diagnostics.py
@@ -1,0 +1,68 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""User-facing diagnostics for embedding-dependent feature degradation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_FASTEMBED_REPO_ID = "qdrant/all-MiniLM-L6-v2-onnx"
+
+
+def resolve_fastembed_cache_dir() -> str:
+    """Return the fastembed cache directory used by Datus defaults."""
+    if cache_path := os.getenv("FASTEMBED_CACHE_PATH"):
+        return str(Path(cache_path).expanduser().resolve())
+    hf_home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")).expanduser()
+    return str((hf_home / "fastembed").resolve())
+
+
+def fastembed_environment_details(cache_dir: Optional[str] = None) -> str:
+    """Format cache-related environment details for logs and errors."""
+    hf_home = os.environ.get("HF_HOME")
+    fastembed_cache_path = os.environ.get("FASTEMBED_CACHE_PATH")
+    effective_cache_dir = cache_dir or resolve_fastembed_cache_dir()
+    default_hf_home = str((Path.home() / ".cache" / "huggingface").resolve())
+    default_fastembed_cache = str((Path(default_hf_home) / "fastembed").resolve())
+    return (
+        f"cache_dir={effective_cache_dir}; "
+        f"HF_HOME={hf_home or f'(not set, default {default_hf_home})'}; "
+        f"FASTEMBED_CACHE_PATH={fastembed_cache_path or '(not set)'}; "
+        f"default_fastembed_cache={default_fastembed_cache}"
+    )
+
+
+def format_fastembed_download_error(
+    *,
+    model_name: str,
+    repo_id: Optional[str],
+    cache_dir: Optional[str],
+    cause: BaseException,
+) -> str:
+    """Build a clear FastEmbed cache/download failure message."""
+    resolved_repo_id = repo_id or DEFAULT_FASTEMBED_REPO_ID
+    return (
+        "Embedding model cache is missing and the FastEmbed model could not be downloaded from Hugging Face. "
+        f"model={model_name}; repo_id={resolved_repo_id}; {fastembed_environment_details(cache_dir)}. "
+        "Remediation: configure a Hugging Face proxy or mirror, pre-cache the model artifacts, "
+        "or configure an OpenAI-compatible embedding provider for embedding-backed stores. "
+        f"Original error: {cause}"
+    )
+
+
+def format_context_degraded_warning(error: BaseException | str | None = None) -> str:
+    """Build the non-fatal warning shown when context search is unavailable."""
+    details = str(error).strip() if error else ""
+    message = (
+        "Context search and @ references are disabled because the embedding model is unavailable. "
+        "Database tools and normal chat remain available. "
+        "Remediation: configure a Hugging Face proxy or mirror, pre-cache the FastEmbed model, "
+        "or configure an OpenAI-compatible embedding provider."
+    )
+    if details:
+        message = f"{message} Details: {details}"
+    return message

--- a/datus/storage/embedding_diagnostics.py
+++ b/datus/storage/embedding_diagnostics.py
@@ -66,3 +66,19 @@ def format_context_degraded_warning(error: BaseException | str | None = None) ->
     if details:
         message = f"{message} Details: {details}"
     return message
+
+
+def is_embedding_unavailable_error(error: BaseException | str | None) -> bool:
+    """Return True for embedding-cache/provider failures that should degrade search."""
+    if not error:
+        return False
+    message = str(error)
+    return any(
+        marker in message
+        for marker in (
+            "MODEL_EMBEDDING_ERROR",
+            "error_code=300019",
+            "Embedding model cache is missing",
+            "embedding model is unavailable",
+        )
+    )

--- a/datus/storage/embedding_models.py
+++ b/datus/storage/embedding_models.py
@@ -45,6 +45,14 @@ logger = get_logger(__name__)
 EMBEDDING_DEVICE_TYPE = ""
 
 
+def _clean_exception_message(error: BaseException | str) -> str:
+    message = str(error)
+    marker = "error_message="
+    if marker in message:
+        return message.split(marker, 1)[1]
+    return message
+
+
 @dataclass
 class EmbeddingModel:
     model_name: str
@@ -102,25 +110,13 @@ class EmbeddingModel:
         """Get the embedding model, with lazy loading and error handling."""
         # If model initialization failed before, raise exception
         if self.is_model_failed:
-            # If the stored error is already a formatted DatusException message, use it directly
-            if "error_code=" in self.model_error_message:
-                # Extract just the core error message without the DatusException wrapper
-                import re
-
-                match = re.search(r"error_message=(.+)$", self.model_error_message)
-                if match:
-                    core_message = match.group(1)
-                else:
-                    core_message = self.model_error_message
-                raise DatusException(
-                    ErrorCode.MODEL_EMBEDDING_ERROR,
-                    message=f"Embedding model '{self.model_name}' is not available: {core_message}",
-                )
-            else:
-                raise DatusException(
-                    ErrorCode.MODEL_EMBEDDING_ERROR,
-                    message=f"Embedding model '{self.model_name}' is not available: {self.model_error_message}",
-                )
+            raise DatusException(
+                ErrorCode.MODEL_EMBEDDING_ERROR,
+                message=(
+                    f"Embedding model '{self.model_name}' is not available: "
+                    f"{_clean_exception_message(self.model_error_message)}"
+                ),
+            )
 
         # Lazy load the model
         if self._model is None:
@@ -130,11 +126,26 @@ class EmbeddingModel:
                         self.model_initialization_attempted = True
                         logger.debug(f"Loading embedding model: {self.model_name} on {self.device}")
                         self.init_model()
-                    except Exception as e:
-                        # Save error state, don't immediately raise exception
+                        if self._model is None:
+                            raise DatusException(
+                                ErrorCode.MODEL_EMBEDDING_ERROR,
+                                message=f"Embedding model '{self.model_name}' initialization produced no model",
+                            )
+                    except DatusException as e:
                         self.is_model_failed = True
-                        self.model_error_message = str(e)
+                        self.model_error_message = _clean_exception_message(e)
                         logger.error(f"Failed to load embedding model '{self.model_name}': {e}")
+                        raise
+                    except Exception as e:
+                        self.is_model_failed = True
+                        self.model_error_message = _clean_exception_message(e)
+                        logger.error(f"Failed to load embedding model '{self.model_name}': {e}")
+                        raise DatusException(
+                            ErrorCode.MODEL_EMBEDDING_ERROR,
+                            message=(
+                                f"Embedding model '{self.model_name}' initialization failed: {self.model_error_message}"
+                            ),
+                        ) from e
 
         return self._model
 
@@ -174,7 +185,7 @@ class EmbeddingModel:
             except Exception as e:
                 # Save error state silently
                 self.is_model_failed = True
-                self.model_error_message = str(e)
+                self.model_error_message = _clean_exception_message(e)
                 logger.warning(f"Silent initialization failed for embedding model '{self.model_name}': {e}")
                 return False
 
@@ -194,9 +205,12 @@ class EmbeddingModel:
                 )
                 # first download
                 logger.debug(f"Model {self.registry_name}/{self.model_name} initialized successfully")
+            except DatusException:
+                raise
             except Exception as e:
                 raise DatusException(
-                    ErrorCode.MODEL_EMBEDDING_ERROR, message=f"Embedding Model initialized failed because of {str(e)}"
+                    ErrorCode.MODEL_EMBEDDING_ERROR,
+                    message=f"Embedding model '{self.model_name}' initialization failed: {str(e)}",
                 ) from e
 
         elif self.registry_name == EmbeddingProvider.OPENAI:

--- a/datus/storage/embedding_models.py
+++ b/datus/storage/embedding_models.py
@@ -153,6 +153,21 @@ class EmbeddingModel:
         """Check if the model is available without triggering initialization."""
         return not self.is_model_failed and (self._model is not None or not self.model_initialization_attempted)
 
+    def has_local_fastembed_snapshot(self) -> bool:
+        """Return whether FastEmbed artifacts are locally cached without downloading."""
+        if self.registry_name not in (EmbeddingProvider.SENTENCE_TRANSFORMERS, EmbeddingProvider.FASTEMBED):
+            return True
+
+        from datus.storage.fastembed_embeddings import FastEmbedEmbeddings, has_local_snapshot
+
+        model_name = FastEmbedEmbeddings._normalize_model_name(self.model_name)
+        cache_dir = self._model.cache_dir if self._model is not None else None
+        if cache_dir is None:
+            from datus.storage.embedding_diagnostics import resolve_fastembed_cache_dir
+
+            cache_dir = resolve_fastembed_cache_dir()
+        return has_local_snapshot(model_name, cache_dir)
+
     async def init_model_async(self):
         """Asynchronously initialize the embedding model."""
         import asyncio

--- a/datus/storage/embedding_models.py
+++ b/datus/storage/embedding_models.py
@@ -161,6 +161,9 @@ class EmbeddingModel:
         from datus.storage.fastembed_embeddings import FastEmbedEmbeddings, has_local_snapshot
 
         model_name = FastEmbedEmbeddings._normalize_model_name(self.model_name)
+        if self._model is not None and not isinstance(self._model, FastEmbedEmbeddings):
+            return True
+
         cache_dir = self._model.cache_dir if self._model is not None else None
         if cache_dir is None:
             from datus.storage.embedding_diagnostics import resolve_fastembed_cache_dir

--- a/datus/storage/fastembed_embeddings.py
+++ b/datus/storage/fastembed_embeddings.py
@@ -1,7 +1,6 @@
 # Copyright 2025-present DatusAI, Inc.
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
-import os.path
 from functools import lru_cache
 from typing import Any, List, Optional, Union
 
@@ -12,7 +11,9 @@ from fastembed.text.text_embedding_base import TextEmbeddingBase
 from huggingface_hub.errors import LocalEntryNotFoundError
 from pydantic import BaseModel, Field
 
+from datus.storage.embedding_diagnostics import format_fastembed_download_error, resolve_fastembed_cache_dir
 from datus.storage.embedding_models import get_embedding_device
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -127,9 +128,17 @@ class FastEmbedEmbeddings(BaseModel, EmbeddingFunction):
 
         try:
             return TextEmbedding(**model_kwargs)
-        except Exception as exc:  # pragma: no cover - delegated to caller
-            logger.error(f"Failed to initialize fastembed model '{self.name}': {exc}")
+        except DatusException:
             raise
+        except Exception as exc:  # pragma: no cover - delegated to caller
+            message = format_fastembed_download_error(
+                model_name=self.name,
+                repo_id=None,
+                cache_dir=self.cache_dir,
+                cause=exc,
+            )
+            logger.error("Failed to initialize fastembed model '%s': %s", self.name, message)
+            raise DatusException(ErrorCode.MODEL_EMBEDDING_ERROR, message=message) from exc
 
     def __hash__(self):
         return hash((self.name, self.device, self.batch_size))
@@ -137,15 +146,9 @@ class FastEmbedEmbeddings(BaseModel, EmbeddingFunction):
 
 def _resolve_cache_dir() -> str:
     """Define the cache directory for fastembed."""
-    from pathlib import Path
-
-    if cache_path := os.getenv("FASTEMBED_CACHE_PATH"):
-        cache_path = Path(cache_path)
-    else:
-        home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface"))
-        cache_path = (home / "fastembed").resolve()
+    cache_path = resolve_fastembed_cache_dir()
     logger.debug(f"Final fastembed cache_dir is: {cache_path}")
-    return str(cache_path)
+    return cache_path
 
 
 def check_snapshot(model_name: str, cache_dir: str) -> None:
@@ -183,5 +186,15 @@ def check_snapshot(model_name: str, cache_dir: str) -> None:
         snapshot_download(repo_id, cache_dir=cache_dir, local_files_only=True)
     except LocalEntryNotFoundError:
         logger.info(f"Downloading {repo_id} to {cache_dir} via huggingface_hub")
-        snapshot_download(repo_id, cache_dir=cache_dir, local_files_only=False)
-        logger.info(f"Model {repo_id} has been downloaded via huggingface_hub to {cache_dir}.")
+        try:
+            snapshot_download(repo_id, cache_dir=cache_dir, local_files_only=False)
+            logger.info(f"Model {repo_id} has been downloaded via huggingface_hub to {cache_dir}.")
+        except Exception as exc:
+            message = format_fastembed_download_error(
+                model_name=model_name,
+                repo_id=repo_id,
+                cache_dir=cache_dir,
+                cause=exc,
+            )
+            logger.error(message)
+            raise DatusException(ErrorCode.MODEL_EMBEDDING_ERROR, message=message) from exc

--- a/datus/storage/fastembed_embeddings.py
+++ b/datus/storage/fastembed_embeddings.py
@@ -158,18 +158,7 @@ def check_snapshot(model_name: str, cache_dir: str) -> None:
     When ``local_files_only`` is True we only verify cached files exist.
     Otherwise a download will be attempted if the cache is missing.
     """
-    try:
-        description = TextEmbedding._get_model_description(model_name)
-    except ValueError as exc:
-        logger.error(f"Model '{model_name}' is not supported by fastembed: {exc}")
-        raise
-
-    repo_id = None
-    sources = getattr(description, "sources", None)
-    if sources is not None and hasattr(sources, "hf"):
-        repo_id = sources.hf  # type: ignore[assignment]
-    elif isinstance(description, dict):
-        repo_id = description.get("sources", {}).get("hf")  # type: ignore[assignment]
+    repo_id = _resolve_repo_id(model_name)
     if not repo_id:
         logger.warning(
             f"FastEmbed does not support models `{model_name}`. Support models: {TextEmbedding.list_supported_models()}"
@@ -198,3 +187,33 @@ def check_snapshot(model_name: str, cache_dir: str) -> None:
             )
             logger.error(message)
             raise DatusException(ErrorCode.MODEL_EMBEDDING_ERROR, message=message) from exc
+
+
+def has_local_snapshot(model_name: str, cache_dir: str) -> bool:
+    """Return whether the fastembed Hugging Face snapshot is cached locally."""
+    repo_id = _resolve_repo_id(model_name)
+    if not repo_id:
+        return True
+
+    from huggingface_hub import snapshot_download
+
+    try:
+        snapshot_download(repo_id, cache_dir=cache_dir, local_files_only=True)
+        return True
+    except LocalEntryNotFoundError:
+        return False
+
+
+def _resolve_repo_id(model_name: str) -> Optional[str]:
+    try:
+        description = TextEmbedding._get_model_description(model_name)
+    except ValueError as exc:
+        logger.error(f"Model '{model_name}' is not supported by fastembed: {exc}")
+        raise
+
+    sources = getattr(description, "sources", None)
+    if sources is not None and hasattr(sources, "hf"):
+        return sources.hf  # type: ignore[return-value]
+    if isinstance(description, dict):
+        return description.get("sources", {}).get("hf")  # type: ignore[return-value]
+    return None

--- a/datus/storage/schema_metadata/store.py
+++ b/datus/storage/schema_metadata/store.py
@@ -119,9 +119,6 @@ class BaseMetadataStorage(BaseEmbeddingStore):
         select_fields: Optional[List[str]] = None,
     ) -> pa.Table:
         """Search all schemas for a given database name."""
-        # Ensure table is ready before searching
-        self._ensure_table_ready()
-
         where = _build_where_clause(
             catalog_name=catalog_name,
             database_name=database_name,

--- a/datus/storage/subject_tree/store.py
+++ b/datus/storage/subject_tree/store.py
@@ -815,9 +815,6 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         Returns:
             List of matching items with subject_path enriched
         """
-        # Ensure table is ready before direct table access
-        self._ensure_table_ready()
-
         # Set up path filters for both exact path and parent+name matching
         path_filter = [(subject_path, "")]
         if subject_path and len(subject_path) > 1:

--- a/datus/tools/search_tools/search_tool.py
+++ b/datus/tools/search_tools/search_tool.py
@@ -10,6 +10,7 @@ from datus_storage_base.conditions import And, Condition, WhereExpr, eq, like
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.doc_search_node_models import DocNavResult, DocSearchInput, DocSearchResult, GetDocResult
 from datus.storage.document.store import DocumentStore, document_store
+from datus.storage.embedding_diagnostics import is_embedding_unavailable_error
 from datus.tools.base import BaseTool
 from datus.utils.loggings import get_logger
 
@@ -443,6 +444,8 @@ class SearchTool(BaseTool):
                         total_count += len(results)
 
                     except Exception as e:
+                        if is_embedding_unavailable_error(e):
+                            raise
                         logger.error(f"Error searching for keyword '{keyword}': {e}")
                         docs[keyword] = []
 

--- a/docs/configuration/storage.md
+++ b/docs/configuration/storage.md
@@ -122,7 +122,7 @@ database:
 
 ### Sentence Transformers (Local)
 
-For local embedding models without external API calls:
+For local embedding models:
 
 ```yaml
 database:
@@ -130,6 +130,29 @@ database:
   model_name: all-MiniLM-L6-v2          # Lightweight option
   dim_size: 384
 ```
+
+!!! warning "Offline and intranet environments"
+    The default local provider uses FastEmbed. If the model is not already cached,
+    FastEmbed may download `qdrant/all-MiniLM-L6-v2-onnx` from Hugging Face for
+    the default `all-MiniLM-L6-v2` model. In offline, intranet, or Hugging
+    Face-blocked environments, pre-cache the model artifacts or configure a
+    Hugging Face proxy/mirror before enabling embedding-backed features.
+
+    Relevant cache locations:
+
+    - `FASTEMBED_CACHE_PATH` when set
+    - `HF_HOME/fastembed` when `HF_HOME` is set
+    - `~/.cache/huggingface/fastembed` by default
+
+    If the embedding model is unavailable, Datus keeps database tools and normal
+    chat available, but disables embedding-dependent features such as context
+    search, semantic search, external knowledge search, reference SQL search,
+    and `@Table` / `@Metrics` / `@Sql` references. CLI and Web sessions show a
+    non-fatal warning with the cache path and remediation guidance.
+
+    To avoid Hugging Face access entirely, configure `registry_name: openai` for
+    each embedding-backed storage section and point `target_model` at an
+    OpenAI-compatible embedding provider.
 
 !!! info "Alternative Local Models"
     Consider these high-quality alternatives:

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -302,6 +302,30 @@ class TestChatAgenticNodeToolSetup:
         assert "context_search_tools" in node.degraded_capabilities
         assert "hf offline" in node.degraded_capabilities["context_search_tools"]
 
+    def test_reference_template_failure_does_not_remove_db_tools(self, real_agent_config, mock_llm_create):
+        """Embedding/template setup failures should only remove template tools."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+        from datus.tools.func_tool.database import DBFuncTool
+
+        with patch("datus.agent.node.chat_agentic_node.ReferenceTemplateTools", side_effect=RuntimeError("hf offline")):
+            node = ChatAgenticNode(
+                node_id="test_reference_template_degraded",
+                description="Test reference template degradation",
+                node_type=NodeType.TYPE_CHAT,
+                agent_config=real_agent_config,
+            )
+
+        tool_names = {tool.name for tool in node.tools}
+        registry = node.tool_registry.to_dict()
+
+        assert isinstance(node.db_func_tool, DBFuncTool)
+        assert node.reference_template_tools is None
+        assert "list_tables" in tool_names
+        assert "reference_template_tools" not in set(registry.values())
+        assert registry["list_tables"] == "db_tools"
+        assert "reference_template_tools" in node.degraded_capabilities
+        assert "hf offline" in node.degraded_capabilities["reference_template_tools"]
+
     def test_has_ask_user_tools(self, real_agent_config, mock_llm_create):
         """Chat node has ask_user tool set up via _setup_ask_user_tool."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -278,6 +278,30 @@ class TestChatAgenticNodeToolSetup:
         # added in ``profiles._NORMAL_RULES`` would never fire.
         assert node.tool_registry.get("execute_command") == "bash_tools"
 
+    def test_context_search_failure_does_not_remove_db_tools(self, real_agent_config, mock_llm_create):
+        """Embedding/context setup failures should only remove context tools."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+        from datus.tools.func_tool.database import DBFuncTool
+
+        with patch("datus.agent.node.chat_agentic_node.ContextSearchTools", side_effect=RuntimeError("hf offline")):
+            node = ChatAgenticNode(
+                node_id="test_context_degraded",
+                description="Test context degradation",
+                node_type=NodeType.TYPE_CHAT,
+                agent_config=real_agent_config,
+            )
+
+        tool_names = {tool.name for tool in node.tools}
+        registry = node.tool_registry.to_dict()
+
+        assert isinstance(node.db_func_tool, DBFuncTool)
+        assert node.context_search_tools is None
+        assert "list_tables" in tool_names
+        assert "context_search_tools" not in set(registry.values())
+        assert registry["list_tables"] == "db_tools"
+        assert "context_search_tools" in node.degraded_capabilities
+        assert "hf offline" in node.degraded_capabilities["context_search_tools"]
+
     def test_has_ask_user_tools(self, real_agent_config, mock_llm_create):
         """Chat node has ask_user tool set up via _setup_ask_user_tool."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -3,7 +3,8 @@
 import asyncio
 import re
 from datetime import datetime
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -321,6 +322,30 @@ class TestChatTaskManagerBehavior:
         await manager._push_event(task, event)
         assert len(task.events) == 1
         assert task.events[0] is event
+
+    @pytest.mark.asyncio
+    async def test_degraded_context_warning_emits_nonfatal_message(self):
+        """Context degradation should be a normal assistant message, not an error event."""
+        manager = ChatTaskManager()
+        task = ChatTask(session_id="s-degraded", asyncio_task=MagicMock())
+        node = SimpleNamespace(
+            degraded_capabilities={
+                "context_search_tools": "Context search and @ references are disabled; DB tools remain available."
+            }
+        )
+
+        next_id = await manager._push_degraded_capability_warnings(task, node, 7)
+
+        assert next_id == 8
+        assert len(task.events) == 1
+        event = task.events[0]
+        assert event.id == 7
+        assert event.event == "message"
+        assert isinstance(event.data, SSEMessageData)
+        assert event.data.type == SSEDataType.CREATE_MESSAGE
+        assert event.data.payload.role == "assistant"
+        assert event.data.payload.content[0].type == "markdown"
+        assert "DB tools remain available" in event.data.payload.content[0].payload["content"]
 
     @pytest.mark.asyncio
     async def test_run_loop_emits_final_response_when_no_plain_assistant_response(self, real_agent_config):
@@ -808,6 +833,21 @@ class TestResolveAtContext:
         assert isinstance(tables, list)
         assert isinstance(metrics, list)
         assert isinstance(sqls, list)
+
+    def test_resolve_at_context_returns_empty_when_completer_fails(self, real_agent_config):
+        manager = ChatTaskManager()
+
+        with patch("datus.api.services.chat_task_manager.AtReferenceCompleter", side_effect=RuntimeError("hf offline")):
+            tables, metrics, sqls = manager._resolve_at_context(
+                real_agent_config,
+                ["db.schema.table"],
+                ["Finance.revenue"],
+                ["Finance.sql"],
+            )
+
+        assert tables == []
+        assert metrics == []
+        assert sqls == []
 
 
 class TestCreateNode:

--- a/tests/unit_tests/api/services/test_tool_service.py
+++ b/tests/unit_tests/api/services/test_tool_service.py
@@ -58,6 +58,14 @@ class TestToolRegistry:
         tools = tool_service.registered_tools
         assert tools == sorted(tools)
 
+    def test_context_tool_initialization_failure_builds_empty_registry(self, mock_agent_config):
+        """ToolService should construct even when embedding-backed context tools fail."""
+        with patch("datus.api.services.tool_service.ContextSearchTools", side_effect=RuntimeError("hf offline")):
+            service = ToolService(mock_agent_config)
+
+        assert service.registered_tools == []
+        assert "hf offline" in service.context_warning
+
 
 class TestToolServiceExecute:
     """Tests for execute() dispatch."""
@@ -87,6 +95,17 @@ class TestToolServiceExecute:
         assert result.success is False
         assert result.errorCode == "TOOL_NOT_FOUND"
         assert "nonexistent_tool" in result.errorMessage
+
+    def test_execute_context_tool_returns_controlled_failure_when_unavailable(self, mock_agent_config):
+        with patch("datus.api.services.tool_service.ContextSearchTools", side_effect=RuntimeError("hf offline")):
+            service = ToolService(mock_agent_config)
+
+        result = service.execute("search_metrics", {"query_text": "revenue"})
+
+        assert result.success is False
+        assert result.errorCode == "TOOL_EXECUTION_ERROR"
+        assert "Context search and @ references are disabled" in result.errorMessage
+        assert "hf offline" in result.errorMessage
 
     def test_execute_invalid_params_returns_error(self, tool_service):
         """execute with wrong params returns INVALID_PARAMETERS error."""

--- a/tests/unit_tests/cli/test_agent_commands.py
+++ b/tests/unit_tests/cli/test_agent_commands.py
@@ -219,6 +219,26 @@ class TestCmdSearchMetrics:
         output = agent_commands.console.file.getvalue()
         assert "Context search and @ references are disabled" in output
 
+    def test_search_embedding_failure_shows_warning_after_prompts(self, agent_commands):
+        from datus.tools.func_tool.base import FuncToolResult
+
+        mock_result = MagicMock(spec=FuncToolResult)
+        mock_result.success = False
+        mock_result.result = None
+        mock_result.error = "error_code=300019 error_message=Embedding model cache is missing"
+        agent_commands.cli.prompt_input = MagicMock(return_value="5")
+
+        with patch.object(agent_commands, "_context_search_tools") as mock_cst:
+            mock_cst.search_metrics.return_value = mock_result
+            with patch.object(agent_commands, "_prompt_subject_path", return_value=None) as prompt_subject:
+                agent_commands.cmd_search_metrics("revenue")
+
+        prompt_subject.assert_called_once()
+        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "Error" not in output
+
     def test_success_displays_metrics(self, agent_commands):
         from datus.tools.func_tool.base import FuncToolResult
 

--- a/tests/unit_tests/cli/test_agent_commands.py
+++ b/tests/unit_tests/cli/test_agent_commands.py
@@ -193,6 +193,42 @@ class TestCmdSchemaLinking:
 
         mock_rag.search_similar.assert_called_once()
 
+    def test_missing_schema_embedding_cache_warns_after_prompts(self, agent_commands):
+        mock_rag = MagicMock()
+        for store in (mock_rag.schema_store, mock_rag.value_store):
+            store._count_rows.return_value = 1
+            store.model.has_local_fastembed_snapshot.return_value = False
+
+        with patch("datus.storage.schema_metadata.SchemaWithValueRAG", return_value=mock_rag):
+            with patch.object(agent_commands, "_prompt_db_layers", return_value=("", "testdb", "")) as prompt_layers:
+                agent_commands.cli.prompt_input = MagicMock(return_value="5")
+                agent_commands.cmd_schema_linking("find tables about revenue")
+
+        prompt_layers.assert_called_once()
+        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
+        mock_rag.search_similar.assert_not_called()
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "FastEmbed cache is" in output
+
+    def test_schema_search_embedding_failure_shows_warning(self, agent_commands):
+        mock_rag = MagicMock()
+        for store in (mock_rag.schema_store, mock_rag.value_store):
+            store._count_rows.return_value = 1
+            store.model.has_local_fastembed_snapshot.return_value = True
+        mock_rag.search_similar.side_effect = RuntimeError(
+            "error_code=300019 error_message=Embedding model cache is missing"
+        )
+
+        with patch("datus.storage.schema_metadata.SchemaWithValueRAG", return_value=mock_rag):
+            with patch.object(agent_commands, "_prompt_db_layers", return_value=("", "testdb", "")):
+                agent_commands.cli.prompt_input = MagicMock(return_value="5")
+                agent_commands.cmd_schema_linking("find tables about revenue")
+
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "Error" not in output
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_search_metrics
@@ -336,6 +372,45 @@ class TestCmdSearchReferenceSql:
         output = agent_commands.console.file.getvalue()
         assert "Context search and @ references are disabled" in output
 
+    def test_missing_reference_sql_embedding_cache_warns_after_prompts(self, agent_commands):
+        mock_model = MagicMock()
+        mock_model.has_local_fastembed_snapshot.return_value = False
+        mock_cst = MagicMock()
+        mock_cst.reference_sql_store.reference_sql_storage.model = mock_model
+        agent_commands._context_search_tools = mock_cst
+        agent_commands.cli.prompt_input = MagicMock(return_value="5")
+
+        with patch.object(agent_commands, "_prompt_subject_path", return_value=None) as prompt_subject:
+            agent_commands.cmd_search_reference_sql("revenue sql")
+
+        prompt_subject.assert_called_once()
+        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
+        mock_cst.search_reference_sql.assert_not_called()
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "FastEmbed cache is" in output
+        assert "missing for reference SQL search" in output
+
+    def test_search_embedding_failure_shows_warning_after_prompts(self, agent_commands):
+        from datus.tools.func_tool.base import FuncToolResult
+
+        mock_result = MagicMock(spec=FuncToolResult)
+        mock_result.success = False
+        mock_result.result = None
+        mock_result.error = "error_code=300019 error_message=Embedding model cache is missing"
+        agent_commands.cli.prompt_input = MagicMock(return_value="5")
+
+        with patch.object(agent_commands, "_context_search_tools") as mock_cst:
+            mock_cst.search_reference_sql.return_value = mock_result
+            with patch.object(agent_commands, "_prompt_subject_path", return_value=None) as prompt_subject:
+                agent_commands.cmd_search_reference_sql("revenue sql")
+
+        prompt_subject.assert_called_once()
+        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "Error" not in output
+
     def test_success_displays_table(self, agent_commands):
         from datus.tools.func_tool.base import FuncToolResult
 
@@ -421,6 +496,41 @@ class TestCmdDocSearch:
         agent_commands.cmd_doc_search("")
         output = agent_commands.console.file.getvalue()
         assert "Keywords cannot be empty." in output
+
+    def test_missing_document_embedding_cache_warns_after_prompts(self, agent_commands):
+        mock_store = MagicMock()
+        mock_store._count_rows.return_value = 1
+        mock_store.model.has_local_fastembed_snapshot.return_value = False
+        mock_tool = MagicMock()
+        mock_tool._get_document_store.return_value = mock_store
+        agent_commands.cli.prompt_input = MagicMock(side_effect=["duckdb", "", "5"])
+
+        with patch("datus.tools.search_tools.search_tool.SearchTool", return_value=mock_tool):
+            agent_commands.cmd_doc_search("create table")
+
+        mock_tool.search_document.assert_not_called()
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "FastEmbed cache is" in output
+        assert "missing for document search" in output
+
+    def test_document_embedding_failure_shows_warning(self, agent_commands):
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.error = "error_code=300019 error_message=Embedding model cache is missing"
+        mock_result.doc_count = 0
+        mock_result.docs = {}
+        mock_tool = MagicMock()
+        mock_tool._get_document_store.return_value = None
+        mock_tool.search_document.return_value = mock_result
+        agent_commands.cli.prompt_input = MagicMock(side_effect=["duckdb", "", "5"])
+
+        with patch("datus.tools.search_tools.search_tool.SearchTool", return_value=mock_tool):
+            agent_commands.cmd_doc_search("create table")
+
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "Error" not in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_agent_commands.py
+++ b/tests/unit_tests/cli/test_agent_commands.py
@@ -239,6 +239,25 @@ class TestCmdSearchMetrics:
         assert "Context search and @ references are disabled" in output
         assert "Error" not in output
 
+    def test_missing_metric_embedding_cache_warns_after_prompts(self, agent_commands):
+        mock_model = MagicMock()
+        mock_model.has_local_fastembed_snapshot.return_value = False
+        mock_cst = MagicMock()
+        mock_cst.metric_rag.storage.model = mock_model
+        agent_commands._context_search_tools = mock_cst
+        agent_commands.cli.prompt_input = MagicMock(return_value="5")
+
+        with patch.object(agent_commands, "_prompt_subject_path", return_value=None) as prompt_subject:
+            agent_commands.cmd_search_metrics("revenue")
+
+        prompt_subject.assert_called_once()
+        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
+        mock_cst.search_metrics.assert_not_called()
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+        assert "FastEmbed cache is" in output
+        assert "missing for metric search" in output
+
     def test_success_displays_metrics(self, agent_commands):
         from datus.tools.func_tool.base import FuncToolResult
 

--- a/tests/unit_tests/cli/test_agent_commands.py
+++ b/tests/unit_tests/cli/test_agent_commands.py
@@ -193,29 +193,8 @@ class TestCmdSchemaLinking:
 
         mock_rag.search_similar.assert_called_once()
 
-    def test_missing_schema_embedding_cache_warns_after_prompts(self, agent_commands):
-        mock_rag = MagicMock()
-        for store in (mock_rag.schema_store, mock_rag.value_store):
-            store._count_rows.return_value = 1
-            store.model.has_local_fastembed_snapshot.return_value = False
-
-        with patch("datus.storage.schema_metadata.SchemaWithValueRAG", return_value=mock_rag):
-            with patch.object(agent_commands, "_prompt_db_layers", return_value=("", "testdb", "")) as prompt_layers:
-                agent_commands.cli.prompt_input = MagicMock(return_value="5")
-                agent_commands.cmd_schema_linking("find tables about revenue")
-
-        prompt_layers.assert_called_once()
-        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
-        mock_rag.search_similar.assert_not_called()
-        output = agent_commands.console.file.getvalue()
-        assert "Context search and @ references are disabled" in output
-        assert "FastEmbed cache is" in output
-
     def test_schema_search_embedding_failure_shows_warning(self, agent_commands):
         mock_rag = MagicMock()
-        for store in (mock_rag.schema_store, mock_rag.value_store):
-            store._count_rows.return_value = 1
-            store.model.has_local_fastembed_snapshot.return_value = True
         mock_rag.search_similar.side_effect = RuntimeError(
             "error_code=300019 error_message=Embedding model cache is missing"
         )
@@ -274,25 +253,6 @@ class TestCmdSearchMetrics:
         output = agent_commands.console.file.getvalue()
         assert "Context search and @ references are disabled" in output
         assert "Error" not in output
-
-    def test_missing_metric_embedding_cache_warns_after_prompts(self, agent_commands):
-        mock_model = MagicMock()
-        mock_model.has_local_fastembed_snapshot.return_value = False
-        mock_cst = MagicMock()
-        mock_cst.metric_rag.storage.model = mock_model
-        agent_commands._context_search_tools = mock_cst
-        agent_commands.cli.prompt_input = MagicMock(return_value="5")
-
-        with patch.object(agent_commands, "_prompt_subject_path", return_value=None) as prompt_subject:
-            agent_commands.cmd_search_metrics("revenue")
-
-        prompt_subject.assert_called_once()
-        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
-        mock_cst.search_metrics.assert_not_called()
-        output = agent_commands.console.file.getvalue()
-        assert "Context search and @ references are disabled" in output
-        assert "FastEmbed cache is" in output
-        assert "missing for metric search" in output
 
     def test_success_displays_metrics(self, agent_commands):
         from datus.tools.func_tool.base import FuncToolResult
@@ -371,25 +331,6 @@ class TestCmdSearchReferenceSql:
 
         output = agent_commands.console.file.getvalue()
         assert "Context search and @ references are disabled" in output
-
-    def test_missing_reference_sql_embedding_cache_warns_after_prompts(self, agent_commands):
-        mock_model = MagicMock()
-        mock_model.has_local_fastembed_snapshot.return_value = False
-        mock_cst = MagicMock()
-        mock_cst.reference_sql_store.reference_sql_storage.model = mock_model
-        agent_commands._context_search_tools = mock_cst
-        agent_commands.cli.prompt_input = MagicMock(return_value="5")
-
-        with patch.object(agent_commands, "_prompt_subject_path", return_value=None) as prompt_subject:
-            agent_commands.cmd_search_reference_sql("revenue sql")
-
-        prompt_subject.assert_called_once()
-        agent_commands.cli.prompt_input.assert_called_once_with("Enter top_n to match", default="5")
-        mock_cst.search_reference_sql.assert_not_called()
-        output = agent_commands.console.file.getvalue()
-        assert "Context search and @ references are disabled" in output
-        assert "FastEmbed cache is" in output
-        assert "missing for reference SQL search" in output
 
     def test_search_embedding_failure_shows_warning_after_prompts(self, agent_commands):
         from datus.tools.func_tool.base import FuncToolResult
@@ -496,23 +437,6 @@ class TestCmdDocSearch:
         agent_commands.cmd_doc_search("")
         output = agent_commands.console.file.getvalue()
         assert "Keywords cannot be empty." in output
-
-    def test_missing_document_embedding_cache_warns_after_prompts(self, agent_commands):
-        mock_store = MagicMock()
-        mock_store._count_rows.return_value = 1
-        mock_store.model.has_local_fastembed_snapshot.return_value = False
-        mock_tool = MagicMock()
-        mock_tool._get_document_store.return_value = mock_store
-        agent_commands.cli.prompt_input = MagicMock(side_effect=["duckdb", "", "5"])
-
-        with patch("datus.tools.search_tools.search_tool.SearchTool", return_value=mock_tool):
-            agent_commands.cmd_doc_search("create table")
-
-        mock_tool.search_document.assert_not_called()
-        output = agent_commands.console.file.getvalue()
-        assert "Context search and @ references are disabled" in output
-        assert "FastEmbed cache is" in output
-        assert "missing for document search" in output
 
     def test_document_embedding_failure_shows_warning(self, agent_commands):
         mock_result = MagicMock()

--- a/tests/unit_tests/cli/test_agent_commands.py
+++ b/tests/unit_tests/cli/test_agent_commands.py
@@ -206,6 +206,19 @@ class TestCmdSearchMetrics:
         output = agent_commands.console.file.getvalue()
         assert "Error" in output
 
+    def test_context_tools_unavailable_shows_warning(self, agent_commands):
+        """When ContextSearchTools fails, cmd_search_metrics prints a warning instead of crashing."""
+        with patch(
+            "datus.cli.agent_commands.ContextSearchTools",
+            side_effect=RuntimeError("embedding model download failed"),
+        ):
+            agent_commands._context_search_tools = None
+            agent_commands._context_search_warning = ""
+            agent_commands.cmd_search_metrics("revenue")
+
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
+
     def test_success_displays_metrics(self, agent_commands):
         from datus.tools.func_tool.base import FuncToolResult
 
@@ -270,6 +283,19 @@ class TestCmdSearchReferenceSql:
         agent_commands.cmd_search_reference_sql("")
         output = agent_commands.console.file.getvalue()
         assert "Error" in output
+
+    def test_context_tools_unavailable_shows_warning(self, agent_commands):
+        """When ContextSearchTools fails, cmd_search_reference_sql prints a warning instead of crashing."""
+        with patch(
+            "datus.cli.agent_commands.ContextSearchTools",
+            side_effect=RuntimeError("embedding model download failed"),
+        ):
+            agent_commands._context_search_tools = None
+            agent_commands._context_search_warning = ""
+            agent_commands.cmd_search_reference_sql("revenue sql")
+
+        output = agent_commands.console.file.getvalue()
+        assert "Context search and @ references are disabled" in output
 
     def test_success_displays_table(self, agent_commands):
         from datus.tools.func_tool.base import FuncToolResult

--- a/tests/unit_tests/cli/test_autocomplete.py
+++ b/tests/unit_tests/cli/test_autocomplete.py
@@ -313,6 +313,11 @@ class _StubCompleter(DynamicAtReferenceCompleter):
         return self._stub_data, flatten, 2
 
 
+class _FailingCompleter(DynamicAtReferenceCompleter):
+    def _build_snapshot(self):
+        raise RuntimeError("storage unavailable")
+
+
 class TestDynamicAtReferenceCompleterInit:
     def test_init_defaults(self):
         c = _StubCompleter()
@@ -360,6 +365,17 @@ class TestDynamicAtReferenceCompleterEnsureLoaded:
         c._ensure_loaded()
         c._ensure_loaded()
         assert call_count == 1
+
+    def test_ensure_loaded_failure_marks_completer_unavailable(self):
+        c = _FailingCompleter()
+
+        c._ensure_loaded()
+
+        assert c._loaded is True
+        assert c._data == {}
+        assert c.flatten_data == {}
+        assert c.max_level == 0
+        assert c.last_error == "storage unavailable"
 
 
 class TestDynamicAtReferenceCompleterReloadData:
@@ -453,6 +469,15 @@ class TestDynamicAtReferenceCompleterReloadData:
         assert "key_a" in captured and "key_b" not in captured
         assert c.flatten_data is not captured
         assert "key_b" in c.flatten_data
+
+    def test_reload_failure_marks_completer_unavailable(self):
+        c = _FailingCompleter()
+
+        c.reload_data()
+
+        assert c._loaded is True
+        assert c.flatten_data == {}
+        assert c.last_error == "storage unavailable"
 
 
 class TestDynamicAtReferenceCompleterGetData:
@@ -772,6 +797,39 @@ class TestAtReferenceCompleterParseAtContext:
         assert completer.table_completer._loaded is False
         completer.parse_at_context("@Table users")
         assert completer.table_completer._loaded is True
+
+    def test_reload_data_isolates_reference_type_failures(self, real_agent_config):
+        completer = AtReferenceCompleter(real_agent_config)
+        completer.table_completer._build_snapshot = lambda: (_ for _ in ()).throw(
+            RuntimeError("table storage unavailable")
+        )
+        completer.metric_completer._build_snapshot = lambda: ({}, {"Finance.revenue": {"name": "revenue"}}, 2)
+        completer.sql_completer._build_snapshot = lambda: ({}, {"Finance.sql": {"name": "sql", "sql": "select 1"}}, 2)
+
+        completer.reload_data()
+
+        assert completer.table_completer.last_error == "table storage unavailable"
+        assert completer.metric_completer.flatten_data == {"Finance.revenue": {"name": "revenue"}}
+        assert completer.sql_completer.flatten_data == {"Finance.sql": {"name": "sql", "sql": "select 1"}}
+
+    def test_parse_at_context_skips_unavailable_type_and_returns_available(self, real_agent_config):
+        completer = AtReferenceCompleter(real_agent_config)
+        completer.table_completer._build_snapshot = lambda: (_ for _ in ()).throw(
+            RuntimeError("table storage unavailable")
+        )
+        completer.metric_completer._build_snapshot = lambda: (
+            {},
+            {"Finance.revenue": {"name": "revenue", "description": "Revenue metric"}},
+            2,
+        )
+
+        tables, metrics, sqls, agent = completer.parse_at_context("@Table users @Metrics Finance.revenue")
+
+        assert tables == []
+        assert [metric.name for metric in metrics] == ["revenue"]
+        assert sqls == []
+        assert agent is None
+        assert completer.table_completer.last_error == "table storage unavailable"
 
     def test_parse_unknown_agent_drops_silently(self, real_agent_config):
         """A misspelt agent name must NOT be returned as a routing hint —

--- a/tests/unit_tests/cli/test_background_sync.py
+++ b/tests/unit_tests/cli/test_background_sync.py
@@ -251,6 +251,40 @@ class TestFailureKeepsOldData:
         cli.at_completer.table_completer.reload_data.assert_not_called()
         assert mgr.is_running() is False
 
+    def test_startup_sync_skips_missing_fastembed_cache(self, bg_loop, monkeypatch):
+        init_called = {"n": 0}
+
+        async def fake_init_async(*args, **kwargs):
+            init_called["n"] += 1
+
+        missing_model = MagicMock()
+        missing_model.has_local_fastembed_snapshot.return_value = False
+        fake_store = SimpleNamespace(
+            schema_store=SimpleNamespace(model=missing_model),
+            value_store=SimpleNamespace(model=missing_model),
+        )
+
+        monkeypatch.setattr(
+            "datus.storage.schema_metadata.local_init.init_local_schema_async",
+            fake_init_async,
+        )
+        monkeypatch.setattr(
+            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            lambda *a, **kw: fake_store,
+        )
+
+        cli = _make_cli(bg_loop)
+        cli.at_completer.table_completer.reload_data = MagicMock()
+
+        mgr = BackgroundSchemaSyncManager(cli)
+        mgr.schedule(datasource="local_db", reason="startup")
+        _wait_for_future(mgr._current_future)
+
+        assert init_called["n"] == 0
+        missing_model.has_local_fastembed_snapshot.assert_called_once()
+        cli.at_completer.table_completer.reload_data.assert_not_called()
+        assert mgr.is_running() is False
+
 
 class TestDriftGuard:
     def test_current_datasource_drift_skips_sync(self, bg_loop, monkeypatch):

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -19,6 +19,7 @@ threading side effects.
 """
 
 import io
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -45,6 +46,7 @@ def _make_cli(agent_config, available_subagents=None):
     cli.agent = None
     cli.agent_ready = False
     cli.agent_initializing = False
+    cli.startup_warnings = []
     cli.plan_mode_active = False
     cli.default_agent = ""
     cli.at_completer = MagicMock()
@@ -198,6 +200,50 @@ class TestAutoResumeIfRequested:
         cli._run_prompt_session()
 
         cli._auto_resume_if_requested.assert_called_once_with()
+
+
+class TestPreLoadStorage:
+    def test_pre_load_storage_records_warning_when_completer_raises(self, cli):
+        cli.at_completer.reload_data.side_effect = RuntimeError("download unavailable")
+
+        cli._pre_load_storage()
+
+        assert len(cli.startup_warnings) == 1
+        assert "Context search and @ references are disabled" in cli.startup_warnings[0]
+        assert "download unavailable" in cli.startup_warnings[0]
+        assert cli.agent is None
+        assert cli.agent_ready is False
+
+    def test_pre_load_storage_records_warning_from_degraded_completer(self, cli):
+        cli.at_completer = SimpleNamespace(
+            reload_data=MagicMock(),
+            table_completer=SimpleNamespace(last_error="table cache unavailable"),
+            metric_completer=SimpleNamespace(last_error=None),
+            sql_completer=SimpleNamespace(last_error=None),
+        )
+
+        cli._pre_load_storage()
+
+        assert cli.at_completer.reload_data.call_count == 1
+        assert len(cli.startup_warnings) == 1
+        assert "table cache unavailable" in cli.startup_warnings[0]
+
+    def test_background_init_keeps_agent_ready_after_preload_failure(self, cli):
+        agent = object()
+        cli.args = SimpleNamespace(debug=False)
+        cli.agent_initializing = True
+        cli.at_completer.reload_data.side_effect = RuntimeError("download unavailable")
+        cli._create_workflow_runner = MagicMock(return_value="runner")
+        cli._maybe_schedule_startup_sync = MagicMock()
+
+        with patch("datus.agent.agent.Agent", return_value=agent):
+            cli._background_init_agent()
+
+        assert cli.agent is agent
+        assert cli.agent_ready is True
+        assert cli.agent_initializing is False
+        assert cli._workflow_runner == "runner"
+        assert "download unavailable" in cli.startup_warnings[0]
 
 
 class TestCmdExitShutsDownBgSync:

--- a/tests/unit_tests/storage/document/test_store.py
+++ b/tests/unit_tests/storage/document/test_store.py
@@ -489,6 +489,31 @@ class TestDocumentStoreGetAllRows:
 # ============================================================
 
 
+class TestDocumentStoreReadOnlyDegradation:
+    """Read-only wrappers must not force embedding model initialization."""
+
+    def test_list_versions_without_embedding_on_empty_store(self, doc_store):
+        """list_versions on an empty store returns [] without initializing embeddings."""
+        doc_store._shared.initialized = False
+        versions = doc_store.list_versions()
+        assert versions == []
+        assert doc_store._shared.initialized is False
+
+    def test_get_stats_without_embedding_on_empty_store(self, doc_store):
+        """get_stats on an empty store returns zero stats without initializing embeddings."""
+        doc_store._shared.initialized = False
+        stats = doc_store.get_stats()
+        assert stats["total_chunks"] == 0
+        assert doc_store._shared.initialized is False
+
+    def test_get_all_rows_without_embedding_on_empty_store(self, doc_store):
+        """get_all_rows on an empty store returns [] without initializing embeddings."""
+        doc_store._shared.initialized = False
+        rows = doc_store.get_all_rows()
+        assert rows == []
+        assert doc_store._shared.initialized is False
+
+
 class TestDocumentStoreHasData:
     """Tests for has_data method."""
 

--- a/tests/unit_tests/storage/schema_metadata/test_store.py
+++ b/tests/unit_tests/storage/schema_metadata/test_store.py
@@ -395,6 +395,18 @@ class TestSearchTablesNameParsing:
 # ---------------------------------------------------------------------------
 
 
+class TestSearchAllReadOnlyDegradation:
+    """BaseMetadataStorage.search_all must not force embedding initialization."""
+
+    def test_search_all_without_embedding_on_empty_store(self, tmp_path):
+        """search_all on an empty store returns empty result without initializing embeddings."""
+        store = SchemaStorage(get_db_embedding_model())
+        store._shared.initialized = False
+        result = store.search_all(catalog_name="cat")
+        assert result.num_rows == 0
+        assert store._shared.initialized is False
+
+
 class TestSearchSimilar:
     """Tests for search_similar and do_search_similar."""
 

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -1009,3 +1009,12 @@ class TestSearchAll:
 
         result = store._search_all(limit=2)
         assert result.num_rows == 2
+
+    def test_search_all_with_zero_limit_returns_no_rows(self, tmp_path):
+        """_search_all preserves an explicit zero limit."""
+        store = self._make_store(tmp_path)
+        data = [self._make_row(i) for i in range(5)]
+        store.store_batch(data)
+
+        result = store._search_all(limit=0)
+        assert result.num_rows == 0

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -6,7 +6,9 @@
 
 import re
 from datetime import datetime
+from unittest.mock import MagicMock
 
+import pyarrow as pa
 import pytest
 from datus_storage_base.conditions import eq
 
@@ -14,6 +16,51 @@ from datus.storage.base import BaseEmbeddingStore, StorageBase
 from datus.storage.embedding_models import EmbeddingModel, get_db_embedding_model
 from datus.storage.schema_metadata import SchemaStorage
 from datus.utils.exceptions import DatusException
+
+
+class _UnavailableEmbeddingModel:
+    batch_size = 64
+    device = "cpu"
+    is_model_failed = True
+    model_error_message = "download unavailable"
+    model_name = "missing-model"
+
+    @property
+    def model(self):  # pragma: no cover - failure path assertion
+        raise AssertionError("read-only storage path touched the embedding model")
+
+    @property
+    def dim_size(self):
+        return 2
+
+
+class _ReadOnlyTable:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def count_rows(self, where=None):
+        return len(self.rows)
+
+    def search_all(self, where=None, select_fields=None, limit=None):
+        rows = self.rows[:limit] if limit is not None else list(self.rows)
+        if select_fields is not None:
+            rows = [{field: row.get(field) for field in select_fields if field in row} for row in rows]
+        return pa.Table.from_pylist(rows)
+
+
+class _ReadOnlyVectorDb:
+    def __init__(self, *, exists: bool, table=None):
+        self.exists = exists
+        self.table = table
+        self.open_table_calls = []
+
+    def table_exists(self, table_name):
+        return self.exists
+
+    def open_table(self, table_name, **kwargs):
+        self.open_table_calls.append((table_name, kwargs))
+        return self.table
+
 
 # ---------------------------------------------------------------------------
 # StorageBase._get_current_timestamp
@@ -234,6 +281,85 @@ class TestCheckEmbeddingModelReady:
             store._check_embedding_model_ready()
         assert "not available" in str(exc_info.value)
         assert "Download failed" in str(exc_info.value)
+
+    def test_check_embedding_model_ready_raises_when_model_property_returns_none(self):
+        """A failed lazy init that leaves no model must fail closed."""
+        model = MagicMock()
+        model.is_model_failed = False
+        model.model_name = "empty-model"
+        model.model = None
+
+        store = BaseEmbeddingStore(table_name="test_table", embedding_model=model)
+
+        with pytest.raises(DatusException) as exc_info:
+            store._check_embedding_model_ready()
+
+        assert "initialization produced no model" in str(exc_info.value)
+
+
+class TestReadOnlyPathsWithoutEmbedding:
+    """Read-only storage paths should not initialize embedding models."""
+
+    def _make_store(self, db):
+        schema = pa.schema(
+            [
+                pa.field("name", pa.string()),
+                pa.field("definition", pa.string()),
+                pa.field("vector", pa.list_(pa.float32(), list_size=2)),
+            ]
+        )
+        return BaseEmbeddingStore(
+            table_name="test_table",
+            embedding_model=_UnavailableEmbeddingModel(),
+            db=db,
+            schema=schema,
+        )
+
+    def test_missing_table_count_returns_zero_without_embedding(self):
+        db = _ReadOnlyVectorDb(exists=False)
+        store = self._make_store(db)
+
+        assert store._count_rows() == 0
+        assert store.table_size() == 0
+        assert db.open_table_calls == []
+        assert store._shared.initialized is False
+
+    def test_missing_table_search_returns_empty_schema_without_embedding(self):
+        db = _ReadOnlyVectorDb(exists=False)
+        store = self._make_store(db)
+
+        result = store._search_all()
+
+        assert result.num_rows == 0
+        assert result.column_names == ["name", "definition", "datasource_id"]
+        assert db.open_table_calls == []
+        assert store._shared.initialized is False
+
+    def test_missing_table_query_with_filter_returns_selected_empty_schema(self):
+        db = _ReadOnlyVectorDb(exists=False)
+        store = self._make_store(db)
+
+        result = store.query_with_filter(select_fields=["name"])
+
+        assert result.num_rows == 0
+        assert result.column_names == ["name"]
+        assert db.open_table_calls == []
+        assert store._shared.initialized is False
+
+    def test_existing_table_read_path_opens_without_embedding_function(self):
+        table = _ReadOnlyTable(
+            [
+                {"name": "orders", "definition": "CREATE TABLE orders(id int)", "vector": [0.1, 0.2]},
+            ]
+        )
+        db = _ReadOnlyVectorDb(exists=True, table=table)
+        store = self._make_store(db)
+
+        result = store._search_all(select_fields=["name", "vector"])
+
+        assert result.to_pylist() == [{"name": "orders"}]
+        assert db.open_table_calls == [("test_table", {})]
+        assert store._shared.initialized is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -361,6 +361,16 @@ class TestReadOnlyPathsWithoutEmbedding:
         assert db.open_table_calls == [("test_table", {})]
         assert store._shared.initialized is False
 
+    def test_query_with_filter_zero_limit_without_embedding(self):
+        """query_with_filter(limit=0) returns empty without touching embedding model."""
+        table = _ReadOnlyTable([{"name": "orders", "definition": "CREATE TABLE orders(id int)", "vector": [0.1, 0.2]}])
+        db = _ReadOnlyVectorDb(exists=True, table=table)
+        store = self._make_store(db)
+
+        result = store.query_with_filter(limit=0, select_fields=["name"])
+        assert result.num_rows == 0
+        assert store._shared.initialized is False
+
 
 # ---------------------------------------------------------------------------
 # BaseEmbeddingStore.truncate
@@ -800,6 +810,15 @@ class TestQueryWithFilter:
         result = store.query_with_filter(select_fields=["identifier", "table_name"])
         assert "identifier" in result.column_names
         assert "table_name" in result.column_names
+
+    def test_query_with_filter_zero_limit_returns_empty(self, tmp_path):
+        """query_with_filter(limit=0) must return an empty table, not all rows."""
+        store = self._make_store(tmp_path)
+        data = [self._make_row(i) for i in range(5)]
+        store.store_batch(data)
+
+        result = store.query_with_filter(limit=0)
+        assert result.num_rows == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/test_embedding_lazy_loading.py
+++ b/tests/unit_tests/storage/test_embedding_lazy_loading.py
@@ -5,8 +5,10 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 
 from datus.storage.base import BaseEmbeddingStore
+from datus.storage.embedding_diagnostics import format_fastembed_download_error
 from datus.storage.embedding_models import EmbeddingModel
 from datus.utils.exceptions import DatusException
 
@@ -96,7 +98,61 @@ def test_silent_initialization_records_failure(monkeypatch):
     assert model.model_error_message == "download unavailable"
 
 
-def test_storage_defers_failed_model_error_until_first_use():
+def test_model_property_failed_initialization_raises_and_repeats(monkeypatch):
+    def fail_init_model(self):
+        raise RuntimeError("download unavailable")
+
+    monkeypatch.setattr(EmbeddingModel, "init_model", fail_init_model)
+    model = EmbeddingModel(model_name="missing-model", dim_size=2)
+
+    with pytest.raises(DatusException) as first_exc:
+        _ = model.model
+
+    assert "missing-model" in str(first_exc.value)
+    assert "download unavailable" in str(first_exc.value)
+    assert model.model_initialization_attempted is True
+    assert model.is_model_failed is True
+
+    with pytest.raises(DatusException) as second_exc:
+        _ = model.model
+
+    assert "missing-model" in str(second_exc.value)
+    assert "download unavailable" in str(second_exc.value)
+
+
+def test_model_property_init_without_model_fails(monkeypatch):
+    def empty_init_model(self):
+        return None
+
+    monkeypatch.setattr(EmbeddingModel, "init_model", empty_init_model)
+    model = EmbeddingModel(model_name="empty-model", dim_size=2)
+
+    with pytest.raises(DatusException) as exc_info:
+        _ = model.model
+
+    assert "initialization produced no model" in str(exc_info.value)
+    assert model.is_model_failed is True
+
+
+def test_storage_read_only_size_ignores_failed_model_for_missing_table():
+    failed_model = EmbeddingModel(model_name="missing-model", dim_size=2)
+    failed_model.is_model_failed = True
+    failed_model.model_error_message = "download unavailable"
+    db = MagicMock()
+    db.table_exists.return_value = False
+
+    storage = BaseEmbeddingStore(table_name="test_table", embedding_model=failed_model, db=db)
+
+    assert storage._shared.initialized is False
+    db.create_table.assert_not_called()
+
+    assert storage.table_size() == 0
+
+    assert storage._shared.initialized is False
+    db.create_table.assert_not_called()
+
+
+def test_storage_write_fails_closed_when_embedding_model_unavailable():
     failed_model = EmbeddingModel(model_name="missing-model", dim_size=2)
     failed_model.is_model_failed = True
     failed_model.model_error_message = "download unavailable"
@@ -104,19 +160,32 @@ def test_storage_defers_failed_model_error_until_first_use():
 
     storage = BaseEmbeddingStore(table_name="test_table", embedding_model=failed_model, db=db)
 
-    assert storage._shared.initialized is False
-    db.create_table.assert_not_called()
+    with pytest.raises(DatusException) as exc_info:
+        storage.store([{"definition": "test data"}])
 
-    try:
-        storage.table_size()
-    except DatusException as exc:
-        assert "missing-model" in str(exc)
-        assert "download unavailable" in str(exc)
-    else:
-        raise AssertionError("table_size should fail when the embedding model is unavailable")
-
-    assert storage._shared.initialized is False
+    assert "missing-model" in str(exc_info.value)
+    assert "download unavailable" in str(exc_info.value)
     db.create_table.assert_not_called()
+    assert storage._shared.initialized is False
+
+
+def test_fastembed_download_error_includes_cache_and_remediation(monkeypatch):
+    monkeypatch.setenv("HF_HOME", "/tmp/hf-home")
+    monkeypatch.setenv("FASTEMBED_CACHE_PATH", "/tmp/fastembed-cache")
+
+    message = format_fastembed_download_error(
+        model_name="sentence-transformers/all-MiniLM-L6-v2",
+        repo_id="qdrant/all-MiniLM-L6-v2-onnx",
+        cache_dir="/tmp/fastembed-cache",
+        cause=RuntimeError("connection refused"),
+    )
+
+    assert "Embedding model cache is missing" in message
+    assert "qdrant/all-MiniLM-L6-v2-onnx" in message
+    assert "HF_HOME=/tmp/hf-home" in message
+    assert "FASTEMBED_CACHE_PATH=/tmp/fastembed-cache" in message
+    assert "pre-cache the model artifacts" in message
+    assert "OpenAI-compatible embedding provider" in message
 
 
 def test_store_initializes_table_with_loaded_model():

--- a/tests/unit_tests/storage/test_embedding_lazy_loading.py
+++ b/tests/unit_tests/storage/test_embedding_lazy_loading.py
@@ -233,6 +233,17 @@ def test_embedding_unavailable_error_detection():
     assert not is_embedding_unavailable_error("Storage not initialized")
 
 
+def test_fastembed_snapshot_check_skips_loaded_custom_embedding(monkeypatch):
+    def fail_has_local_snapshot(*args, **kwargs):
+        raise AssertionError("should not check fastembed snapshot for custom embedding")
+
+    monkeypatch.setattr("datus.storage.fastembed_embeddings.has_local_snapshot", fail_has_local_snapshot)
+    model = EmbeddingModel(model_name="unit-test-model", dim_size=2)
+    model._model = _FakeEmbeddingFunction()
+
+    assert model.has_local_fastembed_snapshot() is True
+
+
 def test_store_initializes_table_with_loaded_model():
     model = EmbeddingModel(model_name="unit-test-model", dim_size=2)
     model._model = _FakeEmbeddingFunction()

--- a/tests/unit_tests/storage/test_embedding_lazy_loading.py
+++ b/tests/unit_tests/storage/test_embedding_lazy_loading.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from datus.storage.base import BaseEmbeddingStore
-from datus.storage.embedding_diagnostics import format_fastembed_download_error
+from datus.storage.embedding_diagnostics import format_fastembed_download_error, is_embedding_unavailable_error
 from datus.storage.embedding_models import EmbeddingModel
 from datus.utils.exceptions import DatusException
 
@@ -152,6 +152,45 @@ def test_storage_read_only_size_ignores_failed_model_for_missing_table():
     db.create_table.assert_not_called()
 
 
+def test_vector_search_returns_empty_without_embedding_when_table_missing():
+    model = MagicMock()
+    model.batch_size = 64
+    model.has_local_fastembed_snapshot.side_effect = AssertionError("should not check embedding cache")
+    db = MagicMock()
+    db.table_exists.return_value = False
+
+    storage = BaseEmbeddingStore(table_name="test_table", embedding_model=model, db=db)
+
+    result = storage.search("find data")
+
+    assert result.num_rows == 0
+    model.has_local_fastembed_snapshot.assert_not_called()
+    db.create_table.assert_not_called()
+    assert storage._shared.initialized is False
+
+
+def test_vector_search_fails_fast_when_embedding_cache_missing():
+    model = MagicMock()
+    model.batch_size = 64
+    model.has_local_fastembed_snapshot.return_value = False
+    table = MagicMock()
+    table.count_rows.return_value = 1
+    db = MagicMock()
+    db.table_exists.return_value = True
+    db.open_table.return_value = table
+
+    storage = BaseEmbeddingStore(table_name="test_table", embedding_model=model, db=db)
+
+    with pytest.raises(DatusException) as exc_info:
+        storage.search("find data")
+
+    assert "error_code=300019" in str(exc_info.value)
+    assert "Embedding model cache is missing" in str(exc_info.value)
+    model.has_local_fastembed_snapshot.assert_called_once()
+    db.create_table.assert_not_called()
+    assert storage._shared.initialized is False
+
+
 def test_storage_write_fails_closed_when_embedding_model_unavailable():
     failed_model = EmbeddingModel(model_name="missing-model", dim_size=2)
     failed_model.is_model_failed = True
@@ -186,6 +225,12 @@ def test_fastembed_download_error_includes_cache_and_remediation(monkeypatch):
     assert "FASTEMBED_CACHE_PATH=/tmp/fastembed-cache" in message
     assert "pre-cache the model artifacts" in message
     assert "OpenAI-compatible embedding provider" in message
+
+
+def test_embedding_unavailable_error_detection():
+    assert is_embedding_unavailable_error("error_code=300019 error_message=Embedding model cache is missing")
+    assert is_embedding_unavailable_error("Embedding model cache is missing")
+    assert not is_embedding_unavailable_error("Storage not initialized")
 
 
 def test_store_initializes_table_with_loaded_model():

--- a/tests/unit_tests/tools/search_tools/test_search_tool.py
+++ b/tests/unit_tests/tools/search_tools/test_search_tool.py
@@ -311,6 +311,18 @@ class TestSearchDocument:
         assert result.success is True
         assert result.docs["badkeyword"] == []
 
+    def test_embedding_keyword_search_exception_returns_failure(self):
+        tool = _make_tool()
+        store = _make_store_with_data()
+        store.search_docs.side_effect = Exception("error_code=300019 error_message=Embedding model cache is missing")
+        with (
+            patch.object(tool, "_get_document_store", return_value=store),
+            patch.object(tool, "_resolve_latest_version", return_value="v1.0"),
+        ):
+            result = tool.search_document("snowflake", ["badkeyword"])
+        assert result.success is False
+        assert "error_code=300019" in result.error
+
     def test_handles_outer_exception(self):
         tool = _make_tool()
         with patch.object(tool, "_get_document_store", side_effect=RuntimeError("outer error")):


### PR DESCRIPTION
## Why

Closes #868.

In offline, intranet, or Hugging-Face-blocked environments, the default FastEmbed model may be missing from local cache and fail to download. Before this change, read-only context/autocomplete setup could initialize embeddings early and block REPL or Web context flows even when the user only needed basic chat or database tools.

## Solution

- Keep read-only vector-store operations from initializing or downloading embedding models when tables are missing or only being listed/counted.
- Convert FastEmbed initialization/download failures into clear diagnostics that name the model, Hugging Face repo, cache path, relevant environment variables, and remediation options.
- Make REPL preload, @-reference autocomplete, ChatAgenticNode context tools, Web SSE warnings, and ToolService context execution degrade at the context-search feature level while preserving DB tools and normal chat.
- Preserve explicit `limit=0` read-path semantics before dispatching to LanceDB, which treats zero as unbounded.
- Document offline deployment options for pre-caching FastEmbed artifacts or using an OpenAI-compatible embedding provider.

## Test Cases

- `uv run pytest tests/unit_tests/storage/test_base.py tests/unit_tests/storage/test_embedding_lazy_loading.py tests/unit_tests/cli/test_autocomplete.py tests/unit_tests/cli/test_repl.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/api/services/test_chat_task_manager.py tests/unit_tests/api/services/test_tool_service.py -q --cov=datus --cov-report=xml:/private/tmp/issue868-targeted-coverage-r2.xml --cov-report=term` -> 445 passed.
- `PATH="$PWD/.venv/bin:$PATH" diff-cover /private/tmp/issue868-targeted-coverage-r2.xml --compare-branch=upstream/main --fail-under=80` -> 90%.
- `.venv/bin/python ci/audit_tests.py --paths tests/unit_tests/storage/test_base.py tests/unit_tests/storage/test_embedding_lazy_loading.py tests/unit_tests/cli/test_autocomplete.py tests/unit_tests/cli/test_repl.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/api/services/test_chat_task_manager.py tests/unit_tests/api/services/test_tool_service.py` -> P0=0, P1=0.
- `.venv/bin/ruff format --check . && .venv/bin/ruff check .` -> passed.
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python ci/run-pr-tests.py upstream/main` was attempted locally before the reviewer fix; it passed 186 acceptance tests and failed one unrelated SQLite integration test because this sandbox cannot open `/Users/kangxue/benchmark/bird/dev_20240627/dev_databases/card_games/card_games.sqlite`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graceful degradation when context-search or embedding components fail; agent, CLI and tools continue operating while surfacing a user-facing warning.

* **Improvements**
  * Startup and SSE emit a non-fatal assistant message when context-search is unavailable.
  * Autocomplete/@-reference resolution and CLI commands tolerate failures and report consolidated warnings.
  * Read-only storage queries no longer trigger embedding initialization; embedding errors provide clearer diagnostics and formatted guidance.

* **Documentation**
  * Updated storage/embedder guidance for offline/intranet setups.

* **Tests**
  * Expanded coverage for degraded-context, autocomplete, CLI, background sync, and read-only embedding behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
