### PR TITLE
[BugFix] Run print mode under workflow execution_mode

### DIFF
--- a/datus/cli/print_mode.py
+++ b/datus/cli/print_mode.py
@@ -66,6 +66,7 @@ class PrintModeRunner:
             node_id_suffix="_print",
             scope=self.scope,
             session_id=self.session_id,
+            execution_mode="workflow",
         )
 
         if self.proxy_tool_patterns:

--- a/tests/unit_tests/cli/test_print_mode.py
+++ b/tests/unit_tests/cli/test_print_mode.py
@@ -356,6 +356,7 @@ class TestResumeSessionId:
             node_id_suffix="_print",
             scope=None,
             session_id="session_uuid123",
+            execution_mode="workflow",
         )
 
 
@@ -393,7 +394,12 @@ class TestRunUsesFactory:
             runner.run()
 
         mock_create_node.assert_called_once_with(
-            None, runner.agent_config, node_id_suffix="_print", scope=None, session_id=None
+            None,
+            runner.agent_config,
+            node_id_suffix="_print",
+            scope=None,
+            session_id=None,
+            execution_mode="workflow",
         )
         mock_create_input.assert_called_once()
         assert mock_node.input == mock_input


### PR DESCRIPTION
## Why

`datus -p` (print mode) is the scripting / CI entry point — its output is consumed by another process via stdout JSON, and there is typically no human attached to a TTY. Today the print-mode node is constructed with the default `execution_mode="interactive"`, which has two undesirable consequences in this setting:

1. `PermissionHooks` treats ASK / EXTERNAL filesystem hits as broker requests and blocks awaiting an answer that no one will ever provide.
2. The node honors the user's `/permission` profile (`normal` / `auto` / `dangerous`), so a CI run can hit unexpected ASK prompts depending on whatever profile happened to be persisted in `.datus/config.yml`.

This makes `-p` unreliable for automation and inconsistent with the other non-interactive flows (`/bootstrap`, scheduler subagents, `auto_create`) which already run as `workflow`.

## Solution

Pass `execution_mode="workflow"` when print mode constructs its node via `create_interactive_node` (`datus/cli/print_mode.py`). This reuses the existing workflow semantics documented in `agentic_node.py:1270-1276` / `2474-2477`:

- `PermissionHooks` is built with `non_interactive=True`, so ASK / EXTERNAL hits short-circuit to `PermissionDeniedException` instead of awaiting the broker.
- `_setup_permission_manager` forces the `dangerous` profile, ignoring whatever profile the user has selected interactively — print mode now has a single, predictable permission surface.

LLM-driven `ask_user` tool calls (which arrive as `INTERACTION` actions, not permission ASKs) are still handled by the existing stdin loop in `print_mode.py:99-112`, so the proxy / piped-interaction protocol is unchanged.

## Test Cases

Updated existing unit tests in `tests/unit_tests/cli/test_print_mode.py` to assert the new kwarg:

- `TestRunUsesFactory::test_run_calls_factory` — verifies the default `datus -p` path passes `execution_mode="workflow"`.
- `TestResumeSessionId::test_resume_subagent_name_from_args` — verifies the resume + subagent path also passes `execution_mode="workflow"`.

No new integration / nightly tests added: the workflow-mode semantics (non-interactive PermissionHooks, dangerous-profile setup) are already covered by `tests/unit_tests/tools/permission/test_permission_hooks.py` and the existing workflow callers in `datus/agent/node/node.py`; this PR only changes the call site in print mode.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [x] release/0.3.2