### PR TITLE
[Doc] Remove report_dist config from gen_visual_report guide

### DIFF
--- a/docs/subagent/gen_visual_report.md
+++ b/docs/subagent/gen_visual_report.md
@@ -97,16 +97,12 @@ agent:
     gen_visual_report:
       model: claude              # Optional: defaults to the configured model
       max_turns: 30              # Optional: defaults to 30
-      report_dist: ~/report_dist # Optional: local renderer assets for offline HTML compilation
 ```
 
 | Parameter | Required | Description | Default |
 |-----------|----------|-------------|---------|
 | `model` | No | LLM model to use | Configured default |
 | `max_turns` | No | Maximum agent iterations before the run stops | 30 |
-| `report_dist` | No | Local directory with pre-built renderer assets. When set, the compiled report references these local files instead of loading from a CDN — useful for offline / air-gapped use. | Empty (CDN mode) |
-
-`report_dist` can also come from the `--report-dist` CLI flag.
 
 ## Tips for Better Prompts
 

--- a/docs/subagent/gen_visual_report.zh.md
+++ b/docs/subagent/gen_visual_report.zh.md
@@ -97,16 +97,12 @@ agent:
     gen_visual_report:
       model: claude              # 可选，默认使用当前配置的模型
       max_turns: 30              # 可选，默认 30
-      report_dist: ~/report_dist # 可选，HTML 离线编译时使用的本地渲染器资源目录
 ```
 
 | 参数 | 必填 | 说明 | 默认值 |
 |------|------|------|--------|
 | `model` | 否 | 使用的 LLM 模型 | 当前配置的默认模型 |
 | `max_turns` | 否 | agent 最多迭代多少轮后强制结束 | 30 |
-| `report_dist` | 否 | 本地预构建渲染器资源目录。设置后，编译出的报告会引用本地文件，而不是从 CDN 加载——适合离线 / 内网环境。 | 空（走 CDN） |
-
-`report_dist` 也可以通过 CLI 参数 `--report-dist` 传入。
 
 ## 怎么让 prompt 更有效
 


### PR DESCRIPTION
## Why

The `report_dist` option (and the `--report-dist` CLI flag) is being phased out of the `gen_visual_report` workflow, but it was still documented as a supported config override. Keeping it in the guide misleads users into configuring an option that no longer applies.

## Solution

Remove the `report_dist` entry from the `gen_visual_report` guide in both the English (`gen_visual_report.md`) and Chinese (`gen_visual_report.zh.md`) versions:
- Drop the `report_dist: ~/report_dist` line from the sample `agent.yml` block.
- Drop the `report_dist` row from the parameter table.
- Drop the sentence noting it can be passed via the `--report-dist` CLI flag.

The remaining `model` / `max_turns` config documentation is unchanged.

## Test Cases

None — documentation-only change, no code paths affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `gen_visual_report` configuration documentation to streamline parameter guidance. The documentation now focuses on the `model` and `max_turns` parameters in both English and Chinese versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->