### PR TITLE
[BugFix] End normally when a visual artifact run answers in prose without binding

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -638,6 +638,14 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         """
         return None
 
+    def _binding_tool_action_types(self) -> set:
+        """Tool action types that bind an artifact for this run.
+
+        Used to tell a real "never bound" failure apart from an
+        informational prose answer (which makes no binding attempt).
+        """
+        return {f"start_new_{self.ARTIFACT_KIND}", f"bind_existing_{self.ARTIFACT_KIND}"}
+
     def _missing_binding_error(self) -> str:
         kind = self.ARTIFACT_KIND
         return (
@@ -725,15 +733,30 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         )
 
         if app_jsx_rel_path is None:
-            error_msg = (
-                self._missing_binding_error() if self._active_artifact_slug is None else self._incomplete_render_error()
+            # No render produced. Separate a genuine "forgot to bind / render"
+            # failure from a legitimate informational turn: when the model
+            # never attempted to bind an artifact and answered the user in
+            # prose (e.g. "what changes did I make?"), that's a valid response
+            # — end normally instead of forcing the missing-binding error.
+            binding_attempted = any(a.action_type in self._binding_tool_action_types() for a in all_actions)
+            informational_answer = (
+                self._active_artifact_slug is None and not binding_attempted and bool(response_content.strip())
             )
-            if hasattr(result, "error"):
-                result.error = error_msg  # type: ignore[attr-defined]
-            # When the render is incomplete, success must reflect that so the
-            # template's final action emits SUCCESS=False status.
-            if hasattr(result, "success"):
-                result.success = False  # type: ignore[attr-defined]
+            if informational_answer:
+                if hasattr(result, "success"):
+                    result.success = True  # type: ignore[attr-defined]
+            else:
+                error_msg = (
+                    self._missing_binding_error()
+                    if self._active_artifact_slug is None
+                    else self._incomplete_render_error()
+                )
+                if hasattr(result, "error"):
+                    result.error = error_msg  # type: ignore[attr-defined]
+                # When the render is incomplete, success must reflect that so the
+                # template's final action emits SUCCESS=False status.
+                if hasattr(result, "success"):
+                    result.success = False  # type: ignore[attr-defined]
 
         # Stash artifact summary so ``_final_summary_for_action`` (used by the
         # base template's final action emit) can render the right message.

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -326,13 +326,13 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
 
 
 @pytest.mark.asyncio
-async def test_execute_stream_fails_when_no_binding(real_agent_config, mock_llm_create):
-    """If the LLM never calls start_/bind_existing_dashboard, the node fails clearly."""
+async def test_execute_stream_fails_when_no_binding_and_no_answer(real_agent_config, mock_llm_create):
+    """No binding AND no prose answer (the run did nothing) → fails clearly."""
     mock_llm_create.reset(
         responses=[
             build_tool_then_response(
                 tool_calls=[],
-                content="I changed my mind.",
+                content="",
             ),
         ]
     )
@@ -349,6 +349,35 @@ async def test_execute_stream_fails_when_no_binding(real_agent_config, mock_llm_
     assert isinstance(result, dict)
     assert result["success"] is False
     assert "start_new_dashboard" in (result.get("error") or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_stream_informational_answer_ends_normally(real_agent_config, mock_llm_create):
+    """An informational question (e.g. "what changes did I make?") answered in
+    prose without binding an artifact must end normally — not surface the
+    internal "Run finished without binding a dashboard" error."""
+    answer = "In this session you changed 2 charts: revenue trend → bar, product mix → donut."
+    mock_llm_create.reset(
+        responses=[
+            build_tool_then_response(tool_calls=[], content=answer),
+        ]
+    )
+
+    node = _make_node(real_agent_config)
+    node.input = GenVisualDashboardNodeInput(user_message="what changes did I make?", database="california_schools")
+    actions = []
+    async for action in node.execute_stream(ActionHistoryManager()):
+        actions.append(action)
+
+    final = actions[-1]
+    assert final.status == ActionStatus.SUCCESS
+    result = final.output
+    assert isinstance(result, dict)
+    assert result["success"] is True
+    assert not result.get("error")
+    assert result["dashboard_slug"] is None
+    assert result["app_jsx_path"] is None
+    assert result["response"] == answer
 
 
 class TestNodeFactoryDashboardBranch:

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -397,13 +397,13 @@ class TestAutoOpenInBrowser:
 
 
 @pytest.mark.asyncio
-async def test_execute_stream_without_binding_marks_failure(real_agent_config, mock_llm_create):
-    """LLM never binds a report → run reports a binding-required failure."""
+async def test_execute_stream_without_binding_and_no_answer_marks_failure(real_agent_config, mock_llm_create):
+    """No binding AND no prose answer (the run did nothing) → binding-required failure."""
     from tests.unit_tests.mock_llm_model import build_simple_response
 
     mock_llm_create.reset(
         responses=[
-            build_simple_response("I gathered context but never bound a report."),
+            build_simple_response(""),
         ]
     )
 
@@ -432,6 +432,33 @@ async def test_execute_stream_without_binding_marks_failure(real_agent_config, m
     assert result["name"] is None
     assert result["description"] is None
     assert result["created_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_stream_informational_answer_ends_normally(real_agent_config, mock_llm_create):
+    """An informational question answered in prose without binding a report
+    ends normally instead of surfacing the internal missing-binding error."""
+    from tests.unit_tests.mock_llm_model import build_simple_response
+
+    answer = "Earlier you switched the revenue chart to monthly and added a YoY column."
+    mock_llm_create.reset(responses=[build_simple_response(answer)])
+
+    node = _make_node(real_agent_config)
+    node.input = GenVisualReportNodeInput(user_message="what did I change?")
+
+    actions = []
+    async for action in node.execute_stream(ActionHistoryManager()):
+        actions.append(action)
+
+    final = actions[-1]
+    assert final.status == ActionStatus.SUCCESS
+    result = final.output
+    assert isinstance(result, dict)
+    assert result["success"] is True
+    assert not result.get("error")
+    assert result["report_slug"] is None
+    assert result["app_jsx_path"] is None
+    assert result["response"] == answer
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

When a user asks a visual report / dashboard subagent an **informational question** — e.g. *"what changes did I make?"* — the model correctly answers in prose without binding or producing an artifact. The run then ends with a user-facing error:

> Run finished without binding a dashboard. The LLM must call either start_new_dashboard(...) or bind_existing_dashboard(...) before producing the artifact.

The model's answer streamed fine; the error message is an internal contract signal (`_build_success_result` forces `success=False` + the missing-binding error whenever no render was produced) and shouldn't be shown for a legitimate prose answer.

## Solution

In the shared `BaseVisualArtifactAgenticNode._build_success_result`, distinguish a genuine "forgot to bind / render" failure from a legitimate informational turn:

- A run that **never attempted to bind** an artifact (no `start_new_<kind>` / `bind_existing_<kind>` in the action history) **and** produced a non-empty prose response is treated as a normal informational answer → `success=True`, no error, the answer is preserved.
- All real failure paths are unchanged:
  - binding attempted but no render → still the "incomplete render" error;
  - nothing bound **and** no prose answer (the run did nothing) → still the missing-binding error.

The discriminator is `_binding_tool_action_types()` (= `{start_new_<kind>, bind_existing_<kind>}`), so an informational reply is told apart from a failed build by whether a binding was ever attempted — not by inspecting the prose. Shared by both report and dashboard via the base node.

## Test Cases

`tests/unit_tests/agent/node/`:
- `test_gen_visual_dashboard_agentic_node` / `test_gen_visual_report_agentic_node`: new `test_execute_stream_informational_answer_ends_normally` — prose answer, no binding → `success=True`, no error, response preserved.
- Repurposed the prior "without binding fails" tests to the genuine no-op case (empty response + no binding) so the missing-binding failure path stays covered.

Diff coverage 100% on the changed source; `ruff` + test-quality audit (P0=0, P1=0) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of informational responses that don't bind artifacts, distinguishing between genuine failures (no binding and no answer) and valid prose-only responses.

* **Tests**
  * Added test coverage for informational answers without artifact binding.
  * Enhanced test specificity for failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->