### PR TITLE
[BugFix] Make ask_* prompt self-contained; stop chat-template + bash/skill leakage

### DIFF
--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -66,6 +66,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
 
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
+from datus.agent.node.gen_sql_agentic_node import prepare_template_context
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.artifact_manifest import ARTIFACT_SLUG_RE
 from datus.schemas.chat_agentic_node_models import ChatNodeInput
@@ -426,6 +427,55 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         except Exception:
             return False
 
+    def _group_whitelisted(self, group: str) -> bool:
+        """True if the configured ``tools`` grants any tool in ``group``.
+
+        Group-level membership test (does the whitelist mention this group at
+        all, via ``group`` / ``group.*`` / ``group.<method>``). Used to gate
+        the lazy bash / skill re-injection :class:`AgenticNode` performs on
+        every prompt build — see :meth:`_ensure_bash_tool_in_tools`.
+        """
+        patterns = self._parse_tool_whitelist(self.node_config.get("tools"))
+        return any(p == group or p.startswith(f"{group}.") for p in patterns)
+
+    # ── Lazy-injection gates (honor the whitelist post-setup_tools) ─────
+
+    def _ensure_bash_tool_in_tools(self) -> None:
+        """Gate :class:`AgenticNode`'s lazy bash re-injection on the whitelist.
+
+        ``_finalize_system_prompt`` re-adds ``execute_command`` to
+        ``self.tools`` on every prompt build — AFTER ``setup_tools()`` already
+        pruned it — which silently re-exposes bash on an ask_* agent whose
+        ``tools`` never granted ``bash_tools`` (the model then sees it in its
+        SDK tool list and offers/runs shell commands). Skip the re-injection
+        unless the whitelist actually grants the group.
+        """
+        if not self._group_whitelisted("bash_tools"):
+            return
+        super()._ensure_bash_tool_in_tools()
+
+    def _ensure_skill_tools_in_tools(self) -> None:
+        """Gate :class:`AgenticNode`'s lazy skill-tool re-injection on the whitelist.
+
+        Same prompt-build bypass as bash (see :meth:`_ensure_bash_tool_in_tools`):
+        the skill loader tools are re-added regardless of the prune. Skip
+        unless ``skills`` is whitelisted.
+        """
+        if not self._group_whitelisted("skills"):
+            return
+        super()._ensure_skill_tools_in_tools()
+
+    def _get_available_skills_context(self) -> str:
+        """Suppress the skills XML when ``skills`` isn't whitelisted.
+
+        The skill loader tools are gated in :meth:`_ensure_skill_tools_in_tools`;
+        advertising skills in the prompt while their loader tool is absent would
+        just offer the model a capability it has no tool to invoke.
+        """
+        if not self._group_whitelisted("skills"):
+            return ""
+        return super()._get_available_skills_context()
+
     # ── Artifact binding resolution ─────────────────────────────────────
 
     def _resolve_artifact_binding_early(self, agent_config: Optional[AgentConfig]) -> None:
@@ -743,28 +793,22 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         conversation_summary: Optional[str] = None,
         prompt_version: Optional[str] = None,
     ) -> str:
-        """Render the ask-* system prompt with artifact context added.
+        """Render a SELF-CONTAINED ask-* system prompt.
 
-        Delegates to ``ChatAgenticNode._get_system_prompt`` for the
-        heavy lifting (template lookup, skill XML injection, memory,
-        language directive) and then prepends a markdown header block
-        with the artifact's manifest fields and raw intent.md so the
-        chat template's general copy ("You are the follow-up
-        consultant…") already knows what it's talking about by the
-        time the user's first message arrives.
+        Two parts, both ask-owned: the artifact-context header (node-rendered
+        manifest / intent / schema snapshot / query catalog / behavioral rules)
+        followed by the purpose-built ask tool catalogue
+        (``_render_ask_base_prompt``).
+
+        Deliberately does NOT chain into ``ChatAgenticNode._get_system_prompt``.
+        That path renders ``{system_prompt or node_name}_system`` and SILENTLY
+        FALLS BACK to ``chat_system`` when the per-subagent template file is
+        absent (the SaaS case) — dumping the entire chat tool catalogue, the
+        ``task()`` subagent-routing rubric, and write/SQL capabilities into a
+        read-only consultant's prompt. ``_render_ask_base_prompt`` resolves
+        only the ask template (builtin fallback), never chat.
         """
-        # We can't simply override the template context dict the base
-        # builds — ``prepare_template_context`` returns a fresh dict per
-        # call. Instead, hook ``_finalize_system_prompt`` style: render
-        # via parent, then prepend our artifact-context block so the
-        # template-specific copy ("You are the follow-up consultant…")
-        # already knows what it's talking about by the time the user's
-        # first message arrives.
-        #
-        # The cleaner long-term fix is to let ``_get_system_prompt`` take
-        # an extra context dict; for now this two-step approach keeps the
-        # base class untouched.
-        base_prompt = super()._get_system_prompt(conversation_summary, prompt_version)
+        base_prompt = self._render_ask_base_prompt(conversation_summary, prompt_version)
         artifact_header = self._render_artifact_context_block()
         final_prompt = (artifact_header + "\n\n" + base_prompt) if artifact_header else base_prompt
         # Observability hook: real-world prompt growth after the
@@ -790,6 +834,99 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             base_bytes,
         )
         return final_prompt
+
+    def _render_ask_base_prompt(
+        self,
+        conversation_summary: Optional[str],
+        prompt_version: Optional[str],
+    ) -> str:
+        """Render the ask tool catalogue from the purpose-built ask template.
+
+        Mirrors the context-building of ``ChatAgenticNode._get_system_prompt``
+        (the ``has_*`` flags keyed off the *exposed* tool surface) but resolves
+        the template independently: the per-subagent ``{name}_system`` first,
+        then the BUILTIN ask template (``ask_report_system`` /
+        ``ask_dashboard_system``) which always ships in the package. It NEVER
+        falls back to ``chat_system`` — that fallback is exactly what polluted
+        the consultant with the full chat tool/task-routing surface.
+        """
+        exposed = self._exposed_tool_names()
+        context = prepare_template_context(
+            node_config=self.node_config,
+            has_db_tools=self._tool_group_exposed(self.db_func_tool, exposed),
+            has_filesystem_tools=self._tool_group_exposed(self.filesystem_func_tool, exposed),
+            has_mf_tools=False,
+            has_context_search_tools=self._tool_group_exposed(self.context_search_tools, exposed),
+            has_reference_template_tools=(
+                self._tool_group_exposed(self.reference_template_tools, exposed)
+                and bool(self.reference_template_tools and self.reference_template_tools.has_reference_templates)
+            ),
+            has_parsing_tools=self._tool_group_exposed(self.date_parsing_tools, exposed),
+            has_platform_doc_tools=self._tool_group_exposed(self._platform_doc_tool, exposed),
+            has_semantic_tools=self._tool_group_exposed(getattr(self, "semantic_tools", None), exposed),
+            agent_config=self.agent_config,
+            workspace_root=self._resolve_workspace_root(),
+        )
+        context["conversation_summary"] = conversation_summary
+        # Ask consultants never carry the task() delegation tool; set it
+        # explicitly so a shared partial can't advertise a tool they lack.
+        context["has_task_tool"] = False
+        context["active_profile"] = getattr(self.agent_config, "active_profile_name", None) or "normal"
+        from datus.utils.time_utils import get_default_current_date
+
+        context["current_date"] = get_default_current_date(None)
+
+        from datus.prompts.prompt_manager import get_prompt_manager
+
+        pm = get_prompt_manager(agent_config=self.agent_config)
+        prompt_version = prompt_version or self.node_config.get("prompt_version")
+        configured_name = self.node_config.get("system_prompt") or self.get_node_name()
+        # (template_name, version) attempts in priority order; the final entry
+        # — builtin ask template at latest version — is guaranteed to exist, so
+        # the loop terminates without ever reaching chat_system.
+        attempts: List[Tuple[str, Optional[str]]] = [(f"{configured_name}_system", prompt_version)]
+        attempts.append((f"{self.NODE_NAME}_system", prompt_version))
+        attempts.append((f"{self.NODE_NAME}_system", None))
+        seen: set = set()
+        last_error: Optional[Exception] = None
+        for template_name, version in attempts:
+            if (template_name, version) in seen:
+                continue
+            seen.add((template_name, version))
+            try:
+                base = pm.render_template(template_name=template_name, version=version, **context)
+                return self._finalize_system_prompt(base)
+            except FileNotFoundError as exc:
+                last_error = exc
+                continue
+        # The builtin ask template is part of the package; reaching here is a
+        # genuine packaging error. Fail loudly rather than degrade to chat.
+        raise DatusException(
+            code=ErrorCode.COMMON_TEMPLATE_NOT_FOUND,
+            message_args={"template_name": f"{self.NODE_NAME}_system", "version": prompt_version or "latest"},
+        ) from last_error
+
+    def _finalize_system_prompt(self, base_prompt: str, memory_node_name_override: Optional[str] = None) -> str:
+        """Lean finalize for a read-only artifact consultant.
+
+        Drops the chat-agent extras :meth:`AgenticNode._finalize_system_prompt`
+        appends — the project ``AGENTS.md`` block and the persistent-memory
+        instructions — which are noise for an agent scoped to one artifact and
+        only widen the capability surface the model believes it has. Keeps the
+        whitelisted tool injections (gated to the configured ``tools``; no-op
+        otherwise), the skills XML (suppressed unless ``skills`` is
+        whitelisted), and the response-language directive.
+        """
+        # Re-inject whitelisted bash / skill tools (gated; no-op when the
+        # whitelist didn't grant them). These add to ``self.tools``, not prompt
+        # text — needed so a whitelist that DID grant them still works.
+        self._ensure_skill_tools_in_tools()
+        self._ensure_bash_tool_in_tools()
+        if self.skill_func_tool:
+            skills_xml = self._get_available_skills_context()
+            if skills_xml:
+                base_prompt = base_prompt + "\n\n" + skills_xml
+        return self._inject_response_language(base_prompt)
 
     def _render_artifact_context_block(self) -> str:
         """Build the artifact-context preamble prepended to the chat prompt.
@@ -1600,6 +1737,22 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "from the snapshot and say plainly when something cannot be verified live)"
         )
         lines: List[str] = ["### Behavioral Rules (load-bearing)", ""]
+        if not db_exposed:
+            # The artifact context is dense with SQL bodies + table schemas,
+            # which tempts the model to claim live DB/SQL capability it does
+            # not have and then fail at call time ("Tool ... not found"). The
+            # has_db_tools template flag already suppresses the tool catalogue,
+            # but a positive boundary statement is what actually stops the
+            # model from offering to run queries. State it up front.
+            lines.append(
+                "**This agent has NO live database access.** You cannot query "
+                "the database or introspect schema live (no `read_query`, "
+                "`list_tables`, or `describe_table`). Do NOT offer to run SQL "
+                "or fetch fresh data — answer only from the inlined data + "
+                "artifact files above, and say plainly when a question would "
+                "require a live query you can't run."
+            )
+            lines.append("")
         lines.append(
             "1. **Answer from the inlined context first**. The header above "
             "already contains the manifest, the original intent, the "

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -2113,3 +2113,103 @@ class TestPromptToolConsistency:
         rules = node._render_behavioral_rules_section()
         assert "execute_sql" not in rules
         assert "live SQL execution is not enabled" in rules
+
+
+# --------------------------------------------------------------------------- #
+# Chat decoupling + lazy-injection gating                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestChatDecoupling:
+    """The ask_* system prompt is self-contained.
+
+    Two regressions: (1) the prompt must never carry the ``chat_system``
+    template (the silent FileNotFoundError fallback dumped the full chat tool
+    catalogue + ``task()`` routing rubric into a read-only consultant), and
+    (2) ``_finalize_system_prompt``'s lazy bash/skill re-injection — which runs
+    on every prompt build, AFTER ``setup_tools()`` pruned the whitelist — must
+    not silently re-expose tools the ``tools`` whitelist never granted.
+    """
+
+    def test_prompt_excludes_chat_template_content(self, real_agent_config):
+        """Self-contained ask prompt: the ask template is used, and none of the
+        chat system template / chat-agent finalize extras leak in."""
+        node = _make_ask_report_with_tools(
+            real_agent_config,
+            "date_parsing_tools.*,filesystem_tools.*,semantic_tools.*",
+            name="ask_decouple",
+            slug="decouple",
+        )
+        prompt = node._get_system_prompt()
+        assert "ask_report consultant" in prompt  # purpose-built ask template
+        for marker in (
+            "You are a helpful AI assistant integrated with Datus-agent",
+            'task(type="gen_sql"',
+            "Routing decision",
+            "Persistent memory at",  # chat-agent memory block (dropped by lean finalize)
+        ):
+            assert marker not in prompt, f"chat content leaked into ask prompt: {marker!r}"
+
+    def test_missing_subagent_template_falls_back_to_builtin_ask_not_chat(self, real_agent_config):
+        """When the per-subagent ``{name}_system`` template is absent (the SaaS
+        case that produced the leaked chat prompt), resolution falls through to
+        the BUILTIN ask template — never ``chat_system``."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "filesystem_tools.*", name="ask_missing_tpl", slug="missing_tpl"
+        )
+        # A template root that doesn't ship -> configured attempt raises
+        # FileNotFoundError, forcing the builtin-ask fallback.
+        node.node_config["system_prompt"] = "ask_nonexistent_subagent_xyz"
+        prompt = node._get_system_prompt()
+        assert "ask_report consultant" in prompt
+        assert "You are a helpful AI assistant integrated with Datus-agent" not in prompt
+
+    def test_bash_not_reinjected_after_prompt_build(self, real_agent_config):
+        """``execute_command`` stays out of the surface across a prompt build
+        when ``bash_tools`` isn't whitelisted — the core lazy-injection leak."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "date_parsing_tools.*,filesystem_tools.*", name="ask_nobash", slug="nobash"
+        )
+        assert "execute_command" not in _tool_names(node)
+        node._get_system_prompt()  # runs the lazy bash re-injection path
+        assert "execute_command" not in _tool_names(node), "bash leaked via prompt-build lazy injection"
+
+    def test_skills_not_reinjected_after_prompt_build(self, real_agent_config):
+        """Same lazy-injection bypass as bash, for the skill loader tools."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "date_parsing_tools.*,filesystem_tools.*", name="ask_noskill", slug="noskill"
+        )
+        node._get_system_prompt()
+        leaked = {"load_skill", "skill_execute_command"} & _tool_names(node)
+        assert not leaked, f"skill tools leaked via prompt-build lazy injection: {sorted(leaked)}"
+
+    def test_bash_present_when_whitelisted(self, real_agent_config):
+        """The gate is whitelist-driven, not a blanket block: ``bash_tools.*``
+        keeps ``execute_command`` available through the prompt build."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "bash_tools.*,filesystem_tools.*", name="ask_bash", slug="withbash"
+        )
+        node._get_system_prompt()
+        assert "execute_command" in _tool_names(node)
+
+    def test_skills_present_when_whitelisted(self, real_agent_config):
+        """Symmetric to bash: ``skills.*`` keeps the skill loader tool through
+        the prompt build (``load_skill`` is always offered by SkillFuncTool)."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "skills.*,filesystem_tools.*", name="ask_skills", slug="withskills"
+        )
+        node._get_system_prompt()
+        assert "load_skill" in _tool_names(node)
+
+    def test_no_db_boundary_statement_gated_on_db_exposure(self, real_agent_config):
+        """A db-less whitelist gets the explicit 'no live database access'
+        boundary (countering DB-capability hallucination); a db whitelist omits
+        it."""
+        nodb = _make_ask_report_with_tools(
+            real_agent_config, "filesystem_tools.*,semantic_tools.*", name="ask_boundary", slug="boundary"
+        )
+        assert "This agent has NO live database access" in nodb._render_behavioral_rules_section()
+        withdb = _make_ask_report_with_tools(
+            real_agent_config, "db_tools.*,filesystem_tools.*", name="ask_boundary_db", slug="boundary_db"
+        )
+        assert "This agent has NO live database access" not in withdb._render_behavioral_rules_section()


### PR DESCRIPTION
## Why

`ask_report` / `ask_dashboard` are read-only consultants bound to a single
artifact. In production their captured system prompt had the **entire
`chat_system` template appended** — the full chat tool catalogue, the
`task()` subagent-routing rubric, "execute SQL", "read and write files",
persistent-memory instructions. Root cause: these nodes subclass
`ChatAgenticNode`, whose `_get_system_prompt` resolves
`{system_prompt or node_name}_system` and **silently falls back to
`chat_system` on `FileNotFoundError`**. The per-subagent template isn't
shipped in the SaaS path, so every ask turn fell through to chat.

Consequences observed on a subagent whose `tools` were
`date_parsing_tools.*,filesystem_tools.*,semantic_tools.*`:

- The model claimed it could use DB/SQL tools (`read_query`, `list_tables`,
  `describe_table`) on the first ask — they aren't in its surface, so a real
  call later returned "not found".
- `execute_command` (bash) was actually invocable despite `bash_tools` not
  being whitelisted: `_finalize_system_prompt` lazily re-injects bash + skill
  tools into `self.tools` on **every** prompt build — i.e. *after*
  `setup_tools()` pruned the whitelist — bypassing it entirely.

## Solution

Keep `ChatAgenticNode` as the parent (it supplies the tool/permission/MCP/
result plumbing the ask whitelist prunes from), but make the ask prompt and
tool surface fully self-contained:

- **`_get_system_prompt` no longer chains into chat.** New
  `_render_ask_base_prompt` builds the `has_*` flags from the *exposed* tool
  surface and resolves only the ask template: per-subagent `{name}_system`
  first, then the builtin `ask_report_system` / `ask_dashboard_system` (always
  shipped). It **never** falls back to `chat_system`; a genuinely missing
  builtin raises `COMMON_TEMPLATE_NOT_FOUND` rather than degrading.
- **Lean `_finalize_system_prompt`** drops the chat-agent `AGENTS.md` and
  persistent-memory blocks (noise for an artifact-scoped consultant); keeps
  the response-language directive, the whitelisted tool injection, and the
  skills XML.
- **Gate the lazy re-injection on the whitelist**: override
  `_ensure_bash_tool_in_tools` / `_ensure_skill_tools_in_tools` /
  `_get_available_skills_context` so `bash_tools` / `skills` are injected and
  advertised only when the configured `tools` grant them (`_group_whitelisted`
  helper). The gate is whitelist-driven, not a blanket block.
- **Explicit capability boundary**: when no db tools are whitelisted, the
  behavioral rules now state plainly "This agent has NO live database access
  (no `read_query`, `list_tables`, or `describe_table`)" to counter the
  DB-capability hallucination the SQL-dense artifact context invites.

Note: this also makes ask robust to the backend not shipping a per-subagent
`{name}_system` template — worth a separate look at why
`AgentService._copy_prompt_template` doesn't produce one for ask subagents,
but the fallback is no longer chat either way.

## Test Cases

Unit tests in `tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py`
(new `TestChatDecoupling` class, CI tier — no external deps):

- `test_prompt_excludes_chat_template_content` — the rendered prompt carries
  the ask template and none of the chat system template / chat-agent extras.
- `test_missing_subagent_template_falls_back_to_builtin_ask_not_chat` — a
  missing `{name}_system` resolves to the builtin ask template, never chat.
- `test_bash_not_reinjected_after_prompt_build` /
  `test_skills_not_reinjected_after_prompt_build` — the lazy-injection leak:
  `execute_command` / `load_skill` stay out across a prompt build when not
  whitelisted.
- `test_bash_present_when_whitelisted` / `test_skills_present_when_whitelisted`
  — the gate is whitelist-driven, not a blanket block.
- `test_no_db_boundary_statement_gated_on_db_exposure` — boundary statement
  present without db tools, absent with them.

Full file: 82 passed. diff-cover 96.4%. audit P0=0/P1=0. ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Ask functionality now operates independently from chat system, preventing unintended feature mixing and tool exposure leaks.
  * Tool access is strictly controlled via whitelist—bash and skills tools only available when explicitly permitted.
  * Clear database access restrictions enforced when database tools are not available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->