### PR TITLE
[BugFix] Package visual_artifact HTML templates into the wheel (backport #907 to release/0.3.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ exclude = ["benchmark*", "docs*"]
     "sample_data/superset/*",
 ]
 "datus.cli.web" = ["templates/*.html"]
-"datus.agent.node" = ["templates/*.html"]
+"datus.agent.node.visual_artifact" = ["templates/*.html"]
 "datus.prompts" = ["*.txt", "*.md", "*.j2"]
 "datus.prompts.prompt_templates" = ["*.j2"]
 


### PR DESCRIPTION
Backport of #907 to `release/0.3.2`.

## Why

`release/0.3.2` currently ships `0.3.2rc3` (and any subsequent rc/stable cut from this branch) without the two visual_artifact Jinja templates:

- `datus/agent/node/visual_artifact/templates/report_index.html`
- `datus/agent/node/visual_artifact/templates/dashboard_index.html`

After `pip install datus-agent==0.3.2rc3` the `templates/` directory does not exist under `site-packages/datus/agent/node/visual_artifact/`. At runtime `render_report_html` / `render_dashboard_html` call `spec.template_path.read_text(...)` (`_artifact_html_renderer.py`), which raises `FileNotFoundError`. The error is swallowed by `_maybe_compile_html`'s broad `except Exception` (returns `None` after logging), so the CLI silently produces no report HTML — only the log line `Failed to compile report HTML for ...` reveals the cause.

Editable installs (`uv pip install -e .`) work fine because the templates are read directly from the source tree, which is why this regression didn't show up in dev.

Root cause is in `pyproject.toml`:

```toml
"datus.agent.node" = ["templates/*.html"]
```

The templates live under `datus.agent.node.visual_artifact`, so setuptools resolves the glob against a non-existent `datus/agent/node/templates/` directory and packs nothing.

## Solution

Cherry-pick the one-line fix from #907 (merge commit `b81b218d`) — point the package-data entry at the correct subpackage:

```toml
"datus.agent.node.visual_artifact" = ["templates/*.html"]
```

Verified on `main` by rebuilding the wheel and inspecting it with `unzip -l`; both HTML files now appear under `datus/agent/node/visual_artifact/templates/`.

## Test Cases

No new automated tests. This is a packaging metadata fix; the failure mode (missing data files in the wheel) is not exercised by `pytest` against the source tree because editable / source installs read files directly from the repo. Verified by building the wheel from this branch and confirming both templates are present in the archive.