### PR TITLE
[Enhancement] Show compiled report HTML absolute path in CLI message stream

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -633,12 +633,14 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         """
         raise NotImplementedError
 
-    def _post_validate_hook(self, artifact_slug: str, result: ResultT) -> None:
+    def _post_validate_hook(self, artifact_slug: str, result: ResultT) -> Optional[ActionHistory]:
         """Run artifact-specific work after a successful ``validate_render``.
 
-        The report subagent uses this to compile a standalone HTML and
-        optionally open it in the browser; dashboard mode has nothing to
-        do here. Default is a no-op.
+        The report subagent uses this to compile a standalone HTML, open it
+        in the browser, and return a stream message naming the compiled
+        file's absolute path; dashboard mode has nothing to do here.
+        Returning an :class:`ActionHistory` makes ``_stream_post_build``
+        emit it into the action stream; ``None`` (the default) emits nothing.
         """
         return None
 
@@ -858,4 +860,6 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             result.finalize_warnings = finalize_summary["warnings"]  # type: ignore[attr-defined]
         if hasattr(result, "finalize_error") and finalize_summary.get("error"):
             result.finalize_error = finalize_summary["error"]  # type: ignore[attr-defined]
-        self._post_validate_hook(slug, result)
+        post_action = self._post_validate_hook(slug, result)
+        if post_action is not None:
+            yield post_action

--- a/datus/agent/node/gen_visual_report_agentic_node.py
+++ b/datus/agent/node/gen_visual_report_agentic_node.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from datus.agent.node.base_visual_artifact_agentic_node import BaseVisualArtifactAgenticNode
-from datus.schemas.action_history import ActionHistory
+from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.schemas.gen_visual_report_models import (
     GenVisualReportNodeInput,
     GenVisualReportNodeResult,
@@ -162,16 +162,45 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
             created_at=manifest.get("created_at"),
         )
 
-    def _post_validate_hook(self, artifact_slug: str, result: GenVisualReportNodeResult) -> None:
+    def _post_validate_hook(self, artifact_slug: str, result: GenVisualReportNodeResult) -> Optional[ActionHistory]:
         """CLI-mode side effect: compile a standalone HTML and open it.
 
         Dashboard mode has no analogue (its queries are templates that
         must run against a live datasource), so this stays in the report
         subclass and the base class skips the hook in dashboard mode.
+
+        Returns a stream message carrying the compiled HTML's absolute path
+        so the user can reopen the report after closing the auto-opened
+        browser tab; ``None`` when no HTML was compiled (non-CLI mode).
         """
         html_rel_path = self._maybe_compile_html(artifact_slug)
-        if html_rel_path:
-            result.html_path = html_rel_path
+        if not html_rel_path:
+            return None
+        result.html_path = html_rel_path
+        project_root = Path(self.agent_config.project_root).resolve()
+        html_abs_path = (project_root / html_rel_path).resolve()
+        return self._build_html_path_action(artifact_slug, html_abs_path)
+
+    def _build_html_path_action(self, report_slug: str, html_abs_path: Path) -> ActionHistory:
+        """Stream a status message naming the compiled report's absolute path.
+
+        The CLI auto-opens the report in a browser; once the user closes that
+        tab they otherwise have no record of where the artifact lives. Emitting
+        the absolute path into the action stream keeps it in the scrollback for
+        later reference. Uses the ``WORKFLOW`` role (the node status-message
+        convention) so the TUI same-turn assistant-response dedup never drops it.
+        """
+        message = (
+            f"Report saved to {html_abs_path} — open this file in a browser to view it again after closing the tab."
+        )
+        return ActionHistory.create_action(
+            role=ActionRole.WORKFLOW,
+            action_type="report_html_path",
+            messages=message,
+            input_data={"report_slug": report_slug},
+            output_data={"html_path": str(html_abs_path), "url": html_abs_path.as_uri()},
+            status=ActionStatus.SUCCESS,
+        )
 
     # ----------------------------------------------------------- CLI compile
 

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -26,7 +26,7 @@ from pathlib import Path
 import pytest
 
 from datus.configuration.node_type import NodeType
-from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.gen_visual_report_models import GenVisualReportNodeInput
 from datus.tools.func_tool import (
     DBFuncTool,
@@ -278,6 +278,17 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     assert result["html_path"] == expected_html_rel
     assert (report_dir / "index.html").is_file()
 
+    # CLI mode streams a WORKFLOW status message carrying the compiled HTML's
+    # absolute path so the user can reopen it after closing the browser tab.
+    path_actions = [a for a in actions if a.action_type == "report_html_path"]
+    assert len(path_actions) == 1, "expected exactly one report_html_path action in CLI mode"
+    path_action = path_actions[0]
+    assert path_action.role == ActionRole.WORKFLOW
+    abs_html = str((report_dir / "index.html").resolve())
+    assert abs_html in path_action.messages
+    assert path_action.output["html_path"] == abs_html
+    assert path_action.output["url"].startswith("file://")
+
     # Artifact card fields surface through the result so the SSE artifact
     # event can be built without touching disk a second time.
     assert result["artifact_kind"] == "report"
@@ -330,6 +341,48 @@ class TestReportDistResolution:
         node._maybe_compile_html(report_slug)
         copied_css = Path(real_agent_config.project_root) / "reports" / report_slug / "_assets" / "index.css"
         assert copied_css.read_text(encoding="utf-8") == "/* node-only css */"
+
+
+class TestHtmlPathStreamMessage:
+    """Verify the compiled-HTML absolute path is surfaced into the action stream."""
+
+    def test_post_validate_hook_emits_path_action_in_cli_mode(self, real_agent_config, mock_llm_create):
+        from datus.schemas.gen_visual_report_models import GenVisualReportNodeResult
+
+        node = _make_node(real_agent_config)
+        report_slug = "path_msg_cli"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
+
+        result = GenVisualReportNodeResult(success=True)
+        action = node._post_validate_hook(report_slug, result)
+
+        assert isinstance(action, ActionHistory)
+        assert action.action_type == "report_html_path"
+        assert action.role == ActionRole.WORKFLOW
+        abs_html = str((Path(real_agent_config.project_root) / "reports" / report_slug / "index.html").resolve())
+        assert action.output["html_path"] == abs_html
+        assert abs_html in action.messages
+        # The relative path is still recorded on the result for SaaS/task consumers.
+        assert result.html_path == f"reports/{report_slug}/index.html"
+
+    def test_post_validate_hook_returns_none_in_non_cli_mode(self, real_agent_config, mock_llm_create):
+        from datus.schemas.gen_visual_report_models import GenVisualReportNodeResult
+
+        # filesystem_strict flips the node into SaaS/API mode, which renders
+        # reports dynamically server-side and never compiles a standalone HTML.
+        real_agent_config.filesystem_strict = True
+        node = _make_node(real_agent_config)
+        report_slug = "path_msg_saas"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
+
+        result = GenVisualReportNodeResult(success=True)
+        action = node._post_validate_hook(report_slug, result)
+
+        assert action is None
+        assert result.html_path is None
+        assert not (Path(real_agent_config.project_root) / "reports" / report_slug / "index.html").exists()
 
 
 class _InlineThread:


### PR DESCRIPTION
## Why

In CLI mode, `gen_visual_report` compiles the report artifact into a standalone `index.html` (via `report_html_renderer.render_report_html`) and auto-opens it in the system browser. Once the user closes that browser tab, nothing in the conversation tells them where the artifact actually lives, so they cannot reopen it without re-running the agent.

## Solution

After the CLI HTML compile succeeds, the report node now emits a status message into the action stream naming the compiled file's **absolute path** (plus a `file://` URL), so it stays in the scrollback for later reference.

Key decisions:

- **New stream action.** `GenVisualReportAgenticNode._post_validate_hook` reconstructs the absolute path from `project_root` + the relative `html_path` and returns a `report_html_path` `ActionHistory`. The base `BaseVisualArtifactAgenticNode._post_validate_hook` signature changes from `-> None` to `-> Optional[ActionHistory]`, and `_stream_post_build` yields the returned action into the stream when present.
- **`WORKFLOW` role, not `ASSISTANT`.** The CLI TUI same-turn dedup (`action_display/streaming.py`) drops any depth-0 `ASSISTANT`/`SUCCESS` action emitted after the main response was already streamed, which would silently swallow the message when the report node runs as the active agent. `WORKFLOW` is the established node status-message role (used by `generate_sql_node`, `execute_sql_node`, etc.) and renders reliably as `⏺ 🟡 <message>` in both TUI and non-TUI modes, and inside the sub-agent group when run via `task`.
- **CLI-only by construction.** `_maybe_compile_html` already returns `None` in SaaS/API mode (`filesystem_strict`), so `_post_validate_hook` returns `None` there and no extra action is emitted. The relative `html_path` recorded on the result for SaaS/task consumers is unchanged. Dashboard mode keeps the base no-op.

## Test Cases

Unit tests in `tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py`:

- `test_execute_stream_end_to_end` — extended to assert the stream contains exactly one `report_html_path` `WORKFLOW` action whose message + `output.html_path` carry the compiled `index.html` absolute path and a `file://` URL.
- `TestHtmlPathStreamMessage::test_post_validate_hook_emits_path_action_in_cli_mode` — CLI mode returns the path action and still records the relative `html_path` on the result.
- `TestHtmlPathStreamMessage::test_post_validate_hook_returns_none_in_non_cli_mode` — `filesystem_strict` (SaaS) mode compiles no HTML and returns `None`.

Gates: report + dashboard node unit tests pass (36); `diff-cover` 100% on changed lines; test-quality audit P0=0/P1=0; ruff clean. (Pre-existing, unrelated full-suite failures requiring prebuilt test datasources — `TestNodeFactory` `california_schools`, `test_compress` `card_games`, `test_detect_toxicology_db`, `test_create_metric_with_valid_yaml` — are environmental and untouched by this change.)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post-validation workflow now emits streaming workflow actions containing compiled HTML report paths and file:// URLs upon successful compilation, delivering real-time feedback to end users.

* **Tests**
  * Extended unit test suite to validate action streaming behavior across CLI and API/SaaS deployment modes, ensuring correct message emissions and mode-specific validations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->