### PR TITLE
[BugFix] Honor SubAgent.tools whitelist on ask_report / ask_dashboard nodes

### DIFF
--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -157,6 +157,25 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     # (``ask_dashboard``) keep this False so the disk path stays available.
     BLOB_REQUIRED: ClassVar[bool] = False
 
+    # Capability tool groups gated by the subagent's ``tools`` whitelist, mapped
+    # to the node attribute that holds the built tool instance. Infrastructure
+    # tools (artifact-anchored filesystem, ask_user, plan/todo, sub-agent
+    # delegation) are deliberately ABSENT: a read-only consultant needs them to
+    # read its bound artifact and converse regardless of the whitelist, so they
+    # always survive pruning — mirroring GenSQLAgenticNode's always-on
+    # filesystem + sub_agent_task + plan set. ``read_query`` & friends live
+    # under ``db_tools`` and are dropped unless explicitly whitelisted.
+    _WHITELIST_GROUP_ATTRS: ClassVar[Dict[str, str]] = {
+        "db_tools": "db_func_tool",
+        "context_search_tools": "context_search_tools",
+        "semantic_tools": "semantic_tools",
+        "reference_template_tools": "reference_template_tools",
+        "date_parsing_tools": "date_parsing_tools",
+        "platform_doc_tools": "_platform_doc_tool",
+        "bash_tools": "bash_tool",
+        "skills": "skill_func_tool",
+    }
+
     def __init__(
         self,
         node_id: str,
@@ -176,6 +195,13 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # need our own (``node_name`` from agentic_nodes, e.g. "ask_xxx") so
         # template resolution + node_config lookup land on the right entry.
         self._configured_subagent_name = node_name or self.NODE_NAME
+
+        # ChatAgenticNode never builds semantic tools, but an ask_* ``tools``
+        # whitelist may request them (metric/dimension/attribution analysis).
+        # Declare the slot before super().__init__() (which triggers
+        # ``setup_tools``) so the whitelist pass can build it on demand and
+        # ``_tool_category_map`` can reference it safely.
+        self.semantic_tools = None
 
         # Resolve the artifact binding BEFORE super().__init__() because
         # ChatAgenticNode.__init__ calls ``setup_tools()`` synchronously,
@@ -230,6 +256,148 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if name:
             return name
         return self.configured_node_name or self.NODE_NAME
+
+    # ── Tool whitelist enforcement (honor SubAgent.tools) ───────────────
+
+    def setup_tools(self) -> None:
+        """Build the full chat tool surface, then constrain capability tools
+        to the subagent's configured ``tools`` whitelist.
+
+        ChatAgenticNode wires its capability tools (db_tools, context_search,
+        …) unconditionally and never consults ``tools``. For an ask_*
+        consultant that field is a hard whitelist — the agent must not reach a
+        capability the operator did not grant (e.g. ``read_query`` when only
+        semantic/context tools were configured). We reuse the base setup so all
+        infrastructure (permission/skill managers, artifact-anchored
+        filesystem, plan + sub-agent tooling) is built correctly, then apply
+        the whitelist. An empty/absent whitelist leaves the inherited surface
+        untouched (back-compat for ask agents created before tool scoping).
+        """
+        super().setup_tools()
+        self._apply_tools_whitelist()
+
+    def _rebuild_tools(self) -> None:
+        """Re-apply the whitelist after any base rebuild.
+
+        ``ChatAgenticNode._rebuild_tools`` (also reached via a mid-session
+        datasource switch) repopulates ``self.tools`` from the full set of tool
+        instances, which would silently re-expose pruned capabilities. Re-running
+        the whitelist here keeps the constraint enforced for the life of the
+        node. Safe during ``super().__init__`` because the slots it reads are
+        initialised beforehand or accessed via ``getattr``.
+        """
+        super()._rebuild_tools()
+        self._apply_tools_whitelist()
+
+    def _tool_category_map(self) -> Dict[str, List[Any]]:
+        """Register semantic tools under their canonical permission category.
+
+        The chat base has no semantic tools so its map omits them; when the
+        whitelist makes us build them, surface them here so PermissionHooks
+        matches ``semantic_tools.*`` rules instead of the ``tools.*`` catch-all.
+        """
+        mapping = super()._tool_category_map()
+        if getattr(self, "semantic_tools", None):
+            mapping["semantic_tools"] = list(self.semantic_tools.available_tools())
+        return mapping
+
+    def _apply_tools_whitelist(self) -> None:
+        """Constrain ``self.tools`` to the configured whitelist + infrastructure."""
+        patterns = self._parse_tool_whitelist(self.node_config.get("tools"))
+        if not patterns:
+            # Unconfigured -> keep the inherited full surface (back-compat).
+            return
+        self._ensure_whitelisted_groups_present(patterns)
+        self._prune_capability_tools(patterns)
+
+    @staticmethod
+    def _parse_tool_whitelist(tools_value: Any) -> List[str]:
+        """Split the comma-separated ``tools`` field into trimmed patterns."""
+        if not tools_value or not str(tools_value).strip():
+            return []
+        return [p.strip() for p in str(tools_value).split(",") if p.strip()]
+
+    @staticmethod
+    def _tool_matches_whitelist(group: str, tool_name: str, patterns: List[str]) -> bool:
+        """True if ``group``/``tool_name`` is granted by any whitelist pattern.
+
+        Accepts the same three shapes GenSQLAgenticNode does: ``group`` (whole
+        group), ``group.*`` (wildcard) and ``group.<method>`` (single tool).
+        """
+        candidates = {group, f"{group}.*", f"{group}.{tool_name}"}
+        return any(p in candidates for p in patterns)
+
+    def _ensure_whitelisted_groups_present(self, patterns: List[str]) -> None:
+        """Build + surface whitelisted capability groups the chat base omits.
+
+        Only ``semantic_tools`` falls in this bucket today — ChatAgenticNode
+        builds every other gated group. Built once, then re-surfaced into
+        ``self.tools`` on every call so a post-rebuild whitelist pass does not
+        lose it (``_rebuild_tools`` never re-adds semantic tools itself).
+        """
+        wants_semantic = any(p == "semantic_tools" or p.startswith("semantic_tools.") for p in patterns)
+        if not wants_semantic:
+            return
+        if not getattr(self, "semantic_tools", None):
+            try:
+                from datus.tools.func_tool.semantic_tools import SemanticTools
+
+                self.semantic_tools = SemanticTools(
+                    agent_config=self.agent_config,
+                    sub_agent_name=self.node_config.get("system_prompt"),
+                    adapter_type=self.node_config.get("adapter_type", "metricflow"),
+                )
+            except Exception as exc:
+                logger.error("%s: failed to build whitelisted semantic_tools: %s", self.get_node_name(), exc)
+                return
+        present = {t.name for t in self.tools}
+        for tool in self.semantic_tools.available_tools():
+            if tool.name not in present:
+                self.tools.append(tool)
+
+    def _capability_tool_groups(self) -> Dict[str, str]:
+        """Map each built capability tool *name* -> its whitelist group label.
+
+        Built only from the gated groups in ``_WHITELIST_GROUP_ATTRS``;
+        infrastructure tools are intentionally excluded so they never appear
+        here and therefore always survive pruning.
+        """
+        name_to_group: Dict[str, str] = {}
+        for group, attr in self._WHITELIST_GROUP_ATTRS.items():
+            inst = getattr(self, attr, None)
+            if not inst:
+                continue
+            try:
+                for tool in inst.available_tools():
+                    name_to_group[tool.name] = group
+            except Exception as exc:
+                logger.warning("%s: cannot enumerate %s tools for whitelist: %s", self.get_node_name(), group, exc)
+        return name_to_group
+
+    def _prune_capability_tools(self, patterns: List[str]) -> None:
+        """Drop every capability tool not granted by the whitelist.
+
+        A tool is kept when it is NOT a gated capability (i.e. infrastructure)
+        or when a whitelist pattern grants it. Idempotent — safe to call on
+        every rebuild.
+        """
+        name_to_group = self._capability_tool_groups()
+        kept: List[Any] = []
+        dropped: List[str] = []
+        for tool in self.tools:
+            group = name_to_group.get(tool.name)
+            if group is None or self._tool_matches_whitelist(group, tool.name, patterns):
+                kept.append(tool)
+            else:
+                dropped.append(tool.name)
+        self.tools = kept
+        if dropped:
+            logger.info(
+                "%s tools whitelist applied: dropped=%s exposed=%s",
+                self.get_node_name(),
+                sorted(set(dropped)),
+                sorted({t.name for t in kept}),
+            )
 
     # ── Artifact binding resolution ─────────────────────────────────────
 

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -1783,3 +1783,207 @@ class TestTableSchemasSection:
         # "snapshot only" contract visible from the tree itself.
         assert any("inlined above" in line for line in tree_lines)
         assert any("describe_table" in line for line in tree_lines)
+
+
+# --------------------------------------------------------------------------- #
+# Tool whitelist enforcement (honor SubAgent.tools)                           #
+# --------------------------------------------------------------------------- #
+
+
+def _register_ask_agent_with_tools(
+    agent_config,
+    *,
+    name: str,
+    kind: str,
+    slug: str,
+    tools,
+    blob: dict | None = None,
+) -> None:
+    """Register an ask_* agentic_nodes entry with an explicit ``tools`` value.
+
+    The shared :func:`_register_ask_agent` hardcodes ``tools`` to a db-tools
+    whitelist; these tests need to drive the whitelist directly (including the
+    empty / absent cases), so we register the entry by hand. ``tools=None``
+    omits the key entirely (the "never configured" path).
+    """
+    agent_type = "ask_report" if kind == "report" else "ask_dashboard"
+    if not hasattr(agent_config, "agentic_nodes") or agent_config.agentic_nodes is None:
+        agent_config.agentic_nodes = {}
+    entry = {
+        "type": agent_type,
+        "artifact_slug": slug,
+        "agent_description": f"Ask consultant for {slug}",
+        "rules": [],
+        "max_turns": 5,
+    }
+    if tools is not None:
+        entry["tools"] = tools
+    if blob is not None:
+        entry["artifact_blob"] = blob
+    agent_config.agentic_nodes[name] = entry
+
+
+def _make_ask_report_with_tools(agent_config, tools, *, name: str = "ask_wl_report", slug: str = "wl_report"):
+    """Build an AskReportAgenticNode whose ``tools`` whitelist is ``tools``."""
+    _seed_artifact(agent_config.project_root, "report", slug)
+    blob = _blob_from_disk(agent_config.project_root, "report", slug)
+    _register_ask_agent_with_tools(agent_config, name=name, kind="report", slug=slug, tools=tools, blob=blob)
+    return AskReportAgenticNode(
+        node_id=f"{name}_t",
+        description="d",
+        node_type="chat",
+        agent_config=agent_config,
+        node_name=name,
+    )
+
+
+def _make_ask_dashboard_with_tools(agent_config, tools, *, name: str = "ask_wl_dash", slug: str = "wl_dash"):
+    """Build an AskDashboardAgenticNode (disk path) with ``tools`` whitelist."""
+    _seed_artifact(agent_config.project_root, "dashboard", slug)
+    _register_ask_agent_with_tools(agent_config, name=name, kind="dashboard", slug=slug, tools=tools)
+    return AskDashboardAgenticNode(
+        node_id=f"{name}_t",
+        description="d",
+        node_type="chat",
+        agent_config=agent_config,
+        node_name=name,
+    )
+
+
+def _tool_names(node) -> set:
+    return {t.name for t in node.tools}
+
+
+def _fs_tool_names(node) -> set:
+    return {t.name for t in node.filesystem_func_tool.available_tools()}
+
+
+# Mirrors the real ``customer_retention_analysis`` subagent: semantic-heavy,
+# a few specific context_search methods, all date parsing — and crucially NO
+# db_tools, so ``read_query`` must not leak in.
+_NO_DB_WHITELIST = (
+    "context_search_tools.get_metrics,context_search_tools.list_subject_tree,"
+    "context_search_tools.search_metrics,date_parsing_tools.*,"
+    "semantic_tools.attribution_analyze,semantic_tools.get_dimensions,"
+    "semantic_tools.list_metrics,semantic_tools.query_metrics"
+)
+
+
+class TestToolsWhitelist:
+    """A configured ``tools`` whitelist is a hard cap on the LLM-facing surface.
+
+    Pins the fix for the leak where ask_* nodes (ChatAgenticNode subclasses)
+    ignored ``tools`` and always wired db_tools, leaving ``read_query``
+    callable for a subagent that only whitelisted semantic/context tools.
+    """
+
+    def test_db_tools_dropped_when_not_whitelisted(self, real_agent_config):
+        """The core regression: ``read_query`` (and siblings) must be gone
+        when the whitelist omits ``db_tools``."""
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        for db_tool in ("read_query", "list_tables", "describe_table", "get_table_ddl"):
+            assert db_tool not in names, f"{db_tool} leaked despite not being whitelisted"
+
+    def test_whitelisted_tools_are_exposed(self, real_agent_config):
+        """Whitelisted tools the runtime actually builds are present — including
+        semantic tools the chat base never builds (proving on-demand build).
+
+        ``attribution_analyze`` and the context_search tools are gated on
+        optional adapters / subject-KB content absent from the CI fixture, so
+        we assert on the adapter-independent semantic wrappers + date parsing,
+        all of which are reliably built here.
+        """
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        expected = {"query_metrics", "get_dimensions", "list_metrics", "parse_temporal_expressions"}
+        missing = expected - names
+        assert not missing, f"whitelisted tools missing from node surface: {sorted(missing)}"
+
+    def test_method_level_whitelist_is_precise(self, real_agent_config):
+        """``db_tools.read_query`` grants exactly that method — sibling db
+        methods that weren't listed stay dropped."""
+        node = _make_ask_report_with_tools(real_agent_config, "db_tools.read_query")
+        names = _tool_names(node)
+        # Listed → present.
+        assert "read_query" in names
+        # Not listed (other DBFuncTool methods) → absent.
+        for other in ("list_tables", "describe_table", "get_table_ddl"):
+            assert other not in names, f"{other} should not be exposed by a method-level whitelist"
+
+    def test_infrastructure_tools_always_survive(self, real_agent_config):
+        """Filesystem tools anchor the consultant to its artifact and must
+        survive even though the whitelist never lists them."""
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        fs_names = _fs_tool_names(node)
+        assert fs_names, "filesystem tool exposes no tools — fixture broken"
+        assert fs_names <= names, f"infrastructure filesystem tools were pruned: {sorted(fs_names - names)}"
+
+    def test_wildcard_group_keeps_all_group_methods(self, real_agent_config):
+        """``date_parsing_tools.*`` keeps every method of that group."""
+        node = _make_ask_report_with_tools(real_agent_config, "date_parsing_tools.*")
+        names = _tool_names(node)
+        assert "parse_temporal_expressions" in names
+        # db_tools omitted from this whitelist → still dropped.
+        assert "read_query" not in names
+
+    def test_db_tools_wildcard_keeps_read_query(self, real_agent_config):
+        """Sanity check the other direction: whitelisting ``db_tools.*``
+        keeps ``read_query`` so the prune isn't unconditionally stripping db."""
+        node = _make_ask_report_with_tools(real_agent_config, "db_tools.*")
+        names = _tool_names(node)
+        assert "read_query" in names
+        assert "list_tables" in names
+
+    def test_empty_whitelist_keeps_full_surface(self, real_agent_config):
+        """An empty ``tools`` string is back-compat: keep the inherited full
+        chat surface (db_tools included) rather than stripping to nothing."""
+        node = _make_ask_report_with_tools(real_agent_config, "")
+        assert "read_query" in _tool_names(node)
+
+    def test_absent_tools_key_keeps_full_surface(self, real_agent_config):
+        """``tools`` key absent entirely (subagent created before scoping) →
+        same back-compat full surface."""
+        node = _make_ask_report_with_tools(real_agent_config, None)
+        assert "read_query" in _tool_names(node)
+
+    def test_dashboard_honors_whitelist(self, real_agent_config):
+        """The fix lives on the shared base, so ask_dashboard enforces the
+        whitelist too (disk-bound path)."""
+        node = _make_ask_dashboard_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        assert "read_query" not in names
+        assert "query_metrics" in names
+
+    def test_semantic_build_failure_degrades_gracefully(self, real_agent_config, monkeypatch):
+        """If building the whitelisted semantic group raises (e.g. a broken
+        adapter import), node init must not crash: the db prune still holds
+        and the node simply lacks the semantic tools it couldn't build."""
+        import datus.tools.func_tool.semantic_tools as sem_mod
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("semantic adapter exploded")
+
+        monkeypatch.setattr(sem_mod, "SemanticTools", _boom)
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST, name="ask_sem_fail", slug="sem_fail")
+        names = _tool_names(node)
+        # Whitelist still enforced (db dropped); semantic absent but no crash.
+        assert "read_query" not in names
+        assert "query_metrics" not in names
+        # Infrastructure (artifact filesystem) survives so the node still works.
+        assert "read_file" in names
+
+    def test_rebuild_tools_re_applies_whitelist(self, real_agent_config):
+        """A mid-session datasource switch routes through ``_rebuild_tools``,
+        which repopulates from the full instance set. The whitelist must be
+        re-applied so pruned capabilities don't silently come back."""
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        assert "read_query" not in _tool_names(node)
+        # Force the path a `/database` switch would take.
+        node._rebuild_tools()
+        names = _tool_names(node)
+        assert "read_query" not in names, "whitelist not re-enforced after _rebuild_tools"
+        # Whitelisted semantic tool also survives the rebuild (it isn't
+        # re-added by the base _rebuild_tools, so the override must re-surface it).
+        assert "query_metrics" in names


### PR DESCRIPTION
## Why

`ask_report` / `ask_dashboard` subagents ignored the `tools` whitelist configured on the `SubAgent` record. Both subclass `ChatAgenticNode`, whose `setup_tools()` wires `db_tools` (and the rest of the chat surface) **unconditionally** and never consults the node's `tools` field. So a subagent that only granted, say, `semantic_tools.*` + `context_search_tools.*` still exposed `read_query` and every other db tool to the LLM at chat time — observed in dev with subagent `customer_retention_analysis` (type `ask_report`), whose whitelist contained no `db_tools` yet `read_query` was callable.

Unlike `GenSQLAgenticNode` (which builds its tool surface from `tools` patterns), the ask_* nodes had no equivalent enforcement, so the whitelist was effectively advisory.

## Solution

Enforce the whitelist on the shared base `BaseArtifactAskAgenticNode` (covers both ask_report and ask_dashboard):

- After `super().setup_tools()` builds the full chat surface, `_apply_tools_whitelist()`:
  1. **Builds** whitelisted capability groups the chat base omits — only `semantic_tools` today (ChatAgenticNode never builds it), so a subagent that whitelists semantic tools actually gets them.
  2. **Prunes** every capability tool not granted by a whitelist pattern. Matching mirrors `GenSQLAgenticNode`: `group`, `group.*`, and `group.<method>`.
- **Infrastructure tools always survive** the prune regardless of the whitelist — the artifact-anchored filesystem (needed to read the bound artifact), `ask_user`, plan/todo, and the sub-agent task tool. Gated capability groups are `db_tools`, `context_search_tools`, `semantic_tools`, `reference_template_tools`, `date_parsing_tools`, `platform_doc_tools`, `bash_tools`, `skills`.
- **Empty / absent whitelist** keeps the inherited full surface (back-compat for ask agents created before tool scoping).
- The constraint is **re-applied on `_rebuild_tools`** so a mid-session datasource switch (which repopulates from the full instance set) can't silently re-expose pruned tools.
- `_tool_category_map` now registers the on-demand `semantic_tools` so PermissionHooks matches `semantic_tools.*` rules rather than the `tools.*` catch-all.

Net effect for `customer_retention_analysis`: `read_query` and the other non-whitelisted capabilities are dropped; the whitelisted semantic/context/date tools are exposed (semantic built on demand).

Trade-off: the ask_* prompt still references `execute_sql`/`describe_table` for "live" questions; when an operator's whitelist excludes `db_tools` those rules become moot for that agent — that is the operator's explicit choice and out of scope here.

## Test Cases

Added `TestToolsWhitelist` (11 cases) to `tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py`. These are unit tests rather than integration/nightly because the behavior is deterministic node-construction logic with no LLM/network involved — the existing ask_* suite is unit-level for the same reason. Coverage of the changed lines is 97% (diff-cover); `ci/audit_tests.py --diff-only upstream/main` reports P0=0/P1=0.

- `read_query` (+ `list_tables` / `describe_table` / `get_table_ddl`) dropped when `db_tools` not whitelisted.
- Whitelisted tools — including on-demand-built `semantic_tools` — are exposed.
- Method-level precision: `db_tools.read_query` grants only `read_query`, not sibling db methods.
- Infrastructure (filesystem) tools survive the prune unconditionally.
- `group.*` wildcard keeps the whole group; `db_tools.*` keeps `read_query`.
- Empty `tools` and absent `tools` key both preserve the full inherited surface (back-compat).
- `ask_dashboard` honors the whitelist too (shared base).
- Whitelist re-applied after `_rebuild_tools` (datasource-switch path).
- Semantic-build failure degrades gracefully (no crash; db still pruned).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now support tool-whitelist configuration to control which database and capability tools are exposed, with wildcard matching support. Infrastructure tools remain always available.

* **Tests**
  * Added comprehensive test coverage for tool-whitelist enforcement across agent types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->