### PR TITLE
[Feature] Add nightly trace diagnostics

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -420,6 +420,9 @@ jobs:
             nightly-manifest.json
             nightly-failure-classification.json
             provider-coverage-manifest.json
+            nightly-trace-references.jsonl
+            nightly-trace-summary.jsonl
+            nightly-process-diagnostics.json
           retention-days: 7
 
       - name: Send Feishu notification

--- a/ci/collect_nightly_trace_summary.py
+++ b/ci/collect_nightly_trace_summary.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Collect optional Langfuse trace diagnostics for Datus nightly runs.
+
+Nightly pass/fail must not depend on Langfuse availability. This script writes
+diagnostic artifacts and exits successfully when credentials or trace data are
+missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import urllib.parse
+import urllib.request
+from collections import Counter, defaultdict
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BASE_URL = "https://us.cloud.langfuse.com"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Collect nightly Langfuse trace diagnostics")
+    parser.add_argument("--trace-references-jsonl", required=True)
+    parser.add_argument("--output-jsonl", required=True)
+    parser.add_argument("--diagnostics-json", required=True)
+    parser.add_argument("--from-start-time", default="")
+    parser.add_argument("--to-start-time", default="")
+    parser.add_argument(
+        "--base-url", default=os.getenv("LANGFUSE_BASE_URL") or os.getenv("LANGFUSE_HOST") or DEFAULT_BASE_URL
+    )
+    parser.add_argument("--public-key", default=os.getenv("LANGFUSE_PUBLIC_KEY", ""))
+    parser.add_argument("--secret-key", default=os.getenv("LANGFUSE_SECRET_KEY", ""))
+    parser.add_argument("--project-id", default=os.getenv("LANGFUSE_PROJECT_ID", ""))
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--slow-span-threshold-seconds", type=float, default=30.0)
+    parser.add_argument("--max-pages", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    refs = load_jsonl(Path(args.trace_references_jsonl))
+    from_start_time, to_start_time = default_time_bounds(args.from_start_time, args.to_start_time)
+    has_credentials = bool(args.public_key and args.secret_key)
+
+    rows: list[dict[str, Any]] = []
+    for ref in refs:
+        trace_id = str(ref.get("trace_id") or "")
+        if not trace_id:
+            rows.append(build_missing_row(ref, "missing_trace_reference"))
+            continue
+        if not has_credentials:
+            rows.append(build_missing_row(ref, "no_credentials"))
+            continue
+        try:
+            observations = fetch_observations(
+                trace_id=trace_id,
+                base_url=args.base_url,
+                public_key=args.public_key,
+                secret_key=args.secret_key,
+                from_start_time=from_start_time,
+                to_start_time=to_start_time,
+                timeout=args.timeout,
+                max_pages=args.max_pages,
+            )
+            rows.append(
+                summarize_trace(
+                    ref,
+                    observations,
+                    base_url=args.base_url,
+                    project_id=args.project_id,
+                    slow_span_threshold_seconds=args.slow_span_threshold_seconds,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - non-blocking diagnostics.
+            rows.append(build_missing_row(ref, "api_error", str(exc)))
+
+    write_jsonl(Path(args.output_jsonl), rows)
+    diagnostics = build_process_diagnostics(rows)
+    write_json(Path(args.diagnostics_json), diagnostics)
+    print(f"Generated nightly trace diagnostics: {args.output_jsonl} ({len(rows)} rows), {args.diagnostics_json}")
+    return 0
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                rows.append(payload)
+    return dedupe_trace_refs(rows)
+
+
+def dedupe_trace_refs(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep the latest row per suite/nodeid/trace-id combination."""
+
+    selected: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        suite = str(row.get("suite") or "")
+        nodeid = str(row.get("nodeid") or "")
+        trace_id = str(row.get("trace_id") or "")
+        key = (suite, nodeid, trace_id)
+        selected[key] = row
+    return [selected[key] for key in sorted(selected, key=lambda item: (item[0], item[1], item[2]))]
+
+
+def default_time_bounds(from_start_time: str, to_start_time: str) -> tuple[str, str]:
+    end = _parse_datetime(to_start_time) or datetime.now(UTC) + timedelta(minutes=5)
+    start = _parse_datetime(from_start_time) or (end - timedelta(days=14))
+    return _format_iso(start), _format_iso(end)
+
+
+def fetch_observations(
+    *,
+    trace_id: str,
+    base_url: str,
+    public_key: str,
+    secret_key: str,
+    from_start_time: str,
+    to_start_time: str,
+    timeout: float,
+    max_pages: int,
+) -> list[dict[str, Any]]:
+    observations: list[dict[str, Any]] = []
+    cursor = ""
+    for _ in range(max_pages):
+        query = {
+            "traceId": trace_id,
+            "fromStartTime": from_start_time,
+            "toStartTime": to_start_time,
+            "limit": "1000",
+        }
+        if cursor:
+            query["cursor"] = cursor
+        url = f"{base_url.rstrip('/')}/api/public/v2/observations?{urllib.parse.urlencode(query)}"
+        request = urllib.request.Request(url, headers=_auth_headers(public_key, secret_key))
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 - URL is configured by CI.
+            payload = json.loads(response.read().decode("utf-8"))
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(data, list):
+            observations.extend(item for item in data if isinstance(item, dict))
+        meta = payload.get("meta") if isinstance(payload, dict) else None
+        next_cursor = ""
+        if isinstance(meta, dict):
+            next_cursor = str(meta.get("nextCursor") or meta.get("next_cursor") or "")
+        if not next_cursor:
+            break
+        cursor = next_cursor
+    return observations
+
+
+def build_missing_row(ref: dict[str, Any], status: str, error: str = "") -> dict[str, Any]:
+    return {
+        **_base_trace_row(ref),
+        "trace_fetch_status": status,
+        "observation_count": 0,
+        "duration_seconds": None,
+        "tool_span_count": 0,
+        "generation_span_count": 0,
+        "agent_span_count": 0,
+        "failed_span_count": 0,
+        "token_usage": {},
+        "slowest_spans": [],
+        "finding_type_counts": {},
+        "diagnostic_findings": [],
+        "error": error or None,
+    }
+
+
+def summarize_trace(
+    ref: dict[str, Any],
+    observations: list[dict[str, Any]],
+    *,
+    base_url: str,
+    project_id: str,
+    slow_span_threshold_seconds: float,
+) -> dict[str, Any]:
+    row = {
+        **_base_trace_row(ref),
+        "trace_fetch_status": "fetched",
+        **summarize_observations(observations, slow_span_threshold_seconds=slow_span_threshold_seconds),
+    }
+    if not row.get("trace_url") and row.get("trace_id") and project_id:
+        row["trace_url"] = f"{base_url.rstrip('/')}/project/{project_id}/traces/{row['trace_id']}"
+    return row
+
+
+def summarize_observations(
+    observations: list[dict[str, Any]],
+    *,
+    slow_span_threshold_seconds: float = 30.0,
+) -> dict[str, Any]:
+    type_counts = Counter(_observation_type(item) for item in observations)
+    failed_spans = [item for item in observations if _is_failed_observation(item)]
+    durations = [(_observation_duration(item), item) for item in observations]
+    durations = [(duration, item) for duration, item in durations if duration is not None]
+    slowest = sorted(durations, key=lambda item: item[0], reverse=True)[:5]
+    start_times = [_parse_datetime(_observation_start(item)) for item in observations]
+    end_times = [_parse_datetime(_observation_end(item)) for item in observations]
+    start_times = [item for item in start_times if item is not None]
+    end_times = [item for item in end_times if item is not None]
+
+    findings: list[dict[str, Any]] = []
+    for item in failed_spans[:10]:
+        findings.append(
+            {
+                "type": "failed_span",
+                "severity": "warning",
+                "name": item.get("name"),
+                "span_type": _observation_type(item),
+                "message": str(item.get("statusMessage") or item.get("error") or "Trace span failed"),
+            }
+        )
+    for duration, item in slowest:
+        if duration >= slow_span_threshold_seconds:
+            findings.append(
+                {
+                    "type": "slow_span",
+                    "severity": "info",
+                    "name": item.get("name"),
+                    "span_type": _observation_type(item),
+                    "duration_seconds": duration,
+                    "threshold_seconds": slow_span_threshold_seconds,
+                }
+            )
+
+    if observations and type_counts.get("GENERATION", 0) == 0:
+        findings.append(
+            {
+                "type": "missing_generation_span",
+                "severity": "warning",
+                "message": "Trace has no generation span.",
+            }
+        )
+
+    return {
+        "observation_count": len(observations),
+        "duration_seconds": _duration_between(min(start_times), max(end_times)) if start_times and end_times else None,
+        "tool_span_count": type_counts.get("TOOL", 0),
+        "generation_span_count": type_counts.get("GENERATION", 0),
+        "agent_span_count": type_counts.get("AGENT", 0),
+        "failed_span_count": len(failed_spans),
+        "token_usage": _collect_token_usage(observations),
+        "slowest_spans": [_span_summary(item, duration) for duration, item in slowest],
+        "finding_type_counts": dict(Counter(str(finding.get("type")) for finding in findings)),
+        "diagnostic_findings": findings,
+        "error": None,
+    }
+
+
+def build_process_diagnostics(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    suite_rows: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        suite_rows[str(row.get("suite") or "unknown")].append(row)
+
+    suite_summaries = []
+    for suite_name in sorted(suite_rows):
+        suite_summaries.append({"suite": suite_name, **summarize_rows(suite_rows[suite_name])})
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "summary": summarize_rows(rows),
+        "suites": suite_summaries,
+    }
+
+
+def summarize_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    fetch_status_counts: Counter[str] = Counter()
+    finding_type_counts: Counter[str] = Counter()
+    token_usage: Counter[str] = Counter()
+    durations: list[float] = []
+    tool_spans = generation_spans = agent_spans = failed_spans = observations = 0
+    trace_refs = 0
+
+    for row in rows:
+        status = str(row.get("trace_fetch_status") or "unknown")
+        fetch_status_counts[status] += 1
+        if row.get("trace_id"):
+            trace_refs += 1
+        observations += int(row.get("observation_count") or 0)
+        tool_spans += int(row.get("tool_span_count") or 0)
+        generation_spans += int(row.get("generation_span_count") or 0)
+        agent_spans += int(row.get("agent_span_count") or 0)
+        failed_spans += int(row.get("failed_span_count") or 0)
+        duration = row.get("duration_seconds")
+        if isinstance(duration, (int, float)) and not isinstance(duration, bool):
+            durations.append(float(duration))
+        for key, value in (row.get("finding_type_counts") or {}).items():
+            finding_type_counts[str(key)] += int(value or 0)
+        for key, value in (row.get("token_usage") or {}).items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                token_usage[str(key)] += int(value)
+
+    return {
+        "case_count": len(rows),
+        "trace_reference_count": trace_refs,
+        "trace_fetch_status_counts": dict(sorted(fetch_status_counts.items())),
+        "finding_type_counts": dict(sorted(finding_type_counts.items())),
+        "observation_count": observations,
+        "tool_span_count": tool_spans,
+        "generation_span_count": generation_spans,
+        "agent_span_count": agent_spans,
+        "failed_span_count": failed_spans,
+        "avg_duration_seconds": round(sum(durations) / len(durations), 3) if durations else None,
+        "token_usage": dict(sorted(token_usage.items())),
+    }
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _base_trace_row(ref: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "suite": ref.get("suite") or "unknown",
+        "nodeid": ref.get("nodeid"),
+        "outcome": ref.get("outcome"),
+        "pytest_duration_seconds": ref.get("duration_seconds"),
+        "trace_expected": bool(ref.get("trace_expected")),
+        "trace_id": ref.get("trace_id"),
+        "trace_url": ref.get("trace_url"),
+        "trace_provider": ref.get("trace_provider"),
+        "trace_run_id": ref.get("trace_run_id"),
+        "trace_span_id": ref.get("trace_span_id"),
+    }
+
+
+def _auth_headers(public_key: str, secret_key: str) -> dict[str, str]:
+    token = base64.b64encode(f"{public_key}:{secret_key}".encode("utf-8")).decode("ascii")
+    return {"Accept": "application/json", "Authorization": f"Basic {token}"}
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _format_iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _duration_between(start: datetime, end: datetime) -> float | None:
+    if end < start:
+        return None
+    return (end - start).total_seconds()
+
+
+def _duration_from_values(start: Any, end: Any) -> float | None:
+    parsed_start = _parse_datetime(start)
+    parsed_end = _parse_datetime(end)
+    if not parsed_start or not parsed_end:
+        return None
+    return _duration_between(parsed_start, parsed_end)
+
+
+def _observation_type(item: dict[str, Any]) -> str:
+    return str(item.get("type") or item.get("observationType") or "UNKNOWN").upper()
+
+
+def _observation_start(item: dict[str, Any]) -> Any:
+    return item.get("startTime") or item.get("start_time")
+
+
+def _observation_end(item: dict[str, Any]) -> Any:
+    return item.get("endTime") or item.get("end_time")
+
+
+def _observation_duration(item: dict[str, Any]) -> float | None:
+    for key in ["duration", "latency", "durationSeconds", "duration_seconds"]:
+        value = item.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            return float(value)
+    return _duration_from_values(_observation_start(item), _observation_end(item))
+
+
+def _is_failed_observation(item: dict[str, Any]) -> bool:
+    level = str(item.get("level") or item.get("status") or "").upper()
+    if level in {"ERROR", "FAILED"}:
+        return True
+    return bool(item.get("statusMessage") or item.get("error"))
+
+
+def _span_summary(item: dict[str, Any], duration: float | None) -> dict[str, Any]:
+    return {
+        "id": item.get("id"),
+        "name": item.get("name"),
+        "span_type": _observation_type(item),
+        "duration_seconds": duration,
+    }
+
+
+def _collect_token_usage(observations: list[dict[str, Any]]) -> dict[str, int]:
+    totals: Counter[str] = Counter()
+    for item in observations:
+        for payload_key in ["usageDetails", "usage_details", "usage", "usageMetadata"]:
+            payload = item.get(payload_key)
+            if isinstance(payload, dict):
+                _merge_numeric_usage(totals, payload)
+        for key in ["promptTokens", "completionTokens", "totalTokens", "inputTokens", "outputTokens"]:
+            value = item.get(key)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                totals[_normalize_usage_key(key)] += int(value)
+    return dict(totals)
+
+
+def _merge_numeric_usage(target: Counter[str], payload: dict[str, Any]) -> None:
+    for key, value in payload.items():
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            target[_normalize_usage_key(str(key))] += int(value)
+
+
+def _normalize_usage_key(key: str) -> str:
+    aliases = {
+        "promptTokens": "input_tokens",
+        "inputTokens": "input_tokens",
+        "completionTokens": "output_tokens",
+        "outputTokens": "output_tokens",
+        "totalTokens": "total_tokens",
+    }
+    return aliases.get(key, key)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/collect_nightly_trace_summary.py
+++ b/ci/collect_nightly_trace_summary.py
@@ -142,6 +142,7 @@ def fetch_observations(
             "fromStartTime": from_start_time,
             "toStartTime": to_start_time,
             "limit": "1000",
+            "fields": "core,basic,usage,metrics",
         }
         if cursor:
             query["cursor"] = cursor
@@ -155,7 +156,7 @@ def fetch_observations(
         meta = payload.get("meta") if isinstance(payload, dict) else None
         next_cursor = ""
         if isinstance(meta, dict):
-            next_cursor = str(meta.get("nextCursor") or meta.get("next_cursor") or "")
+            next_cursor = str(meta.get("cursor") or meta.get("nextCursor") or meta.get("next_cursor") or "")
         if not next_cursor:
             break
         cursor = next_cursor
@@ -423,14 +424,19 @@ def _span_summary(item: dict[str, Any], duration: float | None) -> dict[str, Any
 def _collect_token_usage(observations: list[dict[str, Any]]) -> dict[str, int]:
     totals: Counter[str] = Counter()
     for item in observations:
+        usage_payload: dict[str, Any] | None = None
         for payload_key in ["usageDetails", "usage_details", "usage", "usageMetadata"]:
             payload = item.get(payload_key)
             if isinstance(payload, dict):
-                _merge_numeric_usage(totals, payload)
-        for key in ["promptTokens", "completionTokens", "totalTokens", "inputTokens", "outputTokens"]:
-            value = item.get(key)
-            if isinstance(value, (int, float)) and not isinstance(value, bool):
-                totals[_normalize_usage_key(key)] += int(value)
+                usage_payload = payload
+                break
+        if usage_payload is not None:
+            _merge_numeric_usage(totals, usage_payload)
+        else:
+            for key in ["promptTokens", "completionTokens", "totalTokens", "inputTokens", "outputTokens"]:
+                value = item.get(key)
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    totals[_normalize_usage_key(key)] += int(value)
     return dict(totals)
 
 

--- a/ci/format-nightly-feishu-report.js
+++ b/ci/format-nightly-feishu-report.js
@@ -74,6 +74,19 @@ function readProviderCoverageManifest(workspace = '.') {
   }
 }
 
+function readNightlyProcessDiagnostics(workspace = '.') {
+  const diagnosticsPath = path.join(workspace, 'nightly-process-diagnostics.json');
+  if (!fs.existsSync(diagnosticsPath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(diagnosticsPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function pushUnique(items, item) {
   const value = String(item || '').trim();
   if (value && !items.includes(value)) {
@@ -275,6 +288,30 @@ function summarizeProviderCoverage(providerCoverage) {
   return `${providersTotal} providers, ${deterministicCovered} deterministic covered, ${liveDeclared} live smoke declared, ${liveCollected} live smoke collected, ${liveMissing} live smoke missing/undeclared${errorText}`;
 }
 
+function summarizeTraceDiagnostics(processDiagnostics) {
+  if (!processDiagnostics || !processDiagnostics.summary) {
+    return null;
+  }
+
+  const summary = processDiagnostics.summary;
+  const caseCount = summary.case_count || 0;
+  const traceReferenceCount = summary.trace_reference_count || 0;
+  const fetchStatusText = formatCounts(summary.trace_fetch_status_counts || {});
+  const findingText = formatCounts(summary.finding_type_counts || {});
+  const failedSpanCount = summary.failed_span_count || 0;
+  const avgDuration = summary.avg_duration_seconds;
+  const tokenUsage = summary.token_usage || {};
+  const totalTokens = tokenUsage.total || tokenUsage.total_tokens || 0;
+  const durationText = avgDuration != null ? `, avg trace duration: ${avgDuration}s` : '';
+  const tokenText = totalTokens > 0 ? `, total tokens: ${totalTokens}` : '';
+  const failedSpanText = failedSpanCount > 0 ? `, failed spans: ${failedSpanCount}` : '';
+
+  return {
+    headline: `${caseCount} expected/traced cases, ${traceReferenceCount} trace refs${fetchStatusText ? ` (${fetchStatusText})` : ''}${durationText}${tokenText}${failedSpanText}`,
+    findingText,
+  };
+}
+
 function buildNightlyFeishuMessage({
   status,
   runNumber,
@@ -288,8 +325,10 @@ function buildNightlyFeishuMessage({
   const manifest = readNightlyManifest(workspace);
   const classification = readFailureClassification(workspace);
   const providerCoverage = readProviderCoverageManifest(workspace);
+  const processDiagnostics = readNightlyProcessDiagnostics(workspace);
   const classificationSummary = summarizeClassification(classification);
   const providerCoverageSummary = summarizeProviderCoverage(providerCoverage);
+  const traceDiagnosticsSummary = summarizeTraceDiagnostics(processDiagnostics);
   const normalizedStatus = status || 'UNKNOWN';
   const isPassed = normalizedStatus === 'PASSED';
 
@@ -326,6 +365,13 @@ function buildNightlyFeishuMessage({
 
   if (providerCoverageSummary) {
     lines.push(`**Provider Coverage:** ${providerCoverageSummary}.`);
+  }
+
+  if (traceDiagnosticsSummary) {
+    lines.push(`**Trace Diagnostics:** ${traceDiagnosticsSummary.headline}.`);
+    if (traceDiagnosticsSummary.findingText) {
+      lines.push(`**Trace Findings:** ${traceDiagnosticsSummary.findingText}.`);
+    }
   }
 
   if (classificationSummary && classificationSummary.blockingFindings.length > 0) {
@@ -382,9 +428,11 @@ module.exports = {
   findLatestNightlyLog,
   readFailureClassification,
   readLatestNightlyLog,
+  readNightlyProcessDiagnostics,
   readProviderCoverageManifest,
   summarizeClassification,
   summarizeProviderCoverage,
+  summarizeTraceDiagnostics,
   stripAnsi,
   summarizeNightlyLog,
 };

--- a/ci/pytest_trace_reference_plugin.py
+++ b/ci/pytest_trace_reference_plugin.py
@@ -1,0 +1,82 @@
+"""Record nightly pytest case trace references.
+
+This plugin is intentionally inert unless ``DATUS_NIGHTLY_TRACE_REFERENCES_FILE``
+is set. It is loaded by the nightly runner so trace references can be joined
+back to pytest nodeids after the run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    item.stash[_trace_before_key] = _current_trace_metadata()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]):
+    outcome = yield
+    report = outcome.get_result()
+    if report.when != "call":
+        return
+
+    if os.environ.get("DATUS_TEST_LAYER") != "nightly":
+        return
+
+    output_file = os.environ.get("DATUS_NIGHTLY_TRACE_REFERENCES_FILE", "")
+    if not output_file:
+        return
+
+    current = _current_trace_metadata()
+    before = item.stash.get(_trace_before_key, None)
+    has_new_trace = bool(current and current != before)
+    trace_expected = _truthy(os.environ.get("DATUS_NIGHTLY_TRACE_EXPECTED", ""))
+
+    if not has_new_trace and not trace_expected:
+        return
+
+    row: dict[str, Any] = {
+        "suite": os.environ.get("DATUS_NIGHTLY_SUITE_NAME", ""),
+        "nodeid": item.nodeid,
+        "outcome": report.outcome,
+        "duration_seconds": getattr(report, "duration", None),
+        "trace_expected": trace_expected,
+        "recorded_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+    if has_new_trace and current:
+        row.update(current)
+
+    _append_jsonl(Path(output_file), row)
+
+
+_trace_before_key: pytest.StashKey[dict[str, str] | None] = pytest.StashKey()
+
+
+def _current_trace_metadata() -> dict[str, str] | None:
+    try:
+        from datus.utils.traceable_utils import get_trace_reference
+
+        ref = get_trace_reference()
+    except Exception:
+        return None
+    if ref is None:
+        return None
+    return ref.to_metadata()
+
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)

--- a/ci/pytest_trace_reference_plugin.py
+++ b/ci/pytest_trace_reference_plugin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -76,7 +77,14 @@ def _truthy(value: str) -> bool:
 
 
 def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    line = json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n"
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(line)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+    except OSError as exc:
+        warnings.warn(
+            f"Failed to write nightly trace reference to {path}: {exc}",
+            RuntimeWarning,
+            stacklevel=2,
+        )

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -18,6 +18,10 @@ NIGHTLY_FAILURE_CLASSIFICATION_FINALIZED=0
 PROVIDER_COVERAGE_MANIFEST_FILE="${PROVIDER_COVERAGE_MANIFEST_FILE:-provider-coverage-manifest.json}"
 PROVIDER_COVERAGE_MANIFEST_ENABLED="${PROVIDER_COVERAGE_MANIFEST_ENABLED:-1}"
 PROVIDER_COVERAGE_MANIFEST_FINALIZED=0
+NIGHTLY_TRACE_REFERENCES_FILE="${NIGHTLY_TRACE_REFERENCES_FILE:-nightly-trace-references.jsonl}"
+NIGHTLY_TRACE_SUMMARY_FILE="${NIGHTLY_TRACE_SUMMARY_FILE:-nightly-trace-summary.jsonl}"
+NIGHTLY_PROCESS_DIAGNOSTICS_FILE="${NIGHTLY_PROCESS_DIAGNOSTICS_FILE:-nightly-process-diagnostics.json}"
+NIGHTLY_TRACE_DIAGNOSTICS_FINALIZED=0
 test_exit_code=0
 last_command_exit_code=0
 NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
@@ -25,6 +29,7 @@ AGENT_TEST_CONFIG="${AGENT_TEST_CONFIG:-tests/conf/agent.yml}"
 DATUS_TEST_PROJECT_NAME="${DATUS_TEST_PROJECT_NAME:-datus_agent_nightly}"
 export DATUS_TEST_PROJECT_NAME
 NIGHTLY_REQUIRE_LANGFUSE_TRACING="${NIGHTLY_REQUIRE_LANGFUSE_TRACING:-0}"
+NIGHTLY_STARTED_AT="${NIGHTLY_STARTED_AT:-}"
 NIGHTLY_COMPOSE_PROJECT_PREFIX="${NIGHTLY_COMPOSE_PROJECT_PREFIX:-datus-nightly-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-}"
 
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(cd "${REPO_ROOT}/.." && pwd)}"
@@ -35,7 +40,7 @@ UNIT_TEST_HOME="${NIGHTLY_UNIT_TEST_HOME:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-
 UNIT_TEST_PROJECT_ROOT="${NIGHTLY_UNIT_TEST_PROJECT_ROOT:-${UNIT_TEST_HOME}/workspace}"
 NIGHTLY_PYTEST_BASETEMP="${NIGHTLY_PYTEST_BASETEMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-nightly-pytest-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}}"
 AGENT_TEST_CONFIG_BACKUP="${AGENT_TEST_CONFIG_BACKUP:-${TMPDIR:-/tmp}/datus-agent-nightly-config-${GITHUB_RUN_ID:-$$}.bak}"
-export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE PROVIDER_COVERAGE_MANIFEST_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP
+export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE PROVIDER_COVERAGE_MANIFEST_FILE NIGHTLY_TRACE_REFERENCES_FILE NIGHTLY_TRACE_SUMMARY_FILE NIGHTLY_PROCESS_DIAGNOSTICS_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP NIGHTLY_STARTED_AT
 
 NIGHTLY_PYTEST_ROOTS=(tests/integration tests/regression)
 
@@ -643,6 +648,63 @@ prepare_nightly_langfuse_tracing() {
   log "Langfuse tracing enabled for nightly suites: base_url=$LANGFUSE_BASE_URL"
 }
 
+nightly_trace_expected_for_group() {
+  case "$1" in
+    "Gen Agent Tests" | \
+      "Reference Template Nightly Tests" | \
+      "Web UI Nightly Tests" | \
+      "Product E2E Nightly Tests" | \
+      "Superset Nightly Tests" | \
+      "Grafana Nightly Tests" | \
+      "Airflow Nightly Tests" | \
+      "Provider Health Tests")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+collect_nightly_trace_diagnostics() {
+  if [ "$NIGHTLY_TRACE_DIAGNOSTICS_FINALIZED" = "1" ]; then
+    return 0
+  fi
+  NIGHTLY_TRACE_DIAGNOSTICS_FINALIZED=1
+
+  local ended_at
+  ended_at="$(utc_now)"
+
+  if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+    "${REPO_ROOT}/.venv/bin/python" ci/collect_nightly_trace_summary.py \
+      --trace-references-jsonl "$NIGHTLY_TRACE_REFERENCES_FILE" \
+      --output-jsonl "$NIGHTLY_TRACE_SUMMARY_FILE" \
+      --diagnostics-json "$NIGHTLY_PROCESS_DIAGNOSTICS_FILE" \
+      --from-start-time "${NIGHTLY_STARTED_AT:-}" \
+      --to-start-time "$ended_at" 2>>"$LOG_FILE"
+  elif command -v uv >/dev/null 2>&1; then
+    uv run python ci/collect_nightly_trace_summary.py \
+      --trace-references-jsonl "$NIGHTLY_TRACE_REFERENCES_FILE" \
+      --output-jsonl "$NIGHTLY_TRACE_SUMMARY_FILE" \
+      --diagnostics-json "$NIGHTLY_PROCESS_DIAGNOSTICS_FILE" \
+      --from-start-time "${NIGHTLY_STARTED_AT:-}" \
+      --to-start-time "$ended_at" 2>>"$LOG_FILE"
+  else
+    python3 ci/collect_nightly_trace_summary.py \
+      --trace-references-jsonl "$NIGHTLY_TRACE_REFERENCES_FILE" \
+      --output-jsonl "$NIGHTLY_TRACE_SUMMARY_FILE" \
+      --diagnostics-json "$NIGHTLY_PROCESS_DIAGNOSTICS_FILE" \
+      --from-start-time "${NIGHTLY_STARTED_AT:-}" \
+      --to-start-time "$ended_at" 2>>"$LOG_FILE"
+  fi
+
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "WARNING: nightly trace diagnostics collection failed; continuing because trace diagnostics are non-blocking." | tee -a "$LOG_FILE" >&2
+    return 0
+  fi
+}
+
 nightly_kb_ready_dir() {
   echo "${NIGHTLY_HOME}/data/${DATUS_TEST_PROJECT_NAME}/datus_db"
 }
@@ -713,6 +775,7 @@ cleanup_all() {
     manifest_finalize
     provider_coverage_finalize
     failure_classification_finalize
+    collect_nightly_trace_diagnostics
   fi
   restore_agent_test_config
   rm -f "$AGENT_TEST_CONFIG_BACKUP"
@@ -840,7 +903,15 @@ run_logged_unfiltered() {
   local started_at
   started_at="$(utc_now)"
   collect_pytest_suite "$group_name" "$@"
-  "$@" 2>&1 | tee -a "$LOG_FILE"
+  local trace_expected=0
+  if nightly_trace_expected_for_group "$group_name"; then
+    trace_expected=1
+  fi
+  PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:$PYTHONPATH}" \
+    DATUS_NIGHTLY_SUITE_NAME="$group_name" \
+    DATUS_NIGHTLY_TRACE_EXPECTED="$trace_expected" \
+    DATUS_NIGHTLY_TRACE_REFERENCES_FILE="$NIGHTLY_TRACE_REFERENCES_FILE" \
+    "$@" 2>&1 | tee -a "$LOG_FILE"
   local cmd_status=${PIPESTATUS[0]}
   local ended_at
   ended_at="$(utc_now)"
@@ -881,7 +952,15 @@ run_logged_warn_only_unfiltered() {
   local started_at
   started_at="$(utc_now)"
   collect_pytest_suite "$group_name" "$@"
-  "$@" 2>&1 | tee -a "$LOG_FILE"
+  local trace_expected=0
+  if nightly_trace_expected_for_group "$group_name"; then
+    trace_expected=1
+  fi
+  PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:$PYTHONPATH}" \
+    DATUS_NIGHTLY_SUITE_NAME="$group_name" \
+    DATUS_NIGHTLY_TRACE_EXPECTED="$trace_expected" \
+    DATUS_NIGHTLY_TRACE_REFERENCES_FILE="$NIGHTLY_TRACE_REFERENCES_FILE" \
+    "$@" 2>&1 | tee -a "$LOG_FILE"
   local cmd_status=${PIPESTATUS[0]}
   local ended_at
   ended_at="$(utc_now)"
@@ -1421,11 +1500,18 @@ run_compose_suite() {
   return 0
 }
 
+NIGHTLY_STARTED_AT="$(utc_now)"
+export NIGHTLY_STARTED_AT
+rm -f "$NIGHTLY_TRACE_REFERENCES_FILE" "$NIGHTLY_TRACE_SUMMARY_FILE" "$NIGHTLY_PROCESS_DIAGNOSTICS_FILE"
+
 manifest_init
 
 log "Nightly log: $LOG_FILE"
 log "Nightly manifest: $NIGHTLY_MANIFEST_FILE"
 log "Nightly failure classification: $NIGHTLY_FAILURE_CLASSIFICATION_FILE"
+log "Nightly trace references: $NIGHTLY_TRACE_REFERENCES_FILE"
+log "Nightly trace summary: $NIGHTLY_TRACE_SUMMARY_FILE"
+log "Nightly process diagnostics: $NIGHTLY_PROCESS_DIAGNOSTICS_FILE"
 log "DB_ADAPTERS_ROOT=$DB_ADAPTERS_ROOT"
 log "BI_ADAPTERS_ROOT=$BI_ADAPTERS_ROOT"
 log "SCHEDULER_ADAPTERS_ROOT=$SCHEDULER_ADAPTERS_ROOT"
@@ -1459,9 +1545,9 @@ validate_nightly_group_filter || exit 1
 validate_pytest_basetemp "$NIGHTLY_PYTEST_BASETEMP" || exit 1
 rm -rf "$NIGHTLY_PYTEST_BASETEMP"
 if [ -n "${PYTEST_ADDOPTS:-}" ]; then
-  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --basetemp=$NIGHTLY_PYTEST_BASETEMP"
+  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --basetemp=$NIGHTLY_PYTEST_BASETEMP -p ci.pytest_trace_reference_plugin"
 else
-  export PYTEST_ADDOPTS="--basetemp=$NIGHTLY_PYTEST_BASETEMP"
+  export PYTEST_ADDOPTS="--basetemp=$NIGHTLY_PYTEST_BASETEMP -p ci.pytest_trace_reference_plugin"
 fi
 require_docker_runtime || exit "$test_exit_code"
 
@@ -1531,12 +1617,16 @@ run_logged_unfiltered "Flaky Log Classification" uv run python ci/check_flaky_re
 manifest_finalize
 provider_coverage_finalize
 failure_classification_finalize
+collect_nightly_trace_diagnostics
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "log_file=$LOG_FILE" >> "$GITHUB_OUTPUT"
   echo "manifest_file=$NIGHTLY_MANIFEST_FILE" >> "$GITHUB_OUTPUT"
   echo "failure_classification_file=$NIGHTLY_FAILURE_CLASSIFICATION_FILE" >> "$GITHUB_OUTPUT"
   echo "provider_coverage_manifest_file=$PROVIDER_COVERAGE_MANIFEST_FILE" >> "$GITHUB_OUTPUT"
+  echo "nightly_trace_references_file=$NIGHTLY_TRACE_REFERENCES_FILE" >> "$GITHUB_OUTPUT"
+  echo "nightly_trace_summary_file=$NIGHTLY_TRACE_SUMMARY_FILE" >> "$GITHUB_OUTPUT"
+  echo "nightly_process_diagnostics_file=$NIGHTLY_PROCESS_DIAGNOSTICS_FILE" >> "$GITHUB_OUTPUT"
   echo "test_exit_code=$test_exit_code" >> "$GITHUB_OUTPUT"
 fi
 

--- a/tests/unit_tests/ci/test_collect_nightly_trace_summary.py
+++ b/tests/unit_tests/ci/test_collect_nightly_trace_summary.py
@@ -1,6 +1,13 @@
 import json
+import urllib.parse
 
-from ci.collect_nightly_trace_summary import build_process_diagnostics, dedupe_trace_refs, summarize_observations
+from ci.collect_nightly_trace_summary import (
+    _collect_token_usage,
+    build_process_diagnostics,
+    dedupe_trace_refs,
+    fetch_observations,
+    summarize_observations,
+)
 
 
 def test_summarize_observations_reports_counts_tokens_and_findings():
@@ -94,3 +101,67 @@ def test_dedupe_trace_refs_keeps_latest_row_for_same_case():
         {"suite": "S", "nodeid": "n", "outcome": "passed"},
         {"suite": "S", "nodeid": "n", "trace_id": "t", "outcome": "passed"},
     ]
+
+
+def test_fetch_observations_uses_v2_cursor_from_meta(monkeypatch):
+    requested_cursors: list[str] = []
+    requested_fields: list[str] = []
+
+    class FakeResponse:
+        def __init__(self, payload: dict):
+            self.payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(self.payload).encode("utf-8")
+
+    responses = [
+        {"data": [{"id": "first"}], "meta": {"cursor": "cursor-2"}},
+        {"data": [{"id": "second"}], "meta": {}},
+    ]
+
+    def fake_urlopen(request, timeout):
+        parsed = urllib.parse.urlparse(request.full_url)
+        query = urllib.parse.parse_qs(parsed.query)
+        requested_cursors.append(query.get("cursor", [""])[0])
+        requested_fields.append(query.get("fields", [""])[0])
+        return FakeResponse(responses.pop(0))
+
+    monkeypatch.setattr("ci.collect_nightly_trace_summary.urllib.request.urlopen", fake_urlopen)
+
+    observations = fetch_observations(
+        trace_id="trace-1",
+        base_url="https://langfuse.test",
+        public_key="pk",
+        secret_key="sk",
+        from_start_time="2026-05-28T00:00:00Z",
+        to_start_time="2026-05-28T01:00:00Z",
+        timeout=1.0,
+        max_pages=3,
+    )
+
+    assert [item["id"] for item in observations] == ["first", "second"]
+    assert requested_cursors == ["", "cursor-2"]
+    assert requested_fields == ["core,basic,usage,metrics", "core,basic,usage,metrics"]
+
+
+def test_collect_token_usage_prefers_one_usage_payload_over_top_level_fields():
+    usage = _collect_token_usage(
+        [
+            {
+                "usageDetails": {"input": 10, "output": 5, "total": 15},
+                "usage": {"input": 99, "output": 99, "total": 198},
+                "promptTokens": 10,
+                "completionTokens": 5,
+                "totalTokens": 15,
+            },
+            {"promptTokens": 3, "completionTokens": 2, "totalTokens": 5},
+        ]
+    )
+
+    assert usage == {"input": 10, "output": 5, "total": 15, "input_tokens": 3, "output_tokens": 2, "total_tokens": 5}

--- a/tests/unit_tests/ci/test_collect_nightly_trace_summary.py
+++ b/tests/unit_tests/ci/test_collect_nightly_trace_summary.py
@@ -1,0 +1,96 @@
+import json
+
+from ci.collect_nightly_trace_summary import build_process_diagnostics, dedupe_trace_refs, summarize_observations
+
+
+def test_summarize_observations_reports_counts_tokens_and_findings():
+    observations = [
+        {
+            "id": "agent-1",
+            "type": "AGENT",
+            "name": "Agent workflow",
+            "startTime": "2026-05-28T00:00:00Z",
+            "endTime": "2026-05-28T00:00:10Z",
+        },
+        {
+            "id": "gen-1",
+            "type": "GENERATION",
+            "name": "generation",
+            "startTime": "2026-05-28T00:00:01Z",
+            "endTime": "2026-05-28T00:00:40Z",
+            "usageDetails": {"input": 12, "output": 8, "total": 20},
+        },
+        {
+            "id": "tool-1",
+            "type": "TOOL",
+            "name": "read_query",
+            "level": "ERROR",
+            "statusMessage": "query failed",
+            "startTime": "2026-05-28T00:00:03Z",
+            "endTime": "2026-05-28T00:00:04Z",
+        },
+    ]
+
+    summary = summarize_observations(observations, slow_span_threshold_seconds=30.0)
+
+    assert summary["observation_count"] == 3
+    assert summary["agent_span_count"] == 1
+    assert summary["generation_span_count"] == 1
+    assert summary["tool_span_count"] == 1
+    assert summary["failed_span_count"] == 1
+    assert summary["token_usage"] == {"input": 12, "output": 8, "total": 20}
+    assert summary["finding_type_counts"] == {"failed_span": 1, "slow_span": 1}
+
+
+def test_build_process_diagnostics_groups_by_suite():
+    diagnostics = build_process_diagnostics(
+        [
+            {
+                "suite": "Gen Agent Tests",
+                "nodeid": "tests/test_agent.py::test_a",
+                "trace_id": "trace-a",
+                "trace_fetch_status": "fetched",
+                "observation_count": 3,
+                "tool_span_count": 1,
+                "generation_span_count": 1,
+                "agent_span_count": 1,
+                "failed_span_count": 0,
+                "duration_seconds": 10.0,
+                "finding_type_counts": {"slow_span": 1},
+                "token_usage": {"total": 100},
+            },
+            {
+                "suite": "Gen Agent Tests",
+                "nodeid": "tests/test_agent.py::test_b",
+                "trace_fetch_status": "missing_trace_reference",
+                "observation_count": 0,
+                "finding_type_counts": {},
+                "token_usage": {},
+            },
+        ]
+    )
+
+    assert diagnostics["summary"]["case_count"] == 2
+    assert diagnostics["summary"]["trace_reference_count"] == 1
+    assert diagnostics["summary"]["trace_fetch_status_counts"] == {
+        "fetched": 1,
+        "missing_trace_reference": 1,
+    }
+    assert diagnostics["summary"]["finding_type_counts"] == {"slow_span": 1}
+    assert diagnostics["summary"]["token_usage"] == {"total": 100}
+    assert diagnostics["suites"][0]["suite"] == "Gen Agent Tests"
+
+
+def test_dedupe_trace_refs_keeps_latest_row_for_same_case():
+    rows = [
+        {"suite": "S", "nodeid": "n", "trace_id": "t", "outcome": "failed"},
+        {"suite": "S", "nodeid": "n", "trace_id": "t", "outcome": "passed"},
+        {"suite": "S", "nodeid": "n", "outcome": "passed"},
+    ]
+
+    deduped = dedupe_trace_refs(json.loads(json.dumps(rows)))
+
+    assert deduped == [
+        {"suite": "S", "nodeid": "n", "outcome": "passed"},
+        {"suite": "S", "nodeid": "n", "trace_id": "t", "outcome": "passed"},
+    ]

--- a/tests/unit_tests/ci/test_format_nightly_feishu_report.py
+++ b/tests/unit_tests/ci/test_format_nightly_feishu_report.py
@@ -123,3 +123,43 @@ console.log(message);
     assert "### Diagnostic Signals" in message
     assert "all findings" not in message
     assert "### Failure Classification" not in message
+
+
+def test_nightly_feishu_report_includes_trace_diagnostics(tmp_path):
+    (tmp_path / "nightly-process-diagnostics.json").write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "case_count": 3,
+                    "trace_reference_count": 2,
+                    "trace_fetch_status_counts": {"fetched": 2, "missing_trace_reference": 1},
+                    "finding_type_counts": {"failed_span": 1, "slow_span": 2},
+                    "failed_span_count": 1,
+                    "avg_duration_seconds": 12.5,
+                    "token_usage": {"total": 100},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    script = f"""
+const {{ buildNightlyFeishuMessage }} = require({json.dumps(str(REPO_ROOT / "ci/format-nightly-feishu-report.js"))});
+const message = buildNightlyFeishuMessage({{
+  status: 'PASSED',
+  runNumber: '76',
+  runUrl: 'https://example.test/run/76',
+  date: '2026-05-18',
+  workspace: {json.dumps(str(tmp_path))},
+  logContent: '',
+}});
+console.log(message);
+"""
+    result = subprocess.run([_find_node_executable(), "-e", script], check=True, capture_output=True, text=True)
+    message = result.stdout
+
+    assert (
+        "**Trace Diagnostics:** 3 expected/traced cases, 2 trace refs (fetched: 2, missing_trace_reference: 1), avg trace duration: 12.5s, total tokens: 100, failed spans: 1."
+        in message
+    )
+    assert "**Trace Findings:** failed_span: 1, slow_span: 2." in message

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from ci.pytest_trace_reference_plugin import _append_jsonl
 from tests.unit_tests import conftest as unit_conftest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -133,3 +134,17 @@ def test_unit_conftest_pytest_configure_strips_and_restores_langfuse_env_for_uni
         assert observed_env == expected_env
     finally:
         _restore_unit_conftest_langfuse_state(original_saved_env, original_stripped)
+
+
+def test_trace_reference_jsonl_write_is_warn_only(monkeypatch, tmp_path):
+    output = tmp_path / "missing-parent" / "trace.jsonl"
+
+    def fail_mkdir(*args, **kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(Path, "mkdir", fail_mkdir)
+
+    with pytest.warns(RuntimeWarning, match="Failed to write nightly trace reference"):
+        _append_jsonl(output, {"trace_id": "trace-1"})
+
+    assert not output.exists()


### PR DESCRIPTION
Summary
- Record nightly pytest nodeids with Datus trace references via a pytest plugin.
- Collect Langfuse observation summaries into nightly-trace-summary.jsonl and nightly-process-diagnostics.json as non-blocking diagnostics.
- Upload trace diagnostics artifacts and include a compact trace diagnostics section in Feishu nightly reports.

Validation
- bash -n ci/run-nightly-tests.sh
- node --check ci/format-nightly-feishu-report.js
- python3 -m py_compile ci/collect_nightly_trace_summary.py ci/pytest_trace_reference_plugin.py
- uv run ruff check ci/collect_nightly_trace_summary.py ci/pytest_trace_reference_plugin.py tests/unit_tests/ci/test_collect_nightly_trace_summary.py tests/unit_tests/ci/test_format_nightly_feishu_report.py
- uv run ruff format --check ci/collect_nightly_trace_summary.py ci/pytest_trace_reference_plugin.py tests/unit_tests/ci/test_collect_nightly_trace_summary.py tests/unit_tests/ci/test_format_nightly_feishu_report.py
- uv run pytest tests/unit_tests/ci/test_nightly_tracing_boundaries.py tests/unit_tests/ci/test_collect_nightly_trace_summary.py tests/unit_tests/ci/test_format_nightly_feishu_report.py -q
- Manual plugin smoke: pytest writes nodeid + fake trace reference to nightly-trace-references.jsonl

Notes
- Trace diagnostics are warn-only and do not affect nightly pass/fail.
- The collector returns successful status when Langfuse credentials or trace data are unavailable.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
## Summary by CodeRabbit

* **Chores**
  * Added trace diagnostics collection to nightly test runs
  * Enhanced nightly test reports to include trace findings and diagnostic summaries
  * Improved diagnostic artifact generation for better test visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Nightly test runs now collect and export additional trace and diagnostics artifacts.
  * Diagnostics collection is non-blocking and summarized at job end.

* **New Features**
  * Nightly report messages now include a "Trace Diagnostics" section with optional "Trace Findings".

* **Tests**
  * Added unit tests covering diagnostics summarization, trace reference handling, and reporting integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->