### PR TITLE
[BugFix] Package visual_artifact HTML templates into the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ exclude = ["benchmark*", "docs*"]
     "sample_data/superset/*",
 ]
 "datus.cli.web" = ["templates/*.html"]
-"datus.agent.node" = ["templates/*.html"]
+"datus.agent.node.visual_artifact" = ["templates/*.html"]
 "datus.prompts" = ["*.txt", "*.md", "*.j2"]
 "datus.prompts.prompt_templates" = ["*.j2"]
 


### PR DESCRIPTION
## Why

The visual_artifact renderer ships two Jinja templates that must be present at runtime:

- `datus/agent/node/visual_artifact/templates/report_index.html`
- `datus/agent/node/visual_artifact/templates/dashboard_index.html`

The published wheel (`pip install datus-agent==0.3.2rc3` and earlier rc/stable builds) is missing both files. After install the `templates/` directory does not exist under `site-packages/datus/agent/node/visual_artifact/`, so any code that loads these templates fails at runtime.

Root cause is in `pyproject.toml`:

```toml
"datus.agent.node" = ["templates/*.html"]
```

The templates live under `datus.agent.node.visual_artifact`, not `datus.agent.node`, so setuptools resolves the glob against a non-existent `datus/agent/node/templates/` directory and silently packs nothing.

## Solution

Point the package-data entry at the correct subpackage:

```toml
"datus.agent.node.visual_artifact" = ["templates/*.html"]
```

Verified locally with `python -m build --wheel`: the resulting wheel now contains both HTML files.

```
datus/agent/node/visual_artifact/templates/dashboard_index.html
datus/agent/node/visual_artifact/templates/report_index.html
datus/cli/web/templates/index.html
```

## Test Cases

No new automated tests. This is a packaging metadata fix; the failure mode (missing data files in the wheel) is not exercised by `pytest` against the source tree because editable / source installs read files directly from the repo. Verified by building the wheel and inspecting its contents with `unzip -l`.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [x] release/0.3.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project packaging configuration to reorganize internal template resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->