### PR TITLE
[BugFix] Harden semantic metric query handling

### DIFF
--- a/datus/storage/semantic_model/auto_create.py
+++ b/datus/storage/semantic_model/auto_create.py
@@ -121,6 +121,56 @@ def _lookup_sql_evidence(table: str, sql_evidence_by_table: Optional[dict[str, l
     return []
 
 
+def _agent_config_dialect(agent_config: AgentConfig) -> str:
+    raw = getattr(agent_config, "db_type", "")
+    raw = getattr(raw, "value", raw)
+    if isinstance(raw, str) and raw:
+        return raw
+
+    try:
+        db_config = agent_config.current_db_config()
+    except Exception:
+        return ""
+    raw = getattr(db_config, "type", "")
+    raw = getattr(raw, "value", raw)
+    return raw if isinstance(raw, str) else ""
+
+
+def _resolved_table_target(table: str, agent_config: AgentConfig, current_db_config: object) -> dict[str, str]:
+    from datus.utils.sql_utils import parse_table_name_parts
+
+    dialect = _agent_config_dialect(agent_config)
+    parsed = parse_table_name_parts(table, dialect=dialect or "snowflake")
+    table_name = parsed.get("table_name") or str(table).split(".")[-1]
+
+    return {
+        "catalog_name": parsed.get("catalog_name") or getattr(current_db_config, "catalog", "") or "",
+        "database_name": parsed.get("database_name") or getattr(current_db_config, "database", "") or "",
+        "schema_name": parsed.get("schema_name") or getattr(current_db_config, "schema", "") or "",
+        "table_name": table_name,
+    }
+
+
+def _format_table_target_for_prompt(table: str, agent_config: AgentConfig, current_db_config: object) -> str:
+    target = _resolved_table_target(table, agent_config, current_db_config)
+    lines = [
+        f"- table_name: {target['table_name']}",
+        f"- database: {target['database_name'] or '[default]'}",
+        f"- schema_name: {target['schema_name'] or '[default]'}",
+    ]
+    if target["catalog_name"]:
+        lines.insert(1, f"- catalog: {target['catalog_name']}")
+    tool_args = [f'table_name="{target["table_name"]}"']
+    if target["catalog_name"]:
+        tool_args.append(f'catalog="{target["catalog_name"]}"')
+    if target["database_name"]:
+        tool_args.append(f'database="{target["database_name"]}"')
+    if target["schema_name"]:
+        tool_args.append(f'schema_name="{target["schema_name"]}"')
+    lines.append(f"- database tool arguments: {', '.join(tool_args)}")
+    return "\n".join(lines)
+
+
 def find_missing_semantic_models(
     tables: Set[str],
     agent_config: AgentConfig,
@@ -194,24 +244,40 @@ async def create_semantic_model_for_table(
     from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
     from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
 
-    user_message = f"Generate semantic models for the following tables: {table}"
-    if related_tables:
-        others = [t for t in related_tables if t != table]
-        if others:
-            user_message += f"\n\nRelated tables (for join context): {', '.join(others)}"
-    if sql_evidence:
-        user_message += (
-            "\n\nSuccess-story SQL evidence for this table. Use these queries as "
-            "primary modeling evidence, preserving joins that derive business "
-            "dimensions or real time columns:\n\n" + "\n\n".join(sql_evidence)
+    try:
+        current_db_config = agent_config.current_db_config()
+        target = _resolved_table_target(table, agent_config, current_db_config)
+        user_message = (
+            "Generate a semantic model for the following table.\n\n"
+            "Target table coordinate:\n"
+            f"{_format_table_target_for_prompt(table, agent_config, current_db_config)}\n\n"
+            "When calling database tools, pass the namespace fields separately exactly as shown above; "
+            "do not collapse a schema name into the database argument."
         )
+        if related_tables:
+            others = [t for t in related_tables if t != table]
+            if others:
+                related_context = "\n\n".join(
+                    _format_table_target_for_prompt(related_table, agent_config, current_db_config)
+                    for related_table in others
+                )
+                user_message += f"\n\nRelated tables (for join context):\n{related_context}"
+        if sql_evidence:
+            user_message += (
+                "\n\nSuccess-story SQL evidence for this table. Use these queries as "
+                "primary modeling evidence, preserving joins that derive business "
+                "dimensions or real time columns:\n\n" + "\n\n".join(sql_evidence)
+            )
+    except Exception as e:
+        error = f"Error preparing semantic model input for table {table}: {e}"
+        logger.error(error, exc_info=True)
+        return False, error
 
-    current_db_config = agent_config.current_db_config()
     semantic_input = SemanticNodeInput(
         user_message=user_message,
-        catalog=current_db_config.catalog,
-        database=current_db_config.database,
-        db_schema=current_db_config.schema,
+        catalog=target["catalog_name"],
+        database=target["database_name"],
+        db_schema=target["schema_name"],
     )
 
     semantic_node = GenSemanticModelAgenticNode(

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -11,7 +11,7 @@ Tools delegate to registered semantic adapters while leveraging unified storage 
 
 import inspect
 import json
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Set
 
 from agents import Tool
 
@@ -77,6 +77,62 @@ def _normalize_name_list(value) -> List[str]:
         if text:
             names.append(text)
     return names
+
+
+_TIME_GRANULARITIES = {"day", "week", "month", "quarter", "year"}
+
+
+def _split_dimension_granularity(name: str) -> tuple[str, Optional[str]]:
+    parts = name.rsplit("__", 1)
+    if len(parts) != 2:
+        return name, None
+    base_name, suffix = parts[0], parts[1].lower()
+    if suffix in _TIME_GRANULARITIES:
+        return base_name, suffix
+    return name, None
+
+
+def _is_metric_time_dimension(name: str) -> bool:
+    base_name, _ = _split_dimension_granularity(name.strip().lower())
+    return base_name == "metric_time"
+
+
+def _dimension_type(row: dict) -> str:
+    return str(row.get("type") or row.get("dimension_type") or "").lower()
+
+
+def _dimension_names_by_lookup(rows: List[dict]) -> Dict[str, str]:
+    names = {}
+    for row in rows:
+        name = str(row.get("name") or "").strip()
+        if name:
+            names[name.lower()] = name
+    return names
+
+
+def _dimension_supported(requested_dimension: str, rows: List[dict]) -> bool:
+    name = requested_dimension.strip().lower()
+    if not name:
+        return True
+
+    names = _dimension_names_by_lookup(rows)
+    if name in names:
+        return True
+
+    base_name, granularity = _split_dimension_granularity(name)
+    if not granularity or base_name not in names:
+        return False
+
+    # If adapter metadata marks the base as non-time, do not treat a
+    # granularity suffix as a valid alias. Missing type is intentionally
+    # permissive so older adapters can still delegate final validation.
+    for row in rows:
+        row_name = str(row.get("name") or "").strip().lower()
+        if row_name != base_name:
+            continue
+        dim_type = _dimension_type(row)
+        return not dim_type or "time" in dim_type
+    return False
 
 
 def _serialize_validation_issue(issue) -> dict:
@@ -524,6 +580,95 @@ class SemanticTools:
                 error=f"Failed to get dimensions: {str(e)}",
             )
 
+    def _preflight_query_dimensions(
+        self,
+        metrics: List[str],
+        dimensions: List[str],
+        path: Optional[List[str]],
+    ) -> Optional[FuncToolResult]:
+        if not dimensions:
+            return None
+
+        metric_time_dimensions = list(dict.fromkeys(d for d in dimensions if _is_metric_time_dimension(d)))
+        checked_dimensions = [d for d in dimensions if not _is_metric_time_dimension(d)]
+        if not checked_dimensions:
+            return None
+
+        dimensions_by_metric: Dict[str, List[dict]] = {}
+        dimension_names_by_metric: Dict[str, List[str]] = {}
+        try:
+            for metric_name in metrics:
+                raw_dimensions = _run_async(self.adapter.get_dimensions(metric_name=metric_name, path=path or None))
+                rows = _normalize_dimension_rows(raw_dimensions)
+                dimensions_by_metric[metric_name] = rows
+                dimension_names_by_metric[metric_name] = sorted(
+                    _dimension_names_by_lookup(rows).values(), key=str.lower
+                )
+        except Exception as e:
+            logger.debug(f"Skipping query_metrics dimension preflight: {e}")
+            return None
+
+        invalid_dimensions = []
+        for dimension in checked_dimensions:
+            unsupported_metrics = [
+                metric_name
+                for metric_name, rows in dimensions_by_metric.items()
+                if not _dimension_supported(dimension, rows)
+            ]
+            if not unsupported_metrics:
+                continue
+            invalid_dimensions.append(
+                {
+                    "name": dimension,
+                    "unsupported_metrics": unsupported_metrics,
+                    "supported_metrics": [m for m in metrics if m not in unsupported_metrics],
+                }
+            )
+
+        if not invalid_dimensions:
+            return None
+
+        common_dimensions: Optional[Set[str]] = None
+        for rows in dimensions_by_metric.values():
+            metric_dimensions = set(_dimension_names_by_lookup(rows).keys())
+            common_dimensions = (
+                metric_dimensions if common_dimensions is None else common_dimensions & metric_dimensions
+            )
+
+        suggested_groups: Dict[tuple[str, ...], List[str]] = {}
+        for metric_name, rows in dimensions_by_metric.items():
+            supported_requested_dimensions = tuple(
+                dimension for dimension in checked_dimensions if _dimension_supported(dimension, rows)
+            )
+            suggested_groups.setdefault(supported_requested_dimensions, []).append(metric_name)
+
+        suggestions = [
+            {
+                "metrics": group_metrics,
+                "dimensions": list(dict.fromkeys([*metric_time_dimensions, *group_dimensions])),
+            }
+            for group_dimensions, group_metrics in suggested_groups.items()
+        ]
+        common_dimension_names = list(dict.fromkeys([*metric_time_dimensions, *sorted(common_dimensions or [])]))
+
+        invalid_names = ", ".join(item["name"] for item in invalid_dimensions)
+        return FuncToolResult(
+            success=0,
+            error=(
+                "query_metrics dimension preflight failed: requested dimension(s) "
+                f"{invalid_names} are not supported by all requested metrics. "
+                "Use only common dimensions for a multi-metric query, or split the query by compatible metric groups."
+            ),
+            result={
+                "metrics": metrics,
+                "requested_dimensions": dimensions,
+                "invalid_dimensions": invalid_dimensions,
+                "common_dimensions": common_dimension_names,
+                "dimensions_by_metric": dimension_names_by_metric,
+                "suggested_metric_groups": suggestions,
+            },
+        )
+
     def query_metrics(
         self,
         metrics: List[str],
@@ -589,6 +734,10 @@ class SemanticTools:
         )
 
         try:
+            preflight_result = self._preflight_query_dimensions(metrics=metrics, dimensions=dimensions, path=path)
+            if preflight_result is not None:
+                return preflight_result
+
             # Execute query via adapter
             result = _run_async(
                 self.adapter.query_metrics(

--- a/datus/utils/compress_utils.py
+++ b/datus/utils/compress_utils.py
@@ -53,11 +53,23 @@ def _compress_pyarrow_table(table: pa.Table) -> Tuple[pa.Table, List[int], List[
     head_table = table.slice(0, 10)
     tail_table = table.slice(total_rows - 10, 10)
 
-    # Create ellipsis row
-    ellipsis_data = {}
-    for col_name in table.column_names:
-        ellipsis_data[col_name] = ["..."]
-    ellipsis_table = pa.table(ellipsis_data)
+    # The ellipsis row is display-only, so normalize compressed Arrow chunks to
+    # nullable strings before concatenating. This avoids schema mismatches for
+    # typed Snowflake results like DATE/DECIMAL or string not null columns.
+    display_schema = pa.schema([pa.field(col_name, pa.string()) for col_name in table.column_names])
+    head_table = pa.Table.from_arrays(
+        [head_table[col_name].cast(pa.string()) for col_name in table.column_names],
+        schema=display_schema,
+    )
+    tail_table = pa.Table.from_arrays(
+        [tail_table[col_name].cast(pa.string()) for col_name in table.column_names],
+        schema=display_schema,
+    )
+
+    ellipsis_table = pa.Table.from_arrays(
+        [pa.array(["..."], type=pa.string()) for _ in table.column_names],
+        schema=display_schema,
+    )
 
     # Merge tables
     compressed_table = pa.concat_tables([head_table, ellipsis_table, tail_table])

--- a/tests/unit_tests/storage/semantic_model/test_auto_create.py
+++ b/tests/unit_tests/storage/semantic_model/test_auto_create.py
@@ -520,6 +520,69 @@ class TestCreateSemanticModelForTable:
         assert "Success-story SQL evidence" in user_message
         assert "JOIN date_dim" in user_message
 
+    @pytest.mark.asyncio
+    async def test_fully_qualified_snowflake_table_sets_target_namespace(self) -> None:
+        """Snowflake database.schema.table names are passed as separate DB tool coordinates."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
+
+        mock_config = MagicMock()
+        mock_config.db_type = "snowflake"
+        mock_db_config = MagicMock()
+        mock_db_config.catalog = ""
+        mock_db_config.database = "SNOWFLAKE_SAMPLE_DATA"
+        mock_db_config.schema = "TPCH_SF1"
+        mock_config.current_db_config.return_value = mock_db_config
+        semantic_input_cls = MagicMock(return_value=MagicMock())
+
+        class MockNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+
+            async def execute_stream(self, ahm):
+                yield SimpleNamespace(status=ActionStatus.SUCCESS, messages="ok")
+
+        with (
+            patch(
+                "datus.agent.node.gen_semantic_model_agentic_node.GenSemanticModelAgenticNode",
+                MockNode,
+            ),
+            patch(
+                "datus.schemas.semantic_agentic_node_models.SemanticNodeInput",
+                semantic_input_cls,
+            ),
+        ):
+            success, error = await create_semantic_model_for_table(
+                "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.ORDERS",
+                mock_config,
+            )
+
+        assert success is True
+        assert error == ""
+        kwargs = semantic_input_cls.call_args.kwargs
+        assert kwargs["catalog"] == ""
+        assert kwargs["database"] == "SNOWFLAKE_SAMPLE_DATA"
+        assert kwargs["db_schema"] == "TPCH_SF1"
+        assert 'table_name="ORDERS"' in kwargs["user_message"]
+        assert 'database="SNOWFLAKE_SAMPLE_DATA"' in kwargs["user_message"]
+        assert 'schema_name="TPCH_SF1"' in kwargs["user_message"]
+
+    @pytest.mark.asyncio
+    async def test_target_preparation_exception_returns_table_scoped_failure(self) -> None:
+        """Target-resolution failures are isolated to the table being generated."""
+        from datus.storage.semantic_model.auto_create import create_semantic_model_for_table
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.side_effect = RuntimeError("missing datasource")
+
+        success, error = await create_semantic_model_for_table("orders", mock_config)
+
+        assert success is False
+        assert error == "Error preparing semantic model input for table orders: missing datasource"
+
 
 # ---------------------------------------------------------------------------
 # create_semantic_models_for_tables (batch with per-table isolation)

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -124,7 +124,14 @@ class TestQueryMetricsCompression:
         )
         mock_adapter.query_metrics = Mock(return_value=query_result)
 
-        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=query_result):
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "date"}],
+                [{"name": "date"}],
+                query_result,
+            ],
+        ):
             result = semantic_tools.query_metrics(
                 metrics=["revenue", "orders"],
                 dimensions=["date"],
@@ -251,6 +258,81 @@ class TestQueryMetricsCompression:
             dry_run=False,
         )
 
+    def test_query_metrics_rejects_dimensions_not_common_to_all_metrics(self, semantic_tools, mock_adapter):
+        """Preflight reports incompatible metric/dimension combinations before adapter query."""
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "ship_date"}, {"name": "ship_mode"}],
+                [{"name": "ship_date"}, {"name": "ship_mode"}],
+                [{"name": "ship_date"}, {"name": "supplier_nation"}],
+            ],
+        ):
+            result = semantic_tools.query_metrics(
+                metrics=["shipped_revenue", "discount_amount", "discount_rate"],
+                dimensions=["supplier_nation"],
+            )
+
+        assert result.success == 0
+        assert "dimension preflight failed" in result.error
+        assert result.result["invalid_dimensions"] == [
+            {
+                "name": "supplier_nation",
+                "unsupported_metrics": ["shipped_revenue", "discount_amount"],
+                "supported_metrics": ["discount_rate"],
+            }
+        ]
+        assert result.result["common_dimensions"] == ["ship_date"]
+        assert result.result["suggested_metric_groups"] == [
+            {"metrics": ["shipped_revenue", "discount_amount"], "dimensions": []},
+            {"metrics": ["discount_rate"], "dimensions": ["supplier_nation"]},
+        ]
+        mock_adapter.query_metrics.assert_not_called()
+
+    def test_query_metrics_preflight_preserves_metric_time_in_retry_guidance(self, semantic_tools, mock_adapter):
+        """Preflight retry guidance keeps requested metric-time dimensions."""
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "ship_date"}, {"name": "ship_mode"}],
+                [{"name": "ship_date"}, {"name": "supplier_nation"}],
+            ],
+        ):
+            result = semantic_tools.query_metrics(
+                metrics=["shipped_revenue", "discount_rate"],
+                dimensions=["metric_time__month", "supplier_nation"],
+            )
+
+        assert result.success == 0
+        assert result.result["common_dimensions"] == ["metric_time__month", "ship_date"]
+        assert result.result["suggested_metric_groups"] == [
+            {"metrics": ["shipped_revenue"], "dimensions": ["metric_time__month"]},
+            {"metrics": ["discount_rate"], "dimensions": ["metric_time__month", "supplier_nation"]},
+        ]
+        mock_adapter.query_metrics.assert_not_called()
+
+    def test_query_metrics_preflight_allows_time_grain_alias_for_known_time_dimension(self, semantic_tools):
+        query_result = QueryResult(
+            columns=["metric_time__month", "orders"],
+            data=[{"metric_time__month": "2024-01-01", "orders": 10}],
+            metadata={},
+        )
+
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "order_date", "type": "TIME"}],
+                query_result,
+            ],
+        ):
+            result = semantic_tools.query_metrics(
+                metrics=["orders"],
+                dimensions=["order_date__month"],
+                time_granularity="month",
+            )
+
+        assert result.success == 1
+
     def test_query_metrics_adapter_exception(self, semantic_tools):
         """Test query_metrics handles adapter exceptions gracefully."""
         with patch(
@@ -351,7 +433,13 @@ class TestQueryMetricsCompression:
         """Test that all parameters are correctly passed to the adapter."""
         query_result = QueryResult(columns=["x"], data=[{"x": 1}], metadata={})
 
-        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=query_result):
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "region"}],
+                query_result,
+            ],
+        ):
             result = semantic_tools.query_metrics(
                 metrics=["revenue"],
                 dimensions=["region"],

--- a/tests/unit_tests/utils/test_compress_utils.py
+++ b/tests/unit_tests/utils/test_compress_utils.py
@@ -1,3 +1,5 @@
+from datetime import date
+from decimal import Decimal
 from typing import Dict, List
 from unittest.mock import patch
 
@@ -234,6 +236,47 @@ class TestCompressPyarrowTable:
         df = compressed.to_pandas()
         assert df.iloc[10]["col"] == "..."
 
+    def test_large_typed_table_compressed_without_schema_mismatch(self):
+        table = pa.table(
+            {
+                "SHIP_DATE": pa.array([date(1998, 2, (i % 28) + 1) for i in range(30)], type=pa.date32()),
+                "SHIPPED_REVENUE": pa.array(
+                    [Decimal(f"{i}.12") for i in range(30)],
+                    type=pa.decimal128(12, 2),
+                ),
+                "LINE_COUNT": pa.array(list(range(30)), type=pa.int64()),
+            }
+        )
+
+        compressed, head_idx, tail_idx = _compress_pyarrow_table(table)
+
+        assert len(compressed) == 21
+        assert compressed.schema == pa.schema([pa.field(name, pa.string()) for name in table.column_names])
+        assert head_idx == list(range(10))
+        assert tail_idx == list(range(20, 30))
+        assert compressed.to_pandas().iloc[10]["SHIP_DATE"] == "..."
+
+    def test_large_not_null_string_table_compressed_without_schema_mismatch(self):
+        schema = pa.schema(
+            [
+                pa.field("SHIP_DATE", pa.string(), nullable=False),
+                pa.field("SHIPPED_REVENUE", pa.string()),
+            ]
+        )
+        table = pa.Table.from_arrays(
+            [
+                pa.array([f"1998-02-{(i % 28) + 1:02d}" for i in range(30)], type=pa.string()),
+                pa.array([str(i) for i in range(30)], type=pa.string()),
+            ],
+            schema=schema,
+        )
+
+        compressed, _, _ = _compress_pyarrow_table(table)
+
+        assert len(compressed) == 21
+        assert compressed.schema == pa.schema([pa.field(name, pa.string()) for name in table.column_names])
+        assert compressed.to_pandas().iloc[10]["SHIP_DATE"] == "..."
+
 
 # ---------------------------------------------------------------------------
 # _get_row_count_fast (line 75, 81)
@@ -451,12 +494,16 @@ class TestDataCompressorCompress:
     @patch("datus.utils.compress_utils.litellm.token_counter", side_effect=_mock_token_counter)
     def test_large_pyarrow_table_row_compression(self, _mock):
         dc = DataCompressor(token_threshold=100000)
-        # Use all-string columns so the ellipsis row ("...") matches schema
-        data = [{"id": str(i), "name": f"user_{i}"} for i in range(30)]
-        table = pa.table(pd.DataFrame(data))
+        table = pa.table(
+            {
+                "id": pa.array(list(range(30)), type=pa.int64()),
+                "ship_date": pa.array([date(1998, 2, (i % 28) + 1) for i in range(30)], type=pa.date32()),
+            }
+        )
         result = dc.compress(table)
         assert result["is_compressed"] is True
         assert result["compression_type"] == "rows"
+        assert "..." in result["compressed_data"]
 
     @patch("datus.utils.compress_utils.litellm.token_counter")
     def test_small_data_column_compression_when_over_threshold(self, mock_tc):


### PR DESCRIPTION

## Summary
- Preserve Snowflake database/schema/table coordinates when prompting semantic model generation.
- Add query_metrics dimension compatibility preflight with actionable split-query suggestions.
- Normalize compressed PyArrow result chunks to nullable strings before inserting display ellipsis rows.

## Validation
- .venv/bin/python -m pytest tests/unit_tests/storage/semantic_model/test_auto_create.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/utils/test_compress_utils.py -q
- .venv/bin/python -m ruff check datus/storage/semantic_model/auto_create.py datus/tools/func_tool/semantic_tools.py datus/utils/compress_utils.py tests/unit_tests/storage/semantic_model/test_auto_create.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/utils/test_compress_utils.py
- .venv/bin/python -m ruff format --check datus/storage/semantic_model/auto_create.py datus/tools/func_tool/semantic_tools.py datus/utils/compress_utils.py tests/unit_tests/storage/semantic_model/test_auto_create.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/utils/test_compress_utils.py

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [x] release/0.3.3
## Summary by CodeRabbit

* **New Features**
  * Added validation for dimension compatibility across multiple metrics, with suggestions for compatible metric combinations.

* **Bug Fixes**
  * Fixed display issues when compressing tables with non-string data types (dates, decimals, etc.).

* **Improvements**
  * Enhanced semantic model generation to properly resolve fully-qualified table identifiers with correct catalog, database, and schema assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/Datus-agent/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preflight validation of requested dimensions across multiple metrics with grouped suggestions for compatible metric sets and time-granularity alias support.

* **Bug Fixes**
  * Fixed display/compression issues when showing the ellipsis row for tables with non-string or non-nullable column types.

* **Improvements**
  * Resolve and surface fully qualified table coordinates (catalog/database/schema) in semantic-model prompts and fail gracefully with table-scoped errors.

* **Tests**
  * Added and updated unit tests for dimension preflight, target-resolution, and typed-table compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->