### PR TITLE
[Enhancement] Support Snowflake key pair auth for metrics

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-test.txt
-          pip install --upgrade --no-cache-dir datus-semantic-metricflow==0.2.2
+          pip install --upgrade --no-cache-dir datus-semantic-metricflow
           pip install packaging==26.2
 
       - name: Check release metadata

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -54,7 +54,9 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-test.txt
-          pip install --upgrade --no-cache-dir datus-semantic-metricflow
+          pip install --upgrade --no-cache-dir \
+            "datus-metricflow @ https://github.com/stukid/metricflow/archive/95fe9271d2fbe1e12797595b2d841c84c1ce6f3d.tar.gz" \
+            "datus-semantic-metricflow @ https://github.com/stukid/datus-semantic-adapter/archive/002b93e39b906f42ecf9bc513ace3c1594139462.tar.gz#subdirectory=datus-semantic-metricflow"
           pip install packaging==26.2
 
       - name: Check release metadata

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -55,8 +55,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-test.txt
           pip install --upgrade --no-cache-dir \
-            "datus-metricflow @ https://github.com/stukid/metricflow/archive/95fe9271d2fbe1e12797595b2d841c84c1ce6f3d.tar.gz" \
-            "datus-semantic-metricflow @ https://github.com/stukid/datus-semantic-adapter/archive/002b93e39b906f42ecf9bc513ace3c1594139462.tar.gz#subdirectory=datus-semantic-metricflow"
+            "datus-metricflow @ https://github.com/Datus-ai/metricflow/archive/95fe9271d2fbe1e12797595b2d841c84c1ce6f3d.tar.gz" \
+            "datus-semantic-metricflow @ https://github.com/Datus-ai/datus-semantic-adapter/archive/002b93e39b906f42ecf9bc513ace3c1594139462.tar.gz#subdirectory=datus-semantic-metricflow"
           pip install packaging==26.2
 
       - name: Check release metadata

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -120,11 +120,13 @@ jobs:
           uv pip install --upgrade --no-cache-dir \
             --reinstall-package datus-semantic-core \
             --reinstall-package datus-semantic-metricflow \
+            --reinstall-package datus-snowflake \
             pytest-playwright \
             ./external/datus-semantic-adapter/datus-semantic-core \
             ./external/datus-semantic-adapter/datus-semantic-metricflow \
             ./external/datus-db-adapters/datus-db-core \
             ./external/datus-db-adapters/datus-sqlalchemy \
+            ./external/datus-db-adapters/datus-snowflake \
             ./external/datus-db-adapters/datus-postgresql \
             ./external/datus-db-adapters/datus-mysql \
             ./external/datus-db-adapters/datus-clickhouse \

--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -42,8 +42,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-test.txt
           pip install --upgrade --no-cache-dir \
-            "datus-metricflow @ https://github.com/stukid/metricflow/archive/95fe9271d2fbe1e12797595b2d841c84c1ce6f3d.tar.gz" \
-            "datus-semantic-metricflow @ https://github.com/stukid/datus-semantic-adapter/archive/002b93e39b906f42ecf9bc513ace3c1594139462.tar.gz#subdirectory=datus-semantic-metricflow"
+            "datus-metricflow @ https://github.com/Datus-ai/metricflow/archive/95fe9271d2fbe1e12797595b2d841c84c1ce6f3d.tar.gz" \
+            "datus-semantic-metricflow @ https://github.com/Datus-ai/datus-semantic-adapter/archive/002b93e39b906f42ecf9bc513ace3c1594139462.tar.gz#subdirectory=datus-semantic-metricflow"
           pip install pytest-cov 'chardet<6' diff-cover packaging
 
       - name: Check release metadata

--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-test.txt
-          pip install --upgrade --no-cache-dir datus-semantic-metricflow
+          pip install --upgrade --no-cache-dir \
+            "datus-metricflow @ https://github.com/stukid/metricflow/archive/95fe9271d2fbe1e12797595b2d841c84c1ce6f3d.tar.gz" \
+            "datus-semantic-metricflow @ https://github.com/stukid/datus-semantic-adapter/archive/002b93e39b906f42ecf9bc513ace3c1594139462.tar.gz#subdirectory=datus-semantic-metricflow"
           pip install pytest-cov 'chardet<6' diff-cover packaging
 
       - name: Check release metadata

--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -156,6 +156,10 @@ agent:
         account: ${SNOWFLAKE_ACCOUNT}  # Use environment variables or real values
         username: ${SNOWFLAKE_USER}
         password: ${SNOWFLAKE_PASSWORD}
+        # For Snowflake key pair auth, omit password and use:
+        # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+        # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # optional
+        # role: ${SNOWFLAKE_ROLE}  # optional
         # database: BBC
         # schema: BBC_NEWS
       # bird_sqlite: # This section is configured for the bird-dev benchmarking, you should download the database file and unzip it before you can continue

--- a/datus/configuration/README.md
+++ b/datus/configuration/README.md
@@ -64,7 +64,9 @@ Configure database connections by datasource:
       type: snowflake
       account: ${SNOWFLAKE_ACCOUNT}
       username: ${SNOWFLAKE_USER}
-      password: ${SNOWFLAKE_PASSWORD}
+      password: ${SNOWFLAKE_PASSWORD} # Use either password or private_key_file
+      # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+      # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
 
     local_sqlite:
       type: sqlite
@@ -158,6 +160,9 @@ export DEEPSEEK_API_KEY="..."
 export SNOWFLAKE_ACCOUNT="your-account"
 export SNOWFLAKE_USER="your-user"
 export SNOWFLAKE_PASSWORD="your-password"
+export SNOWFLAKE_PRIVATE_KEY_FILE="/path/to/rsa_key.p8"
+export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=""
+export SNOWFLAKE_ROLE=""
 export STARROCKS_HOST="localhost"
 export STARROCKS_PORT="9030"
 export STARROCKS_USER="root"
@@ -294,10 +299,11 @@ agent:
       type: snowflake
       account: ${SNOWFLAKE_ACCOUNT}
       username: ${SNOWFLAKE_USER}
-      password: ${SNOWFLAKE_PASSWORD}
+      password: ${SNOWFLAKE_PASSWORD} # Use either password or private_key_file
       database: PRODUCTION
       schema: PUBLIC
       warehouse: COMPUTE_WH
+      role: ${SNOWFLAKE_ROLE}
 ```
 
 ## Benchmark Configuration

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -227,6 +227,9 @@ class DbConfig:
     database: str = field(default="", init=True)
     schema: str = field(default="", init=True)
     warehouse: str = field(default="", init=True)
+    role: str = field(default="", init=True)
+    private_key_file: str = field(default="", init=True)
+    private_key_file_pwd: str = field(default="", init=True)
     catalog: str = field(default="", init=True)
     logic_name: str = field(default="", init=True)  # Logical name for the database entry
     default: bool = field(default=False, init=True)  # Whether this is the default database

--- a/datus/storage/metric/adapter_init.py
+++ b/datus/storage/metric/adapter_init.py
@@ -8,7 +8,7 @@ Initialize metrics from semantic adapters.
 
 from typing import List, Optional
 
-from datus.configuration.agent_config import AgentConfig
+from datus.configuration.agent_config import AgentConfig, _db_config_to_semantic_adapter_config
 from datus.tools.semantic_tools.registry import semantic_adapter_registry
 from datus.tools.semantic_tools.storage_sync import SemanticStorageManager
 from datus.utils.loggings import get_logger
@@ -66,12 +66,7 @@ async def init_from_adapter(
             db_config = None
             if ns_configs:
                 db_config_obj = list(ns_configs.values())[0]
-                raw = db_config_obj.to_dict()
-                db_config = {
-                    k: str(v)
-                    for k, v in raw.items()
-                    if v is not None and v != "" and k not in ("extra", "logic_name", "path_pattern", "catalog")
-                }
+                db_config = _db_config_to_semantic_adapter_config(db_config_obj)
             semantic_models_path = str(agent_config.path_manager.semantic_model_path(datasource))
 
             if metadata and metadata.config_class:

--- a/datus/storage/semantic_model/adapter_init.py
+++ b/datus/storage/semantic_model/adapter_init.py
@@ -8,7 +8,7 @@ Initialize semantic models from semantic adapters.
 
 from typing import Optional
 
-from datus.configuration.agent_config import AgentConfig
+from datus.configuration.agent_config import AgentConfig, _db_config_to_semantic_adapter_config
 from datus.tools.semantic_tools.registry import semantic_adapter_registry
 from datus.tools.semantic_tools.storage_sync import SemanticStorageManager
 from datus.utils.loggings import get_logger
@@ -64,12 +64,7 @@ async def init_from_adapter(
             db_config = None
             if ns_configs:
                 db_config_obj = list(ns_configs.values())[0]
-                raw = db_config_obj.to_dict()
-                db_config = {
-                    k: str(v)
-                    for k, v in raw.items()
-                    if v is not None and v != "" and k not in ("extra", "logic_name", "path_pattern", "catalog")
-                }
+                db_config = _db_config_to_semantic_adapter_config(db_config_obj)
             semantic_models_path = str(agent_config.path_manager.semantic_model_path(datasource))
 
             if metadata and metadata.config_class:

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -132,7 +132,9 @@ warehouse:
   type: snowflake
   account: your_account
   username: your_username
-  password: your_password
+  password: your_password  # Use either password or private_key_file
+  # private_key_file: /path/to/rsa_key.p8
+  # private_key_file_pwd: optional_key_passphrase
   warehouse: your_warehouse
   database: your_database
   schema: your_schema

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -128,7 +128,9 @@ warehouse:
   type: snowflake
   account: your_account
   username: your_username
-  password: your_password
+  password: your_password  # password 和 private_key_file 二选一
+  # private_key_file: /path/to/rsa_key.p8
+  # private_key_file_pwd: optional_key_passphrase
   warehouse: your_warehouse
   database: your_database
   schema: your_schema

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -71,10 +71,13 @@ my_snowflake:
   type: snowflake
   account: ${SNOWFLAKE_ACCOUNT}
   username: ${SNOWFLAKE_USER}
-  password: ${SNOWFLAKE_PASSWORD}
+  password: ${SNOWFLAKE_PASSWORD}      # Use either password or private_key_file
+  # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+  # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # Optional
   database: ${SNOWFLAKE_DATABASE}    # Optional
   schema: ${SNOWFLAKE_SCHEMA}        # Optional
   warehouse: ${SNOWFLAKE_WAREHOUSE}  # Optional
+  role: ${SNOWFLAKE_ROLE}            # Optional
   default: true                      # Optional: mark as default
 ```
 

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -72,10 +72,13 @@ my_snowflake:
   type: snowflake
   account: ${SNOWFLAKE_ACCOUNT}
   username: ${SNOWFLAKE_USER}
-  password: ${SNOWFLAKE_PASSWORD}
+  password: ${SNOWFLAKE_PASSWORD}      # password 和 private_key_file 二选一
+  # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+  # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # 可选
   database: ${SNOWFLAKE_DATABASE}    # 可选
   schema: ${SNOWFLAKE_SCHEMA}        # 可选
   warehouse: ${SNOWFLAKE_WAREHOUSE}  # 可选
+  role: ${SNOWFLAKE_ROLE}            # 可选
   default: true                      # 可选：设为默认数据库
 ```
 

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -222,8 +222,11 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}
+        password: ${SNOWFLAKE_PASSWORD}  # Use either password or private_key_file
+        # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+        # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # Optional
         warehouse: ${SNOWFLAKE_WAREHOUSE}
+        role: ${SNOWFLAKE_ROLE}  # Optional
 ```
 
 Bootstrap and run selected tasks:

--- a/docs/develop/README.zh.md
+++ b/docs/develop/README.zh.md
@@ -222,8 +222,11 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}
+        password: ${SNOWFLAKE_PASSWORD}  # password 和 private_key_file 二选一
+        # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+        # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # 可选
         warehouse: ${SNOWFLAKE_WAREHOUSE}
+        role: ${SNOWFLAKE_ROLE}  # 可选
 ```
 
 初始化并运行指定任务：

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -152,6 +152,22 @@ class TestDbConfigFilterKwargs:
         cfg = DbConfig.filter_kwargs(DbConfig, kwargs)
         assert cfg.extra == {"custom_option": "value123"}
 
+    def test_snowflake_auth_fields_are_first_class(self):
+        kwargs = {
+            "type": "snowflake",
+            "account": "sf_account",
+            "username": "sf_user",
+            "role": "ANALYST",
+            "private_key_file": "/tmp/rsa_key.p8",
+            "private_key_file_pwd": 1234,
+            "custom_option": "value123",
+        }
+        cfg = DbConfig.filter_kwargs(DbConfig, kwargs)
+        assert cfg.role == "ANALYST"
+        assert cfg.private_key_file == "/tmp/rsa_key.p8"
+        assert cfg.private_key_file_pwd == "1234"
+        assert cfg.extra == {"custom_option": "value123"}
+
     def test_name_sets_logic_name(self):
         kwargs = {"type": "sqlite", "uri": "sqlite:///db.db", "name": "my_logic_name"}
         cfg = DbConfig.filter_kwargs(DbConfig, kwargs)
@@ -580,6 +596,37 @@ class TestAgentConfigServiceSelectors:
         config = cfg.build_semantic_adapter_config()
         assert config["type"] == "metricflow"
         assert config["datasource"] == "demo"
+
+    def test_build_semantic_adapter_config_preserves_snowflake_key_pair_fields(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {
+                    "sf": {
+                        "type": "snowflake",
+                        "account": "sf_account",
+                        "username": "sf_user",
+                        "role": "ANALYST",
+                        "private_key_file": "/tmp/rsa_key.p8",
+                        "private_key_file_pwd": 1234,
+                        "warehouse": "COMPUTE_WH",
+                        "database": "ANALYTICS",
+                        "default": True,
+                    }
+                },
+                "semantic_layer": {"metricflow": {}},
+            },
+        )
+
+        config = cfg.build_semantic_adapter_config()
+
+        assert config["type"] == "metricflow"
+        assert config["datasource"] == "sf"
+        assert config["db_config"]["type"] == "snowflake"
+        assert config["db_config"]["role"] == "ANALYST"
+        assert config["db_config"]["private_key_file"] == "/tmp/rsa_key.p8"
+        assert config["db_config"]["private_key_file_pwd"] == "1234"
+        assert "default" not in config["db_config"]
 
     def test_file_datasource_preserves_adapter_specific_extra_fields(self, tmp_path):
         cfg = self._make(

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -426,6 +426,27 @@ class TestDbConfigToConnectionConfigAdapterBranch:
         assert result.get("warehouse") == "COMPUTE_WH"
         assert result.get("role") == "ANALYST"
 
+    def test_adapter_preserves_snowflake_key_pair_fields(self):
+        """Snowflake key-pair auth fields are passed to the external adapter."""
+        mgr = self._make_manager()
+        cfg = _cfg(
+            type="snowflake",
+            account="sf_account",
+            username="sf_user",
+            database="ANALYTICS",
+            warehouse="COMPUTE_WH",
+            role="ANALYST",
+            private_key_file="/tmp/rsa_key.p8",
+            private_key_file_pwd="1234",
+        )
+        result = mgr._db_config_to_connection_config(cfg)
+
+        assert result["account"] == "sf_account"
+        assert result["warehouse"] == "COMPUTE_WH"
+        assert result["role"] == "ANALYST"
+        assert result["private_key_file"] == "/tmp/rsa_key.p8"
+        assert result["private_key_file_pwd"] == "1234"
+
     def test_adapter_none_values_removed(self):
         """None-valued fields are excluded from the result dict."""
         mgr = self._make_manager()

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -1022,6 +1022,9 @@ class TestExtractDbConfig:
             "host": "localhost",
             "port": 3306,
             "password": "secret",
+            "role": "ANALYST",
+            "private_key_file": "/tmp/rsa_key.p8",
+            "private_key_file_pwd": 1234,
             "extra": "skip",
             "logic_name": "skip",
             "path_pattern": "skip",
@@ -1034,6 +1037,9 @@ class TestExtractDbConfig:
         assert result["db_type"] == "mysql"
         assert result["host"] == "localhost"
         assert result["port"] == "3306"
+        assert result["role"] == "ANALYST"
+        assert result["private_key_file"] == "/tmp/rsa_key.p8"
+        assert result["private_key_file_pwd"] == "1234"
         assert "extra" not in result
         assert "logic_name" not in result
         assert "path_pattern" not in result


### PR DESCRIPTION
## Summary
- add first-class Snowflake datasource fields for `role`, `private_key_file`, and `private_key_file_pwd`
- preserve those fields when building DB connector configs and semantic MetricFlow adapter configs
- reuse the central semantic datasource conversion in metric and semantic-model adapter initialization paths
- document Snowflake password vs RSA key-pair auth in examples and datasource docs

## Why
Snowflake deployments with MFA commonly require key-pair auth. Datus needs to pass the same Snowflake auth fields to both the database connector used for SQL access and the MetricFlow semantic adapter used for metric generation, validation, and metric queries.

Related stack PRs:
- Datus-ai/datus-db-adapters#66
- Datus-ai/metricflow#37
- Datus-ai/datus-semantic-adapter#25

## Validation
- `uv run pytest tests/unit_tests/configuration/test_agent_config.py tests/unit_tests/tools/db_tools/test_db_manager.py::TestDbConfigToConnectionConfigAdapterBranch tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestExtractDbConfig tests/unit_tests/storage/metric/test_adapter_init.py tests/unit_tests/storage/semantic_model/test_adapter_init.py -q`
- `uv run pytest tests/unit_tests/cli/test_service_manager.py tests/unit_tests/cli/test_datasource_commands.py tests/unit_tests/cli/test_datasource_manager.py -q`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
## Summary by CodeRabbit

* **New Features**
  * Added Snowflake key-pair authentication support as an alternative to password-based authentication. Users can now configure `private_key_file` and optional `private_key_file_pwd` for secure connections.
  * Added support for configurable Snowflake `role` parameter in database configuration.

* **Documentation**
  * Updated configuration examples and guides across all supported languages to document the new Snowflake authentication options and role parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Snowflake key-pair authentication (private key file with optional passphrase) and a configurable Snowflake role in DB configs.

* **Documentation**
  * Updated configuration examples and guides (including localized docs) and environment variable references to document private-key auth and role usage.

* **Tests**
  * Added unit tests verifying preservation and handling of Snowflake key-pair and role fields.

* **Chores**
  * Updated CI workflow dependency install commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->