### PR TITLE
[BugFix] Backport ask_* tool whitelist + report path surfacing to 0.3.2

### DIFF
--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -157,6 +157,25 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     # (``ask_dashboard``) keep this False so the disk path stays available.
     BLOB_REQUIRED: ClassVar[bool] = False
 
+    # Capability tool groups gated by the subagent's ``tools`` whitelist, mapped
+    # to the node attribute that holds the built tool instance. Infrastructure
+    # tools (artifact-anchored filesystem, ask_user, plan/todo, sub-agent
+    # delegation) are deliberately ABSENT: a read-only consultant needs them to
+    # read its bound artifact and converse regardless of the whitelist, so they
+    # always survive pruning — mirroring GenSQLAgenticNode's always-on
+    # filesystem + sub_agent_task + plan set. ``read_query`` & friends live
+    # under ``db_tools`` and are dropped unless explicitly whitelisted.
+    _WHITELIST_GROUP_ATTRS: ClassVar[Dict[str, str]] = {
+        "db_tools": "db_func_tool",
+        "context_search_tools": "context_search_tools",
+        "semantic_tools": "semantic_tools",
+        "reference_template_tools": "reference_template_tools",
+        "date_parsing_tools": "date_parsing_tools",
+        "platform_doc_tools": "_platform_doc_tool",
+        "bash_tools": "bash_tool",
+        "skills": "skill_func_tool",
+    }
+
     def __init__(
         self,
         node_id: str,
@@ -176,6 +195,13 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # need our own (``node_name`` from agentic_nodes, e.g. "ask_xxx") so
         # template resolution + node_config lookup land on the right entry.
         self._configured_subagent_name = node_name or self.NODE_NAME
+
+        # ChatAgenticNode never builds semantic tools, but an ask_* ``tools``
+        # whitelist may request them (metric/dimension/attribution analysis).
+        # Declare the slot before super().__init__() (which triggers
+        # ``setup_tools``) so the whitelist pass can build it on demand and
+        # ``_tool_category_map`` can reference it safely.
+        self.semantic_tools = None
 
         # Resolve the artifact binding BEFORE super().__init__() because
         # ChatAgenticNode.__init__ calls ``setup_tools()`` synchronously,
@@ -230,6 +256,148 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if name:
             return name
         return self.configured_node_name or self.NODE_NAME
+
+    # ── Tool whitelist enforcement (honor SubAgent.tools) ───────────────
+
+    def setup_tools(self) -> None:
+        """Build the full chat tool surface, then constrain capability tools
+        to the subagent's configured ``tools`` whitelist.
+
+        ChatAgenticNode wires its capability tools (db_tools, context_search,
+        …) unconditionally and never consults ``tools``. For an ask_*
+        consultant that field is a hard whitelist — the agent must not reach a
+        capability the operator did not grant (e.g. ``read_query`` when only
+        semantic/context tools were configured). We reuse the base setup so all
+        infrastructure (permission/skill managers, artifact-anchored
+        filesystem, plan + sub-agent tooling) is built correctly, then apply
+        the whitelist. An empty/absent whitelist leaves the inherited surface
+        untouched (back-compat for ask agents created before tool scoping).
+        """
+        super().setup_tools()
+        self._apply_tools_whitelist()
+
+    def _rebuild_tools(self) -> None:
+        """Re-apply the whitelist after any base rebuild.
+
+        ``ChatAgenticNode._rebuild_tools`` (also reached via a mid-session
+        datasource switch) repopulates ``self.tools`` from the full set of tool
+        instances, which would silently re-expose pruned capabilities. Re-running
+        the whitelist here keeps the constraint enforced for the life of the
+        node. Safe during ``super().__init__`` because the slots it reads are
+        initialised beforehand or accessed via ``getattr``.
+        """
+        super()._rebuild_tools()
+        self._apply_tools_whitelist()
+
+    def _tool_category_map(self) -> Dict[str, List[Any]]:
+        """Register semantic tools under their canonical permission category.
+
+        The chat base has no semantic tools so its map omits them; when the
+        whitelist makes us build them, surface them here so PermissionHooks
+        matches ``semantic_tools.*`` rules instead of the ``tools.*`` catch-all.
+        """
+        mapping = super()._tool_category_map()
+        if getattr(self, "semantic_tools", None):
+            mapping["semantic_tools"] = list(self.semantic_tools.available_tools())
+        return mapping
+
+    def _apply_tools_whitelist(self) -> None:
+        """Constrain ``self.tools`` to the configured whitelist + infrastructure."""
+        patterns = self._parse_tool_whitelist(self.node_config.get("tools"))
+        if not patterns:
+            # Unconfigured -> keep the inherited full surface (back-compat).
+            return
+        self._ensure_whitelisted_groups_present(patterns)
+        self._prune_capability_tools(patterns)
+
+    @staticmethod
+    def _parse_tool_whitelist(tools_value: Any) -> List[str]:
+        """Split the comma-separated ``tools`` field into trimmed patterns."""
+        if not tools_value or not str(tools_value).strip():
+            return []
+        return [p.strip() for p in str(tools_value).split(",") if p.strip()]
+
+    @staticmethod
+    def _tool_matches_whitelist(group: str, tool_name: str, patterns: List[str]) -> bool:
+        """True if ``group``/``tool_name`` is granted by any whitelist pattern.
+
+        Accepts the same three shapes GenSQLAgenticNode does: ``group`` (whole
+        group), ``group.*`` (wildcard) and ``group.<method>`` (single tool).
+        """
+        candidates = {group, f"{group}.*", f"{group}.{tool_name}"}
+        return any(p in candidates for p in patterns)
+
+    def _ensure_whitelisted_groups_present(self, patterns: List[str]) -> None:
+        """Build + surface whitelisted capability groups the chat base omits.
+
+        Only ``semantic_tools`` falls in this bucket today — ChatAgenticNode
+        builds every other gated group. Built once, then re-surfaced into
+        ``self.tools`` on every call so a post-rebuild whitelist pass does not
+        lose it (``_rebuild_tools`` never re-adds semantic tools itself).
+        """
+        wants_semantic = any(p == "semantic_tools" or p.startswith("semantic_tools.") for p in patterns)
+        if not wants_semantic:
+            return
+        if not getattr(self, "semantic_tools", None):
+            try:
+                from datus.tools.func_tool.semantic_tools import SemanticTools
+
+                self.semantic_tools = SemanticTools(
+                    agent_config=self.agent_config,
+                    sub_agent_name=self.node_config.get("system_prompt"),
+                    adapter_type=self.node_config.get("adapter_type", "metricflow"),
+                )
+            except Exception as exc:
+                logger.error("%s: failed to build whitelisted semantic_tools: %s", self.get_node_name(), exc)
+                return
+        present = {t.name for t in self.tools}
+        for tool in self.semantic_tools.available_tools():
+            if tool.name not in present:
+                self.tools.append(tool)
+
+    def _capability_tool_groups(self) -> Dict[str, str]:
+        """Map each built capability tool *name* -> its whitelist group label.
+
+        Built only from the gated groups in ``_WHITELIST_GROUP_ATTRS``;
+        infrastructure tools are intentionally excluded so they never appear
+        here and therefore always survive pruning.
+        """
+        name_to_group: Dict[str, str] = {}
+        for group, attr in self._WHITELIST_GROUP_ATTRS.items():
+            inst = getattr(self, attr, None)
+            if not inst:
+                continue
+            try:
+                for tool in inst.available_tools():
+                    name_to_group[tool.name] = group
+            except Exception as exc:
+                logger.warning("%s: cannot enumerate %s tools for whitelist: %s", self.get_node_name(), group, exc)
+        return name_to_group
+
+    def _prune_capability_tools(self, patterns: List[str]) -> None:
+        """Drop every capability tool not granted by the whitelist.
+
+        A tool is kept when it is NOT a gated capability (i.e. infrastructure)
+        or when a whitelist pattern grants it. Idempotent — safe to call on
+        every rebuild.
+        """
+        name_to_group = self._capability_tool_groups()
+        kept: List[Any] = []
+        dropped: List[str] = []
+        for tool in self.tools:
+            group = name_to_group.get(tool.name)
+            if group is None or self._tool_matches_whitelist(group, tool.name, patterns):
+                kept.append(tool)
+            else:
+                dropped.append(tool.name)
+        self.tools = kept
+        if dropped:
+            logger.info(
+                "%s tools whitelist applied: dropped=%s exposed=%s",
+                self.get_node_name(),
+                sorted(set(dropped)),
+                sorted({t.name for t in kept}),
+            )
 
     # ── Artifact binding resolution ─────────────────────────────────────
 

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -66,6 +66,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
 
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
+from datus.agent.node.gen_sql_agentic_node import prepare_template_context
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.artifact_manifest import ARTIFACT_SLUG_RE
 from datus.schemas.chat_agentic_node_models import ChatNodeInput
@@ -426,6 +427,55 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         except Exception:
             return False
 
+    def _group_whitelisted(self, group: str) -> bool:
+        """True if the configured ``tools`` grants any tool in ``group``.
+
+        Group-level membership test (does the whitelist mention this group at
+        all, via ``group`` / ``group.*`` / ``group.<method>``). Used to gate
+        the lazy bash / skill re-injection :class:`AgenticNode` performs on
+        every prompt build — see :meth:`_ensure_bash_tool_in_tools`.
+        """
+        patterns = self._parse_tool_whitelist(self.node_config.get("tools"))
+        return any(p == group or p.startswith(f"{group}.") for p in patterns)
+
+    # ── Lazy-injection gates (honor the whitelist post-setup_tools) ─────
+
+    def _ensure_bash_tool_in_tools(self) -> None:
+        """Gate :class:`AgenticNode`'s lazy bash re-injection on the whitelist.
+
+        ``_finalize_system_prompt`` re-adds ``execute_command`` to
+        ``self.tools`` on every prompt build — AFTER ``setup_tools()`` already
+        pruned it — which silently re-exposes bash on an ask_* agent whose
+        ``tools`` never granted ``bash_tools`` (the model then sees it in its
+        SDK tool list and offers/runs shell commands). Skip the re-injection
+        unless the whitelist actually grants the group.
+        """
+        if not self._group_whitelisted("bash_tools"):
+            return
+        super()._ensure_bash_tool_in_tools()
+
+    def _ensure_skill_tools_in_tools(self) -> None:
+        """Gate :class:`AgenticNode`'s lazy skill-tool re-injection on the whitelist.
+
+        Same prompt-build bypass as bash (see :meth:`_ensure_bash_tool_in_tools`):
+        the skill loader tools are re-added regardless of the prune. Skip
+        unless ``skills`` is whitelisted.
+        """
+        if not self._group_whitelisted("skills"):
+            return
+        super()._ensure_skill_tools_in_tools()
+
+    def _get_available_skills_context(self) -> str:
+        """Suppress the skills XML when ``skills`` isn't whitelisted.
+
+        The skill loader tools are gated in :meth:`_ensure_skill_tools_in_tools`;
+        advertising skills in the prompt while their loader tool is absent would
+        just offer the model a capability it has no tool to invoke.
+        """
+        if not self._group_whitelisted("skills"):
+            return ""
+        return super()._get_available_skills_context()
+
     # ── Artifact binding resolution ─────────────────────────────────────
 
     def _resolve_artifact_binding_early(self, agent_config: Optional[AgentConfig]) -> None:
@@ -743,28 +793,22 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         conversation_summary: Optional[str] = None,
         prompt_version: Optional[str] = None,
     ) -> str:
-        """Render the ask-* system prompt with artifact context added.
+        """Render a SELF-CONTAINED ask-* system prompt.
 
-        Delegates to ``ChatAgenticNode._get_system_prompt`` for the
-        heavy lifting (template lookup, skill XML injection, memory,
-        language directive) and then prepends a markdown header block
-        with the artifact's manifest fields and raw intent.md so the
-        chat template's general copy ("You are the follow-up
-        consultant…") already knows what it's talking about by the
-        time the user's first message arrives.
+        Two parts, both ask-owned: the artifact-context header (node-rendered
+        manifest / intent / schema snapshot / query catalog / behavioral rules)
+        followed by the purpose-built ask tool catalogue
+        (``_render_ask_base_prompt``).
+
+        Deliberately does NOT chain into ``ChatAgenticNode._get_system_prompt``.
+        That path renders ``{system_prompt or node_name}_system`` and SILENTLY
+        FALLS BACK to ``chat_system`` when the per-subagent template file is
+        absent (the SaaS case) — dumping the entire chat tool catalogue, the
+        ``task()`` subagent-routing rubric, and write/SQL capabilities into a
+        read-only consultant's prompt. ``_render_ask_base_prompt`` resolves
+        only the ask template (builtin fallback), never chat.
         """
-        # We can't simply override the template context dict the base
-        # builds — ``prepare_template_context`` returns a fresh dict per
-        # call. Instead, hook ``_finalize_system_prompt`` style: render
-        # via parent, then prepend our artifact-context block so the
-        # template-specific copy ("You are the follow-up consultant…")
-        # already knows what it's talking about by the time the user's
-        # first message arrives.
-        #
-        # The cleaner long-term fix is to let ``_get_system_prompt`` take
-        # an extra context dict; for now this two-step approach keeps the
-        # base class untouched.
-        base_prompt = super()._get_system_prompt(conversation_summary, prompt_version)
+        base_prompt = self._render_ask_base_prompt(conversation_summary, prompt_version)
         artifact_header = self._render_artifact_context_block()
         final_prompt = (artifact_header + "\n\n" + base_prompt) if artifact_header else base_prompt
         # Observability hook: real-world prompt growth after the
@@ -790,6 +834,99 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             base_bytes,
         )
         return final_prompt
+
+    def _render_ask_base_prompt(
+        self,
+        conversation_summary: Optional[str],
+        prompt_version: Optional[str],
+    ) -> str:
+        """Render the ask tool catalogue from the purpose-built ask template.
+
+        Mirrors the context-building of ``ChatAgenticNode._get_system_prompt``
+        (the ``has_*`` flags keyed off the *exposed* tool surface) but resolves
+        the template independently: the per-subagent ``{name}_system`` first,
+        then the BUILTIN ask template (``ask_report_system`` /
+        ``ask_dashboard_system``) which always ships in the package. It NEVER
+        falls back to ``chat_system`` — that fallback is exactly what polluted
+        the consultant with the full chat tool/task-routing surface.
+        """
+        exposed = self._exposed_tool_names()
+        context = prepare_template_context(
+            node_config=self.node_config,
+            has_db_tools=self._tool_group_exposed(self.db_func_tool, exposed),
+            has_filesystem_tools=self._tool_group_exposed(self.filesystem_func_tool, exposed),
+            has_mf_tools=False,
+            has_context_search_tools=self._tool_group_exposed(self.context_search_tools, exposed),
+            has_reference_template_tools=(
+                self._tool_group_exposed(self.reference_template_tools, exposed)
+                and bool(self.reference_template_tools and self.reference_template_tools.has_reference_templates)
+            ),
+            has_parsing_tools=self._tool_group_exposed(self.date_parsing_tools, exposed),
+            has_platform_doc_tools=self._tool_group_exposed(self._platform_doc_tool, exposed),
+            has_semantic_tools=self._tool_group_exposed(getattr(self, "semantic_tools", None), exposed),
+            agent_config=self.agent_config,
+            workspace_root=self._resolve_workspace_root(),
+        )
+        context["conversation_summary"] = conversation_summary
+        # Ask consultants never carry the task() delegation tool; set it
+        # explicitly so a shared partial can't advertise a tool they lack.
+        context["has_task_tool"] = False
+        context["active_profile"] = getattr(self.agent_config, "active_profile_name", None) or "normal"
+        from datus.utils.time_utils import get_default_current_date
+
+        context["current_date"] = get_default_current_date(None)
+
+        from datus.prompts.prompt_manager import get_prompt_manager
+
+        pm = get_prompt_manager(agent_config=self.agent_config)
+        prompt_version = prompt_version or self.node_config.get("prompt_version")
+        configured_name = self.node_config.get("system_prompt") or self.get_node_name()
+        # (template_name, version) attempts in priority order; the final entry
+        # — builtin ask template at latest version — is guaranteed to exist, so
+        # the loop terminates without ever reaching chat_system.
+        attempts: List[Tuple[str, Optional[str]]] = [(f"{configured_name}_system", prompt_version)]
+        attempts.append((f"{self.NODE_NAME}_system", prompt_version))
+        attempts.append((f"{self.NODE_NAME}_system", None))
+        seen: set = set()
+        last_error: Optional[Exception] = None
+        for template_name, version in attempts:
+            if (template_name, version) in seen:
+                continue
+            seen.add((template_name, version))
+            try:
+                base = pm.render_template(template_name=template_name, version=version, **context)
+                return self._finalize_system_prompt(base)
+            except FileNotFoundError as exc:
+                last_error = exc
+                continue
+        # The builtin ask template is part of the package; reaching here is a
+        # genuine packaging error. Fail loudly rather than degrade to chat.
+        raise DatusException(
+            code=ErrorCode.COMMON_TEMPLATE_NOT_FOUND,
+            message_args={"template_name": f"{self.NODE_NAME}_system", "version": prompt_version or "latest"},
+        ) from last_error
+
+    def _finalize_system_prompt(self, base_prompt: str, memory_node_name_override: Optional[str] = None) -> str:
+        """Lean finalize for a read-only artifact consultant.
+
+        Drops the chat-agent extras :meth:`AgenticNode._finalize_system_prompt`
+        appends — the project ``AGENTS.md`` block and the persistent-memory
+        instructions — which are noise for an agent scoped to one artifact and
+        only widen the capability surface the model believes it has. Keeps the
+        whitelisted tool injections (gated to the configured ``tools``; no-op
+        otherwise), the skills XML (suppressed unless ``skills`` is
+        whitelisted), and the response-language directive.
+        """
+        # Re-inject whitelisted bash / skill tools (gated; no-op when the
+        # whitelist didn't grant them). These add to ``self.tools``, not prompt
+        # text — needed so a whitelist that DID grant them still works.
+        self._ensure_skill_tools_in_tools()
+        self._ensure_bash_tool_in_tools()
+        if self.skill_func_tool:
+            skills_xml = self._get_available_skills_context()
+            if skills_xml:
+                base_prompt = base_prompt + "\n\n" + skills_xml
+        return self._inject_response_language(base_prompt)
 
     def _render_artifact_context_block(self) -> str:
         """Build the artifact-context preamble prepended to the chat prompt.
@@ -1600,6 +1737,22 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "from the snapshot and say plainly when something cannot be verified live)"
         )
         lines: List[str] = ["### Behavioral Rules (load-bearing)", ""]
+        if not db_exposed:
+            # The artifact context is dense with SQL bodies + table schemas,
+            # which tempts the model to claim live DB/SQL capability it does
+            # not have and then fail at call time ("Tool ... not found"). The
+            # has_db_tools template flag already suppresses the tool catalogue,
+            # but a positive boundary statement is what actually stops the
+            # model from offering to run queries. State it up front.
+            lines.append(
+                "**This agent has NO live database access.** You cannot query "
+                "the database or introspect schema live (no `read_query`, "
+                "`list_tables`, or `describe_table`). Do NOT offer to run SQL "
+                "or fetch fresh data — answer only from the inlined data + "
+                "artifact files above, and say plainly when a question would "
+                "require a live query you can't run."
+            )
+            lines.append("")
         lines.append(
             "1. **Answer from the inlined context first**. The header above "
             "already contains the manifest, the original intent, the "

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -157,20 +157,23 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     # (``ask_dashboard``) keep this False so the disk path stays available.
     BLOB_REQUIRED: ClassVar[bool] = False
 
-    # Capability tool groups gated by the subagent's ``tools`` whitelist, mapped
-    # to the node attribute that holds the built tool instance. Infrastructure
-    # tools (artifact-anchored filesystem, ask_user, plan/todo, sub-agent
-    # delegation) are deliberately ABSENT: a read-only consultant needs them to
-    # read its bound artifact and converse regardless of the whitelist, so they
-    # always survive pruning — mirroring GenSQLAgenticNode's always-on
-    # filesystem + sub_agent_task + plan set. ``read_query`` & friends live
-    # under ``db_tools`` and are dropped unless explicitly whitelisted.
+    # Tool groups selectable via the subagent's ``tools`` whitelist, mapped to
+    # the node attribute that holds the built tool instance. An ask_* agent's
+    # LLM-facing tool surface is determined SOLELY by this whitelist: only the
+    # groups listed here are eligible, and a tool is exposed only when a
+    # whitelist pattern grants it. There is no chat-surface carryover and no
+    # always-on infrastructure — an empty/absent ``tools`` exposes nothing
+    # (the agent answers from the inlined artifact context), and e.g.
+    # ``filesystem_tools.*`` yields ONLY filesystem tools. ``filesystem_tools``
+    # is therefore gated like any other group; ``ask_user`` / ``task`` /
+    # plan-mode tools are not expressible here and are never exposed on ask_*.
     _WHITELIST_GROUP_ATTRS: ClassVar[Dict[str, str]] = {
         "db_tools": "db_func_tool",
         "context_search_tools": "context_search_tools",
         "semantic_tools": "semantic_tools",
         "reference_template_tools": "reference_template_tools",
         "date_parsing_tools": "date_parsing_tools",
+        "filesystem_tools": "filesystem_func_tool",
         "platform_doc_tools": "_platform_doc_tool",
         "bash_tools": "bash_tool",
         "skills": "skill_func_tool",
@@ -260,18 +263,18 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     # ── Tool whitelist enforcement (honor SubAgent.tools) ───────────────
 
     def setup_tools(self) -> None:
-        """Build the full chat tool surface, then constrain capability tools
-        to the subagent's configured ``tools`` whitelist.
+        """Restrict the LLM-facing tool surface to the configured ``tools``.
 
-        ChatAgenticNode wires its capability tools (db_tools, context_search,
-        …) unconditionally and never consults ``tools``. For an ask_*
-        consultant that field is a hard whitelist — the agent must not reach a
-        capability the operator did not grant (e.g. ``read_query`` when only
-        semantic/context tools were configured). We reuse the base setup so all
-        infrastructure (permission/skill managers, artifact-anchored
-        filesystem, plan + sub-agent tooling) is built correctly, then apply
-        the whitelist. An empty/absent whitelist leaves the inherited surface
-        untouched (back-compat for ask agents created before tool scoping).
+        ChatAgenticNode wires its full tool surface (db_tools, context_search,
+        filesystem, bash, …) unconditionally. For an ask_* consultant the
+        ``tools`` field is the *sole* determinant of what the LLM may call —
+        nothing carries over from the chat surface. We reuse the base setup so
+        infrastructure that is NOT a tool (permission/skill managers,
+        artifact-anchored filesystem instance, sessions, MCP) is built
+        correctly, then replace ``self.tools`` with exactly the tools the
+        whitelist grants. An empty/absent ``tools`` exposes nothing (the agent
+        answers purely from the inlined artifact context); ``filesystem_tools.*``
+        exposes only filesystem tools; and so on.
         """
         super().setup_tools()
         self._apply_tools_whitelist()
@@ -281,10 +284,10 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
 
         ``ChatAgenticNode._rebuild_tools`` (also reached via a mid-session
         datasource switch) repopulates ``self.tools`` from the full set of tool
-        instances, which would silently re-expose pruned capabilities. Re-running
-        the whitelist here keeps the constraint enforced for the life of the
-        node. Safe during ``super().__init__`` because the slots it reads are
-        initialised beforehand or accessed via ``getattr``.
+        instances, which would silently re-expose tools outside the whitelist.
+        Re-running the restriction here keeps the surface locked to ``tools``
+        for the life of the node. Safe during ``super().__init__`` because the
+        slots it reads are initialised beforehand or accessed via ``getattr``.
         """
         super()._rebuild_tools()
         self._apply_tools_whitelist()
@@ -302,13 +305,14 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         return mapping
 
     def _apply_tools_whitelist(self) -> None:
-        """Constrain ``self.tools`` to the configured whitelist + infrastructure."""
+        """Replace ``self.tools`` with exactly the tools the whitelist grants.
+
+        No early return on an empty whitelist: an empty/absent ``tools`` must
+        yield an empty tool surface, not the inherited chat surface.
+        """
         patterns = self._parse_tool_whitelist(self.node_config.get("tools"))
-        if not patterns:
-            # Unconfigured -> keep the inherited full surface (back-compat).
-            return
         self._ensure_whitelisted_groups_present(patterns)
-        self._prune_capability_tools(patterns)
+        self._restrict_tools_to_whitelist(patterns)
 
     @staticmethod
     def _parse_tool_whitelist(tools_value: Any) -> List[str]:
@@ -355,12 +359,13 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             if tool.name not in present:
                 self.tools.append(tool)
 
-    def _capability_tool_groups(self) -> Dict[str, str]:
-        """Map each built capability tool *name* -> its whitelist group label.
+    def _whitelist_tool_groups(self) -> Dict[str, str]:
+        """Map each selectable tool *name* -> its whitelist group label.
 
-        Built only from the gated groups in ``_WHITELIST_GROUP_ATTRS``;
-        infrastructure tools are intentionally excluded so they never appear
-        here and therefore always survive pruning.
+        Built from every group in ``_WHITELIST_GROUP_ATTRS`` (filesystem
+        included). Tools whose name is absent from this map are not expressible
+        in the ``tools`` field (e.g. ``ask_user`` / ``task`` / plan-mode) and
+        are therefore never exposed on an ask_* agent.
         """
         name_to_group: Dict[str, str] = {}
         for group, attr in self._WHITELIST_GROUP_ATTRS.items():
@@ -374,30 +379,52 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                 logger.warning("%s: cannot enumerate %s tools for whitelist: %s", self.get_node_name(), group, exc)
         return name_to_group
 
-    def _prune_capability_tools(self, patterns: List[str]) -> None:
-        """Drop every capability tool not granted by the whitelist.
+    def _restrict_tools_to_whitelist(self, patterns: List[str]) -> None:
+        """Keep only tools a whitelist pattern grants; drop everything else.
 
-        A tool is kept when it is NOT a gated capability (i.e. infrastructure)
-        or when a whitelist pattern grants it. Idempotent — safe to call on
-        every rebuild.
+        A tool survives only when it maps to a selectable group AND a pattern
+        grants it. Tools outside the selectable groups (``ask_user`` / ``task``
+        / plan-mode) and every tool when ``patterns`` is empty are dropped, so
+        the surface equals exactly what ``tools`` requested. Idempotent — safe
+        to call on every rebuild.
         """
-        name_to_group = self._capability_tool_groups()
+        name_to_group = self._whitelist_tool_groups()
         kept: List[Any] = []
         dropped: List[str] = []
         for tool in self.tools:
             group = name_to_group.get(tool.name)
-            if group is None or self._tool_matches_whitelist(group, tool.name, patterns):
+            if group is not None and self._tool_matches_whitelist(group, tool.name, patterns):
                 kept.append(tool)
             else:
                 dropped.append(tool.name)
         self.tools = kept
         if dropped:
             logger.info(
-                "%s tools whitelist applied: dropped=%s exposed=%s",
+                "%s tools whitelist applied: configured=%r exposed=%s dropped=%s",
                 self.get_node_name(),
-                sorted(set(dropped)),
+                self.node_config.get("tools"),
                 sorted({t.name for t in kept}),
+                sorted(set(dropped)),
             )
+
+    def _db_tools_exposed(self) -> bool:
+        """True if any db_tools tool survived the whitelist prune.
+
+        Gates the prompt's db-tool guidance (rule 1's live-data path, the
+        dashboard ad-hoc-SQL rule, the schema-snapshot ``describe_table``
+        hints). When the subagent whitelist excludes db_tools we must not
+        instruct the model to call tools it no longer has, or it will attempt
+        them and hit "Tool ... not found". The ``db_func_tool`` instance often
+        still exists (reference-template execution needs it), so check the
+        exposed ``self.tools`` rather than the instance.
+        """
+        if not self.db_func_tool:
+            return False
+        exposed = {tool.name for tool in self.tools}
+        try:
+            return any(tool.name in exposed for tool in self.db_func_tool.available_tools())
+        except Exception:
+            return False
 
     # ── Artifact binding resolution ─────────────────────────────────────
 
@@ -1086,18 +1113,31 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if not isinstance(tables, list) or not tables:
             return ""
 
-        intro = (
-            "Columns of every table in `manifest.key_tables` at the time "
-            "the artifact was finalized. **This is a SNAPSHOT — call "
-            "`describe_table('<table>')` instead when the user explicitly "
-            "asks about the LATEST / CURRENT schema, when they reference "
-            "a column NOT in this list (could be a typo or a post-"
-            "finalize addition), or when they ask about tables NOT in "
-            "`manifest.key_tables`.** For everything else (writing "
-            "follow-up SQL on the listed tables, explaining a column, "
-            "planning a join between listed tables), use this snapshot "
-            "directly — no `describe_table` round-trip needed."
-        )
+        db_exposed = self._db_tools_exposed()
+        if db_exposed:
+            intro = (
+                "Columns of every table in `manifest.key_tables` at the time "
+                "the artifact was finalized. **This is a SNAPSHOT — call "
+                "`describe_table('<table>')` instead when the user explicitly "
+                "asks about the LATEST / CURRENT schema, when they reference "
+                "a column NOT in this list (could be a typo or a post-"
+                "finalize addition), or when they ask about tables NOT in "
+                "`manifest.key_tables`.** For everything else (writing "
+                "follow-up SQL on the listed tables, explaining a column, "
+                "planning a join between listed tables), use this snapshot "
+                "directly — no `describe_table` round-trip needed."
+            )
+        else:
+            # No db tools for this agent — describe_table isn't callable, so
+            # don't suggest it. The snapshot is the only schema source.
+            intro = (
+                "Columns of every table in `manifest.key_tables` at the time "
+                "the artifact was finalized. **This is a SNAPSHOT and live "
+                "schema tools are not enabled for this agent** — treat it as "
+                "the authoritative schema, and if the user asks about the "
+                "current/latest schema or a column not listed here, say it "
+                "can't be verified live rather than guessing."
+            )
 
         lines: List[str] = ["### Table Schemas (`analysis/key_tables_schema.json`)", "", intro, ""]
         # Measure in UTF-8 bytes (not code points) since the cap is
@@ -1111,7 +1151,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         for tbl in tables:
             if not isinstance(tbl, dict):
                 continue
-            entry_lines = self._render_table_schema_entry(tbl)
+            entry_lines = self._render_table_schema_entry(tbl, db_exposed)
             entry_bytes = sum(len(line.encode("utf-8")) + 1 for line in entry_lines)
             if running_bytes + entry_bytes > INLINE_SCHEMA_BYTES_CAP:
                 cap_reached = True
@@ -1120,20 +1160,24 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             lines.append("")
             running_bytes += entry_bytes
         if cap_reached:
-            lines.append(
-                "_(schema section cap reached — remaining tables omitted; "
-                "call `describe_table('<table>')` for any name in "
-                "`manifest.key_tables` not shown above.)_"
-            )
+            if db_exposed:
+                lines.append(
+                    "_(schema section cap reached — remaining tables omitted; "
+                    "call `describe_table('<table>')` for any name in "
+                    "`manifest.key_tables` not shown above.)_"
+                )
+            else:
+                lines.append("_(schema section cap reached — remaining tables omitted from this snapshot.)_")
         return "\n".join(lines).rstrip()
 
-    def _render_table_schema_entry(self, tbl: Dict[str, Any]) -> List[str]:
+    def _render_table_schema_entry(self, tbl: Dict[str, Any], db_exposed: bool) -> List[str]:
         """Render one table block: header + optional description + columns.
 
         Per-table ``error`` (populated when ``describe_table`` failed
-        at finalize) surfaces as a "schema unavailable" hint with the
-        exact remediation (call ``describe_table('<name>')``) so the
-        LLM has a clear next step rather than guessing.
+        at finalize) surfaces as a "schema unavailable" hint. The
+        ``describe_table('<name>')`` remediation is only suggested when db
+        tools are actually exposed (``db_exposed``); otherwise pointing the
+        LLM at a tool it cannot call just produces a "Tool not found".
         """
         name = tbl.get("name") or "?"
         if not isinstance(name, str):
@@ -1146,7 +1190,10 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if description:
             lines.append(f"_(description: {description})_")
         if error:
-            lines.append(f"_(schema unavailable: {error}; call `describe_table('{name}')` to fetch live schema.)_")
+            if db_exposed:
+                lines.append(f"_(schema unavailable: {error}; call `describe_table('{name}')` to fetch live schema.)_")
+            else:
+                lines.append(f"_(schema unavailable in the snapshot: {error}.)_")
             return lines
         if not isinstance(columns, list):
             return lines
@@ -1169,7 +1216,10 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             lines.append(line)
         if truncated:
             remaining = len(columns) - INLINE_SCHEMA_COLS_PER_TABLE
-            lines.append(f"- _(... {remaining} more columns; call `describe_table('{name}')` for the full list.)_")
+            if db_exposed:
+                lines.append(f"- _(... {remaining} more columns; call `describe_table('{name}')` for the full list.)_")
+            else:
+                lines.append(f"- _(... {remaining} more columns not shown in this snapshot.)_")
         return lines
 
     def _render_insights_section(self) -> str:
@@ -1420,13 +1470,33 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             return False
         return isinstance(insights, list) and bool(insights)
 
+    def _render_narrative_readable(self) -> bool:
+        """ask_report only: is the report's ``render/`` body readable on demand?
+
+        For a report, ``render/*.jsx`` *is* the written report (cover,
+        executive summary, per-section commentary, and whatever conclusion /
+        recommendation sections the author wrote) — none of which is inlined.
+        Only ``render/app.jsx`` is guaranteed to exist (the React entry that
+        imports the section components); the section filenames are arbitrary.
+        It's worth reading when the user asks about the report's wording, but
+        only if ``read_file`` was actually granted (per the subagent's
+        ``tools``). Dashboards keep render off-limits: their render tier is
+        parameterized chart presentation, and the answerable content lives in
+        queries / params.
+        """
+        if self.ARTIFACT_KIND != "report":
+            return False
+        return "read_file" in {tool.name for tool in self.tools}
+
     def _render_filesystem_layout_section(self) -> str:
         """Tell the LLM what's already inlined vs what still needs read_file.
 
         The directory tree mirrors the on-disk artifact layout but
         annotates each entry with "inlined above" vs "DO NOT read" vs
         "read on demand" so a model trying to be helpful by pre-fetching
-        files immediately sees that defensive reads are not useful.
+        files immediately sees that defensive reads are not useful. For a
+        report whose ``render/`` body is readable, that tree points the LLM
+        at the right component instead of forbidding the read.
         """
         layout_root_label = self._artifact_root.name if self._artifact_root is not None else self.ARTIFACT_ROOT_DIR_NAME
         has_insights = self._artifact_has_insights()
@@ -1438,6 +1508,15 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "`queries/*.brief.json` plus the inlined slice of "
             "`queries/*` data + SQL above"
         )
+        # Reports surface their narrative body in render/*.jsx (not inlined);
+        # mention it in the intro so the read-on-demand path is explicit.
+        narrative_clause = (
+            " — or when the user asks about the report's narrative, executive "
+            "summary, conclusions, recommendations, or a section's commentary, which "
+            "live in `render/*.jsx` (start at `render/app.jsx`), not inlined"
+            if self._render_narrative_readable()
+            else ""
+        )
         lines: List[str] = [
             "### Artifact Filesystem Layout",
             "",
@@ -1447,7 +1526,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                 f"already loaded into this prompt: {loaded_list}.** "
                 f"**Do NOT `read_file` / `glob` them defensively.** Read on "
                 f"demand only when the catalog above flags a query's data as "
-                f"sampled or its SQL as truncated."
+                f"sampled or its SQL as truncated" + narrative_clause + "."
             ),
             "",
             "```",
@@ -1462,16 +1541,34 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # unconditionally (no insights file by design).
         if has_insights:
             lines.append("│   ├── insights.json            # inlined above")
+        schema_line = (
+            "│   ├── key_tables_schema.json   # inlined above (if present); snapshot only — describe_table() for live"
+            if self._db_tools_exposed()
+            else "│   ├── key_tables_schema.json   # inlined above (if present); snapshot only — no live schema tools enabled"
+        )
         lines.extend(
             [
                 "│   ├── subject_refs.json        # inlined above (if present)",
-                "│   ├── key_tables_schema.json   # inlined above (if present); snapshot only — describe_table() for live",
+                schema_line,
                 "│   └── suggested_questions.json # UI chips — DO NOT read",
                 "├── queries/                     # briefs always inlined; data + SQL inlined or sampled per catalog above",
-                "└── render/                     # presentation tier — DO NOT READ",
-                "```",
             ]
         )
+        # ``render/`` holds the written report for a report kind; point the LLM
+        # at the guaranteed entry (``app.jsx``, which imports the section
+        # components) instead of forbidding the read or assuming arbitrary
+        # section filenames. Off-limits when render can't be read (no
+        # read_file) or for dashboards (parameterized chart presentation).
+        if self._render_narrative_readable():
+            lines.append(
+                "└── render/                      # the report's written body (NOT inlined) — read "
+                "`render/app.jsx` (entry: cover + executive summary; it imports the section "
+                "components) and follow its imports on demand for the report's wording / "
+                "conclusions / recommendations / a section's commentary"
+            )
+        else:
+            lines.append("└── render/                      # presentation tier — DO NOT READ")
+        lines.append("```")
         return "\n".join(lines)
 
     def _render_behavioral_rules_section(self) -> str:
@@ -1492,6 +1589,16 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # rule 1 claim "confirmed insights" are inlined, both of
         # which would mislead the LLM.
         has_insights = self._artifact_has_insights()
+        # When the subagent whitelist drops db_tools, the model has no
+        # describe_table / read_query to call — promising them in the rules
+        # makes it attempt unavailable tools ("Tool ... not found").
+        db_exposed = self._db_tools_exposed()
+        live_data_clause = (
+            "(call `describe_table` / `execute_sql` for those)"
+            if db_exposed
+            else "(live database tools are not enabled for this agent, so answer "
+            "from the snapshot and say plainly when something cannot be verified live)"
+        )
         lines: List[str] = ["### Behavioral Rules (load-bearing)", ""]
         lines.append(
             "1. **Answer from the inlined context first**. The header above "
@@ -1505,8 +1612,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "explicitly flagged a query's data as sampled or its SQL as "
             "truncated, (b) the user asks about LIVE / CURRENT state "
             "the snapshot can't answer — fresh schema after a DDL "
-            "change, live row counts, today's data (call "
-            "`describe_table` / `execute_sql` for those), or (c) the "
+            "change, live row counts, today's data " + live_data_clause + ", or (c) the "
             "inlined summary genuinely doesn't address the question. "
             "When you do, briefly say which file or tool and why."
         )
@@ -1533,15 +1639,26 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             "user explicitly asks, but call it out in your answer."
         )
         if self.ARTIFACT_KIND == "dashboard":
-            lines.append(
-                "6. **Dashboard queries have no precomputed data**. The "
-                "`queries/<slug>.sql.j2` files (inlined above) are "
-                "templates; to answer quantitative questions, run an "
-                "equivalent ad-hoc SQL via `execute_sql` within the "
-                "dashboard's datasource scope, or use the params "
-                "declaration to explain what user-controllable filters "
-                "exist."
-            )
+            if db_exposed:
+                lines.append(
+                    "6. **Dashboard queries have no precomputed data**. The "
+                    "`queries/<slug>.sql.j2` files (inlined above) are "
+                    "templates; to answer quantitative questions, run an "
+                    "equivalent ad-hoc SQL via `execute_sql` within the "
+                    "dashboard's datasource scope, or use the params "
+                    "declaration to explain what user-controllable filters "
+                    "exist."
+                )
+            else:
+                lines.append(
+                    "6. **Dashboard queries have no precomputed data**. The "
+                    "`queries/<slug>.sql.j2` files (inlined above) are "
+                    "templates and live SQL execution is not enabled for this "
+                    "agent; answer quantitative questions from the inlined "
+                    "sample data and use the params declaration to explain "
+                    "what user-controllable filters exist, flagging anything "
+                    "that would need a live query."
+                )
         elif has_insights:
             lines.append(
                 "6. **`insights.json` is the authoritative findings "

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -635,12 +635,14 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         """
         raise NotImplementedError
 
-    def _post_validate_hook(self, artifact_slug: str, result: ResultT) -> None:
+    def _post_validate_hook(self, artifact_slug: str, result: ResultT) -> Optional[ActionHistory]:
         """Run artifact-specific work after a successful ``validate_render``.
 
-        The report subagent uses this to compile a standalone HTML and
-        optionally open it in the browser; dashboard mode has nothing to
-        do here. Default is a no-op.
+        The report subagent uses this to compile a standalone HTML, open it
+        in the browser, and return a stream message naming the compiled
+        file's absolute path; dashboard mode has nothing to do here.
+        Returning an :class:`ActionHistory` makes ``_stream_post_build``
+        emit it into the action stream; ``None`` (the default) emits nothing.
         """
         return None
 
@@ -860,4 +862,6 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             result.finalize_warnings = finalize_summary["warnings"]  # type: ignore[attr-defined]
         if hasattr(result, "finalize_error") and finalize_summary.get("error"):
             result.finalize_error = finalize_summary["error"]  # type: ignore[attr-defined]
-        self._post_validate_hook(slug, result)
+        post_action = self._post_validate_hook(slug, result)
+        if post_action is not None:
+            yield post_action

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -379,23 +379,53 @@ class ChatAgenticNode(AgenticNode):
 
     # ── System Prompt ───────────────────────────────────────────────────
 
+    def _exposed_tool_names(self) -> set:
+        """Names of the tools currently exposed to the LLM (``self.tools``)."""
+        return {tool.name for tool in (self.tools or [])}
+
+    @staticmethod
+    def _tool_group_exposed(tool_instance, exposed_names: set) -> bool:
+        """True if ``tool_instance`` exists and at least one of its tools is exposed.
+
+        Used to derive the prompt's ``has_*`` flags from the live tool surface
+        so a pruned-but-still-instantiated group (see ``_get_system_prompt``)
+        is not advertised to the model.
+        """
+        if not tool_instance:
+            return False
+        try:
+            return any(tool.name in exposed_names for tool in tool_instance.available_tools())
+        except Exception:
+            return False
+
     def _get_system_prompt(
         self,
         conversation_summary: Optional[str] = None,
         prompt_version: Optional[str] = None,
     ) -> str:
         """Get the system prompt using enhanced template context."""
+        # Derive the ``has_*`` flags from the tools actually exposed to the LLM
+        # (``self.tools``), not from the existence of the tool *instance*. A
+        # subclass may build a tool instance for internal use yet prune its
+        # tools from the LLM-facing list (e.g. ``BaseArtifactAskAgenticNode``
+        # keeps ``db_func_tool`` for reference-template execution but drops
+        # db_tools from ``self.tools`` when the subagent whitelist excludes
+        # them). Keying the prompt flags off the instance would then advertise
+        # tools the model cannot actually call, producing "Tool X not found".
+        exposed = self._exposed_tool_names()
         context = prepare_template_context(
             node_config=self.node_config,
-            has_db_tools=bool(self.db_func_tool),
-            has_filesystem_tools=bool(self.filesystem_func_tool),
+            has_db_tools=self._tool_group_exposed(self.db_func_tool, exposed),
+            has_filesystem_tools=self._tool_group_exposed(self.filesystem_func_tool, exposed),
             has_mf_tools=False,
-            has_context_search_tools=bool(self.context_search_tools),
-            has_reference_template_tools=bool(
-                self.reference_template_tools and self.reference_template_tools.has_reference_templates
+            has_context_search_tools=self._tool_group_exposed(self.context_search_tools, exposed),
+            has_reference_template_tools=(
+                self._tool_group_exposed(self.reference_template_tools, exposed)
+                and bool(self.reference_template_tools and self.reference_template_tools.has_reference_templates)
             ),
-            has_parsing_tools=bool(self.date_parsing_tools),
-            has_platform_doc_tools=bool(self._platform_doc_tool),
+            has_parsing_tools=self._tool_group_exposed(self.date_parsing_tools, exposed),
+            has_platform_doc_tools=self._tool_group_exposed(self._platform_doc_tool, exposed),
+            has_semantic_tools=self._tool_group_exposed(getattr(self, "semantic_tools", None), exposed),
             agent_config=self.agent_config,
             workspace_root=self._resolve_workspace_root(),
         )

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -940,6 +940,7 @@ def prepare_template_context(
     has_reference_template_tools: bool = False,
     has_parsing_tools: bool = True,
     has_platform_doc_tools: bool = False,
+    has_semantic_tools: bool = False,
     agent_config: Optional[AgentConfig] = None,
     workspace_root: Optional[str] = None,
 ) -> dict:
@@ -955,6 +956,7 @@ def prepare_template_context(
         has_reference_template_tools: Whether reference template tools are available
         has_parsing_tools: Whether date parsing tools are available
         has_platform_doc_tools: Whether platform documentation search tools are available
+        has_semantic_tools: Whether semantic / metric tools are available
         agent_config: Agent configuration
         workspace_root: Workspace root path
 
@@ -969,6 +971,7 @@ def prepare_template_context(
         "has_reference_template_tools": has_reference_template_tools,
         "has_parsing_tools": has_parsing_tools,
         "has_platform_doc_tools": has_platform_doc_tools,
+        "has_semantic_tools": has_semantic_tools,
     }
     if not isinstance(node_config, SubAgentConfig):
         node_config = SubAgentConfig.model_validate(node_config)

--- a/datus/agent/node/gen_visual_report_agentic_node.py
+++ b/datus/agent/node/gen_visual_report_agentic_node.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from datus.agent.node.base_visual_artifact_agentic_node import BaseVisualArtifactAgenticNode
-from datus.schemas.action_history import ActionHistory
+from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.schemas.gen_visual_report_models import (
     GenVisualReportNodeInput,
     GenVisualReportNodeResult,
@@ -162,16 +162,45 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
             created_at=manifest.get("created_at"),
         )
 
-    def _post_validate_hook(self, artifact_slug: str, result: GenVisualReportNodeResult) -> None:
+    def _post_validate_hook(self, artifact_slug: str, result: GenVisualReportNodeResult) -> Optional[ActionHistory]:
         """CLI-mode side effect: compile a standalone HTML and open it.
 
         Dashboard mode has no analogue (its queries are templates that
         must run against a live datasource), so this stays in the report
         subclass and the base class skips the hook in dashboard mode.
+
+        Returns a stream message carrying the compiled HTML's absolute path
+        so the user can reopen the report after closing the auto-opened
+        browser tab; ``None`` when no HTML was compiled (non-CLI mode).
         """
         html_rel_path = self._maybe_compile_html(artifact_slug)
-        if html_rel_path:
-            result.html_path = html_rel_path
+        if not html_rel_path:
+            return None
+        result.html_path = html_rel_path
+        project_root = Path(self.agent_config.project_root).resolve()
+        html_abs_path = (project_root / html_rel_path).resolve()
+        return self._build_html_path_action(artifact_slug, html_abs_path)
+
+    def _build_html_path_action(self, report_slug: str, html_abs_path: Path) -> ActionHistory:
+        """Stream a status message naming the compiled report's absolute path.
+
+        The CLI auto-opens the report in a browser; once the user closes that
+        tab they otherwise have no record of where the artifact lives. Emitting
+        the absolute path into the action stream keeps it in the scrollback for
+        later reference. Uses the ``WORKFLOW`` role (the node status-message
+        convention) so the TUI same-turn assistant-response dedup never drops it.
+        """
+        message = (
+            f"Report saved to {html_abs_path} — open this file in a browser to view it again after closing the tab."
+        )
+        return ActionHistory.create_action(
+            role=ActionRole.WORKFLOW,
+            action_type="report_html_path",
+            messages=message,
+            input_data={"report_slug": report_slug},
+            output_data={"html_path": str(html_abs_path), "url": html_abs_path.as_uri()},
+            status=ActionStatus.SUCCESS,
+        )
 
     # ----------------------------------------------------------- CLI compile
 

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -1783,3 +1783,207 @@ class TestTableSchemasSection:
         # "snapshot only" contract visible from the tree itself.
         assert any("inlined above" in line for line in tree_lines)
         assert any("describe_table" in line for line in tree_lines)
+
+
+# --------------------------------------------------------------------------- #
+# Tool whitelist enforcement (honor SubAgent.tools)                           #
+# --------------------------------------------------------------------------- #
+
+
+def _register_ask_agent_with_tools(
+    agent_config,
+    *,
+    name: str,
+    kind: str,
+    slug: str,
+    tools,
+    blob: dict | None = None,
+) -> None:
+    """Register an ask_* agentic_nodes entry with an explicit ``tools`` value.
+
+    The shared :func:`_register_ask_agent` hardcodes ``tools`` to a db-tools
+    whitelist; these tests need to drive the whitelist directly (including the
+    empty / absent cases), so we register the entry by hand. ``tools=None``
+    omits the key entirely (the "never configured" path).
+    """
+    agent_type = "ask_report" if kind == "report" else "ask_dashboard"
+    if not hasattr(agent_config, "agentic_nodes") or agent_config.agentic_nodes is None:
+        agent_config.agentic_nodes = {}
+    entry = {
+        "type": agent_type,
+        "artifact_slug": slug,
+        "agent_description": f"Ask consultant for {slug}",
+        "rules": [],
+        "max_turns": 5,
+    }
+    if tools is not None:
+        entry["tools"] = tools
+    if blob is not None:
+        entry["artifact_blob"] = blob
+    agent_config.agentic_nodes[name] = entry
+
+
+def _make_ask_report_with_tools(agent_config, tools, *, name: str = "ask_wl_report", slug: str = "wl_report"):
+    """Build an AskReportAgenticNode whose ``tools`` whitelist is ``tools``."""
+    _seed_artifact(agent_config.project_root, "report", slug)
+    blob = _blob_from_disk(agent_config.project_root, "report", slug)
+    _register_ask_agent_with_tools(agent_config, name=name, kind="report", slug=slug, tools=tools, blob=blob)
+    return AskReportAgenticNode(
+        node_id=f"{name}_t",
+        description="d",
+        node_type="chat",
+        agent_config=agent_config,
+        node_name=name,
+    )
+
+
+def _make_ask_dashboard_with_tools(agent_config, tools, *, name: str = "ask_wl_dash", slug: str = "wl_dash"):
+    """Build an AskDashboardAgenticNode (disk path) with ``tools`` whitelist."""
+    _seed_artifact(agent_config.project_root, "dashboard", slug)
+    _register_ask_agent_with_tools(agent_config, name=name, kind="dashboard", slug=slug, tools=tools)
+    return AskDashboardAgenticNode(
+        node_id=f"{name}_t",
+        description="d",
+        node_type="chat",
+        agent_config=agent_config,
+        node_name=name,
+    )
+
+
+def _tool_names(node) -> set:
+    return {t.name for t in node.tools}
+
+
+def _fs_tool_names(node) -> set:
+    return {t.name for t in node.filesystem_func_tool.available_tools()}
+
+
+# Mirrors the real ``customer_retention_analysis`` subagent: semantic-heavy,
+# a few specific context_search methods, all date parsing — and crucially NO
+# db_tools, so ``read_query`` must not leak in.
+_NO_DB_WHITELIST = (
+    "context_search_tools.get_metrics,context_search_tools.list_subject_tree,"
+    "context_search_tools.search_metrics,date_parsing_tools.*,"
+    "semantic_tools.attribution_analyze,semantic_tools.get_dimensions,"
+    "semantic_tools.list_metrics,semantic_tools.query_metrics"
+)
+
+
+class TestToolsWhitelist:
+    """A configured ``tools`` whitelist is a hard cap on the LLM-facing surface.
+
+    Pins the fix for the leak where ask_* nodes (ChatAgenticNode subclasses)
+    ignored ``tools`` and always wired db_tools, leaving ``read_query``
+    callable for a subagent that only whitelisted semantic/context tools.
+    """
+
+    def test_db_tools_dropped_when_not_whitelisted(self, real_agent_config):
+        """The core regression: ``read_query`` (and siblings) must be gone
+        when the whitelist omits ``db_tools``."""
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        for db_tool in ("read_query", "list_tables", "describe_table", "get_table_ddl"):
+            assert db_tool not in names, f"{db_tool} leaked despite not being whitelisted"
+
+    def test_whitelisted_tools_are_exposed(self, real_agent_config):
+        """Whitelisted tools the runtime actually builds are present — including
+        semantic tools the chat base never builds (proving on-demand build).
+
+        ``attribution_analyze`` and the context_search tools are gated on
+        optional adapters / subject-KB content absent from the CI fixture, so
+        we assert on the adapter-independent semantic wrappers + date parsing,
+        all of which are reliably built here.
+        """
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        expected = {"query_metrics", "get_dimensions", "list_metrics", "parse_temporal_expressions"}
+        missing = expected - names
+        assert not missing, f"whitelisted tools missing from node surface: {sorted(missing)}"
+
+    def test_method_level_whitelist_is_precise(self, real_agent_config):
+        """``db_tools.read_query`` grants exactly that method — sibling db
+        methods that weren't listed stay dropped."""
+        node = _make_ask_report_with_tools(real_agent_config, "db_tools.read_query")
+        names = _tool_names(node)
+        # Listed → present.
+        assert "read_query" in names
+        # Not listed (other DBFuncTool methods) → absent.
+        for other in ("list_tables", "describe_table", "get_table_ddl"):
+            assert other not in names, f"{other} should not be exposed by a method-level whitelist"
+
+    def test_infrastructure_tools_always_survive(self, real_agent_config):
+        """Filesystem tools anchor the consultant to its artifact and must
+        survive even though the whitelist never lists them."""
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        fs_names = _fs_tool_names(node)
+        assert fs_names, "filesystem tool exposes no tools — fixture broken"
+        assert fs_names <= names, f"infrastructure filesystem tools were pruned: {sorted(fs_names - names)}"
+
+    def test_wildcard_group_keeps_all_group_methods(self, real_agent_config):
+        """``date_parsing_tools.*`` keeps every method of that group."""
+        node = _make_ask_report_with_tools(real_agent_config, "date_parsing_tools.*")
+        names = _tool_names(node)
+        assert "parse_temporal_expressions" in names
+        # db_tools omitted from this whitelist → still dropped.
+        assert "read_query" not in names
+
+    def test_db_tools_wildcard_keeps_read_query(self, real_agent_config):
+        """Sanity check the other direction: whitelisting ``db_tools.*``
+        keeps ``read_query`` so the prune isn't unconditionally stripping db."""
+        node = _make_ask_report_with_tools(real_agent_config, "db_tools.*")
+        names = _tool_names(node)
+        assert "read_query" in names
+        assert "list_tables" in names
+
+    def test_empty_whitelist_keeps_full_surface(self, real_agent_config):
+        """An empty ``tools`` string is back-compat: keep the inherited full
+        chat surface (db_tools included) rather than stripping to nothing."""
+        node = _make_ask_report_with_tools(real_agent_config, "")
+        assert "read_query" in _tool_names(node)
+
+    def test_absent_tools_key_keeps_full_surface(self, real_agent_config):
+        """``tools`` key absent entirely (subagent created before scoping) →
+        same back-compat full surface."""
+        node = _make_ask_report_with_tools(real_agent_config, None)
+        assert "read_query" in _tool_names(node)
+
+    def test_dashboard_honors_whitelist(self, real_agent_config):
+        """The fix lives on the shared base, so ask_dashboard enforces the
+        whitelist too (disk-bound path)."""
+        node = _make_ask_dashboard_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        names = _tool_names(node)
+        assert "read_query" not in names
+        assert "query_metrics" in names
+
+    def test_semantic_build_failure_degrades_gracefully(self, real_agent_config, monkeypatch):
+        """If building the whitelisted semantic group raises (e.g. a broken
+        adapter import), node init must not crash: the db prune still holds
+        and the node simply lacks the semantic tools it couldn't build."""
+        import datus.tools.func_tool.semantic_tools as sem_mod
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("semantic adapter exploded")
+
+        monkeypatch.setattr(sem_mod, "SemanticTools", _boom)
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST, name="ask_sem_fail", slug="sem_fail")
+        names = _tool_names(node)
+        # Whitelist still enforced (db dropped); semantic absent but no crash.
+        assert "read_query" not in names
+        assert "query_metrics" not in names
+        # Infrastructure (artifact filesystem) survives so the node still works.
+        assert "read_file" in names
+
+    def test_rebuild_tools_re_applies_whitelist(self, real_agent_config):
+        """A mid-session datasource switch routes through ``_rebuild_tools``,
+        which repopulates from the full instance set. The whitelist must be
+        re-applied so pruned capabilities don't silently come back."""
+        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
+        assert "read_query" not in _tool_names(node)
+        # Force the path a `/database` switch would take.
+        node._rebuild_tools()
+        names = _tool_names(node)
+        assert "read_query" not in names, "whitelist not re-enforced after _rebuild_tools"
+        # Whitelisted semantic tool also survives the rebuild (it isn't
+        # re-added by the base _rebuild_tools, so the override must re-surface it).
+        assert "query_metrics" in names

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -2113,3 +2113,103 @@ class TestPromptToolConsistency:
         rules = node._render_behavioral_rules_section()
         assert "execute_sql" not in rules
         assert "live SQL execution is not enabled" in rules
+
+
+# --------------------------------------------------------------------------- #
+# Chat decoupling + lazy-injection gating                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestChatDecoupling:
+    """The ask_* system prompt is self-contained.
+
+    Two regressions: (1) the prompt must never carry the ``chat_system``
+    template (the silent FileNotFoundError fallback dumped the full chat tool
+    catalogue + ``task()`` routing rubric into a read-only consultant), and
+    (2) ``_finalize_system_prompt``'s lazy bash/skill re-injection — which runs
+    on every prompt build, AFTER ``setup_tools()`` pruned the whitelist — must
+    not silently re-expose tools the ``tools`` whitelist never granted.
+    """
+
+    def test_prompt_excludes_chat_template_content(self, real_agent_config):
+        """Self-contained ask prompt: the ask template is used, and none of the
+        chat system template / chat-agent finalize extras leak in."""
+        node = _make_ask_report_with_tools(
+            real_agent_config,
+            "date_parsing_tools.*,filesystem_tools.*,semantic_tools.*",
+            name="ask_decouple",
+            slug="decouple",
+        )
+        prompt = node._get_system_prompt()
+        assert "ask_report consultant" in prompt  # purpose-built ask template
+        for marker in (
+            "You are a helpful AI assistant integrated with Datus-agent",
+            'task(type="gen_sql"',
+            "Routing decision",
+            "Persistent memory at",  # chat-agent memory block (dropped by lean finalize)
+        ):
+            assert marker not in prompt, f"chat content leaked into ask prompt: {marker!r}"
+
+    def test_missing_subagent_template_falls_back_to_builtin_ask_not_chat(self, real_agent_config):
+        """When the per-subagent ``{name}_system`` template is absent (the SaaS
+        case that produced the leaked chat prompt), resolution falls through to
+        the BUILTIN ask template — never ``chat_system``."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "filesystem_tools.*", name="ask_missing_tpl", slug="missing_tpl"
+        )
+        # A template root that doesn't ship -> configured attempt raises
+        # FileNotFoundError, forcing the builtin-ask fallback.
+        node.node_config["system_prompt"] = "ask_nonexistent_subagent_xyz"
+        prompt = node._get_system_prompt()
+        assert "ask_report consultant" in prompt
+        assert "You are a helpful AI assistant integrated with Datus-agent" not in prompt
+
+    def test_bash_not_reinjected_after_prompt_build(self, real_agent_config):
+        """``execute_command`` stays out of the surface across a prompt build
+        when ``bash_tools`` isn't whitelisted — the core lazy-injection leak."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "date_parsing_tools.*,filesystem_tools.*", name="ask_nobash", slug="nobash"
+        )
+        assert "execute_command" not in _tool_names(node)
+        node._get_system_prompt()  # runs the lazy bash re-injection path
+        assert "execute_command" not in _tool_names(node), "bash leaked via prompt-build lazy injection"
+
+    def test_skills_not_reinjected_after_prompt_build(self, real_agent_config):
+        """Same lazy-injection bypass as bash, for the skill loader tools."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "date_parsing_tools.*,filesystem_tools.*", name="ask_noskill", slug="noskill"
+        )
+        node._get_system_prompt()
+        leaked = {"load_skill", "skill_execute_command"} & _tool_names(node)
+        assert not leaked, f"skill tools leaked via prompt-build lazy injection: {sorted(leaked)}"
+
+    def test_bash_present_when_whitelisted(self, real_agent_config):
+        """The gate is whitelist-driven, not a blanket block: ``bash_tools.*``
+        keeps ``execute_command`` available through the prompt build."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "bash_tools.*,filesystem_tools.*", name="ask_bash", slug="withbash"
+        )
+        node._get_system_prompt()
+        assert "execute_command" in _tool_names(node)
+
+    def test_skills_present_when_whitelisted(self, real_agent_config):
+        """Symmetric to bash: ``skills.*`` keeps the skill loader tool through
+        the prompt build (``load_skill`` is always offered by SkillFuncTool)."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "skills.*,filesystem_tools.*", name="ask_skills", slug="withskills"
+        )
+        node._get_system_prompt()
+        assert "load_skill" in _tool_names(node)
+
+    def test_no_db_boundary_statement_gated_on_db_exposure(self, real_agent_config):
+        """A db-less whitelist gets the explicit 'no live database access'
+        boundary (countering DB-capability hallucination); a db whitelist omits
+        it."""
+        nodb = _make_ask_report_with_tools(
+            real_agent_config, "filesystem_tools.*,semantic_tools.*", name="ask_boundary", slug="boundary"
+        )
+        assert "This agent has NO live database access" in nodb._render_behavioral_rules_section()
+        withdb = _make_ask_report_with_tools(
+            real_agent_config, "db_tools.*,filesystem_tools.*", name="ask_boundary_db", slug="boundary_db"
+        )
+        assert "This agent has NO live database access" not in withdb._render_behavioral_rules_section()

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -1811,6 +1811,12 @@ def _register_ask_agent_with_tools(
         agent_config.agentic_nodes = {}
     entry = {
         "type": agent_type,
+        # Pin the prompt template to the builtin ask_* template so
+        # ``_get_system_prompt`` renders ``_ask_artifact_common.j2`` (which the
+        # prompt-consistency tests inspect) instead of falling back to the
+        # default chat template. In production the backend copies this same
+        # builtin to ``{name}_system.j2`` (AgentService._copy_prompt_template).
+        "system_prompt": agent_type,
         "artifact_slug": slug,
         "agent_description": f"Ask consultant for {slug}",
         "rules": [],
@@ -1870,11 +1876,12 @@ _NO_DB_WHITELIST = (
 
 
 class TestToolsWhitelist:
-    """A configured ``tools`` whitelist is a hard cap on the LLM-facing surface.
+    """An ask_* agent's LLM tool surface is determined SOLELY by ``tools``.
 
-    Pins the fix for the leak where ask_* nodes (ChatAgenticNode subclasses)
-    ignored ``tools`` and always wired db_tools, leaving ``read_query``
-    callable for a subagent that only whitelisted semantic/context tools.
+    Nothing carries over from the ChatAgenticNode surface: only the groups the
+    whitelist lists are exposed, an empty/absent ``tools`` exposes nothing, and
+    a single group (e.g. ``filesystem_tools.*``) yields only that group — db /
+    bash / etc. stay out unless explicitly granted.
     """
 
     def test_db_tools_dropped_when_not_whitelisted(self, real_agent_config):
@@ -1911,14 +1918,20 @@ class TestToolsWhitelist:
         for other in ("list_tables", "describe_table", "get_table_ddl"):
             assert other not in names, f"{other} should not be exposed by a method-level whitelist"
 
-    def test_infrastructure_tools_always_survive(self, real_agent_config):
-        """Filesystem tools anchor the consultant to its artifact and must
-        survive even though the whitelist never lists them."""
-        node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST)
-        names = _tool_names(node)
-        fs_names = _fs_tool_names(node)
-        assert fs_names, "filesystem tool exposes no tools — fixture broken"
-        assert fs_names <= names, f"infrastructure filesystem tools were pruned: {sorted(fs_names - names)}"
+    def test_filesystem_tools_require_whitelist(self, real_agent_config):
+        """Filesystem tools are gated like every other group — present only
+        when ``filesystem_tools`` is whitelisted, dropped otherwise. There is
+        no always-on infrastructure on an ask_* agent."""
+        # The no-db whitelist omits filesystem_tools -> filesystem dropped.
+        nofs = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST, name="ask_nofs", slug="nofs")
+        assert not (_fs_tool_names(nofs) & _tool_names(nofs)), "filesystem leaked without being whitelisted"
+        # ``filesystem_tools.*`` alone -> ONLY filesystem tools, nothing else
+        # (no db, no bash, no semantic) — the exact contract the operator set.
+        withfs = _make_ask_report_with_tools(real_agent_config, "filesystem_tools.*", name="ask_withfs", slug="withfs")
+        names = _tool_names(withfs)
+        fs_names = _fs_tool_names(withfs)
+        assert fs_names and fs_names <= names
+        assert names == fs_names, f"filesystem_tools.* exposed non-filesystem tools: {sorted(names - fs_names)}"
 
     def test_wildcard_group_keeps_all_group_methods(self, real_agent_config):
         """``date_parsing_tools.*`` keeps every method of that group."""
@@ -1936,17 +1949,18 @@ class TestToolsWhitelist:
         assert "read_query" in names
         assert "list_tables" in names
 
-    def test_empty_whitelist_keeps_full_surface(self, real_agent_config):
-        """An empty ``tools`` string is back-compat: keep the inherited full
-        chat surface (db_tools included) rather than stripping to nothing."""
-        node = _make_ask_report_with_tools(real_agent_config, "")
-        assert "read_query" in _tool_names(node)
+    def test_empty_whitelist_exposes_no_tools(self, real_agent_config):
+        """An empty ``tools`` string exposes NOTHING — no chat-surface
+        carryover, no infrastructure default. The agent answers purely from
+        the inlined artifact context."""
+        node = _make_ask_report_with_tools(real_agent_config, "", name="ask_empty", slug="empty_wl")
+        assert _tool_names(node) == set()
 
-    def test_absent_tools_key_keeps_full_surface(self, real_agent_config):
-        """``tools`` key absent entirely (subagent created before scoping) →
-        same back-compat full surface."""
-        node = _make_ask_report_with_tools(real_agent_config, None)
-        assert "read_query" in _tool_names(node)
+    def test_absent_tools_key_exposes_no_tools(self, real_agent_config):
+        """``tools`` key absent entirely also exposes nothing — the surface is
+        determined solely by ``tools``."""
+        node = _make_ask_report_with_tools(real_agent_config, None, name="ask_absent", slug="absent_wl")
+        assert _tool_names(node) == set()
 
     def test_dashboard_honors_whitelist(self, real_agent_config):
         """The fix lives on the shared base, so ask_dashboard enforces the
@@ -1968,11 +1982,10 @@ class TestToolsWhitelist:
         monkeypatch.setattr(sem_mod, "SemanticTools", _boom)
         node = _make_ask_report_with_tools(real_agent_config, _NO_DB_WHITELIST, name="ask_sem_fail", slug="sem_fail")
         names = _tool_names(node)
-        # Whitelist still enforced (db dropped); semantic absent but no crash.
+        # Node built without crashing; db still absent and the failed semantic
+        # group simply contributes no tools.
         assert "read_query" not in names
         assert "query_metrics" not in names
-        # Infrastructure (artifact filesystem) survives so the node still works.
-        assert "read_file" in names
 
     def test_rebuild_tools_re_applies_whitelist(self, real_agent_config):
         """A mid-session datasource switch routes through ``_rebuild_tools``,
@@ -1987,3 +2000,116 @@ class TestToolsWhitelist:
         # Whitelisted semantic tool also survives the rebuild (it isn't
         # re-added by the base _rebuild_tools, so the override must re-surface it).
         assert "query_metrics" in names
+
+
+# --------------------------------------------------------------------------- #
+# System-prompt / tool-surface consistency                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestPromptToolConsistency:
+    """The system prompt must advertise only tools the whitelist exposes.
+
+    Regression for the mismatch where ask_* kept the ``db_func_tool`` instance
+    for internal use after pruning db_tools from the LLM surface, so the
+    prompt's ``has_db_tools`` flag (keyed off the instance) still advertised
+    db tools the model could not call — leading it to attempt ``list_tables`` /
+    ``read_query`` and hit "Tool ... not found".
+    """
+
+    def test_no_db_whitelist_prompt_omits_db_tools(self, real_agent_config):
+        """A whitelist without db_tools must not advertise or instruct db tools,
+        while semantic tools it DID whitelist are advertised (built on demand)."""
+        node = _make_ask_report_with_tools(
+            real_agent_config,
+            "date_parsing_tools.*,filesystem_tools.*,semantic_tools.*",
+            name="ask_nodb_prompt",
+            slug="nodb_prompt",
+        )
+        assert node._db_tools_exposed() is False
+        prompt = node._get_system_prompt()
+        # db tools are not callable -> never advertised nor instructed.
+        assert "**Database tools**" not in prompt
+        assert "execute_sql" not in prompt
+        assert "`describe_table` / `execute_sql`" not in prompt
+        # rule 1's live-data path reflects that db tools are unavailable.
+        assert "live database tools are not enabled" in prompt
+        # semantic tools ARE exposed (whitelisted + built on demand) -> advertised.
+        assert "Semantic / metric tools" in prompt
+
+    def test_db_whitelist_prompt_includes_db_tools(self, real_agent_config):
+        """A whitelist with db_tools keeps the db advertisement + live-data
+        guidance — the fix must not strip db tooling when it's legitimately
+        granted."""
+        node = _make_ask_report_with_tools(
+            real_agent_config,
+            "db_tools.*,filesystem_tools.*",
+            name="ask_db_prompt",
+            slug="db_prompt",
+        )
+        assert node._db_tools_exposed() is True
+        prompt = node._get_system_prompt()
+        assert "**Database tools**" in prompt
+        assert "`describe_table` / `execute_sql`" in prompt
+
+    def test_behavioral_rules_gate_db_guidance(self, real_agent_config):
+        """``_render_behavioral_rules_section`` swaps the live-data clause based
+        on db availability (unit-level check, independent of full prompt)."""
+        nodb = _make_ask_report_with_tools(
+            real_agent_config, "filesystem_tools.*,date_parsing_tools.*", name="ask_rules_nodb", slug="rules_nodb"
+        )
+        rules = nodb._render_behavioral_rules_section()
+        assert "execute_sql" not in rules
+        assert "live database tools are not enabled" in rules
+
+    def test_table_schemas_section_gates_describe_table_when_no_db(self, real_agent_config):
+        """The schema snapshot's ``describe_table`` refresh hint is dropped when
+        db tools aren't whitelisted — the snapshot becomes the sole source."""
+        from datus.agent.node.base_artifact_ask_agentic_node import INLINE_SCHEMA_COLS_PER_TABLE
+
+        slug = "schema_nodb"
+        _seed_artifact(real_agent_config.project_root, "report", slug)
+        root = Path(real_agent_config.project_root) / "reports" / slug
+        # Cover all three describe_table hint paths in one no-db render: the
+        # intro, a per-table ``error`` hint, and a wide-table truncation hint.
+        wide_cols = [{"name": f"c{i}", "type": "int"} for i in range(INLINE_SCHEMA_COLS_PER_TABLE + 5)]
+        _seed_analysis_extras(
+            root,
+            key_tables_schema={
+                "tables": [
+                    {"name": "orders", "columns": [{"name": "id", "type": "int"}]},
+                    {"name": "broken", "error": "connection refused"},
+                    {"name": "wide", "columns": wide_cols},
+                ]
+            },
+        )
+        blob = _blob_from_disk(real_agent_config.project_root, "report", slug)
+        _register_ask_agent_with_tools(
+            real_agent_config,
+            name="ask_schema_nodb",
+            kind="report",
+            slug=slug,
+            tools="filesystem_tools.*,date_parsing_tools.*",
+            blob=blob,
+        )
+        node = AskReportAgenticNode(
+            node_id="x", description="d", node_type="chat", agent_config=real_agent_config, node_name="ask_schema_nodb"
+        )
+        section = node._render_table_schemas_section()
+        assert "orders" in section  # snapshot still rendered
+        assert "live schema tools are not enabled" in section
+        # No describe_table suggestion anywhere — not the intro, the error hint,
+        # nor the truncation hint — since the tool isn't callable.
+        assert "describe_table(" not in section
+        assert "more columns not shown in this snapshot" in section  # truncation hint, no-db form
+        assert "schema unavailable in the snapshot" in section  # error hint, no-db form
+
+    def test_dashboard_rule6_gated_when_no_db(self, real_agent_config):
+        """ask_dashboard rule 6 must not promise ad-hoc ``execute_sql`` when the
+        whitelist grants no db tools (disk-bound dashboard path)."""
+        node = _make_ask_dashboard_with_tools(
+            real_agent_config, "filesystem_tools.*,semantic_tools.*", name="ask_dash_nodb", slug="dash_nodb"
+        )
+        rules = node._render_behavioral_rules_section()
+        assert "execute_sql" not in rules
+        assert "live SQL execution is not enabled" in rules

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -26,7 +26,7 @@ from pathlib import Path
 import pytest
 
 from datus.configuration.node_type import NodeType
-from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.gen_visual_report_models import GenVisualReportNodeInput
 from datus.tools.func_tool import (
     DBFuncTool,
@@ -278,6 +278,17 @@ async def test_execute_stream_end_to_end(real_agent_config, mock_llm_create):
     assert result["html_path"] == expected_html_rel
     assert (report_dir / "index.html").is_file()
 
+    # CLI mode streams a WORKFLOW status message carrying the compiled HTML's
+    # absolute path so the user can reopen it after closing the browser tab.
+    path_actions = [a for a in actions if a.action_type == "report_html_path"]
+    assert len(path_actions) == 1, "expected exactly one report_html_path action in CLI mode"
+    path_action = path_actions[0]
+    assert path_action.role == ActionRole.WORKFLOW
+    abs_html = str((report_dir / "index.html").resolve())
+    assert abs_html in path_action.messages
+    assert path_action.output["html_path"] == abs_html
+    assert path_action.output["url"].startswith("file://")
+
     # Artifact card fields surface through the result so the SSE artifact
     # event can be built without touching disk a second time.
     assert result["artifact_kind"] == "report"
@@ -330,6 +341,48 @@ class TestReportDistResolution:
         node._maybe_compile_html(report_slug)
         copied_css = Path(real_agent_config.project_root) / "reports" / report_slug / "_assets" / "index.css"
         assert copied_css.read_text(encoding="utf-8") == "/* node-only css */"
+
+
+class TestHtmlPathStreamMessage:
+    """Verify the compiled-HTML absolute path is surfaced into the action stream."""
+
+    def test_post_validate_hook_emits_path_action_in_cli_mode(self, real_agent_config, mock_llm_create):
+        from datus.schemas.gen_visual_report_models import GenVisualReportNodeResult
+
+        node = _make_node(real_agent_config)
+        report_slug = "path_msg_cli"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
+
+        result = GenVisualReportNodeResult(success=True)
+        action = node._post_validate_hook(report_slug, result)
+
+        assert isinstance(action, ActionHistory)
+        assert action.action_type == "report_html_path"
+        assert action.role == ActionRole.WORKFLOW
+        abs_html = str((Path(real_agent_config.project_root) / "reports" / report_slug / "index.html").resolve())
+        assert action.output["html_path"] == abs_html
+        assert abs_html in action.messages
+        # The relative path is still recorded on the result for SaaS/task consumers.
+        assert result.html_path == f"reports/{report_slug}/index.html"
+
+    def test_post_validate_hook_returns_none_in_non_cli_mode(self, real_agent_config, mock_llm_create):
+        from datus.schemas.gen_visual_report_models import GenVisualReportNodeResult
+
+        # filesystem_strict flips the node into SaaS/API mode, which renders
+        # reports dynamically server-side and never compiles a standalone HTML.
+        real_agent_config.filesystem_strict = True
+        node = _make_node(real_agent_config)
+        report_slug = "path_msg_saas"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
+
+        result = GenVisualReportNodeResult(success=True)
+        action = node._post_validate_hook(report_slug, result)
+
+        assert action is None
+        assert result.html_path is None
+        assert not (Path(real_agent_config.project_root) / "reports" / report_slug / "index.html").exists()
 
 
 class _InlineThread:


### PR DESCRIPTION
## Why

Backport the following fixes/enhancements from `main` to `release/0.3.2` so they ship with the 0.3.2 line:

- #877 — Honor `SubAgent.tools` whitelist on `ask_report` / `ask_dashboard` nodes
- #878 — Drive `ask_*` tool surface solely from the configured whitelist
- #881 — Make `ask_*` prompt self-contained; stop chat-template + bash/skill leakage
- #894 — Surface compiled report HTML absolute path in CLI message stream

The first three are a tightly coupled `ask_*` tooling fix sequence (whitelist enforcement → tool-surface unification → prompt isolation); #894 is a small UX enhancement that also touches `base_visual_artifact_agentic_node.py` and is bundled here to keep the visual artifact surface coherent on 0.3.2.

## Solution

Cherry-picked the four commits from `main` onto `upstream/release/0.3.2` in chronological order:

1. `aadf1c5b` [BugFix] Honor SubAgent.tools whitelist on ask_report / ask_dashboard nodes (#877)
2. `32cd508c` [BugFix] Drive ask_* tool surface solely from the configured whitelist (#878)
3. `2d8a8ec7` [BugFix] Make ask_* prompt self-contained; stop chat-template + bash/skill leakage (#881)
4. `c5ae712f` [Enhancement] Surface compiled report HTML absolute path in CLI message stream (#894)

All four picks applied cleanly (one auto-merge in `base_visual_artifact_agentic_node.py` for #894, no conflicts). Each commit carries the original `(cherry picked from commit …)` trailer via `git cherry-pick -x`.

## Test Cases

No new tests added in this backport — the cherry-picked commits already include their own unit tests (see the individual PRs on `main`). Those tests come along with the picks and run as part of this branch's CI on `release/0.3.2`.