### PR TITLE
[Enhancement] Guard metric generation queryability

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -19,6 +19,10 @@ from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, Semant
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.generation_tools import GenerationTools
+from datus.tools.func_tool.metric_queryability import (
+    extract_metric_queryability_contracts,
+    summarize_queryability_contracts,
+)
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -375,6 +379,7 @@ class GenMetricsAgenticNode(AgenticNode):
             ) from e
 
     def _build_template_context(self, ctx: StreamRunContext) -> Optional[dict]:
+        self._set_metric_queryability_contracts_from_input(ctx.user_input)
         return self._prepare_template_context(ctx.user_input)
 
     def _build_success_result(self, ctx: StreamRunContext) -> SemanticNodeResult:
@@ -437,6 +442,12 @@ class GenMetricsAgenticNode(AgenticNode):
             raise RuntimeError(f"Metric generation reported {kind}_file outside Knowledge Base sandbox: {path!r}")
         return resolved_path
 
+    def _set_metric_queryability_contracts_from_input(self, user_input: Optional[SemanticNodeInput]) -> None:
+        if not user_input:
+            return
+        contracts = extract_metric_queryability_contracts(getattr(user_input, "user_message", "") or "")
+        self.generation_evidence.set_metric_queryability_contracts(contracts)
+
     def _finalize_metric_generation(
         self,
         semantic_model_file: Optional[str],
@@ -468,6 +479,7 @@ class GenMetricsAgenticNode(AgenticNode):
 
         if not self.generation_tools:
             raise RuntimeError("Metric generation produced a metric_file, but generation tools are unavailable.")
+        self._set_metric_queryability_contracts_from_input(getattr(self, "input", None))
 
         if not self.generation_evidence.validation_passed:
             if not getattr(self, "semantic_tools", None):
@@ -498,6 +510,14 @@ class GenMetricsAgenticNode(AgenticNode):
                     "query_metrics(dry_run=True) failed for generated metric(s) "
                     f"{', '.join(metric_names)}: {self._tool_error(dry_run_result)}"
                 )
+        if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
+            missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
+            raise RuntimeError(
+                "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions before "
+                "publishing metrics. Run a dry-run query for the generated metric names with the matching "
+                "dimensions/time grain, fix semantic model join or dimension issues, and retry. "
+                f"Missing: {summarize_queryability_contracts(missing_contracts)}"
+            )
 
         publish_result = self.generation_tools.end_metric_generation(
             metric_file=abs_metric_file,

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -23,6 +23,7 @@ from datus.tools.func_tool.metric_queryability import (
     extract_metric_queryability_contracts,
     summarize_queryability_contracts,
 )
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -512,11 +513,12 @@ class GenMetricsAgenticNode(AgenticNode):
                 )
         if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
             missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
-            raise RuntimeError(
+            raise DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
                 "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions before "
                 "publishing metrics. Run a dry-run query for the generated metric names with the matching "
                 "dimensions/time grain, fix semantic model join or dimension issues, and retry. "
-                f"Missing: {summarize_queryability_contracts(missing_contracts)}"
+                f"Missing: {summarize_queryability_contracts(missing_contracts)}",
             )
 
         publish_result = self.generation_tools.end_metric_generation(

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -281,7 +281,15 @@ class GenerationHooks(AgentHooks):
             if not isinstance(tool_args, dict) or tool_args.get("dry_run") is not True:
                 return
             metrics = tool_args.get("metrics") or []
-            self.generation_evidence.record_metric_dry_run(metrics, result)
+            dimensions = tool_args.get("dimensions") or []
+            if isinstance(dimensions, str):
+                dimensions = [dimensions]
+            self.generation_evidence.record_metric_dry_run(
+                metrics,
+                result,
+                dimensions=dimensions,
+                time_granularity=tool_args.get("time_granularity"),
+            )
         except Exception as e:
             logger.debug(f"Error recording query_metrics evidence: {e}")
 

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -146,7 +146,7 @@ Skip any metric that already exists — do NOT update or overwrite.
 
 1. **Write files**: Use `write_file` to save metric YAML (and semantic model if newly created)
 2. **Validate (MUST PASS)**: Use `validate_semantic` — if validation fails, fix errors with `edit_file` and retry until it **passes**. Do NOT proceed to Step 6 until validation passes.
-3. **Dry-run SQL**: Use `query_metrics(metrics=["metric_name"], dry_run=True)` to generate SQL
+3. **Dry-run SQL**: Use `query_metrics(metrics=["metric_name"], dry_run=True)` to generate SQL. If the source SQL groups by dimensions or a time grain, also dry-run the generated metric set with matching `dimensions` / `time_granularity` from that source query. Use `get_dimensions` to find the exact generated dimension names; if a grouped source dimension cannot be queried, fix the semantic model joins/dimensions and retry.
 
 Collect each generated SQL into `metric_sqls_json`.
 

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -214,6 +214,8 @@ Do not read, edit, or pass `metric_file` / `semantic_model_file` paths from anot
    - **Do NOT proceed to Phase 4 until validation passes.** No exceptions.
 
 4. **Dry-run SQL**: Call `query_metrics(metrics=["{metric_name}"], dry_run=True)` to generate the SQL.
+   - If the source SQL groups by dimensions or a time grain, also dry-run the generated metric set with matching `dimensions` / `time_granularity` from that source query.
+   - Use `get_dimensions` to find exact generated dimension names; if a grouped source dimension cannot be queried, fix the semantic model joins/dimensions and retry.
    - Collect the SQL into a dict: `{"{metric_name}": "SELECT ..."}`
 
 ## Phase 4: Batch Sync to Knowledge Base

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -163,12 +163,15 @@ class GenerationEvidence:
         for hint in contract.get("dimension_hints") or []:
             if not isinstance(hint, str) or not hint.strip():
                 continue
-            if _looks_time_dimension(hint) and (
-                time_granularity or any(_is_metric_time_dimension(d) for d in dimensions)
+            if any(_dimension_matches_hint(dimension, hint) for dimension in dimensions):
+                continue
+            if (
+                _looks_time_dimension(hint)
+                and time_granularity
+                and any(_is_metric_time_dimension(dimension) for dimension in dimensions)
             ):
                 continue
-            if not any(_dimension_matches_hint(dimension, hint) for dimension in dimensions):
-                return False
+            return False
         return True
 
     def mark_kb_sync(self, kind: str = "") -> None:

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -6,8 +6,9 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set
 
 
 def _result_success(result: Any) -> bool:
@@ -49,7 +50,9 @@ class GenerationEvidence:
     validation_passed: bool = False
     metric_dry_run_passed: bool = False
     metric_dry_run_metrics: Set[str] = field(default_factory=set)
+    metric_dry_run_queries: List[Dict[str, Any]] = field(default_factory=list)
     metric_sqls: Dict[str, str] = field(default_factory=dict)
+    metric_queryability_contracts: List[Dict[str, Any]] = field(default_factory=list)
     semantic_kb_sync_passed: bool = False
     metric_kb_sync_passed: bool = False
     generic_kb_sync_passed: bool = False
@@ -64,13 +67,34 @@ class GenerationEvidence:
         if _result_success(result) and valid:
             self.validation_passed = True
 
-    def record_metric_dry_run(self, metrics: Optional[Iterable[str]], result: Any) -> None:
+    def set_metric_queryability_contracts(self, contracts: Optional[Iterable[Dict[str, Any]]]) -> None:
+        self.metric_queryability_contracts = [
+            contract for contract in (contracts or []) if isinstance(contract, dict) and contract.get("dimension_hints")
+        ]
+
+    def record_metric_dry_run(
+        self,
+        metrics: Optional[Iterable[str]],
+        result: Any,
+        dimensions: Optional[Iterable[str]] = None,
+        time_granularity: Optional[str] = None,
+    ) -> None:
         if not _result_success(result):
             return
         self.metric_dry_run_passed = True
 
-        metrics_list = [m for m in (metrics or []) if isinstance(m, str) and m]
+        metric_candidates = [metrics] if isinstance(metrics, str) else list(metrics or [])
+        dimension_candidates = [dimensions] if isinstance(dimensions, str) else list(dimensions or [])
+        metrics_list = [m for m in metric_candidates if isinstance(m, str) and m]
         self.metric_dry_run_metrics.update(metrics_list)
+        dimensions_list = [d for d in dimension_candidates if isinstance(d, str) and d]
+        self.metric_dry_run_queries.append(
+            {
+                "metrics": metrics_list,
+                "dimensions": dimensions_list,
+                "time_granularity": time_granularity if isinstance(time_granularity, str) else None,
+            }
+        )
         metadata = _metadata_from_result(result)
         metric_sqls = metadata.get("metric_sqls")
         if isinstance(metric_sqls, dict):
@@ -98,6 +122,55 @@ class GenerationEvidence:
             return self.metric_dry_run_passed
         return self.metric_dry_run_passed and names.issubset(self.metric_dry_run_metrics)
 
+    def has_required_queryability_dry_runs(self, metric_names: Optional[Iterable[str]] = None) -> bool:
+        contracts = self.metric_queryability_contracts
+        if not contracts:
+            return True
+        generated_metrics = {m for m in (metric_names or []) if isinstance(m, str) and m}
+        for contract in contracts:
+            if not self._contract_has_matching_dry_run(contract, generated_metrics):
+                return False
+        return True
+
+    def missing_queryability_contracts(self, metric_names: Optional[Iterable[str]] = None) -> List[Dict[str, Any]]:
+        generated_metrics = {m for m in (metric_names or []) if isinstance(m, str) and m}
+        return [
+            contract
+            for contract in self.metric_queryability_contracts
+            if not self._contract_has_matching_dry_run(contract, generated_metrics)
+        ]
+
+    def _contract_has_matching_dry_run(self, contract: Dict[str, Any], generated_metrics: Set[str]) -> bool:
+        required_metrics = {
+            name
+            for name in (contract.get("metric_hints") or [])
+            if isinstance(name, str) and (not generated_metrics or name in generated_metrics)
+        }
+        if not required_metrics:
+            required_metrics = generated_metrics
+
+        for dry_run in self.metric_dry_run_queries:
+            dry_run_metrics = {m for m in dry_run.get("metrics", []) if isinstance(m, str)}
+            if required_metrics and not required_metrics.issubset(dry_run_metrics):
+                continue
+            if self._dimensions_satisfy_contract(dry_run, contract):
+                return True
+        return False
+
+    def _dimensions_satisfy_contract(self, dry_run: Dict[str, Any], contract: Dict[str, Any]) -> bool:
+        dimensions = [d for d in dry_run.get("dimensions", []) if isinstance(d, str)]
+        time_granularity = dry_run.get("time_granularity")
+        for hint in contract.get("dimension_hints") or []:
+            if not isinstance(hint, str) or not hint.strip():
+                continue
+            if _looks_time_dimension(hint) and (
+                time_granularity or any(_is_metric_time_dimension(d) for d in dimensions)
+            ):
+                continue
+            if not any(_dimension_matches_hint(dimension, hint) for dimension in dimensions):
+                return False
+        return True
+
     def mark_kb_sync(self, kind: str = "") -> None:
         if kind == "metric":
             self.metric_kb_sync_passed = True
@@ -105,3 +178,43 @@ class GenerationEvidence:
             self.semantic_kb_sync_passed = True
         else:
             self.generic_kb_sync_passed = True
+
+
+_GENERIC_DIMENSION_TOKENS = {"id", "key", "name", "dim", "dimension", "value"}
+_TIME_DIMENSION_TOKENS = {"date", "time", "day", "week", "month", "quarter", "year", "ds"}
+
+
+def _name_tokens(value: str) -> Set[str]:
+    return {token for token in re.split(r"[^a-z0-9]+", str(value).lower()) if token}
+
+
+def _normalize_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", str(value).strip().lower()).strip("_")
+
+
+def _semantic_tokens(value: str) -> Set[str]:
+    tokens = _name_tokens(value)
+    reduced = {token for token in tokens if token not in _GENERIC_DIMENSION_TOKENS}
+    return reduced or tokens
+
+
+def _looks_time_dimension(value: str) -> bool:
+    return bool(_name_tokens(value) & _TIME_DIMENSION_TOKENS)
+
+
+def _is_metric_time_dimension(value: str) -> bool:
+    return str(value).strip().lower().startswith("metric_time")
+
+
+def _dimension_matches_hint(dimension: str, hint: str) -> bool:
+    normalized_dimension = _normalize_name(dimension)
+    normalized_hint = _normalize_name(hint)
+    if normalized_dimension == normalized_hint:
+        return True
+    dimension_tokens = _semantic_tokens(dimension)
+    hint_tokens = _semantic_tokens(hint)
+    if not dimension_tokens or not hint_tokens:
+        return False
+    if len(hint_tokens) > 1:
+        return hint_tokens.issubset(dimension_tokens)
+    return bool(dimension_tokens & hint_tokens)

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -15,6 +15,7 @@ from datus.storage.metric.store import MetricRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
+from datus.tools.func_tool.metric_queryability import summarize_queryability_contracts
 from datus.utils.loggings import get_logger
 from datus.utils.path_manager import get_path_manager
 
@@ -333,6 +334,23 @@ class GenerationTools:
                         "metric_file": metric_file,
                         "semantic_model_file": semantic_model_file,
                         "metric_sqls": metric_sqls,
+                    },
+                )
+            if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
+                missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
+                contract_summary = summarize_queryability_contracts(missing_contracts)
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions before "
+                        "publishing metrics. Run a dry-run query for the generated metric names with the matching "
+                        f"dimensions/time grain, fix semantic model join or dimension issues, and retry. Missing: {contract_summary}"
+                    ),
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_file": semantic_model_file,
+                        "metric_sqls": metric_sqls,
+                        "queryability_contracts": missing_contracts,
                     },
                 )
 

--- a/datus/tools/func_tool/metric_queryability.py
+++ b/datus/tools/func_tool/metric_queryability.py
@@ -13,6 +13,20 @@ from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
 
+_SQL_FENCE_LANGS = {
+    "bigquery",
+    "duckdb",
+    "mysql",
+    "postgres",
+    "postgresql",
+    "snowflake",
+    "sql",
+    "sqlite",
+    "starrocks",
+    "trino",
+}
+_FENCED_SQL_PATTERN = re.compile(r"```(?:\s*([^\n`]+))?\n(.*?)```", flags=re.IGNORECASE | re.DOTALL)
+
 
 def extract_metric_queryability_contracts(text: Optional[str]) -> List[Dict[str, Any]]:
     """Extract queryability contracts from SQL evidence embedded in text.
@@ -42,17 +56,27 @@ def summarize_queryability_contracts(contracts: Iterable[Dict[str, Any]]) -> str
 
 def _extract_sql_snippets(text: str) -> List[str]:
     snippets: List[str] = []
-    for match in re.finditer(r"```(?:sql)?\s*(.*?)```", text, flags=re.IGNORECASE | re.DOTALL):
-        candidate = match.group(1).strip()
+    for match in _FENCED_SQL_PATTERN.finditer(text):
+        fence_lang = (match.group(1) or "").strip().lower()
+        candidate = match.group(2).strip()
+        if fence_lang and fence_lang not in _SQL_FENCE_LANGS:
+            continue
         if re.search(r"\bselect\b", candidate, flags=re.IGNORECASE):
             snippets.append(_strip_sql(candidate))
 
-    remaining = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
-    for match in re.finditer(r"(?is)\bselect\b.*?(?:;|$)", remaining):
+    remaining = _FENCED_SQL_PATTERN.sub(_fence_replacement_for_fallback, text)
+    for match in re.finditer(r"(?is)\b(?:with\b.*?\bselect\b|select\b).*?(?:;|$)", remaining):
         candidate = _strip_sql(match.group(0))
         if candidate and candidate not in snippets:
             snippets.append(candidate)
     return snippets
+
+
+def _fence_replacement_for_fallback(match: re.Match[str]) -> str:
+    fence_lang = (match.group(1) or "").strip().lower()
+    if not fence_lang or fence_lang in _SQL_FENCE_LANGS:
+        return " "
+    return f" {match.group(2)} "
 
 
 def _strip_sql(sql: str) -> str:
@@ -64,28 +88,31 @@ def _contract_from_sql(sql: str, source: str) -> Optional[Dict[str, Any]]:
     if parsed is None:
         return None
 
+    select = _final_select(parsed)
+    if select is None:
+        return None
+
     dimension_hints: List[str] = []
     metric_hints: List[str] = []
-    for select in _iter_selects(parsed):
-        aliases_by_expr = _projection_aliases_by_expr(select)
-        projection_aliases = [_projection_name(expr) for expr in select.expressions]
+    aliases_by_expr = _projection_aliases_by_expr(select)
+    projection_aliases = [_projection_name(expr) for expr in select.expressions]
 
-        group = select.args.get("group")
-        if group:
-            for group_expr in group.expressions:
-                hint = _dimension_hint_from_group_expr(group_expr, aliases_by_expr, projection_aliases)
-                if hint:
-                    dimension_hints.append(hint)
+    group = select.args.get("group")
+    if group:
+        for group_expr in group.expressions:
+            hint = _dimension_hint_from_group_expr(group_expr, aliases_by_expr, projection_aliases)
+            if hint:
+                dimension_hints.append(hint)
 
-        grouped_hints = {_normalize_name(hint) for hint in dimension_hints}
-        for projection in select.expressions:
-            name = _projection_name(projection)
-            if not name:
-                continue
-            if _normalize_name(name) in grouped_hints:
-                continue
-            if _looks_metric_projection(projection):
-                metric_hints.append(name)
+    grouped_hints = {_normalize_name(hint) for hint in dimension_hints}
+    for projection in select.expressions:
+        name = _projection_name(projection)
+        if not name:
+            continue
+        if _normalize_name(name) in grouped_hints:
+            continue
+        if _looks_metric_projection(projection):
+            metric_hints.append(name)
 
     dimension_hints = _dedupe(dimension_hints)
     metric_hints = _dedupe(metric_hints)
@@ -113,16 +140,15 @@ def _parse_sql(sql: str):
     return None
 
 
-def _iter_selects(expression) -> Iterable[Any]:
+def _final_select(expression) -> Optional[Any]:
     try:
         from sqlglot import expressions as exp
 
         if isinstance(expression, exp.Select):
-            yield expression
-            return
-        yield from expression.find_all(exp.Select)
+            return expression
+        return expression.find(exp.Select)
     except Exception:
-        return
+        return None
 
 
 def _projection_aliases_by_expr(select) -> Dict[str, str]:

--- a/datus/tools/func_tool/metric_queryability.py
+++ b/datus/tools/func_tool/metric_queryability.py
@@ -1,0 +1,214 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Helpers for validating generated metrics against source-query shape."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def extract_metric_queryability_contracts(text: Optional[str]) -> List[Dict[str, Any]]:
+    """Extract queryability contracts from SQL evidence embedded in text.
+
+    The contracts are intentionally adapter-neutral: they capture metric output
+    aliases and GROUP BY dimension aliases from source SQL. Runtime validation
+    later proves those dimensions are actually queryable through the configured
+    semantic adapter.
+    """
+    contracts: List[Dict[str, Any]] = []
+    for index, sql in enumerate(_extract_sql_snippets(text or "")):
+        contract = _contract_from_sql(sql, source=f"sql_{index + 1}")
+        if contract:
+            contracts.append(contract)
+    return contracts
+
+
+def summarize_queryability_contracts(contracts: Iterable[Dict[str, Any]]) -> str:
+    parts = []
+    for contract in contracts:
+        dimensions = ", ".join(contract.get("dimension_hints") or [])
+        metrics = ", ".join(contract.get("metric_hints") or [])
+        if dimensions:
+            parts.append(f"{contract.get('source') or 'source SQL'} group-by [{dimensions}] metrics [{metrics}]")
+    return "; ".join(parts)
+
+
+def _extract_sql_snippets(text: str) -> List[str]:
+    snippets: List[str] = []
+    for match in re.finditer(r"```(?:sql)?\s*(.*?)```", text, flags=re.IGNORECASE | re.DOTALL):
+        candidate = match.group(1).strip()
+        if re.search(r"\bselect\b", candidate, flags=re.IGNORECASE):
+            snippets.append(_strip_sql(candidate))
+
+    remaining = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+    for match in re.finditer(r"(?is)\bselect\b.*?(?:;|$)", remaining):
+        candidate = _strip_sql(match.group(0))
+        if candidate and candidate not in snippets:
+            snippets.append(candidate)
+    return snippets
+
+
+def _strip_sql(sql: str) -> str:
+    return sql.strip().rstrip(";").strip()
+
+
+def _contract_from_sql(sql: str, source: str) -> Optional[Dict[str, Any]]:
+    parsed = _parse_sql(sql)
+    if parsed is None:
+        return None
+
+    dimension_hints: List[str] = []
+    metric_hints: List[str] = []
+    for select in _iter_selects(parsed):
+        aliases_by_expr = _projection_aliases_by_expr(select)
+        projection_aliases = [_projection_name(expr) for expr in select.expressions]
+
+        group = select.args.get("group")
+        if group:
+            for group_expr in group.expressions:
+                hint = _dimension_hint_from_group_expr(group_expr, aliases_by_expr, projection_aliases)
+                if hint:
+                    dimension_hints.append(hint)
+
+        grouped_hints = {_normalize_name(hint) for hint in dimension_hints}
+        for projection in select.expressions:
+            name = _projection_name(projection)
+            if not name:
+                continue
+            if _normalize_name(name) in grouped_hints:
+                continue
+            if _looks_metric_projection(projection):
+                metric_hints.append(name)
+
+    dimension_hints = _dedupe(dimension_hints)
+    metric_hints = _dedupe(metric_hints)
+    if not dimension_hints:
+        return None
+    return {
+        "source": source,
+        "dimension_hints": dimension_hints,
+        "metric_hints": metric_hints,
+        "sql": sql,
+    }
+
+
+def _parse_sql(sql: str):
+    try:
+        import sqlglot
+
+        for dialect in ("snowflake", None):
+            try:
+                return sqlglot.parse_one(sql, read=dialect) if dialect else sqlglot.parse_one(sql)
+            except Exception:
+                continue
+    except Exception as exc:
+        logger.debug(f"Skipping queryability SQL parsing: {exc}")
+    return None
+
+
+def _iter_selects(expression) -> Iterable[Any]:
+    try:
+        from sqlglot import expressions as exp
+
+        if isinstance(expression, exp.Select):
+            yield expression
+            return
+        yield from expression.find_all(exp.Select)
+    except Exception:
+        return
+
+
+def _projection_aliases_by_expr(select) -> Dict[str, str]:
+    aliases: Dict[str, str] = {}
+    for projection in select.expressions:
+        name = _projection_name(projection)
+        if not name:
+            continue
+        expr = projection.this if projection.__class__.__name__ == "Alias" else projection
+        for key in {_normalize_sql(expr), _normalize_sql(projection)}:
+            if key:
+                aliases[key] = name
+    return aliases
+
+
+def _projection_name(projection) -> str:
+    alias = getattr(projection, "alias", None)
+    if alias:
+        return str(alias)
+    name = getattr(projection, "name", None)
+    return str(name) if name else ""
+
+
+def _dimension_hint_from_group_expr(group_expr, aliases_by_expr: Dict[str, str], projection_aliases: List[str]) -> str:
+    try:
+        from sqlglot import expressions as exp
+
+        if isinstance(group_expr, exp.Literal) and group_expr.is_int:
+            ordinal = int(group_expr.name)
+            if 1 <= ordinal <= len(projection_aliases):
+                return projection_aliases[ordinal - 1]
+    except Exception:
+        pass
+
+    alias = aliases_by_expr.get(_normalize_sql(group_expr))
+    if alias:
+        return alias
+
+    name = getattr(group_expr, "name", None)
+    if name:
+        return str(name)
+    return _safe_name(getattr(group_expr, "sql", lambda: "")())
+
+
+def _looks_metric_projection(projection) -> bool:
+    try:
+        from sqlglot import expressions as exp
+
+        metric_classes = (exp.Sum, exp.Count, exp.Avg, exp.Min, exp.Max)
+        expr = projection.this if isinstance(projection, exp.Alias) else projection
+        return isinstance(expr, metric_classes) or any(
+            isinstance(node[0] if isinstance(node, tuple) else node, metric_classes) for node in expr.walk()
+        )
+    except Exception:
+        return False
+
+
+def _normalize_sql(expr) -> str:
+    if expr is None:
+        return ""
+    try:
+        text = expr.sql(dialect="snowflake")
+    except Exception:
+        try:
+            text = expr.sql()
+        except Exception:
+            text = str(expr)
+    return re.sub(r"\s+", "", text).strip().lower()
+
+
+def _normalize_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", str(value).strip().lower()).strip("_")
+
+
+def _safe_name(value: str) -> str:
+    normalized = _normalize_name(value)
+    return normalized[:80]
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    deduped = []
+    seen = set()
+    for value in values:
+        normalized = _normalize_name(value)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(value)
+    return deduped

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -777,7 +777,12 @@ class SemanticTools:
                 result=result_dict,
             )
             if dry_run and self.generation_evidence:
-                self.generation_evidence.record_metric_dry_run(metrics, tool_result)
+                self.generation_evidence.record_metric_dry_run(
+                    metrics,
+                    tool_result,
+                    dimensions=dimensions,
+                    time_granularity=time_granularity,
+                )
             return tool_result
 
         except Exception as e:

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -856,6 +856,7 @@ class TestExecuteStreamGenMetricsError:
     def test_final_metric_publish_requires_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.tools.func_tool.base import FuncToolResult
+        from datus.utils.exceptions import DatusException
 
         datasource = real_agent_config.current_datasource
         metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
@@ -882,7 +883,7 @@ class TestExecuteStreamGenMetricsError:
         )
         node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
 
-        with pytest.raises(RuntimeError, match="source SQL group-by dimensions"):
+        with pytest.raises(DatusException, match="source SQL group-by dimensions"):
             node._finalize_metric_generation(reported_semantic_path, reported_metric_path, "generated")
 
         node.semantic_tools.query_metrics.assert_called_once_with(metrics=["revenue_total"], dry_run=True)

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -853,6 +853,79 @@ class TestExecuteStreamGenMetricsError:
             semantic_model_file=str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml"),
         )
 
+    def test_final_metric_publish_requires_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+
+        datasource = real_agent_config.current_datasource
+        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
+        metric_dir.mkdir(parents=True, exist_ok=True)
+        metric_path = metric_dir / "revenue_metrics.yml"
+        metric_path.write_text(
+            "metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n",
+            encoding="utf-8",
+        )
+        reported_semantic_path = f"subject/semantic_models/{datasource}/orders.yml"
+        reported_metric_path = f"subject/semantic_models/{datasource}/metrics/revenue_metrics.yml"
+
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(
+            user_message=(
+                "Create this metric from SQL: "
+                "SELECT customer_segment, SUM(revenue) AS revenue_total FROM orders GROUP BY customer_segment;"
+            )
+        )
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
+        node.semantic_tools.query_metrics = MagicMock(
+            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
+        )
+        node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
+
+        with pytest.raises(RuntimeError, match="source SQL group-by dimensions"):
+            node._finalize_metric_generation(reported_semantic_path, reported_metric_path, "generated")
+
+        node.semantic_tools.query_metrics.assert_called_once_with(metrics=["revenue_total"], dry_run=True)
+        node.generation_tools.end_metric_generation.assert_not_called()
+
+    def test_final_metric_publish_accepts_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+
+        datasource = real_agent_config.current_datasource
+        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
+        metric_dir.mkdir(parents=True, exist_ok=True)
+        metric_path = metric_dir / "revenue_metrics.yml"
+        metric_path.write_text(
+            "metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n",
+            encoding="utf-8",
+        )
+        reported_semantic_path = f"subject/semantic_models/{datasource}/orders.yml"
+        reported_metric_path = f"subject/semantic_models/{datasource}/metrics/revenue_metrics.yml"
+
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(
+            user_message=(
+                "Create this metric from SQL: "
+                "SELECT customer_segment, SUM(revenue) AS revenue_total FROM orders GROUP BY customer_segment;"
+            )
+        )
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
+        node.generation_evidence.record_metric_dry_run(
+            ["revenue_total"],
+            FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}}),
+            dimensions=["customer_segment"],
+        )
+        node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
+
+        node._finalize_metric_generation(reported_semantic_path, reported_metric_path, "generated")
+
+        node.generation_tools.end_metric_generation.assert_called_once_with(
+            metric_file=str(metric_path),
+            semantic_model_file=str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml"),
+        )
+
     @pytest.mark.asyncio
     async def test_final_metric_file_rejects_out_of_sandbox_absolute_path(
         self, real_agent_config, mock_llm_create, tmp_path

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -8,6 +8,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from datus.tools.func_tool.base import FuncToolResult
+
 
 @pytest.fixture
 def mock_agent_config():
@@ -341,6 +343,57 @@ class TestEndMetricGenerationPreflight:
     def test_accepts_file_with_metric_block(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
         generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue_total")
+        good = tmp_path / "semantic_models" / "good_metric.yml"
+        good.parent.mkdir(parents=True, exist_ok=True)
+        good.write_text("metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
+        with (
+            self._patch_path_resolution(generation_tools, tmp_path),
+            patch.object(generation_tools, "_sync_metric_to_db", return_value={"success": True, "message": "ok"}),
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(good))
+        assert result.success == 1
+
+    def test_rejects_missing_grouped_queryability_dry_run(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue_total")
+        generation_tools.generation_evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["revenue_total"],
+                    "dimension_hints": ["customer_segment"],
+                }
+            ]
+        )
+        good = tmp_path / "semantic_models" / "good_metric.yml"
+        good.parent.mkdir(parents=True, exist_ok=True)
+        good.write_text("metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
+        with (
+            self._patch_path_resolution(generation_tools, tmp_path),
+            patch.object(generation_tools, "_sync_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(good))
+        assert result.success == 0
+        assert "source SQL group-by dimensions" in result.error
+        assert result.result["queryability_contracts"][0]["dimension_hints"] == ["customer_segment"]
+        sync_mock.assert_not_called()
+
+    def test_accepts_grouped_queryability_dry_run(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        generation_tools.generation_evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["revenue_total"],
+                    "dimension_hints": ["customer_segment"],
+                }
+            ]
+        )
+        generation_tools.generation_evidence.record_metric_dry_run(
+            ["revenue_total"],
+            FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}}),
+            dimensions=["customer_segment"],
+        )
         good = tmp_path / "semantic_models" / "good_metric.yml"
         good.parent.mkdir(parents=True, exist_ok=True)
         good.write_text("metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -9,6 +9,7 @@ import pytest
 
 from datus.tools.func_tool.base import FuncToolResult, normalize_null
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
+from datus.tools.func_tool.metric_queryability import extract_metric_queryability_contracts
 from datus.tools.func_tool.semantic_tools import _run_async
 from datus.tools.semantic_tools.models import QueryResult
 
@@ -58,6 +59,75 @@ class TestGenerationEvidence:
         assert evidence.metric_dry_run_passed is True
         assert evidence.metric_sqls == {}
         assert evidence.has_metric_dry_run(["revenue"]) is True
+
+    def test_queryability_contract_requires_grouped_dry_run(self):
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["revenue_total"],
+                    "dimension_hints": ["customer_segment"],
+                }
+            ]
+        )
+        result = FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}})
+
+        evidence.record_metric_dry_run(["revenue_total"], result)
+
+        assert evidence.has_metric_dry_run(["revenue_total"]) is True
+        assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is False
+
+        evidence.record_metric_dry_run(["revenue_total"], result, dimensions=["customer__segment_name"])
+
+        assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is True
+
+    def test_queryability_contract_rejects_partial_dimension_token_match(self):
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["revenue_total"],
+                    "dimension_hints": ["customer_segment"],
+                }
+            ]
+        )
+
+        evidence.record_metric_dry_run(
+            ["revenue_total"],
+            FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}}),
+            dimensions=["customer_region"],
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is False
+
+    def test_extracts_grouped_metric_queryability_contract_from_sql(self):
+        contracts = extract_metric_queryability_contracts(
+            """
+            SQL:
+            SELECT n.n_name AS supplier_nation, SUM(l.l_extendedprice) AS shipped_revenue
+            FROM lineitem l
+            JOIN supplier s ON l.l_suppkey = s.s_suppkey
+            JOIN nation n ON s.s_nationkey = n.n_nationkey
+            GROUP BY n.n_name;
+            """
+        )
+
+        assert contracts == [
+            {
+                "source": "sql_1",
+                "dimension_hints": ["supplier_nation"],
+                "metric_hints": ["shipped_revenue"],
+                "sql": (
+                    "SELECT n.n_name AS supplier_nation, SUM(l.l_extendedprice) AS shipped_revenue\n"
+                    "            FROM lineitem l\n"
+                    "            JOIN supplier s ON l.l_suppkey = s.s_suppkey\n"
+                    "            JOIN nation n ON s.s_nationkey = n.n_nationkey\n"
+                    "            GROUP BY n.n_name"
+                ),
+            }
+        ]
 
 
 class TestNormalizeNull:
@@ -371,11 +441,29 @@ class TestQueryMetricsCompression:
             metadata={"sql": "SELECT SUM(revenue) AS revenue FROM orders"},
         )
 
-        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=query_result):
-            result = semantic_tools.query_metrics(metrics=["revenue"], dry_run=True)
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "customer_segment"}],
+                query_result,
+            ],
+        ):
+            result = semantic_tools.query_metrics(
+                metrics=["revenue"],
+                dimensions=["customer_segment"],
+                time_granularity="month",
+                dry_run=True,
+            )
 
         assert result.success == 1
         assert evidence.metric_dry_run_passed is True
+        assert evidence.metric_dry_run_queries == [
+            {
+                "metrics": ["revenue"],
+                "dimensions": ["customer_segment"],
+                "time_granularity": "month",
+            }
+        ]
         assert evidence.metric_sqls == {"revenue": "SELECT SUM(revenue) AS revenue FROM orders"}
 
     def test_query_metrics_non_dry_run_does_not_record_publish_evidence(self, semantic_tools):

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -102,6 +102,56 @@ class TestGenerationEvidence:
 
         assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is False
 
+    def test_queryability_contract_time_hint_requires_metric_time_dimension_and_grain(self):
+        result = FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}})
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["order_count"],
+                    "dimension_hints": ["order_date"],
+                }
+            ]
+        )
+        evidence.record_metric_dry_run(["order_count"], result, time_granularity="month")
+
+        assert evidence.has_required_queryability_dry_runs(["order_count"]) is False
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["order_count"],
+                    "dimension_hints": ["order_date"],
+                }
+            ]
+        )
+        evidence.record_metric_dry_run(["order_count"], result, dimensions=["metric_time__month"])
+
+        assert evidence.has_required_queryability_dry_runs(["order_count"]) is False
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["order_count"],
+                    "dimension_hints": ["order_date"],
+                }
+            ]
+        )
+        evidence.record_metric_dry_run(
+            ["order_count"],
+            result,
+            dimensions=["metric_time__month"],
+            time_granularity="month",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["order_count"]) is True
+
     def test_extracts_grouped_metric_queryability_contract_from_sql(self):
         contracts = extract_metric_queryability_contracts(
             """
@@ -128,6 +178,64 @@ class TestGenerationEvidence:
                 ),
             }
         ]
+
+    def test_extracts_grouped_contract_from_dialect_fenced_sql(self):
+        contracts = extract_metric_queryability_contracts(
+            """
+            ```snowflake
+            SELECT customer_segment, SUM(revenue) AS revenue_total
+            FROM orders
+            GROUP BY customer_segment;
+            ```
+            """
+        )
+
+        assert contracts == [
+            {
+                "source": "sql_1",
+                "dimension_hints": ["customer_segment"],
+                "metric_hints": ["revenue_total"],
+                "sql": (
+                    "SELECT customer_segment, SUM(revenue) AS revenue_total\n"
+                    "            FROM orders\n"
+                    "            GROUP BY customer_segment"
+                ),
+            }
+        ]
+
+    def test_extracts_contract_from_final_select_not_grouped_cte(self):
+        contracts = extract_metric_queryability_contracts(
+            """
+            WITH daily AS (
+                SELECT order_date, customer_segment, SUM(revenue) AS day_revenue
+                FROM orders
+                GROUP BY order_date, customer_segment
+            )
+            SELECT customer_segment, SUM(day_revenue) AS revenue_total
+            FROM daily
+            GROUP BY customer_segment;
+            """
+        )
+
+        assert len(contracts) == 1
+        assert contracts[0]["source"] == "sql_1"
+        assert contracts[0]["dimension_hints"] == ["customer_segment"]
+        assert contracts[0]["metric_hints"] == ["revenue_total"]
+        assert contracts[0]["sql"].startswith("WITH daily AS")
+
+    def test_ignores_nested_group_when_final_select_is_ungrouped(self):
+        contracts = extract_metric_queryability_contracts(
+            """
+            WITH grouped AS (
+                SELECT customer_segment, SUM(revenue) AS revenue
+                FROM orders
+                GROUP BY customer_segment
+            )
+            SELECT SUM(revenue) AS revenue_total FROM grouped;
+            """
+        )
+
+        assert contracts == []
 
 
 class TestNormalizeNull:


### PR DESCRIPTION
## Summary
- Extract source-SQL GROUP BY queryability contracts during metric generation.
- Record `query_metrics(dry_run=True)` query shapes, including dimensions and time granularity.
- Block metric publishing until generated metrics can dry-run with the source SQL group-by dimensions.
- Update gen-metrics instructions and add focused unit coverage.

## Root Cause
`validate_semantic` and metric-only dry runs proved that generated metric definitions were structurally valid, but they did not prove that the original success-story query shape, especially GROUP BY dimensions, was queryable through MetricFlow.

## Validation
- `.venv/bin/python -m pytest tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py -q`
- `.venv/bin/python -m ruff check datus/tools/func_tool/metric_queryability.py datus/tools/func_tool/generation_evidence.py datus/tools/func_tool/semantic_tools.py datus/cli/generation_hooks.py datus/tools/func_tool/generation_tools.py datus/agent/node/gen_metrics_agentic_node.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py`
- `.venv/bin/python -m ruff format --check datus/tools/func_tool/metric_queryability.py datus/tools/func_tool/generation_evidence.py datus/tools/func_tool/semantic_tools.py datus/cli/generation_hooks.py datus/tools/func_tool/generation_tools.py datus/agent/node/gen_metrics_agentic_node.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [x] release/0.3.3
## Summary by CodeRabbit

* **New Features**
  * Metric queryability validation now enforces that generated metrics can be queried with specified dimensions and time granularities.

* **Improvements**
  * Enhanced metric query preflight checks to validate dimension compatibility across requested metrics.
  * Improved error messages displaying missing queryability contracts.
  * Enhanced semantic model creation with better table coordinate handling.

* **Documentation**
  * Updated metrics generation workflow instructions for dimension and granularity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation during metric publication to verify generated metrics are queryable with specified dimensions and time granularity.
  * Enhanced metric generation workflow to properly handle source SQL containing GROUP BY dimensions.

* **Bug Fixes**
  * Improved metric validation preflight checks with detailed error messaging for missing queryability requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->