### PR TITLE
[Feature] Add `datus upgrade` self-upgrade command and startup version notice

### DIFF
--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -495,6 +495,15 @@ def main():
     import signal
     import sys
 
+    # Intercept 'upgrade'/'update' subcommand: self-upgrade datus-agent and the
+    # installed datus-* adapter packages. Handled before the REPL is built so it
+    # works even when the installed CLI is otherwise broken.
+    if len(sys.argv) > 1 and sys.argv[1] in ("upgrade", "update"):
+        from datus.cli.upgrade_cli import run_upgrade_command
+
+        configure_logging(False, console_output=False)
+        sys.exit(run_upgrade_command(sys.argv[2:]))
+
     # Intercept 'skill' subcommand and delegate to datus.main's skill handler
     if len(sys.argv) > 1 and sys.argv[1] == "skill":
         from datus.main import create_parser as create_main_parser

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -11,7 +11,6 @@ Main entry point for the CLI application.
 import argparse
 
 from datus import __version__
-from datus.cli.repl import DatusCLI
 from datus.utils.async_utils import setup_windows_policy
 from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
@@ -233,6 +232,10 @@ class Application:
         elif args.web:
             self._run_web_interface(args)
         else:
+            # Import lazily so the 'upgrade'/'update' interceptor in main() can run
+            # even when datus.cli.repl is broken (the whole point of self-upgrade).
+            from datus.cli.repl import DatusCLI
+
             cli = DatusCLI(args)
             cli.run()
 

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -974,6 +974,7 @@ class DatusCLI:
     def _run_prompt_session(self):
         """Classic ``PromptSession`` main loop (used for non-TTY fallback)."""
         self._print_welcome()
+        self._check_for_upgrade()
         self._warn_no_model()
         self._warn_no_datasource()
         self._bootstrap_services()
@@ -1031,6 +1032,7 @@ class DatusCLI:
         """
         self._pin_tui_to_bottom()
         self._print_welcome()
+        self._check_for_upgrade()
         self._warn_no_model()
         self._warn_no_datasource()
         self._bootstrap_services()
@@ -2140,6 +2142,59 @@ class DatusCLI:
         """Print a one-time hint when no datasource is configured."""
         if not self.agent_config.services.datasources:
             self.console.print("[yellow]No datasources configured. Use /datasource to add one.[/]")
+
+    def _check_for_upgrade(self) -> None:
+        """Hint that a newer ``datus-agent`` is available, then refresh the cache.
+
+        Two-step, deliberately non-blocking and non-racy:
+
+        * **Synchronous fast path** — if a *fresh* on-disk cache already
+          knows of a newer release, print a one-line yellow hint right
+          after the banner. A cold cache shows nothing (no network call on
+          the main thread).
+        * **Background refresh** — a daemon thread re-queries PyPI and
+          updates the cache only. It never prints (which would interleave
+          with the prompt); the hint surfaces from the next launch onward.
+
+        Skipped entirely for non-interactive sessions or when
+        ``DATUS_DISABLE_VERSION_CHECK`` is set. Any failure is swallowed —
+        a version check must never abort startup.
+        """
+        import os
+
+        if os.environ.get("DATUS_DISABLE_VERSION_CHECK"):
+            return
+        try:
+            from datus.cli.service_bootstrap import _is_interactive
+
+            if not _is_interactive():
+                return
+        except Exception:  # pragma: no cover - defensive
+            return
+
+        from datus import __version__
+        from datus.cli import upgrade_service as upgrade_svc
+
+        try:
+            newer = upgrade_svc.newer_version_available(__version__, agent_config=self.agent_config, cached_only=True)
+            if newer:
+                self.console.print(
+                    f"[yellow]A new datus-agent is available: {__version__} -> {newer}. "
+                    f"Run [bold]datus upgrade[/] to update.[/]"
+                )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("cached version check failed: %s", exc)
+
+        def _worker() -> None:
+            try:
+                upgrade_svc.get_latest_version(agent_config=self.agent_config)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("background version fetch failed: %s", exc)
+
+        try:
+            threading.Thread(target=_worker, daemon=True).start()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("could not start version-check thread: %s", exc)
 
     def _bootstrap_services(self) -> None:
         """Pin project defaults and kick off background adapter installs.

--- a/datus/cli/upgrade_cli.py
+++ b/datus/cli/upgrade_cli.py
@@ -1,0 +1,114 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Non-REPL handler for the ``datus upgrade`` / ``datus update`` subcommand.
+
+Lists the ``datus-*`` packages installed in the active interpreter and
+upgrades them to the latest release in a single ``uv``/``pip`` run. Lives
+outside the REPL so it works even when the installed CLI is broken — the
+``main()`` entry point intercepts the subcommand before building the app.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+from rich.console import Console
+
+from datus.cli import upgrade_service as svc
+from datus.cli.cli_styles import print_error, print_info, print_status, print_warning
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def _parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="datus upgrade",
+        description="Upgrade datus-agent and installed datus-* adapter packages to the latest version.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only report the installed packages and the latest datus-agent version; do not install.",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Reserved for non-interactive use; upgrades run without an extra confirmation prompt.",
+    )
+    return parser.parse_args(argv)
+
+
+def _print_installed(console: Console, packages: List[svc.DatusPackage]) -> None:
+    print_info(console, "Installed datus packages:")
+    for pkg in packages:
+        suffix = "  [dim](editable/source — will be skipped)[/]" if pkg.editable else ""
+        console.print(f"  [cyan]{pkg.name}[/] {pkg.version}{suffix}")
+
+
+def run_upgrade_command(argv: List[str]) -> int:
+    """Entry point for ``datus upgrade``. Returns a process exit code."""
+    args = _parse_args(argv)
+    console = Console()
+
+    packages = svc.enumerate_datus_packages()
+    _print_installed(console, packages)
+
+    if args.check:
+        latest = svc.get_latest_version(force=True)
+        current = next((p.version for p in packages if p.name == svc.DISTRIBUTION_NAME), "")
+        if latest is None:
+            print_warning(console, "Could not reach PyPI to determine the latest datus-agent version.")
+        elif latest == current:
+            print_info(console, f"datus-agent is up to date ({current}).")
+        else:
+            newer = svc.newer_version_available(current) if current else latest
+            if newer:
+                print_warning(console, f"A newer datus-agent is available: {current} -> {latest}. Run `datus upgrade`.")
+            else:
+                print_info(console, f"Latest datus-agent on PyPI is {latest} (installed {current}).")
+        return 0
+
+    upgradable = [p for p in packages if not p.editable]
+    if not upgradable:
+        print_warning(
+            console,
+            "All datus packages are editable/source installs; nothing to upgrade via pip. "
+            "Update your checkout with git instead.",
+        )
+        return 0
+
+    print_info(console, f"Upgrading {len(upgradable)} package(s) to the latest version...")
+    result = svc.upgrade_packages(packages)
+
+    if result.skipped_editable:
+        print_warning(console, "Skipped editable/source installs: " + ", ".join(result.skipped_editable))
+
+    if result.ok:
+        # Clear the version-check cache so the startup hint clears next launch.
+        try:
+            svc._write_cache(svc._cache_path(), None)
+        except Exception:  # pragma: no cover - cache is best-effort
+            pass
+        if not result.changes:
+            print_status(console, "All datus packages are already up to date.", ok=True)
+            return 0
+        print_status(console, "Upgrade complete.", ok=True)
+        for name, old, new in result.changes:
+            console.print(f"  [green]{name}[/] {old} -> {new}")
+        print_info(console, "Restart datus for the new version(s) to take effect.")
+        return 0
+
+    print_status(console, "Upgrade failed.", ok=False)
+    tail = (result.stderr or result.stdout or "").strip().splitlines()[-10:]
+    for line in tail:
+        console.print(f"  [dim]{line}[/]")
+    print_error(console, result.error or "unknown error")
+    return 1
+
+
+__all__ = ["run_upgrade_command"]

--- a/datus/cli/upgrade_cli.py
+++ b/datus/cli/upgrade_cli.py
@@ -38,7 +38,7 @@ def _parse_args(argv: List[str]) -> argparse.Namespace:
         "--yes",
         "-y",
         action="store_true",
-        help="Reserved for non-interactive use; upgrades run without an extra confirmation prompt.",
+        help="Reserved for non-interactive use; currently a no-op (the command never prompts).",
     )
     return parser.parse_args(argv)
 

--- a/datus/cli/upgrade_service.py
+++ b/datus/cli/upgrade_service.py
@@ -1,0 +1,331 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Self-upgrade helpers for the ``datus upgrade`` subcommand.
+
+Two concerns live here, both pure Python (no prompt_toolkit / Rich import)
+so they can be unit-tested by monkey-patching ``subprocess.run``,
+``shutil.which``, ``httpx.Client`` and ``importlib.metadata.distributions``:
+
+1. **Package discovery + upgrade.** Enumerate every ``datus-*``
+   distribution installed in the active interpreter
+   (:func:`enumerate_datus_packages`) and run a single ``uv pip install
+   --upgrade`` (or ``pip install --upgrade``) over the non-editable ones
+   (:func:`upgrade_packages`). Editable / source-tree installs are
+   detected via ``direct_url.json`` (mirrors
+   ``ci/nightly_manifest.package_info``) and skipped — pip-upgrading over
+   a checkout would be wrong.
+
+2. **Latest-version check.** Query the public PyPI JSON API for the
+   latest ``datus-agent`` release (:func:`get_latest_version`), cached on
+   disk for 24h under ``{datus_home}/cache/version_check.json``. The REPL
+   banner uses :func:`newer_version_available` to decide whether to show
+   a one-line upgrade hint. Every network / disk failure degrades to
+   ``None`` so a check never blocks or breaks startup.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata as importlib_metadata
+import json
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+DISTRIBUTION_NAME = "datus-agent"
+_PYPI_URL = "https://pypi.org/pypi/{name}/json"
+_CACHE_TTL_SECONDS = 24 * 60 * 60
+_HTTP_TIMEOUT = 3.0  # short so the background check never lingers
+
+
+@dataclass
+class DatusPackage:
+    """One installed ``datus-*`` distribution."""
+
+    name: str  # canonical (PEP 503) dist name, e.g. "datus-agent"
+    version: str  # currently installed version
+    editable: bool = False  # editable / source-tree install → skip pip upgrade
+
+
+@dataclass
+class UpgradeResult:
+    """Outcome of :func:`upgrade_packages`.
+
+    ``ok`` is the field callers branch on; ``stdout`` / ``stderr`` are
+    captured so the CLI can render a tail of the failed pip/uv run.
+    """
+
+    ok: bool
+    packages: List[str] = field(default_factory=list)
+    skipped_editable: List[str] = field(default_factory=list)
+    # (name, old_version, new_version) for packages whose version actually
+    # changed after the upgrade. Empty when everything was already current.
+    changes: List[Tuple[str, str, str]] = field(default_factory=list)
+    label: str = ""
+    stdout: str = ""
+    stderr: str = ""
+    error: Optional[str] = None
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normalization for comparison (``datus_foo`` → ``datus-foo``)."""
+    return name.lower().replace("_", "-")
+
+
+def _is_editable(dist: importlib_metadata.Distribution) -> bool:
+    """True for editable / local source installs.
+
+    Mirrors ``ci/nightly_manifest.package_info``: editable installs carry
+    a ``direct_url.json`` whose ``dir_info.editable`` is true, or whose
+    ``url`` is a local ``file://`` path. Missing / malformed metadata is
+    treated as a normal (non-editable) install.
+    """
+    try:
+        text = dist.read_text("direct_url.json")
+    except Exception:  # pragma: no cover - defensive, metadata read can raise
+        return False
+    if not text:
+        return False
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    dir_info = data.get("dir_info")
+    if isinstance(dir_info, dict) and dir_info.get("editable"):
+        return True
+    return str(data.get("url", "")).startswith("file://")
+
+
+def enumerate_datus_packages() -> List[DatusPackage]:
+    """Return every installed ``datus-*`` distribution, sorted by name.
+
+    ``datus-agent`` is always present in the result: when it is not an
+    installed distribution (running straight from a source checkout) we
+    synthesize an entry from :data:`datus.__version__` and flag it
+    ``editable`` so the upgrade path never pip-installs over the tree.
+    """
+    found: dict[str, DatusPackage] = {}
+    for dist in importlib_metadata.distributions():
+        try:
+            raw = dist.metadata.get("Name") or ""
+        except Exception:  # pragma: no cover - corrupt metadata
+            continue
+        if not raw:
+            continue
+        norm = _normalize(raw)
+        if not norm.startswith("datus-"):
+            continue
+        # First writer wins; duplicate dist dirs for the same name are rare
+        # but possible, and either entry is acceptable for our purposes.
+        if norm not in found:
+            found[norm] = DatusPackage(name=norm, version=dist.version, editable=_is_editable(dist))
+
+    if DISTRIBUTION_NAME not in found:
+        from datus import __version__
+
+        found[DISTRIBUTION_NAME] = DatusPackage(name=DISTRIBUTION_NAME, version=__version__, editable=True)
+
+    return sorted(found.values(), key=lambda p: p.name)
+
+
+def _upgrade_command(pkgs: List[str]) -> Tuple[List[str], str]:
+    """Build the upgrade command, preferring ``uv pip`` when available.
+
+    Mirrors ``service_adapter_installer._install_command`` but adds
+    ``--upgrade`` and accepts multiple packages. ``uv tool install`` /
+    bare ``uv venv`` environments do not seed ``pip``, so routing through
+    ``uv pip install --python <sys.executable>`` reuses the active
+    interpreter without requiring ``pip`` to be present. Returns
+    ``(argv, label)`` where ``label`` names the underlying tool for error
+    messages.
+    """
+    uv_path = shutil.which("uv")
+    if uv_path:
+        return [uv_path, "pip", "install", "--upgrade", "--python", sys.executable, *pkgs], "uv pip install --upgrade"
+    return [sys.executable, "-m", "pip", "install", "--upgrade", *pkgs], "pip install --upgrade"
+
+
+def upgrade_packages(packages: List[DatusPackage]) -> UpgradeResult:
+    """Upgrade every non-editable package in one ``uv``/``pip`` invocation.
+
+    Editable / source-tree installs are skipped (recorded in
+    ``skipped_editable``). When nothing is upgradable the function returns
+    ``ok=True`` with an explanatory ``error`` and never shells out.
+    """
+    upgradable = [p.name for p in packages if not p.editable]
+    skipped = [p.name for p in packages if p.editable]
+    if not upgradable:
+        return UpgradeResult(
+            ok=True,
+            packages=[],
+            skipped_editable=skipped,
+            error="No upgradable packages (all editable / source installs).",
+        )
+
+    old_versions = {p.name: p.version for p in packages if not p.editable}
+    cmd, label = _upgrade_command(upgradable)
+    logger.info("Upgrading datus packages: %s", " ".join(cmd))
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except Exception as exc:  # uv / pip missing, OSError, etc.
+        return UpgradeResult(ok=False, packages=upgradable, skipped_editable=skipped, label=label, error=str(exc))
+
+    stdout = proc.stdout or ""
+    stderr = proc.stderr or ""
+    if proc.returncode != 0:
+        return UpgradeResult(
+            ok=False,
+            packages=upgradable,
+            skipped_editable=skipped,
+            label=label,
+            stdout=stdout,
+            stderr=stderr,
+            error=f"{label} exited with code {proc.returncode}",
+        )
+    return UpgradeResult(
+        ok=True,
+        packages=upgradable,
+        skipped_editable=skipped,
+        changes=_collect_changes(old_versions, upgradable),
+        label=label,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _collect_changes(old_versions: dict, names: List[str]) -> List[Tuple[str, str, str]]:
+    """Re-read installed versions after an upgrade and return the diffs.
+
+    ``importlib.invalidate_caches()`` makes the freshly-installed
+    ``dist-info`` directories visible to a re-scan in the same process
+    (mirrors ``service_adapter_installer.ensure_adapter``). Only packages
+    whose version actually changed are returned; a package that was
+    already current is omitted.
+    """
+    importlib.invalidate_caches()
+    after = {p.name: p.version for p in enumerate_datus_packages()}
+    changes: List[Tuple[str, str, str]] = []
+    for name in names:
+        old = old_versions.get(name, "")
+        new = after.get(name, old)
+        if new != old:
+            changes.append((name, old, new))
+    return changes
+
+
+# ── latest-version check (public PyPI JSON + 24h on-disk cache) ────────
+
+
+def _cache_path(agent_config=None) -> Path:
+    """Resolve ``{datus_home}/cache/version_check.json``."""
+    from datus.utils.path_manager import get_path_manager
+
+    return get_path_manager(agent_config=agent_config).datus_home / "cache" / "version_check.json"
+
+
+def _read_cache(path: Path) -> Optional[dict]:
+    """Return the cached payload if present and younger than the TTL."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    checked_at = data.get("checked_at", 0)
+    if not isinstance(checked_at, (int, float)):
+        return None
+    if (time.time() - checked_at) > _CACHE_TTL_SECONDS:
+        return None
+    return data
+
+
+def _write_cache(path: Path, latest: Optional[str]) -> None:
+    """Persist the check result (best-effort; failures are swallowed).
+
+    Negative results (``latest=None``) are cached too so an offline run
+    does not re-hit the network on every launch within the TTL window.
+    """
+    payload = {"checked_at": time.time(), "latest": latest, "name": DISTRIBUTION_NAME}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _fetch_latest_from_pypi() -> Optional[str]:
+    """Fetch the latest ``datus-agent`` version from PyPI, or ``None``."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+            resp = client.get(_PYPI_URL.format(name=DISTRIBUTION_NAME))
+            resp.raise_for_status()
+            version = resp.json().get("info", {}).get("version")
+    except Exception as exc:  # offline, timeout, HTTP error, bad JSON
+        logger.debug("PyPI version check failed: %s", exc)
+        return None
+    return version if isinstance(version, str) and version else None
+
+
+def get_latest_version(*, agent_config=None, force: bool = False) -> Optional[str]:
+    """Latest ``datus-agent`` version, using a fresh cache when available.
+
+    Returns ``None`` on any failure / offline state. Always refreshes the
+    on-disk cache when it fetches (including negative results).
+    """
+    path = _cache_path(agent_config)
+    if not force:
+        cached = _read_cache(path)
+        if cached is not None:
+            return cached.get("latest")
+    latest = _fetch_latest_from_pypi()
+    _write_cache(path, latest)
+    return latest
+
+
+def newer_version_available(current: str, *, agent_config=None, cached_only: bool = False) -> Optional[str]:
+    """Return the latest version if it is strictly newer than ``current``.
+
+    ``cached_only=True`` never touches the network — it consults only a
+    fresh on-disk cache (used at REPL startup so a cold cache shows no
+    hint and the check never blocks). Returns ``None`` when there is no
+    newer version, no cached/fetched answer, or either version string is
+    unparseable.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    if cached_only:
+        cached = _read_cache(_cache_path(agent_config))
+        latest = cached.get("latest") if cached else None
+    else:
+        latest = get_latest_version(agent_config=agent_config)
+
+    if not latest:
+        return None
+    try:
+        return latest if Version(latest) > Version(current) else None
+    except InvalidVersion:
+        return None
+
+
+__all__ = [
+    "DatusPackage",
+    "UpgradeResult",
+    "enumerate_datus_packages",
+    "upgrade_packages",
+    "get_latest_version",
+    "newer_version_available",
+]

--- a/datus/cli/upgrade_service.py
+++ b/datus/cli/upgrade_service.py
@@ -83,12 +83,15 @@ def _normalize(name: str) -> str:
 
 
 def _is_editable(dist: importlib_metadata.Distribution) -> bool:
-    """True for editable / local source installs.
+    """True for editable / local source (directory) installs.
 
-    Mirrors ``ci/nightly_manifest.package_info``: editable installs carry
-    a ``direct_url.json`` whose ``dir_info.editable`` is true, or whose
-    ``url`` is a local ``file://`` path. Missing / malformed metadata is
-    treated as a normal (non-editable) install.
+    Per PEP 610, a ``direct_url.json`` describes a directory install via
+    ``dir_info`` and a local wheel/archive install via ``archive_info``.
+    A distribution is treated as editable/source when it was installed from
+    a directory (``dir_info`` present), either explicitly editable
+    (``dir_info.editable`` true) or from a local ``file://`` path. Local
+    wheels/archives (``archive_info``) and missing / malformed metadata are
+    treated as normal (non-editable) installs that pip/uv can upgrade.
     """
     try:
         text = dist.read_text("direct_url.json")
@@ -103,7 +106,11 @@ def _is_editable(dist: importlib_metadata.Distribution) -> bool:
     if not isinstance(data, dict):
         return False
     dir_info = data.get("dir_info")
-    if isinstance(dir_info, dict) and dir_info.get("editable"):
+    if not isinstance(dir_info, dict):
+        # Local wheels/archives carry ``archive_info`` (no ``dir_info``); pip/uv
+        # can upgrade those, so they are not editable/source installs.
+        return False
+    if dir_info.get("editable"):
         return True
     return str(data.get("url", "")).startswith("file://")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "sqlalchemy==2.0.23",
     "sqlglot>=26.12.0",
     "pyyaml==6.0.1",
+    "packaging>=21.0",
     "structlog>=23.1.0",
     "openai>=2.8.0",
     "httpx[socks]==0.27.2",

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -95,7 +95,7 @@ class TestApplicationRun:
             patch("datus.cli.main.configure_logging"),
             patch.object(app, "_ensure_project_config"),
             patch.object(app, "_resolve_default_datasource", return_value=""),
-            patch("datus.cli.main.DatusCLI", return_value=mock_cli) as mock_cli_cls,
+            patch("datus.cli.repl.DatusCLI", return_value=mock_cli) as mock_cli_cls,
         ):
             app.run()
         mock_cli_cls.assert_called_once_with(mock_args)
@@ -111,7 +111,7 @@ class TestApplicationRun:
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
             patch("datus.cli.main.configure_logging"),
             patch.object(app, "_resolve_default_datasource", return_value=""),
-            patch("datus.cli.main.DatusCLI") as mock_cli_cls,
+            patch("datus.cli.repl.DatusCLI") as mock_cli_cls,
         ):
             app.run()
         mock_cli_cls.assert_not_called()
@@ -128,7 +128,7 @@ class TestApplicationRun:
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
             patch("datus.cli.main.configure_logging"),
             patch.object(app, "_ensure_project_config"),
-            patch("datus.cli.main.DatusCLI") as mock_cli_cls,
+            patch("datus.cli.repl.DatusCLI") as mock_cli_cls,
         ):
             app.run()
         mock_cli_cls.assert_called_once_with(mock_args)
@@ -181,7 +181,7 @@ class TestApplicationRun:
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),
             patch("datus.cli.main.configure_logging"),
             patch.object(app, "_ensure_project_config") as mock_ensure,
-            patch("datus.cli.main.DatusCLI", return_value=mock_cli) as MockCLI,
+            patch("datus.cli.repl.DatusCLI", return_value=mock_cli) as MockCLI,
         ):
             app.run()
         mock_ensure.assert_called_once_with(mock_args)

--- a/tests/unit_tests/cli/test_upgrade_cli.py
+++ b/tests/unit_tests/cli/test_upgrade_cli.py
@@ -1,0 +1,160 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for ``datus.cli.upgrade_cli.run_upgrade_command``.
+
+CI-level: package enumeration and the upgrade subprocess are
+monkey-patched; output is captured via a Rich ``Console`` writing to a
+``StringIO`` so we can assert on rendered text.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+from datus.cli import upgrade_cli
+from datus.cli import upgrade_service as svc
+
+
+@pytest.fixture
+def capture_console(monkeypatch):
+    """Force ``run_upgrade_command`` to render into a captured buffer."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, width=200)
+    monkeypatch.setattr(upgrade_cli, "Console", lambda *a, **k: console)
+    return buffer
+
+
+def test_all_editable_warns_and_skips_upgrade(capture_console, monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "enumerate_datus_packages",
+        lambda: [svc.DatusPackage("datus-agent", "0.3.1", editable=True)],
+    )
+    called = []
+    monkeypatch.setattr(svc, "upgrade_packages", lambda pkgs: called.append(pkgs))
+
+    rc = upgrade_cli.run_upgrade_command([])
+    output = capture_console.getvalue()
+
+    assert rc == 0
+    assert called == []  # upgrade_packages must not be invoked
+    assert "nothing to upgrade" in output
+
+
+def test_success_shows_version_diffs_and_clears_cache(capture_console, monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "enumerate_datus_packages",
+        lambda: [svc.DatusPackage("datus-agent", "0.3.1", editable=False)],
+    )
+    monkeypatch.setattr(
+        svc,
+        "upgrade_packages",
+        lambda pkgs: svc.UpgradeResult(
+            ok=True,
+            packages=["datus-agent"],
+            changes=[("datus-agent", "0.3.1", "0.3.2")],
+            label="pip install --upgrade",
+        ),
+    )
+    cache_writes = []
+    monkeypatch.setattr(svc, "_cache_path", lambda agent_config=None: "/tmp/fake")
+    monkeypatch.setattr(svc, "_write_cache", lambda path, latest: cache_writes.append((path, latest)))
+
+    rc = upgrade_cli.run_upgrade_command([])
+    output = capture_console.getvalue()
+
+    assert rc == 0
+    assert "datus-agent 0.3.1 -> 0.3.2" in output
+    assert "Upgrade complete" in output
+    assert "Restart datus" in output
+    assert cache_writes == [("/tmp/fake", None)]  # version-check cache cleared
+
+
+def test_no_changes_reports_already_up_to_date(capture_console, monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "enumerate_datus_packages",
+        lambda: [svc.DatusPackage("datus-agent", "0.3.2", editable=False)],
+    )
+    monkeypatch.setattr(
+        svc,
+        "upgrade_packages",
+        lambda pkgs: svc.UpgradeResult(ok=True, packages=["datus-agent"], changes=[], label="pip install --upgrade"),
+    )
+    monkeypatch.setattr(svc, "_cache_path", lambda agent_config=None: "/tmp/fake")
+    monkeypatch.setattr(svc, "_write_cache", lambda path, latest: None)
+
+    rc = upgrade_cli.run_upgrade_command([])
+    output = capture_console.getvalue()
+
+    assert rc == 0
+    assert "already up to date" in output
+    assert "->" not in output
+    assert "Restart datus" not in output
+
+
+def test_failure_shows_error_and_stderr_tail(capture_console, monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "enumerate_datus_packages",
+        lambda: [svc.DatusPackage("datus-agent", "0.3.1", editable=False)],
+    )
+    monkeypatch.setattr(
+        svc,
+        "upgrade_packages",
+        lambda pkgs: svc.UpgradeResult(
+            ok=False,
+            packages=["datus-agent"],
+            label="pip install --upgrade",
+            stderr="line-a\nERROR: resolution impossible",
+            error="pip install --upgrade exited with code 1",
+        ),
+    )
+
+    rc = upgrade_cli.run_upgrade_command([])
+    output = capture_console.getvalue()
+
+    assert rc == 1
+    assert "Upgrade failed" in output
+    assert "resolution impossible" in output
+    assert "exited with code 1" in output
+
+
+def test_check_flag_does_not_upgrade(capture_console, monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "enumerate_datus_packages",
+        lambda: [svc.DatusPackage("datus-agent", "0.3.1", editable=False)],
+    )
+    upgrade_called = []
+    monkeypatch.setattr(svc, "upgrade_packages", lambda pkgs: upgrade_called.append(pkgs))
+    monkeypatch.setattr(svc, "get_latest_version", lambda **k: "0.4.0")
+    monkeypatch.setattr(svc, "newer_version_available", lambda current, **k: "0.4.0")
+
+    rc = upgrade_cli.run_upgrade_command(["--check"])
+    output = capture_console.getvalue()
+
+    assert rc == 0
+    assert upgrade_called == []
+    assert "0.4.0" in output
+
+
+def test_check_flag_reports_up_to_date(capture_console, monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "enumerate_datus_packages",
+        lambda: [svc.DatusPackage("datus-agent", "0.4.0", editable=False)],
+    )
+    monkeypatch.setattr(svc, "upgrade_packages", lambda pkgs: pytest.fail("must not upgrade"))
+    monkeypatch.setattr(svc, "get_latest_version", lambda **k: "0.4.0")
+
+    rc = upgrade_cli.run_upgrade_command(["--check"])
+    output = capture_console.getvalue()
+
+    assert rc == 0
+    assert "up to date" in output

--- a/tests/unit_tests/cli/test_upgrade_service.py
+++ b/tests/unit_tests/cli/test_upgrade_service.py
@@ -35,8 +35,14 @@ def _editable_direct_url() -> str:
     return json.dumps({"url": "file:///home/user/datus-bi-superset", "dir_info": {"editable": True}})
 
 
-def _file_url_direct_url() -> str:
-    return json.dumps({"url": "file:///home/user/some-pkg"})
+def _local_dir_direct_url() -> str:
+    # Non-editable directory install (``pip install ./path``): dir_info present.
+    return json.dumps({"url": "file:///home/user/some-pkg", "dir_info": {"editable": False}})
+
+
+def _local_wheel_direct_url() -> str:
+    # Local wheel/archive install (``pip install ./foo.whl``): archive_info, no dir_info.
+    return json.dumps({"url": "file:///home/user/foo-0.1.0.whl", "archive_info": {}})
 
 
 def _wheel_direct_url() -> str:
@@ -79,12 +85,21 @@ class TestEnumerateDatusPackages:
         pkg = next(p for p in svc.enumerate_datus_packages() if p.name == "datus-bi-superset")
         assert pkg.editable is True
 
-    def test_editable_flag_from_file_url(self, monkeypatch):
-        dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=_file_url_direct_url())]
+    def test_editable_flag_from_local_dir_file_url(self, monkeypatch):
+        # A local directory install (dir_info present, file:// url) is source/editable.
+        dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=_local_dir_direct_url())]
         monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
         monkeypatch.setattr("datus.__version__", "0.3.1", raising=False)
         pkg = next(p for p in svc.enumerate_datus_packages() if p.name == "datus-bi-superset")
         assert pkg.editable is True
+
+    def test_local_wheel_install_is_not_editable(self, monkeypatch):
+        # A local wheel/archive (archive_info, file:// url) is upgradable, not editable.
+        dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=_local_wheel_direct_url())]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        monkeypatch.setattr("datus.__version__", "0.3.1", raising=False)
+        pkg = next(p for p in svc.enumerate_datus_packages() if p.name == "datus-bi-superset")
+        assert pkg.editable is False
 
     def test_normal_wheel_install_is_not_editable(self, monkeypatch):
         dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=_wheel_direct_url())]

--- a/tests/unit_tests/cli/test_upgrade_service.py
+++ b/tests/unit_tests/cli/test_upgrade_service.py
@@ -1,0 +1,357 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for ``datus.cli.upgrade_service``.
+
+CI-level: ``subprocess.run``, ``shutil.which``, ``httpx.Client`` and
+``importlib.metadata.distributions`` are monkey-patched so no real pip /
+network / disk-outside-tmp access happens.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+from datus.cli import upgrade_service as svc
+
+
+class _FakeDist:
+    """Minimal stand-in for ``importlib.metadata.Distribution``."""
+
+    def __init__(self, name: str, version: str, direct_url: str | None = None):
+        self.metadata = {"Name": name}
+        self.version = version
+        self._direct_url = direct_url
+
+    def read_text(self, filename: str):
+        if filename == "direct_url.json":
+            return self._direct_url
+        return None
+
+
+def _editable_direct_url() -> str:
+    return json.dumps({"url": "file:///home/user/datus-bi-superset", "dir_info": {"editable": True}})
+
+
+def _file_url_direct_url() -> str:
+    return json.dumps({"url": "file:///home/user/some-pkg"})
+
+
+def _wheel_direct_url() -> str:
+    return json.dumps({"url": "https://pypi.org/simple/foo", "archive_info": {}})
+
+
+# ── enumerate_datus_packages ──────────────────────────────────────────
+
+
+class TestEnumerateDatusPackages:
+    def test_filters_non_datus_distributions(self, monkeypatch):
+        dists = [
+            _FakeDist("datus-agent", "0.3.1"),
+            _FakeDist("requests", "2.0.0"),
+            _FakeDist("datus-bi-superset", "0.1.0"),
+        ]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        names = [p.name for p in svc.enumerate_datus_packages()]
+        assert names == ["datus-agent", "datus-bi-superset"]
+
+    def test_normalizes_underscore_names(self, monkeypatch):
+        dists = [_FakeDist("datus_bi_superset", "0.1.0"), _FakeDist("datus-agent", "0.3.1")]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        names = [p.name for p in svc.enumerate_datus_packages()]
+        assert "datus-bi-superset" in names
+
+    def test_synthesizes_datus_agent_when_not_installed(self, monkeypatch):
+        dists = [_FakeDist("datus-bi-superset", "0.1.0")]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        monkeypatch.setattr("datus.__version__", "9.9.9", raising=False)
+        packages = svc.enumerate_datus_packages()
+        agent = next(p for p in packages if p.name == "datus-agent")
+        assert agent.editable is True  # source/checkout → never pip over it
+        assert agent.version == "9.9.9"
+
+    def test_editable_flag_from_dir_info(self, monkeypatch):
+        dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=_editable_direct_url())]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        monkeypatch.setattr("datus.__version__", "0.3.1", raising=False)
+        pkg = next(p for p in svc.enumerate_datus_packages() if p.name == "datus-bi-superset")
+        assert pkg.editable is True
+
+    def test_editable_flag_from_file_url(self, monkeypatch):
+        dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=_file_url_direct_url())]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        monkeypatch.setattr("datus.__version__", "0.3.1", raising=False)
+        pkg = next(p for p in svc.enumerate_datus_packages() if p.name == "datus-bi-superset")
+        assert pkg.editable is True
+
+    def test_normal_wheel_install_is_not_editable(self, monkeypatch):
+        dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=_wheel_direct_url())]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        monkeypatch.setattr("datus.__version__", "0.3.1", raising=False)
+        pkg = next(p for p in svc.enumerate_datus_packages() if p.name == "datus-bi-superset")
+        assert pkg.editable is False
+
+    def test_missing_direct_url_is_not_editable(self, monkeypatch):
+        dists = [_FakeDist("datus-bi-superset", "0.1.0", direct_url=None)]
+        monkeypatch.setattr(svc.importlib_metadata, "distributions", lambda: iter(dists))
+        monkeypatch.setattr("datus.__version__", "0.3.1", raising=False)
+        pkg = next(p for p in svc.enumerate_datus_packages() if p.name == "datus-bi-superset")
+        assert pkg.editable is False
+
+
+# ── _upgrade_command ──────────────────────────────────────────────────
+
+
+class TestUpgradeCommand:
+    def test_prefers_uv_when_on_path(self, monkeypatch):
+        monkeypatch.setattr(svc.shutil, "which", lambda name: "/usr/local/bin/uv" if name == "uv" else None)
+        argv, label = svc._upgrade_command(["datus-agent", "datus-bi-superset"])
+        assert argv == [
+            "/usr/local/bin/uv",
+            "pip",
+            "install",
+            "--upgrade",
+            "--python",
+            svc.sys.executable,
+            "datus-agent",
+            "datus-bi-superset",
+        ]
+        assert label == "uv pip install --upgrade"
+
+    def test_falls_back_to_pip(self, monkeypatch):
+        monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+        argv, label = svc._upgrade_command(["datus-agent"])
+        assert argv == [svc.sys.executable, "-m", "pip", "install", "--upgrade", "datus-agent"]
+        assert label == "pip install --upgrade"
+
+
+# ── upgrade_packages ──────────────────────────────────────────────────
+
+
+class TestUpgradePackages:
+    def test_all_editable_skips_subprocess(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(svc.subprocess, "run", lambda *a, **k: called.append(a))
+        packages = [svc.DatusPackage("datus-agent", "0.3.1", editable=True)]
+        result = svc.upgrade_packages(packages)
+        assert result.ok is True
+        assert result.packages == []
+        assert result.skipped_editable == ["datus-agent"]
+        assert called == []
+
+    def test_mixed_passes_only_non_editable(self, monkeypatch):
+        monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+        captured = {}
+
+        def fake_run(cmd, capture_output, text, check):
+            captured["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+
+        monkeypatch.setattr(svc.subprocess, "run", fake_run)
+        # After-upgrade snapshot: datus-agent bumped, nothing else relevant.
+        monkeypatch.setattr(
+            svc, "enumerate_datus_packages", lambda: [svc.DatusPackage("datus-agent", "0.3.2", editable=False)]
+        )
+        packages = [
+            svc.DatusPackage("datus-agent", "0.3.1", editable=False),
+            svc.DatusPackage("datus-bi-superset", "0.1.0", editable=True),
+        ]
+        result = svc.upgrade_packages(packages)
+        assert result.ok is True
+        assert result.packages == ["datus-agent"]
+        assert result.skipped_editable == ["datus-bi-superset"]
+        assert "datus-agent" in captured["cmd"]
+        assert "datus-bi-superset" not in captured["cmd"]
+
+    def test_changes_only_report_version_diffs(self, monkeypatch):
+        """A package whose version did not move is omitted from ``changes``."""
+        monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            svc.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        # datus-agent moved 0.3.1 -> 0.3.2; datus-db-core stayed at 0.1.4.
+        monkeypatch.setattr(
+            svc,
+            "enumerate_datus_packages",
+            lambda: [
+                svc.DatusPackage("datus-agent", "0.3.2", editable=False),
+                svc.DatusPackage("datus-db-core", "0.1.4", editable=False),
+            ],
+        )
+        packages = [
+            svc.DatusPackage("datus-agent", "0.3.1", editable=False),
+            svc.DatusPackage("datus-db-core", "0.1.4", editable=False),
+        ]
+        result = svc.upgrade_packages(packages)
+        assert result.ok is True
+        assert result.changes == [("datus-agent", "0.3.1", "0.3.2")]
+
+    def test_no_changes_when_all_current(self, monkeypatch):
+        monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            svc.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        monkeypatch.setattr(
+            svc, "enumerate_datus_packages", lambda: [svc.DatusPackage("datus-agent", "0.3.1", editable=False)]
+        )
+        result = svc.upgrade_packages([svc.DatusPackage("datus-agent", "0.3.1", editable=False)])
+        assert result.ok is True
+        assert result.changes == []
+
+    def test_nonzero_returncode_marks_failure(self, monkeypatch):
+        monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            svc.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="ERROR: resolve failed"),
+        )
+        result = svc.upgrade_packages([svc.DatusPackage("datus-agent", "0.3.1")])
+        assert result.ok is False
+        assert result.error == "pip install --upgrade exited with code 1"
+        assert "ERROR" in result.stderr
+
+    def test_subprocess_raises_marks_failure(self, monkeypatch):
+        monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+
+        def boom(*a, **k):
+            raise OSError("uv vanished")
+
+        monkeypatch.setattr(svc.subprocess, "run", boom)
+        result = svc.upgrade_packages([svc.DatusPackage("datus-agent", "0.3.1")])
+        assert result.ok is False
+        assert "uv vanished" in (result.error or "")
+
+
+# ── version check + cache ─────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, payload=None, raise_exc=None):
+        self._payload = payload
+        self._raise = raise_exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get(self, url):
+        if self._raise is not None:
+            raise self._raise
+        return _FakeResponse(self._payload)
+
+
+def _patch_cache_path(monkeypatch, tmp_path):
+    path = tmp_path / "version_check.json"
+    monkeypatch.setattr(svc, "_cache_path", lambda agent_config=None: path)
+    return path
+
+
+class TestGetLatestVersion:
+    def test_uses_fresh_cache_without_network(self, monkeypatch, tmp_path):
+        path = _patch_cache_path(monkeypatch, tmp_path)
+        path.write_text(json.dumps({"checked_at": time.time(), "latest": "1.2.3", "name": "datus-agent"}))
+
+        def explode():
+            raise AssertionError("network must not be hit when cache is fresh")
+
+        monkeypatch.setattr(svc, "_fetch_latest_from_pypi", explode)
+        assert svc.get_latest_version() == "1.2.3"
+
+    def test_fetches_and_writes_cache_when_stale(self, monkeypatch, tmp_path):
+        path = _patch_cache_path(monkeypatch, tmp_path)
+        stale = time.time() - (svc._CACHE_TTL_SECONDS + 100)
+        path.write_text(json.dumps({"checked_at": stale, "latest": "0.0.1", "name": "datus-agent"}))
+        monkeypatch.setattr(svc, "_fetch_latest_from_pypi", lambda: "2.0.0")
+        assert svc.get_latest_version() == "2.0.0"
+        written = json.loads(path.read_text())
+        assert written["latest"] == "2.0.0"
+
+    def test_http_error_returns_none_and_caches_negative(self, monkeypatch, tmp_path):
+        path = _patch_cache_path(monkeypatch, tmp_path)
+        monkeypatch.setattr(svc.importlib_metadata, "version", lambda name: "0.3.1", raising=False)
+        monkeypatch.setattr(
+            "httpx.Client", lambda timeout: _FakeClient(raise_exc=RuntimeError("offline")), raising=False
+        )
+        assert svc.get_latest_version() is None
+        written = json.loads(path.read_text())
+        assert written["latest"] is None
+
+    def test_fetch_parses_info_version(self, monkeypatch, tmp_path):
+        _patch_cache_path(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "httpx.Client", lambda timeout: _FakeClient(payload={"info": {"version": "3.1.4"}}), raising=False
+        )
+        assert svc._fetch_latest_from_pypi() == "3.1.4"
+
+
+class TestNewerVersionAvailable:
+    def test_returns_latest_when_strictly_newer(self, monkeypatch):
+        monkeypatch.setattr(svc, "get_latest_version", lambda **k: "1.2.0")
+        assert svc.newer_version_available("1.0.0") == "1.2.0"
+
+    def test_none_when_equal(self, monkeypatch):
+        monkeypatch.setattr(svc, "get_latest_version", lambda **k: "1.0.0")
+        assert svc.newer_version_available("1.0.0") is None
+
+    def test_none_when_older(self, monkeypatch):
+        monkeypatch.setattr(svc, "get_latest_version", lambda **k: "0.9.0")
+        assert svc.newer_version_available("1.0.0") is None
+
+    def test_none_when_latest_missing(self, monkeypatch):
+        monkeypatch.setattr(svc, "get_latest_version", lambda **k: None)
+        assert svc.newer_version_available("1.0.0") is None
+
+    def test_invalid_version_returns_none(self, monkeypatch):
+        monkeypatch.setattr(svc, "get_latest_version", lambda **k: "not-a-version")
+        assert svc.newer_version_available("1.0.0") is None
+
+    def test_cached_only_does_not_touch_network(self, monkeypatch, tmp_path):
+        path = _patch_cache_path(monkeypatch, tmp_path)
+        path.write_text(json.dumps({"checked_at": time.time(), "latest": "5.0.0", "name": "datus-agent"}))
+
+        def explode(**k):
+            raise AssertionError("cached_only must not call get_latest_version")
+
+        monkeypatch.setattr(svc, "get_latest_version", explode)
+        assert svc.newer_version_available("1.0.0", cached_only=True) == "5.0.0"
+
+    def test_cached_only_cold_cache_returns_none(self, monkeypatch, tmp_path):
+        _patch_cache_path(monkeypatch, tmp_path)  # file absent
+        assert svc.newer_version_available("1.0.0", cached_only=True) is None
+
+
+class TestCacheTtl:
+    def test_entry_older_than_ttl_is_ignored(self, monkeypatch, tmp_path):
+        path = tmp_path / "version_check.json"
+        old = time.time() - (svc._CACHE_TTL_SECONDS + 1)
+        path.write_text(json.dumps({"checked_at": old, "latest": "1.0.0", "name": "datus-agent"}))
+        assert svc._read_cache(path) is None
+
+    def test_fresh_entry_is_returned(self, tmp_path):
+        path = tmp_path / "version_check.json"
+        path.write_text(json.dumps({"checked_at": time.time(), "latest": "1.0.0", "name": "datus-agent"}))
+        assert svc._read_cache(path)["latest"] == "1.0.0"
+
+    def test_corrupt_cache_returns_none(self, tmp_path):
+        path = tmp_path / "version_check.json"
+        path.write_text("{not json")
+        assert svc._read_cache(path) is None


### PR DESCRIPTION


## Why
Updating datus-agent and its installed datus-* adapter packages previously required users to run pip/uv install --upgrade by hand, one package at a time, with no in-app signal that a newer release exists.

## Solution
- New top-level subcommand `datus upgrade` (alias `datus update`), intercepted in `datus/cli/main.py::main()` before the REPL is built (mirrors the existing `skill` subcommand), so it works even when the installed CLI is broken.
- `datus/cli/upgrade_service.py`: enumerates every installed `datus-*` distribution via importlib.metadata, detects editable/source installs through direct_url.json and skips them, then runs a single `uv pip install --upgrade` (pip fallback) over the rest. After a successful run it re-reads versions and reports only packages whose version actually changed (`old -> new`); when nothing moved it reports "already up to date". Also provides a PyPI JSON latest-version check cached for 24h under {datus_home}/cache.
- `datus/cli/upgrade_cli.py`: renders the install list, `--check` (report only) and `--yes` flags, and the version-diff / failure output.
- REPL startup (`repl.py::_check_for_upgrade`): prints a one-line yellow hint after the banner when a fresh cache knows of a newer datus-agent, and refreshes the cache on a daemon thread. Gated by TTY and DATUS_DISABLE_VERSION_CHECK; never blocks or aborts startup.
- Declare `packaging` explicitly in pyproject.toml (used for version compare).

## Test Cases
- tests/unit_tests/cli/test_upgrade_service.py: package enumeration + editable detection, uv/pip command construction, upgrade success/failure/exception, version-diff filtering, PyPI fetch + 24h cache (fresh/stale/offline/cached-only).
- tests/unit_tests/cli/test_upgrade_cli.py: all-editable skip, version-diff output, already-up-to-date, failure tail, --check branches.
- 35 new unit tests; mock subprocess/httpx/importlib.metadata, no network.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **New Features**
  * Added `datus upgrade` and `datus update` subcommands to manage package updates.
  * Interactive CLI now checks for newer versions at startup with optional notifications.
  * Use `--check` flag to review available versions without installing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New datus upgrade / datus update subcommands to list and apply package updates; supports a --check mode to preview available versions.
  * Upgrade command runs immediately (before any interactive session starts) and works even if the interactive module is unavailable.
  * Interactive CLI now shows a non-blocking startup hint if a newer agent version is known and refreshes version info in the background; honors an env var to disable checks.

* **Tests**
  * Added unit tests covering upgrade flow, package discovery, version checks, caching, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->