### PR TITLE
[BugFix] minor compact don't archive tool call arguments

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1399,9 +1399,10 @@ class AgenticNode(Node):
 
         Walks ``items[lo:cutoff)`` (everything older than the most recent
         ``keep_recent_user_turns`` user turns) and replaces any
-        ``function_call.arguments`` / ``function_call_output.output`` that
-        exceeds ``archive_threshold`` with a single-line text marker pointing
-        to a disk-backed archive file. The kept window
+        ``function_call_output.output`` that exceeds ``archive_threshold`` with
+        a single-line text marker pointing to a disk-backed archive file.
+        ``function_call.arguments`` is left untouched so the tool-call payload
+        stays valid for the LLM service. The kept window
         (``items[cutoff:]``) and the already-compacted prefix
         (``items[:lo]``) are untouched, preserving cache for stable sections
         of the prompt.
@@ -2335,12 +2336,24 @@ class AgenticNode(Node):
           model's internal monologue never lands in the final response) and
           ``ctx.last_tool_summary`` from successful tool actions.
         """
+        # ``max_turns`` precedence: a per-call value on the input wins, but only
+        # when the caller set it explicitly (tracked via Pydantic
+        # ``model_fields_set``); otherwise fall back to the node's configured
+        # limit (agent.yml ``agentic_nodes.<name>.max_turns``). The input field's
+        # own default must never shadow the node config -- otherwise a config
+        # value can never take effect.
+        explicit_turns = (
+            getattr(ctx.user_input, "max_turns", None)
+            if "max_turns" in getattr(ctx.user_input, "model_fields_set", ())
+            else None
+        )
+        effective_max_turns = explicit_turns if explicit_turns is not None else self.max_turns
         async for stream_action in self.model.generate_with_tools_stream(
             prompt=ctx.user_prompt,
             tools=self.tools or [],
             mcp_servers=self.mcp_servers,
             instruction=ctx.system_instruction,
-            max_turns=getattr(ctx.user_input, "max_turns", None) or self.max_turns,
+            max_turns=effective_max_turns,
             session=ctx.session,
             action_history_manager=ctx.action_history_manager,
             hooks=self._compose_run_hooks(ctx),

--- a/datus/agent/node/compact_archive.py
+++ b/datus/agent/node/compact_archive.py
@@ -2,15 +2,20 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Disk-backed archive for compact tool I/O.
+"""Disk-backed archive for compact tool output.
 
 When the rule-based minor compact pass scans the eligible region (everything
 older than ``keep_recent_user_turns`` user-message turns), any
-``function_call.arguments`` or ``function_call_output.output`` text whose
-length crosses ``archive_threshold`` is written verbatim to a file under
-``path_manager.session_data_dir(session_id)`` and replaced in-session with a
-single-line plain-text marker. The marker carries the absolute file path and
-a short preview so the LLM can ``read_file(<path>)`` to recover the original.
+``function_call_output.output`` text whose length crosses ``archive_threshold``
+is written verbatim to a file under ``path_manager.session_data_dir(session_id)``
+and replaced in-session with a single-line plain-text marker. The marker carries
+the absolute file path and a short preview so the LLM can ``read_file(<path>)``
+to recover the original.
+
+``function_call.arguments`` is intentionally left untouched: it must stay a
+well-formed tool-call payload, and substituting a marker string for it can
+make the LLM service reject the turn or imitate the marker shape in later
+tool calls. Only outputs are archived.
 
 Two design properties matter:
 
@@ -36,31 +41,13 @@ from datus.utils.path_manager import DatusPathManager, get_path_manager
 
 logger = logging.getLogger(__name__)
 
-#: Fixed prefix written into ``function_call.arguments`` (after JSON-string
-#: encoding) and ``function_call_output.output`` whenever an item has been
-#: offloaded to disk. The choice of bracketed all-caps keeps the marker
-#: visually distinct from real tool output and unlikely to collide with any
-#: legitimate JSON payload.
+#: Fixed prefix written into ``function_call_output.output`` whenever an item
+#: has been offloaded to disk. The choice of bracketed all-caps keeps the
+#: marker visually distinct from real tool output and unlikely to collide with
+#: any legitimate JSON payload.
 ARCHIVED_MARKER = "[DATUS_ARCHIVED]"
 
 _ERROR_FALLBACK_MARKERS = ('"success": 0', "'success': 0", '"error":', "'error':", "Traceback")
-
-
-def is_archived_args(arguments_str: Any) -> bool:
-    """Detect whether ``function_call.arguments`` is already an archive marker.
-
-    The field is stored as a JSON-encoded string on the wire. After
-    ``json.loads`` the underlying value must be a ``str`` starting with
-    :data:`ARCHIVED_MARKER` — anything else (an object, a number, malformed
-    JSON) is treated as live arguments worth archiving.
-    """
-    if not isinstance(arguments_str, str):
-        return False
-    try:
-        decoded = json.loads(arguments_str)
-    except (TypeError, ValueError):
-        return False
-    return isinstance(decoded, str) and decoded.startswith(ARCHIVED_MARKER)
 
 
 def is_archived_output(output_str: Any) -> bool:
@@ -154,8 +141,7 @@ class ToolArchive:
         Returns:
             A single-line string of the form
             ``"[DATUS_ARCHIVED] path=<abs> preview=<text>"``. Callers store
-            this verbatim in ``output`` and JSON-string-encode it before
-            assigning to ``arguments``.
+            this verbatim in ``function_call_output.output``.
         """
         if kind not in ("args", "output"):
             raise DatusException(
@@ -222,30 +208,21 @@ def maybe_truncate_item(
 ) -> Dict[str, Any]:
     """Apply the archive rule to a single session item.
 
-    Returns the input ``item`` unchanged when nothing was archived (already a
-    marker, below threshold, or wrong type) so callers can identity-compare to
-    detect modifications. Otherwise returns a new dict with the targeted text
-    field replaced by the marker.
+    Only ``function_call_output.output`` is eligible. ``function_call.arguments``
+    is deliberately never archived — it must stay a valid tool-call payload (see
+    the module docstring) — so ``function_call`` items always pass through.
 
-    Idempotency: items whose text field already begins with
-    :data:`ARCHIVED_MARKER` (after JSON-decoding for ``arguments``) are
-    skipped — re-running the pass over a partially-archived prefix produces
+    Returns the input ``item`` unchanged when nothing was archived (already a
+    marker, below threshold, or not an eligible type) so callers can
+    identity-compare to detect modifications. Otherwise returns a new dict with
+    ``output`` replaced by the marker.
+
+    Idempotency: outputs whose text already begins with :data:`ARCHIVED_MARKER`
+    are skipped — re-running the pass over a partially-archived prefix produces
     no extra writes and no double-encoded markers.
     """
     item_type = item.get("type")
-    if item_type == "function_call":
-        args_text = item.get("arguments", "")
-        if not isinstance(args_text, str) or len(args_text) < threshold:
-            return item
-        if is_archived_args(args_text):
-            return item
-        try:
-            marker = archive.archive(args_text, idx, "args")
-        except OSError as exc:
-            logger.warning("compact archive write failed (idx=%s, kind=args): %s", idx, exc)
-            return _inline_truncated(item, "arguments", args_text, archive.preview_chars)
-        return {**item, "arguments": json.dumps(marker)}
-    elif item_type == "function_call_output":
+    if item_type == "function_call_output":
         out_text = item.get("output", "")
         if not isinstance(out_text, str) or len(out_text) < threshold:
             return item
@@ -260,22 +237,20 @@ def maybe_truncate_item(
                 if archive._is_error(out_text)
                 else archive.preview_chars
             )
-            return _inline_truncated(item, "output", out_text, preview_n)
+            return _inline_truncated(item, out_text, preview_n)
         return {**item, "output": marker}
     return item
 
 
-def _inline_truncated(item: Dict[str, Any], field: str, text: str, preview_n: int) -> Dict[str, Any]:
+def _inline_truncated(item: Dict[str, Any], text: str, preview_n: int) -> Dict[str, Any]:
     """Degrade gracefully when the disk archive write fails.
 
-    Drops back to an inline preview-only placeholder so the rest of the
-    compact pass can still proceed. Information is lost on this branch, but
-    only when the disk itself is broken — the alternative (raising) would
+    Drops back to an inline preview-only placeholder in ``output`` so the rest
+    of the compact pass can still proceed. Information is lost on this branch,
+    but only when the disk itself is broken — the alternative (raising) would
     crash a session over a transient ENOSPC. The placeholder still carries
     :data:`ARCHIVED_MARKER` so a later pass treats it as already-handled.
     """
     preview = text[:preview_n].replace("\n", " ").replace("\r", " ").strip()
     marker = f"{ARCHIVED_MARKER} path=<unavailable: archive write failed> preview={preview}"
-    if field == "arguments":
-        return {**item, field: json.dumps(marker)}
-    return {**item, field: marker}
+    return {**item, "output": marker}

--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -44,15 +44,6 @@ def _extract_function(action: ActionHistory) -> tuple[str, dict]:
         except json.JSONDecodeError:
             arguments = {}
 
-    # Minor-compact archives a long arguments payload by storing the marker
-    # string in place of the original JSON object. Surface the inline preview
-    # so callers (e.g. ``/chat/history``) render a placeholder instead of
-    # dropping the params to ``{}`` and losing all signal.
-    if isinstance(arguments, str):
-        marker = parse_archived_marker(arguments)
-        if marker is not None:
-            return function_name, {"archived": True, "preview": marker["preview"]}
-
     if not isinstance(arguments, dict):
         arguments = {}
 

--- a/datus/schemas/chat_agentic_node_models.py
+++ b/datus/schemas/chat_agentic_node_models.py
@@ -26,7 +26,15 @@ class ChatNodeInput(BaseInput):
     catalog: Optional[str] = Field(default=None, description="Database catalog for context")
     database: Optional[str] = Field(default=None, description="Database name for context")
     db_schema: Optional[str] = Field(default=None, description="Database schema for context")
-    max_turns: int = Field(default=30, description="Maximum conversation turns per interaction")
+    max_turns: int = Field(
+        default=30,
+        description=(
+            "Per-interaction override for the maximum conversation turns. "
+            "Only takes effect when set explicitly by the caller; otherwise "
+            "the chat node's configured max_turns "
+            "(agent.yml ``agentic_nodes.chat.max_turns``) is used."
+        ),
+    )
     external_knowledge: Optional[str] = Field(default="", description="External knowledge")
     workspace_root: Optional[str] = Field(default=None, description="Root directory path for filesystem MCP server")
     prompt_version: Optional[str] = Field(default=None, description="Version for prompt template")

--- a/tests/unit_tests/agent/node/test_compact_archive.py
+++ b/tests/unit_tests/agent/node/test_compact_archive.py
@@ -14,7 +14,6 @@ import pytest
 from datus.agent.node.compact_archive import (
     ARCHIVED_MARKER,
     ToolArchive,
-    is_archived_args,
     is_archived_output,
     maybe_truncate_item,
     parse_archived_marker,
@@ -125,23 +124,6 @@ class TestIsError:
 class TestArchivedMarkerDetection:
     """Idempotency helpers: detect already-archived items in re-scan."""
 
-    def test_args_marker_detected_after_json_round_trip(self):
-        # arguments is stored as a JSON-encoded string — i.e. the marker
-        # lives inside ``json.dumps("[DATUS_ARCHIVED] ...")``.
-        wire = json.dumps(f"{ARCHIVED_MARKER} path=/tmp/x preview=...")
-        assert is_archived_args(wire) is True
-
-    def test_args_marker_not_detected_for_real_arguments(self):
-        wire = json.dumps({"path": "datus/foo.py"})
-        assert is_archived_args(wire) is False
-
-    def test_args_marker_not_detected_for_invalid_json(self):
-        assert is_archived_args("not json at all {") is False
-
-    def test_args_marker_not_detected_for_non_string(self):
-        assert is_archived_args(None) is False
-        assert is_archived_args(123) is False
-
     def test_output_marker_detected_directly(self):
         assert is_archived_output(f"{ARCHIVED_MARKER} path=/tmp/y preview=...") is True
 
@@ -201,15 +183,16 @@ class TestParseArchivedMarker:
 
 
 class TestMaybeTruncateItem:
-    def test_long_args_get_archived(self, archive):
+    def test_long_args_now_pass_through(self, archive):
+        # ``function_call.arguments`` is never archived — a marker string in
+        # ``arguments`` would break the tool-call payload sent to the LLM. Even
+        # a 2000-char payload must come back byte-identical, with no file
+        # written to the archive dir.
         item = {"type": "function_call", "name": "f", "arguments": "z" * 2000, "call_id": "c1"}
         out = maybe_truncate_item(item, archive, threshold=1000, idx=3)
-        assert out is not item
-        decoded = json.loads(out["arguments"])
-        assert isinstance(decoded, str) and decoded.startswith(ARCHIVED_MARKER)
-        # Other fields preserved.
-        assert out["name"] == "f"
-        assert out["call_id"] == "c1"
+        assert out is item  # identity preserved → caller sees "no change"
+        assert out["arguments"] == "z" * 2000
+        assert list(archive.dir.iterdir()) == []
 
     def test_long_output_get_archived(self, archive):
         item = {"type": "function_call_output", "output": "y" * 2000, "call_id": "c1"}
@@ -231,18 +214,6 @@ class TestMaybeTruncateItem:
         for item in ({"type": "message", "content": "z" * 5000}, {"type": "reasoning", "content": "z" * 5000}):
             assert maybe_truncate_item(item, archive, threshold=10, idx=7) is item
 
-    def test_idempotent_already_archived_args_skipped(self, archive):
-        # Second pass over the same item must not produce a new file or
-        # rewrap the marker — this is the core idempotency guarantee that
-        # lets ``_compacted_until`` be a pure performance hint.
-        item = {"type": "function_call", "arguments": "z" * 5000, "name": "f"}
-        first = maybe_truncate_item(item, archive, threshold=1000, idx=9)
-        before = sorted(p.name for p in archive.dir.iterdir())
-        second = maybe_truncate_item(first, archive, threshold=1000, idx=9)
-        after = sorted(p.name for p in archive.dir.iterdir())
-        assert second is first  # identity returned → no rewrite
-        assert before == after  # no new file created
-
     def test_idempotent_already_archived_output_skipped(self, archive):
         item = {"type": "function_call_output", "output": "y" * 5000}
         first = maybe_truncate_item(item, archive, threshold=1000, idx=10)
@@ -260,10 +231,9 @@ class TestMaybeTruncateItem:
             raise OSError("disk full")
 
         monkeypatch.setattr(archive, "archive", raise_oserror)
-        item = {"type": "function_call", "arguments": "x" * 5000, "name": "f"}
+        item = {"type": "function_call_output", "output": "x" * 5000, "call_id": "c1"}
         out = maybe_truncate_item(item, archive, threshold=1000, idx=8)
-        decoded = json.loads(out["arguments"])
-        assert isinstance(decoded, str) and decoded.startswith(ARCHIVED_MARKER)
-        assert "<unavailable" in decoded
+        assert out["output"].startswith(ARCHIVED_MARKER)
+        assert "<unavailable" in out["output"]
         # New dict so the rest of the compact pass continues.
         assert out is not item

--- a/tests/unit_tests/agent/node/test_compact_minor.py
+++ b/tests/unit_tests/agent/node/test_compact_minor.py
@@ -11,7 +11,6 @@ The pass keeps the original tool I/O of the most recent
 older to disk via a single-line ``[DATUS_ARCHIVED]`` marker.
 """
 
-import json
 from pathlib import Path
 from typing import AsyncGenerator, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -90,20 +89,16 @@ def _tool_pair(idx, args_text, output_text):
     ]
 
 
-def _decoded_args_marker(rewritten_item):
-    """Return the marker string stored in ``arguments`` after JSON-decoding."""
-    return json.loads(rewritten_item["arguments"])
-
-
 def _build_turns(num_turns, *, args_long=True, output_long=False):
     """Build ``num_turns`` user turns, each followed by one tool pair.
 
     Layout per turn (3 items): [user_message, function_call, function_call_output].
 
-    ``args_long=True`` (the typical case) makes args exceed threshold so they
-    are archived. ``output_long`` defaults to False so existing tests that
-    assert "kept window output stays as ``{"success": 1}``" continue to hold;
-    set it True when the test wants to archive outputs too.
+    ``args_long=True`` (the typical case) makes args exceed threshold; arguments
+    are never archived, so this only exercises the "args preserved verbatim"
+    assertions. ``output_long`` defaults to False so existing tests that assert
+    "kept window output stays as ``{"success": 1}``" continue to hold; set it
+    True when the test wants the output archived.
     """
     items = []
     for i in range(num_turns):
@@ -116,24 +111,25 @@ def _build_turns(num_turns, *, args_long=True, output_long=False):
 
 @pytest.mark.asyncio
 async def test_minor_compact_archives_tool_io_of_older_user_turns(tmp_path):
-    """Older user turns' tool I/O get archived; the kept window stays verbatim."""
+    """Older user turns' output gets archived; arguments and the kept window
+    stay verbatim. ``function_call.arguments`` is never archived.
+    """
     node = _build_node(tmp_path, keep_recent_user_turns=2, archive_threshold=100)
-    # 4 user turns; latest 2 must be preserved. Both args and output of the
-    # archived turns are long so we can verify the marker is written into
-    # BOTH fields (args and output use different code paths in the archiver).
+    # 4 user turns; latest 2 must be preserved. Outputs of the archived turns
+    # are long; arguments are long too but must NOT be archived.
     items = _build_turns(4, output_long=True)
     node._session = _mock_session(items)
 
     result = await node._minor_compact(reason="t")
 
     assert result["success"]
-    # First 2 user turns × 1 tool pair × (args + output) = 4 archives.
-    assert result["archived_count"] == 4
+    # First 2 user turns × 1 tool pair × output only = 2 archives (args never archived).
+    assert result["archived_count"] == 2
     rewritten = node._session.add_items.await_args.args[0]
-    # Turn 0 (items 1-2) and turn 1 (items 4-5) had long args → archived.
-    assert _decoded_args_marker(rewritten[1]).startswith(ARCHIVED_MARKER)
+    # Turn 0 (items 1-2) and turn 1 (items 4-5): output archived, args preserved.
+    assert rewritten[1]["arguments"] == "x" * 500
     assert rewritten[2]["output"].startswith(ARCHIVED_MARKER)
-    assert _decoded_args_marker(rewritten[4]).startswith(ARCHIVED_MARKER)
+    assert rewritten[4]["arguments"] == "x" * 500
     assert rewritten[5]["output"].startswith(ARCHIVED_MARKER)
     # Latest 2 user turns (items 6+) untouched — args still the original.
     assert rewritten[7]["arguments"] == "x" * 500
@@ -143,17 +139,19 @@ async def test_minor_compact_archives_tool_io_of_older_user_turns(tmp_path):
 @pytest.mark.asyncio
 async def test_minor_compact_preserves_recent_user_turns(tmp_path):
     """The most-recent ``keep_recent_user_turns`` user turns are never
-    compacted, even if their args/output cross ``archive_threshold``.
+    compacted, even if their output crosses ``archive_threshold``. (Older
+    turns' long output is archived, which is what triggers the rewrite.)
     """
     node = _build_node(tmp_path, keep_recent_user_turns=2, archive_threshold=100)
-    items = _build_turns(4)
+    items = _build_turns(4, output_long=True)
     node._session = _mock_session(items)
 
     await node._minor_compact(reason="t")
     rewritten = node._session.add_items.await_args.args[0]
-    # User-turn 2 (items 6-8) and user-turn 3 (items 9-11) must remain raw.
+    # User-turn 2 (items 6-8) and user-turn 3 (items 9-11) must remain raw —
+    # args were never archive-eligible, and recent output stays verbatim.
     assert rewritten[7]["arguments"] == "x" * 500
-    assert rewritten[8]["output"] == '{"success": 1}'
+    assert rewritten[8]["output"] == "y" * 500
     assert rewritten[10]["arguments"] == "x" * 500
 
 
@@ -164,7 +162,7 @@ async def test_minor_compact_idempotent_second_pass(tmp_path):
     ``maybe_truncate_item`` is the canonical idempotency guarantee.
     """
     node = _build_node(tmp_path, keep_recent_user_turns=1, archive_threshold=100)
-    items = _build_turns(3)
+    items = _build_turns(3, output_long=True)
     node._session = _mock_session(items)
 
     first = await node._minor_compact(reason="t1")
@@ -191,7 +189,7 @@ async def test_minor_compact_correct_when_state_lost(tmp_path):
     archived item is detected via its in-message ``[DATUS_ARCHIVED]`` marker.
     """
     node = _build_node(tmp_path, keep_recent_user_turns=1, archive_threshold=100)
-    items = _build_turns(3)
+    items = _build_turns(3, output_long=True)
     node._session = _mock_session(items)
     await node._minor_compact(reason="first")
     rewritten = node._session.add_items.await_args.args[0]
@@ -240,7 +238,7 @@ async def test_minor_compact_archives_to_disk_byte_equal(tmp_path):
     original = "abcdef" * 200  # 1200 chars
     items = (
         [_user_message("first ask")]
-        + _tool_pair(0, original, '{"success": 1}')
+        + _tool_pair(0, "short", original)
         + [_user_message("second ask")]
         + _tool_pair(1, "short", "short")
     )
@@ -248,8 +246,8 @@ async def test_minor_compact_archives_to_disk_byte_equal(tmp_path):
 
     await node._minor_compact(reason="t")
     rewritten = node._session.add_items.await_args.args[0]
-    args_marker = _decoded_args_marker(rewritten[1])
-    archived_path = args_marker.split("path=", 1)[1].split(" preview=", 1)[0]
+    output_marker = rewritten[2]["output"]
+    archived_path = output_marker.split("path=", 1)[1].split(" preview=", 1)[0]
     assert Path(archived_path).read_bytes() == original.encode("utf-8")
 
 

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -98,28 +98,19 @@ class TestExtractFunction:
         assert name == "fn"
         assert args == {}
 
-    def test_archived_arguments_surface_preview(self):
-        """Minor-compact replaces long args with a marker — the SSE layer must
-        surface the inline preview instead of dropping the params to ``{}``.
-
-        ``arguments`` on the wire is a JSON-encoded string of the marker
-        (``maybe_truncate_item`` stores it as ``json.dumps(marker)``), so the
-        existing ``json.loads`` step unwraps to a bare marker string and the
-        new branch then parses the preview out of it. The web UI sees an
-        ``archived: True`` flag plus the preview text — no disk read, no
-        original-arguments recovery.
+    def test_archived_arguments_marker_no_longer_parsed(self):
+        """``function_call.arguments`` is never archived anymore, so a marker
+        string in ``arguments`` is just opaque, non-dict content. The SSE layer
+        unwraps the JSON string and falls back to ``{}`` — it must NOT emit the
+        old ``archived/preview`` payload.
         """
-        marker = "[DATUS_ARCHIVED] path=/sessions/p/sid/data/000004_args_a1b2c3d4.json preview=SELECT * FROM orders WHERE region IN ('NA','EU')"
-        wire_arguments = json.dumps(marker)
+        marker = "[DATUS_ARCHIVED] path=/sessions/p/sid/data/000004_args_a1b2c3d4.json preview=SELECT * FROM orders"
         action = _make_action(
-            input={"function_name": "execute_sql", "arguments": wire_arguments},
+            input={"function_name": "execute_sql", "arguments": json.dumps(marker)},
         )
         name, args = _extract_function(action)
         assert name == "execute_sql"
-        assert args == {
-            "archived": True,
-            "preview": "SELECT * FROM orders WHERE region IN ('NA','EU')",
-        }
+        assert args == {}
 
 
 # ------------------------------------------------------------------
@@ -143,18 +134,17 @@ class TestBuildToolCallContent:
         assert contents[0].payload["toolName"] == "search_table_metadata"
         assert contents[0].payload["toolParams"] == {"query": "revenue"}
 
-    def test_archived_arguments_become_preview_payload(self):
-        """Archived tool params are surfaced as an ``archived/preview`` pair."""
+    def test_archived_arguments_marker_falls_back_to_empty_params(self):
+        """A marker string in ``arguments`` (only possible in legacy sessions)
+        is no longer special-cased; it yields empty ``toolParams``.
+        """
         marker = "[DATUS_ARCHIVED] path=/x/000004_args_dead.json preview=COPY orders FROM 's3://...'"
         action = _make_action(
             action_id="tool-arch-1",
             input={"function_name": "execute_sql", "arguments": json.dumps(marker)},
         )
         contents = _build_tool_call_content(action)
-        assert contents[0].payload["toolParams"] == {
-            "archived": True,
-            "preview": "COPY orders FROM 's3://...'",
-        }
+        assert contents[0].payload["toolParams"] == {}
 
 
 class TestBuildToolResultContent:


### PR DESCRIPTION
 ## Why

  Two robustness bugs in the agentic chat node:

  1. **Archived tool-call arguments break the LLM turn.** The minor compact pass
     (#871) replaced any over-threshold `function_call.arguments` with a
     `[DATUS_ARCHIVED] path=... preview=...` marker, just like it does for
     outputs. But `arguments` is the tool-call payload the model must emit as
     well-formed JSON matching the tool schema. Substituting a marker string for
     it can make the LLM service reject the turn, or teach the model to imitate
     the marker shape in subsequent tool calls, producing malformed arguments.

  2. **`max_turns` node config never took effect.** `ChatNodeInput.max_turns`
     carries a field default of `30`. The run loop used
     `getattr(ctx.user_input, "max_turns", None) or self.max_turns`, so the input
     default always shadowed the node-level config
     (`agent.yml agentic_nodes.<name>.max_turns`) — the configured value could
     never win even when the caller never set `max_turns`.

  ## Solution

  1. **Stop archiving arguments; keep them original.**
     - `compact_archive.py`: `maybe_truncate_item()` no longer handles
       `function_call` — only `function_call_output.output` is archived; any
       `function_call` item passes through unchanged. Removed the now-dead
       `is_archived_args()` helper and the `arguments` fallback branch in
       `_inline_truncated()`. Updated module/`archive()` docstrings.
     - `action_sse_converter.py`: `_extract_function()` no longer parses an
       archive marker out of `arguments` (that code path is gone); string
       arguments are JSON-decoded and fall back to `{}` otherwise.
     - Output archiving, `is_archived_output()`, and `parse_archived_marker()`
       (still used for outputs) are unchanged. No reverse-recovery of arguments
       already archived in legacy sessions — this is a forward-looking change.

  2. **Fix `max_turns` precedence.** The run loop now treats a per-call
     `max_turns` as an override only when the caller set it explicitly (tracked
     via Pydantic `model_fields_set`); otherwise it falls back to `self.max_turns`
     from node config. Clarified the `ChatNodeInput.max_turns` field description
     to document this contract.

  ## Test Cases

  Updated unit tests (CI tier, hermetic, no LLM/network):
  
  - `tests/unit_tests/agent/node/test_compact_archive.py`: `function_call`
    arguments now pass through verbatim at any length with no file written;
    removed the obsolete `is_archived_args` detection and arguments-idempotency
    cases; the disk-failure fallback case now exercises `output`.
  - `tests/unit_tests/agent/node/test_compact_minor.py`: older turns archive
    only `output` (`archived_count` reflects outputs only); arguments are
    asserted to stay original in both the eligible and kept windows.
  - `tests/unit_tests/api/services/test_action_sse_converter.py`: a marker string
    in `arguments` is no longer special-cased — it falls back to empty
    `toolParams` (output-archiving display cases unchanged).

  No new test was added for the `max_turns` precedence fix; it is a small,
  config-resolution change covered by existing chat-node run-loop tests. (Worth
  adding a dedicated case asserting node-config fallback vs. explicit override in
  a follow-up.)

- [ ] release/0.3.1
- [ ] release/0.3.2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Tool call arguments are now fully preserved during archival, ensuring tool invocation payloads remain valid and functional
- Node-level maximum turn limits are now properly respected when not explicitly overridden per interaction
- Large tool outputs are more efficiently archived while maintaining system stability

**Documentation**
- Enhanced clarity on maximum turn configuration and per-interaction override behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->