### PR TITLE
[Feature] Add metrics provenance sidecar

### DIFF
--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1302,7 +1302,7 @@ class GenerationHooks(AgentHooks):
                 if metric_objects:
                     metric_rag.upsert_batch(metric_objects)
                     metric_rag.create_indices()
-                return {
+                result = {
                     "success": True,
                     "message": (
                         f"Synced {len(all_objects)} objects "
@@ -1310,6 +1310,9 @@ class GenerationHooks(AgentHooks):
                         f"{', '.join(synced_items[:5])}..."
                     ),
                 }
+                if metric_objects:
+                    result["metric_artifact_ids"] = [obj["id"] for obj in metric_objects if obj.get("id")]
+                return result
             else:
                 if include_metrics and not include_semantic_objects and metrics_list:
                     return {

--- a/datus/storage/knowledge_provenance.py
+++ b/datus/storage/knowledge_provenance.py
@@ -22,6 +22,7 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 REFERENCE_SQL_ARTIFACT_TYPE = "reference_sql"
+METRIC_ARTIFACT_TYPE = "metric"
 
 
 def _coerce_bool(value: Any, default: bool = False) -> bool:
@@ -76,6 +77,16 @@ def reference_sql_artifact_ids_for_items(items: Iterable[Dict[str, Any]]) -> Lis
     for item in items:
         sql = item.get("sql") or ""
         artifact_id = str(item.get("id") or gen_reference_sql_id(sql) or "").strip()
+        if artifact_id and artifact_id not in ids:
+            ids.append(artifact_id)
+    return ids
+
+
+def metric_artifact_ids_for_items(items: Iterable[Dict[str, Any]]) -> List[str]:
+    """Return metric artifact IDs affected by processed bootstrap items."""
+    ids: List[str] = []
+    for item in items:
+        artifact_id = str(item.get("id") or item.get("artifact_id") or "").strip()
         if artifact_id and artifact_id not in ids:
             ids.append(artifact_id)
     return ids
@@ -240,6 +251,19 @@ class KnowledgeProvenanceStore:
                 entry["source_metadata"].append(metadata)
         return result
 
+    def delete_for_artifact_type(self, artifact_type: str) -> int:
+        normalized_type = str(artifact_type or "").strip()
+        if not normalized_type:
+            return 0
+
+        with self._locked():
+            existing = self._load_rows()
+            kept = [dict(row) for row in existing if row.get("artifact_type") != normalized_type]
+            deleted = len(existing) - len(kept)
+            if deleted:
+                self._write_rows(sorted(kept, key=self._row_key))
+            return deleted
+
 
 def build_reference_sql_provenance_rows(items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Build sidecar rows from processed reference SQL bootstrap items."""
@@ -277,6 +301,39 @@ def build_reference_sql_provenance_rows(items: Iterable[Dict[str, Any]]) -> List
     return rows
 
 
+def build_metric_provenance_rows(items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Build sidecar rows from metric bootstrap artifacts and source rows."""
+    rows: List[Dict[str, Any]] = []
+    for item in items:
+        artifact_id = str(item.get("id") or item.get("artifact_id") or "").strip()
+        if not artifact_id:
+            continue
+
+        source_id = str(item.get("source_id") or "")
+        context_ids = _normalize_string_list(item.get("source_context_ids") or item.get("source_context_id"))
+        if not source_id and not context_ids:
+            continue
+
+        metadata = item.get("source_metadata") if isinstance(item.get("source_metadata"), dict) else {}
+        source_type = str(item.get("source_type") or metadata.get("source_type") or "success_story")
+        if not source_id:
+            source_id = str(metadata.get("source_id") or "")
+        context_values = context_ids or [""]
+
+        for context_id in context_values:
+            rows.append(
+                {
+                    "artifact_type": METRIC_ARTIFACT_TYPE,
+                    "artifact_id": artifact_id,
+                    "source_id": source_id,
+                    "source_context_id": context_id,
+                    "source_type": source_type,
+                    "source_metadata": metadata,
+                }
+            )
+    return rows
+
+
 def enrich_reference_sql_results(agent_config: AgentConfig, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     if not results or not is_knowledge_provenance_enabled(agent_config):
         return results
@@ -286,6 +343,34 @@ def enrich_reference_sql_results(agent_config: AgentConfig, results: List[Dict[s
         return results
 
     provenance = KnowledgeProvenanceStore(agent_config).find_by_artifact_ids(REFERENCE_SQL_ARTIFACT_TYPE, ids)
+    if not provenance:
+        return results
+
+    enriched: List[Dict[str, Any]] = []
+    for item in results:
+        if not isinstance(item, dict):
+            enriched.append(item)
+            continue
+        artifact_id = str(item.get("id") or "")
+        metadata = provenance.get(artifact_id)
+        if metadata:
+            updated = dict(item)
+            updated.update(metadata)
+            enriched.append(updated)
+        else:
+            enriched.append(item)
+    return enriched
+
+
+def enrich_metric_results(agent_config: AgentConfig, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not results or not is_knowledge_provenance_enabled(agent_config):
+        return results
+
+    ids = [str(item.get("id")) for item in results if isinstance(item, dict) and item.get("id")]
+    if not ids:
+        return results
+
+    provenance = KnowledgeProvenanceStore(agent_config).find_by_artifact_ids(METRIC_ARTIFACT_TYPE, ids)
     if not provenance:
         return results
 

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -157,11 +157,17 @@ def _sync_metric_provenance(
 ) -> int:
     if not metric_artifact_ids or not source_entries or not is_knowledge_provenance_enabled(agent_config):
         return 0
+    if len(source_entries) != 1:
+        logger.warning(
+            "Skipping metric provenance sync because source-to-metric attribution is ambiguous for %d source row(s)",
+            len(source_entries),
+        )
+        return 0
 
+    source = source_entries[0]
     items: list[dict[str, Any]] = []
     for artifact_id in metric_artifact_ids:
-        for source in source_entries:
-            items.append({"id": artifact_id, **source})
+        items.append({"id": artifact_id, **source})
     rows = build_metric_provenance_rows(items)
     if not rows:
         return 0

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -3,7 +3,9 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import asyncio
+import json
 import os
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 import pandas as pd
@@ -18,6 +20,12 @@ from datus.schemas.action_history import (
 )
 from datus.schemas.batch_events import BatchEventEmitter, BatchEventHelper
 from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.storage.knowledge_provenance import (
+    METRIC_ARTIFACT_TYPE,
+    KnowledgeProvenanceStore,
+    build_metric_provenance_rows,
+    is_knowledge_provenance_enabled,
+)
 from datus.storage.semantic_model.auto_create import ensure_semantic_models_exist, extract_tables_from_sql_list
 from datus.utils.loggings import get_logger
 from datus.utils.terminal_utils import suppress_keyboard_input
@@ -32,6 +40,143 @@ def _action_status_value(action: Any) -> Optional[str]:
     if status is None:
         return None
     return status.value if hasattr(status, "value") else str(status)
+
+
+def _clean_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(value).strip()
+
+
+def _parse_context_ids(value: Any) -> list[str]:
+    text = _clean_cell(value)
+    if not text:
+        return []
+    parts = [part.strip() for part in text.replace(",", ";").split(";")]
+    return [part for part in parts if part]
+
+
+def _parse_source_metadata(value: Any) -> dict[str, Any]:
+    text = _clean_cell(value)
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {"raw": text}
+    return parsed if isinstance(parsed, dict) else {"raw": text}
+
+
+def _source_provenance_from_row(row: Any, row_index: int, success_story: str) -> Optional[dict[str, Any]]:
+    context_ids: list[str] = []
+    for column in ("source_context_ids", "source_context_id", "context_ids", "context_id"):
+        context_ids.extend(_parse_context_ids(row.get(column)))
+    context_ids = list(dict.fromkeys(context_ids))
+    if not context_ids:
+        return None
+
+    metadata = _parse_source_metadata(row.get("source_metadata"))
+    source_id = _clean_cell(row.get("source_id")) or f"{Path(success_story).name}:{row_index}"
+    source_type = _clean_cell(row.get("source_type")) or "success_story"
+    metadata.setdefault("source_id", source_id)
+    metadata.setdefault("source_type", source_type)
+    metadata.setdefault("row_index", row_index)
+    question = _clean_cell(row.get("question"))
+    if question:
+        metadata.setdefault("question", question)
+    task_id = _clean_cell(row.get("task_id"))
+    if task_id:
+        metadata.setdefault("task_id", task_id)
+
+    return {
+        "source_id": source_id,
+        "source_type": source_type,
+        "source_context_ids": context_ids,
+        "source_metadata": metadata,
+    }
+
+
+def _extract_metric_artifact_ids(payload: Any) -> list[str]:
+    ids: list[str] = []
+
+    def add(value: Any) -> None:
+        if value is None:
+            return
+        values = value if isinstance(value, (list, tuple, set)) else [value]
+        for item in values:
+            text = str(item).strip()
+            if text and text not in ids:
+                ids.append(text)
+
+    def visit(value: Any) -> None:
+        if isinstance(value, dict):
+            add(value.get("metric_artifact_ids"))
+            add(value.get("_synced_metric_artifact_ids"))
+            for nested_key in ("result", "sync", "execution_stats", "metric_sync"):
+                if nested_key in value:
+                    visit(value[nested_key])
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                visit(item)
+
+    visit(payload)
+    return ids
+
+
+def _metric_ids_in_storage(agent_config: AgentConfig) -> set[str]:
+    try:
+        from datus.storage.metric.store import MetricRAG
+
+        return {
+            str(row["id"]) for row in MetricRAG(agent_config).search_all_metrics(select_fields=["id"]) if row.get("id")
+        }
+    except Exception as exc:  # pragma: no cover - defensive fallback for storage readiness issues
+        logger.debug("Failed to snapshot metric IDs for provenance fallback: %s", exc)
+        return set()
+
+
+def _clear_metric_provenance(agent_config: AgentConfig) -> int:
+    if not is_knowledge_provenance_enabled(agent_config):
+        return 0
+    try:
+        return KnowledgeProvenanceStore(agent_config).delete_for_artifact_type(METRIC_ARTIFACT_TYPE)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to clear metric provenance sidecar: %s", exc)
+        return 0
+
+
+def _sync_metric_provenance(
+    agent_config: AgentConfig,
+    metric_artifact_ids: list[str],
+    source_entries: list[dict[str, Any]],
+) -> int:
+    if not metric_artifact_ids or not source_entries or not is_knowledge_provenance_enabled(agent_config):
+        return 0
+
+    items: list[dict[str, Any]] = []
+    for artifact_id in metric_artifact_ids:
+        for source in source_entries:
+            items.append({"id": artifact_id, **source})
+    rows = build_metric_provenance_rows(items)
+    if not rows:
+        return 0
+
+    try:
+        written = KnowledgeProvenanceStore(agent_config).upsert_many(rows)
+        logger.info(
+            "Synced %d metric provenance row(s) for %d metric artifact(s)",
+            written,
+            len(metric_artifact_ids),
+        )
+        return written
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to sync metric provenance sidecar: %s", exc)
+        return 0
 
 
 DEFAULT_METRICS_BATCH_SIZE = 1
@@ -80,6 +225,7 @@ async def _generate_metrics_batch(
     try:
         final_result = None
         terminal_error = None
+        synced_metric_artifact_ids: list[str] = []
         async for action in metrics_node.execute_stream(action_history_manager):
             if action_callback is not None:
                 try:
@@ -95,6 +241,9 @@ async def _generate_metrics_batch(
                     output=action.output,
                 )
             action_type = getattr(action, "action_type", "")
+            for artifact_id in _extract_metric_artifact_ids(getattr(action, "output", None)):
+                if artifact_id not in synced_metric_artifact_ids:
+                    synced_metric_artifact_ids.append(artifact_id)
             if action.status == ActionStatus.FAILED and action_type == "error":
                 terminal_error = action.messages or "Metrics extraction failed"
                 logger.error(terminal_error)
@@ -110,6 +259,8 @@ async def _generate_metrics_batch(
             return False, terminal_error, None
         if final_result is None:
             return False, "Metrics extraction completed but produced no output", None
+        if isinstance(final_result, dict) and synced_metric_artifact_ids:
+            final_result["_synced_metric_artifact_ids"] = synced_metric_artifact_ids
         return True, "", final_result
     except Exception as e:
         logger.error(f"Error in metrics extraction (batch {batch_idx}): {e}")
@@ -163,6 +314,9 @@ async def init_success_story_metrics_async(
             agent_config.project_name,
         )
         MetricRAG(agent_config).truncate()
+        cleared_provenance = _clear_metric_provenance(agent_config)
+        if cleared_provenance:
+            logger.info("Cleared %d stale metric provenance row(s)", cleared_provenance)
     elif build_mode == "incremental":
         from datus.storage.metric.init_utils import exists_metrics
         from datus.storage.metric.store import MetricRAG
@@ -206,15 +360,21 @@ async def init_success_story_metrics_async(
         if error:
             logger.warning(f"Semantic model generation had partial failures: {error}")
 
-    # Build query strings for all rows
-    all_query_strings = []
+    # Build query records for all rows. Optional source-context columns are only
+    # used by benchmark provenance mode and do not affect normal bootstrap data.
+    all_query_records: list[dict[str, Any]] = []
     for idx, row in df.iterrows():
         sql = row["sql"]
         question = row["question"]
-        all_query_strings.append(f"Query {idx + 1}:\nQuestion: {question}\nSQL:\n{sql}")
+        all_query_records.append(
+            {
+                "query": f"Query {idx + 1}:\nQuestion: {question}\nSQL:\n{sql}",
+                "source": _source_provenance_from_row(row, idx, success_story),
+            }
+        )
 
     # Split into batches
-    batches = [all_query_strings[i : i + batch_size] for i in range(0, len(all_query_strings), batch_size)]
+    batches = [all_query_records[i : i + batch_size] for i in range(0, len(all_query_records), batch_size)]
     total_batches = len(batches)
 
     logger.info(
@@ -226,8 +386,13 @@ async def init_success_story_metrics_async(
     completed_batches = 0
     failed_batches: list[tuple[int, str]] = []
     merged_result: Optional[dict[str, Any]] = None
+    provenance_entries = 0
 
-    for batch_idx, batch_queries in enumerate(batches):
+    for batch_idx, batch_records in enumerate(batches):
+        batch_queries = [record["query"] for record in batch_records]
+        source_entries = [record["source"] for record in batch_records if record.get("source")]
+        metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
+
         logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
 
         success, error, batch_result = await _generate_metrics_batch(
@@ -242,12 +407,24 @@ async def init_success_story_metrics_async(
 
         if success and batch_result is not None:
             completed_batches += 1
+            metric_artifact_ids = _extract_metric_artifact_ids(batch_result)
+            if source_entries and not metric_artifact_ids:
+                metric_artifact_ids = sorted(_metric_ids_in_storage(agent_config) - metric_ids_before)
+            batch_provenance_entries = _sync_metric_provenance(agent_config, metric_artifact_ids, source_entries)
+            provenance_entries += batch_provenance_entries
+            if isinstance(batch_result, dict) and batch_provenance_entries:
+                batch_result["provenance_entries"] = (
+                    batch_result.get("provenance_entries", 0) + batch_provenance_entries
+                )
+
             if merged_result is None:
                 merged_result = batch_result
             elif isinstance(merged_result, dict) and isinstance(batch_result, dict):
                 for key, value in batch_result.items():
                     if key in merged_result and isinstance(merged_result[key], list) and isinstance(value, list):
                         merged_result[key].extend(value)
+                    elif key in merged_result and isinstance(merged_result[key], int) and isinstance(value, int):
+                        merged_result[key] += value
                     elif key not in merged_result:
                         merged_result[key] = value
             logger.info(f"Batch {batch_idx + 1}/{total_batches} completed successfully")
@@ -266,6 +443,9 @@ async def init_success_story_metrics_async(
     if failed_batches:
         partial_error = "; ".join(f"batch {i + 1}: {e}" for i, e in failed_batches)
         logger.warning(f"Metrics extraction partially succeeded: {partial_error}")
+
+    if isinstance(merged_result, dict) and provenance_entries:
+        merged_result["provenance_entries"] = provenance_entries
 
     logger.info(f"Metrics extraction completed: {completed_batches}/{total_batches} batch(es) succeeded")
     event_helper.task_completed(

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -11,6 +11,7 @@ from datus_storage_base.conditions import WhereExpr, in_
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
+from datus.storage.knowledge_provenance import enrich_metric_results, is_knowledge_provenance_enabled
 from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore, base_schema_columns
 from datus.utils.loggings import get_logger
 
@@ -504,7 +505,9 @@ class MetricRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
+        self.agent_config = agent_config
         self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self._provenance_enabled = is_knowledge_provenance_enabled(agent_config)
         self.storage: MetricStorage = get_storage(MetricStorage, "metric", project=agent_config.project_name)
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.storage, "metrics")
 
@@ -514,6 +517,30 @@ class MetricRAG:
         if self._sub_agent_filter:
             conditions.append(self._sub_agent_filter)
         return conditions
+
+    def _selected_fields_with_provenance_id(
+        self, selected_fields: Optional[List[str]]
+    ) -> tuple[Optional[List[str]], bool]:
+        if not self._provenance_enabled or selected_fields is None or "id" in selected_fields:
+            return selected_fields, False
+        return [*selected_fields, "id"], True
+
+    def _enrich_metric_results(
+        self, results: List[Dict[str, Any]], strip_internal_id: bool = False
+    ) -> List[Dict[str, Any]]:
+        enriched = enrich_metric_results(self.agent_config, results)
+        if not strip_internal_id:
+            return enriched
+
+        cleaned: List[Dict[str, Any]] = []
+        for item in enriched:
+            if isinstance(item, dict):
+                updated = dict(item)
+                updated.pop("id", None)
+                cleaned.append(updated)
+            else:
+                cleaned.append(item)
+        return cleaned
 
     def truncate(self) -> None:
         """Delete all metrics for this datasource."""
@@ -533,11 +560,13 @@ class MetricRAG:
         subject_path: Optional[List[str]] = None,
         select_fields: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
-        return self.storage.search_all_metrics(
+        fields, strip_internal_id = self._selected_fields_with_provenance_id(select_fields)
+        results = self.storage.search_all_metrics(
             subject_path=subject_path,
-            select_fields=select_fields,
+            select_fields=fields,
             extra_conditions=self._sub_agent_conditions(),
         )
+        return self._enrich_metric_results(results, strip_internal_id)
 
     def after_init(self):
         self.storage.create_indices()
@@ -555,21 +584,23 @@ class MetricRAG:
         self, query_text: str, subject_path: Optional[List[str]] = None, top_n: int = 5
     ) -> List[Dict[str, Any]]:
         """Search metrics by query text with optional subject path filtering."""
-        return self.storage.search_metrics(
+        results = self.storage.search_metrics(
             query_text=query_text,
             subject_path=subject_path,
             top_n=top_n,
             extra_conditions=self._sub_agent_conditions(),
         )
+        return self._enrich_metric_results(results)
 
     def get_metrics_detail(self, subject_path: List[str], name: str) -> List[Dict[str, Any]]:
         """Get metrics detail by subject path and name."""
         full_path = subject_path.copy()
         full_path.append(name)
-        return self.storage.search_all_metrics(
+        results = self.storage.search_all_metrics(
             subject_path=full_path,
             extra_conditions=self._sub_agent_conditions(),
         )
+        return self._enrich_metric_results(results)
 
     def create_indices(self):
         """Create indices for metric storage."""

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -638,6 +638,31 @@ class TestMetricProvenanceHelpers:
         assert written == 1
         assert found["metric:Sales.activity_count"]["source_context_ids"] == ["metric:seed:0"]
 
+    def test_sync_metric_provenance_skips_ambiguous_multi_source_batch(self, tmp_path):
+        from types import SimpleNamespace
+
+        from datus.storage.knowledge_provenance import METRIC_ARTIFACT_TYPE, KnowledgeProvenanceStore
+
+        config = SimpleNamespace(
+            knowledge_base={"provenance": {"enabled": True}},
+            path_manager=SimpleNamespace(project_data_dir=tmp_path),
+        )
+
+        written = _sync_metric_provenance(
+            config,
+            ["metric:Sales.activity_count"],
+            [
+                {"source_id": "seed_context.csv:0", "source_context_ids": ["metric:seed:0"]},
+                {"source_id": "seed_context.csv:1", "source_context_ids": ["metric:seed:1"]},
+            ],
+        )
+
+        found = KnowledgeProvenanceStore(config).find_by_artifact_ids(
+            METRIC_ARTIFACT_TYPE, ["metric:Sales.activity_count"]
+        )
+        assert written == 0
+        assert found == {}
+
 
 # ---------------------------------------------------------------------------
 # DEFAULT_METRICS_BATCH_SIZE constant

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -13,7 +13,10 @@ from datus.storage.metric.metric_init import (
     BIZ_NAME,
     DEFAULT_METRICS_BATCH_SIZE,
     _action_status_value,
+    _extract_metric_artifact_ids,
     _generate_metrics_batch,
+    _source_provenance_from_row,
+    _sync_metric_provenance,
     init_semantic_yaml_metrics,
 )
 
@@ -562,6 +565,81 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
 
 
 # ---------------------------------------------------------------------------
+# provenance helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestMetricProvenanceHelpers:
+    def test_source_provenance_from_row_reads_context_columns(self):
+        row = {
+            "source_context_id": "metric:seed:7; metric:task:21",
+            "source_id": "seed_context.csv:7",
+            "source_metadata": '{"task_id": "21"}',
+            "question": "delivery activities",
+        }
+
+        result = _source_provenance_from_row(row, 7, "/tmp/seed_context.csv")
+
+        assert result == {
+            "source_id": "seed_context.csv:7",
+            "source_type": "success_story",
+            "source_context_ids": ["metric:seed:7", "metric:task:21"],
+            "source_metadata": {
+                "task_id": "21",
+                "source_id": "seed_context.csv:7",
+                "source_type": "success_story",
+                "row_index": 7,
+                "question": "delivery activities",
+            },
+        }
+
+    def test_extract_metric_artifact_ids_recurses_nested_tool_result(self):
+        payload = {
+            "result": {
+                "sync": {
+                    "metric_artifact_ids": ["metric:Sales.activity_count", "metric:Sales.activity_count"],
+                }
+            }
+        }
+
+        assert _extract_metric_artifact_ids(payload) == ["metric:Sales.activity_count"]
+
+    def test_extract_metric_artifact_ids_reads_synced_field(self):
+        payload = {"_synced_metric_artifact_ids": ["metric:Sales.activity_count"]}
+
+        assert _extract_metric_artifact_ids(payload) == ["metric:Sales.activity_count"]
+
+    def test_sync_metric_provenance_writes_sidecar(self, tmp_path):
+        from types import SimpleNamespace
+
+        from datus.storage.knowledge_provenance import METRIC_ARTIFACT_TYPE, KnowledgeProvenanceStore
+
+        config = SimpleNamespace(
+            knowledge_base={"provenance": {"enabled": True}},
+            path_manager=SimpleNamespace(project_data_dir=tmp_path),
+        )
+
+        written = _sync_metric_provenance(
+            config,
+            ["metric:Sales.activity_count"],
+            [
+                {
+                    "source_id": "seed_context.csv:0",
+                    "source_context_ids": ["metric:seed:0"],
+                    "source_metadata": {"row_index": 0},
+                }
+            ],
+        )
+
+        found = KnowledgeProvenanceStore(config).find_by_artifact_ids(
+            METRIC_ARTIFACT_TYPE, ["metric:Sales.activity_count"]
+        )
+        assert written == 1
+        assert found["metric:Sales.activity_count"]["source_context_ids"] == ["metric:seed:0"]
+
+
+# ---------------------------------------------------------------------------
 # DEFAULT_METRICS_BATCH_SIZE constant
 # ---------------------------------------------------------------------------
 
@@ -622,6 +700,55 @@ class TestGenerateMetricsBatch:
         assert ok is True
         assert err == ""
         assert result == {"metrics": ["revenue"]}
+
+    @pytest.mark.asyncio
+    async def test_success_captures_synced_metric_artifact_ids(self):
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.schemas.batch_events import BatchEventHelper
+
+        mock_node = MagicMock()
+
+        async def fake_stream(_ahm):
+            tool_action = MagicMock()
+            tool_action.status = ActionStatus.SUCCESS
+            tool_action.action_type = "end_metric_generation"
+            tool_action.output = {"result": {"sync": {"metric_artifact_ids": ["metric:Sales.activity_count"]}}}
+            tool_action.messages = "published"
+            yield tool_action
+
+            final_action = MagicMock()
+            final_action.status = ActionStatus.SUCCESS
+            final_action.action_type = "gen_metrics_response"
+            final_action.output = {"metrics": ["activity_count"]}
+            final_action.messages = "ok"
+            yield final_action
+
+        mock_node.execute_stream = fake_stream
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
+        ):
+            ok, err, result = await _generate_metrics_batch(
+                ["Query 1:\nQuestion: rev?\nSQL:\nSELECT 1"],
+                0,
+                mock_config,
+                None,
+                None,
+                BatchEventHelper("test", None),
+                None,
+            )
+
+        assert ok is True
+        assert err == ""
+        assert result["_synced_metric_artifact_ids"] == ["metric:Sales.activity_count"]
 
     @pytest.mark.asyncio
     async def test_terminal_error_returns_failure(self):

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -655,3 +655,64 @@ class TestSyncYamlSubjectTreeForSubtree:
 
         # Should not raise
         metric_storage.sync_yaml_subject_tree_for_subtree(node["node_id"])
+
+
+# ---------------------------------------------------------------------------
+# MetricRAG provenance enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestMetricRAGProvenance:
+    def _rag(self, tmp_path, enabled=True):
+        from types import SimpleNamespace
+
+        from datus.storage.metric.store import MetricRAG
+
+        config = SimpleNamespace(
+            knowledge_base={"provenance": {"enabled": enabled}},
+            path_manager=SimpleNamespace(project_data_dir=tmp_path),
+        )
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.agent_config = config
+        rag._provenance_enabled = enabled
+        return rag, config
+
+    def test_selected_fields_adds_internal_id_only_when_needed(self, tmp_path):
+        rag, _ = self._rag(tmp_path, enabled=True)
+
+        assert rag._selected_fields_with_provenance_id(None) == (None, False)
+        assert rag._selected_fields_with_provenance_id(["name", "id"]) == (["name", "id"], False)
+        assert rag._selected_fields_with_provenance_id(["name"]) == (["name", "id"], True)
+
+        disabled, _ = self._rag(tmp_path, enabled=False)
+        assert disabled._selected_fields_with_provenance_id(["name"]) == (["name"], False)
+
+    def test_enrich_metric_results_adds_provenance_and_strips_internal_id(self, tmp_path):
+        from datus.storage.knowledge_provenance import KnowledgeProvenanceStore, build_metric_provenance_rows
+
+        rag, config = self._rag(tmp_path, enabled=True)
+        KnowledgeProvenanceStore(config).upsert_many(
+            build_metric_provenance_rows(
+                [
+                    {
+                        "id": "metric:Sales.activity_count",
+                        "source_id": "seed_context.csv:0",
+                        "source_context_id": "metric:seed:0",
+                    }
+                ]
+            )
+        )
+
+        result = rag._enrich_metric_results(
+            [{"id": "metric:Sales.activity_count", "name": "activity_count"}],
+            strip_internal_id=True,
+        )
+
+        assert result == [
+            {
+                "name": "activity_count",
+                "source_ids": ["seed_context.csv:0"],
+                "source_context_ids": ["metric:seed:0"],
+                "source_metadata": [],
+            }
+        ]

--- a/tests/unit_tests/storage/test_knowledge_provenance.py
+++ b/tests/unit_tests/storage/test_knowledge_provenance.py
@@ -5,9 +5,12 @@
 from types import SimpleNamespace
 
 from datus.storage.knowledge_provenance import (
+    METRIC_ARTIFACT_TYPE,
     REFERENCE_SQL_ARTIFACT_TYPE,
     KnowledgeProvenanceStore,
+    build_metric_provenance_rows,
     build_reference_sql_provenance_rows,
+    enrich_metric_results,
     enrich_reference_sql_results,
     is_knowledge_provenance_enabled,
     reference_sql_artifact_ids_for_items,
@@ -154,3 +157,39 @@ def test_replace_for_artifact_ids_deletes_when_current_rows_are_empty(tmp_path):
 
     assert store.replace_for_artifact_ids(REFERENCE_SQL_ARTIFACT_TYPE, [artifact_id], []) == 0
     assert store.find_by_artifact_ids(REFERENCE_SQL_ARTIFACT_TYPE, [artifact_id]) == {}
+
+
+def test_metric_provenance_sidecar_enriches_results(tmp_path):
+    config = _config(tmp_path, enabled=True)
+    rows = build_metric_provenance_rows(
+        [
+            {
+                "id": "metric:Sales.activity_count",
+                "source_id": "seed_context.csv:7",
+                "source_context_ids": ["metric:seed:7", "metric:task:21"],
+                "source_type": "success_story",
+                "source_metadata": {"row_index": 7},
+            }
+        ]
+    )
+
+    written = KnowledgeProvenanceStore(config).upsert_many(rows)
+    enriched = enrich_metric_results(config, [{"id": "metric:Sales.activity_count", "name": "activity_count"}])
+
+    assert written == 2
+    assert enriched[0]["source_ids"] == ["seed_context.csv:7"]
+    assert enriched[0]["source_context_ids"] == ["metric:seed:7", "metric:task:21"]
+    assert enriched[0]["source_metadata"] == [{"row_index": 7}]
+
+
+def test_delete_for_artifact_type_only_removes_matching_type(tmp_path):
+    config = _config(tmp_path, enabled=True)
+    store = KnowledgeProvenanceStore(config)
+    store.upsert_many(
+        build_reference_sql_provenance_rows([{"sql": "SELECT 1", "source_context_id": "refsql:task:0"}])
+        + build_metric_provenance_rows([{"id": "metric:Sales.activity_count", "source_context_id": "metric:seed:0"}])
+    )
+
+    assert store.delete_for_artifact_type(METRIC_ARTIFACT_TYPE) == 1
+    assert store.find_by_artifact_ids(METRIC_ARTIFACT_TYPE, ["metric:Sales.activity_count"]) == {}
+    assert store.find_by_artifact_ids(REFERENCE_SQL_ARTIFACT_TYPE, [gen_reference_sql_id("SELECT 1")])


### PR DESCRIPTION
Summary
- Add metrics provenance sidecar support keyed by generated metric artifact IDs.
- Enrich metric search/detail results with source_context_ids when provenance is enabled.
- Sync metric provenance from bootstrap success-story rows when source context metadata is provided.

Validation
- uv run ruff check datus/storage/knowledge_provenance.py datus/storage/metric/metric_init.py datus/storage/metric/store.py datus/cli/generation_hooks.py tests/unit_tests/storage/test_knowledge_provenance.py tests/unit_tests/storage/metric/test_store.py tests/unit_tests/storage/metric/test_metric_init.py
- uv run pytest tests/unit_tests/storage/test_knowledge_provenance.py tests/unit_tests/storage/metric/test_store.py::TestMetricRAGProvenance tests/unit_tests/storage/metric/test_metric_init.py -q

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
## Summary by CodeRabbit

* **New Features**
  * Extended provenance tracking to support metric-based data lineage alongside existing reference flows
  * Metric search results now enriched with source tracking and metadata information when provenance is enabled
  * Added capability to manage and query metric provenance artifacts

* **Tests**
  * Added comprehensive test coverage for metric provenance helpers, initialization, and search enrichment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provenance tracking extended to include metric-based lineage alongside existing reference flows
  * Metric search and detail results can be enriched with source IDs, context IDs, and source metadata when provenance is enabled
  * Sync operations now surface linked metric artifact IDs in success responses; provenance entries can be cleared or upserted per update mode

* **Tests**
  * Added comprehensive tests for metric provenance helpers, initialization, syncing, and search enrichment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->