### PR TITLE
[Enhancement] Skip finalize LLM stage for render-only visual artifact edits

### DIFF
--- a/datus/agent/node/_visual_artifact_finalize.py
+++ b/datus/agent/node/_visual_artifact_finalize.py
@@ -1191,6 +1191,7 @@ def run_finalize_analysis(
     actions: Iterable[ActionHistory],
     db_func_tool: Optional[Any] = None,
     on_progress: Optional[Callable[[int], None]] = None,
+    skip_narrative: bool = False,
 ) -> Dict[str, Any]:
     """Top-level orchestrator. Returns a result dict::
 
@@ -1233,65 +1234,73 @@ def run_finalize_analysis(
       second LLM call when the first one is already broken.
     * ``analysis/subject_refs.json`` — present iff non-empty. LLM-free.
     * ``manifest.json`` — ``key_tables`` field refreshed. LLM-free.
+
+    ``skip_narrative`` short-circuits the two LLM stages (insights /
+    suggested_questions + intent curation) for render-only edits where the
+    underlying data is unchanged. The existing ``insights.json`` /
+    ``suggested_questions.json`` are left in place (NOT deleted — they're
+    still valid), and the deterministic aggregations below still run so the
+    ask_* consultant's indices stay fresh. The result carries
+    ``skipped_narrative: True`` and ``ok: True``.
     """
     warnings: List[str] = []
-
-    intent_md = load_intent_md(analysis_dir)
-    query_briefs = collect_query_briefs(queries_dir)
-    query_previews = collect_query_previews(queries_dir)
-    action_hints = collect_action_history_hints(actions)
-    existing_insights, existing_sq = load_existing_finalize_output(analysis_dir)
-
-    prompt = build_finalize_prompt(
-        artifact_kind=artifact_kind,
-        intent_md=intent_md,
-        query_briefs=query_briefs,
-        query_previews=query_previews,
-        action_history_hints=action_hints,
-        existing_insights=existing_insights,
-        existing_suggested_questions=existing_sq,
-    )
-
     output: Optional[FinalizeAnalysisOutput] = None
     llm_error: Optional[str] = None
 
-    if on_progress is not None:
-        try:
-            on_progress(1)
-        except Exception as exc:
-            logger.debug("Finalize on_progress(1) raised: %s", exc)
+    if not skip_narrative:
+        intent_md = load_intent_md(analysis_dir)
+        query_briefs = collect_query_briefs(queries_dir)
+        query_previews = collect_query_previews(queries_dir)
+        action_hints = collect_action_history_hints(actions)
+        existing_insights, existing_sq = load_existing_finalize_output(analysis_dir)
 
-    try:
-        raw = model.generate_with_json_output(prompt)
-    except Exception as exc:
-        logger.warning("Finalize LLM call failed: %s", exc)
-        llm_error = f"finalize llm call failed: {exc}"
-
-    if llm_error is None:
-        try:
-            output = parse_finalize_output(raw, artifact_kind=artifact_kind)
-        except Exception as exc:
-            logger.warning("Finalize output validation failed: %s", exc)
-            llm_error = f"finalize output invalid: {exc}"
-
-    if output is not None:
-        warnings.extend(write_finalize_output(analysis_dir, output=output, artifact_kind=artifact_kind))
+        prompt = build_finalize_prompt(
+            artifact_kind=artifact_kind,
+            intent_md=intent_md,
+            query_briefs=query_briefs,
+            query_previews=query_previews,
+            action_history_hints=action_hints,
+            existing_insights=existing_insights,
+            existing_suggested_questions=existing_sq,
+        )
 
         if on_progress is not None:
             try:
-                on_progress(2)
+                on_progress(1)
             except Exception as exc:
-                logger.debug("Finalize on_progress(2) raised: %s", exc)
+                logger.debug("Finalize on_progress(1) raised: %s", exc)
 
-        # Independent LLM call: curate intent.md by stripping operational
-        # nudges + pure render adjustments. Failures degrade to "leave the
-        # original file unchanged + record a warning" — never blocks the
-        # main artifact (which is already on disk by now). Gated on the
-        # main finalize LLM succeeding so we don't keep hammering the
-        # model when it's already returned us nothing usable.
-        curation_warning = run_intent_curation(model, analysis_dir / "intent.md")
-        if curation_warning:
-            warnings.append(curation_warning)
+        try:
+            raw = model.generate_with_json_output(prompt)
+        except Exception as exc:
+            logger.warning("Finalize LLM call failed: %s", exc)
+            llm_error = f"finalize llm call failed: {exc}"
+
+        if llm_error is None:
+            try:
+                output = parse_finalize_output(raw, artifact_kind=artifact_kind)
+            except Exception as exc:
+                logger.warning("Finalize output validation failed: %s", exc)
+                llm_error = f"finalize output invalid: {exc}"
+
+        if output is not None:
+            warnings.extend(write_finalize_output(analysis_dir, output=output, artifact_kind=artifact_kind))
+
+            if on_progress is not None:
+                try:
+                    on_progress(2)
+                except Exception as exc:
+                    logger.debug("Finalize on_progress(2) raised: %s", exc)
+
+            # Independent LLM call: curate intent.md by stripping operational
+            # nudges + pure render adjustments. Failures degrade to "leave the
+            # original file unchanged + record a warning" — never blocks the
+            # main artifact (which is already on disk by now). Gated on the
+            # main finalize LLM succeeding so we don't keep hammering the
+            # model when it's already returned us nothing usable.
+            curation_warning = run_intent_curation(model, analysis_dir / "intent.md")
+            if curation_warning:
+                warnings.append(curation_warning)
 
     # Deterministic aggregations below — these only read files on disk
     # and never call the LLM, so they run regardless of LLM success.
@@ -1336,6 +1345,18 @@ def run_finalize_analysis(
         "reference_sql": len(refs.reference_sql),
         "ext_knowledge": len(refs.ext_knowledge),
     }
+
+    if skip_narrative:
+        # Render-only edit: narrative outputs were intentionally not
+        # regenerated and the prior insights / suggested_questions stay on
+        # disk untouched. No consistency_check (no fresh ``output`` to check).
+        return {
+            "ok": True,
+            "skipped_narrative": True,
+            "warnings": warnings,
+            "key_tables": key_tables,
+            "subject_refs_count": subject_refs_count,
+        }
 
     if llm_error is not None:
         # LLM failed but the deterministic outputs are already on disk.

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -466,6 +466,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         artifact_slug: str,
         actions: List[ActionHistory],
         on_progress: Optional[Any] = None,
+        skip_narrative: bool = False,
     ) -> Dict[str, Any]:
         """Run the finalize analysis stage for the just-completed artifact.
 
@@ -477,6 +478,10 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         stage boundary (1=insights LLM, 2=intent curation, 3=schema bake)
         so the streaming hook can surface stage transitions to the user
         without waiting for the artifact SSE event 10-15 s later.
+
+        ``skip_narrative`` skips the two LLM stages (insights /
+        suggested_questions + intent curation) for render-only edits where
+        the data is unchanged; the deterministic aggregations still run.
         """
         try:
             project_root = Path(self.agent_config.project_root).resolve()
@@ -490,6 +495,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
                 queries_dir=queries_dir,
                 analysis_dir=analysis_dir,
                 actions=actions,
+                skip_narrative=skip_narrative,
                 # ``db_func_tool`` is wired by ``setup_tools`` early in
                 # the run. Passing it through enables the finalize-time
                 # ``key_tables_schema.json`` bake (describe_table snapshot
@@ -743,6 +749,11 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         ctx.extras["artifact_app_jsx_rel_path"] = app_jsx_rel_path
         ctx.extras["artifact_slug"] = self._active_artifact_slug
         ctx.extras["artifact_all_actions"] = all_actions
+        # save_query[_template] is the only path that mutates queries/ during a
+        # run, so "no query saved this run" ⟺ underlying data unchanged (a
+        # render-only edit like a chart-type swap). Insights / suggested
+        # questions stay valid in that case — let finalize skip its LLM stage.
+        ctx.extras["artifact_data_changed"] = len(query_actions) > 0
         return result
 
     def _build_error_result(self, exc: BaseException, ctx: "StreamRunContext") -> ResultT:
@@ -778,6 +789,11 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         if not slug or not app_jsx_rel_path:
             return
 
+        # Render-only edit (no query saved this run): skip the finalize LLM
+        # stage and its per-stage progress bubbles — the only work left is the
+        # deterministic schema/key_tables refresh, which needs no narration.
+        skip_narrative = not ctx.extras.get("artifact_data_changed", True)
+
         progress_queue: asyncio.Queue = asyncio.Queue()
         loop = asyncio.get_running_loop()
         sentinel = object()
@@ -787,9 +803,11 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             # before touching the asyncio.Queue.
             loop.call_soon_threadsafe(progress_queue.put_nowait, stage)
 
+        progress_cb = None if skip_narrative else _on_progress
+
         async def _run_finalize_off_thread() -> Dict[str, Any]:
             try:
-                return await asyncio.to_thread(self._run_finalize, slug, all_actions, _on_progress)
+                return await asyncio.to_thread(self._run_finalize, slug, all_actions, progress_cb, skip_narrative)
             finally:
                 loop.call_soon_threadsafe(progress_queue.put_nowait, sentinel)
 

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -1934,3 +1934,133 @@ class TestRunFinalizeAnalysis:
         # ``model.generate`` is the intent curation entry point — it must
         # not have been called when the primary finalize LLM blew up.
         assert model.generate.call_count == 0
+
+    def test_on_progress_fires_for_each_narrative_stage(self, tmp_path: Path):
+        """The streaming hook drives stage bubbles off ``on_progress``;
+        the narrative path must signal stage 1 (insights LLM), 2 (intent
+        curation) and 3 (schema bake) in order."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+        (analysis_dir / "intent.md").write_text(_ORIGINAL_INTENT, encoding="utf-8")
+
+        model = Mock(spec=["generate_with_json_output", "generate"])
+        model.generate_with_json_output.return_value = _full_finalize_response()
+        model.generate.return_value = _CURATED_BODY
+
+        stages: list[int] = []
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            on_progress=stages.append,
+        )
+
+        assert result["ok"] is True
+        assert stages == [1, 2, 3]
+
+    def test_on_progress_callback_error_does_not_break_finalize(self, tmp_path: Path):
+        """A throwing ``on_progress`` must not abort finalize — the stage
+        callbacks are best-effort UI nudges."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+
+        model = Mock(spec=["generate_with_json_output", "generate"])
+        model.generate_with_json_output.return_value = _full_finalize_response()
+
+        def _boom(_stage: int) -> None:
+            raise RuntimeError("queue closed")
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            on_progress=_boom,
+        )
+
+        assert result["ok"] is True
+        assert (analysis_dir / "insights.json").is_file()
+
+
+class TestRunFinalizeSkipNarrative:
+    """``skip_narrative=True`` (render-only edit): no LLM call, existing
+    narrative files untouched, deterministic aggregations still run."""
+
+    def _seed_existing_narrative(self, analysis_dir: Path) -> tuple[str, str]:
+        insights = json.dumps([{"id": "i1", "title": "t", "summary": "s"}]) + "\n"
+        sq = json.dumps([{"question": "q?", "kind": "quick"}]) + "\n"
+        (analysis_dir / "insights.json").write_text(insights, encoding="utf-8")
+        (analysis_dir / "suggested_questions.json").write_text(sq, encoding="utf-8")
+        return insights, sq
+
+    def test_skips_llm_and_preserves_existing_files(self, tmp_path: Path):
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+        insights, sq = self._seed_existing_narrative(analysis_dir)
+        (analysis_dir / "intent.md").write_text(_ORIGINAL_INTENT, encoding="utf-8")
+
+        model = Mock(spec=["generate_with_json_output", "generate"])
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            skip_narrative=True,
+        )
+
+        assert result["ok"] is True
+        assert result["skipped_narrative"] is True
+        # Neither LLM entry point fired.
+        assert model.generate_with_json_output.call_count == 0
+        assert model.generate.call_count == 0
+        # Prior narrative files + intent.md left exactly as they were.
+        assert (analysis_dir / "insights.json").read_text(encoding="utf-8") == insights
+        assert (analysis_dir / "suggested_questions.json").read_text(encoding="utf-8") == sq
+        assert (analysis_dir / "intent.md").read_text(encoding="utf-8") == _ORIGINAL_INTENT
+
+    def test_still_refreshes_subject_refs_and_key_tables(self, tmp_path: Path):
+        # A real FROM clause so key_tables aggregation has something to record.
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(
+            tmp_path, sql_body="SELECT region FROM finbench.main.Account"
+        )
+
+        result = run_finalize_analysis(
+            model=Mock(spec=["generate_with_json_output", "generate"]),
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            skip_narrative=True,
+        )
+
+        assert result["ok"] is True
+        # Deterministic outputs still produced from on-disk briefs/SQL.
+        assert (analysis_dir / "subject_refs.json").is_file()
+        assert result["subject_refs_count"]["metrics"] == 1
+        assert "finbench.main.Account" in result["key_tables"]
+        manifest = json.loads((artifact_dir / "manifest.json").read_text(encoding="utf-8"))
+        assert "finbench.main.Account" in manifest["key_tables"]
+
+    def test_does_not_create_narrative_files_when_absent(self, tmp_path: Path):
+        # No prior insights/suggested_questions on disk: skip must not mint them.
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+
+        result = run_finalize_analysis(
+            model=Mock(spec=["generate_with_json_output", "generate"]),
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            skip_narrative=True,
+        )
+
+        assert result["ok"] is True
+        assert not (analysis_dir / "insights.json").exists()
+        assert not (analysis_dir / "suggested_questions.json").exists()


### PR DESCRIPTION
## Why

After a visual report / dashboard run, the finalize stage spends **two LLM calls** regenerating `insights.json` + `suggested_questions.json` and curating `intent.md`. For render-only edits — e.g. *"change this chart to a bar chart"*, color/layout tweaks — the underlying data is unchanged, so the existing insights and suggested questions are still valid. Regenerating them burns latency and tokens (and emits confusing "Generating insights…" progress bubbles) for an edit that didn't touch any data.

## Solution

Skip the finalize LLM stage when the run saved **zero** queries.

`save_query` / `save_query_template` is the only path that mutates `queries/` during a run, so "no query saved this run" ⟺ the underlying data is unchanged (a render-only edit). The signal is already computed in `_build_success_result` (`query_actions`); no extra LLM classification or frontend coupling required.

- `base_visual_artifact_agentic_node`: stash `artifact_data_changed = len(query_actions) > 0`; `_stream_post_build` derives `skip_narrative` and, when skipping, passes no progress callback (no stage bubbles).
- `_visual_artifact_finalize.run_finalize_analysis(..., skip_narrative=False)`: when `True`, bypass the insights/suggested_questions LLM call **and** intent curation, leave any existing `insights.json` / `suggested_questions.json` **in place** (they're still valid — not deleted), and still run the deterministic aggregations (`subject_refs.json`, `manifest.key_tables`, schema bake) so the ask_* consultant's indices stay fresh. Result carries `skipped_narrative: True`, `ok: True`.

Shared by both report and dashboard via the base node.

### Edge cases

- New artifact (create mode) always saves queries → never skipped.
- Mixed edits (style + a new column / metric) save a query → not skipped.
- Dashboards already force `insights: []`; skipping mainly saves `suggested_questions` + intent curation.

### Known limitation

A redundant `save_query` on an unchanged query would defeat the skip (falls back to current behavior — no regression, just a missed saving). If telemetry shows this, a fast-follow can have `save_query` report whether the SQL actually changed.

## Test Cases

`tests/unit_tests/agent/node/test_visual_artifact_finalize.py`:
- `TestRunFinalizeSkipNarrative`: skip path makes no LLM call, preserves existing `insights.json` / `suggested_questions.json` + `intent.md`, still refreshes `subject_refs.json` / `manifest.key_tables`, and does not mint narrative files when none existed.
- Added `on_progress` stage-ordering + callback-error tests on the narrative path.

Diff coverage 100% on both changed source files; `ruff` + test-quality audit (P0=0) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional finalization mode that preserves existing analysis content while still refreshing underlying data, enabling faster processing for render-only edits.

* **Tests**
  * Expanded test coverage for finalization workflows, including verification of content preservation and data aggregation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->