### PR TITLE
[Doc] Update Snowflake adapter documentation

### DIFF
--- a/datus/configuration/README.md
+++ b/datus/configuration/README.md
@@ -60,23 +60,27 @@ Configure database connections by datasource:
 ```yaml
   services:
     datasources:
-    snowflake:
-      type: snowflake
-      account: ${SNOWFLAKE_ACCOUNT}
-      username: ${SNOWFLAKE_USER}
-      password: ${SNOWFLAKE_PASSWORD} # Use either password or private_key_file
-      # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
-      # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
+      snowflake:
+        type: snowflake
+        account: ${SNOWFLAKE_ACCOUNT}
+        username: ${SNOWFLAKE_USER}
+        password: ${SNOWFLAKE_PASSWORD} # Use exactly one of password or private_key_file
+        # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+        # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
+        database: ${SNOWFLAKE_DATABASE}
+        schema: ${SNOWFLAKE_SCHEMA}
+        warehouse: ${SNOWFLAKE_WAREHOUSE}
+        role: ${SNOWFLAKE_ROLE}
 
-    local_sqlite:
-      type: sqlite
-      dbs: # Multi-database
-        - name: mydb1
-          uri: sqlite:////path/to/mybd1.db # absolute path
-        - name: mydb2
-          uri: sqlite:///path/to/mybd2.db # relative path
-    bird_sqlite:
-      path_pattern: ~/benchmark/bird/dev_20240627/dev_databases/**/*.sqlite # fuzzy matching, just support glob pattern
+      local_sqlite:
+        type: sqlite
+        dbs: # Multi-database
+          - name: mydb1
+            uri: sqlite:////path/to/mybd1.db # absolute path
+          - name: mydb2
+            uri: sqlite:///path/to/mybd2.db # relative path
+      bird_sqlite:
+        path_pattern: ~/benchmark/bird/dev_20240627/dev_databases/**/*.sqlite # fuzzy matching, just support glob pattern
 ```
 
 ### 4. Storage Configuration
@@ -159,6 +163,7 @@ export DEEPSEEK_API_KEY="..."
 # Database Credentials
 export SNOWFLAKE_ACCOUNT="your-account"
 export SNOWFLAKE_USER="your-user"
+# Use exactly one of SNOWFLAKE_PASSWORD or SNOWFLAKE_PRIVATE_KEY_FILE.
 export SNOWFLAKE_PASSWORD="your-password"
 export SNOWFLAKE_PRIVATE_KEY_FILE="/path/to/rsa_key.p8"
 export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=""
@@ -295,15 +300,15 @@ agent:
 
   services:
     datasources:
-    snowflake_prod:
-      type: snowflake
-      account: ${SNOWFLAKE_ACCOUNT}
-      username: ${SNOWFLAKE_USER}
-      password: ${SNOWFLAKE_PASSWORD} # Use either password or private_key_file
-      database: PRODUCTION
-      schema: PUBLIC
-      warehouse: COMPUTE_WH
-      role: ${SNOWFLAKE_ROLE}
+      snowflake_prod:
+        type: snowflake
+        account: ${SNOWFLAKE_ACCOUNT}
+        username: ${SNOWFLAKE_USER}
+        password: ${SNOWFLAKE_PASSWORD} # Use exactly one of password or private_key_file
+        database: PRODUCTION
+        schema: PUBLIC
+        warehouse: COMPUTE_WH
+        role: ${SNOWFLAKE_ROLE}
 ```
 
 ## Benchmark Configuration

--- a/datus/configuration/README.md
+++ b/datus/configuration/README.md
@@ -64,7 +64,8 @@ Configure database connections by datasource:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD} # Use exactly one of password or private_key_file
+        password: ${SNOWFLAKE_PASSWORD} # Use private_key, or exactly one of password/private_key_file
+        # private_key: ${SNOWFLAKE_PRIVATE_KEY}
         # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
         # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
         database: ${SNOWFLAKE_DATABASE}
@@ -163,10 +164,11 @@ export DEEPSEEK_API_KEY="..."
 # Database Credentials
 export SNOWFLAKE_ACCOUNT="your-account"
 export SNOWFLAKE_USER="your-user"
-# Use exactly one of SNOWFLAKE_PASSWORD or SNOWFLAKE_PRIVATE_KEY_FILE.
+# Use SNOWFLAKE_PRIVATE_KEY, or exactly one of SNOWFLAKE_PASSWORD/SNOWFLAKE_PRIVATE_KEY_FILE.
 export SNOWFLAKE_PASSWORD="your-password"
-export SNOWFLAKE_PRIVATE_KEY_FILE="/path/to/rsa_key.p8"
-export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=""
+# export SNOWFLAKE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+# export SNOWFLAKE_PRIVATE_KEY_FILE="/path/to/rsa_key.p8"
+# export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=""
 export SNOWFLAKE_ROLE=""
 export STARROCKS_HOST="localhost"
 export STARROCKS_PORT="9030"
@@ -304,7 +306,10 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD} # Use exactly one of password or private_key_file
+        password: ${SNOWFLAKE_PASSWORD} # Use private_key, or exactly one of password/private_key_file
+        # private_key: ${SNOWFLAKE_PRIVATE_KEY}
+        # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+        # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
         database: PRODUCTION
         schema: PUBLIC
         warehouse: COMPUTE_WH

--- a/docs/API/knowledge_base.md
+++ b/docs/API/knowledge_base.md
@@ -17,7 +17,7 @@ metrics, external knowledge, and reference SQL.
 | `components`         | string[] | _(required)_   | Components to bootstrap: `metadata`, `semantic_model`, `metrics`, `ext_knowledge`, `reference_sql` |
 | `strategy`           | string   | `incremental`  | `check` (inspect only), `overwrite` (rebuild), or `incremental` (append/update) |
 | `schema_linking_type`| string   | `full`         | Metadata only: `table`, `view`, `mv`, or `full` |
-| `catalog`            | string   | `""`           | Metadata catalog filter (Snowflake, StarRocks) |
+| `catalog`            | string   | `""`           | Metadata catalog filter for catalog-aware engines such as StarRocks; leave empty for Snowflake |
 | `database_name`      | string   | `""`           | Metadata database filter |
 | `success_story`      | string?  | `null`         | Project-root-relative path to success-story CSV |
 | `subject_tree`       | string[]?| `null`         | Predefined hierarchical categories |

--- a/docs/API/knowledge_base.zh.md
+++ b/docs/API/knowledge_base.zh.md
@@ -15,7 +15,7 @@
 | `components`         | string[] | _（必填）_       | 要构建的组件：`metadata`、`semantic_model`、`metrics`、`ext_knowledge`、`reference_sql` |
 | `strategy`           | string   | `incremental`  | `check`（仅检查）、`overwrite`（重建）、`incremental`（增量更新） |
 | `schema_linking_type`| string   | `full`         | metadata 专用：`table`、`view`、`mv`、`full` |
-| `catalog`            | string   | `""`           | metadata catalog 过滤（Snowflake、StarRocks） |
+| `catalog`            | string   | `""`           | 支持 catalog 的引擎的 metadata catalog 过滤，例如 StarRocks；Snowflake 需要留空 |
 | `database_name`      | string   | `""`           | metadata 数据库过滤 |
 | `success_story`      | string?  | `null`         | 项目根目录的相对路径，指向 success-story CSV |
 | `subject_tree`       | string[]?| `null`         | 预定义层级分类 |

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -132,7 +132,7 @@ warehouse:
   type: snowflake
   account: your_account
   username: your_username
-  password: your_password  # Use either password or private_key_file
+  password: your_password  # Use exactly one of password or private_key_file
   # private_key_file: /path/to/rsa_key.p8
   # private_key_file_pwd: optional_key_passphrase
   warehouse: your_warehouse
@@ -140,6 +140,10 @@ warehouse:
   schema: your_schema
   role: your_role  # optional
 ```
+
+Snowflake supports password authentication and key-pair authentication. Configure exactly one of `password` or
+`private_key_file`; set `private_key_file_pwd` only when the private key is encrypted. Snowflake uses `database` and
+`schema`; do not set `catalog` for Snowflake.
 
 ### StarRocks
 

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -132,7 +132,11 @@ warehouse:
   type: snowflake
   account: your_account
   username: your_username
-  password: your_password  # Use exactly one of password or private_key_file
+  password: your_password  # Use private_key, or exactly one of password/private_key_file
+  # private_key: |
+  #   -----BEGIN PRIVATE KEY-----
+  #   ...
+  #   -----END PRIVATE KEY-----
   # private_key_file: /path/to/rsa_key.p8
   # private_key_file_pwd: optional_key_passphrase
   warehouse: your_warehouse
@@ -141,9 +145,10 @@ warehouse:
   role: your_role  # optional
 ```
 
-Snowflake supports password authentication and key-pair authentication. Configure exactly one of `password` or
-`private_key_file`; set `private_key_file_pwd` only when the private key is encrypted. Snowflake uses `database` and
-`schema`; do not set `catalog` for Snowflake.
+Snowflake supports password authentication and key-pair authentication. Configure `private_key`, or exactly one of
+`password` or `private_key_file` when `private_key` is absent. `private_key` takes precedence over
+`private_key_file` and `password`; set `private_key_file_pwd` only when the private key is encrypted. Snowflake uses
+`database` and `schema`; do not set `catalog` for Snowflake.
 
 ### StarRocks
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -128,7 +128,7 @@ warehouse:
   type: snowflake
   account: your_account
   username: your_username
-  password: your_password  # password 和 private_key_file 二选一
+  password: your_password  # password 和 private_key_file 必须二选一
   # private_key_file: /path/to/rsa_key.p8
   # private_key_file_pwd: optional_key_passphrase
   warehouse: your_warehouse
@@ -136,6 +136,8 @@ warehouse:
   schema: your_schema
   role: your_role  # 可选
 ```
+
+Snowflake 支持密码认证和 key-pair 认证。必须且只能配置 `password` 或 `private_key_file` 其中一个；只有私钥加密时才需要配置 `private_key_file_pwd`。Snowflake 使用 `database` 和 `schema`，不要为 Snowflake 配置 `catalog`。
 
 ### StarRocks
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -128,7 +128,11 @@ warehouse:
   type: snowflake
   account: your_account
   username: your_username
-  password: your_password  # password 和 private_key_file 必须二选一
+  password: your_password  # 可配置 private_key，或在没有 private_key 时 password 和 private_key_file 二选一
+  # private_key: |
+  #   -----BEGIN PRIVATE KEY-----
+  #   ...
+  #   -----END PRIVATE KEY-----
   # private_key_file: /path/to/rsa_key.p8
   # private_key_file_pwd: optional_key_passphrase
   warehouse: your_warehouse
@@ -137,7 +141,7 @@ warehouse:
   role: your_role  # 可选
 ```
 
-Snowflake 支持密码认证和 key-pair 认证。必须且只能配置 `password` 或 `private_key_file` 其中一个；只有私钥加密时才需要配置 `private_key_file_pwd`。Snowflake 使用 `database` 和 `schema`，不要为 Snowflake 配置 `catalog`。
+Snowflake 支持密码认证和 key-pair 认证。可以配置 `private_key`，或在没有 `private_key` 时配置 `password` 和 `private_key_file` 其中一个。`private_key` 会优先于 `private_key_file` 和 `password`；私钥加密时再配置 `private_key_file_pwd`。Snowflake 使用 `database` 和 `schema`，不要为 Snowflake 配置 `catalog`。
 
 ### StarRocks
 

--- a/docs/benchmark/benchmark_manual.md
+++ b/docs/benchmark/benchmark_manual.md
@@ -39,8 +39,9 @@ Set the required environment variables for your benchmark:
     export DEEPSEEK_API_KEY=<your_api_key>
     export SNOWFLAKE_ACCOUNT=<your_snowflake_account>
     export SNOWFLAKE_USERNAME=<your_snowflake_username>
-    # Use exactly one of SNOWFLAKE_PASSWORD or SNOWFLAKE_PRIVATE_KEY_FILE.
+    # Use SNOWFLAKE_PRIVATE_KEY, or exactly one of SNOWFLAKE_PASSWORD/SNOWFLAKE_PRIVATE_KEY_FILE.
     export SNOWFLAKE_PASSWORD=<your_snowflake_password>
+    # export SNOWFLAKE_PRIVATE_KEY=<pem_private_key_secret>
     # export SNOWFLAKE_PRIVATE_KEY_FILE=<path_to_rsa_key_p8>
     # export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=<optional_key_passphrase>
     export SNOWFLAKE_WAREHOUSE=<your_snowflake_warehouse>

--- a/docs/benchmark/benchmark_manual.md
+++ b/docs/benchmark/benchmark_manual.md
@@ -39,7 +39,14 @@ Set the required environment variables for your benchmark:
     export DEEPSEEK_API_KEY=<your_api_key>
     export SNOWFLAKE_ACCOUNT=<your_snowflake_account>
     export SNOWFLAKE_USERNAME=<your_snowflake_username>
+    # Use exactly one of SNOWFLAKE_PASSWORD or SNOWFLAKE_PRIVATE_KEY_FILE.
     export SNOWFLAKE_PASSWORD=<your_snowflake_password>
+    # export SNOWFLAKE_PRIVATE_KEY_FILE=<path_to_rsa_key_p8>
+    # export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=<optional_key_passphrase>
+    export SNOWFLAKE_WAREHOUSE=<your_snowflake_warehouse>
+    export SNOWFLAKE_DATABASE=<optional_snowflake_database>
+    export SNOWFLAKE_SCHEMA=<optional_snowflake_schema>
+    export SNOWFLAKE_ROLE=<optional_snowflake_role>
     ```
 
 ### Step 3: Download and Prepare the BIRD Dataset

--- a/docs/benchmark/benchmark_manual.zh.md
+++ b/docs/benchmark/benchmark_manual.zh.md
@@ -39,8 +39,9 @@ datus           # 进入 REPL 后依次使用 /model、/datasource、/init
     export DEEPSEEK_API_KEY=<your_api_key>
     export SNOWFLAKE_ACCOUNT=<your_snowflake_account>
     export SNOWFLAKE_USERNAME=<your_snowflake_username>
-    # SNOWFLAKE_PASSWORD 和 SNOWFLAKE_PRIVATE_KEY_FILE 必须二选一。
+    # 可以设置 SNOWFLAKE_PRIVATE_KEY，或在没有它时设置 SNOWFLAKE_PASSWORD 和 SNOWFLAKE_PRIVATE_KEY_FILE 其中一个。
     export SNOWFLAKE_PASSWORD=<your_snowflake_password>
+    # export SNOWFLAKE_PRIVATE_KEY=<pem_private_key_secret>
     # export SNOWFLAKE_PRIVATE_KEY_FILE=<path_to_rsa_key_p8>
     # export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=<optional_key_passphrase>
     export SNOWFLAKE_WAREHOUSE=<your_snowflake_warehouse>

--- a/docs/benchmark/benchmark_manual.zh.md
+++ b/docs/benchmark/benchmark_manual.zh.md
@@ -39,7 +39,14 @@ datus           # 进入 REPL 后依次使用 /model、/datasource、/init
     export DEEPSEEK_API_KEY=<your_api_key>
     export SNOWFLAKE_ACCOUNT=<your_snowflake_account>
     export SNOWFLAKE_USERNAME=<your_snowflake_username>
+    # SNOWFLAKE_PASSWORD 和 SNOWFLAKE_PRIVATE_KEY_FILE 必须二选一。
     export SNOWFLAKE_PASSWORD=<your_snowflake_password>
+    # export SNOWFLAKE_PRIVATE_KEY_FILE=<path_to_rsa_key_p8>
+    # export SNOWFLAKE_PRIVATE_KEY_FILE_PWD=<optional_key_passphrase>
+    export SNOWFLAKE_WAREHOUSE=<your_snowflake_warehouse>
+    export SNOWFLAKE_DATABASE=<optional_snowflake_database>
+    export SNOWFLAKE_SCHEMA=<optional_snowflake_schema>
+    export SNOWFLAKE_ROLE=<optional_snowflake_role>
     ```
 
 ### 第三步：下载并准备 BIRD 数据集

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -28,7 +28,8 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}  # Use exactly one of password or private_key_file
+        password: ${SNOWFLAKE_PASSWORD}  # Use private_key, or exactly one of password/private_key_file
+        # private_key: ${SNOWFLAKE_PRIVATE_KEY}
         # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
         # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
         database: ${SNOWFLAKE_DATABASE}  # Optional
@@ -77,7 +78,8 @@ my_snowflake:
   type: snowflake
   account: ${SNOWFLAKE_ACCOUNT}
   username: ${SNOWFLAKE_USER}
-  password: ${SNOWFLAKE_PASSWORD}      # Use exactly one of password or private_key_file
+  password: ${SNOWFLAKE_PASSWORD}      # Use private_key, or exactly one of password/private_key_file
+  # private_key: ${SNOWFLAKE_PRIVATE_KEY}
   # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
   # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # Optional
   database: ${SNOWFLAKE_DATABASE}    # Optional
@@ -87,8 +89,11 @@ my_snowflake:
   default: true                      # Optional: mark as default
 ```
 
-Snowflake authentication requires exactly one of `password` or `private_key_file`. For key-pair authentication, set
-`private_key_file` and optionally `private_key_file_pwd`; the adapter uses Snowflake JWT authentication internally.
+Snowflake supports password authentication and key-pair authentication. For hosted/SaaS deployments, prefer
+`private_key` to store the PEM private key as a secret; for local or CI setups with an existing key file, use
+`private_key_file`. When `private_key` is provided, it takes precedence over `private_key_file` and `password`;
+without `private_key`, configure exactly one of `password` or `private_key_file`. Set `private_key_file_pwd`
+when the private key is encrypted. The adapter uses Snowflake JWT authentication internally.
 
 Snowflake uses a `database` + `schema` namespace. Leave `catalog` unset for Snowflake; catalog filters are for
 catalog-aware engines such as StarRocks.

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -28,7 +28,13 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}
+        password: ${SNOWFLAKE_PASSWORD}  # Use exactly one of password or private_key_file
+        # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+        # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
+        database: ${SNOWFLAKE_DATABASE}  # Optional
+        schema: ${SNOWFLAKE_SCHEMA}      # Optional
+        warehouse: ${SNOWFLAKE_WAREHOUSE}
+        role: ${SNOWFLAKE_ROLE}          # Optional
         default: true
 
       my_duckdb:
@@ -71,15 +77,21 @@ my_snowflake:
   type: snowflake
   account: ${SNOWFLAKE_ACCOUNT}
   username: ${SNOWFLAKE_USER}
-  password: ${SNOWFLAKE_PASSWORD}      # Use either password or private_key_file
+  password: ${SNOWFLAKE_PASSWORD}      # Use exactly one of password or private_key_file
   # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
   # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # Optional
   database: ${SNOWFLAKE_DATABASE}    # Optional
   schema: ${SNOWFLAKE_SCHEMA}        # Optional
-  warehouse: ${SNOWFLAKE_WAREHOUSE}  # Optional
+  warehouse: ${SNOWFLAKE_WAREHOUSE}
   role: ${SNOWFLAKE_ROLE}            # Optional
   default: true                      # Optional: mark as default
 ```
+
+Snowflake authentication requires exactly one of `password` or `private_key_file`. For key-pair authentication, set
+`private_key_file` and optionally `private_key_file_pwd`; the adapter uses Snowflake JWT authentication internally.
+
+Snowflake uses a `database` + `schema` namespace. Leave `catalog` unset for Snowflake; catalog filters are for
+catalog-aware engines such as StarRocks.
 
 ### StarRocks
 ```yaml

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -28,7 +28,8 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}  # password 和 private_key_file 必须二选一
+        password: ${SNOWFLAKE_PASSWORD}  # 可配置 private_key，或在没有 private_key 时 password 和 private_key_file 二选一
+        # private_key: ${SNOWFLAKE_PRIVATE_KEY}
         # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
         # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
         database: ${SNOWFLAKE_DATABASE}  # 可选
@@ -78,7 +79,8 @@ my_snowflake:
   type: snowflake
   account: ${SNOWFLAKE_ACCOUNT}
   username: ${SNOWFLAKE_USER}
-  password: ${SNOWFLAKE_PASSWORD}      # password 和 private_key_file 必须二选一
+  password: ${SNOWFLAKE_PASSWORD}      # 可配置 private_key，或在没有 private_key 时 password 和 private_key_file 二选一
+  # private_key: ${SNOWFLAKE_PRIVATE_KEY}
   # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
   # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # 可选
   database: ${SNOWFLAKE_DATABASE}    # 可选
@@ -88,8 +90,10 @@ my_snowflake:
   default: true                      # 可选：设为默认数据库
 ```
 
-Snowflake 认证要求 `password` 和 `private_key_file` 必须二选一。使用 key-pair 认证时，设置
-`private_key_file`，如私钥有 passphrase 再设置 `private_key_file_pwd`；适配器内部会使用 Snowflake JWT 认证。
+Snowflake 支持密码认证和 key-pair 认证。托管/SaaS 场景推荐把 PEM 私钥作为 secret 配置到 `private_key`；
+本地或 CI 已有私钥文件时可以使用 `private_key_file`。如果配置了 `private_key`，它会优先于
+`private_key_file` 和 `password`；没有 `private_key` 时，`password` 和 `private_key_file` 必须二选一。
+私钥加密时再配置 `private_key_file_pwd`；适配器内部会使用 Snowflake JWT 认证。
 
 Snowflake 使用 `database` + `schema` 命名空间。Snowflake 不要配置 `catalog`；`catalog` 过滤只适用于
 StarRocks 等支持 catalog 的引擎。

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -28,7 +28,13 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}
+        password: ${SNOWFLAKE_PASSWORD}  # password 和 private_key_file 必须二选一
+        # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
+        # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}
+        database: ${SNOWFLAKE_DATABASE}  # 可选
+        schema: ${SNOWFLAKE_SCHEMA}      # 可选
+        warehouse: ${SNOWFLAKE_WAREHOUSE}
+        role: ${SNOWFLAKE_ROLE}          # 可选
         default: true
 
       my_duckdb:
@@ -72,15 +78,21 @@ my_snowflake:
   type: snowflake
   account: ${SNOWFLAKE_ACCOUNT}
   username: ${SNOWFLAKE_USER}
-  password: ${SNOWFLAKE_PASSWORD}      # password 和 private_key_file 二选一
+  password: ${SNOWFLAKE_PASSWORD}      # password 和 private_key_file 必须二选一
   # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
   # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # 可选
   database: ${SNOWFLAKE_DATABASE}    # 可选
   schema: ${SNOWFLAKE_SCHEMA}        # 可选
-  warehouse: ${SNOWFLAKE_WAREHOUSE}  # 可选
+  warehouse: ${SNOWFLAKE_WAREHOUSE}
   role: ${SNOWFLAKE_ROLE}            # 可选
   default: true                      # 可选：设为默认数据库
 ```
+
+Snowflake 认证要求 `password` 和 `private_key_file` 必须二选一。使用 key-pair 认证时，设置
+`private_key_file`，如私钥有 passphrase 再设置 `private_key_file_pwd`；适配器内部会使用 Snowflake JWT 认证。
+
+Snowflake 使用 `database` + `schema` 命名空间。Snowflake 不要配置 `catalog`；`catalog` 过滤只适用于
+StarRocks 等支持 catalog 的引擎。
 
 ### StarRocks
 

--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -58,7 +58,13 @@ agent:
         type: snowflake
         account: "${SNOWFLAKE_ACCOUNT}"
         username: "${SNOWFLAKE_USER}"
-        password: "${SNOWFLAKE_PASSWORD}"
+        password: "${SNOWFLAKE_PASSWORD}"  # Use exactly one of password or private_key_file
+        # private_key_file: "${SNOWFLAKE_PRIVATE_KEY_FILE}"
+        # private_key_file_pwd: "${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}"
+        database: "${SNOWFLAKE_DATABASE}"
+        schema: "${SNOWFLAKE_SCHEMA}"
+        warehouse: "${SNOWFLAKE_WAREHOUSE}"
+        role: "${SNOWFLAKE_ROLE}"
         default: true
 
     semantic_layer:

--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -58,7 +58,8 @@ agent:
         type: snowflake
         account: "${SNOWFLAKE_ACCOUNT}"
         username: "${SNOWFLAKE_USER}"
-        password: "${SNOWFLAKE_PASSWORD}"  # Use exactly one of password or private_key_file
+        password: "${SNOWFLAKE_PASSWORD}"  # Use private_key, or exactly one of password/private_key_file
+        # private_key: "${SNOWFLAKE_PRIVATE_KEY}"
         # private_key_file: "${SNOWFLAKE_PRIVATE_KEY_FILE}"
         # private_key_file_pwd: "${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}"
         database: "${SNOWFLAKE_DATABASE}"

--- a/docs/configuration/introduction.zh.md
+++ b/docs/configuration/introduction.zh.md
@@ -40,7 +40,13 @@ agent:
         type: snowflake
         account: "${SNOWFLAKE_ACCOUNT}"
         username: "${SNOWFLAKE_USER}"
-        password: "${SNOWFLAKE_PASSWORD}"
+        password: "${SNOWFLAKE_PASSWORD}"  # password 和 private_key_file 必须二选一
+        # private_key_file: "${SNOWFLAKE_PRIVATE_KEY_FILE}"
+        # private_key_file_pwd: "${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}"
+        database: "${SNOWFLAKE_DATABASE}"
+        schema: "${SNOWFLAKE_SCHEMA}"
+        warehouse: "${SNOWFLAKE_WAREHOUSE}"
+        role: "${SNOWFLAKE_ROLE}"
         default: true
 
     semantic_layer:

--- a/docs/configuration/introduction.zh.md
+++ b/docs/configuration/introduction.zh.md
@@ -40,7 +40,8 @@ agent:
         type: snowflake
         account: "${SNOWFLAKE_ACCOUNT}"
         username: "${SNOWFLAKE_USER}"
-        password: "${SNOWFLAKE_PASSWORD}"  # password 和 private_key_file 必须二选一
+        password: "${SNOWFLAKE_PASSWORD}"  # 可配置 private_key，或在没有 private_key 时 password 和 private_key_file 二选一
+        # private_key: "${SNOWFLAKE_PRIVATE_KEY}"
         # private_key_file: "${SNOWFLAKE_PRIVATE_KEY_FILE}"
         # private_key_file_pwd: "${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}"
         database: "${SNOWFLAKE_DATABASE}"

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -222,12 +222,16 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}  # Use either password or private_key_file
+        password: ${SNOWFLAKE_PASSWORD}  # Use exactly one of password or private_key_file
         # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
         # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # Optional
+        database: ${SNOWFLAKE_DATABASE}  # Optional
+        schema: ${SNOWFLAKE_SCHEMA}  # Optional
         warehouse: ${SNOWFLAKE_WAREHOUSE}
         role: ${SNOWFLAKE_ROLE}  # Optional
 ```
+
+Use `database` and `schema` for Snowflake namespaces. Do not set `catalog` for Snowflake.
 
 Bootstrap and run selected tasks:
 

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -222,7 +222,8 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}  # Use exactly one of password or private_key_file
+        password: ${SNOWFLAKE_PASSWORD}  # Use private_key, or exactly one of password/private_key_file
+        # private_key: ${SNOWFLAKE_PRIVATE_KEY}
         # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
         # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # Optional
         database: ${SNOWFLAKE_DATABASE}  # Optional

--- a/docs/develop/README.zh.md
+++ b/docs/develop/README.zh.md
@@ -222,12 +222,16 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}  # password 和 private_key_file 二选一
+        password: ${SNOWFLAKE_PASSWORD}  # password 和 private_key_file 必须二选一
         # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
         # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # 可选
+        database: ${SNOWFLAKE_DATABASE}  # 可选
+        schema: ${SNOWFLAKE_SCHEMA}  # 可选
         warehouse: ${SNOWFLAKE_WAREHOUSE}
         role: ${SNOWFLAKE_ROLE}  # 可选
 ```
+
+Snowflake 使用 `database` 和 `schema` 命名空间，不要为 Snowflake 设置 `catalog`。
 
 初始化并运行指定任务：
 

--- a/docs/develop/README.zh.md
+++ b/docs/develop/README.zh.md
@@ -222,7 +222,8 @@ agent:
         type: snowflake
         account: ${SNOWFLAKE_ACCOUNT}
         username: ${SNOWFLAKE_USER}
-        password: ${SNOWFLAKE_PASSWORD}  # password 和 private_key_file 必须二选一
+        password: ${SNOWFLAKE_PASSWORD}  # 可配置 private_key，或在没有 private_key 时 password 和 private_key_file 二选一
+        # private_key: ${SNOWFLAKE_PRIVATE_KEY}
         # private_key_file: ${SNOWFLAKE_PRIVATE_KEY_FILE}
         # private_key_file_pwd: ${SNOWFLAKE_PRIVATE_KEY_FILE_PWD}  # 可选
         database: ${SNOWFLAKE_DATABASE}  # 可选

--- a/docs/knowledge_base/metadata.md
+++ b/docs/knowledge_base/metadata.md
@@ -12,13 +12,13 @@ This module contains two types of information: **table definition** and **sample
 
 | Field Name       | Explanation | Supported Database Types |
 |------------------|-------------|--------------------------|
-| `catalog_name` | The top-level container in a database system. It typically represents a collection of databases and provides metadata about them, such as available schemas, tables, and security settings | StarRocks/Snowflake |
+| `catalog_name` | The top-level container in catalog-aware database systems. It typically represents a collection of databases and provides metadata about them, such as available schemas, tables, and security settings. Leave it empty for Snowflake. | StarRocks |
 | `database_name` | A logical container that stores related data. It usually groups together multiple schemas and provides boundaries for data organization, security, and management. | DuckDB/MySQL/StarRocks/Snowflake |
-| `schema_name` | A namespace inside a database. It organizes objects such as tables, views, functions, and procedures into logical groups. Schemas help avoid name conflicts and support role-based access. | DuckDB/Snowflake |
+| `schema_name` | A namespace inside a database. It organizes objects such as tables, views, functions, and procedures into logical groups. Schemas help avoid name conflicts and support role-based access. | DuckDB/PostgreSQL/Snowflake |
 | `table_type` | The types of tables in the database, including `table`, `view`, and `mv` (abbreviation for materialized view). Each database supports table and view. DuckDB and Snowflake support materialized views. | All supported databases |
 | `table_name` | Name of the table/view/materialized view | All supported databases |
 | `definition` | SQL statements for creating tables/views/materialized views | All supported databases |
-| `identifier` | The unique identifier of the current table, which is composed of `catalog_name`, `database_name`, `schema_name` and `table_name`. You don't need to worry about it, because you won't need it in most scenarios. | All supported databases |
+| `identifier` | The unique identifier of the current table. It is composed from the namespace fields supported by the datasource and `table_name`; for Snowflake that means `database_name`, `schema_name`, and `table_name` without `catalog_name`. You don't need to worry about it in most scenarios. | All supported databases |
 
 ## Data Structure of Sample Data
 

--- a/docs/knowledge_base/metadata.zh.md
+++ b/docs/knowledge_base/metadata.zh.md
@@ -12,13 +12,13 @@
 
 | 字段名称       | 说明 | 支持的数据库类型 |
 |------------------|-------------|-----------------------------|
-| `catalog_name` | 数据库系统中的顶层容器。它通常表示数据库的集合，并提供关于它们的元数据，例如可用的 schema、表和安全设置 | StarRocks/Snowflake |
+| `catalog_name` | 支持 catalog 的数据库系统中的顶层容器。它通常表示数据库的集合，并提供关于它们的元数据，例如可用的 schema、表和安全设置。Snowflake 需要留空 | StarRocks |
 | `database_name` | 存储相关数据的逻辑容器。它通常将多个 schema 组合在一起，并为数据组织、安全和管理提供边界 | DuckDB/MySQL/StarRocks/Snowflake |
-| `schema_name` | 数据库内的命名空间。它将表、视图、函数和过程等对象组织到逻辑组中。Schema 有助于避免名称冲突并支持基于角色的访问 | DuckDB/Snowflake |
+| `schema_name` | 数据库内的命名空间。它将表、视图、函数和过程等对象组织到逻辑组中。Schema 有助于避免名称冲突并支持基于角色的访问 | DuckDB/PostgreSQL/Snowflake |
 | `table_type` | 数据库中的表类型，包括 `table`、`view` 和 `mv`（物化视图的缩写）。每个数据库都支持表和视图。DuckDB 和 Snowflake 支持物化视图 | 所有支持的数据库 |
 | `table_name` | 表/视图/物化视图的名称 | 所有支持的数据库 |
 | `definition` | 创建表/视图/物化视图的 SQL 语句 | 所有支持的数据库 |
-| `identifier` | 当前表的唯一标识符，由 `catalog_name`、`database_name`、`schema_name` 和 `table_name` 组成。你不需要担心它，因为在大多数情况下你不需要它 | 所有支持的数据库 |
+| `identifier` | 当前表的唯一标识符，由数据源支持的命名空间字段和 `table_name` 组成；Snowflake 使用 `database_name`、`schema_name` 和 `table_name`，不包含 `catalog_name`。大多数场景下你不需要关心它 | 所有支持的数据库 |
 
 ## 样本数据的数据结构
 


### PR DESCRIPTION
## Summary
- Align Snowflake datasource docs with the latest adapter contract: exactly one of password or private_key_file, required warehouse, and optional role/database/schema.
- Clarify that Snowflake uses database + schema namespaces and should not set catalog filters.
- Update benchmark and internal configuration docs with Snowflake key-pair environment variables.
- Fix YAML indentation in the internal configuration README datasource examples.

## Validation
- git diff --check

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [x] release/0.3.3
## Summary by CodeRabbit

* **Documentation**
  * Clarified Snowflake authentication configuration across documentation: password and private key file authentication are now explicitly mutually exclusive (use exactly one).
  * Added guidance on private key file authentication including optional passphrase support.
  * Updated examples to clarify that `catalog` field should not be set for Snowflake.
  * Enhanced configuration examples and environment variable documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Snowflake authentication: password vs private-key-file are mutually exclusive; added private-key and optional passphrase guidance.
  * Updated environment variable and config examples to show key-based alternatives and precedence.
  * Clarified that `catalog` should generally be empty for Snowflake and added engine-specific guidance for catalog usage (including API bootstrap docs).
  * Refined metadata field explanations and supported-database notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->