### PR TITLE
[BugFix] Fix impacted unit target normalization

### DIFF
--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -176,6 +176,32 @@ def _dedupe_preserve(items: list[str]) -> list[str]:
     return ordered
 
 
+def _is_target_under_dir(target: str, parent_dir: str) -> bool:
+    child = _normalize_path(target).rstrip("/")
+    parent = _normalize_path(parent_dir).rstrip("/")
+    return bool(parent and child != parent and child.startswith(f"{parent}/"))
+
+
+def _collapse_contained_test_targets(targets: list[str]) -> list[str]:
+    """Drop explicit child targets when a parent directory target already covers them.
+
+    Passing both a test directory and files under that directory to pytest can
+    unexpectedly narrow collection to the explicit children. Keep the broadest
+    target so impacted-suite coverage matches the source-to-test mapping.
+    """
+    deduped = _dedupe_preserve(targets)
+    parent_dirs = [target for target in deduped if target.endswith("/")]
+    if not parent_dirs:
+        return deduped
+
+    collapsed: list[str] = []
+    for target in deduped:
+        if any(_is_target_under_dir(target, parent_dir) for parent_dir in parent_dirs):
+            continue
+        collapsed.append(target)
+    return collapsed
+
+
 def _remove_output_path(path: str) -> None:
     if os.path.isdir(path):
         shutil.rmtree(path, ignore_errors=True)
@@ -409,7 +435,7 @@ def select_impacted_unit_tests(changed_files: list[str]) -> list[str]:
                 impacted.append(test_target)
                 break
 
-    return _dedupe_preserve(impacted)
+    return _collapse_contained_test_targets(impacted)
 
 
 def _filter_existing_paths(paths: list[str]) -> list[str]:
@@ -426,7 +452,7 @@ def _filter_existing_paths(paths: list[str]) -> list[str]:
                 existing.append(path)
         elif os.path.exists(path):
             existing.append(path)
-    return existing
+    return _collapse_contained_test_targets(existing)
 
 
 def _git_ref_exists(ref: str) -> bool:

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -521,13 +521,16 @@ class MetricRAG:
     def _selected_fields_with_provenance_id(
         self, selected_fields: Optional[List[str]]
     ) -> tuple[Optional[List[str]], bool]:
-        if not self._provenance_enabled or selected_fields is None or "id" in selected_fields:
+        if not getattr(self, "_provenance_enabled", False) or selected_fields is None or "id" in selected_fields:
             return selected_fields, False
         return [*selected_fields, "id"], True
 
     def _enrich_metric_results(
         self, results: List[Dict[str, Any]], strip_internal_id: bool = False
     ) -> List[Dict[str, Any]]:
+        if not getattr(self, "_provenance_enabled", False):
+            return results
+
         enriched = enrich_metric_results(self.agent_config, results)
         if not strip_internal_id:
             return enriched

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -23,11 +23,7 @@ def test_select_impacted_unit_tests_maps_source_prefixes():
         ]
     )
 
-    assert impacted == [
-        "tests/unit_tests/agent/",
-        "tests/unit_tests/storage/",
-        "tests/unit_tests/",
-    ]
+    assert impacted == ["tests/unit_tests/"]
 
 
 def test_select_impacted_unit_tests_includes_changed_unit_tests_and_dedupes():
@@ -41,10 +37,23 @@ def test_select_impacted_unit_tests_includes_changed_unit_tests_and_dedupes():
     )
 
     assert impacted == [
-        "tests/unit_tests/tools/test_registry.py",
         "tests/unit_tests/tools/",
         "tests/unit_tests/ci/",
     ]
+
+
+def test_select_impacted_unit_tests_collapses_parent_directory_over_child_files():
+    impacted = run_pr_tests.select_impacted_unit_tests(
+        [
+            "datus/storage/knowledge_provenance.py",
+            "datus/storage/metric/store.py",
+            "tests/unit_tests/storage/metric/test_metric_init.py",
+            "tests/unit_tests/storage/metric/test_store.py",
+            "tests/unit_tests/storage/test_knowledge_provenance.py",
+        ]
+    )
+
+    assert impacted == ["tests/unit_tests/storage/"]
 
 
 def test_select_impacted_unit_tests_maps_db_tools_to_db_tools_tests():


### PR DESCRIPTION
## Summary
- Collapse impacted pytest child targets when a parent directory target already covers them.
- Add regression coverage for the #927 storage changed-files shape so PR CI runs the full storage unit slice.
- Make MetricRAG provenance enrichment a no-op when provenance is disabled or not initialized, fixing legacy PyArrow unit construction.

## Validation
- uv run ruff check ci/run-pr-tests.py datus/storage/metric/store.py tests/unit_tests/ci/test_run_pr_tests.py
- uv run pytest tests/unit_tests/ci/test_run_pr_tests.py -q
- uv run pytest tests/unit_tests/storage/test_storage_integration_pyarrow.py -q
- uv run pytest tests/unit_tests/storage/metric/test_store.py::TestMetricRAGProvenance -q
- uv run python ci/run-pr-tests.py upstream/main

Closes #927 follow-up.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of metric result enrichment when handling optional configuration settings that may not be initialized.

* **Chores**
  * Optimized continuous integration test target filtering to reduce redundant test specifications.
  * Enhanced unit test coverage for test selection and filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->