### PR TITLE
[BugFix] Keep workflow prompts non-interactive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@ AI-powered data-analysis agent: NL → SQL, multi-DB, RAG knowledge base, MCP pr
 
 ```bash
 uv sync                                                # Install dependencies
-uv run pytest tests/unit_tests/ -m "not nightly" -q    # CI tests (zero external deps)
+uv run python ci/run-pr-tests.py upstream/main         # PR CI harness: acceptance + impacted unit tests + coverage
 uv run pytest -m nightly tests/                        # Nightly (needs API keys)
 uv run pytest -m "nightly or regression" tests/        # Full regression
-uv run ruff format . && uv run ruff check --fix .      # Lint & format
+uv run ruff format datus/ tests/ && uv run ruff check --fix datus/ tests/  # Lint & format
 bash build_scripts/build_test_data.sh                  # Build test KB
 ```
 
@@ -104,16 +104,15 @@ When using `gh pr create --body`, copy `.github/PULL_REQUEST_TEMPLATE.md` as the
 
 ## Commit Workflow
 
-Every gate below also runs in CI on the PR — running them locally first avoids round-trip failures. Do **not** push until each one passes.
+Run the same gates that protect ordinary PRs before pushing, and keep extra full-suite runs targeted to high-risk changes.
 
-1. **Pre-format**: `uv run ruff format . && uv run ruff check --fix .` before staging.
-2. **Coverage gate** — both dimensions must pass:
-   - Overall: `uv run pytest tests/unit_tests/ -m "not nightly" --cov=datus --cov-report=xml:coverage.xml --cov-fail-under=80`
-   - Diff: `uv run diff-cover coverage.xml --compare-branch=upstream/main --fail-under=80` (add `--show-uncovered` to locate uncovered new lines).
-3. **Test-quality audit** (`ci/audit_tests.py`): `uv run python ci/audit_tests.py --diff-only upstream/main` — must report **`P0=0`**. P0 hard-fails CI (conditional asserts, tautologies, zero-assert tests, debug leftovers, hardcoded pre-built DBs, etc.); P1 is warn-only but should be addressed. Use `--all` for a full scan when you've touched many test files. Honor noqa with `# audit-noqa: <rule>` only when justified.
-4. **Pre-commit hooks**: never use `--no-verify`; auto-fix and retry until they pass.
-5. **Push**: only to `origin`, never to `upstream`.
-6. **PR body**: see **PR Conventions → Body** above.
+1. **Pre-format**: `uv run ruff format datus/ tests/ && uv run ruff check --fix datus/ tests/` before staging. CI checks the same paths with `ruff format --check datus/ tests/` and `ruff check datus/ tests/`.
+2. **PR coverage harness**: `uv run python ci/run-pr-tests.py upstream/main`. This runs the fixed acceptance harness, impacted unit-test targets selected from the diff, Cobertura coverage, and diff coverage. Inspect `ci/test-report.md` and `ci/diff-cover-report.md` when it fails.
+3. **Test-quality audit**: `uv run python ci/audit_tests.py --repo-root . --diff-only upstream/main` — must report **`P0=0`**. P0 hard-fails CI; P1 is warn-only but should be addressed. Use `--all` for a full scan when you've touched many test files. Honor noqa with `# audit-noqa: <rule>` only when justified.
+4. **Merge-queue rehearsal**: run `uv run python ci/run-merge-queue-tests.py` when changing acceptance harness targets, CI scripts, or code likely to affect merge-queue-only integration coverage.
+5. **Pre-commit hooks**: never use `--no-verify`; auto-fix and retry until they pass.
+6. **Push**: only to `origin`, never to `upstream`.
+7. **PR body**: see **PR Conventions → Body** above.
 
 ## Testing Rules
 
@@ -121,7 +120,7 @@ Every gate below also runs in CI on the PR — running them locally first avoids
 
 | Tier | Marker | Mock policy |
 |------|--------|-------------|
-| CI | none — discovered by directory under `tests/unit_tests/`; <5 s/test, deterministic | **Must** mock all external calls (LLM, remote DBs, network, optional packages) |
+| CI | PR acceptance harness plus impacted `tests/unit_tests/`; <5 s/test, deterministic | **Must** mock all external calls (LLM, remote DBs, network, optional packages) |
 | Nightly | `@pytest.mark.nightly` | Real LLM APIs OK; mock unstable services |
 | Regression | `@pytest.mark.regression` | Real services; gate missing keys with `@pytest.mark.skipif` |
 

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -429,6 +429,7 @@ class ChatAgenticNode(AgenticNode):
             workspace_root=self._resolve_workspace_root(),
         )
         context["has_task_tool"] = bool(self.sub_agent_task_tool)
+        context["has_ask_user_tool"] = "ask_user" in exposed
         context["active_profile"] = getattr(self.agent_config, "active_profile_name", None) or "normal"
         from datus.utils.time_utils import get_default_current_date
 

--- a/datus/prompts/prompt_templates/chat_system_1.2.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.2.j2
@@ -8,8 +8,12 @@ You have access to:
 - The ability to generate, execute, and explain SQL queries
 - Date parsing tools: For temporal expression analysis
   - Use `parse_temporal_expressions` to convert relative dates to absolute date ranges in "YYYY-MM-DD" format
+{% if has_ask_user_tool %}
 - Ask user tool (`ask_user`): Request clarification from the user. Accepts a list of questions, each with optional predefined choices (2-10 options per question). A built-in free-text input is always available to the user, so do NOT add an "Other" or "Custom" option yourself
   - **Independent questions only**: Every question in a single `ask_user` call must be answerable independently — do NOT include follow-up questions that depend on the answer to a previous question in the same batch. If you need to ask follow-ups based on the user's answer, use a separate `ask_user` call after receiving the first response.
+{% else %}
+- No ask_user tool is available in this execution mode. If critical information is missing, stop with a concise missing-information response instead of trying to ask interactively.
+{% endif %}
 {% if has_platform_doc_tools -%}
 - Platform Documentation Tools for looking up database-platform-specific syntax and features:
   - `list_document_nav`: Browse the documentation navigation tree for the target platform. Call this FIRST to discover available documentation topics, then drill into specific documents.
@@ -39,7 +43,7 @@ You have access to:
 1. Classify the requested deliverable. Ask: what artifact or answer should exist after this request, and which system owns it?
 2. If the deliverable belongs to a specialized system or workflow handled by a subagent, delegate to that subagent via `task(type=..., ...)`. Task complexity is not the deciding factor; a simple scheduled job, dashboard, persisted table, semantic model, metric definition, or skill still belongs to its owning subagent.
 3. Use direct tools (`list_tables`, `describe_table`, `read_query`, file tools, etc.) when the deliverable is a read-only answer, explanation, or lightweight investigation that does not create or update an artifact owned by another platform/workflow.
-4. If the deliverable ownership or required target is ambiguous (missing metric, table, time range, target system, etc.), call `ask_user` FIRST to clarify, then route.
+4. If the deliverable ownership or required target is ambiguous (missing metric, table, time range, target system, etc.), {% if has_ask_user_tool %}call `ask_user` FIRST to clarify, then route{% else %}route only when the provided context is enough; otherwise stop with the missing information needed to proceed{% endif %}.
 
 The subagent descriptions and "When to use" blocks below are the authoritative routing rubric. Match by deliverable ownership and intent, not by keyword or by perceived complexity.
 
@@ -55,7 +59,11 @@ The subagent descriptions and "When to use" blocks below are the authoritative r
 **When to use `task(type="gen_table")`:**
 - ANY DDL against the user's database: CREATE TABLE, CTAS, ALTER TABLE, DROP TABLE, CREATE / DROP VIEW, CREATE / DROP SCHEMA
 - You yourself do NOT have `execute_ddl` or `execute_write` — `read_query` rejects everything except SELECT / SHOW / DESCRIBE / EXPLAIN, so any schema change or destructive operation MUST go through gen_table
+{% if has_ask_user_tool %}
 - gen_table handles user confirmation for destructive operations internally via its `ask_user` tool, so you don't need to confirm in chat before delegating — just pass the user's intent and let gen_table handle the confirmation
+{% else %}
+- gen_table runs without interactive prompts in this mode. Pass explicit action, target database/table, and overwrite/drop authorization when the request is destructive or may touch an existing object; otherwise expect gen_table to stop.
+{% endif %}
 - Do NOT use gen_table when: the user only wants the DDL shown as text without execution
 
 **When to use `task(type="gen_job")`:**
@@ -72,7 +80,7 @@ The subagent descriptions and "When to use" blocks below are the authoritative r
 - Use `gen_dashboard` when the request is to create / update / inspect a dashboard, chart, dataset, or visualization on a BI platform and the target table or SQL dataset already exists in a BI-registered database.
 - Pass the user's full intent in the prompt: BI platform, serving table or SQL dataset, time range, granularity, chart type if specified, dashboard title.
 - If the user is asking for raw source data to be prepared before dashboarding, route that as a separate `gen_job` / `scheduler` request first. Do not make `gen_dashboard` do data movement.
-- If the user's request is ambiguous (e.g. serving table not specified), call `ask_user` to clarify, THEN delegate — do NOT pre-explore the source DB to "help" `gen_dashboard`.
+- If the user's request is ambiguous (e.g. serving table not specified), {% if has_ask_user_tool %}call `ask_user` to clarify, THEN delegate{% else %}stop with the missing BI/table details instead of delegating{% endif %} — do NOT pre-explore the source DB to "help" `gen_dashboard`.
 - Do NOT use `gen_dashboard` when: the user only wants raw SQL or numbers without any BI artefact.
 
 **When to use `task(type="scheduler")`:**
@@ -97,7 +105,7 @@ The subagent descriptions and "When to use" blocks below are the authoritative r
 **When to use `task(type="gen_ext_knowledge")`:**
 - User asks to build a business-knowledge entry, define a domain concept, or expand the KB through verified examples.
 - Prompt MUST include BOTH a natural-language question AND the gold SQL reference answer.
-- Do NOT use when: only the question or only the SQL is available — clarify with `ask_user` first.
+- Do NOT use when: only the question or only the SQL is available — {% if has_ask_user_tool %}clarify with `ask_user` first{% else %}stop and report the missing required input{% endif %}.
 
 **When to use `task(type="gen_skill")`:**
 - User asks to create a new skill (`gen_skill` will interview them and scaffold the skill directory) or to optimize an existing skill (`optimize <skill-name>`).
@@ -118,7 +126,7 @@ Rules — follow these exactly:
 {% endif %}
 Guidelines:
 
-- **Clarify before acting**: When the user's request is ambiguous or missing key information, call `ask_user` to clarify before proceeding. Do NOT guess or assume defaults.
+- **Clarify before acting**: When the user's request is ambiguous or missing key information, {% if has_ask_user_tool %}call `ask_user` to clarify before proceeding{% else %}stop with a concise missing-information response{% endif %}. Do NOT guess or assume defaults.
 - Be conversational and helpful
 - When users ask about data, use database tools to query, use contextual search tools to retrieve relevant metrics and reference SQL and external knowledge
 - When SQL is involved, explain your approach and provide clear, executable queries

--- a/datus/prompts/prompt_templates/gen_job_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_job_system_1.0.j2
@@ -2,7 +2,7 @@ You are an expert data engineer. You build or update target tables from one or m
 
 You MUST follow the workflow described by the active skills:
 
-1. Use the `gen-table` skill workflow for table creation and DDL decisions.
+1. Use the `gen-table` skill workflow for table creation and DDL decisions, including its interactive vs workflow authorization rules.
 2. Schema-contract validation runs automatically through `table-validation` via ValidationHook.on_end. Do not call or mimic validator skills.
 3. If the source database differs from the target database (cross-database transfer), ALSO follow the `data-migration` skill workflow for type mapping and lightweight reconciliation.
 
@@ -12,7 +12,7 @@ Check `<available_skills>` at the end of this prompt for skill metadata; call `l
 
 - Inspect source and target tables before writing.
 - Create schemas when needed.
-- Create or replace target tables using dialect-correct DDL.
+- Create target tables using dialect-correct DDL; replace existing tables only when explicitly authorized.
 - Write data using `execute_write` (intra-DB) or `transfer_query_result` (cross-DB).
 - Let automatic validation check the resulting table after the run ends.
 
@@ -30,6 +30,7 @@ Check `<available_skills>` at the end of this prompt for skill metadata; call `l
 - NEVER omit the `database` parameter — always be explicit.
 - NEVER fall back to a different target database if the specified target is unavailable. If the target database connection fails (adapter not installed, credentials wrong, host unreachable), STOP immediately and report the error.
 - Before starting, call `list_databases()` to confirm source and target are reachable. In multi-connector mode each entry is a dict (`{"name": "...", "available": true, ...}`) — both MUST show `"available": true`. In single-connector mode entries are plain strings — confirm both names appear. STOP and report when a target is unavailable or missing.
+- In workflow / no-ask_user mode, do not wait for confirmation. Proceed only for explicitly requested non-destructive creates or appends. Require explicit authorization before replacing, truncating, dropping, deleting, updating, or overwriting any existing target object.
 
 ## Required workflow
 
@@ -44,6 +45,7 @@ Check `<available_skills>` at the end of this prompt for skill metadata; call `l
 
 - Use `list_tables(database=target_database)` to check whether the target table exists.
 - If it exists, `describe_table(database=target_database)` to compare schemas and decide between replace vs append.
+- If it exists and the request does not explicitly authorize replacement, overwrite, truncate, or drop/recreate, STOP and report that authorization is required.
 - If the target schema / database does not exist, create it with `execute_ddl(database=target_database)`.
 
 ### Phase 3: Build target DDL (dialect-neutral)
@@ -54,13 +56,13 @@ Check `<available_skills>` at the end of this prompt for skill metadata; call `l
 3. Map source column types → target column types guided by `type_hints`. When ambiguous, prefer widening over narrowing.
 4. Draft the `CREATE TABLE` DDL.
 5. Call `validate_ddl(database=target_database, ddl=<your_ddl>, target_table=<name>)`. Iterate on the DDL until `errors == []`.
-6. Execute the DDL with `execute_ddl(sql, database=target_database)`.
+6. Execute the DDL with `execute_ddl(sql, database=target_database)` only after authorization rules are satisfied.
 
 ### Phase 4: Load data
 
 - **Intra-DB ETL** (`source_database == target_database`): use `execute_ddl` for `CREATE TABLE AS SELECT`, or `execute_write` for `INSERT ... SELECT`.
 - **Cross-DB migration** (`source_database != target_database`): use `transfer_query_result(source_sql, source_database, target_table, target_database, mode)`.
-  - Use `mode='replace'` for fresh migration (truncates target first).
+  - Use `mode='replace'` only for a new target table or when the request explicitly authorizes truncating/replacing existing target data.
   - Use `mode='append'` for incremental loads.
   - Verify `rows_transferred` matches the source row count.
 

--- a/datus/prompts/prompt_templates/gen_table_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_table_system_1.0.j2
@@ -10,14 +10,19 @@ descriptions (CREATE TABLE for new schemas).
 
 ## Critical Rules
 
+{% if has_ask_user_tool %}
 ### Cancel = Immediate Stop
 **If the user selects "Cancel" at ANY `ask_user` prompt, STOP ALL WORK IMMEDIATELY.** Do not ask follow-up questions, do not regenerate DDL, do not continue to any phase. Return the final JSON with empty table_name.
 
 ### DDL Must Be Inside ask_user
 When running as a sub-agent, all intermediate assistant messages are collapsed — the user can ONLY see the `ask_user` widget. **Always include the COMPLETE DDL SQL inside the `ask_user` question text.** Do NOT abbreviate the DDL.
+{% else %}
+### Workflow Mode Has No ask_user
+No `ask_user` tool is available. Do not call it and do not wait for interactive confirmation. Treat the original request as authorization only for the specific non-destructive CREATE TABLE / CTAS it explicitly asks for. If the target is ambiguous, critical schema details are missing, or the operation would replace/drop/alter/truncate an existing object without explicit authorization, stop and report what is missing.
+{% endif %}
 
 ### SQL Mode: No Unnecessary Questions
-When the user provides a SQL query (SELECT/JOIN), the SQL already defines the output schema. Do NOT ask about table usage, purpose, or column selection. Go directly to DDL generation → embed in `ask_user` → confirm → execute.
+When the user provides a SQL query (SELECT/JOIN), the SQL already defines the output schema. Do NOT ask about table usage, purpose, or column selection. Go directly to DDL generation{% if has_ask_user_tool %} → embed in `ask_user` → confirm{% else %} → apply workflow authorization rules{% endif %} → execute.
 
 ## Instructions
 
@@ -33,16 +38,22 @@ When the user provides a SQL query (SELECT/JOIN), the SQL already defines the ou
 
 2. **Analyze schema** (description mode only — SQL mode skips this):
    - Use `describe_table` to understand referenced tables
-   - Only call `ask_user` if critical schema information is missing
+   - If critical schema information is missing, {% if has_ask_user_tool %}call `ask_user` to clarify{% else %}stop and report the missing information{% endif %}
 
-3. **Generate DDL and confirm with user**:
+3. **Generate DDL and authorize execution**:
    - Generate the complete DDL statement
+{% if has_ask_user_tool %}
    - Call `ask_user` with the COMPLETE DDL SQL in the question text + options ["Execute", "Modify", "Cancel"]
    - If user selects "Cancel": **STOP IMMEDIATELY**
    - If user selects "Modify": adjust and re-confirm
+{% else %}
+   - Do not call `ask_user`
+   - Proceed only for explicit non-destructive CREATE TABLE / CTAS requests
+   - Stop if the DDL replaces, drops, alters, truncates, or overwrites an existing object without explicit authorization
+{% endif %}
 
 4. **Execute DDL** via `execute_ddl(sql)`:
-   - Only after user selects "Execute"
+   - {% if has_ask_user_tool %}Only after user selects "Execute"{% else %}Only after workflow authorization is satisfied{% endif %}
    - Verify the created table with `describe_table` or `read_query`
 
 5. **Report summary** with table name, row count, and column list

--- a/datus/resources/skills/gen-table/SKILL.md
+++ b/datus/resources/skills/gen-table/SKILL.md
@@ -15,6 +15,12 @@ allowed_agents:
   - gen_job
 ---
 
+## CRITICAL: Interactive vs Workflow Mode
+
+- When `ask_user` is available, use it for DDL confirmation and clarification.
+- When `ask_user` is not available (workflow, batch, or print mode), never call `ask_user` and never wait for user input. Treat the original request as authorization only for the specific non-destructive `CREATE TABLE` / CTAS it explicitly asks for.
+- If critical schema details, target table, target database, or destructive authorization are missing and `ask_user` is unavailable, stop and report exactly what is missing.
+
 ## CRITICAL: Cancel = Immediate Stop
 
 **If the user selects "Cancel" at ANY point (any `ask_user` response), you MUST immediately stop ALL work.** Do NOT:
@@ -42,7 +48,7 @@ The user's SQL already fully defines the output schema. Do NOT ask the user abou
 2. **Call `describe_table`** for each source table to understand column types.
 3. **Optionally call `read_query`** with `LIMIT 10` to validate the query output.
 4. **Determine table name**: Derive from the SQL context (e.g., `wide_order_customer`). If the user specified a name, use it.
-5. **Go directly to Phase 2** — do NOT call `ask_user` here. The DDL confirmation in Phase 2 is the only user interaction needed.
+5. **Go directly to Phase 2** — do NOT ask about table usage, purpose, or column selection.
 
 ### Description Mode (CREATE TABLE) — Confirm Schema First
 
@@ -50,14 +56,12 @@ Natural language is ambiguous, so clarification may be needed before generating 
 
 1. **Parse user description**: Extract table name, columns, types, constraints.
 2. **Call `describe_table`** for any referenced existing tables to infer column types.
-3. **If critical information is missing** (e.g., no column names or types specified), call `ask_user` to clarify. Only ask about genuinely missing information — do NOT ask about table usage or purpose if the user already described the schema.
+3. **If critical information is missing** (e.g., no column names or types specified), clarify with `ask_user` when available. If `ask_user` is unavailable, stop and report the missing fields instead of guessing.
 4. **Go to Phase 2** once the schema is clear.
 
-## Phase 2: Generate DDL and Confirm (MANDATORY ask_user)
+## Phase 2: Generate DDL and Authorize
 
-Generate the exact DDL SQL statement and present it to the user for confirmation.
-
-**Include the full DDL SQL inside the `ask_user` question text.** This is required because when running as a sub-agent, all intermediate assistant messages are collapsed in the UI — the user can ONLY see the `ask_user` interaction widget.
+Generate the exact DDL SQL statement.
 
 ### SQL Mode
 Generate CTAS: `CREATE TABLE {schema}.{table_name} AS ({select_sql})`
@@ -65,7 +69,7 @@ Generate CTAS: `CREATE TABLE {schema}.{table_name} AS ({select_sql})`
 ### Description Mode
 Generate: `CREATE TABLE {schema}.{table_name} ({column_defs})`
 
-### Both Modes — DDL Confirmation via ask_user
+### When `ask_user` is available — DDL Confirmation
 
 Call `ask_user` with the complete DDL embedded in the question:
 
@@ -87,9 +91,17 @@ ask_user(questions=[{
 - **Modify**: ask what to change, regenerate DDL, call `ask_user` again with the updated DDL
 - **Cancel**: **STOP IMMEDIATELY.** Return `{"table_name": "", "output": "Cancelled by user."}`. Do NOT continue.
 
+### When `ask_user` is unavailable — Workflow Authorization
+
+- Do not call `ask_user`.
+- Proceed to Phase 3 only when the request explicitly asks to create this table or CTAS result and the target database/table is unambiguous.
+- If the target table already exists, proceed only if the request explicitly authorizes replacement, overwrite, drop/recreate, or equivalent destructive behavior.
+- If the DDL includes `DROP`, `ALTER`, `TRUNCATE`, `CREATE OR REPLACE`, or any existing-object replacement, require explicit authorization in the original request. Otherwise stop and report the required authorization.
+- Include the final DDL in the output summary so the caller can audit what was executed.
+
 ## Phase 3: Execute and Verify
 
-1. **Call `execute_ddl(sql)`** with the confirmed DDL statement.
+1. **Call `execute_ddl(sql)`** with the confirmed or workflow-authorized DDL statement.
 2. **Verify**:
    - SQL Mode: Call `read_query("SELECT COUNT(*) FROM {schema}.{table_name}")` to confirm row count
    - Description Mode: Call `describe_table("{schema}.{table_name}")` to confirm schema matches
@@ -97,8 +109,9 @@ ask_user(questions=[{
 
 If DDL fails:
 - Parse the error message
-- Fix the SQL, show the updated DDL to the user via `ask_user`, and retry (up to 3 attempts)
-- If still failing, report the error to the user via `ask_user`
+- If `ask_user` is available, fix the SQL, show the updated DDL to the user via `ask_user`, and retry (up to 3 attempts)
+- If `ask_user` is unavailable, fix and retry directly up to 3 attempts when the intent remains the same and no new destructive action is introduced
+- If still failing, report the final error and the last attempted DDL in the output
 
 ## Phase 4: Summary
 
@@ -111,9 +124,10 @@ Output a summary including:
 
 ## Important Rules
 
-- **MUST call `ask_user`** before executing any DDL — never create tables without user confirmation
-- **DDL is irreversible** — always show the exact DDL SQL to the user before execution
-- If the target table already exists, warn the user and ask whether to DROP and recreate or abort
+- Use `ask_user` before executing DDL only when the tool is available.
+- In workflow mode, execute only explicitly requested non-destructive table creation; block ambiguous or destructive work instead of guessing.
+- **DDL is irreversible** — always include the exact DDL SQL in `ask_user` confirmation when interactive, or in the final output when workflow mode executes.
+- If the target table already exists, ask whether to drop/recreate/abort when interactive; require explicit replacement authorization when workflow mode.
 - Language: match user's language (Chinese input → Chinese output)
 - Do NOT modify the source tables — only create new tables
 - **Single responsibility** — gen-table only creates tables, does not generate semantic model YAML. For semantic model, suggest using `gen_semantic_model`

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -669,6 +669,42 @@ class TestChatAgenticNodeSystemPrompt:
         assert "Current permission profile: dangerous" in prompt
         assert "authoritative for this turn" in prompt
 
+    def test_workflow_prompt_does_not_advertise_ask_user(self, real_agent_config, mock_llm_create):
+        """Workflow chat has no ask_user tool, so the prompt must not route to it."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        node = ChatAgenticNode(
+            node_id="test_prompt_workflow",
+            description="Test workflow prompt",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+        )
+
+        prompt = node._get_system_prompt()
+
+        assert "Ask user tool (`ask_user`)" not in prompt
+        assert "call `ask_user` FIRST" not in prompt
+        assert "No ask_user tool is available" in prompt
+        assert "stop with a concise missing-information response" in prompt
+
+    def test_interactive_prompt_advertises_ask_user(self, real_agent_config, mock_llm_create):
+        """Interactive chat keeps ask_user routing guidance."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        node = ChatAgenticNode(
+            node_id="test_prompt_interactive",
+            description="Test interactive prompt",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+            execution_mode="interactive",
+        )
+
+        prompt = node._get_system_prompt()
+
+        assert "Ask user tool (`ask_user`)" in prompt
+        assert "call `ask_user` FIRST" in prompt
+
     def test_get_system_prompt_fallback_on_missing_template(self, real_agent_config, mock_llm_create):
         """_get_system_prompt falls back to chat_system when configured template is missing."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode

--- a/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
@@ -132,6 +132,18 @@ class TestGenJobAgenticNodeInit:
         assert "execute_write" in db_names
         assert "transfer_query_result" in db_names
 
+    def test_system_prompt_requires_explicit_authorization_for_replacement(self, real_agent_config, mock_llm_create):
+        """gen_job inherits gen-table behavior and must not overwrite in workflow mode by default."""
+        from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
+
+        node = GenJobAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        context = node._prepare_template_context(SemanticNodeInput(user_message="Build ETL table"))
+        prompt = node._get_system_prompt(context)
+
+        assert "interactive vs workflow authorization rules" in prompt
+        assert "replace existing tables only when explicitly authorized" in prompt
+        assert "Use `mode='replace'` only for a new target table" in prompt
+
 
 # ---------------------------------------------------------------------------
 # Execution Tests

--- a/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
@@ -351,6 +351,27 @@ class TestPrepareTemplateContextGenTable:
 
         assert "execute_ddl" in context["native_tools"]
 
+    def test_workflow_prompt_uses_non_interactive_authorization(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
+
+        node = GenTableAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        context = node._prepare_template_context(SemanticNodeInput(user_message="Create table"))
+        prompt = node._get_system_prompt(context)
+
+        assert "Workflow Mode Has No ask_user" in prompt
+        assert "Call `ask_user` with the COMPLETE DDL SQL" not in prompt
+        assert "Proceed only for explicit non-destructive CREATE TABLE / CTAS requests" in prompt
+
+    def test_interactive_prompt_keeps_ddl_confirmation(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
+
+        node = GenTableAgenticNode(agent_config=real_agent_config, execution_mode="interactive")
+        context = node._prepare_template_context(SemanticNodeInput(user_message="Create table"))
+        prompt = node._get_system_prompt(context)
+
+        assert "DDL Must Be Inside ask_user" in prompt
+        assert "Call `ask_user` with the COMPLETE DDL SQL" in prompt
+
 
 # ---------------------------------------------------------------------------
 # NodeType and Node Factory Tests


### PR DESCRIPTION
## Why

Symphony runs Datus-agent through print mode without a human interaction surface. Some chat/gen-table/gen-job workflow instructions still assumed `ask_user` could be called, so unattended issue work could stall or attempt interactive confirmation for table creation and ETL decisions.

## Solution

- Derive chat prompt `has_ask_user_tool` from the tools actually exposed to the model.
- Split chat and gen-table prompt guidance into interactive confirmation vs workflow authorization paths.
- Teach gen-job to require explicit authorization before replacing, truncating, or overwriting existing target data.
- Align `CLAUDE.md` with the current PR CI harness: format/lint, `ci/run-pr-tests.py`, and test audit.

## Test Cases

- Added/updated unit prompt coverage for chat, gen-table, and gen-job workflow vs interactive behavior.
- `uv run pytest tests/unit_tests/cli/test_print_mode.py tests/unit_tests/cli/test_main.py tests/unit_tests/agent/node/test_gen_table_agentic_node.py tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/agent/node/test_gen_job_agentic_node.py`
- `uv run ruff format --check datus/ tests/`
- `uv run ruff check datus/ tests/`
- `uv run python ci/audit_tests.py --paths tests/unit_tests/agent/node/test_chat_agentic_node.py tests/unit_tests/agent/node/test_gen_job_agentic_node.py tests/unit_tests/agent/node/test_gen_table_agentic_node.py`
- `uv run python ci/audit_tests.py --repo-root . --diff-only upstream/main`
- `uv run python ci/run-pr-tests.py upstream/main` (`276 passed`, diff coverage `100.00`, `test_outcome=success`)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent behavior now adapts based on ask_user tool availability: interactive mode enables user clarification, workflow mode enforces strict authorization.

* **Bug Fixes**
  * Stricter authorization requirements for table operations; explicit authorization now required before creating or replacing existing tables.

* **Documentation**
  * Updated CI/dev workflow guidance and agent skill specifications for clearer control flows.

* **Tests**
  * Added tests validating execution-mode-specific prompt behavior and authorization handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->