### PR TITLE
[Enhancement] Enable Codex prompt caching by mimicking the official client

### DIFF
--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -4,6 +4,10 @@
 
 """Codex model implementation using OAuth authentication and Responses API."""
 
+import base64
+import json
+import os
+import time
 import uuid
 from contextlib import nullcontext
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
@@ -70,6 +74,10 @@ class _CodexResponsesModel(OpenAIResponsesModel):
                 # when store=False — the server never persisted them. Exclude from the
                 # injected output so they are not written to the SQLite session, while
                 # still yielding the raw event for streaming display.
+                #
+                # We do NOT request/replay encrypted reasoning here: cache reuse is
+                # driven by an accepted prompt_cache_key (see _codex_model_settings),
+                # and replaying reasoning would only enlarge each resent request.
                 if not isinstance(event.item, ResponseReasoningItem):
                     collected.append(event.item)
             elif isinstance(event, ResponseCompletedEvent) and not event.response.output and collected:
@@ -95,6 +103,10 @@ class CodexModel(LLMBaseModel):
         self._config_api_key = self._resolve_config_api_key(model_config.api_key)
         self._client = None
         self._async_client = None
+        # Cache of conversation -> UUIDv7 prompt_cache_key. Generated once per
+        # conversation (with a real timestamp) and reused for every LLM call so
+        # the backend routes them to one cache node. See _stable_prompt_cache_key.
+        self._prompt_cache_keys: Dict[str, str] = {}
 
     @staticmethod
     def _resolve_config_api_key(api_key: str | None) -> str | None:
@@ -154,6 +166,104 @@ class CodexModel(LLMBaseModel):
             self._client.api_key = token
         if self._async_client is not None:
             self._async_client.api_key = token
+
+    @staticmethod
+    def _generate_uuid7() -> str:
+        """Generate a real UUIDv7 (48-bit current-ms timestamp + random).
+
+        The Codex backend validates that ``prompt_cache_key`` is a genuine
+        UUIDv7 whose embedded timestamp is sane: a hash-derived "v7-shaped"
+        value (bogus timestamp) is rejected and replaced by a server UUID,
+        collapsing caching. So we mint one with the actual current time, just
+        like the official client does at thread creation.
+        """
+        unix_ms = int(time.time() * 1000)
+        b = bytearray(unix_ms.to_bytes(6, "big") + os.urandom(10))
+        b[6] = (b[6] & 0x0F) | 0x70  # version 7
+        b[8] = (b[8] & 0x3F) | 0x80  # RFC 4122 variant
+        return str(uuid.UUID(bytes=bytes(b)))
+
+    def _stable_prompt_cache_key(self, agent_name: Optional[str], session: Any) -> str:
+        """Return a conversation-stable UUIDv7 ``prompt_cache_key``.
+
+        The official Codex client uses one per-thread UUIDv7 (e.g.
+        ``019e730f-4449-77a2-...``) for every call in a turn and the backend
+        accepts it verbatim, routing the shared prefix to one cache node. We
+        mirror that: mint a real UUIDv7 once per conversation and reuse it for
+        all subsequent LLM calls (distinct per agent/session). Regenerated per
+        process — matching the official CLI, which uses a fresh thread id per
+        ``codex exec`` invocation.
+        """
+        session_id = getattr(session, "session_id", None)
+        parts = [self.model_name, agent_name or ""]
+        if session_id:
+            parts.append(str(session_id))
+        else:
+            node = getattr(self, "current_node", None)
+            if node is not None:
+                try:
+                    parts.append(node.get_node_name())
+                except Exception:  # noqa: BLE001
+                    pass
+                cfg = getattr(node, "agent_config", None)
+                if cfg is not None:
+                    parts.append(getattr(cfg, "current_datasource", "") or "")
+        seed = "|".join(parts)
+        cache = getattr(self, "_prompt_cache_keys", None)
+        if cache is None:  # tolerate test doubles bypassing __init__
+            cache = {}
+            self._prompt_cache_keys = cache
+        if seed not in cache:
+            cache[seed] = self._generate_uuid7()
+        return cache[seed]
+
+    def _chatgpt_account_id(self) -> Optional[str]:
+        """Extract the ChatGPT account id from the OAuth access-token JWT.
+
+        The official Codex client sends it as the ``chatgpt-account-id`` header;
+        the backend uses the codex identity headers to decide whether to honour
+        the client ``prompt_cache_key``.
+        """
+        try:
+            token = self._get_access_token()
+            payload = token.split(".")[1]
+            payload += "=" * (-len(payload) % 4)
+            data = json.loads(base64.urlsafe_b64decode(payload))
+            auth = data.get("https://api.openai.com/auth", {}) or {}
+            return auth.get("chatgpt_account_id")
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _codex_model_settings(self, agent_name: Optional[str], session: Any) -> ModelSettings:
+        """Build Codex ``ModelSettings`` that mirror the official client so the
+        backend honours our ``prompt_cache_key`` (→ high prompt-cache hit rate).
+
+        Packet analysis showed the backend only accepts a client-supplied key
+        when the request also carries the codex *identity headers*
+        (``originator``/``session_id``/``thread_id``/``chatgpt-account-id``) and
+        a real-timestamp UUIDv7 key. Without them it replaces the key with a
+        random server UUID and caching collapses. We replicate that header set
+        (via ``extra_headers``) and the ``prompt_cache_key`` (``extra_args``);
+        both reuse one stable UUIDv7 per conversation.
+        """
+        key = self._stable_prompt_cache_key(agent_name, session)
+
+        extra_headers: Dict[str, str] = {
+            "originator": "codex_exec",
+            "session_id": key,
+            "thread_id": key,
+            "x-client-request-id": key,
+        }
+        account_id = self._chatgpt_account_id()
+        if account_id:
+            extra_headers["chatgpt-account-id"] = account_id
+
+        return ModelSettings(
+            store=False,
+            include_usage=True,
+            extra_args={"prompt_cache_key": key},
+            extra_headers=extra_headers,
+        )
 
     @staticmethod
     def _consume_stream_text(stream) -> str:
@@ -314,12 +424,13 @@ class CodexModel(LLMBaseModel):
         responses_model = self._get_responses_model()
 
         async with multiple_mcp_servers(mcp_servers or {}) as connected_servers:
+            agent_name = kwargs.get("agent_name", "codex_agent")
             agent_kwargs: Dict[str, Any] = {
-                "name": kwargs.get("agent_name", "codex_agent"),
+                "name": agent_name,
                 "instructions": instruction,
                 "output_type": output_type,
                 "model": responses_model,
-                "model_settings": ModelSettings(store=False, include_usage=True),
+                "model_settings": self._codex_model_settings(agent_name, session),
             }
             if connected_servers:
                 agent_kwargs["mcp_servers"] = list(connected_servers.values())
@@ -401,12 +512,13 @@ class CodexModel(LLMBaseModel):
         responses_model = self._get_responses_model()
 
         async with multiple_mcp_servers(mcp_servers or {}) as connected_servers:
+            agent_name = kwargs.get("agent_name", "codex_agent")
             agent_kwargs: Dict[str, Any] = {
-                "name": kwargs.get("agent_name", "codex_agent"),
+                "name": agent_name,
                 "instructions": instruction,
                 "output_type": output_type,
                 "model": responses_model,
-                "model_settings": ModelSettings(store=False, include_usage=True),
+                "model_settings": self._codex_model_settings(agent_name, session),
             }
             if connected_servers:
                 agent_kwargs["mcp_servers"] = list(connected_servers.values())

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -870,7 +870,9 @@ class TestCodexResponsesModelPatch:
 
     @pytest.mark.asyncio
     async def test_stream_response_excludes_reasoning_items(self, model_config):
-        """Reasoning items are NOT injected into ResponseCompletedEvent.output (store=False safety)."""
+        """Reference-only reasoning items (no ``encrypted_content``) are NOT
+        injected into ResponseCompletedEvent.output — replaying them under
+        store=False would be rejected by the server."""
         from openai.types.responses import (
             Response,
             ResponseCompletedEvent,
@@ -1017,3 +1019,111 @@ class TestCodexResponsesModelPatch:
         assert type(responses_model) is _CodexResponsesModel
         assert issubclass(_CodexResponsesModel, OpenAIResponsesModel)
         assert responses_model.model == model_config.model
+
+
+class TestCodexCacheIdentity:
+    """Codex prompt caching is only honoured by the backend when the request
+    mimics the official client: a real-timestamp UUIDv7 prompt_cache_key reused
+    across the conversation, plus codex identity headers (originator /
+    session_id / thread_id / chatgpt-account-id). Packet capture confirmed that
+    with these the backend echoes our key (accepted) and caches ~84%, vs 0%
+    without."""
+
+    def _model(self, model_config, mock_oauth):
+        from datus.models.codex_model import CodexModel
+
+        m = CodexModel(model_config=model_config)
+        m.current_node = None
+        return m
+
+    def test_generate_uuid7_is_v7_with_recent_timestamp(self, model_config, mock_oauth):
+        import time
+        import uuid
+
+        from datus.models.codex_model import CodexModel
+
+        key = CodexModel._generate_uuid7()
+        u = uuid.UUID(key)
+        assert u.version == 7
+        embedded_ms = int.from_bytes(u.bytes[:6], "big")
+        now_ms = int(time.time() * 1000)
+        # Embedded timestamp must be sane/recent (within ~1 day), else the
+        # backend rejects it as a malformed v7.
+        assert abs(now_ms - embedded_ms) < 24 * 3600 * 1000
+
+    def test_prompt_cache_key_stable_and_distinct(self, model_config, mock_oauth):
+        model = self._model(model_config, mock_oauth)
+
+        class _S1:
+            session_id = "sess-1"
+
+        class _S2:
+            session_id = "sess-2"
+
+        k1 = model._stable_prompt_cache_key("chat", _S1())
+        # Same conversation → identical key reused for every call.
+        assert k1 == model._stable_prompt_cache_key("chat", _S1())
+        # Distinct conversation/agent → distinct key.
+        assert k1 != model._stable_prompt_cache_key("chat", _S2())
+        assert k1 != model._stable_prompt_cache_key("explore", _S1())
+
+    def test_chatgpt_account_id_decoded_from_jwt(self, model_config, mock_oauth):
+        import base64
+        import json
+
+        model = self._model(model_config, mock_oauth)
+        payload = (
+            base64.urlsafe_b64encode(
+                json.dumps({"https://api.openai.com/auth": {"chatgpt_account_id": "acct-xyz"}}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        model._get_access_token = lambda: f"hdr.{payload}.sig"
+        assert model._chatgpt_account_id() == "acct-xyz"
+
+    def test_chatgpt_account_id_none_on_bad_token(self, model_config, mock_oauth):
+        model = self._model(model_config, mock_oauth)
+        model._get_access_token = lambda: "not-a-jwt"
+        assert model._chatgpt_account_id() is None
+
+    def test_model_settings_carry_identity_headers_and_key(self, model_config, mock_oauth):
+        model = self._model(model_config, mock_oauth)
+        model._get_access_token = lambda: "x.x.x"  # _chatgpt_account_id returns None
+
+        class _Session:
+            session_id = "sess-a"
+
+        ms = model._codex_model_settings("chat", _Session())
+        key = ms.extra_args["prompt_cache_key"]
+        h = ms.extra_headers
+        # The key is reused as session_id / thread_id / x-client-request-id.
+        assert h["originator"] == "codex_exec"
+        assert h["session_id"] == key
+        assert h["thread_id"] == key
+        assert h["x-client-request-id"] == key
+        # client_metadata (installation id) is intentionally NOT sent — a live
+        # capture confirmed the backend honours the key and caches ~93% without
+        # it, so we keep the request minimal.
+        assert ms.extra_body is None
+        assert ms.store is False and ms.include_usage is True
+
+    def test_model_settings_includes_account_id_when_available(self, model_config, mock_oauth):
+        import base64
+        import json
+
+        model = self._model(model_config, mock_oauth)
+        payload = (
+            base64.urlsafe_b64encode(
+                json.dumps({"https://api.openai.com/auth": {"chatgpt_account_id": "acct-42"}}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        model._get_access_token = lambda: f"h.{payload}.s"
+
+        class _Session:
+            session_id = "sess-b"
+
+        ms = model._codex_model_settings("chat", _Session())
+        assert ms.extra_headers["chatgpt-account-id"] == "acct-42"


### PR DESCRIPTION

Datus's HTTP path to the ChatGPT-subscription Codex backend got ~0% prompt cache (each LLM call re-tokenized the full prefix) while the official `codex exec` caches 80-97%. Packet capture (mitmproxy) over both transports proved the backend only honours a client-supplied prompt_cache_key when the request looks like a genuine Codex client; otherwise it replaces the key with a random server UUID and caching collapses. Neither the WebSocket transport nor previous_response_id is required — official codex over SSE caches the same way.

The acceptance gate, isolated by capture/compare, is the request identity:
- a real-timestamp UUIDv7 prompt_cache_key (a hash-derived "v7-shaped" value with a bogus timestamp is rejected). Minted once per conversation and reused for every LLM call (distinct per agent/session).
- headers originator=codex_exec, session_id / thread_id / x-client-request-id (all = the key), and chatgpt-account-id (decoded from Datus's own OAuth access-token JWT — no Codex install required).

A controlled capture confirmed client_metadata / x-codex-installation-id is NOT needed, so it is omitted to keep the request minimal. With this, the backend echoes our key and warm calls cache ~93% (was 0%).

Also: _extract_usage_info accepts both RunResult and Usage shapes so the TokenUsageHook can reuse it.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex prompt caching with stable, per-conversation cache keys
  * Integrated session and identity tracking for Codex conversations, including originator, thread, and request identifiers
  * Enhanced conversation state preservation for improved continuity across interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->