### PR TITLE
[BugFix] Drop OpenRouter "-fast" Claude routing aliases from model catalog

### DIFF
--- a/datus/cli/provider_model_catalog.py
+++ b/datus/cli/provider_model_catalog.py
@@ -176,6 +176,13 @@ def _bucket_by_vendor(
             continue
         if provider_key == "claude":
             slug = slug.replace(".", "-")
+            # OpenRouter advertises "-fast" routing aliases (claude-opus-4-8-fast, …)
+            # that are not real Anthropic model IDs. The `claude` provider calls
+            # api.anthropic.com directly, which rejects the alias with
+            # not_found_error; the un-suffixed base model is always present in the
+            # same payload, so drop the alias.
+            if slug.endswith("-fast"):
+                continue
         entry: Dict[str, Any] = {"id": slug}
         name = item.get("name")
         if isinstance(name, str) and name:

--- a/tests/unit_tests/cli/test_provider_model_catalog.py
+++ b/tests/unit_tests/cli/test_provider_model_catalog.py
@@ -332,6 +332,25 @@ class TestBucketByVendor:
         )
         assert _ids_only(buckets) == {"openai": ["gpt-4o"]}
 
+    def test_claude_fast_routing_aliases_are_dropped(self) -> None:
+        """OpenRouter exposes "-fast" routing aliases (e.g. claude-opus-4.8-fast)
+        that are not real Anthropic model IDs; the direct `claude` provider rejects
+        them with not_found_error. They must be dropped, keeping only the base model."""
+        buckets = pmc._bucket_by_vendor(
+            [
+                {"id": "anthropic/claude-opus-4.8-fast"},
+                {"id": "anthropic/claude-opus-4.8"},
+                {"id": "anthropic/claude-opus-4.7-fast"},
+                {"id": "anthropic/claude-opus-4.7"},
+            ]
+        )
+        assert _ids_only(buckets) == {"claude": ["claude-opus-4-8", "claude-opus-4-7"]}
+
+    def test_fast_suffix_is_kept_for_non_claude_vendors(self) -> None:
+        """The "-fast" drop is claude-specific; other vendors keep such slugs."""
+        buckets = pmc._bucket_by_vendor([{"id": "qwen/qwen3-fast"}])
+        assert _ids_only(buckets) == {"qwen": ["qwen3-fast"]}
+
     def test_non_chat_models_are_filtered(self) -> None:
         buckets = pmc._bucket_by_vendor(
             [


### PR DESCRIPTION


OpenRouter advertises "-fast" routing aliases (e.g. anthropic/claude-opus-4.8-fast) alongside the real base models. After the claude "."->"-" normalization these surfaced as claude-opus-4-8-fast in the /model picker, but the `claude` provider calls api.anthropic.com directly, which rejects them with not_found_error since they are not real Anthropic model IDs. The un-suffixed base model is always present in the same payload, so drop the alias in _bucket_by_vendor().

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed OpenRouter model catalog to properly filter out Anthropic Claude "-fast" routing aliases, ensuring only canonical base model IDs are included in catalog results.

* **Tests**
  * Added unit tests verifying correct handling of "-fast" routing alias filtering for Claude models and proper retention for other vendors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->