### PR TITLE
[BugFix] Resolve release branch diff coverage base

### DIFF
--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -461,7 +461,7 @@ def _resolve_explicit_compare_ref(base_ref: str) -> str | None:
     elif ref.startswith("refs/remotes/"):
         add(ref.removeprefix("refs/remotes/"))
         add(ref)
-    elif "/" in ref:
+    elif ref.startswith(("origin/", "upstream/")):
         add(ref)
     else:
         add(f"origin/{ref}")

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -210,6 +210,12 @@ def test_resolve_explicit_compare_ref_prefers_origin_for_branch_name(monkeypatch
     assert run_pr_tests._resolve_explicit_compare_ref("main") == "origin/main"
 
 
+def test_resolve_explicit_compare_ref_prefers_origin_for_slash_branch_name(monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "_git_ref_exists", lambda ref: ref == "origin/release/0.3.2")
+
+    assert run_pr_tests._resolve_explicit_compare_ref("release/0.3.2") == "origin/release/0.3.2"
+
+
 def test_resolve_explicit_compare_ref_accepts_remote_ref(monkeypatch):
     monkeypatch.setattr(run_pr_tests, "_git_ref_exists", lambda ref: ref == "upstream/main")
 


### PR DESCRIPTION
Summary
- Resolve slash-containing base branches such as release/0.3.2 to origin/release/0.3.2 for PR diff coverage.
- Keep explicit remote refs such as origin/main and upstream/main supported as-is.
- Add unit coverage for release branch base-ref resolution.

Validation
- uv run pytest tests/unit_tests/ci/test_run_pr_tests.py -q
- uv run python ci/audit_tests.py --paths tests/unit_tests/ci/test_run_pr_tests.py
- uv run ruff check ci/run-pr-tests.py tests/unit_tests/ci/test_run_pr_tests.py
- uv run ruff format --check ci/run-pr-tests.py tests/unit_tests/ci/test_run_pr_tests.py

Follow-up from release backport PR #884.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of branch names containing slashes (e.g., `release/0.3.2`) in PR testing by refining reference resolution logic.

* **Tests**
  * Added test coverage for branch name resolution with slashes in PR testing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->