### PR TITLE
[BugFix] Isolate nightly tracing env from unit tests

### DIFF
--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -37,6 +37,8 @@ NIGHTLY_PYTEST_BASETEMP="${NIGHTLY_PYTEST_BASETEMP:-${RUNNER_TEMP:-${TMPDIR:-/tm
 AGENT_TEST_CONFIG_BACKUP="${AGENT_TEST_CONFIG_BACKUP:-${TMPDIR:-/tmp}/datus-agent-nightly-config-${GITHUB_RUN_ID:-$$}.bak}"
 export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE PROVIDER_COVERAGE_MANIFEST_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP
 
+NIGHTLY_PYTEST_ROOTS=(tests/integration tests/regression)
+
 default_repo_root() {
   local explicit_root="$1"
   local repo_name="$2"
@@ -1431,6 +1433,7 @@ log "NIGHTLY_HOME=$NIGHTLY_HOME"
 log "DATUS_TEST_PROJECT_NAME=$DATUS_TEST_PROJECT_NAME"
 log "UNIT_TEST_HOME=$UNIT_TEST_HOME"
 log "NIGHTLY_PYTEST_BASETEMP=$NIGHTLY_PYTEST_BASETEMP"
+log "NIGHTLY_PYTEST_ROOTS=${NIGHTLY_PYTEST_ROOTS[*]}"
 log "NIGHTLY_COMPOSE_PROJECT_PREFIX=$NIGHTLY_COMPOSE_PROJECT_PREFIX"
 log "SUPERSET_URL=$SUPERSET_URL SUPERSET_PORT=$SUPERSET_PORT SUPERSET_POSTGRES_HOST=$SUPERSET_POSTGRES_HOST SUPERSET_POSTGRES_PORT=$SUPERSET_POSTGRES_PORT"
 log "GRAFANA_URL=$GRAFANA_URL GRAFANA_PORT=$GRAFANA_PORT GRAFANA_POSTGRES_HOST=$GRAFANA_POSTGRES_HOST GRAFANA_POSTGRES_PORT=$GRAFANA_POSTGRES_PORT"
@@ -1466,17 +1469,17 @@ run_logged_unfiltered "Flaky Registry Check" uv run python ci/check_flaky_regist
 
 validate_unit_test_home "$UNIT_TEST_HOME" || exit 1
 rm -rf "$UNIT_TEST_HOME"
-run_logged "Full Unit Tests" run_with_agent_home "$UNIT_TEST_HOME" "$UNIT_TEST_PROJECT_ROOT" uv run pytest tests/unit_tests/ -m "not nightly and not quarantine" --tb=short --verbose --timeout=300 --dist=loadscope -n auto
+run_logged "Full Unit Tests" run_with_agent_home "$UNIT_TEST_HOME" "$UNIT_TEST_PROJECT_ROOT" env DATUS_TEST_LAYER=unit uv run pytest tests/unit_tests/ -m "not nightly and not quarantine" --tb=short --verbose --timeout=300 --dist=loadscope -n auto
 
 ensure_nightly_kb_data
 
-run_logged "MCP Server Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/tools/test_mcp_server.py --tb=short --verbose --timeout=60
+run_logged "MCP Server Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/tools/test_mcp_server.py --tb=short --verbose --timeout=60
 
-run_logged "Gen Agent Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/agent/test_gen_semantic_model_agentic.py tests/integration/agent/test_gen_metrics_agentic.py tests/integration/agent/test_gen_ext_knowledge_agentic.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
+run_logged "Gen Agent Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_gen_semantic_model_agentic.py tests/integration/agent/test_gen_metrics_agentic.py tests/integration/agent/test_gen_ext_knowledge_agentic.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 
-run_logged "Reference Template Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/tools/test_reference_template.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
+run_logged "Reference Template Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/tools/test_reference_template.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 
-run_logged "Web UI Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/regression/test_regression_web_e2e.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5
+run_logged "Web UI Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/regression/test_regression_web_e2e.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5
 
 # These suites are not skipped. They are run by dedicated groups above/below
 # so the broad "tests/" collection used by Main/Product E2E does not duplicate
@@ -1502,26 +1505,26 @@ NIGHTLY_DEDICATED_SUITE_DESELECTS=(
   --deselect tests/regression/test_regression_web_e2e.py
 )
 
-run_logged "Main Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m "nightly and not provider_health and not product_e2e" tests/ "${NIGHTLY_DEDICATED_SUITE_DESELECTS[@]}" --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5 --dist=loadscope -n auto
+run_logged "Main Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and not provider_health and not product_e2e" "${NIGHTLY_PYTEST_ROOTS[@]}" "${NIGHTLY_DEDICATED_SUITE_DESELECTS[@]}" --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5 --dist=loadscope -n auto
 
-run_logged "Product E2E Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m "nightly and product_e2e and not provider_health" tests/ "${NIGHTLY_DEDICATED_SUITE_DESELECTS[@]}" --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
+run_logged "Product E2E Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and product_e2e and not provider_health" "${NIGHTLY_PYTEST_ROOTS[@]}" "${NIGHTLY_DEDICATED_SUITE_DESELECTS[@]}" --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 
-run_compose_suite "Superset Nightly Tests" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
+run_compose_suite "Superset Nightly Tests" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 
-run_compose_suite "Grafana Nightly Tests" "$GRAFANA_COMPOSE" "postgres:300" "grafana:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/tools/test_bi_grafana.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5
+run_compose_suite "Grafana Nightly Tests" "$GRAFANA_COMPOSE" "postgres:300" "grafana:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/tools/test_bi_grafana.py --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5
 
-run_compose_suite "Airflow Nightly Tests" "$AIRFLOW_COMPOSE" "airflow:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/agent/test_scheduler_agentic.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
+run_compose_suite "Airflow Nightly Tests" "$AIRFLOW_COMPOSE" "airflow:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_scheduler_agentic.py --tb=short --verbose --timeout=600 --reruns 1 --reruns-delay 5
 
-run_compose_suite "PostgreSQL Adapter Tests" "$POSTGRES_COMPOSE" "postgres:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_postgresql.py --tb=short --verbose --timeout=300
-run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_mysql.py --tb=short --verbose --timeout=300
-run_compose_suite "ClickHouse Adapter Tests" "$CLICKHOUSE_COMPOSE" "clickhouse:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_clickhouse.py --tb=short --verbose --timeout=300
-run_compose_suite "StarRocks Adapter Tests" "$STARROCKS_COMPOSE" "starrocks:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_starrocks.py --tb=short --verbose --timeout=300
-run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_trino.py --tb=short --verbose --timeout=300
-run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300
-run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300
-run_compose_suite "Spark Adapter Tests" "$SPARK_COMPOSE" "spark-thrift:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m nightly tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300
+run_compose_suite "PostgreSQL Adapter Tests" "$POSTGRES_COMPOSE" "postgres:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_postgresql.py --tb=short --verbose --timeout=300
+run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_mysql.py --tb=short --verbose --timeout=300
+run_compose_suite "ClickHouse Adapter Tests" "$CLICKHOUSE_COMPOSE" "clickhouse:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_clickhouse.py --tb=short --verbose --timeout=300
+run_compose_suite "StarRocks Adapter Tests" "$STARROCKS_COMPOSE" "starrocks:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_starrocks.py --tb=short --verbose --timeout=300
+run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_trino.py --tb=short --verbose --timeout=300
+run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300
+run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300
+run_compose_suite "Spark Adapter Tests" "$SPARK_COMPOSE" "spark-thrift:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300
 
-run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" uv run pytest -m "nightly and provider_health" tests/ --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5
+run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and provider_health" "${NIGHTLY_PYTEST_ROOTS[@]}" --tb=short --verbose --timeout=300 --reruns 1 --reruns-delay 5
 
 run_logged_unfiltered "Flaky Log Classification" uv run python ci/check_flaky_registry.py --registry ci/flaky-registry.yml --log-file "$LOG_FILE" --warn-only
 

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.unit_tests import conftest as unit_conftest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+NIGHTLY_SCRIPT = REPO_ROOT / "ci" / "run-nightly-tests.sh"
+
+
+def _nightly_script_text() -> str:
+    return NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _pytest_script_line_containing(label: str) -> str:
+    matches = [line for line in _nightly_script_text().splitlines() if label in line and " uv run pytest " in line]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_nightly_broad_suites_do_not_collect_unit_tests():
+    script = _nightly_script_text()
+
+    assert "NIGHTLY_PYTEST_ROOTS=(tests/integration tests/regression)" in script
+
+    for suite_name in (
+        "Main Nightly Tests",
+        "Product E2E Nightly Tests",
+        "Provider Health Tests",
+    ):
+        line = _pytest_script_line_containing(suite_name)
+        assert '"${NIGHTLY_PYTEST_ROOTS[@]}"' in line
+        assert " tests/ " not in line
+
+
+def test_nightly_pytest_commands_set_explicit_test_layer():
+    pytest_command_lines = [
+        line
+        for line in _nightly_script_text().splitlines()
+        if " uv run pytest " in line and ("run_logged" in line or "run_compose_suite" in line)
+    ]
+
+    assert len(pytest_command_lines) == 19
+    for line in pytest_command_lines:
+        expected_layer = "unit" if "Full Unit Tests" in line else "nightly"
+        assert f"env DATUS_TEST_LAYER={expected_layer} uv run pytest" in line
+
+
+@pytest.mark.parametrize(
+    ("test_layer", "expected_cleanup_enabled"),
+    [
+        (None, True),
+        ("", True),
+        ("unit", True),
+        ("ci", True),
+        ("nightly", False),
+        (" Nightly ", False),
+        ("integration", False),
+        ("regression", False),
+        ("product_e2e", False),
+        ("provider_health", False),
+    ],
+)
+def test_unit_conftest_keeps_external_tracing_for_non_unit_layers(test_layer, expected_cleanup_enabled):
+    assert unit_conftest._external_tracing_cleanup_enabled(test_layer) == expected_cleanup_enabled
+
+
+def _restore_unit_conftest_langfuse_state(saved_env: dict[str, str | None], stripped: bool) -> None:
+    unit_conftest._saved_langfuse_env.clear()
+    unit_conftest._saved_langfuse_env.update(saved_env)
+    unit_conftest._langfuse_env_stripped = stripped
+
+
+def test_unit_conftest_pytest_configure_keeps_langfuse_env_for_nightly_layer(monkeypatch):
+    original_saved_env = dict(unit_conftest._saved_langfuse_env)
+    original_stripped = unit_conftest._langfuse_env_stripped
+    expected_env = {
+        "LANGFUSE_PUBLIC_KEY": "pk-test",
+        "LANGFUSE_SECRET_KEY": "sk-test",
+        "LANGFUSE_BASE_URL": "https://langfuse.test",
+    }
+
+    try:
+        unit_conftest._saved_langfuse_env.clear()
+        monkeypatch.setenv("DATUS_TEST_LAYER", "nightly")
+        for key, value in expected_env.items():
+            monkeypatch.setenv(key, value)
+
+        unit_conftest.pytest_configure(config=None)
+
+        observed_env = {key: os.environ[key] for key in expected_env}
+        assert observed_env == expected_env
+        assert unit_conftest._saved_langfuse_env == {}
+        assert unit_conftest._langfuse_env_stripped is False
+
+        unit_conftest.pytest_unconfigure(config=None)
+
+        observed_env = {key: os.environ[key] for key in expected_env}
+        assert observed_env == expected_env
+    finally:
+        _restore_unit_conftest_langfuse_state(original_saved_env, original_stripped)
+
+
+def test_unit_conftest_pytest_configure_strips_and_restores_langfuse_env_for_unit_layer(monkeypatch):
+    original_saved_env = dict(unit_conftest._saved_langfuse_env)
+    original_stripped = unit_conftest._langfuse_env_stripped
+    expected_env = {
+        "LANGFUSE_PUBLIC_KEY": "pk-test",
+        "LANGFUSE_SECRET_KEY": "sk-test",
+        "LANGFUSE_BASE_URL": "https://langfuse.test",
+    }
+    expected_saved_env = {**expected_env, "LANGFUSE_HOST": None}
+
+    try:
+        unit_conftest._saved_langfuse_env.clear()
+        monkeypatch.delenv("DATUS_TEST_LAYER", raising=False)
+        for key, value in expected_env.items():
+            monkeypatch.setenv(key, value)
+
+        unit_conftest.pytest_configure(config=None)
+
+        observed_env = {key: os.environ.get(key) for key in expected_env}
+        assert observed_env == dict.fromkeys(expected_env)
+        assert unit_conftest._saved_langfuse_env == expected_saved_env
+        assert unit_conftest._langfuse_env_stripped is True
+
+        unit_conftest.pytest_unconfigure(config=None)
+
+        observed_env = {key: os.environ[key] for key in expected_env}
+        assert observed_env == expected_env
+    finally:
+        _restore_unit_conftest_langfuse_state(original_saved_env, original_stripped)

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -23,18 +23,35 @@ from unittest.mock import patch
 
 import pytest
 
-# Clear Langfuse env vars BEFORE any test module imports trigger setup_tracing().
+# Clear Langfuse env vars BEFORE any unit test module imports trigger setup_tracing().
 # Session-scoped fixtures run too late (after collection), so we use pytest_configure.
+# Nightly/integration invocations set DATUS_TEST_LAYER to keep external tracing intact
+# even if this conftest is loaded during collection.
 _LANGFUSE_ENV_KEYS = ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST", "LANGFUSE_BASE_URL")
 _saved_langfuse_env = {}
+_langfuse_env_stripped = False
+_EXTERNAL_TRACING_TEST_LAYERS = {"integration", "nightly", "product_e2e", "provider_health", "regression"}
+
+
+def _external_tracing_cleanup_enabled(test_layer: str | None) -> bool:
+    return (test_layer or "").strip().lower() not in _EXTERNAL_TRACING_TEST_LAYERS
 
 
 def pytest_configure(config):
+    global _langfuse_env_stripped
+    if not _external_tracing_cleanup_enabled(os.environ.get("DATUS_TEST_LAYER")):
+        _langfuse_env_stripped = False
+        return
+
+    _langfuse_env_stripped = True
     for key in _LANGFUSE_ENV_KEYS:
         _saved_langfuse_env[key] = os.environ.pop(key, None)
 
 
 def pytest_unconfigure(config):
+    if not _langfuse_env_stripped:
+        return
+
     for key, val in _saved_langfuse_env.items():
         if val is None:
             os.environ.pop(key, None)
@@ -82,6 +99,10 @@ def _disable_langsmith_tracing():
     Overrides any inherited env vars so UT runs never upload traces, even when
     the developer's shell has LANGSMITH_TRACING=true or an API key set.
     """
+    if not _external_tracing_cleanup_enabled(os.environ.get("DATUS_TEST_LAYER")):
+        yield
+        return
+
     saved = {
         k: os.environ.get(k)
         for k in (


### PR DESCRIPTION
Summary
- Limit broad nightly pytest runs to integration/regression roots so they never collect unit-test conftest side effects.
- Set DATUS_TEST_LAYER explicitly for unit and nightly pytest invocations.
- Keep Langfuse/LangSmith env cleanup enabled for unit tests, but disabled when pytest is invoked as nightly/integration/product/provider layer.
- Add unit coverage that locks the nightly tracing boundary and conftest env behavior.

Validation
- bash -n ci/run-nightly-tests.sh
- uv run pytest tests/unit_tests/ci/test_audit_tests.py tests/unit_tests/ci/test_nightly_tracing_boundaries.py -q
- uv run python ci/audit_tests.py --paths tests/unit_tests/ci/test_nightly_tracing_boundaries.py tests/unit_tests/conftest.py
- uv run ruff check tests/unit_tests/conftest.py tests/unit_tests/ci/test_nightly_tracing_boundaries.py
- uv run ruff format --check tests/unit_tests/conftest.py tests/unit_tests/ci/test_nightly_tracing_boundaries.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced nightly test suite organization with explicit test layer definitions.
  * Added validation to ensure correct test layer configuration and environment handling.

* **Chores**
  * Improved environment variable management during test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->