### PR TITLE
[Refactor] Decouple session reuse from execution_mode so --resume works in any IO mode

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2204,9 +2204,12 @@ class AgenticNode(Node):
         try:
             await self._before_stream(ctx)
 
-            if self.execution_mode == "interactive":
-                await self._auto_compact()
-                ctx.session = self._get_or_create_session()
+            # Session injection is independent of ``execution_mode``: workflow
+            # callers (print mode ``--resume``, API chat with ``interactive=False``,
+            # sub-agents continuing a parent session) all want SDK to see prior
+            # items. ``execution_mode`` controls human-in-the-loop, not history.
+            await self._auto_compact()
+            ctx.session = self._get_or_create_session()
 
             template_context = self._build_template_context(ctx)
             prompt_version = getattr(self.input, "prompt_version", None)
@@ -2957,18 +2960,12 @@ class AgenticNode(Node):
         bypass ``__init__`` don't trip on a missing attribute, and so the
         hook is only created in the loop where it will actually be used.
 
-        Returns ``None`` when:
-        - the compact subsystem is disabled in config (both ``major.enabled``
-          and ``minor.enabled`` off), or
-        - the node is running in non-interactive mode (workflow / single-shot
-          subagent). Those nodes don't loop with the user, so the rolling-
-          window minor compact has nothing to accumulate and the in-loop
-          major trigger has no observer — the legacy behavior (let the run
-          fail with ``MaxTurnsExceeded`` and rely on the model-layer
-          overflow callback) is the right answer there.
+        Returns ``None`` when the compact subsystem is disabled in config
+        (both ``major.enabled`` and ``minor.enabled`` off). Enabled for all
+        ``execution_mode`` values: ``cfg.*.enabled`` is the real gate, so
+        workflow callers that span multiple turns (API chat resume, sub-agents
+        with shared session_id) still get rolling-window compaction.
         """
-        if getattr(self, "execution_mode", None) != "interactive":
-            return None
         self._ensure_compact_state()
         cfg = self._compact_cfg
         if not (cfg.major.enabled or cfg.minor.enabled):

--- a/datus/agent/node/stream_run_context.py
+++ b/datus/agent/node/stream_run_context.py
@@ -32,7 +32,8 @@ class StreamRunContext:
     Attributes are populated in order by the template method:
 
     1. ``user_input`` / ``action_history_manager`` — set at construction.
-    2. ``session`` — set after session setup (None in workflow mode).
+    2. ``session`` — set after session setup; always populated so SDK
+       receives prior items regardless of ``execution_mode``.
     3. ``system_instruction`` / ``user_prompt`` — set during prompt assembly.
     4. ``response_content`` / ``last_successful_output`` / ``last_tool_summary``
        — populated incrementally as actions flow through ``_stream_once``.

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -137,7 +137,7 @@ class ArgumentParser:
             "--resume",
             type=str,
             default=None,
-            help="Resume an existing session by session_id (for print mode)",
+            help="Resume an existing session by session_id (REPL or --print mode)",
         )
 
         self.parser.add_argument(
@@ -222,9 +222,6 @@ class Application:
             args.datasource = self._resolve_default_datasource(args, allow_empty=is_repl)
             if not args.datasource and not is_repl:
                 return
-
-        if args.resume and args.print_mode is None:
-            self.arg_parser.parser.error("--resume requires --print mode")
 
         if args.proxy_tools and args.print_mode is None:
             self.arg_parser.parser.error("--proxy_tools requires --print mode")

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -975,6 +975,7 @@ class DatusCLI:
         self._warn_no_model()
         self._warn_no_datasource()
         self._bootstrap_services()
+        self._auto_resume_if_requested()
 
         while True:
             try:
@@ -1031,6 +1032,7 @@ class DatusCLI:
         self._warn_no_model()
         self._warn_no_datasource()
         self._bootstrap_services()
+        self._auto_resume_if_requested()
 
         # Prefill support mirrors the PromptSession path: ``.rewind`` stores
         # the replayed user message in ``_prefill_input`` and expects the
@@ -2131,6 +2133,17 @@ class DatusCLI:
             service_bootstrap.run(self)
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(f"service bootstrap failed: {exc}")
+
+    def _auto_resume_if_requested(self) -> None:
+        """Auto-trigger ``/resume`` when ``--resume <session_id>`` is set.
+
+        Same effect as entering the REPL and typing ``/resume <session_id>``:
+        rehydrates the node and replays history before the first prompt.
+        """
+        session_id = getattr(self.args, "resume", None)
+        if not session_id:
+            return
+        self.chat_commands.cmd_resume(session_id)
 
     def prompt_input(self, message: str, default: str = "", choices: list = None, multiline: bool = False):
         """

--- a/tests/unit_tests/agent/node/test_agentic_node_template.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_template.py
@@ -250,24 +250,27 @@ class TestTemplateMethodHappyPath:
 
 class TestExecutionModeGuard:
     @pytest.mark.asyncio
-    async def test_workflow_mode_skips_session_setup(self):
-        """In workflow mode the template must not call _get_or_create_session."""
+    async def test_workflow_mode_also_builds_session(self):
+        """Workflow mode must also build a session so ``--resume`` / API chat
+        callers receive prior items via SDK; only the interactive *capability*
+        (broker prompts, ask_user tool) is gated on ``execution_mode``."""
         model = _StreamModel([[_ok_action("x")]])
         node = FakeAgenticNode(model, execution_mode="workflow")
         node.input = FakeInput(user_message="m")
+        calls = {"count": 0}
 
-        sentinel = {"called": False}
+        original = node._get_or_create_session
 
-        def _bomb():
-            sentinel["called"] = True
-            raise RuntimeError("workflow mode must not build a session")
+        def _spy():
+            calls["count"] += 1
+            return original()
 
-        node._get_or_create_session = _bomb  # type: ignore[assignment]
+        node._get_or_create_session = _spy  # type: ignore[assignment]
 
         async for _ in node.execute_stream(ActionHistoryManager()):
             pass
 
-        assert sentinel["called"] is False
+        assert calls["count"] == 1
 
     @pytest.mark.asyncio
     async def test_interactive_mode_builds_session_once(self):

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -444,16 +444,20 @@ class TestGenDashboardPermissionWiring:
 
         A ``None`` hook means the permission_manager never intercepts tool
         calls — rules defined in the profile are effectively ignored.
+
+        Workflow mode now also wires ``CompactHook`` (multi-turn history is
+        enabled for all modes), so ``_compose_hooks`` may return a
+        ``CompositeHooks`` bundle. Validate the permission gate on the node.
         """
         _add_dashboard_config(real_agent_config)
         _bi_core_mock.adapter_registry.get.return_value = lambda **kwargs: FullMockAdapter()
         with patch.dict(sys.modules, _BI_MODULES_PATCH):
             from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
-            from datus.tools.permission.permission_hooks import PermissionHooks
 
             node = GenDashboardAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
             hooks = node._compose_hooks()
-            assert isinstance(hooks, PermissionHooks)
+            assert hooks is not None
+            assert node.permission_hooks is not None
 
     def test_tool_registry_routes_delete_chart_to_bi_tools(self, real_agent_config, mock_llm_create):
         """After ``_ensure_permission_hooks`` runs, registry must classify ``delete_chart``.

--- a/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_ext_knowledge_agentic_node.py
@@ -715,10 +715,13 @@ class TestGenExtKnowledgeNonInteractiveBridge:
     """
 
     def test_workflow_mode_compose_hooks_is_non_interactive(self, real_agent_config, mock_llm_create):
-        from datus.tools.permission.permission_hooks import PermissionHooks
-
         node = _create_node(real_agent_config, execution_mode="workflow")
+        # ``_compose_hooks`` may return ``CompositeHooks`` (permission + compact)
+        # in workflow mode now that multi-turn history is enabled. Validate the
+        # permission gate directly — its presence + ``non_interactive`` is what
+        # keeps /bootstrap pools from deadlocking on broker prompts.
         hooks = node._compose_hooks()
-        assert isinstance(hooks, PermissionHooks)
-        assert hooks.non_interactive is True
+        assert hooks is not None
+        assert node.permission_hooks is not None
+        assert node.permission_hooks.non_interactive is True
         assert node.permission_manager.active_profile == "dangerous"

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -1086,10 +1086,13 @@ class TestGenMetricsNonInteractiveBridge:
 
     def test_workflow_mode_compose_hooks_is_non_interactive(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.permission.permission_hooks import PermissionHooks
 
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        # Workflow mode may now compose CompositeHooks (permission + compact)
+        # because multi-turn history is enabled for all modes. Validate the
+        # permission gate via ``node.permission_hooks`` instead of the bundle.
         hooks = node._compose_hooks()
-        assert isinstance(hooks, PermissionHooks)
-        assert hooks.non_interactive is True
+        assert hooks is not None
+        assert node.permission_hooks is not None
+        assert node.permission_hooks.non_interactive is True
         assert node.permission_manager.active_profile == "dangerous"

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -497,12 +497,14 @@ class TestExecutionModeGenSemanticModel:
         """Workflow mode → PermissionHooks must run with non_interactive=True
         so ASK / EXTERNAL fs hits raise PermissionDeniedException instead of
         awaiting a broker that nobody will answer (``/bootstrap`` flow)."""
-        from datus.tools.permission.permission_hooks import PermissionHooks
-
         node = _make_node(real_agent_config, mock_llm_create, execution_mode="workflow")
+        # Workflow now also composes CompactHook (multi-turn history enabled
+        # in all modes), so _compose_hooks may return CompositeHooks. Check
+        # the permission gate on the node so the test stays robust.
         hooks = node._compose_hooks()
-        assert isinstance(hooks, PermissionHooks)
-        assert hooks.non_interactive is True
+        assert hooks is not None
+        assert node.permission_hooks is not None
+        assert node.permission_hooks.non_interactive is True
         # Permission manager must be loaded with the dangerous profile, not the
         # user's profile, so workflow flows always operate against a known
         # baseline.

--- a/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_sql_summary_agentic_node.py
@@ -483,10 +483,13 @@ class TestSqlSummaryNonInteractiveBridge:
     """
 
     def test_workflow_mode_compose_hooks_is_non_interactive(self, real_agent_config, mock_llm_create):
-        from datus.tools.permission.permission_hooks import PermissionHooks
-
         node = _create_node(real_agent_config, execution_mode="workflow")
+        # Workflow now also wires CompactHook (multi-turn history is enabled
+        # for all execution_mode values), so _compose_hooks may return a
+        # CompositeHooks bundle. Validate the permission gate directly on the
+        # node — that's what keeps /bootstrap parallel pools from deadlocking.
         hooks = node._compose_hooks()
-        assert isinstance(hooks, PermissionHooks)
-        assert hooks.non_interactive is True
+        assert hooks is not None
+        assert node.permission_hooks is not None
+        assert node.permission_hooks.non_interactive is True
         assert node.permission_manager.active_profile == "dangerous"

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -116,7 +116,10 @@ class TestApplicationRun:
             app.run()
         mock_cli_cls.assert_not_called()
 
-    def test_resume_without_print_mode_errors(self):
+    def test_resume_without_print_mode_enters_repl(self):
+        """``--resume <id>`` without ``-p`` is now valid: it enters the REPL
+        and the CLI's ``_auto_resume_if_requested`` replays the session before
+        the first prompt (same effect as typing ``/resume <id>`` after start)."""
         app = Application()
         mock_args = SimpleNamespace(
             debug=False, datasource="ns1", print_mode=None, web=False, resume="sess_123", proxy_tools=None, config=None
@@ -125,9 +128,10 @@ class TestApplicationRun:
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
             patch("datus.cli.main.configure_logging"),
             patch.object(app, "_ensure_project_config"),
+            patch("datus.cli.main.DatusCLI") as mock_cli_cls,
         ):
-            with pytest.raises(SystemExit):
-                app.run()
+            app.run()
+        mock_cli_cls.assert_called_once_with(mock_args)
 
     def test_proxy_tools_without_print_mode_errors(self):
         """Verify that --proxy_tools without --print raises SystemExit."""

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -162,6 +162,44 @@ class TestMaybeScheduleStartupSync:
         assert not hasattr(cli, "bg_sync")
 
 
+class TestAutoResumeIfRequested:
+    """``_auto_resume_if_requested`` mirrors ``/resume <id>`` at REPL startup.
+
+    Triggered from ``_run_prompt_session`` / ``_run_tui`` right after
+    ``_bootstrap_services``: ``datus --resume <id>`` enters the REPL with the
+    given session already rehydrated, no slash-command needed.
+    """
+
+    def test_noop_when_no_resume_flag(self, cli):
+        cli.args = MagicMock(resume=None)
+        cli._auto_resume_if_requested()
+        cli.chat_commands.cmd_resume.assert_not_called()
+
+    def test_invokes_cmd_resume_with_session_id(self, cli):
+        cli.args = MagicMock(resume="sess_abc123")
+        cli._auto_resume_if_requested()
+        cli.chat_commands.cmd_resume.assert_called_once_with("sess_abc123")
+
+    def test_run_prompt_session_invokes_auto_resume(self, cli):
+        """The prompt-session main loop must call ``_auto_resume_if_requested``
+        once before reading the first user prompt — that's what makes
+        ``datus --resume <id>`` work without an extra slash command."""
+        cli.args = MagicMock(resume="sess_abc")
+        cli._prefill_input = None
+        cli._print_welcome = MagicMock()
+        cli._warn_no_model = MagicMock()
+        cli._warn_no_datasource = MagicMock()
+        cli._bootstrap_services = MagicMock()
+        cli._auto_resume_if_requested = MagicMock()
+        cli._get_prompt_text = MagicMock(return_value="> ")
+        cli.session = MagicMock()
+        cli.session.prompt = MagicMock(side_effect=EOFError())  # exit loop immediately
+
+        cli._run_prompt_session()
+
+        cli._auto_resume_if_requested.assert_called_once_with()
+
+
 class TestCmdExitShutsDownBgSync:
     def test_exit_calls_bg_sync_shutdown(self, cli):
         cli.bg_sync = MagicMock()


### PR DESCRIPTION
## Why

`datus -p '...' --resume <session_id>` did not actually continue the prior conversation — the SDK never received any history, even though the session DB and ID were both wired up. Same root cause blocks API chat (`interactive=False`) from resuming a stable `node_id` and forced print mode to be a single-shot.

Root cause: `AgenticNode.execution_mode` over-encoded two unrelated concerns into one flag:
1. **Is there a human in the loop?** (InteractionBroker / permission ASK / `ask_user_tool` / `confirm_plan`)
2. **Should the SDK see prior turns?** (`ctx.session = _get_or_create_session()`, auto_compact, CompactHook)

`_execute_template` gated #2 on `execution_mode == "interactive"`, so workflow callers — including `-p --resume`, API chat with `interactive=False`, and any sub-agent inheriting a workflow parent — silently dropped session history.

Additionally `--resume` was rejected outside `--print`, even though REPL has full `/resume` infrastructure.

## Solution

- **Decouple `execution_mode` from session reuse.** `_execute_template` and `_make_compact_hook` no longer branch on `execution_mode`. All modes inject `ctx.session` and run CompactHook; `cfg.major.enabled / cfg.minor.enabled` remains the real gate for compaction. `execution_mode == "workflow"` now strictly means "no human-in-the-loop": `non_interactive=True` on PermissionHooks, dangerous-profile permission manager, no `ask_user_tool` registration — unchanged.
- **REPL `--resume`.** Lifts the `--resume requires --print mode` argparse guard. `DatusCLI` adds `_auto_resume_if_requested`, invoked once right after `_bootstrap_services` in both `_run_prompt_session` and `_run_tui`, equivalent to typing `/resume <id>` at the first prompt.
- **`print_mode.py`.** Stays hardcoded `execution_mode="workflow"`; the multi-turn capability now comes from the decoupled session path, no IO-mode swap needed.

### Side effects

- `/bootstrap` parallel pools now create one empty SQLite session DB per per-item node (auto-generated `session_id`, no collision). DB files are tiny (~1KB) and not cleaned up — recorded for a follow-up.
- API chat `chat_task_manager.py:741` (`interactive=False`) automatically gains multi-turn capability, matching the design intent of its stable `node_id` parameter.
- `_count_session_tokens` and `_user_turn_count_from_session` already return 0 on empty sessions (verified at `agentic_node.py:1048-1059` and `1168-1184`), so single-shot workflow nodes don't hit unhandled exceptions.

## Test Cases

- **Updated** `test_workflow_mode_skips_session_setup` → `test_workflow_mode_also_builds_session` (`test_agentic_node_template.py`): asserts workflow mode now invokes `_get_or_create_session` exactly once.
- **Updated** `test_workflow_mode_compose_hooks_is_non_interactive` across `test_gen_ext_knowledge_agentic_node.py`, `test_gen_metrics_agentic_node.py`, `test_gen_semantic_model_agentic_node.py`, `test_sql_summary_agentic_node.py`, `test_gen_dashboard_agentic_node.py`: `_compose_hooks` may return `CompositeHooks` now (permission + compact bundled), so they validate `node.permission_hooks.non_interactive is True` directly instead of `isinstance(hooks, PermissionHooks)`.
- **Updated** `test_resume_without_print_mode_errors` → `test_resume_without_print_mode_enters_repl` (`test_main.py`): asserts the REPL path constructs `DatusCLI` rather than `sys.exit`.
- **Added** `TestAutoResumeIfRequested` (`test_repl.py`): three cases covering no-op when `resume=None`, dispatch to `cmd_resume` when set, and that `_run_prompt_session` invokes the helper before the first prompt.

Diff coverage on changed lines = 88% (above 80% gate). Full `not nightly` suite passes (one unrelated pre-existing failure in `test_explorer_service.py::test_create_metric_with_valid_yaml` due to local missing `metricflow`, confirmed on main).

Manual E2E:
```bash
# 1. record a fact
datus -p "Remember: my name is felix"  # capture session_id from output

# 2. continue with --resume in print mode
datus -p "What is my name?" --resume <session_id>  # → "felix"

# 3. REPL auto-resume
datus --resume <session_id>  # banner → Session resumed → history → prompt
```

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [x] release/0.3.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-resume sessions on startup when `--resume <session_id>` is provided via CLI.

* **Improvements**
  * Session persistence now enabled across all execution modes, not just interactive mode.
  * `--resume` option expanded to work in both REPL and print modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->