### PR TITLE
[Enhancement] Persist sub-agent IM channels to agent.yml on edit

### DIFF
--- a/datus/api/models/agent_models.py
+++ b/datus/api/models/agent_models.py
@@ -116,6 +116,39 @@ class GetAgentData(BaseModel):
     agent: IAgentInfo
 
 
+# ========== Channels ==========
+
+
+class ChannelInput(BaseModel):
+    """One IM gateway channel binding submitted with an agent edit.
+
+    Each channel carries its own ``enabled`` switch (adapters toggle
+    independently) and a generic ``secrets`` bag whose keys depend on the
+    adapter ``type`` — e.g. ``app_token`` / ``bot_token`` for slack. Values are
+    written verbatim into the ``agent.yml`` ``channels`` section (no
+    encryption); ``${ENV_VAR}`` placeholders are resolved at load time.
+    """
+
+    enabled: bool = Field(True, description="Whether this channel's gateway adapter is active.")
+    type: str = Field(..., description="Adapter type, e.g. 'slack'.")
+    name: str = Field(..., min_length=1, description="Reference name, used as the channel config key.")
+    secrets: dict = Field(
+        default_factory=dict,
+        description="Adapter-specific secret fields (e.g. app_token/bot_token). Written into `extra` verbatim.",
+    )
+
+
+class ChannelBinding(BaseModel):
+    """The channel state for one sub-agent.
+
+    Carries the full desired channel list for the agent being edited; the
+    backend replaces only that agent's entries in the global ``channels`` map
+    (matched by ``subagent_id``). An empty list clears this agent's channels.
+    """
+
+    channels: Optional[List[ChannelInput]] = Field(default=None, description="Channel bindings for this agent.")
+
+
 # ========== Edit Agent ==========
 
 
@@ -157,4 +190,8 @@ class EditAgentInput(BaseModel):
             "from the persisted binding the request is rejected with "
             "``IMMUTABLE_FIELD``. Identical / omitted values are silently dropped."
         ),
+    )
+    channels: Optional[ChannelBinding] = Field(
+        default=None,
+        description="IM gateway channel bindings for this agent. Omit to leave channels untouched.",
     )

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -672,6 +672,28 @@ def _save_agentic_nodes(agent_config: AgentConfig, nodes: dict) -> None:
     cfg_mgr.save()
 
 
+def _save_channels(agent_config: AgentConfig, channels: dict) -> None:
+    """Persist the global ``channels`` map back to the loaded ``agent.yml``.
+
+    Mirrors :func:`_save_agentic_nodes`: routes through the
+    ``ConfigurationManager`` singleton so the write lands in the source config
+    file (``--config`` path) and the ``agent:`` wrapping is round-tripped. An
+    empty map drops the ``channels`` section entirely. The in-memory
+    ``agent_config.channels_config`` is updated too so the running API process
+    stays consistent — the separate gateway process reads channels once at
+    startup and still needs a restart to pick up the change.
+    """
+    from datus.configuration.agent_config_loader import configuration_manager
+
+    cfg_mgr = configuration_manager()
+    if channels:
+        cfg_mgr.data["channels"] = channels
+    else:
+        cfg_mgr.data.pop("channels", None)
+    cfg_mgr.save()
+    agent_config.channels_config = channels
+
+
 class AgentService:
     """Service for Agent API operations.
 
@@ -1020,6 +1042,15 @@ class AgentService:
                     ),
                 )
 
+        # Channel bindings live in a separate top-level ``channels`` yaml
+        # section (consumed by the gateway), so persist them independently of
+        # the agentic_nodes update below — and before the no-op short-circuit,
+        # so a channels-only edit still saves.
+        if request.channels is not None:
+            channel_error = self._apply_channel_binding(request, agent_config)
+            if channel_error is not None:
+                return channel_error
+
         # If prompt_template content is provided, save to template file
         prompt_content = request.prompt_template
         if prompt_content is not None:
@@ -1038,7 +1069,7 @@ class AgentService:
         # API ``description`` lands on the runtime-visible ``agent_description``
         # key; drop any legacy flat ``description`` left over from older edits
         # so the read path doesn't see two competing values.
-        update_data = request.model_dump(exclude={"id", "name", "prompt_template"}, exclude_none=True)
+        update_data = request.model_dump(exclude={"id", "name", "prompt_template", "channels"}, exclude_none=True)
         if "description" in update_data:
             update_data["agent_description"] = update_data.pop("description")
             agent.pop("description", None)
@@ -1121,6 +1152,50 @@ class AgentService:
 
         return Result(success=True, data={"name": request.id, "id": request.id})
 
+    def _apply_channel_binding(self, request: EditAgentInput, agent_config: AgentConfig):
+        """Replace this agent's entries in the global ``channels`` map.
+
+        The binding carries the full desired channel list for ``request.id``.
+        We drop the agent's existing entries (matched by ``subagent_id``),
+        keeping channels routed to other agents, then append the new ones and
+        persist. Each entry takes the gateway's yaml shape::
+
+            <name>:
+              adapter: <type>
+              enabled: <bool>
+              subagent_id: <agent id>   # routes inbound messages to this agent
+              extra: {<secret fields>}  # written verbatim, no encryption
+
+        Returns a failure :class:`Result` on a bad entry, else ``None``.
+        """
+        binding = request.channels
+        channels = dict(getattr(agent_config, "channels_config", None) or {})
+
+        # Keep only channels NOT routed to this agent.
+        channels = {
+            key: value
+            for key, value in channels.items()
+            if not (isinstance(value, dict) and value.get("subagent_id") == request.id)
+        }
+
+        for channel in binding.channels or []:
+            name = (channel.name or "").strip()
+            if not name:
+                return Result(
+                    success=False,
+                    errorCode="INVALID_CHANNEL_NAME",
+                    errorMessage="Channel name cannot be empty",
+                )
+            channels[name] = {
+                "adapter": channel.type,
+                "enabled": channel.enabled,
+                "subagent_id": request.id,
+                "extra": dict(channel.secrets or {}),
+            }
+
+        _save_channels(agent_config, channels)
+        return None
+
     async def delete_agent(
         self,
         agent_id: str,
@@ -1153,6 +1228,17 @@ class AgentService:
 
         del agentic_nodes[agent_id]
         _save_agentic_nodes(agent_config, agentic_nodes)
+
+        # Drop any channels routed to this agent so deleting it doesn't leave
+        # dangling gateway bindings pointing at a non-existent sub-agent.
+        channels = getattr(agent_config, "channels_config", None) or {}
+        remaining = {
+            key: value
+            for key, value in channels.items()
+            if not (isinstance(value, dict) and value.get("subagent_id") == agent_id)
+        }
+        if len(remaining) != len(channels):
+            _save_channels(agent_config, remaining)
 
         try:
             self._delete_prompt_templates(agent_id, agent_config)

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -1186,6 +1186,16 @@ class AgentService:
                     errorCode="INVALID_CHANNEL_NAME",
                     errorMessage="Channel name cannot be empty",
                 )
+            # ``channels`` no longer holds this agent's own entries, so any name
+            # collision here belongs to a different agent — reject instead of
+            # silently clobbering its binding.
+            existing = channels.get(name)
+            if isinstance(existing, dict) and existing.get("subagent_id") != request.id:
+                return Result(
+                    success=False,
+                    errorCode="CHANNEL_NAME_CONFLICT",
+                    errorMessage=f"Channel name '{name}' is already bound to another sub-agent",
+                )
             channels[name] = {
                 "adapter": channel.type,
                 "enabled": channel.enabled,

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -2231,6 +2231,26 @@ class TestEditAgentChannels:
         assert "slack-a" not in channels  # old entry for agent_a replaced
         assert "slack-a2" in channels
 
+    async def test_edit_agent_channel_name_conflict_with_other_agent(self, real_agent_config, agent_yml_with_singleton):
+        """Binding a channel name already owned by another agent is rejected."""
+        svc = AgentService()
+        await self._create(svc, real_agent_config, "agent_a")
+        await self._create(svc, real_agent_config, "agent_b")
+        await svc.edit_agent(
+            self._edit_with_channels("agent_a", [self._slack(name="shared", secrets={"app_token": "a"})]),
+            real_agent_config,
+        )
+
+        # agent_b tries to claim the same channel name — must fail, not clobber.
+        result = await svc.edit_agent(
+            self._edit_with_channels("agent_b", [self._slack(name="shared", secrets={"app_token": "b"})]),
+            real_agent_config,
+        )
+        assert result.success is False
+        assert result.errorCode == "CHANNEL_NAME_CONFLICT"
+        # agent_a's binding is untouched.
+        assert real_agent_config.channels_config["shared"]["subagent_id"] == "agent_a"
+
     async def test_edit_agent_rejects_blank_channel_name(self, real_agent_config, agent_yml_with_singleton):
         """A whitespace-only channel name is rejected."""
         svc = AgentService()

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -2130,3 +2130,128 @@ class TestDeleteAgentRoute:
         )
         assert result.success is False
         assert result.errorCode == "AGENT_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+class TestEditAgentChannels:
+    """Tests for edit_agent / delete_agent IM gateway channel persistence."""
+
+    async def _create(self, svc, real_agent_config, name):
+        from datus.api.models.agent_models import CreateAgentInput
+
+        await svc.create_agent(CreateAgentInput(name=name, type="gen_sql"), real_agent_config)
+
+    def _edit_with_channels(self, agent_id, channels):
+        from datus.api.models.agent_models import ChannelBinding, EditAgentInput
+
+        return EditAgentInput(id=agent_id, channels=ChannelBinding(channels=channels))
+
+    def _slack(self, name="slack-main", enabled=True, secrets=None):
+        from datus.api.models.agent_models import ChannelInput
+
+        return ChannelInput(type="slack", name=name, enabled=enabled, secrets=secrets or {})
+
+    async def test_edit_agent_adds_channel(self, real_agent_config, agent_yml_with_singleton):
+        """A channel binding lands in the global ``channels`` map and persists."""
+        from datus.configuration import agent_config_loader
+
+        svc = AgentService()
+        await self._create(svc, real_agent_config, "chan_agent")
+
+        result = await svc.edit_agent(
+            self._edit_with_channels(
+                "chan_agent",
+                [self._slack(secrets={"app_token": "${SLACK_APP_TOKEN}", "bot_token": "${SLACK_BOT_TOKEN}"})],
+            ),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        # In-memory config updated.
+        entry = real_agent_config.channels_config["slack-main"]
+        assert entry == {
+            "adapter": "slack",
+            "enabled": True,
+            "subagent_id": "chan_agent",
+            "extra": {"app_token": "${SLACK_APP_TOKEN}", "bot_token": "${SLACK_BOT_TOKEN}"},
+        }
+        # Persisted to agent.yml under the ``channels`` section.
+        persisted = agent_config_loader.configuration_manager().data["channels"]["slack-main"]
+        assert persisted["subagent_id"] == "chan_agent"
+        # Secrets written verbatim — no encryption.
+        assert persisted["extra"]["app_token"] == "${SLACK_APP_TOKEN}"
+
+    async def test_edit_agent_disabled_channel_kept(self, real_agent_config, agent_yml_with_singleton):
+        """A disabled channel is still persisted (gateway honours `enabled`)."""
+        svc = AgentService()
+        await self._create(svc, real_agent_config, "chan_agent")
+
+        result = await svc.edit_agent(
+            self._edit_with_channels("chan_agent", [self._slack(enabled=False, secrets={"app_token": "x"})]),
+            real_agent_config,
+        )
+        assert result.success is True
+        assert real_agent_config.channels_config["slack-main"]["enabled"] is False
+
+    async def test_edit_agent_empty_list_clears_this_agents_channels(self, real_agent_config, agent_yml_with_singleton):
+        """An empty channel list removes this agent's entries."""
+        svc = AgentService()
+        await self._create(svc, real_agent_config, "chan_agent")
+        await svc.edit_agent(
+            self._edit_with_channels("chan_agent", [self._slack(secrets={"app_token": "x"})]),
+            real_agent_config,
+        )
+        assert "slack-main" in real_agent_config.channels_config
+
+        result = await svc.edit_agent(self._edit_with_channels("chan_agent", []), real_agent_config)
+        assert result.success is True
+        assert "slack-main" not in real_agent_config.channels_config
+
+    async def test_edit_agent_channels_scoped_per_agent(self, real_agent_config, agent_yml_with_singleton):
+        """Editing one agent's channels leaves another agent's channels intact."""
+        svc = AgentService()
+        await self._create(svc, real_agent_config, "agent_a")
+        await self._create(svc, real_agent_config, "agent_b")
+        await svc.edit_agent(
+            self._edit_with_channels("agent_a", [self._slack(name="slack-a", secrets={"app_token": "a"})]),
+            real_agent_config,
+        )
+        await svc.edit_agent(
+            self._edit_with_channels("agent_b", [self._slack(name="slack-b", secrets={"app_token": "b"})]),
+            real_agent_config,
+        )
+
+        # Re-edit agent_a — agent_b's channel must survive.
+        await svc.edit_agent(
+            self._edit_with_channels("agent_a", [self._slack(name="slack-a2", secrets={"app_token": "a2"})]),
+            real_agent_config,
+        )
+        channels = real_agent_config.channels_config
+        assert "slack-b" in channels
+        assert "slack-a" not in channels  # old entry for agent_a replaced
+        assert "slack-a2" in channels
+
+    async def test_edit_agent_rejects_blank_channel_name(self, real_agent_config, agent_yml_with_singleton):
+        """A whitespace-only channel name is rejected."""
+        svc = AgentService()
+        await self._create(svc, real_agent_config, "chan_agent")
+        result = await svc.edit_agent(
+            self._edit_with_channels("chan_agent", [self._slack(name="   ", secrets={"app_token": "x"})]),
+            real_agent_config,
+        )
+        assert result.success is False
+        assert result.errorCode == "INVALID_CHANNEL_NAME"
+
+    async def test_delete_agent_removes_its_channels(self, real_agent_config, agent_yml_with_singleton):
+        """Deleting an agent drops the channels routed to it."""
+        svc = AgentService()
+        await self._create(svc, real_agent_config, "chan_agent")
+        await svc.edit_agent(
+            self._edit_with_channels("chan_agent", [self._slack(secrets={"app_token": "x"})]),
+            real_agent_config,
+        )
+        assert "slack-main" in real_agent_config.channels_config
+
+        result = await svc.delete_agent("chan_agent", real_agent_config)
+        assert result.success is True
+        assert "slack-main" not in real_agent_config.channels_config


### PR DESCRIPTION
## What

`edit_agent` (and the API route it backs) can now persist a sub-agent's **IM gateway channel bindings** into the top-level `channels:` section of `agent.yml`, in the exact shape the gateway consumes:

```yml
channels:
  slack-main:
    adapter: slack
    enabled: true
    subagent_id: my_agent
    extra:
      app_token: ${SLACK_APP_TOKEN}   # xapp-... (App-Level Token)
      bot_token: ${SLACK_BOT_TOKEN}   # xoxb-... (Bot User OAuth Token)
```

## Changes

- **`EditAgentInput.channels`** — a `ChannelBinding { channels: [ChannelInput] }` block. Each `ChannelInput` has its own `enabled` switch (adapters toggle independently) and a generic `secrets` bag whose keys depend on `type` (e.g. `app_token`/`bot_token` for slack).
- **`_apply_channel_binding`** — replaces only the edited agent's entries in the global `channels` map, matched by `subagent_id`, so channels routed to *other* agents survive. An empty list clears this agent's channels.
- **`_save_channels`** — mirrors `_save_agentic_nodes`: round-trips through `ConfigurationManager` so the write lands in the source `--config` file under `agent:`, drops the section when empty, and refreshes the in-memory `channels_config`.
- **`delete_agent`** — drops the deleted agent's channels so no dangling gateway bindings remain.

## Notes

- **No encryption** — secrets are written verbatim. Literal tokens are stored as-is; `${ENV_VAR}` placeholders resolve at load via `AgentConfig`'s `_resolve_nested_value`. (This is the CLI/YAML path; the SaaS path encrypts secrets in Postgres instead.)
- **`subagent_id`** is set to the edited agent so `gateway/bridge.py` routes inbound messages to it, and so the global map can be managed per-agent.
- **Hot reload**: the write updates the running API process's `channels_config`, but the separate gateway process reads channels once at startup — it still needs a restart to pick up changes.

## Tests

`TestEditAgentChannels` (6 cases): add channel + verbatim-secret persistence, disabled-kept, empty-list-clears, per-agent scoping (one agent's edit preserves another's), blank-name rejected, and delete-removes-channels. Full agent service + models suite: **185 passed**, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [x] release/0.3.3
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents can now be configured with communication channel bindings for integration with external messaging platforms.
  * Channel settings (adapter type, enabled/disabled state, and credentials) can be managed when editing agents.
  * Channel configurations persist and are properly cleaned up when agents are deleted.

* **Tests**
  * Added comprehensive test suite for channel configuration and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can be bound to communication channels (adapter, enabled state, and raw credentials) which persist separately from agent entries.
  * Editing agents can add/update/remove that agent’s channel bindings; omitting channel data leaves existing bindings unchanged.

* **Bug Fixes**
  * Prevents channel name conflicts across agents and rejects blank names.
  * Deleting an agent removes its routed channel bindings to avoid dangling routes.

* **Tests**
  * Added tests covering add/update/remove, disabled channels, name conflicts, blank names, and deletion cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->