### PR TITLE
[Feature] Add orchestrator issue proxy tools

### DIFF
--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -197,6 +197,14 @@ class ArgumentParser:
             help="Enable streaming thinking deltas in print mode (token-by-token output)",
         )
 
+        self.parser.add_argument(
+            "--orchestrator-tools",
+            dest="orchestrator_tools",
+            action="store_true",
+            default=False,
+            help="Expose orchestrator issue lifecycle tools in print mode",
+        )
+
     def parse_args(self):
         return self.parser.parse_args()
 
@@ -225,6 +233,9 @@ class Application:
 
         if args.proxy_tools and args.print_mode is None:
             self.arg_parser.parser.error("--proxy_tools requires --print mode")
+
+        if getattr(args, "orchestrator_tools", False) and args.print_mode is None:
+            self.arg_parser.parser.error("--orchestrator-tools requires --print mode")
 
         if args.print_mode is not None:
             from datus.cli.print_mode import PrintModeRunner

--- a/datus/cli/print_mode.py
+++ b/datus/cli/print_mode.py
@@ -48,6 +48,7 @@ class PrintModeRunner:
         self.session_id = getattr(args, "resume", None)
         self.subagent_name = getattr(args, "subagent", None) or None
         self.proxy_tool_patterns = getattr(args, "proxy_tools", None)
+        self.orchestrator_tools = getattr(args, "orchestrator_tools", False)
         self.scope = getattr(args, "session_scope", None)
         self.stream_thinking = getattr(args, "stream_thinking", False)
 
@@ -85,6 +86,9 @@ class PrintModeRunner:
             session_id=self.session_id,
             execution_mode="workflow",
         )
+
+        if getattr(self, "orchestrator_tools", None):
+            self._attach_orchestrator_tools(node)
 
         if self.proxy_tool_patterns:
             from datus.tools.proxy.proxy_tool import apply_proxy_tools
@@ -265,6 +269,14 @@ class PrintModeRunner:
     def _write_payload(self, payload: MessagePayload):
         sys.stdout.write(payload.model_dump_json() + "\n")
         sys.stdout.flush()
+
+    def _attach_orchestrator_tools(self, node):
+        from datus.tools.func_tool.orchestrator_tools import OrchestratorIssueTools
+
+        orchestrator_tools = OrchestratorIssueTools()
+        tools = orchestrator_tools.available_tools()
+        node.tools.extend(tools)
+        node.tool_registry.register_tools("orchestrator_tools", tools)
 
     def _read_interaction_input(self) -> str:
         line = sys.stdin.readline()

--- a/datus/cli/print_mode.py
+++ b/datus/cli/print_mode.py
@@ -14,6 +14,7 @@ import os
 import select
 import sys
 import threading
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -270,7 +271,7 @@ class PrintModeRunner:
         sys.stdout.write(payload.model_dump_json() + "\n")
         sys.stdout.flush()
 
-    def _attach_orchestrator_tools(self, node):
+    def _attach_orchestrator_tools(self, node: Any) -> None:
         from datus.tools.func_tool.orchestrator_tools import OrchestratorIssueTools
 
         orchestrator_tools = OrchestratorIssueTools()

--- a/datus/tools/func_tool/__init__.py
+++ b/datus/tools/func_tool/__init__.py
@@ -11,6 +11,7 @@ from datus.tools.func_tool.date_parsing_tools import DateParsingTools
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool, filesystem_function_tools
 from datus.tools.func_tool.generation_tools import GenerationTools
 from datus.tools.func_tool.memory_filesystem_tools import MemoryFilesystemFuncTool
+from datus.tools.func_tool.orchestrator_tools import OrchestratorIssueTools
 from datus.tools.func_tool.plan_tools import PlanTool, SessionTodoStorage
 from datus.tools.func_tool.platform_doc_search import PlatformDocSearchTool
 from datus.tools.func_tool.report_artifact_tools import ReportArtifactTools, ReportFilesystemFuncTool
@@ -41,6 +42,7 @@ __all__ = [
     "SemanticDiscoveryTools",
     "PlatformDocSearchTool",
     "SubAgentTaskTool",
+    "OrchestratorIssueTools",
 ]
 
 try:

--- a/datus/tools/func_tool/orchestrator_tools.py
+++ b/datus/tools/func_tool/orchestrator_tools.py
@@ -1,0 +1,142 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Orchestrator runtime proxy tools.
+
+These tools are intentionally placeholders when executed inside Datus-agent.
+An external orchestrator enables them in print mode and proxies the calls back
+to its tracker adapter, so Datus-agent can request issue updates without holding tracker
+credentials directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from agents import FunctionTool
+
+from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+
+
+class OrchestratorIssueTools:
+    """Issue lifecycle tools owned by an external orchestrator runtime."""
+
+    def available_tools(self) -> List[FunctionTool]:
+        return [
+            trans_to_function_tool(self.create_issue_comment, strict_mode=False),
+            trans_to_function_tool(self.update_issue_status, strict_mode=False),
+            trans_to_function_tool(self.request_human_input, strict_mode=False),
+            trans_to_function_tool(self.mark_blocked, strict_mode=False),
+            trans_to_function_tool(self.finish_mission, strict_mode=False),
+        ]
+
+    def create_issue_comment(self, body: str, issue_id: Optional[str] = None) -> FuncToolResult:
+        """Create an issue comment through the orchestrator.
+
+        Args:
+            body: Markdown comment body to append to the current issue.
+            issue_id: Optional tracker issue id. Omit this for the current issue.
+        """
+        return self._requires_proxy("create_issue_comment", {"issue_id": issue_id, "body": body})
+
+    def update_issue_status(self, status: str, issue_id: Optional[str] = None) -> FuncToolResult:
+        """Move an issue to a tracker status through the orchestrator.
+
+        Args:
+            status: Target issue status name, for example "In Progress" or "In Review".
+            issue_id: Optional tracker issue id. Omit this for the current issue.
+        """
+        return self._requires_proxy("update_issue_status", {"issue_id": issue_id, "status": status})
+
+    def finish_mission(
+        self,
+        outcome: str,
+        summary: str,
+        issue_id: Optional[str] = None,
+        next_status: Optional[str] = None,
+        artifacts: Optional[List[Dict[str, Any]]] = None,
+        validation: Optional[List[Dict[str, Any]]] = None,
+    ) -> FuncToolResult:
+        """Report the final mission outcome to the orchestrator.
+
+        Args:
+            outcome: completed, needs_review, blocked, or failed.
+            summary: Short operator-facing summary.
+            issue_id: Optional tracker issue id. Omit this for the current issue.
+            next_status: Optional tracker status the orchestrator should move the issue to.
+            artifacts: Optional generated artifacts or URLs.
+            validation: Optional validation checks and results.
+        """
+        return self._requires_proxy(
+            "finish_mission",
+            {
+                "issue_id": issue_id,
+                "outcome": outcome,
+                "summary": summary,
+                "next_status": next_status,
+                "artifacts": artifacts or [],
+                "validation": validation or [],
+            },
+        )
+
+    def request_human_input(
+        self,
+        question: str,
+        issue_id: Optional[str] = None,
+        next_status: Optional[str] = None,
+    ) -> FuncToolResult:
+        """Request human input on the current issue.
+
+        Args:
+            question: Specific question or decision needed from the operator.
+            issue_id: Optional tracker issue id. Omit this for the current issue.
+            next_status: Optional tracker status the orchestrator should move the issue to.
+        """
+        return self._requires_proxy(
+            "request_human_input",
+            {
+                "issue_id": issue_id,
+                "question": question,
+                "next_status": next_status,
+            },
+        )
+
+    def mark_blocked(
+        self,
+        reason: str,
+        issue_id: Optional[str] = None,
+        next_status: Optional[str] = None,
+        artifacts: Optional[List[Dict[str, Any]]] = None,
+        validation: Optional[List[Dict[str, Any]]] = None,
+    ) -> FuncToolResult:
+        """Mark the current issue as blocked.
+
+        Args:
+            reason: Concrete blocker that prevents completion.
+            issue_id: Optional tracker issue id. Omit this for the current issue.
+            next_status: Optional tracker status the orchestrator should move the issue to.
+            artifacts: Optional generated artifacts or URLs.
+            validation: Optional validation checks and results.
+        """
+        return self._requires_proxy(
+            "mark_blocked",
+            {
+                "issue_id": issue_id,
+                "reason": reason,
+                "next_status": next_status,
+                "artifacts": artifacts or [],
+                "validation": validation or [],
+            },
+        )
+
+    def _requires_proxy(self, tool_name: str, payload: Dict[str, Any]) -> FuncToolResult:
+        return FuncToolResult(
+            success=0,
+            error=(
+                f"{tool_name} must be proxied by the orchestrator runtime. "
+                "Run Datus-agent print mode with --orchestrator-tools and proxy orchestrator_tools.*."
+            ),
+            result=payload,
+        )

--- a/datus/tools/proxy/proxy_tool.py
+++ b/datus/tools/proxy/proxy_tool.py
@@ -58,6 +58,7 @@ def create_proxy_tool(original: FunctionTool, channel: ToolResultChannel) -> Fun
         description=original.description,
         params_json_schema=original.params_json_schema,
         on_invoke_tool=proxy_invoke,
+        strict_json_schema=original.strict_json_schema,
     )
 
 

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -64,6 +64,12 @@ class TestArgumentParser:
             args = ap.parse_args()
         assert args.resume == "sess_123"
 
+    def test_parse_args_orchestrator_tools(self):
+        ap = ArgumentParser()
+        with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--print", "hello", "--orchestrator-tools"]):
+            args = ap.parse_args()
+        assert args.orchestrator_tools is True
+
     def test_parse_args_web(self):
         ap = ArgumentParser()
         with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--web"]):
@@ -138,6 +144,27 @@ class TestApplicationRun:
         app = Application()
         mock_args = SimpleNamespace(
             debug=False, datasource="ns1", print_mode=None, web=False, resume=None, proxy_tools="*", config=None
+        )
+        with (
+            patch.object(app.arg_parser, "parse_args", return_value=mock_args),
+            patch("datus.cli.main.configure_logging"),
+            patch.object(app, "_ensure_project_config"),
+        ):
+            with pytest.raises(SystemExit):
+                app.run()
+
+    def test_orchestrator_tools_without_print_mode_errors(self):
+        """Verify that --orchestrator-tools without --print raises SystemExit."""
+        app = Application()
+        mock_args = SimpleNamespace(
+            debug=False,
+            datasource="ns1",
+            print_mode=None,
+            web=False,
+            resume=None,
+            proxy_tools=None,
+            orchestrator_tools=True,
+            config=None,
         )
         with (
             patch.object(app.arg_parser, "parse_args", return_value=mock_args),

--- a/tests/unit_tests/cli/test_print_mode.py
+++ b/tests/unit_tests/cli/test_print_mode.py
@@ -527,6 +527,40 @@ class TestRunUsesFactory:
 
 
 class TestRunProxyTools:
+    def test_run_attaches_orchestrator_tools_before_proxying(self):
+        """Verify orchestrator tools are registered and then available to proxy."""
+        runner = _make_runner(orchestrator_tools=True, proxy_tools="orchestrator_tools.*")
+
+        mock_node = MagicMock()
+        mock_node.session_id = None
+        mock_node.tools = []
+        mock_node.tool_registry = MagicMock()
+
+        async def fake_stream(actions):
+            return
+            yield
+
+        mock_node.execute_stream_with_interactions = fake_stream
+
+        with (
+            patch("datus.cli.print_mode.create_interactive_node", return_value=mock_node),
+            patch("datus.cli.print_mode.create_node_input", return_value=MagicMock()),
+            patch("datus.tools.proxy.proxy_tool.apply_proxy_tools") as mock_apply,
+        ):
+            runner.run()
+
+        registered_tools = mock_node.tool_registry.register_tools.call_args.args[1]
+        assert mock_node.tool_registry.register_tools.call_args.args[0] == "orchestrator_tools"
+        assert {tool.name for tool in registered_tools} == {
+            "create_issue_comment",
+            "update_issue_status",
+            "request_human_input",
+            "mark_blocked",
+            "finish_mission",
+        }
+        assert mock_node.tools == registered_tools
+        mock_apply.assert_called_once_with(mock_node, ["orchestrator_tools.*"])
+
     def test_run_applies_proxy_tools_when_patterns_set(self):
         """Verify that apply_proxy_tools is called when proxy_tool_patterns is set."""
         runner = _make_runner(proxy_tools="filesystem_tools.*,db_tools.*")

--- a/tests/unit_tests/tools/func_tool/test_orchestrator_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_orchestrator_tools.py
@@ -1,0 +1,44 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for orchestrator issue lifecycle tools."""
+
+import pytest
+
+from datus.tools.func_tool.orchestrator_tools import OrchestratorIssueTools
+
+
+@pytest.mark.ci
+class TestOrchestratorIssueTools:
+    def test_available_tools_exposes_issue_lifecycle_tools(self):
+        tools = OrchestratorIssueTools().available_tools()
+
+        assert {tool.name for tool in tools} == {
+            "create_issue_comment",
+            "update_issue_status",
+            "request_human_input",
+            "mark_blocked",
+            "finish_mission",
+        }
+        assert all(tool.strict_json_schema is False for tool in tools)
+
+    @pytest.mark.asyncio
+    async def test_tool_returns_proxy_required_error(self):
+        tool = next(tool for tool in OrchestratorIssueTools().available_tools() if tool.name == "finish_mission")
+
+        result = await tool.on_invoke_tool(
+            None,
+            '{"outcome":"completed","summary":"done","next_status":"In Review"}',
+        )
+
+        assert result["success"] == 0
+        assert "must be proxied" in result["error"]
+        assert result["result"] == {
+            "issue_id": None,
+            "outcome": "completed",
+            "summary": "done",
+            "next_status": "In Review",
+            "artifacts": [],
+            "validation": [],
+        }

--- a/tests/unit_tests/tools/func_tool/test_orchestrator_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_orchestrator_tools.py
@@ -11,7 +11,7 @@ from datus.tools.func_tool.orchestrator_tools import OrchestratorIssueTools
 
 @pytest.mark.ci
 class TestOrchestratorIssueTools:
-    def test_available_tools_exposes_issue_lifecycle_tools(self):
+    def test_available_tools_exposes_issue_lifecycle_tools(self) -> None:
         tools = OrchestratorIssueTools().available_tools()
 
         assert {tool.name for tool in tools} == {
@@ -24,7 +24,7 @@ class TestOrchestratorIssueTools:
         assert all(tool.strict_json_schema is False for tool in tools)
 
     @pytest.mark.asyncio
-    async def test_tool_returns_proxy_required_error(self):
+    async def test_tool_returns_proxy_required_error(self) -> None:
         tool = next(tool for tool in OrchestratorIssueTools().available_tools() if tool.name == "finish_mission")
 
         result = await tool.on_invoke_tool(

--- a/tests/unit_tests/tools/proxy/test_proxy_tool.py
+++ b/tests/unit_tests/tools/proxy/test_proxy_tool.py
@@ -173,7 +173,7 @@ class TestCreateProxyTool:
         await task
         assert result == {"success": 1}
 
-    def test_proxy_tool_preserves_strict_json_schema(self):
+    def test_proxy_tool_preserves_strict_json_schema(self) -> None:
         channel = ToolResultChannel()
         original = FunctionTool(
             name="tool",

--- a/tests/unit_tests/tools/proxy/test_proxy_tool.py
+++ b/tests/unit_tests/tools/proxy/test_proxy_tool.py
@@ -173,6 +173,20 @@ class TestCreateProxyTool:
         await task
         assert result == {"success": 1}
 
+    def test_proxy_tool_preserves_strict_json_schema(self):
+        channel = ToolResultChannel()
+        original = FunctionTool(
+            name="tool",
+            description="Tool",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=lambda ctx, args: {},
+            strict_json_schema=False,
+        )
+
+        proxy = create_proxy_tool(original, channel)
+
+        assert proxy.strict_json_schema is False
+
 
 # ---------------------------------------------------------------------------
 # Tests: apply_proxy_tools


### PR DESCRIPTION
## Why

External orchestrators need Datus-agent print mode to request issue lifecycle updates through a proxied runtime without giving Datus-agent direct tracker credentials.

This PR is based directly on `main` and contains only the generic orchestrator proxy tool surface.

## Solution

- Add `--orchestrator-tools` for print mode and reject it outside `--print`.
- Register `orchestrator_tools` on the print-mode node before applying `--proxy_tools` so callers can proxy `orchestrator_tools.*`.
- Add placeholder lifecycle tools for comments, status updates, human-input requests, blocked state, and mission completion.
- Preserve `FunctionTool.strict_json_schema` when wrapping tools for proxy execution.
- Add unit coverage for CLI parsing, print-mode registration, placeholder behavior, and proxy schema preservation.

## Test Cases

- `uv run ruff format datus/cli/main.py datus/cli/print_mode.py datus/tools/func_tool/__init__.py datus/tools/func_tool/orchestrator_tools.py datus/tools/proxy/proxy_tool.py tests/unit_tests/cli/test_main.py tests/unit_tests/cli/test_print_mode.py tests/unit_tests/tools/proxy/test_proxy_tool.py tests/unit_tests/tools/func_tool/test_orchestrator_tools.py`
- `uv run pytest tests/unit_tests/cli/test_main.py tests/unit_tests/cli/test_print_mode.py tests/unit_tests/tools/proxy/test_proxy_tool.py tests/unit_tests/tools/func_tool/test_orchestrator_tools.py`
- `uv run ruff check datus/cli/main.py datus/cli/print_mode.py datus/tools/func_tool/__init__.py datus/tools/func_tool/orchestrator_tools.py datus/tools/proxy/proxy_tool.py tests/unit_tests/cli/test_main.py tests/unit_tests/cli/test_print_mode.py tests/unit_tests/tools/proxy/test_proxy_tool.py tests/unit_tests/tools/func_tool/test_orchestrator_tools.py`
- `uv run python ci/audit_tests.py --repo-root . --diff-only upstream/main`
- `git diff --check upstream/main...HEAD`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **New Features**
  * Added `--orchestrator-tools` CLI flag to expose issue lifecycle management tools in print mode, enabling operations like creating issue comments, updating status, finishing missions, requesting human input, and marking issues as blocked.

* **Bug Fixes**
  * Fixed proxy tools to preserve strict JSON schema settings from original tool configurations.

* **Tests**
  * Added comprehensive unit tests for orchestrator tools functionality and CLI argument parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI option to expose orchestrator issue-lifecycle tools in print mode (commenting, status updates, finishing missions, requesting input, marking blocked).

* **Bug Fixes**
  * Proxy tooling now preserves strict JSON schema behavior from original tools.

* **Tests**
  * Added unit tests for the CLI flag, orchestrator tools exposure/behavior, and proxy schema preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->