### PR TITLE
[BugFix] Prevent semantic validation from scanning temp roots

### DIFF
--- a/datus/api/utils/semantic_validation.py
+++ b/datus/api/utils/semantic_validation.py
@@ -16,7 +16,7 @@ When ``metricflow`` is **not** installed, falls back to a basic
 import os
 import tempfile
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from datus.utils.loggings import get_logger
 
@@ -106,23 +106,19 @@ def _validate_deep(
         if lint_issues:
             return False, [issue.as_readable_str() for issue in lint_issues]
 
-        # Step 3: Collect all existing semantic model files from the same
-        # project tree as ``file_path``. Resolving via the CWD-based
-        # ``DatusPathManager.semantic_model_path()`` would make validation
-        # nondeterministic when the calling process's CWD does not match
-        # the project that owns ``file_path``.
+        # Step 3: Collect existing files only when ``file_path`` is already
+        # anchored in a semantic_models tree. Arbitrary temp paths such as
+        # /tmp/test.yml do not identify a project and must not scan ambient /tmp.
         del datasource  # unused after refactor; kept in signature for compatibility
         del datus_home  # resolution below is file_path-relative
         target_path = Path(file_path).resolve()
-        semantic_yaml_dir = next(
-            (p for p in [target_path.parent, *target_path.parents] if p.name == "semantic_models"),
-            target_path.parent,
-        )
-        file_paths = collect_yaml_config_file_paths(directory=str(semantic_yaml_dir))
+        semantic_yaml_dir = _resolve_semantic_yaml_dir(target_path)
+        file_paths = []
+        if semantic_yaml_dir is not None:
+            file_paths = collect_yaml_config_file_paths(directory=str(semantic_yaml_dir))
 
         # Replace the original file with the temp file for validation
-        if file_path in file_paths:
-            file_paths.remove(file_path)
+        file_paths = [path for path in file_paths if Path(path).resolve() != target_path]
         file_paths.append(temp_file_path)
 
         # Step 4: Cross-file parsing and reference resolution
@@ -146,6 +142,14 @@ def _validate_deep(
             os.remove(temp_file_path)
         if temp_dir and os.path.exists(temp_dir):
             os.rmdir(temp_dir)
+
+
+def _resolve_semantic_yaml_dir(target_path: Path) -> Optional[Path]:
+    """Return the project semantic_models root for paths inside that tree."""
+    return next(
+        (p for p in [target_path.parent, *target_path.parents] if p.name == "semantic_models"),
+        None,
+    )
 
 
 def _issues_to_strings(issues) -> List[str]:

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -783,23 +783,31 @@ class TestExplorerServiceEditKnowledge:
 class TestExplorerServiceValidateMetricYaml:
     """Tests for _validate_metric_yaml — metric YAML validation."""
 
-    async def test_validate_valid_yaml(self, real_agent_config):
+    async def test_validate_valid_yaml(self, real_agent_config, tmp_path):
         """_validate_metric_yaml passes valid metric YAML."""
         svc = ExplorerService(agent_config=real_agent_config)
+        metric_path = (
+            tmp_path / "subject" / "semantic_models" / real_agent_config.current_datasource / "metrics" / "test.yml"
+        )
+        metric_path.parent.mkdir(parents=True)
         is_valid, errors = svc._validate_metric_yaml(
             "metric:\n  name: test\n  type: simple\n",
-            "/tmp/test.yml",
+            str(metric_path),
         )
         # May pass or fail depending on metricflow availability
         assert isinstance(is_valid, bool)
         assert isinstance(errors, list)
 
-    async def test_validate_invalid_yaml(self, real_agent_config):
+    async def test_validate_invalid_yaml(self, real_agent_config, tmp_path):
         """_validate_metric_yaml rejects invalid YAML syntax."""
         svc = ExplorerService(agent_config=real_agent_config)
+        metric_path = (
+            tmp_path / "subject" / "semantic_models" / real_agent_config.current_datasource / "metrics" / "bad.yml"
+        )
+        metric_path.parent.mkdir(parents=True)
         is_valid, errors = svc._validate_metric_yaml(
             ":\n  - ][",
-            "/tmp/bad.yml",
+            str(metric_path),
         )
         assert is_valid is False
         assert len(errors) == 1

--- a/tests/unit_tests/api/utils/test_semantic_validation.py
+++ b/tests/unit_tests/api/utils/test_semantic_validation.py
@@ -1,5 +1,8 @@
 """Tests for datus.api.utils.semantic_validation."""
 
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -127,6 +130,46 @@ class TestDeepValidation:
         assert "Semantic validation failed" in errors[0]
 
 
+class TestDeepValidationPathIsolation:
+    """Tests for metricflow-backed file collection boundaries."""
+
+    def test_non_semantic_models_path_does_not_scan_parent_directory(self, monkeypatch, tmp_path):
+        captured = _install_fake_metricflow(monkeypatch)
+        semantic_validation._METRICFLOW_AVAILABLE = True
+
+        is_valid, errors = validate_semantic_yaml(
+            yaml_content="metric:\n  name: test\n  type: simple\n",
+            file_path=str(tmp_path / "test.yml"),
+            datus_home=str(tmp_path / "home"),
+            datasource="default",
+        )
+
+        assert is_valid is True
+        assert errors == []
+        assert captured["collected_dirs"] == []
+        assert len(captured["parsed_file_paths"]) == 1
+        assert captured["parsed_file_paths"][0].endswith("test.yml")
+
+    def test_semantic_models_path_collects_project_semantic_root(self, monkeypatch, tmp_path):
+        captured = _install_fake_metricflow(monkeypatch)
+        semantic_validation._METRICFLOW_AVAILABLE = True
+        semantic_root = tmp_path / "subject" / "semantic_models"
+        metric_path = semantic_root / "analytics" / "metrics" / "test.yml"
+
+        is_valid, errors = validate_semantic_yaml(
+            yaml_content="metric:\n  name: test\n  type: simple\n",
+            file_path=str(metric_path),
+            datus_home=str(tmp_path / "home"),
+            datasource="analytics",
+        )
+
+        assert is_valid is True
+        assert errors == []
+        assert captured["collected_dirs"] == [str(semantic_root)]
+        assert captured["parsed_file_paths"][0] == str(semantic_root / "existing.yml")
+        assert captured["parsed_file_paths"][-1].endswith("test.yml")
+
+
 # ---------------------------------------------------------------------------
 # Availability detection
 # ---------------------------------------------------------------------------
@@ -156,3 +199,46 @@ class TestMetricflowDetection:
             result = semantic_validation._check_metricflow()
             assert result is False
             assert semantic_validation._METRICFLOW_AVAILABLE is False
+
+
+def _install_fake_metricflow(monkeypatch):
+    captured = {"collected_dirs": [], "parsed_file_paths": []}
+
+    class FakeConfigLinter:
+        def lint_file(self, _file_path):
+            return []
+
+    class FakeModelValidator:
+        def validate_model(self, _model):
+            return SimpleNamespace(issues=None)
+
+    def fake_collect_yaml_config_file_paths(directory):
+        captured["collected_dirs"].append(directory)
+        return [str(Path(directory) / "existing.yml")]
+
+    def fake_parse_yaml_file_paths_to_model(file_paths, raise_issues_as_exceptions=False):
+        captured["parsed_file_paths"] = list(file_paths)
+        assert raise_issues_as_exceptions is False
+        return SimpleNamespace(issues=None, model=object())
+
+    model_validator = ModuleType("metricflow.model.model_validator")
+    model_validator.ModelValidator = FakeModelValidator
+
+    config_linter = ModuleType("metricflow.model.parsing.config_linter")
+    config_linter.ConfigLinter = FakeConfigLinter
+
+    dir_to_model = ModuleType("metricflow.model.parsing.dir_to_model")
+    dir_to_model.collect_yaml_config_file_paths = fake_collect_yaml_config_file_paths
+    dir_to_model.parse_yaml_file_paths_to_model = fake_parse_yaml_file_paths_to_model
+
+    modules = {
+        "metricflow": ModuleType("metricflow"),
+        "metricflow.model": ModuleType("metricflow.model"),
+        "metricflow.model.model_validator": model_validator,
+        "metricflow.model.parsing": ModuleType("metricflow.model.parsing"),
+        "metricflow.model.parsing.config_linter": config_linter,
+        "metricflow.model.parsing.dir_to_model": dir_to_model,
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    return captured


### PR DESCRIPTION
## Summary
- avoid scanning arbitrary parent directories when semantic YAML validation receives a path outside a semantic_models tree
- validate isolated temp-path YAML against only the staged temp file instead of ambient temp YAML files
- move explorer service validation tests off global temp paths and add fake-metricflow regression coverage for path isolation

## Validation
- uv run pytest tests/unit_tests/api/utils/test_semantic_validation.py tests/unit_tests/api/services/test_explorer_service.py::TestExplorerServiceValidateMetricYaml -q
- uv run pytest tests/unit_tests/api/services/ -m "not acceptance and not component and not llm_harness and not nightly and not quarantine" -q
- uv run pytest tests/unit_tests/api/utils/ -q
- uv run ruff format --check datus/api/utils/semantic_validation.py tests/unit_tests/api/utils/test_semantic_validation.py tests/unit_tests/api/services/test_explorer_service.py
- uv run ruff check datus/api/utils/semantic_validation.py tests/unit_tests/api/utils/test_semantic_validation.py tests/unit_tests/api/services/test_explorer_service.py

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [x] release/0.3.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic YAML validation to prevent unnecessary parent directory scanning when validating files outside semantic_models directories, enhancing validation accuracy and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->