### PR TITLE
[BugFix] Fix metric queryability contract validation

### DIFF
--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -146,7 +146,7 @@ Skip any metric that already exists — do NOT update or overwrite.
 
 1. **Write files**: Use `write_file` to save metric YAML (and semantic model if newly created)
 2. **Validate (MUST PASS)**: Use `validate_semantic` — if validation fails, fix errors with `edit_file` and retry until it **passes**. Do NOT proceed to Step 6 until validation passes.
-3. **Dry-run SQL**: Use `query_metrics(metrics=["metric_name"], dry_run=True)` to generate SQL. If the source SQL groups by dimensions or a time grain, also dry-run the generated metric set with matching `dimensions` / `time_granularity` from that source query. Use `get_dimensions` to find the exact generated dimension names; if a grouped source dimension cannot be queried, fix the semantic model joins/dimensions and retry.
+3. **Dry-run SQL**: Use `query_metrics(metrics=["metric_name"], dry_run=True)` to generate SQL. If the source SQL groups by dimensions or a time grain, also dry-run the generated metric set with matching `dimensions` / `time_granularity` from that source query. For a source SQL with multiple output metrics, either dry-run all corresponding generated metrics together with the same grouped dimensions/time grain, or dry-run each generated metric separately with those same grouped arguments. Use `get_dimensions` to find the exact generated dimension names; if a grouped source dimension cannot be queried, fix the semantic model joins/dimensions and retry.
 
 Collect each generated SQL into `metric_sqls_json`.
 
@@ -366,7 +366,7 @@ metric:
 4. **COUNT requires `expr: "1"`**: Never use `expr: {column}` with `agg: COUNT`
 5. **Primary time dimension correctness**: Every metric data_source needs one primary `type: TIME` dimension when a reliable DATE/TIME/TIMESTAMP column or expression exists. Do not force a primary TIME dimension from numeric surrogate keys; use a `sql_query` join to a date dimension or an explicit date conversion first.
 6. **Validate**: Always validate before completing
-7. **Generate SQL**: Use `query_metrics(dry_run=True)` to get SQL for each metric
+7. **Generate SQL**: Use `query_metrics(dry_run=True)` to get SQL for each metric; for grouped source SQL, include matching dimensions/time grain in dry-runs before syncing
 8. **Complete**: You MUST call `end_metric_generation` with `metric_sqls_json` after validation and dry-run pass; final JSON `metric_file` is only a last-resort fallback
 9. **YAML String Quoting**: ALWAYS wrap `description` values in double quotes. Escape special characters: `"` → `\"`, `\` → `\\`
 10. **Snapshot data**: Use `non_additive_dimension` for balance/inventory/point-in-time measures

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -69,7 +69,9 @@ class GenerationEvidence:
 
     def set_metric_queryability_contracts(self, contracts: Optional[Iterable[Dict[str, Any]]]) -> None:
         self.metric_queryability_contracts = [
-            contract for contract in (contracts or []) if isinstance(contract, dict) and contract.get("dimension_hints")
+            contract
+            for contract in (contracts or [])
+            if isinstance(contract, dict) and (contract.get("dimension_hints") or contract.get("time_group_hints"))
         ]
 
     def record_metric_dry_run(
@@ -88,16 +90,18 @@ class GenerationEvidence:
         metrics_list = [m for m in metric_candidates if isinstance(m, str) and m]
         self.metric_dry_run_metrics.update(metrics_list)
         dimensions_list = [d for d in dimension_candidates if isinstance(d, str) and d]
-        self.metric_dry_run_queries.append(
-            {
-                "metrics": metrics_list,
-                "dimensions": dimensions_list,
-                "time_granularity": time_granularity if isinstance(time_granularity, str) else None,
-            }
-        )
+        dry_run_query = {
+            "metrics": metrics_list,
+            "dimensions": dimensions_list,
+            "time_granularity": time_granularity if isinstance(time_granularity, str) else None,
+        }
+        self.metric_dry_run_queries.append(dry_run_query)
         metadata = _metadata_from_result(result)
         metric_sqls = metadata.get("metric_sqls")
         if isinstance(metric_sqls, dict):
+            combined_sql = metric_sqls.get("__query_metrics_dry_run__")
+            if isinstance(combined_sql, str) and combined_sql.strip():
+                dry_run_query["sql"] = combined_sql
             for name, sql in metric_sqls.items():
                 if isinstance(name, str) and isinstance(sql, str) and sql:
                     self.metric_sqls[name] = sql
@@ -111,6 +115,7 @@ class GenerationEvidence:
                 sql = value
                 break
         if sql:
+            dry_run_query["sql"] = sql
             if len(metrics_list) == 1:
                 self.metric_sqls[metrics_list[0]] = sql
             else:
@@ -149,12 +154,17 @@ class GenerationEvidence:
         if not required_metrics:
             required_metrics = generated_metrics
 
+        covered_metrics: Set[str] = set()
         for dry_run in self.metric_dry_run_queries:
             dry_run_metrics = {m for m in dry_run.get("metrics", []) if isinstance(m, str)}
             if required_metrics and not required_metrics.issubset(dry_run_metrics):
+                if required_metrics and self._dimensions_satisfy_contract(dry_run, contract):
+                    covered_metrics.update(required_metrics & dry_run_metrics)
                 continue
             if self._dimensions_satisfy_contract(dry_run, contract):
                 return True
+        if required_metrics and required_metrics.issubset(covered_metrics):
+            return True
         return False
 
     def _dimensions_satisfy_contract(self, dry_run: Dict[str, Any], contract: Dict[str, Any]) -> bool:
@@ -162,6 +172,12 @@ class GenerationEvidence:
         time_granularity = dry_run.get("time_granularity")
         for hint in contract.get("dimension_hints") or []:
             if not isinstance(hint, str) or not hint.strip():
+                continue
+            if _time_group_hint_satisfies(hint, dry_run, contract):
+                continue
+            if _has_time_group_hint_for_hint(hint, contract):
+                return False
+            if _dimension_expr_hint_satisfies(hint, dry_run, contract):
                 continue
             if any(_dimension_matches_hint(dimension, hint) for dimension in dimensions):
                 continue
@@ -184,7 +200,21 @@ class GenerationEvidence:
 
 
 _GENERIC_DIMENSION_TOKENS = {"id", "key", "name", "dim", "dimension", "value"}
-_TIME_DIMENSION_TOKENS = {"date", "time", "day", "week", "month", "quarter", "year", "ds"}
+_TIME_GRAINS = {"day", "week", "month", "quarter", "year"}
+_TIME_DIMENSION_TOKENS = _TIME_GRAINS | {"date", "time", "ds"}
+_SQL_PARSE_DIALECTS = (
+    "snowflake",
+    "bigquery",
+    "duckdb",
+    "mysql",
+    "postgres",
+    "postgresql",
+    "sqlite",
+    "starrocks",
+    "trino",
+    None,
+)
+_SQLGLOT_DIALECT_ALIASES = {"postgresql": "postgres"}
 
 
 def _name_tokens(value: str) -> Set[str]:
@@ -207,6 +237,202 @@ def _looks_time_dimension(value: str) -> bool:
 
 def _is_metric_time_dimension(value: str) -> bool:
     return str(value).strip().lower().startswith("metric_time")
+
+
+def _time_group_hint_satisfies(hint: str, dry_run: Dict[str, Any], contract: Dict[str, Any]) -> bool:
+    for time_hint in contract.get("time_group_hints") or []:
+        if not isinstance(time_hint, dict):
+            continue
+        alias = time_hint.get("alias", "")
+        base_expr = time_hint.get("base_expr", "")
+        if not any(_dimension_matches_hint(candidate, hint) for candidate in (alias, base_expr) if candidate):
+            continue
+        if _dry_run_satisfies_time_group(dry_run, time_hint):
+            return True
+    return False
+
+
+def _has_time_group_hint_for_hint(hint: str, contract: Dict[str, Any]) -> bool:
+    for time_hint in contract.get("time_group_hints") or []:
+        if not isinstance(time_hint, dict):
+            continue
+        alias = time_hint.get("alias", "")
+        base_expr = time_hint.get("base_expr", "")
+        if any(_dimension_matches_hint(candidate, hint) for candidate in (alias, base_expr) if candidate):
+            return True
+    return False
+
+
+def _dimension_expr_hint_satisfies(hint: str, dry_run: Dict[str, Any], contract: Dict[str, Any]) -> bool:
+    for expr_hint in contract.get("dimension_expr_hints") or []:
+        if not isinstance(expr_hint, dict):
+            continue
+        alias = expr_hint.get("alias", "")
+        expression = expr_hint.get("expr", "")
+        if not _dimension_expr_hint_matches_hint(hint, alias, expression):
+            continue
+        if _dry_run_satisfies_dimension_expr(dry_run, expr_hint):
+            return True
+    return False
+
+
+def _dimension_expr_hint_matches_hint(hint: str, alias: str, expression: str) -> bool:
+    if alias and _dimension_matches_hint(alias, hint):
+        return True
+    if expression and _dimension_matches_hint(expression, hint):
+        return True
+    return False
+
+
+def _dry_run_satisfies_dimension_expr(dry_run: Dict[str, Any], expr_hint: Dict[str, str]) -> bool:
+    dimensions = [d for d in dry_run.get("dimensions", []) if isinstance(d, str)]
+    if any(_dimension_matches_expr_hint(dimension, expr_hint) for dimension in dimensions):
+        return True
+
+    sql = dry_run.get("sql", "")
+    expression = expr_hint.get("expr", "")
+    return isinstance(sql, str) and _sql_contains_expression(sql, expression)
+
+
+def _dimension_matches_expr_hint(dimension: str, expr_hint: Dict[str, str]) -> bool:
+    normalized_dimension = _normalize_name(dimension)
+    if not normalized_dimension:
+        return False
+    candidates = {
+        _normalize_name(expr_hint.get("expr", "")),
+        _normalize_name(expr_hint.get("column", "")),
+    }
+    return normalized_dimension in {candidate for candidate in candidates if candidate}
+
+
+def _dry_run_satisfies_time_group(dry_run: Dict[str, Any], time_hint: Dict[str, str]) -> bool:
+    grain = _normalize_time_grain(time_hint.get("grain", ""))
+    dry_run_grain = _normalize_time_grain(dry_run.get("time_granularity"))
+    if not grain or dry_run_grain != grain:
+        return False
+
+    dimensions = [d for d in dry_run.get("dimensions", []) if isinstance(d, str)]
+    base_expr = time_hint.get("base_expr", "")
+    if base_expr and any(_time_base_dimension_matches(dimension, base_expr) for dimension in dimensions):
+        return True
+
+    sql = dry_run.get("sql", "")
+    if not isinstance(sql, str) or not _sql_contains_time_group(sql, base_expr, grain):
+        return False
+    return True
+
+
+def _normalize_time_grain(value: Any) -> str:
+    text = str(value or "").strip().strip("'\"").lower()
+    return text if text in _TIME_GRAINS else ""
+
+
+def _time_base_dimension_matches(dimension: str, base_expr: str) -> bool:
+    if _dimension_matches_hint(dimension, base_expr):
+        return True
+    leaf_name = _last_identifier(base_expr)
+    return bool(leaf_name and _dimension_matches_hint(dimension, leaf_name))
+
+
+def _last_identifier(value: str) -> str:
+    identifiers = re.findall(r"[A-Za-z_][A-Za-z0-9_]*", str(value or ""))
+    return identifiers[-1] if identifiers else ""
+
+
+def _sql_contains_time_group(sql: str, base_expr: str, grain: str) -> bool:
+    normalized_base = _normalize_sql_text(base_expr)
+    if not normalized_base:
+        return False
+    for select in _parse_select_candidates(sql):
+        for node in select.walk():
+            expr = node[0] if isinstance(node, tuple) else node
+            if _time_trunc_expression_matches(expr, normalized_base, grain):
+                return True
+    return False
+
+
+def _sql_contains_expression(sql: str, expression: str) -> bool:
+    normalized_expression = _normalize_sql_text(expression)
+    if not normalized_expression:
+        return False
+    for select in _parse_select_candidates(sql):
+        group = select.args.get("group")
+        if group and any(_sql_expression_matches(expr, normalized_expression) for expr in group.expressions):
+            return True
+        for projection in select.expressions:
+            expr = projection.this if projection.__class__.__name__ == "Alias" else projection
+            if _sql_expression_matches(expr, normalized_expression):
+                return True
+    return False
+
+
+def _parse_select_candidates(sql: str) -> Iterable[Any]:
+    try:
+        import sqlglot
+        from sqlglot import expressions as exp
+
+        seen = set()
+        for dialect in _SQL_PARSE_DIALECTS:
+            read_dialect = _SQLGLOT_DIALECT_ALIASES.get(dialect, dialect)
+            try:
+                parsed = sqlglot.parse_one(sql, read=read_dialect) if read_dialect else sqlglot.parse_one(sql)
+            except Exception:
+                continue
+            select = parsed if isinstance(parsed, exp.Select) else parsed.find(exp.Select)
+            if select is None:
+                continue
+            key = _normalize_sql_text(select.sql(dialect="snowflake"))
+            if key in seen:
+                continue
+            seen.add(key)
+            yield select
+    except Exception:
+        return
+
+
+def _time_trunc_expression_matches(expr: Any, normalized_base: str, grain: str) -> bool:
+    try:
+        from sqlglot import expressions as exp
+
+        if not isinstance(expr, (exp.DateTrunc, exp.DatetimeTrunc, exp.TimeTrunc, exp.TimestampTrunc)):
+            return False
+        expr_grain = _normalize_time_grain(expr.args.get("unit"))
+        if expr_grain != grain:
+            return False
+        base_expr = expr.args.get("this")
+        return _sql_base_expression_matches(base_expr, normalized_base)
+    except Exception:
+        return False
+
+
+def _sql_base_expression_matches(expr: Any, normalized_base: str) -> bool:
+    normalized_expr = _normalize_sql_expression(expr)
+    if normalized_expr == normalized_base:
+        return True
+    expr_leaf = _normalize_name(_last_identifier(normalized_expr))
+    base_leaf = _normalize_name(_last_identifier(normalized_base))
+    return bool(expr_leaf and base_leaf and expr_leaf == base_leaf)
+
+
+def _sql_expression_matches(expr: Any, normalized_expression: str) -> bool:
+    return _normalize_sql_expression(expr) == normalized_expression
+
+
+def _normalize_sql_expression(expr: Any) -> str:
+    if expr is None:
+        return ""
+    try:
+        text = expr.sql(dialect="snowflake")
+    except Exception:
+        try:
+            text = expr.sql()
+        except Exception:
+            text = str(expr)
+    return _normalize_sql_text(text)
+
+
+def _normalize_sql_text(value: str) -> str:
+    return re.sub(r"\s+", "", str(value or "")).strip().lower()
 
 
 def _dimension_matches_hint(dimension: str, hint: str) -> bool:

--- a/datus/tools/func_tool/metric_queryability.py
+++ b/datus/tools/func_tool/metric_queryability.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import re
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -25,7 +27,21 @@ _SQL_FENCE_LANGS = {
     "starrocks",
     "trino",
 }
+_SQL_PARSE_DIALECTS = (
+    "snowflake",
+    "bigquery",
+    "duckdb",
+    "mysql",
+    "postgres",
+    "postgresql",
+    "sqlite",
+    "starrocks",
+    "trino",
+    None,
+)
+_SQLGLOT_DIALECT_ALIASES = {"postgresql": "postgres"}
 _FENCED_SQL_PATTERN = re.compile(r"```(?:\s*([^\n`]+))?\n(.*?)```", flags=re.IGNORECASE | re.DOTALL)
+_LABELED_SQL_PATTERN = re.compile(r"(?is)(?:^|\n)\s*SQL\s*:\s*(.*?)(?=\n\s*---\s*(?:\n|$)|\n\s*Query\s+\d+\s*:|$)")
 
 
 def extract_metric_queryability_contracts(text: Optional[str]) -> List[Dict[str, Any]]:
@@ -64,11 +80,51 @@ def _extract_sql_snippets(text: str) -> List[str]:
         if re.search(r"\bselect\b", candidate, flags=re.IGNORECASE):
             snippets.append(_strip_sql(candidate))
 
+    for candidate in _extract_labeled_sql_snippets(text):
+        if candidate not in snippets:
+            snippets.append(candidate)
+
+    for candidate in _extract_csv_sql_snippets(text):
+        if candidate not in snippets:
+            snippets.append(candidate)
+
     remaining = _FENCED_SQL_PATTERN.sub(_fence_replacement_for_fallback, text)
     for match in re.finditer(r"(?is)\b(?:with\b.*?\bselect\b|select\b).*?(?:;|$)", remaining):
         candidate = _strip_sql(match.group(0))
         if candidate and candidate not in snippets:
             snippets.append(candidate)
+    return snippets
+
+
+def _extract_labeled_sql_snippets(text: str) -> List[str]:
+    snippets: List[str] = []
+    for match in _LABELED_SQL_PATTERN.finditer(text):
+        candidate = _strip_sql(match.group(1))
+        if re.search(r"\bselect\b", candidate, flags=re.IGNORECASE):
+            snippets.append(candidate)
+    return snippets
+
+
+def _extract_csv_sql_snippets(text: str) -> List[str]:
+    try:
+        reader = csv.DictReader(io.StringIO(text))
+    except csv.Error:
+        return []
+    if not reader.fieldnames or "sql" not in {str(name).strip().lower() for name in reader.fieldnames if name}:
+        return []
+
+    sql_field = next((name for name in reader.fieldnames if str(name).strip().lower() == "sql"), None)
+    if not sql_field:
+        return []
+
+    snippets: List[str] = []
+    try:
+        for row in reader:
+            candidate = _strip_sql(row.get(sql_field) or "")
+            if re.search(r"\bselect\b", candidate, flags=re.IGNORECASE):
+                snippets.append(candidate)
+    except csv.Error:
+        return []
     return snippets
 
 
@@ -84,16 +140,28 @@ def _strip_sql(sql: str) -> str:
 
 
 def _contract_from_sql(sql: str, source: str) -> Optional[Dict[str, Any]]:
-    parsed = _parse_sql(sql)
-    if parsed is None:
-        return None
+    best_contract = None
+    has_time_trunc = _contains_time_trunc(sql)
+    for parsed in _parse_sql_candidates(sql):
+        contract = _contract_from_parsed(parsed, sql, source)
+        if contract is None:
+            continue
+        if contract.get("time_group_hints") or best_contract is None:
+            best_contract = contract
+        if contract.get("time_group_hints") or not has_time_trunc:
+            break
+    return best_contract
 
+
+def _contract_from_parsed(parsed: Any, sql: str, source: str) -> Optional[Dict[str, Any]]:
     select = _final_select(parsed)
     if select is None:
         return None
 
     dimension_hints: List[str] = []
     metric_hints: List[str] = []
+    dimension_expr_hints: List[Dict[str, str]] = []
+    time_group_hints: List[Dict[str, str]] = []
     aliases_by_expr = _projection_aliases_by_expr(select)
     projection_aliases = [_projection_name(expr) for expr in select.expressions]
 
@@ -103,6 +171,12 @@ def _contract_from_sql(sql: str, source: str) -> Optional[Dict[str, Any]]:
             hint = _dimension_hint_from_group_expr(group_expr, aliases_by_expr, projection_aliases)
             if hint:
                 dimension_hints.append(hint)
+            time_group_hint = _time_group_hint_from_group_expr(group_expr, select.expressions)
+            if time_group_hint:
+                time_group_hints.append(time_group_hint)
+            dimension_expr_hint = _dimension_expr_hint_from_group_expr(group_expr, select.expressions, hint)
+            if dimension_expr_hint:
+                dimension_expr_hints.append(dimension_expr_hint)
 
     grouped_hints = {_normalize_name(hint) for hint in dimension_hints}
     for projection in select.expressions:
@@ -118,26 +192,43 @@ def _contract_from_sql(sql: str, source: str) -> Optional[Dict[str, Any]]:
     metric_hints = _dedupe(metric_hints)
     if not dimension_hints:
         return None
-    return {
+    contract = {
         "source": source,
         "dimension_hints": dimension_hints,
         "metric_hints": metric_hints,
         "sql": sql,
     }
+    dimension_expr_hints = _dedupe_dimension_expr_hints(dimension_expr_hints)
+    if dimension_expr_hints:
+        contract["dimension_expr_hints"] = dimension_expr_hints
+    time_group_hints = _dedupe_time_group_hints(time_group_hints)
+    if time_group_hints:
+        contract["time_group_hints"] = time_group_hints
+    return contract
 
 
-def _parse_sql(sql: str):
+def _contains_time_trunc(sql: str) -> bool:
+    return bool(re.search(r"\b(?:date|datetime|time|timestamp)_trunc\s*\(", sql, flags=re.IGNORECASE))
+
+
+def _parse_sql_candidates(sql: str) -> Iterable[Any]:
     try:
         import sqlglot
 
-        for dialect in ("snowflake", None):
+        seen = set()
+        for dialect in _SQL_PARSE_DIALECTS:
+            read_dialect = _SQLGLOT_DIALECT_ALIASES.get(dialect, dialect)
             try:
-                return sqlglot.parse_one(sql, read=dialect) if dialect else sqlglot.parse_one(sql)
+                parsed = sqlglot.parse_one(sql, read=read_dialect) if read_dialect else sqlglot.parse_one(sql)
             except Exception:
                 continue
+            key = _normalize_sql(parsed)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield parsed
     except Exception as exc:
         logger.debug(f"Skipping queryability SQL parsing: {exc}")
-    return None
 
 
 def _final_select(expression) -> Optional[Any]:
@@ -193,6 +284,119 @@ def _dimension_hint_from_group_expr(group_expr, aliases_by_expr: Dict[str, str],
     return _safe_name(getattr(group_expr, "sql", lambda: "")())
 
 
+def _time_group_hint_from_group_expr(group_expr, projections: List[Any]) -> Optional[Dict[str, str]]:
+    projection = _projection_for_group_expr(group_expr, projections)
+    expr = projection.this if projection and projection.__class__.__name__ == "Alias" else projection
+    if expr is None:
+        expr = group_expr
+    return _time_group_hint_from_expr(expr, alias=_projection_name(projection) if projection is not None else "")
+
+
+def _projection_for_group_expr(group_expr, projections: List[Any]) -> Optional[Any]:
+    try:
+        from sqlglot import expressions as exp
+
+        if isinstance(group_expr, exp.Literal) and group_expr.is_int:
+            ordinal = int(group_expr.name)
+            if 1 <= ordinal <= len(projections):
+                return projections[ordinal - 1]
+    except Exception:
+        pass
+
+    group_sql = _normalize_sql(group_expr)
+    group_name = _normalize_name(getattr(group_expr, "name", ""))
+    for projection in projections:
+        alias = _normalize_name(_projection_name(projection))
+        expr = projection.this if projection.__class__.__name__ == "Alias" else projection
+        if alias and group_name and alias == group_name:
+            return projection
+        if group_sql and group_sql in {_normalize_sql(expr), _normalize_sql(projection)}:
+            return projection
+    return None
+
+
+def _time_group_hint_from_expr(expr: Any, alias: str = "") -> Optional[Dict[str, str]]:
+    try:
+        if not _is_time_trunc_expr(expr):
+            return None
+        grain = _normalize_time_grain(expr.args.get("unit"))
+        base_expr = expr.args.get("this")
+        base = _sql_name(base_expr)
+        if not grain or not base:
+            return None
+        hint = {
+            "alias": alias or _safe_name(getattr(expr, "sql", lambda: "")()),
+            "base_expr": base,
+            "grain": grain,
+        }
+        return hint
+    except Exception:
+        return None
+
+
+def _dimension_expr_hint_from_group_expr(group_expr, projections: List[Any], alias: str) -> Optional[Dict[str, str]]:
+    if not alias:
+        return None
+    projection = _projection_for_group_expr(group_expr, projections)
+    expr = projection.this if projection and projection.__class__.__name__ == "Alias" else projection
+    if expr is None:
+        expr = group_expr
+    if _is_time_trunc_expr(expr):
+        return None
+    expression = _sql_name(expr)
+    if not expression:
+        return None
+    hint = {
+        "alias": alias,
+        "expr": expression,
+    }
+    column = _column_name(expr)
+    if column:
+        hint["column"] = column
+    return hint
+
+
+def _is_time_trunc_expr(expr: Any) -> bool:
+    try:
+        from sqlglot import expressions as exp
+
+        return isinstance(expr, (exp.DateTrunc, exp.DatetimeTrunc, exp.TimeTrunc, exp.TimestampTrunc))
+    except Exception:
+        return False
+
+
+def _normalize_time_grain(value: Any) -> str:
+    if value is None:
+        return ""
+    name = getattr(value, "name", None)
+    text = str(name if name else value).strip().strip("'\"").lower()
+    allowed = {"day", "week", "month", "quarter", "year"}
+    return text if text in allowed else ""
+
+
+def _sql_name(expr: Any) -> str:
+    if expr is None:
+        return ""
+    try:
+        return expr.sql(dialect="snowflake")
+    except Exception:
+        try:
+            return expr.sql()
+        except Exception:
+            return str(expr)
+
+
+def _column_name(expr: Any) -> str:
+    try:
+        from sqlglot import expressions as exp
+
+        if isinstance(expr, exp.Column):
+            return str(expr.name or "")
+    except Exception:
+        return ""
+    return ""
+
+
 def _looks_metric_projection(projection) -> bool:
     try:
         from sqlglot import expressions as exp
@@ -238,3 +442,36 @@ def _dedupe(values: Iterable[str]) -> List[str]:
         seen.add(normalized)
         deduped.append(value)
     return deduped
+
+
+def _dedupe_dimension_expr_hints(values: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    deduped: List[Dict[str, str]] = []
+    seen = set()
+    for value in values:
+        alias = value.get("alias", "")
+        expression = value.get("expr", "")
+        key = (_normalize_name(alias), _normalize_sql_text(expression))
+        if not alias or not expression or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(value)
+    return deduped
+
+
+def _dedupe_time_group_hints(values: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    deduped: List[Dict[str, str]] = []
+    seen = set()
+    for value in values:
+        alias = value.get("alias", "")
+        base_expr = value.get("base_expr", "")
+        grain = value.get("grain", "")
+        key = (_normalize_name(alias), _normalize_name(base_expr), grain)
+        if not grain or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(value)
+    return deduped
+
+
+def _normalize_sql_text(value: str) -> str:
+    return re.sub(r"\s+", "", str(value or "")).strip().lower()

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -533,19 +533,19 @@ class TestGenerationEvidence:
             }
         ]
 
-    def test_parse_sql_candidates_attempts_advertised_dialects(self, monkeypatch):
+    def test_parse_sql_candidates_attempts_advertised_dialects(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import sqlglot
 
-        calls = []
+        calls: list[str | None] = []
 
         class FakeParsed:
-            def __init__(self, read_dialect):
+            def __init__(self, read_dialect: str | None) -> None:
                 self.read_dialect = read_dialect
 
-            def sql(self, dialect=None):
+            def sql(self, dialect: str | None = None) -> str:
                 return f"SELECT {self.read_dialect or 'default'}"
 
-        def fake_parse_one(sql, read=None):
+        def fake_parse_one(sql: str, read: str | None = None) -> FakeParsed:
             calls.append(read)
             return FakeParsed(read)
 

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from datus.tools.func_tool import metric_queryability
 from datus.tools.func_tool.base import FuncToolResult, normalize_null
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.metric_queryability import extract_metric_queryability_contracts
@@ -82,6 +83,50 @@ class TestGenerationEvidence:
 
         assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is True
 
+    def test_queryability_contract_accepts_split_grouped_dry_runs_for_source_metrics(self):
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["discounted_revenue", "shipped_quantity"],
+            "dimension_hints": ["return_flag"],
+            "dimension_expr_hints": [
+                {
+                    "alias": "return_flag",
+                    "expr": "L_RETURNFLAG",
+                    "column": "L_RETURNFLAG",
+                }
+            ],
+        }
+        result = FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}})
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(["discounted_revenue"], result, dimensions=["l_returnflag"])
+        evidence.record_metric_dry_run(["shipped_quantity"], result, dimensions=["l_returnflag"])
+
+        assert evidence.has_required_queryability_dry_runs(["discounted_revenue", "shipped_quantity"]) is True
+
+    def test_queryability_contract_rejects_split_dry_runs_when_one_metric_lacks_dimensions(self):
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["discounted_revenue", "shipped_quantity"],
+            "dimension_hints": ["return_flag"],
+            "dimension_expr_hints": [
+                {
+                    "alias": "return_flag",
+                    "expr": "L_RETURNFLAG",
+                    "column": "L_RETURNFLAG",
+                }
+            ],
+        }
+        result = FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}})
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(["discounted_revenue"], result, dimensions=["l_returnflag"])
+        evidence.record_metric_dry_run(["shipped_quantity"], result)
+
+        assert evidence.has_required_queryability_dry_runs(["discounted_revenue", "shipped_quantity"]) is False
+
     def test_queryability_contract_rejects_partial_dimension_token_match(self):
         evidence = GenerationEvidence()
         evidence.set_metric_queryability_contracts(
@@ -101,6 +146,109 @@ class TestGenerationEvidence:
         )
 
         assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is False
+
+    def test_queryability_contract_accepts_dimension_alias_with_base_column_dimension(self):
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["shipped_revenue"],
+            "dimension_hints": ["supplier_nation"],
+            "dimension_expr_hints": [
+                {
+                    "alias": "supplier_nation",
+                    "expr": "n.n_name",
+                    "column": "n_name",
+                }
+            ],
+        }
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["shipped_revenue"],
+            FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}}),
+            dimensions=["n_name"],
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["shipped_revenue"]) is True
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["shipped_revenue"],
+            FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}}),
+            dimensions=["nation_name"],
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["shipped_revenue"]) is False
+
+    def test_queryability_contract_accepts_dimension_alias_from_dry_run_sql_expression(self):
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["shipped_revenue"],
+            "dimension_hints": ["supplier_nation"],
+            "dimension_expr_hints": [
+                {
+                    "alias": "supplier_nation",
+                    "expr": "n.n_name",
+                    "column": "n_name",
+                }
+            ],
+        }
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["shipped_revenue"],
+            FuncToolResult(
+                success=1,
+                result={
+                    "metadata": {
+                        "sql": (
+                            "SELECT n.n_name AS nation_name, SUM(l.l_extendedprice) AS shipped_revenue "
+                            "FROM lineitem l JOIN nation n ON l.nation_key = n.n_nationkey GROUP BY n.n_name"
+                        )
+                    }
+                },
+            ),
+            dimensions=["nation_name"],
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["shipped_revenue"]) is True
+
+    def test_queryability_contract_rejects_dimension_expression_only_in_join_condition(self):
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["shipped_revenue"],
+            "dimension_hints": ["supplier_nation"],
+            "dimension_expr_hints": [
+                {
+                    "alias": "supplier_nation",
+                    "expr": "n.n_name",
+                    "column": "n_name",
+                }
+            ],
+        }
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["shipped_revenue"],
+            FuncToolResult(
+                success=1,
+                result={
+                    "metadata": {
+                        "sql": (
+                            "SELECT s.s_name AS supplier_name, SUM(l.l_extendedprice) AS shipped_revenue "
+                            "FROM lineitem l JOIN supplier s ON l.l_suppkey = s.s_suppkey "
+                            "JOIN nation n ON s.s_comment = n.n_name GROUP BY s.s_name"
+                        )
+                    }
+                },
+            ),
+            dimensions=["supplier_name"],
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["shipped_revenue"]) is False
 
     def test_queryability_contract_time_hint_requires_metric_time_dimension_and_grain(self):
         result = FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}})
@@ -152,6 +300,174 @@ class TestGenerationEvidence:
 
         assert evidence.has_required_queryability_dry_runs(["order_count"]) is True
 
+    def test_queryability_contract_accepts_date_trunc_alias_with_base_time_dimension(self):
+        result = FuncToolResult(
+            success=1,
+            result={
+                "metadata": {
+                    "sql": (
+                        "SELECT metric_time__month, SUM(discounted_revenue) AS discounted_revenue "
+                        "FROM (SELECT DATE_TRUNC('month', L_SHIPDATE) AS metric_time__month, "
+                        "L_EXTENDEDPRICE * (1 - L_DISCOUNT) AS discounted_revenue FROM lineitem) "
+                        "GROUP BY metric_time__month"
+                    )
+                }
+            },
+        )
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["discounted_revenue", "shipped_quantity"],
+            "dimension_hints": ["ship_month"],
+            "time_group_hints": [
+                {
+                    "alias": "ship_month",
+                    "base_expr": "L_SHIPDATE",
+                    "grain": "month",
+                }
+            ],
+        }
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["discounted_revenue", "shipped_quantity"],
+            result,
+            dimensions=["l_shipdate"],
+            time_granularity="month",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["discounted_revenue", "shipped_quantity"]) is True
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["discounted_revenue", "shipped_quantity"],
+            result,
+            dimensions=["l_shipdate"],
+            time_granularity="day",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["discounted_revenue", "shipped_quantity"]) is False
+
+    def test_queryability_contract_rejects_time_alias_without_base_time_evidence(self):
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["discounted_revenue"],
+            "dimension_hints": ["ship_month"],
+            "time_group_hints": [
+                {
+                    "alias": "ship_month",
+                    "base_expr": "L_SHIPDATE",
+                    "grain": "month",
+                }
+            ],
+        }
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["discounted_revenue"],
+            FuncToolResult(
+                success=1,
+                result={
+                    "metadata": {
+                        "sql": (
+                            "SELECT ship_month, SUM(discounted_revenue) AS discounted_revenue "
+                            "FROM metrics GROUP BY ship_month"
+                        )
+                    }
+                },
+            ),
+            dimensions=["ship_month"],
+            time_granularity="month",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["discounted_revenue"]) is False
+
+    def test_queryability_contract_accepts_metric_time_dimension_only_when_sql_uses_source_time_column(self):
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["discounted_revenue"],
+            "dimension_hints": ["ship_month"],
+            "time_group_hints": [
+                {
+                    "alias": "ship_month",
+                    "base_expr": "L_SHIPDATE",
+                    "grain": "month",
+                }
+            ],
+        }
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["discounted_revenue"],
+            FuncToolResult(
+                success=1,
+                result={
+                    "metadata": {
+                        "sql": (
+                            "SELECT metric_time__month, SUM(discounted_revenue) AS discounted_revenue "
+                            "FROM (SELECT DATE_TRUNC('month', lineitem.L_SHIPDATE) AS metric_time__month, "
+                            "L_EXTENDEDPRICE AS discounted_revenue FROM lineitem) GROUP BY metric_time__month"
+                        )
+                    }
+                },
+            ),
+            dimensions=["metric_time__month"],
+            time_granularity="month",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["discounted_revenue"]) is True
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["discounted_revenue"],
+            FuncToolResult(
+                success=1,
+                result={
+                    "metadata": {
+                        "sql": (
+                            "SELECT metric_time__month, SUM(discounted_revenue) AS discounted_revenue "
+                            "FROM (SELECT DATE_TRUNC('month', O_ORDERDATE) AS metric_time__month, "
+                            "O_TOTALPRICE AS discounted_revenue FROM orders) GROUP BY metric_time__month"
+                        )
+                    }
+                },
+            ),
+            dimensions=["metric_time__month"],
+            time_granularity="month",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["discounted_revenue"]) is False
+
+    def test_queryability_contract_accepts_generic_date_trunc_alias_with_unqualified_time_dimension(self):
+        result = FuncToolResult(success=1, result={"metadata": {}})
+        contract = {
+            "source": "sql_1",
+            "metric_hints": ["revenue"],
+            "dimension_hints": ["created_week"],
+            "time_group_hints": [
+                {
+                    "alias": "created_week",
+                    "base_expr": "o.created_at",
+                    "grain": "week",
+                }
+            ],
+        }
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts([contract])
+        evidence.record_metric_dry_run(
+            ["revenue"],
+            result,
+            dimensions=["created_at"],
+            time_granularity="week",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["revenue"]) is True
+
     def test_extracts_grouped_metric_queryability_contract_from_sql(self):
         contracts = extract_metric_queryability_contracts(
             """
@@ -168,6 +484,13 @@ class TestGenerationEvidence:
             {
                 "source": "sql_1",
                 "dimension_hints": ["supplier_nation"],
+                "dimension_expr_hints": [
+                    {
+                        "alias": "supplier_nation",
+                        "expr": "n.n_name",
+                        "column": "n_name",
+                    }
+                ],
                 "metric_hints": ["shipped_revenue"],
                 "sql": (
                     "SELECT n.n_name AS supplier_nation, SUM(l.l_extendedprice) AS shipped_revenue\n"
@@ -194,6 +517,13 @@ class TestGenerationEvidence:
             {
                 "source": "sql_1",
                 "dimension_hints": ["customer_segment"],
+                "dimension_expr_hints": [
+                    {
+                        "alias": "customer_segment",
+                        "expr": "customer_segment",
+                        "column": "customer_segment",
+                    }
+                ],
                 "metric_hints": ["revenue_total"],
                 "sql": (
                     "SELECT customer_segment, SUM(revenue) AS revenue_total\n"
@@ -202,6 +532,69 @@ class TestGenerationEvidence:
                 ),
             }
         ]
+
+    def test_parse_sql_candidates_attempts_advertised_dialects(self, monkeypatch):
+        import sqlglot
+
+        calls = []
+
+        class FakeParsed:
+            def __init__(self, read_dialect):
+                self.read_dialect = read_dialect
+
+            def sql(self, dialect=None):
+                return f"SELECT {self.read_dialect or 'default'}"
+
+        def fake_parse_one(sql, read=None):
+            calls.append(read)
+            return FakeParsed(read)
+
+        monkeypatch.setattr(sqlglot, "parse_one", fake_parse_one)
+
+        list(metric_queryability._parse_sql_candidates("SELECT 1"))
+
+        assert {"mysql", "postgres", "sqlite", "starrocks"}.issubset(set(calls))
+        assert calls.count("postgres") >= 2
+        assert None in calls
+
+    def test_extracts_contracts_from_multiple_labeled_sql_blocks_without_semicolons(self):
+        contracts = extract_metric_queryability_contracts(
+            """
+            Analyze the following SQL queries and extract core metrics:
+
+            Query 1:
+            Question: q1
+            SQL:
+            SELECT a AS x, SUM(b) AS m FROM t GROUP BY a
+
+            ---
+
+            Query 2:
+            Question: q2
+            SQL:
+            SELECT c AS y, SUM(d) AS n FROM u GROUP BY c
+            """
+        )
+
+        assert len(contracts) == 2
+        assert contracts[0]["dimension_hints"] == ["x"]
+        assert contracts[0]["metric_hints"] == ["m"]
+        assert contracts[1]["dimension_hints"] == ["y"]
+        assert contracts[1]["metric_hints"] == ["n"]
+
+    def test_extracts_contracts_from_success_story_csv_text(self):
+        contracts = extract_metric_queryability_contracts(
+            """question,sql
+"q1","SELECT a AS x, SUM(b) AS m FROM t GROUP BY a"
+"q2","SELECT c AS y, SUM(d) AS n FROM u GROUP BY c"
+"""
+        )
+
+        assert len(contracts) == 2
+        assert contracts[0]["dimension_hints"] == ["x"]
+        assert contracts[0]["metric_hints"] == ["m"]
+        assert contracts[1]["dimension_hints"] == ["y"]
+        assert contracts[1]["metric_hints"] == ["n"]
 
     def test_extracts_contract_from_final_select_not_grouped_cte(self):
         contracts = extract_metric_queryability_contracts(
@@ -220,8 +613,87 @@ class TestGenerationEvidence:
         assert len(contracts) == 1
         assert contracts[0]["source"] == "sql_1"
         assert contracts[0]["dimension_hints"] == ["customer_segment"]
+        assert contracts[0]["dimension_expr_hints"] == [
+            {
+                "alias": "customer_segment",
+                "expr": "customer_segment",
+                "column": "customer_segment",
+            }
+        ]
         assert contracts[0]["metric_hints"] == ["revenue_total"]
         assert contracts[0]["sql"].startswith("WITH daily AS")
+
+    def test_extracts_date_trunc_grouped_metric_queryability_contract(self):
+        contracts = extract_metric_queryability_contracts(
+            """
+            SQL:
+            SELECT DATE_TRUNC('MONTH', L_SHIPDATE) AS ship_month,
+                   SUM(L_EXTENDEDPRICE * (1 - L_DISCOUNT)) AS discounted_revenue,
+                   SUM(L_QUANTITY) AS shipped_quantity
+            FROM LINEITEM
+            GROUP BY 1;
+            """
+        )
+
+        assert len(contracts) == 1
+        assert contracts[0]["dimension_hints"] == ["ship_month"]
+        assert contracts[0]["metric_hints"] == ["discounted_revenue", "shipped_quantity"]
+        assert contracts[0]["time_group_hints"] == [
+            {
+                "alias": "ship_month",
+                "base_expr": "L_SHIPDATE",
+                "grain": "month",
+            }
+        ]
+
+    def test_extracts_generic_date_trunc_group_by_alias_and_expression_contracts(self):
+        contracts = extract_metric_queryability_contracts(
+            """
+            SELECT DATE_TRUNC('WEEK', o.created_at) AS created_week,
+                   SUM(o.amount) AS revenue
+            FROM orders o
+            GROUP BY created_week;
+
+            SELECT DATE_TRUNC('QUARTER', events.event_ts) AS event_quarter,
+                   COUNT(*) AS event_count
+            FROM events
+            GROUP BY DATE_TRUNC('QUARTER', events.event_ts);
+
+            SELECT DATE_TRUNC(created_at, MONTH) AS created_month,
+                   SUM(amount) AS order_revenue
+            FROM orders
+            GROUP BY created_month;
+            """
+        )
+
+        assert len(contracts) == 3
+        assert contracts[0]["dimension_hints"] == ["created_week"]
+        assert contracts[0]["metric_hints"] == ["revenue"]
+        assert contracts[0]["time_group_hints"] == [
+            {
+                "alias": "created_week",
+                "base_expr": "o.created_at",
+                "grain": "week",
+            }
+        ]
+        assert contracts[1]["dimension_hints"] == ["event_quarter"]
+        assert contracts[1]["metric_hints"] == ["event_count"]
+        assert contracts[1]["time_group_hints"] == [
+            {
+                "alias": "event_quarter",
+                "base_expr": "events.event_ts",
+                "grain": "quarter",
+            }
+        ]
+        assert contracts[2]["dimension_hints"] == ["created_month"]
+        assert contracts[2]["metric_hints"] == ["order_revenue"]
+        assert contracts[2]["time_group_hints"] == [
+            {
+                "alias": "created_month",
+                "base_expr": "created_at",
+                "grain": "month",
+            }
+        ]
 
     def test_ignores_nested_group_when_final_select_is_ungrouped(self):
         contracts = extract_metric_queryability_contracts(
@@ -570,6 +1042,7 @@ class TestQueryMetricsCompression:
                 "metrics": ["revenue"],
                 "dimensions": ["customer_segment"],
                 "time_granularity": "month",
+                "sql": "SELECT SUM(revenue) AS revenue FROM orders",
             }
         ]
         assert evidence.metric_sqls == {"revenue": "SELECT SUM(revenue) AS revenue FROM orders"}


### PR DESCRIPTION
## Summary
- Extract queryability contracts from success-story CSV and labeled SQL blocks.
- Track grouped dimension expressions and DATE_TRUNC time-grain aliases in metric queryability contracts.
- Require dry-run evidence to satisfy the source grouped dimensions/time grain without accepting alias-only false positives.
- Update the metrics bootstrap prompt to allow split dry-runs for grouped source SQL metrics.

## Validation
- uv run pytest tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestGenerationEvidence tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestQueryMetricsCompression::test_query_metrics_dry_run_records_generation_evidence -q
- git diff --check --cached

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **New Features**
  * Added support for extracting metrics from multiple SQL formats including labeled snippets and CSV inputs.
  * Introduced dimension and time-based hints for more precise metric validation.

* **Improvements**
  * Enhanced metric dry-run validation to handle grouped metrics with matching dimensions and time granularity.
  * Improved SQL parsing with multi-dialect support for better metric contract generation.

* **Documentation**
  * Refined metric-generation instructions for clearer dry-run SQL guidance.

* **Tests**
  * Expanded test coverage for metric queryability contracts, dimension alias handling, and time-based validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for extracting metrics from additional SQL formats (labeled snippets, CSV) and recording executed dry-run SQL as evidence.

* **Improvements**
  * More precise metric dry-run validation for grouped metrics (matching dimensions/time granularity and split dry-runs).
  * Enhanced multi-dialect SQL parsing, normalization, and expression/time-grain matching for more reliable contract generation.

* **Documentation**
  * Clarified metric-generation dry-run guidance.

* **Tests**
  * Expanded coverage for queryability contracts, dimension aliasing, and time-grain handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->