### PR TITLE
[Feature] Add AskMetrics metric QA node

### DIFF
--- a/datus/agent/node/__init__.py
+++ b/datus/agent/node/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "CompareAgenticNode",
     "GenSemanticModelAgenticNode",
     "GenMetricsAgenticNode",
+    "AskMetricsAgenticNode",
     "GenReportAgenticNode",
     "GenExtKnowledgeAgenticNode",
     "ExploreAgenticNode",
@@ -35,6 +36,7 @@ __all__ = [
 
 from datus.agent.node.node import Node
 
+from .ask_metrics_agentic_node import AskMetricsAgenticNode
 from .begin_node import BeginNode
 from .chat_agentic_node import ChatAgenticNode
 from .compare_agentic_node import CompareAgenticNode

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1750,6 +1750,7 @@ class AgenticNode(Node):
             "scoped_kb_path",
             "adapter_type",
             "semantic_adapter",
+            "subject_tree_prompt_limit",
             "sql_file_threshold",
             "sql_preview_lines",
             "bi_platform",

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -1,0 +1,465 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""AskMetricsAgenticNode for fast metric-based question answering."""
+
+import json
+from typing import Any, Dict, List, Literal, Optional
+
+from agents import Tool
+
+from datus.agent.node.agentic_node import AgenticNode
+from datus.agent.node.stream_run_context import StreamRunContext
+from datus.configuration.agent_config import AgentConfig
+from datus.schemas.action_history import ActionRole, ActionStatus
+from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput, AskMetricsNodeResult
+from datus.tools.func_tool import (
+    ContextSearchTools,
+    DateParsingTools,
+    DBFuncTool,
+    FilesystemFuncTool,
+    PlatformDocSearchTool,
+    trans_to_function_tool,
+)
+from datus.tools.func_tool.base import FuncToolResult
+from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
+from datus.tools.func_tool.semantic_tools import SemanticTools
+from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+class AskMetricsAgenticNode(AgenticNode):
+    """Fast metric QA node backed by existing semantic metrics."""
+
+    NODE_NAME = "ask_metrics"
+    result_class = AskMetricsNodeResult
+    SUBJECT_TREE_PROMPT_LIMIT = 100
+    DEFAULT_TOOLS = (
+        "context_search_tools.search_metrics",
+        "context_search_tools.get_metrics",
+        "semantic_tools.list_metrics",
+        "semantic_tools.get_dimensions",
+        "semantic_tools.query_metrics",
+        "semantic_tools.attribution_analyze",
+        "context_search_tools.list_subject_tree",
+    )
+
+    _TOOL_NAMES_BY_CATEGORY = {
+        "db_tools": set(DBFuncTool.all_tools_name()),
+        "context_search_tools": set(ContextSearchTools.all_tools_name()),
+        "semantic_tools": set(SemanticTools.all_tools_name()),
+        "reference_template_tools": set(ReferenceTemplateTools.all_tools_name()),
+        "date_parsing_tools": {"parse_temporal_expressions"},
+        "filesystem_tools": set(FilesystemFuncTool.all_tools_name()),
+        "platform_doc_tools": set(PlatformDocSearchTool.all_tools_name()),
+    }
+
+    def __init__(
+        self,
+        node_id: str,
+        description: str,
+        node_type: str,
+        input_data: Optional[AskMetricsNodeInput] = None,
+        agent_config: Optional[AgentConfig] = None,
+        tools: Optional[List[Tool]] = None,
+        node_name: Optional[str] = None,
+        execution_mode: Literal["interactive", "workflow"] = "interactive",
+        scope: Optional[str] = None,
+        is_subagent: bool = False,
+        session_id: Optional[str] = None,
+    ):
+        self.execution_mode = execution_mode
+        self.configured_node_name = node_name
+        self.max_turns = 12
+        if agent_config and hasattr(agent_config, "agentic_nodes") and node_name in agent_config.agentic_nodes:
+            agentic_node_config = agent_config.agentic_nodes[node_name]
+            if isinstance(agentic_node_config, dict):
+                self.max_turns = agentic_node_config.get("max_turns", self.max_turns)
+
+        self.semantic_tools: Optional[SemanticTools] = None
+        self.context_search_tools: Optional[ContextSearchTools] = None
+        self.db_func_tool: Optional[DBFuncTool] = None
+        self.reference_template_tools: Optional[ReferenceTemplateTools] = None
+        self.date_parsing_tools: Optional[DateParsingTools] = None
+        self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
+        self._platform_doc_tool: Optional[PlatformDocSearchTool] = None
+        self.subject_tree: Dict[str, Any] = {}
+        self.subject_tree_metric_entries: List[Dict[str, Any]] = []
+        self.subject_tree_mode: str = "none"
+        self.subject_tree_prompt: str = ""
+        self.startup_error: Optional[str] = None
+
+        super().__init__(
+            node_id=node_id,
+            description=description,
+            node_type=node_type,
+            input_data=input_data,
+            agent_config=agent_config,
+            tools=tools or [],
+            mcp_servers={},
+            scope=scope,
+            is_subagent=is_subagent,
+            session_id=session_id,
+        )
+
+        # AskMetrics defaults to metric QA tools; explicitly configured custom
+        # agents can still opt into additional function-tool categories.
+        self.bash_tool = None
+        self.skill_func_tool = None
+        self.ask_user_tool = None
+        self.sub_agent_task_tool = None
+        self.subject_tree_prompt_limit = self._resolve_subject_tree_prompt_limit()
+        self.setup_tools()
+        self._populate_tool_registry()
+
+        logger.debug("AskMetricsAgenticNode tools: %s", [tool.name for tool in self.tools])
+
+    def get_node_name(self) -> str:
+        return self.configured_node_name or self.NODE_NAME
+
+    def _resolve_adapter_type(self) -> Optional[str]:
+        adapter_type = self.node_config.get("adapter_type") or self.node_config.get("semantic_adapter") or "metricflow"
+        resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
+        if callable(resolver):
+            return resolver(adapter_type)
+        return adapter_type
+
+    def _resolve_subject_tree_prompt_limit(self) -> int:
+        raw_limit = self.node_config.get("subject_tree_prompt_limit", self.SUBJECT_TREE_PROMPT_LIMIT)
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid ask_metrics subject_tree_prompt_limit=%r; using default %s",
+                raw_limit,
+                self.SUBJECT_TREE_PROMPT_LIMIT,
+            )
+            return self.SUBJECT_TREE_PROMPT_LIMIT
+
+        if isinstance(raw_limit, bool) or limit <= 0:
+            logger.warning(
+                "Invalid ask_metrics subject_tree_prompt_limit=%r; using default %s",
+                raw_limit,
+                self.SUBJECT_TREE_PROMPT_LIMIT,
+            )
+            return self.SUBJECT_TREE_PROMPT_LIMIT
+        return limit
+
+    def setup_tools(self) -> None:
+        if not self.agent_config:
+            return
+
+        self.tools = []
+        sub_agent_name = self.get_node_name()
+        tool_patterns = self._configured_tool_patterns()
+
+        try:
+            self.context_search_tools = ContextSearchTools(self.agent_config, sub_agent_name=sub_agent_name)
+            self._prepare_subject_tree_context()
+        except Exception as exc:  # noqa: BLE001
+            message = self._record_context_search_degraded(exc)
+            logger.warning("AskMetrics context search unavailable: %s", message)
+            self.context_search_tools = None
+            self._set_subject_tree_prompt({}, [])
+
+        try:
+            self.semantic_tools = SemanticTools(
+                agent_config=self.agent_config,
+                sub_agent_name=sub_agent_name,
+                adapter_type=self._resolve_adapter_type(),
+            )
+            if self.semantic_tools.adapter is None:
+                self.startup_error = self.semantic_tools._adapter_unavailable_message()
+                logger.warning("AskMetrics semantic adapter unavailable: %s", self.startup_error)
+                return
+        except Exception as exc:  # noqa: BLE001
+            self.startup_error = f"Semantic adapter unavailable: {exc}"
+            logger.warning("AskMetrics semantic adapter setup failed: %s", exc)
+            return
+
+        for pattern in tool_patterns:
+            self._setup_tool_pattern(pattern)
+
+    def _configured_tool_patterns(self) -> List[str]:
+        config_value = self.node_config.get("tools")
+        if not config_value:
+            return list(self.DEFAULT_TOOLS)
+        if isinstance(config_value, str):
+            items = config_value.split(",")
+        elif isinstance(config_value, (list, tuple)):
+            items = config_value
+        else:
+            logger.warning("Invalid ask_metrics tools config %r; using default tools", config_value)
+            return list(self.DEFAULT_TOOLS)
+        patterns = [str(item).strip() for item in items if str(item).strip()]
+        return patterns or list(self.DEFAULT_TOOLS)
+
+    def _setup_tool_pattern(self, pattern: str) -> None:
+        try:
+            if "." not in pattern:
+                category, method_name = pattern, "*"
+            else:
+                category, method_name = pattern.split(".", 1)
+
+            if method_name in {"", "*"}:
+                self._setup_tool_category(category)
+            else:
+                self._setup_specific_tool_method(category, method_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to setup ask_metrics tool pattern %r: %s", pattern, exc)
+
+    def _setup_tool_category(self, category: str) -> None:
+        if category == "context_search_tools":
+            self._add_available_context_tools()
+            return
+
+        tool_instance = self._ensure_tool_instance(category)
+        if not tool_instance:
+            logger.warning("Ignoring unsupported ask_metrics tool category: %s", category)
+            return
+        self._add_available_tools(tool_instance)
+
+    def _setup_specific_tool_method(self, category: str, method_name: str) -> None:
+        if category == "context_search_tools" and method_name == "list_subject_tree":
+            self._add_subject_tree_tool()
+            return
+
+        tool_instance = self._ensure_tool_instance(category)
+        if not tool_instance:
+            logger.warning("Ignoring unsupported ask_metrics tool category: %s", category)
+            return
+        if not hasattr(tool_instance, method_name):
+            logger.warning("Ignoring unsupported ask_metrics tool: %s.%s", category, method_name)
+            return
+
+        method = getattr(tool_instance, method_name)
+        if category == "db_tools" and callable(getattr(tool_instance, "to_function_tool", None)):
+            tool = tool_instance.to_function_tool(method)
+        else:
+            tool = trans_to_function_tool(method)
+        self._append_tool(tool)
+
+    def _ensure_tool_instance(self, category: str) -> Optional[Any]:
+        sub_agent_name = self.get_node_name()
+        if category == "context_search_tools":
+            return self.context_search_tools
+        if category == "semantic_tools":
+            return self.semantic_tools
+        if category == "db_tools":
+            if not self.db_func_tool:
+                self.db_func_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=sub_agent_name)
+            return self.db_func_tool
+        if category == "reference_template_tools":
+            if not self.reference_template_tools:
+                db_tool = self.db_func_tool
+                if not db_tool:
+                    try:
+                        db_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=sub_agent_name)
+                        self.db_func_tool = db_tool
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("Reference template tools will run without db_tools: %s", exc)
+                self.reference_template_tools = ReferenceTemplateTools(
+                    self.agent_config,
+                    sub_agent_name=sub_agent_name,
+                    db_func_tool=db_tool,
+                )
+            return self.reference_template_tools
+        if category == "date_parsing_tools":
+            if not self.date_parsing_tools:
+                self.date_parsing_tools = DateParsingTools(self.agent_config, self.model)
+            return self.date_parsing_tools
+        if category == "filesystem_tools":
+            if not self.filesystem_func_tool:
+                self.filesystem_func_tool = self._make_filesystem_tool()
+            return self.filesystem_func_tool
+        if category == "platform_doc_tools":
+            if not self._platform_doc_tool:
+                self._platform_doc_tool = PlatformDocSearchTool(self.agent_config)
+            return self._platform_doc_tool
+        return None
+
+    def _add_available_tools(self, tool_instance: Any) -> None:
+        available_tools = getattr(tool_instance, "available_tools", None)
+        if not callable(available_tools):
+            return
+        for tool in available_tools():
+            self._append_tool(tool)
+
+    def _add_available_context_tools(self) -> None:
+        if not self.context_search_tools:
+            return
+        available_tools = getattr(self.context_search_tools, "available_tools", None)
+        if not callable(available_tools):
+            return
+        for tool in available_tools():
+            if getattr(tool, "name", "") == "list_subject_tree":
+                self._add_subject_tree_tool()
+            else:
+                self._append_tool(tool)
+
+    def _add_subject_tree_tool(self) -> None:
+        if self.subject_tree_mode == "partial":
+            self._append_tool(trans_to_function_tool(self.list_subject_tree))
+
+    def _append_tool(self, tool: Optional[Tool]) -> None:
+        if not tool:
+            return
+        tool_name = getattr(tool, "name", "")
+        if tool_name and any(getattr(existing, "name", "") == tool_name for existing in self.tools):
+            return
+        self.tools.append(tool)
+
+    def _prepare_subject_tree_context(self) -> None:
+        if not self.context_search_tools:
+            self._set_subject_tree_prompt({}, [])
+            return
+
+        result = self.context_search_tools.list_subject_tree()
+        if not isinstance(result, FuncToolResult) or result.success == 0 or not isinstance(result.result, dict):
+            logger.warning("AskMetrics subject tree unavailable: %s", getattr(result, "error", None))
+            self._set_subject_tree_prompt({}, [])
+            return
+
+        metric_entries = self._extract_subject_tree_metric_entries(result.result)
+        self._set_subject_tree_prompt(result.result, metric_entries)
+
+    def _set_subject_tree_prompt(self, tree: Dict[str, Any], metric_entries: List[Dict[str, Any]]) -> None:
+        self.subject_tree = tree
+        self.subject_tree_metric_entries = metric_entries
+        count = len(metric_entries)
+        if count == 0:
+            self.subject_tree_mode = "none"
+            self.subject_tree_prompt = ""
+        elif count <= self.subject_tree_prompt_limit:
+            self.subject_tree_mode = "full"
+            self.subject_tree_prompt = json.dumps(metric_entries, ensure_ascii=False, indent=2, default=str)
+        else:
+            self.subject_tree_mode = "partial"
+            excerpt = {
+                "shown_entries": metric_entries[: self.subject_tree_prompt_limit],
+                "total_entries": count,
+            }
+            self.subject_tree_prompt = json.dumps(excerpt, ensure_ascii=False, indent=2, default=str)
+
+    @classmethod
+    def _extract_subject_tree_metric_entries(cls, tree: Dict[str, Any]) -> List[Dict[str, Any]]:
+        entries: List[Dict[str, Any]] = []
+
+        def _walk(node: Any, path: List[str]) -> None:
+            if not isinstance(node, dict):
+                return
+
+            metrics = node.get("metrics")
+            if isinstance(metrics, list) and metrics:
+                entries.append({"path": path, "metrics": metrics})
+
+            for key, value in node.items():
+                if key in {"metrics", "reference_sql", "knowledge", "reference_template"}:
+                    continue
+                if isinstance(value, dict):
+                    _walk(value, [*path, str(key)])
+
+        _walk(tree, [])
+        return entries
+
+    def list_subject_tree(self) -> FuncToolResult:
+        """
+        List metric subject entries available to ask_metrics.
+
+        Returns only subject paths and metric names. Non-metric subject-tree
+        content such as reference SQL, external knowledge, and templates is
+        intentionally omitted from this subagent surface.
+        """
+        return FuncToolResult(
+            result={
+                "entries": self.subject_tree_metric_entries,
+                "total_entries": len(self.subject_tree_metric_entries),
+            }
+        )
+
+    async def _before_stream(self, ctx: StreamRunContext) -> None:
+        if self.startup_error:
+            raise DatusException(
+                code=ErrorCode.COMMON_CONFIG_ERROR,
+                message_args={"config_error": f"ask_metrics is unavailable: {self.startup_error}"},
+            )
+
+    def _tool_category_map(self) -> Dict[str, List[Any]]:
+        mapping = super()._tool_category_map()
+        for category, names in self._TOOL_NAMES_BY_CATEGORY.items():
+            category_tools = [tool for tool in self.tools if getattr(tool, "name", "") in names]
+            if category_tools:
+                mapping[category] = category_tools
+        return mapping
+
+    def _get_system_prompt(self, prompt_version: Optional[str] = None) -> str:
+        context: Dict[str, Any] = {
+            "agent_config": self.agent_config,
+            "rules": self.node_config.get("rules", []),
+            "agent_description": self.node_config.get("agent_description", ""),
+            "subject_tree_mode": self.subject_tree_mode,
+            "subject_tree_count": len(self.subject_tree_metric_entries),
+            "subject_tree_prompt": self.subject_tree_prompt,
+            "subject_tree_prompt_limit": self.subject_tree_prompt_limit,
+        }
+
+        if self.agent_config:
+            from datus.utils.node_utils import build_datasource_prompt_context
+
+            context.update(build_datasource_prompt_context(self.agent_config))
+            context["db_name"] = context.get("datasource")
+
+        from datus.utils.time_utils import get_default_current_date
+
+        context["current_date"] = get_default_current_date(None)
+
+        version_value = prompt_version if prompt_version not in (None, "") else self.node_config.get("prompt_version")
+        version = None if version_value in (None, "") else str(version_value)
+        system_prompt_name = self.node_config.get("system_prompt") or self.get_node_name()
+        template_name = f"{system_prompt_name}_system"
+
+        from datus.prompts.prompt_manager import get_prompt_manager
+
+        pm = get_prompt_manager(agent_config=self.agent_config)
+        try:
+            base_prompt = pm.render_template(template_name=template_name, version=version, **context)
+        except FileNotFoundError:
+            logger.warning(
+                "Template %r missing, falling back to ask_metrics_system",
+                system_prompt_name,
+            )
+            base_prompt = pm.render_template(template_name="ask_metrics_system", version=version, **context)
+        return self._finalize_system_prompt(base_prompt)
+
+    def _build_success_result(self, ctx: StreamRunContext) -> AskMetricsNodeResult:
+        response_content = ctx.response_content
+        if not response_content and ctx.last_successful_output:
+            response_content = (
+                ctx.last_successful_output.get("content", "")
+                or ctx.last_successful_output.get("text", "")
+                or ctx.last_successful_output.get("response", "")
+                or str(ctx.last_successful_output)
+            )
+
+        all_actions = ctx.action_history_manager.get_actions()
+        tokens_used = self._extract_total_tokens(all_actions)
+        tool_calls = [a for a in all_actions if a.role == ActionRole.TOOL and a.status == ActionStatus.SUCCESS]
+        if not isinstance(response_content, str):
+            response_content = str(response_content) if response_content else ""
+
+        return AskMetricsNodeResult(
+            success=True,
+            response=response_content,
+            markdown_report=response_content,
+            tokens_used=int(tokens_used),
+            action_history=[a.model_dump() for a in all_actions],
+            execution_stats={
+                "total_actions": len(all_actions),
+                "tool_calls_count": len(tool_calls),
+                "tools_used": sorted({a.action_type for a in tool_calls}),
+                "total_tokens": int(tokens_used),
+            },
+        )

--- a/datus/agent/node/node.py
+++ b/datus/agent/node/node.py
@@ -134,6 +134,21 @@ class Node(ABC):
                 is_subagent=is_subagent,
                 session_id=session_id,
             )
+        elif node_type == NodeType.TYPE_ASK_METRICS:
+            from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+            return AskMetricsAgenticNode(
+                node_id,
+                description,
+                node_type,
+                input_data,
+                agent_config,
+                tools,
+                node_name,
+                execution_mode="workflow",
+                is_subagent=is_subagent,
+                session_id=session_id,
+            )
         elif node_type == NodeType.TYPE_GEN_REPORT:
             from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
 
@@ -495,6 +510,10 @@ class Node(ABC):
                     input_data = ChatNodeInput(**input_data)
                 elif node_dict["type"] == NodeType.TYPE_GEN_SQL:
                     input_data = GenSQLNodeInput(**input_data)
+                elif node_dict["type"] == NodeType.TYPE_ASK_METRICS:
+                    from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+                    input_data = AskMetricsNodeInput(**input_data)
                 elif node_dict["type"] == NodeType.TYPE_GEN_REPORT:
                     from datus.schemas.gen_report_agentic_node_models import GenReportNodeInput
 
@@ -549,6 +568,10 @@ class Node(ABC):
                     result_data = ChatNodeResult(**result_data)
                 elif node_dict["type"] == NodeType.TYPE_GEN_SQL:
                     result_data = GenSQLNodeResult(**result_data)
+                elif node_dict["type"] == NodeType.TYPE_ASK_METRICS:
+                    from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeResult
+
+                    result_data = AskMetricsNodeResult(**result_data)
                 elif node_dict["type"] == NodeType.TYPE_GEN_REPORT:
                     from datus.schemas.gen_report_agentic_node_models import GenReportNodeResult
 

--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -99,6 +99,23 @@ def create_interactive_node(
                 agent_config=agent_config, execution_mode=execution_mode, scope=scope, session_id=session_id
             )
 
+        elif subagent_name == "ask_metrics" or node_class_type == "ask_metrics":
+            from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+            from datus.configuration.node_type import NodeType
+
+            return AskMetricsAgenticNode(
+                node_id=node_id if node_id is not None else f"{subagent_name}{node_id_suffix}",
+                description=f"Metric question-answering node for {subagent_name}",
+                node_type=NodeType.TYPE_ASK_METRICS,
+                input_data=None,
+                agent_config=agent_config,
+                tools=None,
+                node_name=subagent_name,
+                scope=scope,
+                execution_mode=execution_mode,
+                session_id=session_id,
+            )
+
         elif subagent_name == "gen_report" or node_class_type == "gen_report":
             from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
 
@@ -319,6 +336,7 @@ def create_node_input(
         source_session_id: Source session the feedback node should copy from.
             Only consumed by :class:`FeedbackAgenticNode`.
     """
+    from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
     from datus.agent.node.gen_ext_knowledge_agentic_node import GenExtKnowledgeAgenticNode
     from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
     from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
@@ -375,6 +393,16 @@ def create_node_input(
         from datus.schemas.gen_report_agentic_node_models import GenReportNodeInput
 
         return GenReportNodeInput(
+            user_message=user_message,
+            catalog=catalog,
+            database=database,
+            db_schema=db_schema,
+        )
+
+    elif isinstance(node, AskMetricsAgenticNode):
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        return AskMetricsNodeInput(
             user_message=user_message,
             catalog=catalog,
             database=database,
@@ -485,11 +513,15 @@ def resolve_node_name(subagent_name: Optional[str]) -> str:
 
 
 def _resolve_node_class_type(subagent_name: str, agent_config: "AgentConfig") -> Optional[str]:
-    """Resolve node_class from agent config for a subagent."""
+    """Resolve runtime node class from agent config for a subagent.
+
+    ``node_class`` wins for older/custom yaml, while API-created agents store
+    the selected runtime class under ``type``.
+    """
     if hasattr(agent_config, "agentic_nodes") and agent_config.agentic_nodes:
         node_config = agent_config.agentic_nodes.get(subagent_name, {})
         if hasattr(node_config, "model_dump"):
             node_config = node_config.model_dump()
         if isinstance(node_config, dict):
-            return node_config.get("node_class")
+            return node_config.get("node_class") or node_config.get("type")
     return None

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -86,6 +86,7 @@ _TOOL_CATEGORIES_BY_AGENT_TYPE: dict[str, tuple[str, ...]] = {
         "date_parsing_tools",
         "reference_template_tools",
     ),
+    "ask_metrics": _USER_FACING_TOOL_CATEGORIES,
     "ask_report": (
         "db_tools",
         "semantic_tools",
@@ -108,12 +109,10 @@ _TOOL_CATEGORIES_BY_AGENT_TYPE: dict[str, tuple[str, ...]] = {
 def _build_tool_types(agent_type: str) -> dict[str, dict[str, list[str]]]:
     """Compose the ``tool_types`` block returned by ``GET /agent/use_tools``
     for ``agent_type``. Categories are restricted to the per-type whitelist
-    in :data:`_TOOL_CATEGORIES_BY_AGENT_TYPE`; for ``ask_*`` agents,
+    in :data:`_TOOL_CATEGORIES_BY_AGENT_TYPE`; for artifact ``ask_*`` agents,
     ``filesystem_tools`` is further restricted to the read-only subset so
     the editor picker never surfaces ``write_file`` / ``edit_file`` as
-    selectable options. ``_validate_tools_for_agent_type`` reads back from
-    the same block, so the per-type catalog stays the single allowlist for
-    both the picker and the write-path validator.
+    selectable options.
     """
     is_ask_agent = agent_type in {"ask_report", "ask_dashboard"}
     tool_types: dict[str, dict[str, list[str]]] = {}
@@ -155,6 +154,18 @@ SUBAGENT_TOOL_REFERENCE: dict[str, dict[str, Any]] = {
             "context_search_tools.list_subject_tree",
         ],
         "tool_types": _build_tool_types("gen_report"),
+    },
+    "ask_metrics": {
+        "default_tools": [
+            "context_search_tools.search_metrics",
+            "context_search_tools.get_metrics",
+            "semantic_tools.list_metrics",
+            "semantic_tools.get_dimensions",
+            "semantic_tools.query_metrics",
+            "semantic_tools.attribution_analyze",
+            "context_search_tools.list_subject_tree",
+        ],
+        "tool_types": _build_tool_types("ask_metrics"),
     },
     # ask_report / ask_dashboard: read-only follow-up consultant for a single
     # visual artifact. Default tools cover data exploration (db_tools read
@@ -536,16 +547,14 @@ def _validate_tools(tools: list[str]) -> list[str]:
 
 
 def _validate_tools_for_agent_type(tools: list[str], agent_type: str) -> list[str]:
-    """For ``ask_*`` agents, reject any tool pattern outside the read-only
-    catalog. Returns the offending patterns; an empty list means OK.
+    """Reject tool patterns outside a type-specific catalog.
+
+    Returns the offending patterns; an empty list means OK.
 
     The general :func:`_validate_tools` only confirms patterns are
-    syntactically valid (category / method exists). ``ask_*`` agents have
-    an additional contract — they must never mutate the artifact they're
-    bound to — so we enforce a per-type allowlist matching the
-    ``tool_types`` catalog returned by ``GET /agent/use_tools``. This
-    blocks ``filesystem_tools.write_file`` / ``edit_file`` and any wildcard
-    that would expand reach beyond the documented read-only set.
+    syntactically valid (category / method exists). Artifact ask agents also
+    have a narrower read-only filesystem contract, so enforce that allowlist
+    matching the ``tool_types`` catalog returned by ``GET /agent/use_tools``.
     """
     if agent_type not in {"ask_report", "ask_dashboard"}:
         return []
@@ -816,6 +825,7 @@ class AgentService:
     # Map sub-agent type to builtin prompt template base name
     _TYPE_TO_TEMPLATE = {
         "gen_sql": "gen_sql_system",
+        "ask_metrics": "ask_metrics_system",
         "gen_report": "gen_report_system",
         "ask_report": "ask_report_system",
         "ask_dashboard": "ask_dashboard_system",

--- a/datus/configuration/node_type.py
+++ b/datus/configuration/node_type.py
@@ -6,6 +6,7 @@ from typing import Optional, get_type_hints
 
 from pydantic import BaseModel, create_model
 
+from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
 from datus.schemas.chat_agentic_node_models import ChatNodeInput
 from datus.schemas.compare_node_models import CompareInput
 from datus.schemas.date_parser_node_models import DateParserInput
@@ -58,6 +59,7 @@ class NodeType:
     TYPE_GEN_SQL = "gen_sql"  # For SQL generation with conversational AI
     TYPE_SEMANTIC = "semantic"  # For semantic model generation
     TYPE_SQL_SUMMARY = "sql_summary"  # For SQL summary generation
+    TYPE_ASK_METRICS = "ask_metrics"  # For fast metric-based question answering
     TYPE_GEN_REPORT = "gen_report"  # For generic report generation
     TYPE_GEN_VISUAL_REPORT = "gen_visual_report"  # For structured (manifest + queries) report generation
     TYPE_GEN_VISUAL_DASHBOARD = "gen_visual_dashboard"  # For parameterized dashboard generation
@@ -84,6 +86,7 @@ class NodeType:
         TYPE_GEN_SQL,
         TYPE_SEMANTIC,
         TYPE_SQL_SUMMARY,
+        TYPE_ASK_METRICS,
         TYPE_GEN_REPORT,
         TYPE_GEN_VISUAL_REPORT,
         TYPE_GEN_VISUAL_DASHBOARD,
@@ -117,6 +120,7 @@ class NodeType:
         TYPE_GEN_SQL: "SQL generation with conversational AI and tool calling",
         TYPE_SEMANTIC: "Semantic model generation with conversational AI",
         TYPE_SQL_SUMMARY: "SQL summary generation with conversational AI",
+        TYPE_ASK_METRICS: "Fast metric-based question answering with semantic metrics",
         TYPE_GEN_REPORT: "Generic report generation with semantic and database tools",
         TYPE_GEN_VISUAL_REPORT: ("Visualizable report generation producing render/*.jsx + queries/* artifacts"),
         TYPE_GEN_VISUAL_DASHBOARD: (
@@ -176,6 +180,8 @@ class NodeType:
             input_data_cls = SemanticNodeInput
         elif node_type == NodeType.TYPE_SQL_SUMMARY:
             input_data_cls = SqlSummaryNodeInput
+        elif node_type == NodeType.TYPE_ASK_METRICS:
+            input_data_cls = AskMetricsNodeInput
         elif node_type == NodeType.TYPE_GEN_REPORT:
             input_data_cls = GenReportNodeInput
         elif node_type == NodeType.TYPE_GEN_VISUAL_REPORT:

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -1,0 +1,84 @@
+You are AskMetrics, a metric-first question-answering agent in Datus-agent.
+
+Your job is to answer questions quickly and deterministically using existing business metrics. Do not explore raw database tables, do not write SQL, and do not invent metric values.
+
+## Available Metric Workflow
+
+Use the narrow metric workflow below:
+
+1. Identify the subject path from the subject tree context.
+2. Match requested metrics against the subject tree before using search.
+   - Treat snake_case names, space-separated names, and obvious subject-path names as direct matches (`discounted revenue` -> `discounted_revenue`; `Lineitem Volume` with only `shipped_quantity` -> `shipped_quantity`).
+   - When the subject tree gives a direct metric/path match, do not call `search_metrics`; use that metric name and path directly.
+3. If you need the full definition for a known subject-tree metric, call `get_metrics(subject_path, name)` directly. Do not use `search_metrics` just to confirm a known metric.
+4. Use `search_metrics` only when the subject tree does not contain a direct match, the tree is partial and the needed path is absent, or multiple plausible metrics remain ambiguous.
+5. Call `get_dimensions` before grouping, filtering, or attribution.
+6. Call `query_metrics` to retrieve metric values.
+7. For change explanation, root-cause, or contribution questions, call `attribution_analyze` after selecting candidate dimensions.
+8. If no suitable existing metric can answer the question, say so directly and do not fall back to raw SQL.
+
+## Tool Rules
+
+- Use only the metric/context tools available to you.
+- `query_metrics` and `attribution_analyze` are the only tools that may produce metric results or attribution results.
+- `get_metrics` retrieves details for a known subject path and metric name.
+- `search_metrics` discovers candidate metrics only when direct subject-tree matching is insufficient.
+- `list_metrics` is for enumerating executable metrics from the semantic adapter.
+- Prefer `get_dimensions` and `query_metrics` after a direct subject-tree match; only retrieve metric details when the answer depends on the definition text.
+- Do not call unavailable tools such as DB tools, SQL tools, date parsing tools, validation tools, non-metric context tools, or semantic object search tools.
+- Infer concrete time ranges yourself from the current date. Do not ask for a date parser tool.
+
+## Subject Tree
+
+{% if subject_tree_mode == "full" %}
+The complete metric subject entries are available below. They include only subject paths and metric names. Use them as the routing catalog for direct metric matching; do not call `list_subject_tree`, and do not call `search_metrics` for metrics that match these entries directly.
+
+```json
+{{ subject_tree_prompt }}
+```
+{% elif subject_tree_mode == "partial" %}
+The metric subject tree has {{ subject_tree_count }} entries. The first {{ subject_tree_prompt_limit }} entries are shown below. They include only subject paths and metric names; use the excerpt for direct metric matching, and call `list_subject_tree` only when the needed subject path is not in this excerpt.
+
+```json
+{{ subject_tree_prompt }}
+```
+{% else %}
+No subject tree entries were available at startup. You can still use `list_metrics` or metric search tools when available.
+{% endif %}
+
+## Output Format
+
+Return a concise Markdown report, not JSON.
+
+Include:
+- The interpreted question and time range.
+- The metric(s) used.
+- The result, with numbers from tool output.
+- Attribution findings when `attribution_analyze` was used.
+- Any limitation or reason for refusal when the question cannot be answered with existing metrics.
+
+## Context
+
+{% if current_date -%}
+- Current date: {{ current_date }}
+{% endif -%}
+{% if datasource -%}
+{% if current_datasource_dialect -%}
+- Current datasource: {{ datasource }} ({{ current_datasource_dialect }})
+{% else -%}
+- Current datasource: {{ datasource }}
+{% endif -%}
+- Use only the current datasource. If the user asks for another datasource, say AskMetrics is scoped to the current datasource.
+{% endif -%}
+
+{% if rules %}
+## Rules
+{% for rule in rules %}
+- {{ rule }}
+{% endfor %}
+{% endif %}
+
+{% if agent_description %}
+## Role
+{{ agent_description }}
+{% endif %}

--- a/datus/prompts/prompt_templates/chat_system_1.2.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.2.j2
@@ -26,9 +26,10 @@ You have access to:
 - Task delegation tool for specialized subagent execution:
   - Use `task(type="explore", prompt="...")` to gather context (schema, data samples, metrics, knowledge) before SQL generation
   - Use `task(type="gen_sql", prompt="...")` to delegate SQL generation to a specialized SQL expert subagent
+  - Use `task(type="ask_metrics", prompt="...")` to answer existing-metric KPI values, trends, group-bys, and lightweight metric attribution quickly
   - Use `task(type="gen_table", prompt="...")` to delegate **any DDL** (CREATE TABLE / CTAS / ALTER TABLE / DROP TABLE / CREATE or DROP VIEW / CREATE or DROP SCHEMA) — gen_table owns the `execute_ddl` tool and runs post-write validation (existence check + project validator skills) automatically
   - Use `task(type="gen_job", prompt="...")` to delegate ETL pipelines or cross-database migrations — gen_job additionally has `execute_write` / `transfer_query_result` plus post-transfer reconciliation validation
-  - Use `task(type="gen_report", prompt="...")` to delegate metric attribution and root cause analysis to a specialized report subagent
+  - Use `task(type="gen_report", prompt="...")` only when the user explicitly asks to use the `gen_report` subagent
   - Use `task(type="gen_dashboard", prompt="...")` to delegate BI dashboard creation, updates, or inspection on the configured BI platform (Superset, Grafana, future adapters) — gen_dashboard builds BI assets on top of tables or SQL datasets that already exist in a BI-registered database
   - Use `task(type="scheduler", prompt="...")` to delegate scheduled job submission, monitoring, or troubleshooting on the configured scheduler (Airflow, etc.)
   - Use `task(type="gen_semantic_model", prompt="...")` to delegate MetricFlow semantic model generation from existing tables (entities, dimensions, relationships)
@@ -56,6 +57,11 @@ The subagent descriptions and "When to use" blocks below are the authoritative r
 - The query is too complex for you to write confidently after gathering context
 - Do NOT use gen_sql when: the SQL is straightforward (SELECT, COUNT, SUM, GROUP BY, WHERE, JOIN on known tables, TOP N), or you are modifying/refining a previous query
 
+**When to use `task(type="ask_metrics")`:**
+- The question can be answered by existing semantic metrics: simple KPI values, period comparisons, trends, group-bys, top contributors, or lightweight metric attribution
+- Prefer ask_metrics over gen_sql when an existing metric is likely available
+- Do NOT use ask_metrics when: no existing metric can answer the question, the user asks for raw SQL/table logic, or the deliverable is a full narrative root-cause report
+
 **When to use `task(type="gen_table")`:**
 - ANY DDL against the user's database: CREATE TABLE, CTAS, ALTER TABLE, DROP TABLE, CREATE / DROP VIEW, CREATE / DROP SCHEMA
 - You yourself do NOT have `execute_ddl` or `execute_write` — `read_query` rejects everything except SELECT / SHOW / DESCRIBE / EXPLAIN, so any schema change or destructive operation MUST go through gen_table
@@ -72,9 +78,8 @@ The subagent descriptions and "When to use" blocks below are the authoritative r
 - Do NOT use gen_job when: the task is purely a one-off CREATE TABLE (use gen_table), or the user only wants the SQL without execution
 
 **When to use `task(type="gen_report")`:**
-- The question involves analyzing why a metric changed, metric attribution, or root cause analysis
-- The user provides a reference SQL or metric and asks for trend explanation or drill-down analysis
-- Do NOT use gen_report when: the user just wants a simple metric value or a straightforward SQL query
+- Only when the user explicitly names `gen_report` or asks you to route the request to the `gen_report` subagent
+- Do NOT automatically route metric attribution, root-cause analysis, narrative report, or trend explanation requests to gen_report; use `ask_metrics`, `gen_visual_report`, direct tools, or clarification based on the requested deliverable
 
 **When to use `task(type="gen_dashboard")` — overrides the "handle it yourself" default:**
 - Use `gen_dashboard` when the request is to create / update / inspect a dashboard, chart, dataset, or visualization on a BI platform and the target table or SQL dataset already exists in a BI-registered database.

--- a/datus/schemas/ask_metrics_agentic_node_models.py
+++ b/datus/schemas/ask_metrics_agentic_node_models.py
@@ -1,0 +1,31 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""AskMetrics Agentic Node models."""
+
+from typing import Any, Dict, Optional
+
+from pydantic import Field
+
+from datus.schemas.base import BaseInput, BaseResult
+
+
+class AskMetricsNodeInput(BaseInput):
+    """Input model for AskMetricsAgenticNode."""
+
+    user_message: str = Field(..., description="User's metric question")
+    catalog: Optional[str] = Field(None, description="Database catalog")
+    database: Optional[str] = Field(None, description="Database name")
+    db_schema: Optional[str] = Field(None, description="Database schema")
+    max_turns: int = Field(default=12, description="Maximum turns for quick metric answering")
+    prompt_version: Optional[str] = Field(None, description="Prompt template version override")
+
+
+class AskMetricsNodeResult(BaseResult):
+    """Result model for AskMetricsAgenticNode."""
+
+    response: str = Field(default="", description="Markdown metric answer")
+    markdown_report: str = Field(default="", description="Final Markdown report")
+    report_result: Optional[Dict[str, Any]] = Field(default=None, description="Optional structured metadata")
+    tokens_used: int = Field(default=0, description="Total tokens used")

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -6,7 +6,7 @@
 Semantic Function Tools
 
 Provides unified interface to semantic layer services through adapters.
-Tools delegate to registered semantic adapters while leveraging unified storage for performance.
+All public semantic tools require a successfully initialized semantic adapter.
 """
 
 import inspect
@@ -231,7 +231,9 @@ class SemanticTools:
         self.adapter_type = adapter_type
         self.generation_evidence = generation_evidence
 
-        # Initialize storage RAG interfaces
+        # Keep storage handles for compatibility with older call sites, but
+        # public SemanticTools methods use the semantic adapter as their source
+        # of truth. ContextSearchTools owns RAG/storage discovery.
         self.semantic_model_rag = SemanticModelRAG(agent_config, sub_agent_name)
         self.metric_rag = MetricRAG(agent_config, sub_agent_name)
         self.compressor = DataCompressor(model_name=agent_config.active_model().model)
@@ -338,6 +340,29 @@ class SemanticTools:
             self._attribution_tool = DimensionAttributionUtil(self.adapter)
         return self._attribution_tool
 
+    def _adapter_unavailable_message(self) -> str:
+        """Return a consistent message for semantic-adapter failures."""
+        if self._adapter_load_error:
+            adapter_name = self.adapter_type or "configured"
+            return f"Semantic adapter unavailable: failed to load '{adapter_name}': {self._adapter_load_error}"
+
+        adapter_name = self._configured_adapter_type()
+        if not adapter_name:
+            return "Semantic adapter unavailable: no semantic adapter configured."
+
+        return f"Semantic adapter unavailable: failed to load '{adapter_name}'."
+
+    def _require_adapter(self, tool_name: str) -> tuple[Optional[BaseSemanticAdapter], Optional[FuncToolResult]]:
+        """Load the semantic adapter or return a tool failure result."""
+        adapter = self.adapter
+        if adapter is not None:
+            return adapter, None
+        return None, FuncToolResult(
+            success=0,
+            error=f"{tool_name} requires a successfully initialized semantic adapter. "
+            f"{self._adapter_unavailable_message()}",
+        )
+
     def _reload_adapter(self) -> bool:
         """
         Reload the semantic adapter to pick up new configuration changes.
@@ -376,23 +401,17 @@ class SemanticTools:
         Returns:
             List of Tool objects for LLM function calling
         """
-        tools = [
+        if self.adapter is None:
+            logger.warning("SemanticTools unavailable: %s", self._adapter_unavailable_message())
+            return []
+
+        return [
             trans_to_function_tool(self.list_metrics),
             trans_to_function_tool(self.get_dimensions),
             trans_to_function_tool(self.query_metrics),
+            trans_to_function_tool(self.validate_semantic),
+            trans_to_function_tool(self.attribution_analyze),
         ]
-
-        # Add validation whenever an adapter is configured, even if the current
-        # YAML makes adapter construction fail. In that case validate_semantic
-        # returns the adapter-load error so the agent can fix the files.
-        if self._configured_adapter_type():
-            tools.append(trans_to_function_tool(self.validate_semantic))
-
-        # Add attribution tools if attribution_tool is available
-        if self.attribution_tool:
-            tools.append(trans_to_function_tool(self.attribution_analyze))
-
-        return tools
 
     def list_metrics(
         self,
@@ -401,7 +420,7 @@ class SemanticTools:
         offset: int = 0,
     ) -> FuncToolResult:
         """
-        List available metrics from storage (or adapter if storage is empty).
+        List available metrics from the semantic adapter.
 
         Args:
             path: Optional subject tree path filter (e.g., ["Finance", "Revenue"])
@@ -424,40 +443,12 @@ class SemanticTools:
         # Normalize null values from LLM
         path = normalize_null(path)
         logger.info(f"list_metrics called: path={path}, limit={limit}, offset={offset}")
+        adapter, error = self._require_adapter("list_metrics")
+        if error:
+            return error
+
         try:
-            # Try storage first
-            all_metrics = self.metric_rag.search_all_metrics()
-
-            # Filter by subject path if provided
-            if path:
-                all_metrics = [m for m in all_metrics if m.get("subject_path", [])[: len(path)] == path]
-
-            # Apply pagination
-            paginated_metrics = all_metrics[offset : offset + limit]
-
-            if paginated_metrics:
-                formatted_metrics = [
-                    {
-                        "name": m.get("name"),
-                        "description": m.get("description"),
-                        "type": m.get("metric_type"),
-                        "dimensions": m.get("dimensions", []),
-                        "measures": m.get("base_measures", []),
-                        "unit": m.get("unit"),
-                        "format": m.get("format"),
-                        "path": m.get("subject_path", []),
-                    }
-                    for m in paginated_metrics
-                ]
-                return self._build_metrics_envelope(formatted_metrics, total=len(all_metrics), offset=offset)
-
-            # Empty storage AND no adapter → empty envelope (total still reflects
-            # the filtered all_metrics, which may be >0 if offset overshot).
-            if not self.adapter:
-                return self._build_metrics_envelope([], total=len(all_metrics), offset=offset)
-
-            logger.info("Storage empty, falling back to adapter")
-            async_result = _run_async(self.adapter.list_metrics(path=path, limit=limit, offset=offset))
+            async_result = _run_async(adapter.list_metrics(path=path, limit=limit, offset=offset))
             adapter_metrics = [
                 {
                     "name": m.name,
@@ -471,7 +462,7 @@ class SemanticTools:
                 }
                 for m in async_result
             ]
-            # Adapter path has no upstream total — leave it None so consumers
+            # Adapter path has no guaranteed upstream total — leave it None so consumers
             # know to use has_more / len(items) < limit as the pagination hint.
             return self._build_metrics_envelope(adapter_metrics, total=None, offset=offset, limit=limit)
 
@@ -516,8 +507,7 @@ class SemanticTools:
     ) -> FuncToolResult:
         """
         Get available dimensions for a specific metric.
-        When an adapter is configured, returns dimension objects from the adapter.
-        Otherwise falls back to dimension data from storage.
+        Returns dimension objects from the semantic adapter.
 
         Args:
             metric_name: Name of the metric
@@ -535,42 +525,16 @@ class SemanticTools:
         # Normalize null values from LLM
         path = normalize_null(path)
         logger.info(f"get_dimensions called: metric={metric_name}, path={path}")
+        adapter, error = self._require_adapter("get_dimensions")
+        if error:
+            return error
+
         try:
-            # Get dimensions from adapter (MetricFlow) to ensure consistency with query execution
-            if self.adapter:
-                dimensions = _run_async(self.adapter.get_dimensions(metric_name=metric_name, path=path))
-                items = _normalize_dimension_rows(dimensions)
-                return FuncToolResult(
-                    success=1,
-                    result=FuncToolListResult(items=items, total=len(items), has_more=False).model_dump(),
-                )
-
-            # Fallback to storage if no adapter configured
-            metric_details = None
-            if path:
-                metric_details_list = self.metric_rag.storage.search_all_metrics(subject_path=path)
-                metric_details_list = [m for m in metric_details_list if m.get("name") == metric_name]
-                if metric_details_list:
-                    metric_details = metric_details_list[0]
-            else:
-                # Search all metrics
-                all_metrics = self.metric_rag.search_all_metrics()
-                matching = [m for m in all_metrics if m.get("name") == metric_name]
-                if matching:
-                    metric_details = matching[0]
-
-            if metric_details:
-                raw = metric_details.get("dimensions", [])
-                items = _normalize_dimension_rows(raw)
-                return FuncToolResult(
-                    success=1,
-                    result=FuncToolListResult(items=items, total=len(items), has_more=False).model_dump(),
-                )
-
+            dimensions = _run_async(adapter.get_dimensions(metric_name=metric_name, path=path))
+            items = _normalize_dimension_rows(dimensions)
             return FuncToolResult(
-                success=0,
-                error=f"Metric '{metric_name}' not found and no adapter configured",
-                result=FuncToolListResult(items=[], total=0, has_more=False).model_dump(),
+                success=1,
+                result=FuncToolListResult(items=items, total=len(items), has_more=False).model_dump(),
             )
 
         except Exception as e:
@@ -707,6 +671,10 @@ class SemanticTools:
         path = _normalize_name_list(path)
         order_by = _normalize_name_list(order_by)
 
+        adapter, error = self._require_adapter("query_metrics")
+        if error:
+            return error
+
         if not metrics:
             return FuncToolResult(
                 success=0,
@@ -714,12 +682,6 @@ class SemanticTools:
                     "query_metrics requires at least one metric name. "
                     "Call list_metrics first and pass one or more metric names exactly as returned."
                 ),
-            )
-
-        if not self.adapter:
-            return FuncToolResult(
-                success=0,
-                error="No semantic adapter configured. Cannot execute queries without adapter.",
             )
 
         # Sanitize time parameters: LLM may pass string "null"/"None" instead of omitting
@@ -740,7 +702,7 @@ class SemanticTools:
 
             # Execute query via adapter
             result = _run_async(
-                self.adapter.query_metrics(
+                adapter.query_metrics(
                     metrics=metrics,
                     dimensions=dimensions,
                     path=path or None,
@@ -818,19 +780,10 @@ class SemanticTools:
             )
 
         logger.info(f"validate_semantic called scope={scope}")
-        adapter = self.adapter
-        if not adapter:
-            if self._adapter_load_error:
-                return FuncToolResult(
-                    success=0,
-                    error=f"Failed to load semantic adapter '{self.adapter_type}': {self._adapter_load_error}",
-                    result=None,
-                )
-            return FuncToolResult(
-                success=0,
-                error="No semantic adapter configured. Cannot validate without adapter.",
-                result=None,
-            )
+        adapter, error = self._require_adapter("validate_semantic")
+        if error:
+            error.result = None
+            return error
 
         try:
             validate_semantic = adapter.validate_semantic
@@ -933,10 +886,15 @@ class SemanticTools:
             - selected_dimensions: Top dimensions selected for analysis
             - top_dimension_values: Delta contributions of dimension values
         """
-        if not self.attribution_tool:
+        _, error = self._require_adapter("attribution_analyze")
+        if error:
+            return error
+
+        attribution_tool = self.attribution_tool
+        if not attribution_tool:
             return FuncToolResult(
                 success=0,
-                error="Attribution tool not available. Requires semantic adapter.",
+                error="Attribution tool not available. Requires a successfully initialized semantic adapter.",
             )
 
         try:
@@ -950,7 +908,7 @@ class SemanticTools:
                 anomaly_context_dict = anomaly_context.model_dump()
 
             result = _run_async(
-                self.attribution_tool.attribution_analyze(
+                attribution_tool.attribution_analyze(
                     metric_name=metric_name,
                     candidate_dimensions=candidate_dimensions,
                     baseline_start=baseline_start,

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -49,6 +49,7 @@ logger = get_logger(__name__)
 NODE_CLASS_MAP = {
     "gen_sql": NodeType.TYPE_GEN_SQL,
     "chat": NodeType.TYPE_CHAT,
+    "ask_metrics": NodeType.TYPE_ASK_METRICS,
     "gen_report": NodeType.TYPE_GEN_REPORT,
     "gen_visual_report": NodeType.TYPE_GEN_VISUAL_REPORT,
     "gen_visual_dashboard": NodeType.TYPE_GEN_VISUAL_DASHBOARD,
@@ -89,11 +90,17 @@ BUILTIN_SUBAGENT_DESCRIPTIONS = {
         "in PARALLEL with direction-specific prompts.\n"
         "  Returns JSON with {response, tokens_used}."
     ),
+    "ask_metrics": (
+        "Answer metric-based questions quickly using existing semantic metrics. "
+        "Use for KPI values, trends, grouped metric results, and metric attribution "
+        "when the question can be answered by the semantic layer. Does not fall back "
+        "to raw SQL. Returns JSON with {response, markdown_report, tokens_used}."
+    ),
     "gen_report": (
-        "Analyze and attribute metrics using reference SQL and semantic layer. "
-        "Use when the question involves metric attribution, root cause analysis, metric trend explanation, "
-        "or analyzing why a metric changed. "
-        "Prompt: provide the metric question, include reference SQL or metric name if available. "
+        "Legacy Markdown report subagent. Use only when the user explicitly asks to use "
+        "the gen_report subagent; do not automatically route attribution, root-cause, "
+        "trend explanation, or report requests here. "
+        "Prompt: provide the user's explicit gen_report request and any supplied context. "
         "Returns JSON with {response, report_result, tokens_used}."
     ),
     "gen_visual_report": (
@@ -434,6 +441,21 @@ class SubAgentTaskTool:
                 is_subagent=True,
                 session_id=session_id,
             )
+        elif subagent_type == "ask_metrics":
+            from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+            return AskMetricsAgenticNode(
+                node_id=f"task_ask_metrics_{uuid.uuid4().hex[:8]}",
+                description="Metric question-answering node for ask_metrics",
+                node_type="ask_metrics",
+                input_data=None,
+                agent_config=self.agent_config,
+                tools=None,
+                node_name="ask_metrics",
+                execution_mode=self._resolve_execution_mode(),
+                is_subagent=True,
+                session_id=session_id,
+            )
         elif subagent_type == "gen_report":
             from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
 
@@ -584,6 +606,9 @@ class SubAgentTaskTool:
         if subagent_type == "gen_report":
             return NodeType.TYPE_GEN_REPORT, "gen_report"
 
+        if subagent_type == "ask_metrics":
+            return NodeType.TYPE_ASK_METRICS, "ask_metrics"
+
         # Built-in gen_visual_report type
         if subagent_type == "gen_visual_report":
             return NodeType.TYPE_GEN_VISUAL_REPORT, "gen_visual_report"
@@ -598,6 +623,7 @@ class SubAgentTaskTool:
             "gen_metrics": (NodeType.TYPE_SEMANTIC, "gen_metrics"),
             "gen_sql_summary": (NodeType.TYPE_SQL_SUMMARY, "gen_sql_summary"),
             "gen_ext_knowledge": (NodeType.TYPE_EXT_KNOWLEDGE, "gen_ext_knowledge"),
+            "ask_metrics": (NodeType.TYPE_ASK_METRICS, "ask_metrics"),
             "gen_table": (NodeType.TYPE_GEN_TABLE, "gen_table"),
             "gen_job": (NodeType.TYPE_GEN_JOB, "gen_job"),
             "gen_dashboard": (NodeType.TYPE_GEN_DASHBOARD, "gen_dashboard"),
@@ -941,6 +967,16 @@ class SubAgentTaskTool:
                 database=self.agent_config.current_datasource,
             )
 
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+        if isinstance(node, AskMetricsAgenticNode):
+            from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+            return AskMetricsNodeInput(
+                user_message=prompt,
+                database=self.agent_config.current_datasource,
+            )
+
         # Built-in system subagent input types
         from datus.agent.node.gen_ext_knowledge_agentic_node import GenExtKnowledgeAgenticNode
         from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
@@ -1149,6 +1185,15 @@ class SubAgentTaskTool:
                 {
                     "response": response,
                     "report_result": report_result,
+                    "tokens_used": tokens,
+                }
+            )
+
+        if "markdown_report" in output:
+            return _wrap(
+                {
+                    "response": response,
+                    "markdown_report": output.get("markdown_report", response),
                     "tokens_used": tokens,
                 }
             )

--- a/datus/utils/constants.py
+++ b/datus/utils/constants.py
@@ -50,6 +50,7 @@ SYS_SUB_AGENTS = {
     "gen_sql_summary",
     "gen_ext_knowledge",
     "gen_sql",
+    "ask_metrics",
     "gen_report",
     "gen_visual_report",
     "gen_visual_dashboard",

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -170,6 +170,25 @@ class TestAskMetricsAgenticNode:
         assert "metric_1" in prompt
         assert "metric_2" not in prompt
 
+    def test_invalid_subject_tree_prompt_limit_uses_default(self, real_agent_config, mock_llm_create):
+        tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+
+        text_node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={"subject_tree_prompt_limit": "invalid"},
+            node_name="custom_metric_agent",
+        )
+        bool_node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={"subject_tree_prompt_limit": True},
+            node_name="another_metric_agent",
+        )
+
+        assert text_node.subject_tree_prompt_limit == text_node.SUBJECT_TREE_PROMPT_LIMIT
+        assert bool_node.subject_tree_prompt_limit == bool_node.SUBJECT_TREE_PROMPT_LIMIT
+
     def test_tools_follow_custom_configuration(self, real_agent_config, mock_llm_create):
         tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
 
@@ -184,6 +203,45 @@ class TestAskMetricsAgenticNode:
         )
 
         assert [tool.name for tool in node.tools] == ["search_metrics", "query_metrics"]
+
+    def test_tools_config_accepts_list_and_invalid_config_falls_back(self, real_agent_config, mock_llm_create):
+        tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+
+        list_node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={"tools": ["semantic_tools.query_metrics", "context_search_tools.search_metrics"]},
+            node_name="custom_metric_agent",
+        )
+        invalid_node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={"tools": {"semantic_tools": ["query_metrics"]}},
+            node_name="another_metric_agent",
+        )
+
+        assert [tool.name for tool in list_node.tools] == ["query_metrics", "search_metrics"]
+        assert [tool.name for tool in invalid_node.tools] == [
+            "search_metrics",
+            "get_metrics",
+            "list_metrics",
+            "get_dimensions",
+            "query_metrics",
+            "attribution_analyze",
+        ]
+
+    def test_unsupported_tool_patterns_are_ignored(self, real_agent_config, mock_llm_create):
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["revenue"]}}},
+            node_config={"tools": "unknown_tools.*"},
+            node_name="custom_metric_agent",
+        )
+
+        node.semantic_tools = object()
+        node._setup_specific_tool_method("semantic_tools", "missing_method")
+
+        assert node.tools == []
 
     def test_custom_configuration_can_add_tools_outside_default_surface(
         self,
@@ -215,6 +273,52 @@ class TestAskMetricsAgenticNode:
         mapping = node._tool_category_map()
         assert [tool.name for tool in mapping["db_tools"]] == ["read_query"]
         assert [tool.name for tool in mapping["date_parsing_tools"]] == ["parse_temporal_expressions"]
+
+    def test_setup_tools_handles_context_search_failure(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+        semantic_tools = _semantic_tools(adapter=True)
+        with (
+            patch("datus.agent.node.ask_metrics_agentic_node.ContextSearchTools", side_effect=RuntimeError("rag down")),
+            patch("datus.agent.node.ask_metrics_agentic_node.SemanticTools", return_value=semantic_tools),
+            patch("datus.agent.node.ask_metrics_agentic_node.trans_to_function_tool", side_effect=_fake_function_tool),
+        ):
+            node = AskMetricsAgenticNode(
+                node_id="ask_metrics_test",
+                description="Ask metrics",
+                node_type=NodeType.TYPE_ASK_METRICS,
+                agent_config=real_agent_config,
+                node_name="ask_metrics",
+            )
+
+        assert node.context_search_tools is None
+        assert node.subject_tree_mode == "none"
+        assert [tool.name for tool in node.tools] == [
+            "list_metrics",
+            "get_dimensions",
+            "query_metrics",
+            "attribution_analyze",
+        ]
+
+    def test_setup_tools_handles_semantic_setup_failure(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+        context_tools = _context_tools({"Sales": {"Orders": {"metrics": ["revenue"]}}})
+        with (
+            patch("datus.agent.node.ask_metrics_agentic_node.ContextSearchTools", return_value=context_tools),
+            patch("datus.agent.node.ask_metrics_agentic_node.SemanticTools", side_effect=RuntimeError("bad adapter")),
+            patch("datus.agent.node.ask_metrics_agentic_node.trans_to_function_tool", side_effect=_fake_function_tool),
+        ):
+            node = AskMetricsAgenticNode(
+                node_id="ask_metrics_test",
+                description="Ask metrics",
+                node_type=NodeType.TYPE_ASK_METRICS,
+                agent_config=real_agent_config,
+                node_name="ask_metrics",
+            )
+
+        assert node.startup_error == "Semantic adapter unavailable: bad adapter"
+        assert node.tools == []
 
     def test_configured_list_subject_tree_only_exposed_for_partial_tree(self, real_agent_config, mock_llm_create):
         small_tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
@@ -315,6 +419,22 @@ class TestAskMetricsAgenticNode:
 
         assert result.execution_stats["tools_used"] == ["get_dimensions", "query_metrics"]
 
+    def test_success_result_uses_last_output_fallback_and_stringifies(self, real_agent_config, mock_llm_create):
+        from datus.schemas.action_history import ActionHistoryManager
+
+        node, _, _ = _make_node(real_agent_config, tree={})
+
+        result = node._build_success_result(
+            Mock(
+                response_content="",
+                last_successful_output={"response": {"value": 10}},
+                action_history_manager=ActionHistoryManager(),
+            )
+        )
+
+        assert result.response == "{'value': 10}"
+        assert result.markdown_report == "{'value': 10}"
+
     def test_tool_category_map_is_narrow(self, real_agent_config, mock_llm_create):
         tree = {"Sales": {"metrics": ["revenue"]}}
         node, _, _ = _make_node(real_agent_config, tree=tree)
@@ -330,3 +450,8 @@ class TestAskMetricsAgenticNode:
             "search_metrics",
             "get_metrics",
         }
+
+    def test_extract_subject_tree_ignores_non_dict_nodes(self):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+        assert AskMetricsAgenticNode._extract_subject_tree_metric_entries(["not", "a", "tree"]) == []

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -1,0 +1,332 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datus.configuration.node_type import NodeType
+from datus.tools.func_tool.base import FuncToolResult
+
+
+def _fake_function_tool(method):
+    tool = Mock()
+    tool.name = getattr(method, "__name__", None) or getattr(method, "_mock_name", "tool")
+    return tool
+
+
+def _semantic_tools(adapter=True):
+    tools = Mock()
+    tools.adapter = Mock() if adapter else None
+    tools._adapter_unavailable_message.return_value = "semantic adapter missing"
+    for name in ("list_metrics", "get_dimensions", "query_metrics", "validate_semantic", "attribution_analyze"):
+        setattr(tools, name, Mock(name=name))
+    return tools
+
+
+def _context_tools(tree):
+    tools = Mock()
+    tools.list_subject_tree.return_value = FuncToolResult(result=tree)
+    for name in ("search_metrics", "get_metrics"):
+        setattr(tools, name, Mock(name=name))
+    return tools
+
+
+def _make_node(real_agent_config, *, tree, adapter=True, node_config=None, node_name="ask_metrics"):
+    from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+    if node_config is not None:
+        real_agent_config.agentic_nodes[node_name] = node_config
+
+    semantic_tools = _semantic_tools(adapter=adapter)
+    context_tools = _context_tools(tree)
+    with (
+        patch("datus.agent.node.ask_metrics_agentic_node.SemanticTools", return_value=semantic_tools),
+        patch("datus.agent.node.ask_metrics_agentic_node.ContextSearchTools", return_value=context_tools),
+        patch("datus.agent.node.ask_metrics_agentic_node.trans_to_function_tool", side_effect=_fake_function_tool),
+    ):
+        node = AskMetricsAgenticNode(
+            node_id="ask_metrics_test",
+            description="Ask metrics",
+            node_type=NodeType.TYPE_ASK_METRICS,
+            agent_config=real_agent_config,
+            node_name=node_name,
+        )
+    return node, semantic_tools, context_tools
+
+
+class TestAskMetricsAgenticNode:
+    def test_small_subject_tree_in_prompt_and_no_list_subject_tree_tool(self, real_agent_config, mock_llm_create):
+        tree = {
+            "Sales": {
+                "Orders": {
+                    "metrics": ["order_count", "revenue"],
+                    "reference_sql": ["orders_revenue.sql"],
+                    "knowledge": ["orders business rules"],
+                    "reference_template": ["orders_template"],
+                }
+            }
+        }
+
+        node, _, _ = _make_node(real_agent_config, tree=tree)
+
+        tool_names = [tool.name for tool in node.tools]
+        assert tool_names == [
+            "search_metrics",
+            "get_metrics",
+            "list_metrics",
+            "get_dimensions",
+            "query_metrics",
+            "attribution_analyze",
+        ]
+        assert node.subject_tree_mode == "full"
+        assert node.subject_tree_metric_entries == [
+            {"path": ["Sales", "Orders"], "metrics": ["order_count", "revenue"]}
+        ]
+
+        prompt = node._get_system_prompt()
+        assert "The complete metric subject entries are available below" in prompt
+        assert "order_count" in prompt
+        subject_tree_prompt = node.subject_tree_prompt
+        assert "order_count" in subject_tree_prompt
+        assert "orders_revenue.sql" not in prompt
+        assert "orders business rules" not in prompt
+        assert "orders_template" not in prompt
+        assert "reference_sql" not in subject_tree_prompt
+        assert "knowledge" not in subject_tree_prompt
+        assert "reference_template" not in subject_tree_prompt
+        assert "do not call `list_subject_tree`" in prompt
+        assert "do not call `search_metrics` for metrics that match these entries directly" in prompt
+        assert "When the subject tree gives a direct metric/path match" in prompt
+        assert node.subject_tree_prompt_limit == 100
+
+    def test_large_subject_tree_exposes_list_subject_tree_tool(self, real_agent_config, mock_llm_create):
+        tree = {
+            "Domain": {
+                f"Subject_{idx}": {
+                    "metrics": [f"metric_{idx}"],
+                    "reference_sql": [f"reference_{idx}.sql"],
+                }
+                for idx in range(101)
+            }
+        }
+
+        node, _, _ = _make_node(real_agent_config, tree=tree)
+
+        tool_names = [tool.name for tool in node.tools]
+        assert "list_subject_tree" in tool_names
+        assert node.subject_tree_mode == "partial"
+        assert len(node.subject_tree_metric_entries) == 101
+
+        prompt = node._get_system_prompt()
+        assert "The metric subject tree has 101 entries" in prompt
+        assert "use the excerpt for direct metric matching" in prompt
+        assert "total_entries" in prompt
+        assert "reference_0.sql" not in prompt
+
+        result = node.list_subject_tree()
+        assert result.success == 1
+        assert result.result["total_entries"] == 101
+        assert result.result["entries"][0] == {"path": ["Domain", "Subject_0"], "metrics": ["metric_0"]}
+        assert "reference_sql" not in result.result["entries"][0]
+
+    def test_subject_tree_entries_without_metrics_are_not_prompted(self, real_agent_config, mock_llm_create):
+        tree = {
+            "Sales": {
+                "OnlyKnowledge": {"reference_sql": ["sales.sql"], "knowledge": ["sales rules"]},
+                "Orders": {"metrics": ["order_count"]},
+            }
+        }
+
+        node, _, _ = _make_node(real_agent_config, tree=tree)
+
+        assert node.subject_tree_mode == "full"
+        assert node.subject_tree_metric_entries == [{"path": ["Sales", "Orders"], "metrics": ["order_count"]}]
+
+        prompt = node._get_system_prompt()
+        assert "order_count" in prompt
+        assert "OnlyKnowledge" not in prompt
+        assert "sales.sql" not in prompt
+        assert "sales rules" not in prompt
+
+    def test_subject_tree_prompt_limit_is_configurable(self, real_agent_config, mock_llm_create):
+        tree = {"Domain": {f"Subject_{idx}": {"metrics": [f"metric_{idx}"]} for idx in range(3)}}
+
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={"subject_tree_prompt_limit": 2},
+        )
+
+        tool_names = [tool.name for tool in node.tools]
+        assert node.subject_tree_prompt_limit == 2
+        assert node.subject_tree_mode == "partial"
+        assert "list_subject_tree" in tool_names
+
+        prompt = node._get_system_prompt()
+        assert "The first 2 entries are shown below" in prompt
+        assert "metric_0" in prompt
+        assert "metric_1" in prompt
+        assert "metric_2" not in prompt
+
+    def test_tools_follow_custom_configuration(self, real_agent_config, mock_llm_create):
+        tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={
+                "type": "ask_metrics",
+                "tools": "context_search_tools.search_metrics, semantic_tools.query_metrics",
+            },
+            node_name="custom_metric_agent",
+        )
+
+        assert [tool.name for tool in node.tools] == ["search_metrics", "query_metrics"]
+
+    def test_custom_configuration_can_add_tools_outside_default_surface(
+        self,
+        real_agent_config,
+        mock_llm_create,
+    ):
+        tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+        db_tools = Mock()
+        db_tools.read_query = Mock(name="read_query")
+        db_tools.to_function_tool.side_effect = _fake_function_tool
+        date_parsing_tools = Mock()
+        date_parsing_tools.parse_temporal_expressions = Mock(name="parse_temporal_expressions")
+
+        with (
+            patch("datus.agent.node.ask_metrics_agentic_node.DBFuncTool", return_value=db_tools),
+            patch("datus.agent.node.ask_metrics_agentic_node.DateParsingTools", return_value=date_parsing_tools),
+        ):
+            node, _, _ = _make_node(
+                real_agent_config,
+                tree=tree,
+                node_config={
+                    "type": "ask_metrics",
+                    "tools": "db_tools.read_query, date_parsing_tools.parse_temporal_expressions",
+                },
+                node_name="custom_metric_agent",
+            )
+
+        assert [tool.name for tool in node.tools] == ["read_query", "parse_temporal_expressions"]
+        mapping = node._tool_category_map()
+        assert [tool.name for tool in mapping["db_tools"]] == ["read_query"]
+        assert [tool.name for tool in mapping["date_parsing_tools"]] == ["parse_temporal_expressions"]
+
+    def test_configured_list_subject_tree_only_exposed_for_partial_tree(self, real_agent_config, mock_llm_create):
+        small_tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+        small_node, _, _ = _make_node(
+            real_agent_config,
+            tree=small_tree,
+            node_config={"type": "ask_metrics", "tools": "context_search_tools.list_subject_tree"},
+            node_name="custom_metric_agent",
+        )
+        assert "list_subject_tree" not in [tool.name for tool in small_node.tools]
+
+        large_tree = {"Domain": {f"Subject_{idx}": {"metrics": [f"metric_{idx}"]} for idx in range(3)}}
+        large_node, _, _ = _make_node(
+            real_agent_config,
+            tree=large_tree,
+            node_config={
+                "type": "ask_metrics",
+                "tools": "context_search_tools.list_subject_tree",
+                "subject_tree_prompt_limit": 2,
+            },
+            node_name="custom_metric_agent",
+        )
+        assert [tool.name for tool in large_node.tools] == ["list_subject_tree"]
+
+    def test_custom_prompt_template_and_version_are_used(self, real_agent_config, mock_llm_create):
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["revenue"]}}},
+            node_config={"type": "ask_metrics", "prompt_version": "2.0"},
+            node_name="custom_metric_agent",
+        )
+
+        prompt_manager = Mock()
+        prompt_manager.render_template.return_value = "custom ask metrics prompt"
+        with patch("datus.prompts.prompt_manager.get_prompt_manager", return_value=prompt_manager):
+            prompt = node._get_system_prompt()
+
+        assert "custom ask metrics prompt" in prompt
+        prompt_manager.render_template.assert_called_once()
+        call_kwargs = prompt_manager.render_template.call_args.kwargs
+        assert call_kwargs["template_name"] == "custom_metric_agent_system"
+        assert call_kwargs["version"] == "2.0"
+
+    def test_custom_prompt_falls_back_to_builtin_template(self, real_agent_config, mock_llm_create):
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["revenue"]}}},
+            node_config={"type": "ask_metrics", "prompt_version": "2.0"},
+            node_name="custom_metric_agent",
+        )
+
+        prompt_manager = Mock()
+        prompt_manager.render_template.side_effect = [FileNotFoundError("missing"), "builtin ask metrics prompt"]
+        with patch("datus.prompts.prompt_manager.get_prompt_manager", return_value=prompt_manager):
+            prompt = node._get_system_prompt()
+
+        assert "builtin ask metrics prompt" in prompt
+        assert prompt_manager.render_template.call_args_list[0].kwargs["template_name"] == "custom_metric_agent_system"
+        assert prompt_manager.render_template.call_args_list[1].kwargs["template_name"] == "ask_metrics_system"
+        assert prompt_manager.render_template.call_args_list[1].kwargs["version"] == "2.0"
+
+    @pytest.mark.asyncio
+    async def test_adapter_unavailable_fails_before_llm(self, real_agent_config, mock_llm_create):
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        node, _, _ = _make_node(real_agent_config, tree={}, adapter=False)
+
+        assert node.tools == []
+        assert node.startup_error == "semantic adapter missing"
+        with pytest.raises(DatusException, match="ask_metrics is unavailable") as exc_info:
+            await node._before_stream(Mock())
+        assert exc_info.value.code == ErrorCode.COMMON_CONFIG_ERROR
+
+    def test_success_result_reports_sorted_tools_used(self, real_agent_config, mock_llm_create):
+        from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
+
+        node, _, _ = _make_node(real_agent_config, tree={})
+        action_history_manager = ActionHistoryManager()
+        for action_type in ("query_metrics", "get_dimensions", "query_metrics"):
+            action_history_manager.add_action(
+                ActionHistory.create_action(
+                    role=ActionRole.TOOL,
+                    action_type=action_type,
+                    messages="",
+                    input_data={},
+                    output_data={},
+                    status=ActionStatus.SUCCESS,
+                )
+            )
+
+        result = node._build_success_result(
+            Mock(
+                response_content="done",
+                last_successful_output=None,
+                action_history_manager=action_history_manager,
+            )
+        )
+
+        assert result.execution_stats["tools_used"] == ["get_dimensions", "query_metrics"]
+
+    def test_tool_category_map_is_narrow(self, real_agent_config, mock_llm_create):
+        tree = {"Sales": {"metrics": ["revenue"]}}
+        node, _, _ = _make_node(real_agent_config, tree=tree)
+
+        mapping = node._tool_category_map()
+        assert {tool.name for tool in mapping["semantic_tools"]} == {
+            "list_metrics",
+            "get_dimensions",
+            "query_metrics",
+            "attribution_analyze",
+        }
+        assert {tool.name for tool in mapping["context_search_tools"]} == {
+            "search_metrics",
+            "get_metrics",
+        }

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -753,6 +753,26 @@ class TestChatAgenticNodeSystemPrompt:
         assert "Ask user tool (`ask_user`)" in prompt
         assert "call `ask_user` FIRST" in prompt
 
+    def test_prompt_keeps_gen_report_explicit_only(self, real_agent_config, mock_llm_create):
+        """Chat routing must not automatically choose legacy gen_report."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        node = ChatAgenticNode(
+            node_id="test_prompt_gen_report_explicit_only",
+            description="Test gen_report routing",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+            execution_mode="interactive",
+        )
+
+        prompt = node._get_system_prompt()
+
+        assert 'Use `task(type="gen_report", prompt="...")` only when the user explicitly asks' in prompt
+        assert "Only when the user explicitly names `gen_report`" in prompt
+        assert "Do NOT automatically route metric attribution" in prompt
+        assert "delegate metric attribution and root cause analysis to a specialized report subagent" not in prompt
+        assert "The question needs a deeper narrative report for why a metric changed" not in prompt
+
     def test_get_system_prompt_fallback_on_missing_template(self, real_agent_config, mock_llm_create):
         """_get_system_prompt falls back to chat_system when configured template is missing."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode

--- a/tests/unit_tests/agent/node/test_node_factory.py
+++ b/tests/unit_tests/agent/node/test_node_factory.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from datus.agent.node.node import Node
 from datus.agent.node.node_factory import _resolve_node_class_type, create_interactive_node, create_node_input
+from datus.configuration.node_type import NodeType
+from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput, AskMetricsNodeResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -289,6 +292,78 @@ class TestCreateInteractiveNode:
         config = _mock_agent_config()
         create_interactive_node("explore", config, execution_mode="workflow")
         assert mock_init.call_args[1]["execution_mode"] == "workflow"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Node / NodeType ask_metrics wiring
+# ---------------------------------------------------------------------------
+
+
+class TestNodeAskMetricsWiring:
+    @patch("datus.agent.node.ask_metrics_agentic_node.AskMetricsAgenticNode.__init__", return_value=None)
+    def test_new_instance_routes_ask_metrics(self, mock_init):
+        config = _mock_agent_config()
+
+        node = Node.new_instance(
+            node_id="metric_node",
+            description="metric QA",
+            node_type=NodeType.TYPE_ASK_METRICS,
+            input_data=None,
+            agent_config=config,
+            tools=[],
+            node_name="custom_metric_agent",
+            is_subagent=True,
+            session_id="session-1",
+        )
+
+        assert node.__class__.__name__ == "AskMetricsAgenticNode"
+        mock_init.assert_called_once()
+        call_args = mock_init.call_args.args
+        call_kwargs = mock_init.call_args.kwargs
+        assert call_args[:7] == (
+            "metric_node",
+            "metric QA",
+            NodeType.TYPE_ASK_METRICS,
+            None,
+            config,
+            [],
+            "custom_metric_agent",
+        )
+        assert call_kwargs["execution_mode"] == "workflow"
+        assert call_kwargs["is_subagent"] is True
+        assert call_kwargs["session_id"] == "session-1"
+
+    @patch("datus.agent.node.ask_metrics_agentic_node.AskMetricsAgenticNode.__init__", return_value=None)
+    def test_from_dict_converts_ask_metrics_input_and_result(self, mock_init):
+        config = _mock_agent_config()
+        node = Node.from_dict(
+            {
+                "id": "metric_node",
+                "description": "metric QA",
+                "type": NodeType.TYPE_ASK_METRICS,
+                "input": {"user_message": "What was revenue last month?", "database": "warehouse"},
+                "status": "completed",
+                "result": {"success": True, "response": "Revenue was 10.", "markdown_report": "Revenue was 10."},
+                "start_time": None,
+                "end_time": None,
+                "dependencies": [],
+                "metadata": {},
+            },
+            agent_config=config,
+        )
+
+        init_input = mock_init.call_args.args[3]
+        assert isinstance(init_input, AskMetricsNodeInput)
+        assert init_input.user_message == "What was revenue last month?"
+        assert init_input.database == "warehouse"
+        assert isinstance(node.result, AskMetricsNodeResult)
+        assert node.result.response == "Revenue was 10."
+
+    def test_node_type_input_uses_ask_metrics_model(self):
+        result = NodeType.type_input(NodeType.TYPE_ASK_METRICS, {"user_message": "Show revenue"})
+
+        assert isinstance(result, AskMetricsNodeInput)
+        assert result.user_message == "Show revenue"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_node_factory.py
+++ b/tests/unit_tests/agent/node/test_node_factory.py
@@ -41,6 +41,14 @@ class TestResolveNodeClassType:
         config = _mock_agent_config(agentic_nodes={"my_agent": {"node_class": "gen_report"}})
         assert _resolve_node_class_type("my_agent", config) == "gen_report"
 
+    def test_returns_type_when_node_class_missing(self):
+        config = _mock_agent_config(agentic_nodes={"my_agent": {"type": "ask_metrics"}})
+        assert _resolve_node_class_type("my_agent", config) == "ask_metrics"
+
+    def test_node_class_takes_precedence_over_type(self):
+        config = _mock_agent_config(agentic_nodes={"my_agent": {"node_class": "gen_report", "type": "ask_metrics"}})
+        assert _resolve_node_class_type("my_agent", config) == "gen_report"
+
     def test_pydantic_model_dump(self):
         node_config = MagicMock()
         node_config.model_dump.return_value = {"node_class": "gen_report"}
@@ -111,6 +119,33 @@ class TestCreateInteractiveNode:
         call_kwargs = mock_init.call_args[1]
         assert call_kwargs["node_id"] == "gen_report_cli"
         assert call_kwargs["node_type"] == "gen_report"
+
+    @patch("datus.agent.node.ask_metrics_agentic_node.AskMetricsAgenticNode.__init__", return_value=None)
+    def test_ask_metrics(self, mock_init):
+        config = _mock_agent_config()
+        create_interactive_node("ask_metrics", config, node_id_suffix="_cli")
+        mock_init.assert_called_once()
+        call_kwargs = mock_init.call_args[1]
+        assert call_kwargs["node_id"] == "ask_metrics_cli"
+        assert call_kwargs["node_type"] == "ask_metrics"
+        assert call_kwargs["node_name"] == "ask_metrics"
+
+    @patch("datus.agent.node.ask_metrics_agentic_node.AskMetricsAgenticNode.__init__", return_value=None)
+    @patch("datus.agent.node.node_factory._resolve_node_class_type", return_value="ask_metrics")
+    def test_config_driven_ask_metrics(self, mock_resolve, mock_init):
+        config = _mock_agent_config()
+        create_interactive_node("custom_metric_agent", config)
+        mock_init.assert_called_once()
+        assert mock_init.call_args[1]["node_name"] == "custom_metric_agent"
+
+    @patch("datus.agent.node.ask_metrics_agentic_node.AskMetricsAgenticNode.__init__", return_value=None)
+    def test_type_driven_custom_ask_metrics(self, mock_init):
+        config = _mock_agent_config(agentic_nodes={"custom_metric_agent": {"type": "ask_metrics"}})
+        create_interactive_node("custom_metric_agent", config)
+        mock_init.assert_called_once()
+        call_kwargs = mock_init.call_args[1]
+        assert call_kwargs["node_type"] == "ask_metrics"
+        assert call_kwargs["node_name"] == "custom_metric_agent"
 
     @patch("datus.agent.node.gen_report_agentic_node.GenReportAgenticNode.__init__", return_value=None)
     @patch("datus.agent.node.node_factory._resolve_node_class_type", return_value="gen_report")
@@ -334,6 +369,13 @@ class TestCreateNodeInput:
                 "report",
                 {"catalog": "cat", "database": "db"},
                 {"user_message": "report", "catalog": "cat", "database": "db"},
+            ),
+            (
+                "datus.agent.node.ask_metrics_agentic_node",
+                "AskMetricsAgenticNode",
+                "metric answer",
+                {"catalog": "cat", "database": "db"},
+                {"user_message": "metric answer", "catalog": "cat", "database": "db"},
             ),
             (
                 "datus.agent.node.feedback_agentic_node",

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -111,16 +111,15 @@ class TestValidateTools:
 class TestValidateToolsForAgentType:
     """Per-agent-type allowlist gate.
 
-    ``ask_report`` / ``ask_dashboard`` are documented as read-only
-    consultants ("must never mutate the artifact"); the gate prevents
-    a caller from re-enabling write tools or wildcards that would
-    expand reach beyond the documented allowlist.
+    ``ask_report`` / ``ask_dashboard`` are read-only artifact consultants. The
+    gate prevents callers from re-enabling filesystem writes beyond the
+    documented allowlist; other agent types rely on syntactic tool validation.
     """
 
-    def test_non_ask_agents_unrestricted(self):
+    def test_non_artifact_ask_agents_unrestricted(self):
         """Other agent types fall back to the syntactic _validate_tools
         check only — this helper returns empty for them."""
-        for agent_type in ("chat", "gen_sql", "gen_report"):
+        for agent_type in ("chat", "gen_sql", "gen_report", "ask_metrics"):
             assert _validate_tools_for_agent_type(["filesystem_tools.write_file"], agent_type) == []
             assert _validate_tools_for_agent_type(["filesystem_tools.*"], agent_type) == []
 
@@ -177,7 +176,18 @@ class TestValidateToolsForAgentType:
         assert "edit_file" not in fs_methods
         assert {"read_file", "glob", "grep"}.issubset(fs_methods)
 
-    @pytest.mark.parametrize("agent_type", ["ask_report", "ask_dashboard"])
+    def test_ask_metrics_allows_valid_tools_outside_default_surface(self):
+        tools = [
+            "db_tools.read_query",
+            "date_parsing_tools.parse_temporal_expressions",
+            "semantic_tools.validate_semantic",
+            "semantic_tools.*",
+            "context_search_tools.search_reference_sql",
+        ]
+        assert _validate_tools(tools) == []
+        assert _validate_tools_for_agent_type(tools, "ask_metrics") == []
+
+    @pytest.mark.parametrize("agent_type", ["ask_report", "ask_dashboard", "ask_metrics"])
     def test_ask_default_tools_all_resolve(self, agent_type):
         """Every entry in ``default_tools`` for ask_* must be recognised by
         ``_validate_tools``.
@@ -192,7 +202,7 @@ class TestValidateToolsForAgentType:
         invalid = _validate_tools(defaults)
         assert invalid == [], f"{agent_type} default_tools has unrecognised entries: {invalid}"
 
-    @pytest.mark.parametrize("agent_type", ["ask_report", "ask_dashboard"])
+    @pytest.mark.parametrize("agent_type", ["ask_report", "ask_dashboard", "ask_metrics"])
     def test_ask_default_tools_pass_agent_type_gate(self, agent_type):
         """``default_tools`` must also satisfy the per-agent-type allowlist
         — preselected tools should never include anything the saas editor
@@ -297,6 +307,22 @@ class TestConstants:
             "reference_template_tools",
         }
 
+    def test_tool_reference_ask_metrics_has_narrow_defaults(self):
+        """ask_metrics defaults to metric QA tools, while custom configs can opt into more."""
+        entry = SUBAGENT_TOOL_REFERENCE["ask_metrics"]
+        assert entry["default_tools"] == [
+            "context_search_tools.search_metrics",
+            "context_search_tools.get_metrics",
+            "semantic_tools.list_metrics",
+            "semantic_tools.get_dimensions",
+            "semantic_tools.query_metrics",
+            "semantic_tools.attribution_analyze",
+            "context_search_tools.list_subject_tree",
+        ]
+        assert set(entry["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        for category, payload in entry["tool_types"].items():
+            assert payload["tools"] == sorted(VALID_TOOL_METHODS[category])
+
     def test_tool_reference_chat_has_full_default_set(self):
         """chat default_tools enumerates every non-semantic category as wildcard."""
         entry = SUBAGENT_TOOL_REFERENCE["chat"]
@@ -393,6 +419,16 @@ class TestGetUseTools:
             "reference_template_tools",
         }
 
+    def test_ask_metrics_returns_broad_configurable_tool_types(self):
+        """ask_metrics keeps narrow defaults but surfaces valid configurable tools."""
+        result = AgentService.get_use_tools("ask_metrics")
+        assert result.success is True
+        assert result.data["default_tools"] == SUBAGENT_TOOL_REFERENCE["ask_metrics"]["default_tools"]
+        assert set(result.data["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
+        assert "read_query" in result.data["tool_types"]["db_tools"]["tools"]
+        assert "parse_temporal_expressions" in result.data["tool_types"]["date_parsing_tools"]["tools"]
+        assert result.data["tool_types"] == SUBAGENT_TOOL_REFERENCE["ask_metrics"]["tool_types"]
+
     def test_chat_includes_reference_template_tools_in_default(self):
         """chat default_tools wires up reference_template_tools.* (saas parity)."""
         result = AgentService.get_use_tools("chat")
@@ -430,7 +466,7 @@ class TestPerAgentTypeCategoryWhitelist:
 
     The whitelist is now the API's single source of truth: the editor
     renders whatever ``tool_types`` it receives, and the same block gates
-    the write-path validation for ``ask_*`` agents via
+    the artifact ask-agent write-path validation via
     :func:`_validate_tools_for_agent_type`.
     """
 

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -956,6 +956,23 @@ class TestCreateNode:
         assert isinstance(node, GenReportAgenticNode)
         assert not isinstance(node, GenSQLAgenticNode)
 
+    def test_custom_agent_type_ask_metrics(self, real_agent_config, mock_llm_create):
+        """API-created type=ask_metrics agents must instantiate AskMetricsAgenticNode."""
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        real_agent_config.agentic_nodes["my_metric_agent"] = {
+            "system_prompt": "my_metric_agent",
+            "type": "ask_metrics",
+            "tools": "semantic_tools.query_metrics",
+            "max_turns": 5,
+        }
+
+        manager = ChatTaskManager()
+        node = manager._create_node(real_agent_config, "my_metric_agent", "test-session")
+        assert isinstance(node, AskMetricsAgenticNode)
+        assert not isinstance(node, GenSQLAgenticNode)
+
     def test_custom_agent_no_node_class_falls_back_to_gen_sql(self, real_agent_config, mock_llm_create):
         """A custom sub_agent without node_class must default to GenSQLAgenticNode."""
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -736,13 +736,13 @@ class TestAllToolsName:
 
 
 class TestAvailableTools:
-    def test_no_adapter_returns_three_tools(self, semantic_tools_ext):
+    def test_no_adapter_returns_no_tools(self, semantic_tools_ext):
         with patch("datus.tools.func_tool.semantic_tools.trans_to_function_tool") as mock_trans:
             mock_trans.side_effect = lambda f: Mock(name=f.__name__)
             tools = semantic_tools_ext.available_tools()
-        assert len(tools) == 3
+        assert tools == []
 
-    def test_default_metricflow_adapter_exposes_validate_tool(self):
+    def test_default_metricflow_adapter_load_failure_returns_no_tools(self):
         with (
             patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
             patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
@@ -770,7 +770,7 @@ class TestAvailableTools:
                 tools = tool.available_tools()
 
         names = [tool.name for tool in tools]
-        assert "validate_semantic" in names
+        assert names == []
 
     def test_with_adapter_adds_validate_and_attribution_tools(self):
         with (
@@ -790,7 +790,7 @@ class TestAvailableTools:
         # 3 base + validate_semantic + attribution_analyze (both enabled when adapter is set)
         assert len(tools) == 5
 
-    def test_configured_adapter_load_failure_still_exposes_validate(self):
+    def test_configured_adapter_load_failure_exposes_no_tools(self):
         with (
             patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
             patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
@@ -818,7 +818,7 @@ class TestAvailableTools:
                 tools = tool.available_tools()
 
             names = [tool.name for tool in tools]
-            assert "validate_semantic" in names
+            assert names == []
             assert "attribution_analyze" not in names
 
             result = tool.validate_semantic()
@@ -827,21 +827,26 @@ class TestAvailableTools:
 
 
 class TestListMetrics:
-    def test_success_from_storage(self, semantic_tools_ext):
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = [
-            {
-                "name": "orders",
-                "description": "Order count",
-                "metric_type": "count",
-                "dimensions": [],
-                "base_measures": [],
-                "unit": None,
-                "format": None,
-                "subject_path": ["Sales"],
-            }
-        ]
-
+    def test_no_adapter_returns_error(self, semantic_tools_ext):
         result = semantic_tools_ext.list_metrics()
+
+        assert result.success == 0
+        assert "semantic adapter" in result.error.lower()
+
+    def test_success_from_adapter(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        mock_metric = Mock()
+        mock_metric.name = "orders"
+        mock_metric.description = "Order count"
+        mock_metric.type = "count"
+        mock_metric.dimensions = []
+        mock_metric.measures = []
+        mock_metric.unit = None
+        mock_metric.format = None
+        mock_metric.path = ["Sales"]
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=[mock_metric]):
+            result = tool.list_metrics()
 
         assert result.success == 1
         envelope = result.result
@@ -857,134 +862,48 @@ class TestListMetrics:
                 "path": ["Sales"],
             }
         ]
-        assert envelope["total"] == 1
+        assert envelope["total"] is None
         assert envelope["has_more"] is False
         assert envelope["extra"] is None
+        mock_adapter.list_metrics.assert_called_once_with(path=None, limit=100, offset=0)
         # Contract: list_metrics MUST NOT carry compressor artefacts anymore.
         assert "compressed_data" not in envelope
         assert "original_rows" not in envelope
 
-    def test_empty_storage_no_adapter_returns_empty_envelope(self, semantic_tools_ext):
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = []
+    def test_passes_path_and_pagination_to_adapter(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        metrics = []
+        for name in ("m1", "m2", "m3"):
+            metric = Mock()
+            metric.name = name
+            metric.description = ""
+            metric.type = ""
+            metric.dimensions = []
+            metric.measures = []
+            metric.unit = None
+            metric.format = None
+            metric.path = ["Finance"]
+            metrics.append(metric)
 
-        result = semantic_tools_ext.list_metrics()
-
-        assert result.success == 1
-        envelope = result.result
-        assert envelope["items"] == []
-        assert envelope["total"] == 0
-        assert envelope["has_more"] is False
-        assert envelope["extra"] is None
-
-    def test_path_filter_applied(self, semantic_tools_ext):
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = [
-            {
-                "name": "m1",
-                "subject_path": ["Finance"],
-                "description": "",
-                "metric_type": "",
-                "dimensions": [],
-                "base_measures": [],
-                "unit": None,
-                "format": None,
-            },
-            {
-                "name": "m2",
-                "subject_path": ["Sales"],
-                "description": "",
-                "metric_type": "",
-                "dimensions": [],
-                "base_measures": [],
-                "unit": None,
-                "format": None,
-            },
-        ]
-
-        result = semantic_tools_ext.list_metrics(path=["Finance"])
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=metrics):
+            result = tool.list_metrics(path=["Finance"], limit=3, offset=2)
 
         assert result.success == 1
         envelope = result.result
-        names = [row["name"] for row in envelope["items"]]
-        assert names == ["m1"]
-        assert envelope["total"] == 1
-        assert envelope["has_more"] is False
-
-    def test_pagination(self, semantic_tools_ext):
-        metrics = [
-            {
-                "name": f"m{i}",
-                "subject_path": [],
-                "description": "",
-                "metric_type": "",
-                "dimensions": [],
-                "base_measures": [],
-                "unit": None,
-                "format": None,
-            }
-            for i in range(10)
-        ]
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = metrics
-
-        result = semantic_tools_ext.list_metrics(limit=3, offset=2)
-
-        assert result.success == 1
-        envelope = result.result
-        assert [row["name"] for row in envelope["items"]] == ["m2", "m3", "m4"]
-        assert envelope["total"] == 10
+        assert [row["name"] for row in envelope["items"]] == ["m1", "m2", "m3"]
+        assert envelope["total"] is None
         assert envelope["has_more"] is True
         assert envelope["extra"] == {"next_offset": 5}
+        mock_adapter.list_metrics.assert_called_once_with(path=["Finance"], limit=3, offset=2)
 
-    def test_pagination_last_page(self, semantic_tools_ext):
-        metrics = [
-            {
-                "name": f"m{i}",
-                "subject_path": [],
-                "description": "",
-                "metric_type": "",
-                "dimensions": [],
-                "base_measures": [],
-                "unit": None,
-                "format": None,
-            }
-            for i in range(5)
-        ]
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = metrics
+    def test_exception_returns_failure(self, semantic_tools_with_adapter):
+        tool, _ = semantic_tools_with_adapter
 
-        result = semantic_tools_ext.list_metrics(limit=3, offset=3)
-
-        assert result.success == 1
-        envelope = result.result
-        assert [row["name"] for row in envelope["items"]] == ["m3", "m4"]
-        assert envelope["total"] == 5
-        assert envelope["has_more"] is False
-        assert envelope["extra"] is None
-
-    def test_falls_back_to_adapter(self, semantic_tools_with_adapter):
-        tool, mock_adapter = semantic_tools_with_adapter
-        tool.metric_rag.search_all_metrics.return_value = []
-
-        mock_metric = Mock()
-        mock_metric.name = "revenue"
-        mock_metric.description = "Revenue metric"
-        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=[mock_metric]):
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=Exception("adapter error")):
             result = tool.list_metrics()
 
-        assert result.success == 1
-        envelope = result.result
-        assert len(envelope["items"]) == 1
-        assert envelope["items"][0]["name"] == "revenue"
-        # Adapter path has no upstream total — envelope signals unknown via None.
-        assert envelope["total"] is None
-        # has_more heuristic: len(items) == limit (1) < default limit (100) → False.
-        assert envelope["has_more"] is False
-
-    def test_exception_returns_failure(self, semantic_tools_ext):
-        semantic_tools_ext.metric_rag.search_all_metrics.side_effect = Exception("db error")
-
-        result = semantic_tools_ext.list_metrics()
-
         assert result.success == 0
-        assert "db error" in result.error
+        assert "adapter error" in result.error
 
 
 class TestGetDimensions:
@@ -999,44 +918,28 @@ class TestGetDimensions:
         assert envelope["total"] == 2
         assert envelope["has_more"] is False
 
-    def test_no_adapter_from_storage(self, semantic_tools_ext):
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = [
-            {"name": "revenue", "dimensions": ["date", "channel"]}
-        ]
-
+    def test_no_adapter_returns_error(self, semantic_tools_ext):
         result = semantic_tools_ext.get_dimensions("revenue")
 
-        assert result.success == 1
-        envelope = result.result
-        assert envelope["items"] == [{"name": "date"}, {"name": "channel"}]
-        assert envelope["total"] == 2
-
-    def test_no_adapter_metric_not_found(self, semantic_tools_ext):
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = []
-
-        result = semantic_tools_ext.get_dimensions("nonexistent")
-
         assert result.success == 0
-        assert "not found" in result.error
-        # Even the error path returns an envelope shape, keeping the
-        # consumer contract uniform.
-        assert result.result == {"items": [], "total": 0, "has_more": False, "extra": None}
+        assert "semantic adapter" in result.error.lower()
 
-    def test_with_path_filter(self, semantic_tools_ext):
-        mock_storage = Mock()
-        semantic_tools_ext.metric_rag.storage = mock_storage
-        mock_storage.search_all_metrics.return_value = [{"name": "revenue", "dimensions": ["date"]}]
+    def test_with_path_passes_to_adapter(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
 
-        result = semantic_tools_ext.get_dimensions("revenue", path=["Finance"])
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=["date"]):
+            result = tool.get_dimensions("revenue", path=["Finance"])
 
         assert result.success == 1
         envelope = result.result
         assert envelope["items"] == [{"name": "date"}]
+        mock_adapter.get_dimensions.assert_called_once_with(metric_name="revenue", path=["Finance"])
 
-    def test_exception_returns_failure(self, semantic_tools_ext):
-        semantic_tools_ext.metric_rag.search_all_metrics.side_effect = Exception("conn error")
+    def test_exception_returns_failure(self, semantic_tools_with_adapter):
+        tool, _ = semantic_tools_with_adapter
 
-        result = semantic_tools_ext.get_dimensions("revenue")
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=Exception("conn error")):
+            result = tool.get_dimensions("revenue")
 
         assert result.success == 0
         assert "conn error" in result.error
@@ -1222,7 +1125,7 @@ class TestAttributionAnalyze:
             current_end="2024-01-14",
         )
         assert result.success == 0
-        assert "Attribution tool not available" in result.error
+        assert "semantic adapter" in result.error.lower()
 
     def test_success_with_dict_anomaly_context(self, semantic_tools_with_adapter):
         tool, mock_adapter = semantic_tools_with_adapter
@@ -1372,7 +1275,7 @@ class TestCompressorModelName:
             tool = SemanticTools(agent_config=config)
             assert tool.compressor.model_name == "deepseek/deepseek-chat"
 
-    def test_list_metrics_returns_envelope_without_compressor(self, semantic_tools_ext):
+    def test_list_metrics_returns_envelope_without_compressor(self, semantic_tools_with_adapter):
         """list_metrics returns the canonical FuncToolListResult envelope.
 
         Regression: list_metrics used to wrap rows in DataCompressor output
@@ -1380,19 +1283,20 @@ class TestCompressorModelName:
         After the envelope migration it returns ``{items, total, has_more,
         extra}`` with NO compressor artefacts — list_* never compresses.
         """
-        semantic_tools_ext.metric_rag.search_all_metrics.return_value = [
-            {
-                "name": "orders",
-                "description": "",
-                "metric_type": "count",
-                "dimensions": [],
-                "base_measures": [],
-                "unit": None,
-                "format": None,
-                "subject_path": [],
-            }
-        ]
-        result = semantic_tools_ext.list_metrics()
+        tool, _ = semantic_tools_with_adapter
+        mock_metric = Mock()
+        mock_metric.name = "orders"
+        mock_metric.description = ""
+        mock_metric.type = "count"
+        mock_metric.dimensions = []
+        mock_metric.measures = []
+        mock_metric.unit = None
+        mock_metric.format = None
+        mock_metric.path = []
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=[mock_metric]):
+            result = tool.list_metrics()
+
         assert result.success == 1
         envelope = result.result
         assert set(envelope.keys()) == {"items", "total", "has_more", "extra"}

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -236,6 +236,12 @@ class TestResolveNodeType:
         assert NODE_CLASS_MAP["gen_visual_report"] == NodeType.TYPE_GEN_VISUAL_REPORT
         assert "gen_visual_report" in BUILTIN_SUBAGENT_DESCRIPTIONS
 
+    def test_ask_metrics_resolves(self, task_tool):
+        node_type, node_name = task_tool._resolve_node_type("ask_metrics")
+
+        assert node_type == NodeType.TYPE_ASK_METRICS
+        assert node_name == "ask_metrics"
+
     def test_gen_visual_report_constructs_and_builds_input(self, task_tool, tmp_path):
         """Mirror of ``test_gen_visual_dashboard_constructs_and_builds_input``
         for the report subagent — ``_create_builtin_node`` + the
@@ -572,6 +578,17 @@ class TestBuildNodeInput:
         assert result.user_message == "Show all users"
         assert result.database == "test_db"
 
+    def test_ask_metrics_node_input(self, task_tool):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        mock_node = Mock(spec=AskMetricsAgenticNode)
+        result = task_tool._build_node_input(mock_node, "Show revenue by month")
+
+        assert isinstance(result, AskMetricsNodeInput)
+        assert result.user_message == "Show revenue by month"
+        assert result.database == "test_db"
+
 
 # ── _convert_to_func_result ───────────────────────────────────────
 
@@ -612,6 +629,19 @@ class TestConvertToFuncResult:
         result = task_tool._convert_to_func_result(output)
         assert result.success == 1
         assert result.result["response"] == "Some content"
+
+    def test_markdown_report_result(self, task_tool):
+        output = {"response": "Metric answer", "markdown_report": "## Metric answer", "tokens_used": 25}
+
+        result = task_tool._convert_to_func_result(output, session_id="ask-metrics-session")
+
+        assert result.success == 1
+        assert result.result == {
+            "response": "Metric answer",
+            "markdown_report": "## Metric answer",
+            "tokens_used": 25,
+            "session_id": "ask-metrics-session",
+        }
 
     def test_visual_dashboard_result_preserves_documented_fields(self, task_tool):
         """``GenVisualDashboardNodeResult.model_dump()`` carries
@@ -1363,6 +1393,11 @@ class TestResolveNodeTypeBuiltIn:
         assert node_type == NodeType.TYPE_GEN_TABLE
         assert node_name == "gen_table"
 
+    def test_ask_metrics(self, task_tool):
+        node_type, node_name = task_tool._resolve_node_type("ask_metrics")
+        assert node_type == NodeType.TYPE_ASK_METRICS
+        assert node_name == "ask_metrics"
+
 
 # ── Built-in subagent: _create_builtin_node ────────────────────────
 
@@ -1622,6 +1657,17 @@ class TestBuildNodeInputBuiltIn:
         result = task_tool._build_node_input(mock_node, "Create wide table from orders and customers")
         assert isinstance(result, SemanticNodeInput)
         assert result.user_message == "Create wide table from orders and customers"
+        assert result.database == "test_db"
+
+    def test_ask_metrics_node_input(self, task_tool):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        mock_node = Mock(spec=AskMetricsAgenticNode)
+        result = task_tool._build_node_input(mock_node, "Show active users")
+
+        assert isinstance(result, AskMetricsNodeInput)
+        assert result.user_message == "Show active users"
         assert result.database == "test_db"
 
 

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -440,6 +440,7 @@ class TestResolveNodeType:
         expected_map = {
             "gen_sql": NodeType.TYPE_GEN_SQL,
             "chat": NodeType.TYPE_CHAT,
+            "ask_metrics": NodeType.TYPE_ASK_METRICS,
             "gen_report": NodeType.TYPE_GEN_REPORT,
             "gen_visual_report": NodeType.TYPE_GEN_VISUAL_REPORT,
             "gen_visual_dashboard": NodeType.TYPE_GEN_VISUAL_DASHBOARD,
@@ -518,6 +519,14 @@ class TestBuildTaskDescription:
         assert "gen_job" in haystack
         assert "migration" in haystack
         assert "cross-database migration" in haystack
+
+    def test_gen_report_description_is_explicit_only(self, task_tool):
+        """The task tool must not advertise gen_report as automatic root-cause routing."""
+        desc = task_tool._build_task_description()
+        assert "Legacy Markdown report subagent" in desc
+        assert "Use only when the user explicitly asks to use the gen_report subagent" in desc
+        assert "do not automatically route attribution" in desc
+        assert "Use when the question involves metric attribution" not in desc
 
 
 # ── node creation (fresh per invocation) ──────────────────────────
@@ -1545,6 +1554,7 @@ class TestBuiltinNodeInheritsExecutionMode:
         "subagent_type,init_path",
         [
             ("gen_sql", "datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__"),
+            ("ask_metrics", "datus.agent.node.ask_metrics_agentic_node.AskMetricsAgenticNode.__init__"),
             ("gen_report", "datus.agent.node.gen_report_agentic_node.GenReportAgenticNode.__init__"),
             ("gen_skill", "datus.agent.node.gen_skill_agentic_node.SkillCreatorAgenticNode.__init__"),
         ],


### PR DESCRIPTION
## Summary
- Add `ask_metrics` as a first-class metric QA node with dedicated input/output models and prompt template.
- Wire AskMetrics through node creation, task delegation, chat routing, tool catalog metadata, and built-in subagent registration.
- Keep AskMetrics default tools metric-focused while allowing configured custom agents to opt into valid user-facing tool categories.
- Make SemanticTools adapter-backed at runtime so AskMetrics does not expose stale storage-only metric tools when the adapter is unavailable.

## Split note
- The metric queryability contract fixes from the original mixed branch were split into #962.

## Validation
- uv run pytest tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py tests/unit_tests/agent/node/test_chat_agentic_node.py::TestChatAgenticNodeSystemPrompt::test_prompt_keeps_gen_report_explicit_only tests/unit_tests/agent/node/test_node_factory.py tests/unit_tests/api/services/test_agent_service.py tests/unit_tests/api/services/test_chat_task_manager.py::TestCreateNode::test_custom_agent_type_ask_metrics tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py::TestResolveNodeType tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py::TestBuildTaskDescription::test_gen_report_description_is_explicit_only tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py::TestBuiltinNodeInheritsExecutionMode tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestAvailableTools tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestListMetrics tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestGetDimensions tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestAttributionAnalyze::test_no_attribution_tool_returns_error tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestCompressorModelName::test_list_metrics_returns_envelope_without_compressor -q
- git diff --check --cached


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated AskMetrics agent for metric-first Q&A (KPI, trend, group-by, attribution).

* **Documentation**
  * New system prompt template for AskMetrics and updated chat routing guidance to call AskMetrics explicitly.

* **Updates**
  * Agent routing, config and API tool catalog updated to include AskMetrics; semantic tools now require a configured adapter for availability.

* **Tests**
  * Extensive unit tests covering AskMetrics behavior, routing, prompts, tools and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
