### PR TITLE
[Enhancement] Enable Langfuse tracing for nightly tests

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -193,6 +193,7 @@ jobs:
         run: |
           cp /home/datus_ci/ci_template/agent.yml conf/agent.yml
           cp /home/datus_ci/ci_template/ci.env .env
+          cp /home/datus_ci/ci_template/nightly.env .nightly.env
 
       - name: Restore tracked test config
         run: git restore --source=HEAD --worktree --staged tests/conf/agent.yml
@@ -236,16 +237,18 @@ jobs:
 
       - name: Load environment variables
         run: |
-          echo "Loading environment variables from .env file..."
-          while IFS= read -r line || [ -n "$line" ]; do
-            if [[ ! -z "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
-              var_name=$(echo "$line" | cut -d'=' -f1)
-              var_value=$(echo "$line" | cut -d'=' -f2-)
-              echo "::add-mask::$var_value"
-              echo "Loading variable: $var_name"
-              echo "$line" >> $GITHUB_ENV
-            fi
-          done < .env
+          for env_file in .env .nightly.env; do
+            echo "Loading environment variables from ${env_file} file..."
+            while IFS= read -r line || [ -n "$line" ]; do
+              if [[ ! -z "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+                var_name=$(echo "$line" | cut -d'=' -f1)
+                var_value=$(echo "$line" | cut -d'=' -f2-)
+                echo "::add-mask::$var_value"
+                echo "Loading variable: $var_name"
+                echo "$line" >> $GITHUB_ENV
+              fi
+            done < "$env_file"
+          done
           echo "Environment variables loaded successfully"
 
       - name: Enable strict nightly test requirements
@@ -394,6 +397,7 @@ jobs:
         env:
           EXTERNAL_REPOS_ROOT: ${{ github.workspace }}/external
           NIGHTLY_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-nightly-pytest-${{ github.run_id }}-${{ github.run_attempt }}
+          NIGHTLY_REQUIRE_LANGFUSE_TRACING: "1"
         run: |
           ci/run-nightly-tests.sh
 

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -397,6 +397,7 @@ jobs:
         env:
           EXTERNAL_REPOS_ROOT: ${{ github.workspace }}/external
           NIGHTLY_PYTEST_BASETEMP: ${{ runner.temp }}/datus-agent-nightly-pytest-${{ github.run_id }}-${{ github.run_attempt }}
+          LANGFUSE_TRACING_ENABLED: "true"
           NIGHTLY_REQUIRE_LANGFUSE_TRACING: "1"
         run: |
           ci/run-nightly-tests.sh

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -24,6 +24,7 @@ NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
 AGENT_TEST_CONFIG="${AGENT_TEST_CONFIG:-tests/conf/agent.yml}"
 DATUS_TEST_PROJECT_NAME="${DATUS_TEST_PROJECT_NAME:-datus_agent_nightly}"
 export DATUS_TEST_PROJECT_NAME
+NIGHTLY_REQUIRE_LANGFUSE_TRACING="${NIGHTLY_REQUIRE_LANGFUSE_TRACING:-0}"
 NIGHTLY_COMPOSE_PROJECT_PREFIX="${NIGHTLY_COMPOSE_PROJECT_PREFIX:-datus-nightly-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-}"
 
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(cd "${REPO_ROOT}/.." && pwd)}"
@@ -608,6 +609,36 @@ run_with_agent_home() {
   local status=$?
   restore_agent_test_config
   return "$status"
+}
+
+nightly_requires_langfuse_tracing() {
+  case "$(printf '%s' "$NIGHTLY_REQUIRE_LANGFUSE_TRACING" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+prepare_nightly_langfuse_tracing() {
+  if ! nightly_requires_langfuse_tracing; then
+    return 0
+  fi
+
+  export LANGFUSE_BASE_URL="${LANGFUSE_BASE_URL:-https://us.cloud.langfuse.com}"
+
+  local missing=()
+  if [ -z "${LANGFUSE_PUBLIC_KEY:-}" ]; then
+    missing+=(LANGFUSE_PUBLIC_KEY)
+  fi
+  if [ -z "${LANGFUSE_SECRET_KEY:-}" ]; then
+    missing+=(LANGFUSE_SECRET_KEY)
+  fi
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "Langfuse tracing requested for nightly suites, but missing: ${missing[*]}" | tee -a "$LOG_FILE" >&2
+    return 1
+  fi
+
+  log "Langfuse tracing enabled for nightly suites: base_url=$LANGFUSE_BASE_URL"
 }
 
 nightly_kb_ready_dir() {
@@ -1414,6 +1445,11 @@ log "HIVE_HOST=${HIVE_HOST:-} HIVE_PORT=${HIVE_PORT:-} HIVE_METASTORE_HOST_PORT=
 log "SPARK_HOST=${SPARK_HOST:-} SPARK_PORT=${SPARK_PORT:-} SPARK_THRIFT_HOST_PORT=${SPARK_THRIFT_HOST_PORT:-} SPARK_UI_HOST_PORT=${SPARK_UI_HOST_PORT:-}"
 if [ -n "$NIGHTLY_GROUP_FILTER" ]; then
   log "NIGHTLY_GROUP_FILTER=$NIGHTLY_GROUP_FILTER"
+fi
+
+if ! prepare_nightly_langfuse_tracing; then
+  test_exit_code=1
+  exit "$test_exit_code"
 fi
 
 validate_nightly_group_filter || exit 1

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -2123,7 +2123,10 @@ def resolve_env(value: str) -> str:
     pattern = r"\${([^}]+)}"
 
     def replace_env(match):
-        env_var = match.group(1)
+        expr = match.group(1)
+        env_var, separator, default = expr.partition(":-")
+        if separator:
+            return os.getenv(env_var, default)
         return os.getenv(env_var, f"<MISSING:{env_var}>")
 
     return re.sub(pattern, replace_env, value)

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -109,7 +109,7 @@ agent:
 
   observability:
     tracing:
-      enabled: true
+      enabled: ${LANGFUSE_TRACING_ENABLED:-false}
       service_name: datus-agent-nightly
       environment: nightly
       capture_content: true

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -107,6 +107,15 @@ agent:
         pattern: "sql-*"
         permission: ask
 
+  observability:
+    tracing:
+      enabled: true
+      service_name: datus-agent-nightly
+      environment: nightly
+      capture_content: true
+      adapters:
+        - type: langfuse
+
   agentic_nodes:
     gen_semantic_model:
       max_turns: 40

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -57,6 +57,16 @@ class TestResolveEnv:
         result = resolve_env("${DATUS_NONEXISTENT_VAR_XYZ}")
         assert result == "<MISSING:DATUS_NONEXISTENT_VAR_XYZ>"
 
+    def test_missing_env_var_with_default_uses_default(self, monkeypatch):
+        monkeypatch.delenv("DATUS_NONEXISTENT_VAR_XYZ", raising=False)
+        result = resolve_env("${DATUS_NONEXISTENT_VAR_XYZ:-false}")
+        assert result == "false"
+
+    def test_env_var_with_default_uses_env_value(self, monkeypatch):
+        monkeypatch.setenv("DATUS_ENV_WITH_DEFAULT", "true")
+        result = resolve_env("${DATUS_ENV_WITH_DEFAULT:-false}")
+        assert result == "true"
+
     def test_multiple_env_vars_in_string(self, monkeypatch):
         monkeypatch.setenv("HOST_VAR", "localhost")
         monkeypatch.setenv("PORT_VAR", "5432")


### PR DESCRIPTION
## Why

Nightly runs should upload Langfuse traces with a dedicated nightly key so failures can be inspected without sharing the generic CI environment credentials across all CI workflows.

## Solution

- Load a nightly-specific environment file from the self-hosted CI template directory in the nightly workflow.
- Require Langfuse credentials before running nightly tests when `NIGHTLY_REQUIRE_LANGFUSE_TRACING=1`.
- Enable Langfuse tracing in `tests/conf/agent.yml` with nightly-specific service and environment metadata.

## Test Cases

- `bash -n ci/run-nightly-tests.sh`
- `uv run python -c 'import yaml; yaml.safe_load(open(".github/workflows/run-nightly.yml", encoding="utf-8")); print("workflow yaml ok")'`
- `uv run python - <<'PY'
import yaml
with open('tests/conf/agent.yml', encoding='utf-8') as f:
    yaml.safe_load(f)
print('tests/conf/agent.yml yaml ok')
PY`
- `uv run python - <<'PY'
import os
from datus.configuration.agent_config_loader import load_agent_config
os.environ['LANGFUSE_PUBLIC_KEY'] = 'pk-lf-test'
os.environ['LANGFUSE_SECRET_KEY'] = 'sk-lf-test'
os.environ['LANGFUSE_BASE_URL'] = 'https://us.cloud.langfuse.com'
cfg = load_agent_config(config='tests/conf/agent.yml', datasource='bird_school', reload=True, force=True, yes=True)
print(cfg.observability.tracing.enabled, cfg.observability.tracing.service_name, cfg.observability.tracing.environment, cfg.observability.tracing.adapters[0].type)
PY`
- `uv run pytest tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigObservability --tb=short --verbose`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Langfuse tracing for nightly test runs
  * Nightly observability enabled with service/environment identification and content capture

* **Chores**
  * Improved nightly workflow environment loading and masking for reliable test setup
  * Config interpolation now supports default values for environment variables

* **Tests**
  * Added unit tests covering env-variable default interpolation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->