### PR TITLE
[BugFix] Backport release candidate workflows to 0.3.2

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -114,6 +114,9 @@ jobs:
             --allow-current-version
             --allow-no-changes
           )
+          if [[ "${VERSION}" =~ rc[0-9]+$ ]]; then
+            args+=(--allow-same-final-prerelease)
+          fi
           if [[ "${UPDATE_ADAPTER_BOUNDS}" == "true" ]]; then
             args+=(--update-adapter-bounds)
           else

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Stable datus-agent version to publish, for example 0.3.8"
+        description: "datus-agent version to publish, for example 0.3.8 or 0.3.8rc1"
         required: true
         type: string
       ref:
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Build, publish, tag, and sync metadata
+    name: Build, publish, and finalize stable releases
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.repository }}
@@ -68,6 +68,18 @@ jobs:
       - name: Install publish tooling
         run: python -m pip install --upgrade pip build packaging twine
 
+      - name: Classify release version
+        id: release_version
+        shell: bash
+        run: |
+          python - <<'PY' >> "${GITHUB_OUTPUT}"
+          import os
+          from packaging.version import Version
+
+          version = Version(os.environ["VERSION"])
+          print(f"is_prerelease={'true' if version.is_prerelease else 'false'}")
+          PY
+
       - name: Check release readiness
         shell: bash
         env:
@@ -85,6 +97,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          IS_PRERELEASE: ${{ steps.release_version.outputs.is_prerelease }}
         run: |
           set -euo pipefail
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -101,6 +114,10 @@ jobs:
 
           if [[ "${TARGET_REPOSITORY}" != "pypi" ]]; then
             echo "Skipping stable tag validation for ${TARGET_REPOSITORY}"
+            exit 0
+          fi
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            echo "Skipping stable tag validation for prerelease ${VERSION}"
             exit 0
           fi
 
@@ -295,7 +312,7 @@ jobs:
           datus probe-llm --help >/dev/null
 
       - name: Create or verify release tag
-        if: ${{ inputs.repository == 'pypi' }}
+        if: ${{ inputs.repository == 'pypi' && steps.release_version.outputs.is_prerelease != 'true' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
@@ -320,7 +337,7 @@ jobs:
           fi
 
       - name: Dispatch docs deploy
-        if: ${{ inputs.repository == 'pypi' }}
+        if: ${{ inputs.repository == 'pypi' && steps.release_version.outputs.is_prerelease != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
@@ -330,7 +347,7 @@ jobs:
             -f version="${TAG_NAME}"
 
       - name: Create or update main metadata sync PR
-        if: ${{ inputs.repository == 'pypi' && inputs.create_main_metadata_pr }}
+        if: ${{ inputs.repository == 'pypi' && inputs.create_main_metadata_pr && steps.release_version.outputs.is_prerelease != 'true' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
@@ -397,16 +414,23 @@ jobs:
           fi
 
       - name: Record release summary
+        shell: bash
+        env:
+          IS_PRERELEASE: ${{ steps.release_version.outputs.is_prerelease }}
         run: |
           {
             echo "### Release"
             echo
             echo "- Version: \`${VERSION}\`"
+            echo "- Prerelease: \`${IS_PRERELEASE}\`"
             echo "- Repository: \`${TARGET_REPOSITORY}\`"
             echo "- Source ref: \`${RELEASE_REF}\`"
             echo "- Source SHA: \`${{ steps.source.outputs.release_sha }}\`"
-            if [[ "${TARGET_REPOSITORY}" == "pypi" ]]; then
+            if [[ "${TARGET_REPOSITORY}" == "pypi" && "${IS_PRERELEASE}" != "true" ]]; then
               echo "- Tag: \`${TAG_NAME}\`"
               echo "- Docs deploy: dispatched for \`${TAG_NAME}\`"
+              echo "- Main metadata sync: requested = \`${{ inputs.create_main_metadata_pr }}\`"
+            elif [[ "${TARGET_REPOSITORY}" == "pypi" ]]; then
+              echo "- Tag/docs/main metadata sync: skipped for prerelease"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/ci/prepare_release.py
+++ b/ci/prepare_release.py
@@ -36,11 +36,32 @@ def parse_canonical_version(raw_version: str) -> Version:
     return version
 
 
+def is_same_final_prerelease(target_version: Version, current_version: Version) -> bool:
+    return (
+        target_version.is_prerelease
+        and not current_version.is_prerelease
+        and Version(target_version.base_version) == current_version
+    )
+
+
 def ensure_version_can_advance(
-    repo_root: Path, target_version: Version, *, allow_current_version: bool = False
+    repo_root: Path,
+    target_version: Version,
+    *,
+    allow_current_version: bool = False,
+    allow_same_final_prerelease: bool = False,
 ) -> None:
     current_version = read_pyproject_version(repo_root)
-    if target_version < current_version or (target_version == current_version and not allow_current_version):
+    same_final_prerelease = is_same_final_prerelease(target_version, current_version)
+    if target_version < current_version:
+        if not (allow_same_final_prerelease and same_final_prerelease):
+            raise ValueError(f"Release version must advance current version {current_version}; got {target_version}")
+        stable_tag_errors = check_tag_available(repo_root, Version(target_version.base_version))
+        if stable_tag_errors:
+            raise ValueError(
+                f"Cannot prepare prerelease {target_version} from finalized {current_version}: {stable_tag_errors[0]}"
+            )
+    elif target_version == current_version and not allow_current_version:
         raise ValueError(f"Release version must advance current version {current_version}; got {target_version}")
 
     tag_errors = check_tag_available(repo_root, target_version)
@@ -156,6 +177,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow preparing a release branch that already has the target version",
     )
     parser.add_argument(
+        "--allow-same-final-prerelease",
+        action="store_true",
+        help="Allow preparing 0.3.2rcN from current 0.3.2 when the stable tag is not present",
+    )
+    parser.add_argument(
         "--allow-no-changes",
         action="store_true",
         help="Exit successfully when release metadata is already prepared",
@@ -169,7 +195,12 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = args.repo_root.resolve()
     try:
         version = parse_canonical_version(args.version)
-        ensure_version_can_advance(repo_root, version, allow_current_version=args.allow_current_version)
+        ensure_version_can_advance(
+            repo_root,
+            version,
+            allow_current_version=args.allow_current_version,
+            allow_same_final_prerelease=args.allow_same_final_prerelease,
+        )
         changed = prepare_release(
             repo_root,
             version,

--- a/tests/unit_tests/ci/test_prepare_release.py
+++ b/tests/unit_tests/ci/test_prepare_release.py
@@ -102,6 +102,45 @@ def test_ensure_version_can_advance_can_allow_current_version(tmp_path, prepare_
         prepare_release.ensure_version_can_advance(repo_root, Version("0.2.5"), allow_current_version=True)
 
 
+def test_ensure_version_can_allow_same_final_prerelease(tmp_path, prepare_release):
+    repo_root = _write_release_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="must advance current version"):
+        prepare_release.ensure_version_can_advance(repo_root, Version("0.2.6rc1"))
+
+    assert (
+        prepare_release.ensure_version_can_advance(
+            repo_root,
+            Version("0.2.6rc1"),
+            allow_same_final_prerelease=True,
+        )
+        is None
+    )
+
+
+def test_ensure_version_can_allow_same_final_prerelease_rejects_finalized_tag(tmp_path, prepare_release):
+    repo_root = _write_release_repo(tmp_path)
+    subprocess.run(["git", "tag", "v0.2.6"], cwd=repo_root, check=True)
+
+    with pytest.raises(ValueError, match="Cannot prepare prerelease 0.2.6rc1 from finalized 0.2.6"):
+        prepare_release.ensure_version_can_advance(
+            repo_root,
+            Version("0.2.6rc1"),
+            allow_same_final_prerelease=True,
+        )
+
+
+def test_ensure_version_can_allow_same_final_prerelease_rejects_different_line(tmp_path, prepare_release):
+    repo_root = _write_release_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="must advance current version"):
+        prepare_release.ensure_version_can_advance(
+            repo_root,
+            Version("0.2.5rc1"),
+            allow_same_final_prerelease=True,
+        )
+
+
 def test_prepare_release_updates_version_and_adapter_bounds(tmp_path, monkeypatch, prepare_release):
     repo_root = _write_release_repo(tmp_path)
     monkeypatch.setattr(

--- a/tests/unit_tests/ci/test_release_workflows.py
+++ b/tests/unit_tests/ci/test_release_workflows.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_prepare_release_allows_same_final_prerelease_for_rc_inputs():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "prepare-release.yml").read_text(encoding="utf-8")
+
+    assert 'if [[ "${VERSION}" =~ rc[0-9]+$ ]]; then' in workflow
+    assert "args+=(--allow-same-final-prerelease)" in workflow
+
+
+def test_publish_release_skips_finalize_steps_for_prereleases():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "publish-release.yml").read_text(encoding="utf-8")
+
+    assert 'description: "datus-agent version to publish, for example 0.3.8 or 0.3.8rc1"' in workflow
+    assert "id: release_version" in workflow
+    assert 'Version(os.environ["VERSION"])' in workflow
+    assert 'if [[ "${IS_PRERELEASE}" == "true" ]]; then' in workflow
+    assert "Skipping stable tag validation for prerelease ${VERSION}" in workflow
+
+    stable_only_guard = "${{ inputs.repository == 'pypi' && steps.release_version.outputs.is_prerelease != 'true' }}"
+    assert f"Create or verify release tag\n        if: {stable_only_guard}" in workflow
+    assert f"Dispatch docs deploy\n        if: {stable_only_guard}" in workflow
+    assert (
+        "Create or update main metadata sync PR\n"
+        "        if: ${{ inputs.repository == 'pypi' && inputs.create_main_metadata_pr "
+        "&& steps.release_version.outputs.is_prerelease != 'true' }}"
+    ) in workflow
+    assert "Tag/docs/main metadata sync: skipped for prerelease" in workflow


### PR DESCRIPTION
## Summary

Backport release-candidate workflow handling to `release/0.3.2`.

- allow Prepare Release to prepare an RC from the same final version line when the stable tag is not present
- classify Publish And Finalize Release versions as prerelease/stable
- skip stable-only tag creation, docs deploy, and main metadata sync for RC publishes
- add unit coverage for RC version handling and workflow guards

## Validation

- `uv run pytest tests/unit_tests/ci/test_prepare_release.py tests/unit_tests/ci/test_release_workflows.py -q`
- `uv run ruff check ci/prepare_release.py tests/unit_tests/ci/test_prepare_release.py tests/unit_tests/ci/test_release_workflows.py`
- `uv run ruff format --check ci/prepare_release.py tests/unit_tests/ci/test_prepare_release.py tests/unit_tests/ci/test_release_workflows.py`
- `uv run python ci/audit_tests.py --paths tests/unit_tests/ci/test_prepare_release.py tests/unit_tests/ci/test_release_workflows.py`
- `actionlint .github/workflows/prepare-release.yml .github/workflows/publish-release.yml`
