### PR TITLE
[BugFix] Drive ask_* tool surface solely from the configured whitelist

### DIFF
--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -157,20 +157,23 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     # (``ask_dashboard``) keep this False so the disk path stays available.
     BLOB_REQUIRED: ClassVar[bool] = False
 
-    # Capability tool groups gated by the subagent's ``tools`` whitelist, mapped
-    # to the node attribute that holds the built tool instance. Infrastructure
-    # tools (artifact-anchored filesystem, ask_user, plan/todo, sub-agent
-    # delegation) are deliberately ABSENT: a read-only consultant needs them to
-    # read its bound artifact and converse regardless of the whitelist, so they
-    # always survive pruning — mirroring GenSQLAgenticNode's always-on
-    # filesystem + sub_agent_task + plan set. ``read_query`` & friends live
-    # under ``db_tools`` and are dropped unless explicitly whitelisted.
+    # Tool groups selectable via the subagent's ``tools`` whitelist, mapped to
+    # the node attribute that holds the built tool instance. An ask_* agent's
+    # LLM-facing tool surface is determined SOLELY by this whitelist: only the
+    # groups listed here are eligible, and a tool is exposed only when a
+    # whitelist pattern grants it. There is no chat-surface carryover and no
+    # always-on infrastructure — an empty/absent ``tools`` exposes nothing
+    # (the agent answers from the inlined artifact context), and e.g.
+    # ``filesystem_tools.*`` yields ONLY filesystem tools. ``filesystem_tools``
+    # is therefore gated like any other group; ``ask_user`` / ``task`` /
+    # plan-mode tools are not expressible here and are never exposed on ask_*.
     _WHITELIST_GROUP_ATTRS: ClassVar[Dict[str, str]] = {
         "db_tools": "db_func_tool",
         "context_search_tools": "context_search_tools",
         "semantic_tools": "semantic_tools",
         "reference_template_tools": "reference_template_tools",
         "date_parsing_tools": "date_parsing_tools",
+        "filesystem_tools": "filesystem_func_tool",
         "platform_doc_tools": "_platform_doc_tool",
         "bash_tools": "bash_tool",
         "skills": "skill_func_tool",
@@ -260,18 +263,18 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     # ── Tool whitelist enforcement (honor SubAgent.tools) ───────────────
 
     def setup_tools(self) -> None:
-        """Build the full chat tool surface, then constrain capability tools
-        to the subagent's configured ``tools`` whitelist.
+        """Restrict the LLM-facing tool surface to the configured ``tools``.
 
-        ChatAgenticNode wires its capability tools (db_tools, context_search,
-        …) unconditionally and never consults ``tools``. For an ask_*
-        consultant that field is a hard whitelist — the agent must not reach a
-        capability the operator did not grant (e.g. ``read_query`` when only
-        semantic/context tools were configured). We reuse the base setup so all
-        infrastructure (permission/skill managers, artifact-anchored
-        filesystem, plan + sub-agent tooling) is built correctly, then apply
-        the whitelist. An empty/absent whitelist leaves the inherited surface
-        untouched (back-compat for ask agents created before tool scoping).
+        ChatAgenticNode wires its full tool surface (db_tools, context_search,
+        filesystem, bash, …) unconditionally. For an ask_* consultant the
+        ``tools`` field is the *sole* determinant of what the LLM may call —
+        nothing carries over from the chat surface. We reuse the base setup so
+        infrastructure that is NOT a tool (permission/skill managers,
+        artifact-anchored filesystem instance, sessions, MCP) is built
+        correctly, then replace ``self.tools`` with exactly the tools the
+        whitelist grants. An empty/absent ``tools`` exposes nothing (the agent
+        answers purely from the inlined artifact context); ``filesystem_tools.*``
+        exposes only filesystem tools; and so on.
         """
         super().setup_tools()
         self._apply_tools_whitelist()
@@ -281,10 +284,10 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
 
         ``ChatAgenticNode._rebuild_tools`` (also reached via a mid-session
         datasource switch) repopulates ``self.tools`` from the full set of tool
-        instances, which would silently re-expose pruned capabilities. Re-running
-        the whitelist here keeps the constraint enforced for the life of the
-        node. Safe during ``super().__init__`` because the slots it reads are
-        initialised beforehand or accessed via ``getattr``.
+        instances, which would silently re-expose tools outside the whitelist.
+        Re-running the restriction here keeps the surface locked to ``tools``
+        for the life of the node. Safe during ``super().__init__`` because the
+        slots it reads are initialised beforehand or accessed via ``getattr``.
         """
         super()._rebuild_tools()
         self._apply_tools_whitelist()
@@ -302,13 +305,14 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         return mapping
 
     def _apply_tools_whitelist(self) -> None:
-        """Constrain ``self.tools`` to the configured whitelist + infrastructure."""
+        """Replace ``self.tools`` with exactly the tools the whitelist grants.
+
+        No early return on an empty whitelist: an empty/absent ``tools`` must
+        yield an empty tool surface, not the inherited chat surface.
+        """
         patterns = self._parse_tool_whitelist(self.node_config.get("tools"))
-        if not patterns:
-            # Unconfigured -> keep the inherited full surface (back-compat).
-            return
         self._ensure_whitelisted_groups_present(patterns)
-        self._prune_capability_tools(patterns)
+        self._restrict_tools_to_whitelist(patterns)
 
     @staticmethod
     def _parse_tool_whitelist(tools_value: Any) -> List[str]:
@@ -355,12 +359,13 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             if tool.name not in present:
                 self.tools.append(tool)
 
-    def _capability_tool_groups(self) -> Dict[str, str]:
-        """Map each built capability tool *name* -> its whitelist group label.
+    def _whitelist_tool_groups(self) -> Dict[str, str]:
+        """Map each selectable tool *name* -> its whitelist group label.
 
-        Built only from the gated groups in ``_WHITELIST_GROUP_ATTRS``;
-        infrastructure tools are intentionally excluded so they never appear
-        here and therefore always survive pruning.
+        Built from every group in ``_WHITELIST_GROUP_ATTRS`` (filesystem
+        included). Tools whose name is absent from this map are not expressible
+        in the ``tools`` field (e.g. ``ask_user`` / ``task`` / plan-mode) and
+        are therefore never exposed on an ask_* agent.
         """
         name_to_group: Dict[str, str] = {}
         for group, attr in self._WHITELIST_GROUP_ATTRS.items():
@@ -374,30 +379,52 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                 logger.warning("%s: cannot enumerate %s tools for whitelist: %s", self.get_node_name(), group, exc)
         return name_to_group
 
-    def _prune_capability_tools(self, patterns: List[str]) -> None:
-        """Drop every capability tool not granted by the whitelist.
+    def _restrict_tools_to_whitelist(self, patterns: List[str]) -> None:
+        """Keep only tools a whitelist pattern grants; drop everything else.
 
-        A tool is kept when it is NOT a gated capability (i.e. infrastructure)
-        or when a whitelist pattern grants it. Idempotent — safe to call on
-        every rebuild.
+        A tool survives only when it maps to a selectable group AND a pattern
+        grants it. Tools outside the selectable groups (``ask_user`` / ``task``
+        / plan-mode) and every tool when ``patterns`` is empty are dropped, so
+        the surface equals exactly what ``tools`` requested. Idempotent — safe
+        to call on every rebuild.
         """
-        name_to_group = self._capability_tool_groups()
+        name_to_group = self._whitelist_tool_groups()
         kept: List[Any] = []
         dropped: List[str] = []
         for tool in self.tools:
             group = name_to_group.get(tool.name)
-            if group is None or self._tool_matches_whitelist(group, tool.name, patterns):
+            if group is not None and self._tool_matches_whitelist(group, tool.name, patterns):
                 kept.append(tool)
             else:
                 dropped.append(tool.name)
         self.tools = kept
         if dropped:
             logger.info(
-                "%s tools whitelist applied: dropped=%s exposed=%s",
+                "%s tools whitelist applied: configured=%r exposed=%s dropped=%s",
                 self.get_node_name(),
-                sorted(set(dropped)),
+                self.node_config.get("tools"),
                 sorted({t.name for t in kept}),
+                sorted(set(dropped)),
             )
+
+    def _db_tools_exposed(self) -> bool:
+        """True if any db_tools tool survived the whitelist prune.
+
+        Gates the prompt's db-tool guidance (rule 1's live-data path, the
+        dashboard ad-hoc-SQL rule, the schema-snapshot ``describe_table``
+        hints). When the subagent whitelist excludes db_tools we must not
+        instruct the model to call tools it no longer has, or it will attempt
+        them and hit "Tool ... not found". The ``db_func_tool`` instance often
+        still exists (reference-template execution needs it), so check the
+        exposed ``self.tools`` rather than the instance.
+        """
+        if not self.db_func_tool:
+            return False
+        exposed = {tool.name for tool in self.tools}
+        try:
+            return any(tool.name in exposed for tool in self.db_func_tool.available_tools())
+        except Exception:
+            return False
 
     # ── Artifact binding resolution ─────────────────────────────────────
 
@@ -1086,18 +1113,31 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if not isinstance(tables, list) or not tables:
             return ""
 
-        intro = (
-            "Columns of every table in `manifest.key_tables` at the time "
-            "the artifact was finalized. **This is a SNAPSHOT — call "
-            "`describe_table('<table>')` instead when the user explicitly "
-            "asks about the LATEST / CURRENT schema, when they reference "
-            "a column NOT in this list (could be a typo or a post-"
-            "finalize addition), or when they ask about tables NOT in "
-            "`manifest.key_tables`.** For everything else (writing "
-            "follow-up SQL on the listed tables, explaining a column, "
-            "planning a join between listed tables), use this snapshot "
-            "directly — no `describe_table` round-trip needed."
-        )
+        db_exposed = self._db_tools_exposed()
+        if db_exposed:
+            intro = (
+                "Columns of every table in `manifest.key_tables` at the time "
+                "the artifact was finalized. **This is a SNAPSHOT — call "
+                "`describe_table('<table>')` instead when the user explicitly "
+                "asks about the LATEST / CURRENT schema, when they reference "
+                "a column NOT in this list (could be a typo or a post-"
+                "finalize addition), or when they ask about tables NOT in "
+                "`manifest.key_tables`.** For everything else (writing "
+                "follow-up SQL on the listed tables, explaining a column, "
+                "planning a join between listed tables), use this snapshot "
+                "directly — no `describe_table` round-trip needed."
+            )
+        else:
+            # No db tools for this agent — describe_table isn't callable, so
+            # don't suggest it. The snapshot is the only schema source.
+            intro = (
+                "Columns of every table in `manifest.key_tables` at the time "
+                "the artifact was finalized. **This is a SNAPSHOT and live "
+                "schema tools are not enabled for this agent** — treat it as "
+                "the authoritative schema, and if the user asks about the "
+                "current/latest schema or a column not listed here, say it "
+                "can't be verified live rather than guessing."
+            )
 
         lines: List[str] = ["### Table Schemas (`analysis/key_tables_schema.json`)", "", intro, ""]
         # Measure in UTF-8 bytes (not code points) since the cap is
@@ -1111,7 +1151,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         for tbl in tables:
             if not isinstance(tbl, dict):
                 continue
-            entry_lines = self._render_table_schema_entry(tbl)
+            entry_lines = self._render_table_schema_entry(tbl, db_exposed)
             entry_bytes = sum(len(line.encode("utf-8")) + 1 for line in entry_lines)
             if running_bytes + entry_bytes > INLINE_SCHEMA_BYTES_CAP:
                 cap_reached = True
@@ -1120,20 +1160,24 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             lines.append("")
             running_bytes += entry_bytes
         if cap_reached:
-            lines.append(
-                "_(schema section cap reached — remaining tables omitted; "
-                "call `describe_table('<table>')` for any name in "
-                "`manifest.key_tables` not shown above.)_"
-            )
+            if db_exposed:
+                lines.append(
+                    "_(schema section cap reached — remaining tables omitted; "
+                    "call `describe_table('<table>')` for any name in "
+                    "`manifest.key_tables` not shown above.)_"
+                )
+            else:
+                lines.append("_(schema section cap reached — remaining tables omitted from this snapshot.)_")
         return "\n".join(lines).rstrip()
 
-    def _render_table_schema_entry(self, tbl: Dict[str, Any]) -> List[str]:
+    def _render_table_schema_entry(self, tbl: Dict[str, Any], db_exposed: bool) -> List[str]:
         """Render one table block: header + optional description + columns.
 
         Per-table ``error`` (populated when ``describe_table`` failed
-        at finalize) surfaces as a "schema unavailable" hint with the
-        exact remediation (call ``describe_table('<name>')``) so the
-        LLM has a clear next step rather than guessing.
+        at finalize) surfaces as a "schema unavailable" hint. The
+        ``describe_table('<name>')`` remediation is only suggested when db
+        tools are actually exposed (``db_exposed``); otherwise pointing the
+        LLM at a tool it cannot call just produces a "Tool not found".
         """
         name = tbl.get("name") or "?"
         if not isinstance(name, str):
@@ -1146,7 +1190,10 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if description:
             lines.append(f"_(description: {description})_")
         if error:
-            lines.append(f"_(schema unavailable: {error}; call `describe_table('{name}')` to fetch live schema.)_")
+            if db_exposed:
+                lines.append(f"_(schema unavailable: {error}; call `describe_table('{name}')` to fetch live schema.)_")
+            else:
+                lines.append(f"_(schema unavailable in the snapshot: {error}.)_")
             return lines
         if not isinstance(columns, list):
             return lines
@@ -1169,7 +1216,10 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             lines.append(line)
         if truncated:
             remaining = len(columns) - INLINE_SCHEMA_COLS_PER_TABLE
-            lines.append(f"- _(... {remaining} more columns; call `describe_table('{name}')` for the full list.)_")
+            if db_exposed:
+                lines.append(f"- _(... {remaining} more columns; call `describe_table('{name}')` for the full list.)_")
+            else:
+                lines.append(f"- _(... {remaining} more columns not shown in this snapshot.)_")
         return lines
 
     def _render_insights_section(self) -> str:
@@ -1420,13 +1470,33 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             return False
         return isinstance(insights, list) and bool(insights)
 
+    def _render_narrative_readable(self) -> bool:
+        """ask_report only: is the report's ``render/`` body readable on demand?
+
+        For a report, ``render/*.jsx`` *is* the written report (cover,
+        executive summary, per-section commentary, and whatever conclusion /
+        recommendation sections the author wrote) — none of which is inlined.
+        Only ``render/app.jsx`` is guaranteed to exist (the React entry that
+        imports the section components); the section filenames are arbitrary.
+        It's worth reading when the user asks about the report's wording, but
+        only if ``read_file`` was actually granted (per the subagent's
+        ``tools``). Dashboards keep render off-limits: their render tier is
+        parameterized chart presentation, and the answerable content lives in
+        queries / params.
+        """
+        if self.ARTIFACT_KIND != "report":
+            return False
+        return "read_file" in {tool.name for tool in self.tools}
+
     def _render_filesystem_layout_section(self) -> str:
         """Tell the LLM what's already inlined vs what still needs read_file.
 
         The directory tree mirrors the on-disk artifact layout but
         annotates each entry with "inlined above" vs "DO NOT read" vs
         "read on demand" so a model trying to be helpful by pre-fetching
-        files immediately sees that defensive reads are not useful.
+        files immediately sees that defensive reads are not useful. For a
+        report whose ``render/`` body is readable, that tree points the LLM
+        at the right component instead of forbidding the read.
         """
         layout_root_label = self._artifact_root.name if self._artifact_root is not None else self.ARTIFACT_ROOT_DIR_NAME
         has_insights = self._artifact_has_insights()
@@ -1438,6 +1508,15 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "`queries/*.brief.json` plus the inlined slice of "
             "`queries/*` data + SQL above"
         )
+        # Reports surface their narrative body in render/*.jsx (not inlined);
+        # mention it in the intro so the read-on-demand path is explicit.
+        narrative_clause = (
+            " — or when the user asks about the report's narrative, executive "
+            "summary, conclusions, recommendations, or a section's commentary, which "
+            "live in `render/*.jsx` (start at `render/app.jsx`), not inlined"
+            if self._render_narrative_readable()
+            else ""
+        )
         lines: List[str] = [
             "### Artifact Filesystem Layout",
             "",
@@ -1447,7 +1526,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                 f"already loaded into this prompt: {loaded_list}.** "
                 f"**Do NOT `read_file` / `glob` them defensively.** Read on "
                 f"demand only when the catalog above flags a query's data as "
-                f"sampled or its SQL as truncated."
+                f"sampled or its SQL as truncated" + narrative_clause + "."
             ),
             "",
             "```",
@@ -1462,16 +1541,34 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # unconditionally (no insights file by design).
         if has_insights:
             lines.append("│   ├── insights.json            # inlined above")
+        schema_line = (
+            "│   ├── key_tables_schema.json   # inlined above (if present); snapshot only — describe_table() for live"
+            if self._db_tools_exposed()
+            else "│   ├── key_tables_schema.json   # inlined above (if present); snapshot only — no live schema tools enabled"
+        )
         lines.extend(
             [
                 "│   ├── subject_refs.json        # inlined above (if present)",
-                "│   ├── key_tables_schema.json   # inlined above (if present); snapshot only — describe_table() for live",
+                schema_line,
                 "│   └── suggested_questions.json # UI chips — DO NOT read",
                 "├── queries/                     # briefs always inlined; data + SQL inlined or sampled per catalog above",
-                "└── render/                     # presentation tier — DO NOT READ",
-                "```",
             ]
         )
+        # ``render/`` holds the written report for a report kind; point the LLM
+        # at the guaranteed entry (``app.jsx``, which imports the section
+        # components) instead of forbidding the read or assuming arbitrary
+        # section filenames. Off-limits when render can't be read (no
+        # read_file) or for dashboards (parameterized chart presentation).
+        if self._render_narrative_readable():
+            lines.append(
+                "└── render/                      # the report's written body (NOT inlined) — read "
+                "`render/app.jsx` (entry: cover + executive summary; it imports the section "
+                "components) and follow its imports on demand for the report's wording / "
+                "conclusions / recommendations / a section's commentary"
+            )
+        else:
+            lines.append("└── render/                      # presentation tier — DO NOT READ")
+        lines.append("```")
         return "\n".join(lines)
 
     def _render_behavioral_rules_section(self) -> str:
@@ -1492,6 +1589,16 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # rule 1 claim "confirmed insights" are inlined, both of
         # which would mislead the LLM.
         has_insights = self._artifact_has_insights()
+        # When the subagent whitelist drops db_tools, the model has no
+        # describe_table / read_query to call — promising them in the rules
+        # makes it attempt unavailable tools ("Tool ... not found").
+        db_exposed = self._db_tools_exposed()
+        live_data_clause = (
+            "(call `describe_table` / `execute_sql` for those)"
+            if db_exposed
+            else "(live database tools are not enabled for this agent, so answer "
+            "from the snapshot and say plainly when something cannot be verified live)"
+        )
         lines: List[str] = ["### Behavioral Rules (load-bearing)", ""]
         lines.append(
             "1. **Answer from the inlined context first**. The header above "
@@ -1505,8 +1612,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "explicitly flagged a query's data as sampled or its SQL as "
             "truncated, (b) the user asks about LIVE / CURRENT state "
             "the snapshot can't answer — fresh schema after a DDL "
-            "change, live row counts, today's data (call "
-            "`describe_table` / `execute_sql` for those), or (c) the "
+            "change, live row counts, today's data " + live_data_clause + ", or (c) the "
             "inlined summary genuinely doesn't address the question. "
             "When you do, briefly say which file or tool and why."
         )
@@ -1533,15 +1639,26 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "user explicitly asks, but call it out in your answer."
         )
         if self.ARTIFACT_KIND == "dashboard":
-            lines.append(
-                "6. **Dashboard queries have no precomputed data**. The "
-                "`queries/<slug>.sql.j2` files (inlined above) are "
-                "templates; to answer quantitative questions, run an "
-                "equivalent ad-hoc SQL via `execute_sql` within the "
-                "dashboard's datasource scope, or use the params "
-                "declaration to explain what user-controllable filters "
-                "exist."
-            )
+            if db_exposed:
+                lines.append(
+                    "6. **Dashboard queries have no precomputed data**. The "
+                    "`queries/<slug>.sql.j2` files (inlined above) are "
+                    "templates; to answer quantitative questions, run an "
+                    "equivalent ad-hoc SQL via `execute_sql` within the "
+                    "dashboard's datasource scope, or use the params "
+                    "declaration to explain what user-controllable filters "
+                    "exist."
+                )
+            else:
+                lines.append(
+                    "6. **Dashboard queries have no precomputed data**. The "
+                    "`queries/<slug>.sql.j2` files (inlined above) are "
+                    "templates and live SQL execution is not enabled for this "
+                    "agent; answer quantitative questions from the inlined "
+                    "sample data and use the params declaration to explain "
+                    "what user-controllable filters exist, flagging anything "
+                    "that would need a live query."
+                )
         elif has_insights:
             lines.append(
                 "6. **`insights.json` is the authoritative findings "

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -379,23 +379,53 @@ class ChatAgenticNode(AgenticNode):
 
     # ── System Prompt ───────────────────────────────────────────────────
 
+    def _exposed_tool_names(self) -> set:
+        """Names of the tools currently exposed to the LLM (``self.tools``)."""
+        return {tool.name for tool in (self.tools or [])}
+
+    @staticmethod
+    def _tool_group_exposed(tool_instance, exposed_names: set) -> bool:
+        """True if ``tool_instance`` exists and at least one of its tools is exposed.
+
+        Used to derive the prompt's ``has_*`` flags from the live tool surface
+        so a pruned-but-still-instantiated group (see ``_get_system_prompt``)
+        is not advertised to the model.
+        """
+        if not tool_instance:
+            return False
+        try:
+            return any(tool.name in exposed_names for tool in tool_instance.available_tools())
+        except Exception:
+            return False
+
     def _get_system_prompt(
         self,
         conversation_summary: Optional[str] = None,
         prompt_version: Optional[str] = None,
     ) -> str:
         """Get the system prompt using enhanced template context."""
+        # Derive the ``has_*`` flags from the tools actually exposed to the LLM
+        # (``self.tools``), not from the existence of the tool *instance*. A
+        # subclass may build a tool instance for internal use yet prune its
+        # tools from the LLM-facing list (e.g. ``BaseArtifactAskAgenticNode``
+        # keeps ``db_func_tool`` for reference-template execution but drops
+        # db_tools from ``self.tools`` when the subagent whitelist excludes
+        # them). Keying the prompt flags off the instance would then advertise
+        # tools the model cannot actually call, producing "Tool X not found".
+        exposed = self._exposed_tool_names()
         context = prepare_template_context(
             node_config=self.node_config,
-            has_db_tools=bool(self.db_func_tool),
-            has_filesystem_tools=bool(self.filesystem_func_tool),
+            has_db_tools=self._tool_group_exposed(self.db_func_tool, exposed),
+            has_filesystem_tools=self._tool_group_exposed(self.filesystem_func_tool, exposed),
             has_mf_tools=False,
-            has_context_search_tools=bool(self.context_search_tools),
-            has_reference_template_tools=bool(
-                self.reference_template_tools and self.reference_template_tools.has_reference_templates
+            has_context_search_tools=self._tool_group_exposed(self.context_search_tools, exposed),
+            has_reference_template_tools=(
+                self._tool_group_exposed(self.reference_template_tools, exposed)
+                and bool(self.reference_template_tools and self.reference_template_tools.has_reference_templates)
             ),
-            has_parsing_tools=bool(self.date_parsing_tools),
-            has_platform_doc_tools=bool(self._platform_doc_tool),
+            has_parsing_tools=self._tool_group_exposed(self.date_parsing_tools, exposed),
+            has_platform_doc_tools=self._tool_group_exposed(self._platform_doc_tool, exposed),
+            has_semantic_tools=self._tool_group_exposed(getattr(self, "semantic_tools", None), exposed),
             agent_config=self.agent_config,
             workspace_root=self._resolve_workspace_root(),
         )

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -940,6 +940,7 @@ def prepare_template_context(
     has_reference_template_tools: bool = False,
     has_parsing_tools: bool = True,
     has_platform_doc_tools: bool = False,
+    has_semantic_tools: bool = False,
     agent_config: Optional[AgentConfig] = None,
     workspace_root: Optional[str] = None,
 ) -> dict:
@@ -955,6 +956,7 @@ def prepare_template_context(
         has_reference_template_tools: Whether reference template tools are available
         has_parsing_tools: Whether date parsing tools are available
         has_platform_doc_tools: Whether platform documentation search tools are available
+        has_semantic_tools: Whether semantic / metric tools are available
         agent_config: Agent configuration
         workspace_root: Workspace root path
 
@@ -969,6 +971,7 @@ def prepare_template_context(
         "has_reference_template_tools": has_reference_template_tools,
         "has_parsing_tools": has_parsing_tools,
         "has_platform_doc_tools": has_platform_doc_tools,
+        "has_semantic_tools": has_semantic_tools,
     }
     if not isinstance(node_config, SubAgentConfig):
         node_config = SubAgentConfig.model_validate(node_config)

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -1811,6 +1811,12 @@ def _register_ask_agent_with_tools(
         agent_config.agentic_nodes = {}
     entry = {
         "type": agent_type,
+        # Pin the prompt template to the builtin ask_* template so
+        # ``_get_system_prompt`` renders ``_ask_artifact_common.j2`` (which the
+        # prompt-consistency tests inspect) instead of falling back to the
+        # default chat template. In production the backend copies this same
+        # builtin to ``{name}_system.j2`` (AgentService._copy_prompt_template).
+        "system_prompt": agent_type,
         "artifact_slug": slug,
         "agent_description": f"Ask consultant for {slug}",
         "rules": [],
@@ -1870,11 +1876,12 @@ _NO_DB_WHITELIST = (
 
 
 class TestToolsWhitelist:
-    """A configured ``tools`` whitelist is a hard cap on the LLM-facing surface.
+    """An ask_* agent's LLM tool surface is determined SOLELY by ``tools``.
 
-    Pins the fix for the leak where ask_* nodes (ChatAgenticNode subclasses)
-    ignored ``tools`` and always wired db_tools, leaving ``read_query``
-    callable for a subagent that only whitelisted semantic/context tools.
+    Nothing carries over from the ChatAgenticNode surface: only the groups the
+    whitelist lists are exposed, an empty/absent ``tools`` exposes nothing, and
+    a single group (e.g. ``filesystem_tools.*``) yields only that group — db /
+    bash / etc. stay out unless explicitly granted.
     """
 
     def test_db_tools_dropped_when_not_whitelisted(self, real_agent_config):
@@ -1911,14 +1918,20 @@ class TestToolsWhitelist:
         for other in ("list_tables", "describe_table", "get_table_ddl"):
             assert other not in names, f"{other} should not be exposed by a method-level whitelist"
 
-    def test_infrastructure_tools_always_survive(self, real_agent_config):
-        """Filesystem tools anchor the consultant to its artifact and must
-        survive even though the whitelist never lists them."""
-        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
-        names = _tool_names(node)
-        fs_names = _fs_tool_names(node)
-        assert fs_names, "filesystem tool exposes no tools — fixture broken"
-        assert fs_names <= names, f"infrastructure filesystem tools were pruned: {sorted(fs_names - names)}"
+    def test_filesystem_tools_require_whitelist(self, real_agent_config):
+        """Filesystem tools are gated like every other group — present only
+        when ``filesystem_tools`` is whitelisted, dropped otherwise. There is
+        no always-on infrastructure on an ask_* agent."""
+        # The no-db whitelist omits filesystem_tools -> filesystem dropped.
+        nofs = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST, name="ask_nofs", slug="nofs")
+        assert not (_fs_tool_names(nofs) & _tool_names(nofs)), "filesystem leaked without being whitelisted"
+        # ``filesystem_tools.*`` alone -> ONLY filesystem tools, nothing else
+        # (no db, no bash, no semantic) — the exact contract the operator set.
+        withfs = _make_ask_report_with_tools(real_agent_config, "filesystem_tools.*", name="ask_withfs", slug="withfs")
+        names = _tool_names(withfs)
+        fs_names = _fs_tool_names(withfs)
+        assert fs_names and fs_names <= names
+        assert names == fs_names, f"filesystem_tools.* exposed non-filesystem tools: {sorted(names - fs_names)}"
 
     def test_wildcard_group_keeps_all_group_methods(self, real_agent_config):
         """``date_parsing_tools.*`` keeps every method of that group."""
@@ -1936,17 +1949,18 @@ class TestToolsWhitelist:
         assert "read_query" in names
         assert "list_tables" in names
 
-    def test_empty_whitelist_keeps_full_surface(self, real_agent_config):
-        """An empty ``tools`` string is back-compat: keep the inherited full
-        chat surface (db_tools included) rather than stripping to nothing."""
-        node = _make_ask_report_with_tools(real_agent_config, "")
-        assert "read_query" in _tool_names(node)
+    def test_empty_whitelist_exposes_no_tools(self, real_agent_config):
+        """An empty ``tools`` string exposes NOTHING — no chat-surface
+        carryover, no infrastructure default. The agent answers purely from
+        the inlined artifact context."""
+        node = _make_ask_report_with_tools(real_agent_config, "", name="ask_empty", slug="empty_wl")
+        assert _tool_names(node) == set()
 
-    def test_absent_tools_key_keeps_full_surface(self, real_agent_config):
-        """``tools`` key absent entirely (subagent created before scoping) →
-        same back-compat full surface."""
-        node = _make_ask_report_with_tools(real_agent_config, None)
-        assert "read_query" in _tool_names(node)
+    def test_absent_tools_key_exposes_no_tools(self, real_agent_config):
+        """``tools`` key absent entirely also exposes nothing — the surface is
+        determined solely by ``tools``."""
+        node = _make_ask_report_with_tools(real_agent_config, None, name="ask_absent", slug="absent_wl")
+        assert _tool_names(node) == set()
 
     def test_dashboard_honors_whitelist(self, real_agent_config):
         """The fix lives on the shared base, so ask_dashboard enforces the
@@ -1968,11 +1982,10 @@ class TestToolsWhitelist:
         monkeypatch.setattr(sem_mod, "SemanticTools", _boom)
         node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST, name="ask_sem_fail", slug="sem_fail")
         names = _tool_names(node)
-        # Whitelist still enforced (db dropped); semantic absent but no crash.
+        # Node built without crashing; db still absent and the failed semantic
+        # group simply contributes no tools.
         assert "read_query" not in names
         assert "query_metrics" not in names
-        # Infrastructure (artifact filesystem) survives so the node still works.
-        assert "read_file" in names
 
     def test_rebuild_tools_re_applies_whitelist(self, real_agent_config):
         """A mid-session datasource switch routes through ``_rebuild_tools``,
@@ -1987,3 +2000,116 @@ class TestToolsWhitelist:
         # Whitelisted semantic tool also survives the rebuild (it isn't
         # re-added by the base _rebuild_tools, so the override must re-surface it).
         assert "query_metrics" in names
+
+
+# --------------------------------------------------------------------------- #
+# System-prompt / tool-surface consistency                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestPromptToolConsistency:
+    """The system prompt must advertise only tools the whitelist exposes.
+
+    Regression for the mismatch where ask_* kept the ``db_func_tool`` instance
+    for internal use after pruning db_tools from the LLM surface, so the
+    prompt's ``has_db_tools`` flag (keyed off the instance) still advertised
+    db tools the model could not call — leading it to attempt ``list_tables`` /
+    ``read_query`` and hit "Tool ... not found".
+    """
+
+    def test_no_db_whitelist_prompt_omits_db_tools(self, real_agent_config):
+        """A whitelist without db_tools must not advertise or instruct db tools,
+        while semantic tools it DID whitelist are advertised (built on demand)."""
+        node = _make_ask_report_with_tools(
+            real_agent_config,
+            "date_parsing_tools.*,filesystem_tools.*,semantic_tools.*",
+            name="ask_nodb_prompt",
+            slug="nodb_prompt",
+        )
+        assert node._db_tools_exposed() is False
+        prompt = node._get_system_prompt()
+        # db tools are not callable -> never advertised nor instructed.
+        assert "**Database tools**" not in prompt
+        assert "execute_sql" not in prompt
+        assert "`describe_table` / `execute_sql`" not in prompt
+        # rule 1's live-data path reflects that db tools are unavailable.
+        assert "live database tools are not enabled" in prompt
+        # semantic tools ARE exposed (whitelisted + built on demand) -> advertised.
+        assert "Semantic / metric tools" in prompt
+
+    def test_db_whitelist_prompt_includes_db_tools(self, real_agent_config):
+        """A whitelist with db_tools keeps the db advertisement + live-data
+        guidance — the fix must not strip db tooling when it's legitimately
+        granted."""
+        node = _make_ask_report_with_tools(
+            real_agent_config,
+            "db_tools.*,filesystem_tools.*",
+            name="ask_db_prompt",
+            slug="db_prompt",
+        )
+        assert node._db_tools_exposed() is True
+        prompt = node._get_system_prompt()
+        assert "**Database tools**" in prompt
+        assert "`describe_table` / `execute_sql`" in prompt
+
+    def test_behavioral_rules_gate_db_guidance(self, real_agent_config):
+        """``_render_behavioral_rules_section`` swaps the live-data clause based
+        on db availability (unit-level check, independent of full prompt)."""
+        nodb = _make_ask_report_with_tools(
+            real_agent_config, "filesystem_tools.*,date_parsing_tools.*", name="ask_rules_nodb", slug="rules_nodb"
+        )
+        rules = nodb._render_behavioral_rules_section()
+        assert "execute_sql" not in rules
+        assert "live database tools are not enabled" in rules
+
+    def test_table_schemas_section_gates_describe_table_when_no_db(self, real_agent_config):
+        """The schema snapshot's ``describe_table`` refresh hint is dropped when
+        db tools aren't whitelisted — the snapshot becomes the sole source."""
+        from datus.agent.node.base_artifact_ask_agentic_node import INLINE_SCHEMA_COLS_PER_TABLE
+
+        slug = "schema_nodb"
+        _seed_artifact(real_agent_config.project_root, "report", slug)
+        root = Path(real_agent_config.project_root) / "reports" / slug
+        # Cover all three describe_table hint paths in one no-db render: the
+        # intro, a per-table ``error`` hint, and a wide-table truncation hint.
+        wide_cols = [{"name": f"c{i}", "type": "int"} for i in range(INLINE_SCHEMA_COLS_PER_TABLE + 5)]
+        _seed_analysis_extras(
+            root,
+            key_tables_schema={
+                "tables": [
+                    {"name": "orders", "columns": [{"name": "id", "type": "int"}]},
+                    {"name": "broken", "error": "connection refused"},
+                    {"name": "wide", "columns": wide_cols},
+                ]
+            },
+        )
+        blob = _blob_from_disk(real_agent_config.project_root, "report", slug)
+        _register_ask_agent_with_tools(
+            real_agent_config,
+            name="ask_schema_nodb",
+            kind="report",
+            slug=slug,
+            tools="filesystem_tools.*,date_parsing_tools.*",
+            blob=blob,
+        )
+        node = AskReportAgenticNode(
+            node_id="x", description="d", node_type="chat", agent_config=real_agent_config, node_name="ask_schema_nodb"
+        )
+        section = node._render_table_schemas_section()
+        assert "orders" in section  # snapshot still rendered
+        assert "live schema tools are not enabled" in section
+        # No describe_table suggestion anywhere — not the intro, the error hint,
+        # nor the truncation hint — since the tool isn't callable.
+        assert "describe_table(" not in section
+        assert "more columns not shown in this snapshot" in section  # truncation hint, no-db form
+        assert "schema unavailable in the snapshot" in section  # error hint, no-db form
+
+    def test_dashboard_rule6_gated_when_no_db(self, real_agent_config):
+        """ask_dashboard rule 6 must not promise ad-hoc ``execute_sql`` when the
+        whitelist grants no db tools (disk-bound dashboard path)."""
+        node = _make_ask_dashboard_with_tools(
+            real_agent_config, "filesystem_tools.*,semantic_tools.*", name="ask_dash_nodb", slug="dash_nodb"
+        )
+        rules = node._render_behavioral_rules_section()
+        assert "execute_sql" not in rules
+        assert "live SQL execution is not enabled" in rules


### PR DESCRIPTION
## Why

Follow-up to #877. Three issues with how `ask_report` / `ask_dashboard` selected tools and described them:

1. **Tool surface wasn't fully driven by `tools`.** #877 pruned db_tools but kept "infrastructure" tools always-on and treated empty `tools` as "full chat surface". The intended contract: an ask_* agent's LLM tool surface is determined **solely** by its `tools` field.
2. **Prompt/tool mismatch → hard failures.** The prompt still advertised/instructed db tools (`has_db_tools` was keyed off `bool(self.db_func_tool)`, which survives for reference-template execution), so the model called them and hit `Tool list_tables not found in agent ...`.
3. **`render/` was blanket "DO NOT READ" for reports.** But for a report, `render/*.jsx` *is* the written report — cover, executive summary, per-section commentary, and a whole **recommendations** section — none of which is inlined (only the 8 structured findings in `insights.json` are). Follow-ups like "summarize the recommendations" / "what did the executive summary say" had no reachable source.

## Solution

**ask_* tool surface = exactly what `tools` grants.** `BaseArtifactAskAgenticNode` rebuilds `self.tools` after the base setup to contain only tools matched by a `tools` pattern — no carryover, no always-on infrastructure. Empty/absent `tools` → no tools; `filesystem_tools.*` → only filesystem tools; etc. `filesystem_tools` is now a gated group; tools not expressible in the whitelist vocabulary are never exposed. Whitelisted `semantic_tools` (which the chat base never builds) are built on demand; the restriction is re-applied on `_rebuild_tools`.

**Prompt kept consistent with the surface.** `ChatAgenticNode` derives its `has_*` template flags from the tools actually exposed (`self.tools`), not tool-instance existence, and passes `has_semantic_tools` (no-op for chat/gen_sql). `BaseArtifactAskAgenticNode` gates its hand-rolled db guidance (rule 1 live-data path, dashboard ad-hoc-SQL rule, schema snapshot `describe_table` hints, layout tree) on whether db tools survived.

**Report `render/` is read-on-demand.** For `ask_report`, when filesystem read is granted, the layout tree points the LLM at the guaranteed `render/app.jsx` entry (which imports the section components — section filenames are arbitrary, only `app.jsx` is guaranteed) and marks render read-on-demand for narrative / recommendation / wording questions, instead of forbidding the read. Without filesystem — or for dashboards (parameterized chart presentation) — `render/` stays off-limits, so we never advertise a read the agent can't perform.

Supersedes the prune-with-infrastructure / empty-means-full semantics from #877. `prepare_template_context` gains an optional `has_semantic_tools` (default `False`), backward compatible.

## Test Cases

Unit tests in `tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py` (deterministic, no LLM). Diff coverage 91%; `ci/audit_tests.py --diff-only upstream/main` → P0=0/P1=0.

- **Tool surface** (`TestToolsWhitelist`): empty/absent → no tools; `filesystem_tools.*` → only filesystem (db/bash/semantic absent); filesystem requires whitelisting (no always-on infra); method-level precision; `db_tools.*` keeps the group; semantic built on demand; re-applied after `_rebuild_tools`; semantic build failure degrades gracefully.
- **Prompt consistency** (`TestPromptToolConsistency`): no-db whitelist omits the Database tools section + `execute_sql` and advertises semantic; db whitelist keeps them; schema intro / dashboard rule 6 drop `describe_table` / `execute_sql` when db isn't granted.
- The report `render/` read-on-demand path is a small, kind-conditional prompt tweak covered incidentally by the existing report/dashboard prompt tests (no dedicated unit test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tool exposure is now strictly driven by the configured whitelist: empty or missing whitelists expose no tools and filesystem tools must be explicitly allowed.
  * Prompts, rendered guidance, and behavioral rules dynamically reflect available capabilities (live DB queries vs. snapshot-only guidance); report narrative/read-on-demand is enabled only when read tools are exposed.
  * Templates now account for semantic/metric tool availability when rendering guidance.

* **Tests**
  * Added tests verifying whitelist semantics, prompt/tool consistency, and DB-gating of guidance and report render accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
