### PR TITLE
[BugFix] Serialise DuckdbConnector access; fix dashboard multi-chart race

### DIFF
--- a/datus/tools/db_tools/duckdb_connector.py
+++ b/datus/tools/db_tools/duckdb_connector.py
@@ -2,8 +2,10 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import functools
 import re
-from typing import Any, Dict, List, Literal, Optional, Set, override
+import threading
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, TypeVar, override
 
 import duckdb
 from datus_db_core import BaseSqlConnector, SchemaNamespaceMixin, list_to_in_str
@@ -44,6 +46,32 @@ def _metadata_names(_type: str) -> _DBMetadataNames:
     return METADATA_DICT[_type]
 
 
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _serialised(method: _F) -> _F:
+    """Serialise calls that touch ``self.connection`` against the connector's RLock.
+
+    ``DuckDBPyConnection`` is not thread-safe — concurrent ``execute()``
+    on the same instance races on the shared result/statement state and
+    manifests as ``description=None``, empty rows, or DuckDB's NULL-
+    shared_ptr INTERNAL Error (and in our local repro, a Python SIGSEGV).
+    Dashboard's multi-chart fan-out hits this hard because every chart's
+    filter query lands on the same cached connector via ``asyncio.to_thread``.
+
+    Applied as a decorator (rather than ``with self._lock:`` inside each
+    method body) so the lock change is one line per method instead of a
+    full re-indent — the connector's body stays diffable and reviewable.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self: "DuckdbConnector", *args: Any, **kwargs: Any) -> Any:
+        with self._lock:
+            return method(self, *args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
 class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMixin):
     """
     Connector for DuckDB databases with schema support using native DuckDB SDK.
@@ -52,6 +80,9 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
     def __init__(self, config: DuckDBConfig):
         super().__init__(config, dialect=DBType.DUCKDB)
         self.db_path = config.db_path.replace("duckdb:///", "")
+        # ``RLock`` so same-thread re-entry (e.g. ``get_sample_rows`` →
+        # ``get_tables_with_ddl`` → ``_get_meta_with_ddl``) doesn't deadlock.
+        self._lock = threading.RLock()
         self.connection: Optional[duckdb.DuckDBPyConnection] = None
         self.enable_external_access = config.enable_external_access
         self.memory_limit = config.memory_limit
@@ -68,9 +99,16 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
     @override
     def connect(self):
         """Establish connection to DuckDB database."""
+        # Double-checked locking: skip the lock on the hot path (already
+        # connected) and only acquire it for the first-time race window.
         if self.connection:
             return
+        with self._lock:
+            if self.connection:
+                return
+            self._connect_locked()
 
+    def _connect_locked(self):
         try:
             # Align with the `custom_user_agent` that duckdb_engine auto-injects on every connect:
             # without this, any same-process SQLAlchemy+duckdb_engine client (metricflow validator,
@@ -316,6 +354,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         )
 
     @override
+    @_serialised
     def close(self):
         """Close the database connection."""
         if self.connection:
@@ -327,6 +366,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
                 self.connection = None
 
     @override
+    @_serialised
     def test_connection(self) -> bool:
         """Test the database connection."""
         opened_here = self.connection is None
@@ -378,6 +418,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             )
 
     @override
+    @_serialised
     def execute_insert(self, sql: str) -> ExecuteSQLResult:
         """Execute an INSERT SQL statement."""
         try:
@@ -405,6 +446,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             )
 
     @override
+    @_serialised
     def execute_update(self, sql: str) -> ExecuteSQLResult:
         """Execute an UPDATE SQL statement."""
         try:
@@ -432,6 +474,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             )
 
     @override
+    @_serialised
     def execute_delete(self, sql: str) -> ExecuteSQLResult:
         """Execute a DELETE SQL statement."""
         try:
@@ -459,6 +502,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             )
 
     @override
+    @_serialised
     def execute_ddl(self, sql: str) -> ExecuteSQLResult:
         """Execute a DDL SQL statement.
 
@@ -507,13 +551,20 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             )
 
     @override
+    @_serialised
     def execute_query(
         self, sql: str, result_format: Literal["csv", "arrow", "pandas", "list"] = "csv"
     ) -> ExecuteSQLResult:
-        """Execute a SELECT query."""
+        """Execute a SELECT query.
+
+        Each call uses a fresh ``cursor()`` so its result handle is
+        independent — defence in depth on top of the connector-level lock,
+        so a future regression that drops the lock can't silently return
+        rows that belong to a sibling query whose state was just reset.
+        """
         try:
             self.connect()
-            result = self.connection.execute(sql)
+            result = self.connection.cursor().execute(sql)
 
             if result_format == "csv":
                 df = result.df()
@@ -572,6 +623,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         return self.execute_query(sql, result_format="csv")
 
     @override
+    @_serialised
     def execute_queries(self, queries: List[str]) -> List[Any]:
         """Execute multiple queries."""
         results = []
@@ -590,6 +642,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         return results
 
     @override
+    @_serialised
     def execute_content_set(self, sql_query: str) -> ExecuteSQLResult:
         """Execute SET/USE commands."""
         try:
@@ -621,6 +674,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             )
 
     @override
+    @_serialised
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get all table names."""
         self.connect()
@@ -634,6 +688,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         return [row[0] for row in result.fetchall()]
 
     @override
+    @_serialised
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
         """Get all view names."""
         self.connect()
@@ -649,6 +704,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         return [row[0] for row in result.fetchall()]
 
     @override
+    @_serialised
     def get_databases(self, catalog_name: str = "", include_sys: bool = False) -> List[str]:
         """Get list of database names."""
         self.connect()
@@ -670,6 +726,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         return f'"{schema_name}"."{table_name}"' if schema_name else table_name
 
     @override
+    @_serialised
     def get_schemas(self, catalog_name: str = "", database_name: str = "", include_sys: bool = False) -> List[str]:
         self.connect()
         sql = "SELECT schema_name FROM duckdb_schemas()"
@@ -694,6 +751,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         return {"system", "temp", "information_schema"}
 
     @override
+    @_serialised
     def do_switch_context(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
         self.connect()
         if schema_name:
@@ -714,6 +772,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             filter_tables=filter_tables,
         )
 
+    @_serialised
     def _get_meta_with_ddl(
         self,
         database_name: str = "",
@@ -783,6 +842,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         )
 
     @override
+    @_serialised
     def get_sample_rows(
         self,
         tables: Optional[List[str]] = None,
@@ -864,6 +924,7 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
             ) from e
 
     @override
+    @_serialised
     def get_schema(
         self, catalog_name: str = "", database_name: str = "", schema_name: str = "", table_name: str = ""
     ) -> List[Dict[str, str]]:

--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -154,6 +154,5 @@ Explore the detailed configuration for each component:
 - **[Database Adapters](../adapters/db_adapters.md)**: Install additional database connectors
 - **[Workflow Definitions](workflow.md)**: Define custom execution patterns
 - **[Node Configuration](nodes.md)**: Customize individual node behavior
-- **[Session Compact](compact.md)**: Tune major / minor session compaction and the on-disk tool I/O archive
 - **[Storage Settings](storage.md)**: Configure knowledge base and vector storage
 - **[Benchmark Datasets](benchmark.md)**: Set up evaluation and testing

--- a/docs/configuration/introduction.zh.md
+++ b/docs/configuration/introduction.zh.md
@@ -124,6 +124,5 @@ conf/
 - **[数据库适配器](../adapters/db_adapters.md)**：安装额外的数据库连接器
 - **[工作流定义](workflow.md)**：自定义执行路径
 - **[节点配置](nodes.md)**：微调各节点行为
-- **[会话 Compact](compact.zh.md)**：调优 major / minor 压缩策略与磁盘归档
 - **[存储设置](storage.md)**：配置知识库/向量存储
 - **[基准测试](benchmark.md)**：评测与验证


### PR DESCRIPTION
## Why

A user opening a dashboard with multiple charts hits these symptoms randomly across the simultaneous filter queries:

- Some charts succeed.
- Some return **empty rows** silently (no exception, just no data).
- Some fail with `'NoneType' object is not iterable`.
- Some fail with DuckDB `INTERNAL Error: Attempted to dereference shared_ptr that is NULL!` (DuckDB's assertion failure for corrupt internal state).

Root cause: the dashboard viewer fans out one `POST /api/v1/dashboard/query` per chart on first paint. Each request goes through `DashboardService.run_query` → `asyncio.to_thread(connector.execute_query, …)`, so N concurrent requests dispatch into N threads of asyncio's default thread pool. `DBFuncTool._get_connector` returns the cached connector by reference, and `DuckdbConnector.execute_query` called `self.connection.execute(sql)` directly — so every thread hammered the same `DuckDBPyConnection` instance.

`DuckDBPyConnection` is **not thread-safe** (DuckDB docs). All three symptoms above stem from the same race on the shared connection / result state:

| Symptom | Race |
|---|---|
| `'NoneType' object is not iterable` | `result.description` got reset by a sibling thread's `execute()` between `fetchall()` and the column-name list-comp in `execute_query` |
| Empty rows | A sibling thread's `execute()` invalidated the cursor before `fetchall()` could drain it — no exception, just `[]` |
| `INTERNAL Error: NULL shared_ptr` | DuckDB's C++ assertion failure when its prepared-statement state is mutated concurrently |

My local repro on the pre-fix path was actually worse than the user's report — the unguarded shared connection segfaulted Python (`SIGSEGV`, exit 139) under the same fan-out load.

## Solution

DuckDB's recommended pair: **lock + per-call cursor**, both inside `DuckdbConnector` so other backends (Snowflake, MySQL — already thread-safe) aren't affected.

1. **`RLock` around every public entry that touches `self.connection`** — `execute_*`, `get_tables` / `get_views` / `get_databases` / `get_schemas`, `do_switch_context`, `_get_meta_with_ddl`, `get_sample_rows`, `get_schema`, plus `connect` / `close` / `test_connection`. `RLock` (not plain `Lock`) so same-thread re-entry — e.g. `get_sample_rows` → `get_tables_with_ddl` → `_get_meta_with_ddl` — doesn't self-deadlock.

2. **Double-checked locking in `connect()`** — the hot path (connection already up) skips the lock entirely; only the first-time race acquires it.

3. **SELECT-shaped paths now go through `self.connection.cursor()`** so each call owns its own result handle. Defence in depth on top of the lock — a future regression that drops the lock can't silently return wrong rows from a sibling query's reset state.

4. **`execute_content_set` / `do_switch_context` keep using the primary connection**, because `SET` / `USE` mutate connection-level state and `cursor()` is an independent connection duplicate — state changes wouldn't survive.

Tradeoff: queries against the same DuckDB connector are now serialised across threads. DuckDB already parallelises a single query internally (vector engine, `SET threads = N`), so for the dashboard's small KPI / group-by queries the loss is negligible — and "all-clean" beats "60% chance of working" for the user.

## Test Cases

Existing unit tests in `tests/unit_tests/tools/db_tools/test_duckdb_connector.py` and `test_duckdb_migration_mixin.py` (31 tests total) all pass — the locking is transparent to the existing single-threaded callers.

Concurrent smoke (kept locally, not in repo) — 16-thread fan-out × 6 rounds = 96 calls against the patched connector:
```
OK: 96 concurrent calls completed cleanly
```
Same load on the pre-fix path:
```
SIGSEGV (exit code 139)
```

No nightly/integration test was added: simulating "many threads hitting the same connection at the same time" reliably in CI is flaky (depends on GIL release timing, thread-pool size, DuckDB build), and the symptom on the unpatched path is a segfault, which the audit framework can't assert on portably. The fix is mechanical and the contract — "no two threads call `self.connection.<method>` simultaneously" — is enforceable by code review of the connector file.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [x] release/0.3.2
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread-safety for concurrent DuckDB queries to prevent connection errors
  * Improved connection lifecycle management and metadata retrieval reliability
  * Refined result handling across DML/DDL operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency safety for DuckDB operations to prevent connection-related errors
  * More robust connection lifecycle and metadata retrieval for reliable queries and schema inspection
  * Consistent handling of DML/DDL and multi-query execution, including safer transactional behavior

* **Documentation**
  * Updated "Next Steps": removed Session Compact link; added links to Storage Settings and Benchmark Datasets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->