### PR TITLE
[BugFix] Fix run_in_terminal_sync teardown race with _is_running guard (#617)

### DIFF
--- a/datus/cli/tui/console_bridge.py
+++ b/datus/cli/tui/console_bridge.py
@@ -44,8 +44,10 @@ def run_in_terminal_sync(func: Callable[[], None]) -> None:
       avoid; ``in_terminal()`` would blank the full-screen layout for
       every print, which is destructive.
     * **On the prompt_toolkit event loop of a non-full-screen
-      Application** (e.g. legacy modals): dispatch via
-      :func:`run_in_terminal` and return immediately.
+      Application** (e.g. legacy modals): if the app is still running,
+      dispatch via :func:`run_in_terminal` and return immediately; if
+      the app is shutting down (``_is_running`` is ``False``), invoke
+      directly to avoid orphaning a Task on the closing loop.
     * **Off-loop thread with a non-full-screen Application**: submit via
       :func:`asyncio.run_coroutine_threadsafe` and block on completion.
     """
@@ -70,8 +72,15 @@ def run_in_terminal_sync(func: Callable[[], None]) -> None:
         on_event_loop = False
 
     if on_event_loop:
-        # Fire and forget — the callback is scheduled on the same loop and
-        # will run before control returns to the key handler.
+        if not getattr(app, "_is_running", True):
+            # The app is tearing down: loop.close() will call _ready.clear(),
+            # discarding any newly scheduled Task's first __step before it
+            # runs and leaving the inner coroutine GC'd unawaited.
+            func()
+            return
+        # Fire and forget — run_in_terminal schedules its own Task internally
+        # and returns it; we do not await because blocking on the loop that
+        # must run the callback would deadlock.
         run_in_terminal(func)
         return
 

--- a/tests/unit_tests/cli/tui/test_console_bridge.py
+++ b/tests/unit_tests/cli/tui/test_console_bridge.py
@@ -35,29 +35,55 @@ def test_runs_inline_when_no_application() -> None:
 
 
 def test_schedules_via_run_in_terminal_when_on_event_loop() -> None:
-    """On the prompt_toolkit event loop, dispatch fires-and-forgets.
+    """On the prompt_toolkit event loop with a live app, dispatch via run_in_terminal.
 
-    Fire-and-forget because blocking on the returned future would deadlock
-    the loop that has to run the scheduled callback. The no-await path is
-    taken only when ``asyncio.get_running_loop()`` succeeds on the calling
-    thread, so we simulate that with a patch.
+    Fire-and-forget because blocking on the returned awaitable would deadlock
+    the loop that has to run the scheduled callback. run_in_terminal already
+    schedules its own Task internally (ensure_future(run())) and returns it,
+    so no outer wrapping is needed.
     """
-    fake_future = mock.MagicMock()
     fake_app = mock.MagicMock()
     fake_app.full_screen = False  # legacy modal path; full_screen path is exercised separately
+    fake_app._is_running = True
     fake_loop = mock.MagicMock()
 
     with (
         mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
         mock.patch("datus.cli.tui.console_bridge.asyncio.get_running_loop", return_value=fake_loop),
-        mock.patch("datus.cli.tui.console_bridge.run_in_terminal", return_value=fake_future) as mocked_rit,
+        mock.patch("datus.cli.tui.console_bridge.run_in_terminal") as mocked_rit,
     ):
         fn = mock.MagicMock()
         run_in_terminal_sync(fn)
 
         mocked_rit.assert_called_once_with(fn)
-        # On-loop path must NOT block on the future — it would deadlock.
-        fake_future.result.assert_not_called()
+
+
+def test_calls_directly_when_app_is_shutting_down() -> None:
+    """On the event loop but with _is_running=False (app teardown), func must
+    be called inline rather than scheduled.
+
+    Root cause of #617: loop.close() calls _ready.clear(), discarding the
+    Task's pending first __step before it runs. The inner coroutine is then
+    GC'd unawaited, emitting RuntimeWarning. Detecting _is_running=False and
+    falling back to a direct call eliminates the race.
+    """
+    fake_app = mock.MagicMock()
+    fake_app.full_screen = False
+    fake_app._is_running = False
+    called = {"count": 0}
+
+    def _fn() -> None:
+        called["count"] += 1
+
+    with (
+        mock.patch("datus.cli.tui.console_bridge.get_app_or_none", return_value=fake_app),
+        mock.patch("datus.cli.tui.console_bridge.asyncio.get_running_loop", return_value=mock.MagicMock()),
+        mock.patch("datus.cli.tui.console_bridge.run_in_terminal") as mocked_rit,
+    ):
+        run_in_terminal_sync(_fn)
+
+    assert called["count"] == 1
+    mocked_rit.assert_not_called()
 
 
 def test_submits_coroutine_from_off_loop_thread() -> None:


### PR DESCRIPTION
## Why

On the event-loop branch of `run_in_terminal_sync`, calling `run_in_terminal(func)` during prompt_toolkit teardown schedules a Task whose first `__step` lands in `loop._ready`. When the loop is closed before that step runs, `loop.close()` calls `_ready.clear()`, discarding the step — leaving the inner coroutine GC'd unawaited and emitting:

```
RuntimeWarning: coroutine 'run_in_terminal.<locals>.run' was never awaited
```

Fixes #617.

## Solution

Check `app._is_running` before scheduling. prompt_toolkit sets this flag to `False` during teardown (before the loop closes), so it reliably identifies the window where scheduling would orphan a Task. When `_is_running` is `False`, call `func()` directly:

```python
if on_event_loop:
    if not getattr(app, "_is_running", True):
        # app is mid-teardown: loop.close() will call _ready.clear(),
        # discarding any newly scheduled Task's first __step.
        func()
        return
    run_in_terminal(func)
    return
```

**Why `asyncio.ensure_future()` wrapping is not sufficient** (addresses the approach in the original PR description): `run_in_terminal()` already calls `ensure_future(run())` internally and returns the resulting Task. So `ensure_future(that_task)` is a documented no-op — `ensure_future(task) is task → True`. The race is in `loop.close()` discarding `_ready`, not in whether the Task is referenced.

**Related fire-and-forget issues found during investigation** (informational only — not addressed in this PR; each requires a different strategy tied to its event loop):

- `datus/api/services/datus_service_cache.py:106,126` — untracked `asyncio.create_task()` for LRU eviction and deferred shutdown on the FastAPI loop
- `datus/api/routes/chat_routes.py:570` — untracked `asyncio.create_task(_safe_post_chat(...))` for billing/audit hook in a `finally` block

## Test Cases

Updated `tests/unit_tests/cli/tui/test_console_bridge.py`:

- `test_schedules_via_run_in_terminal_when_on_event_loop` — updated: removed the tautological `ensure_future` assertion (it asserted on a Mock, not a real Task); added `fake_app._is_running = True` to clearly exercise the live-app path
- `test_calls_directly_when_app_is_shutting_down` — **new**: sets `_is_running=False`, asserts `func()` is called directly and `run_in_terminal` is NOT called; directly exercises the teardown guard