### PR TITLE
[BugFix] Separate benchmark datasource from SQL context

### DIFF
--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -153,7 +153,10 @@ def log(msg: str) -> None:
     print(f"[ci] {msg}", flush=True)
 
 
-TEST_CMD_TIMEOUT = int(os.environ.get("TEST_CMD_TIMEOUT", "1800"))
+TEST_CMD_TIMEOUT = int(os.environ.get("TEST_CMD_TIMEOUT", "3600"))
+# Worker count for the impacted full unit suite (pytest-xdist). Kept low because
+# CI runners are modest; override via env if a beefier runner is used.
+IMPACTED_UNIT_PARALLEL_WORKERS = os.environ.get("IMPACTED_UNIT_PARALLEL_WORKERS", "2")
 GIT_CMD_TIMEOUT = int(os.environ.get("GIT_CMD_TIMEOUT", "60"))
 DIFF_COVER_TIMEOUT = int(os.environ.get("DIFF_COVER_TIMEOUT", "300"))
 _COMPARE_BRANCH_CACHE: dict[str, str | None] = {}
@@ -332,6 +335,7 @@ def _build_pytest_command(
     append: bool = False,
     emit_reports: bool = True,
     basetemp: str | None = None,
+    parallel: bool = False,
 ) -> list[str]:
     cmd = [
         sys.executable,
@@ -344,6 +348,12 @@ def _build_pytest_command(
 
     if mark_expr:
         cmd.extend(["-m", mark_expr])
+
+    if parallel:
+        # Distribute the suite across a few pytest-xdist workers so the full unit
+        # run stays under TEST_CMD_TIMEOUT; pytest-cov merges per-worker data.
+        # Worker count stays low (default 2) because CI runners are modest.
+        cmd.extend(["-n", IMPACTED_UNIT_PARALLEL_WORKERS])
 
     cmd.append("--cov=datus")
     if append:
@@ -382,6 +392,7 @@ def _run_pytest_suite(
     mark_expr: str | None = None,
     append: bool = False,
     emit_reports: bool = True,
+    parallel: bool = False,
 ) -> int:
     """Run one pytest suite and stream logs to stdout and the CI log file."""
     basetemp = _suite_pytest_basetemp(suite_name)
@@ -393,6 +404,7 @@ def _run_pytest_suite(
         append=append,
         emit_reports=emit_reports,
         basetemp=basetemp,
+        parallel=parallel,
     )
     log(f"Running {suite_name}: {' '.join(cmd)}")
     log(f"{suite_name} pytest basetemp: {basetemp}")
@@ -706,6 +718,7 @@ def run_tests(base_ref: str = "") -> tuple[int, list[str]]:
                     mark_expr=IMPACTED_UNIT_MARK_EXPR,
                     append=True,
                     emit_reports=True,
+                    parallel=True,
                 )
                 exit_codes.append(
                     _normalize_suite_exit_code(

--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -738,7 +738,7 @@ class Agent:
     def do_benchmark(
         self, benchmark_platform: str, target_task_ids: Optional[Set[str]] = None, run_id: Optional[str] = None
     ):
-        db_manager = db_manager_instance(self.global_config.datasource_configs)
+        db_manager = self.db_manager
         default_datasource = self.global_config.current_datasource
         self.check_db()
 

--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -49,6 +49,49 @@ from datus.utils.traceable_utils import optional_traceable
 logger = get_logger(__name__)
 
 
+def _task_item_value(task_item: Dict[str, Any], key: Optional[str]) -> str:
+    if not key:
+        return ""
+    value = task_item.get(key)
+    return "" if value is None else str(value).strip()
+
+
+def _connector_context(conn: Any) -> Dict[str, str]:
+    context: Dict[str, Any] = {}
+    get_current_context = getattr(conn, "get_current_context", None)
+    if callable(get_current_context):
+        try:
+            context = get_current_context() or {}
+        except Exception as exc:  # pragma: no cover - defensive logging only
+            logger.warning(f"Failed to resolve connector context: {exc}")
+
+    return {
+        "catalog_name": str(
+            context["catalog_name"] if "catalog_name" in context else getattr(conn, "catalog_name", "") or ""
+        ),
+        "database_name": str(
+            context["database_name"] if "database_name" in context else getattr(conn, "database_name", "") or ""
+        ),
+        "schema_name": str(
+            context["schema_name"] if "schema_name" in context else getattr(conn, "schema_name", "") or ""
+        ),
+    }
+
+
+def _resolve_benchmark_sql_context(
+    benchmark_config: BenchmarkConfig,
+    task_item: Dict[str, Any],
+    conn: Any,
+) -> Dict[str, str]:
+    connector_context = _connector_context(conn)
+    return {
+        "catalog_name": _task_item_value(task_item, benchmark_config.catalog_key) or connector_context["catalog_name"],
+        "database_name": _task_item_value(task_item, benchmark_config.database_key)
+        or connector_context["database_name"],
+        "schema_name": _task_item_value(task_item, benchmark_config.schema_key) or connector_context["schema_name"],
+    }
+
+
 class Agent:
     """
     Main entry point for the SQL Agent system.
@@ -695,9 +738,8 @@ class Agent:
     def do_benchmark(
         self, benchmark_platform: str, target_task_ids: Optional[Set[str]] = None, run_id: Optional[str] = None
     ):
-        _, conn = db_manager_instance(self.global_config.datasource_configs).first_conn_with_name(
-            self.global_config.current_datasource
-        )
+        db_manager = db_manager_instance(self.global_config.datasource_configs)
+        default_datasource = self.global_config.current_datasource
         self.check_db()
 
         def run_single_task(task_id: str, benchmark_config: BenchmarkConfig, task_item: Dict[str, Any]):
@@ -709,8 +751,18 @@ class Agent:
                     "please check your benchmark configuration."
                 )
                 return task_id, ""
-            database_name = task_item.get(benchmark_config.db_key) or conn.database_name or ""
+            task_datasource = _task_item_value(task_item, benchmark_config.datasource_key) or default_datasource
+            _, task_conn = db_manager.first_conn_with_name(task_datasource)
+            sql_context = _resolve_benchmark_sql_context(benchmark_config, task_item, task_conn)
             logger.info(f"start benchmark with {task_id}: {task}")
+            logger.debug(
+                "Benchmark SQL context for %s: datasource=%s catalog=%s database=%s schema=%s",
+                task_id,
+                task_datasource,
+                sql_context["catalog_name"],
+                sql_context["database_name"],
+                sql_context["schema_name"],
+            )
             use_tables = None if not benchmark_config.use_tables_key else task_item.get(benchmark_config.use_tables_key)
 
             # Use hierarchical save directory structure
@@ -722,7 +774,7 @@ class Agent:
                 task_id=task_id,
                 workflow=getattr(self.args, "workflow", None),
                 context_type=getattr(self.args, "context_type", None),
-                datasource=self.global_config.current_datasource,
+                datasource=task_datasource,
                 agent_home=self.global_config.home,
                 extra={
                     "max_steps": getattr(self.args, "max_steps", None),
@@ -733,9 +785,12 @@ class Agent:
                 result = self.run(
                     SqlTask(
                         id=task_id,
-                        database_type=conn.dialect,
+                        datasource=task_datasource,
+                        database_type=task_conn.dialect,
                         task=task,
-                        database_name=database_name,
+                        catalog_name=sql_context["catalog_name"],
+                        database_name=sql_context["database_name"],
+                        schema_name=sql_context["schema_name"],
                         output_dir=output_dir,
                         current_date=self.args.current_date,
                         tables=use_tables,

--- a/datus/agent/workflow.py
+++ b/datus/agent/workflow.py
@@ -516,7 +516,14 @@ class Workflow:
 
         return workflow
 
+    def _task_datasource(self) -> str:
+        if self.task and self.task.datasource:
+            return self.task.datasource
+        if self._global_config and self._global_config.current_datasource:
+            return self._global_config.current_datasource
+        return ""
+
     def _init_tools(self):
         from datus.tools.func_tool import db_function_tools
 
-        self.tools = db_function_tools(self._global_config, self.task.database_name)
+        self.tools = db_function_tools(self._global_config, self._task_datasource())

--- a/datus/api/service.py
+++ b/datus/api/service.py
@@ -116,6 +116,7 @@ class DatusAPIService:
 
         return SqlTask(
             id=task_id,
+            datasource=request.datasource,
             task=request.task,
             catalog_name=request.catalog_name or "",
             database_name=request.database_name or "default",

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -376,7 +376,10 @@ class BenchmarkConfig:
     question_file: str = ""  # The corresponding task file can be csv/json/json
     question_key: str = ""  # The key corresponding to question
     question_id_key: str = ""  # If empty, use the line number
-    db_key: str | None = None  # The key corresponding to database name
+    datasource_key: str | None = None  # The key corresponding to Datus datasource routing name
+    catalog_key: str | None = None  # The key corresponding to SQL catalog name
+    database_key: str | None = None  # The key corresponding to SQL database name
+    schema_key: str | None = None  # The key corresponding to SQL schema name
     ext_knowledge_key: str | None = None  # The key corresponding to external knowledge
     use_tables_key: str | None = None  # The key corresponding to the table to be used
 
@@ -1545,7 +1548,7 @@ class AgentConfig:
                 question_file="spider2-snow.jsonl",
                 question_id_key="instance_id",
                 question_key="instruction",
-                db_key="db_id",
+                database_key="db_id",
                 ext_knowledge_key="",
                 gold_sql_path="evaluation_suite/gold/sql",
                 gold_result_path="evaluation_suite/gold/exec_result",
@@ -1555,7 +1558,7 @@ class AgentConfig:
                 question_file="dev.json",
                 question_id_key="question_id",
                 question_key="question",
-                db_key="db_id",
+                database_key="db_id",
                 ext_knowledge_key="evidence",
                 gold_sql_path="dev.json",
                 gold_sql_key="SQL",

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -395,6 +395,13 @@ class BenchmarkConfig:
     @staticmethod
     def filter_kwargs(cls, kwargs: dict) -> "BenchmarkConfig":
         valid_fields = {f.name for f in fields(cls)}
+        unknown = set(kwargs) - valid_fields
+        if unknown:
+            logger.warning(
+                "Ignoring unknown benchmark config key(s): %s. Note: 'db_key' was split into "
+                "'datasource_key'/'database_key'/'catalog_key'/'schema_key'; update your config accordingly.",
+                ", ".join(sorted(unknown)),
+            )
         return cls(**{k: v for k, v in kwargs.items() if k in valid_fields})
 
     def validate(self):

--- a/datus/main.py
+++ b/datus/main.py
@@ -533,6 +533,7 @@ def main():
             result = agent.run(
                 SqlTask(
                     id=task_id,
+                    datasource=agent_config.current_datasource,
                     database_type=db_type,
                     catalog_name=args.task_catalog,
                     database_name=db_name,

--- a/datus/schemas/node_models.py
+++ b/datus/schemas/node_models.py
@@ -31,6 +31,7 @@ class SqlTask(BaseModel):
     """
 
     id: str = Field(default="", description="The id of the task")
+    datasource: str = Field(default="", description="Datus datasource routing key")
     database_type: str = Field(default="", description="Type of the database (e.g., sqlite, duckdb, snowflake)")
     task: str = Field(default="", description="The SQL task description or query")
     catalog_name: str = Field(default="", description="Catalog name for context")

--- a/datus/utils/benchmark_utils.py
+++ b/datus/utils/benchmark_utils.py
@@ -613,14 +613,14 @@ class SingleFileGoldProvider(ResultProvider):
         task_id_key: str = "task_id",
         sql_key: str = "",
         query_result_key: str = "",
-        db_key: str = "",
+        database_key: str = "",
         allowed_task_ids: Optional[Iterable[str]] = None,
         frame_cache_size: int = 32,
     ):
         self.task_id_key = task_id_key
         self.query_result_key = query_result_key
         self.sql_key = sql_key
-        self.db_key = db_key
+        self.database_key = database_key
         self.result_file = Path(result_file)
         self.connections = connections
         self.allowed_task_ids = {str(task_id) for task_id in allowed_task_ids} if allowed_task_ids else None
@@ -781,7 +781,7 @@ class SingleFileGoldProvider(ResultProvider):
             if not sql_text:
                 self._errors[task_id] = f"Missing `{self.sql_key or self.query_result_key}` value"
                 return
-            db_name = str(row.get(self.db_key, "") or "").strip()
+            db_name = str(row.get(self.database_key, "") or "").strip()
             self._sql_tasks[task_id] = (sql_text, db_name)
 
         self._store_artifacts(task_id, row)
@@ -2051,7 +2051,7 @@ def _build_gold_result_provider(
     task_id_key = config.question_id_key or "_task_id"
     sql_key = config.gold_sql_key or ""
     query_result_key = config.gold_result_key or ""
-    db_key = config.db_key or ""
+    database_key = config.database_key or ""
 
     if result_path is None:
         gold_sql_path = _resolve_optional_path(base_path, config.gold_sql_path)
@@ -2085,7 +2085,7 @@ def _build_gold_result_provider(
         task_id_key=task_id_key,
         sql_key=sql_key,
         query_result_key=query_result_key,
-        db_key=db_key,
+        database_key=database_key,
         allowed_task_ids=allowed_task_ids,
     )
 

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -72,6 +72,10 @@ class TestTaskItemValue:
     def test_returns_empty_string_when_key_is_none(self):
         assert _task_item_value({"a": "1"}, None) == ""
 
+    def test_returns_empty_string_when_key_is_empty(self):
+        # An empty-string key is falsy too (e.g. an unset benchmark default key).
+        assert _task_item_value({"a": "1"}, "") == ""
+
     def test_returns_empty_string_when_value_missing(self):
         assert _task_item_value({}, "missing") == ""
 

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from datus.agent.agent import Agent, _print_platform_doc_result, bootstrap_platform_doc
+from datus.agent.agent import Agent, _print_platform_doc_result, _task_item_value, bootstrap_platform_doc
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.schemas.batch_events import BatchEvent, BatchStage
 from datus.schemas.node_models import SqlTask
@@ -64,6 +64,23 @@ class _FakeInitResult:
         self.duration_seconds = duration_seconds
         self.version_details = version_details
         self.errors = errors or []
+
+
+class TestTaskItemValue:
+    """Tests for the _task_item_value helper in datus.agent.agent."""
+
+    def test_returns_empty_string_when_key_is_none(self):
+        assert _task_item_value({"a": "1"}, None) == ""
+
+    def test_returns_empty_string_when_value_missing(self):
+        assert _task_item_value({}, "missing") == ""
+
+    def test_returns_empty_string_when_value_is_none(self):
+        assert _task_item_value({"a": None}, "a") == ""
+
+    def test_returns_stripped_string_value(self):
+        assert _task_item_value({"a": "  hello  "}, "a") == "hello"
+        assert _task_item_value({"a": 42}, "a") == "42"
 
 
 class TestPrintPlatformDocResult:

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -571,7 +571,7 @@ def _make_agent_config_ext(datasource="test_ns"):
     cfg.benchmark_config.return_value = MagicMock(
         question_id_key="task_id",
         question_key="question",
-        db_key="db",
+        database_key="db",
         use_tables_key=None,
         ext_knowledge_key=None,
     )

--- a/tests/unit_tests/agent/test_benchmark_sql_context.py
+++ b/tests/unit_tests/agent/test_benchmark_sql_context.py
@@ -1,0 +1,55 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from datus.agent.agent import _resolve_benchmark_sql_context
+from datus.configuration.agent_config import BenchmarkConfig
+
+
+class _Connector:
+    catalog_name = "connector_catalog"
+    database_name = "connector_database"
+    schema_name = "connector_schema"
+
+    def get_current_context(self):
+        return {
+            "catalog_name": "default_catalog",
+            "database_name": "ac_manage",
+            "schema_name": "",
+        }
+
+
+def test_resolve_benchmark_sql_context_uses_explicit_coordinate_keys():
+    cfg = BenchmarkConfig(
+        catalog_key="__datus_catalog",
+        database_key="__datus_database",
+        schema_key="__datus_schema",
+    )
+    row = {
+        "__datus_datasource": "starrocks",
+        "__datus_catalog": "custom_catalog",
+        "__datus_database": "analytics",
+        "__datus_schema": "public",
+    }
+
+    assert _resolve_benchmark_sql_context(cfg, row, _Connector()) == {
+        "catalog_name": "custom_catalog",
+        "database_name": "analytics",
+        "schema_name": "public",
+    }
+
+
+def test_resolve_benchmark_sql_context_falls_back_to_connector_context():
+    cfg = BenchmarkConfig(
+        datasource_key="__datus_datasource",
+        catalog_key="__datus_catalog",
+        database_key="__datus_database",
+        schema_key="__datus_schema",
+    )
+    row = {"__datus_datasource": "starrocks"}
+
+    assert _resolve_benchmark_sql_context(cfg, row, _Connector()) == {
+        "catalog_name": "default_catalog",
+        "database_name": "ac_manage",
+        "schema_name": "",
+    }

--- a/tests/unit_tests/agent/test_workflow.py
+++ b/tests/unit_tests/agent/test_workflow.py
@@ -140,6 +140,22 @@ class TestWorkflowNode:
 class TestWorkflow:
     """Test suite for the Workflow class."""
 
+    def test_init_tools_uses_task_datasource_not_database_name(self, monkeypatch, real_agent_config):
+        captured = {}
+
+        def fake_db_function_tools(agent_config, database_name="", sub_agent_name=None):
+            captured["datasource"] = database_name
+            return []
+
+        monkeypatch.setattr("datus.tools.func_tool.db_function_tools", fake_db_function_tools)
+        Workflow(
+            name="test_workflow",
+            task=SqlTask(task="query", datasource="starrocks", database_name="ac_manage"),
+            agent_config=real_agent_config,
+        )
+
+        assert captured["datasource"] == "starrocks"
+
     def test_create_default_workflow(self, real_agent_config):
         """Test the default workflow creation with core nodes using plan._create_default_workflow."""
 

--- a/tests/unit_tests/agent/test_workflow.py
+++ b/tests/unit_tests/agent/test_workflow.py
@@ -617,3 +617,29 @@ class TestWorkflowDisplay:
             wf.display()
         assert mock_log.call_count == 3
         assert wf.node_order == ["n0"]
+
+
+# ---------------------------------------------------------------------------
+# _task_datasource resolution
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowTaskDatasource:
+    @staticmethod
+    def _workflow_with_task(task):
+        with patch.object(Workflow, "_init_tools", lambda self: setattr(self, "tools", [])):
+            return Workflow(name="wf", task=task, agent_config=None)
+
+    def test_returns_task_datasource_when_set(self):
+        wf = self._workflow_with_task(SqlTask(task="t", datasource="starrocks"))
+        assert wf._task_datasource() == "starrocks"
+
+    def test_falls_back_to_global_config_current_datasource(self):
+        wf = self._workflow_with_task(SqlTask(task="t", datasource=""))
+        wf._global_config = MagicMock(current_datasource="duckdb")
+        assert wf._task_datasource() == "duckdb"
+
+    def test_returns_empty_when_no_datasource_anywhere(self):
+        wf = self._workflow_with_task(SqlTask(task="t", datasource=""))
+        wf._global_config = None
+        assert wf._task_datasource() == ""

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -337,10 +337,18 @@ class TestBenchmarkConfigValidate:
             "question_key": "q",
             "question_file": "f.json",
             "question_id_key": "id",
+            "datasource_key": "__datus_datasource",
+            "catalog_key": "__datus_catalog",
+            "database_key": "__datus_database",
+            "schema_key": "__datus_schema",
             "unknown_field": "ignored",
         }
         cfg = BenchmarkConfig.filter_kwargs(BenchmarkConfig, data)
         assert cfg.question_key == "q"
+        assert cfg.datasource_key == "__datus_datasource"
+        assert cfg.catalog_key == "__datus_catalog"
+        assert cfg.database_key == "__datus_database"
+        assert cfg.schema_key == "__datus_schema"
         assert not hasattr(cfg, "unknown_field")
 
 

--- a/tests/unit_tests/schemas/test_node_models.py
+++ b/tests/unit_tests/schemas/test_node_models.py
@@ -39,6 +39,7 @@ class TestNodeModelsSqlTask:
     def test_default_values(self):
         task = SqlTask(task="count rows")
         assert task.id == ""
+        assert task.datasource == ""
         assert task.database_type == ""
         assert task.catalog_name == ""
         assert task.output_dir == "output"
@@ -46,6 +47,12 @@ class TestNodeModelsSqlTask:
         assert task.schema_linking_type == "table"
         assert task.current_date is None
         assert task.subject_path is None
+
+    def test_datasource_is_distinct_from_database_name(self):
+        task = SqlTask(task="query", datasource="starrocks", database_name="ac_manage")
+        assert task.datasource == "starrocks"
+        assert task.database_name == "ac_manage"
+        assert task.to_dict()["datasource"] == "starrocks"
 
     def test_empty_task_raises(self):
         with pytest.raises(ValueError):

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -333,6 +333,7 @@ class TestMainRunAction:
         mock_config = MagicMock()
         mock_config.current_db_name_type.return_value = ("mydb", "sqlite")
         mock_config.output_dir = "/tmp/output"
+        mock_config.current_datasource = "ns"
 
         with (
             patch("datus.main.configure_logging"),

--- a/tests/unit_tests/utils/test_benchmark_evaluation.py
+++ b/tests/unit_tests/utils/test_benchmark_evaluation.py
@@ -355,7 +355,7 @@ def test_evaluate_benchmark_and_report_with_jsonl_manifest(agent_config: AgentCo
         question_file="tasks.jsonl",
         question_id_key="task_id",
         question_key="prompt",
-        db_key="db_id",
+        database_key="db_id",
         gold_sql_key="gold_sql",
         gold_result_key="expected_answer",
         gold_result_path="tasks.jsonl",


### PR DESCRIPTION
Summary:
- Add SqlTask.datasource as the Datus datasource routing key.
- Keep catalog_name/database_name/schema_name as SQL context only.
- Make benchmark task construction resolve datasource and SQL coordinates separately.
- Initialize workflow DB tools with datasource instead of database_name.

Validation:
- uv run ruff check datus/schemas/node_models.py datus/agent/agent.py datus/agent/workflow.py datus/api/service.py datus/main.py tests/unit_tests/schemas/test_node_models.py tests/unit_tests/agent/test_workflow.py tests/unit_tests/agent/test_benchmark_sql_context.py
- uv run pytest tests/unit_tests/schemas/test_node_models.py::TestNodeModelsSqlTask tests/unit_tests/agent/test_workflow.py::TestWorkflow::test_init_tools_uses_task_datasource_not_database_name tests/unit_tests/agent/test_benchmark_sql_context.py -q
- Local baisheng benchmark using editable local Datus-agent, DB adapters, semantic adapter, and metricflow: default context stable cases passed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
## Summary by CodeRabbit

* **New Features**
  * SQL tasks now support explicit datasource routing configuration
  * Benchmark execution can now select per-task datasources from configuration instead of defaulting to a single global datasource

* **Improvements**
  * Benchmark configuration now uses separate routing keys for datasource, catalog, database, and schema (replacing the single database key)
  * Enhanced task execution context resolution for multi-datasource environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL tasks can carry an explicit datasource; benchmarks can select a per-task datasource.

* **Improvements**
  * Benchmark config now exposes separate routing keys for datasource, catalog, database, and schema.
  * Task execution and tool initialization use resolved per-task datasource and improved SQL context resolution.

* **Tests**
  * Added/updated unit tests for SQL context resolution and datasource-aware workflow/tool init.

* **Chores**
  * CI: longer test timeout and optional parallel test workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->