### PR TITLE
[BugFix] Migrate stale UNIQUE constraint on subject_nodes for existing DBs (#507)

### DIFF
--- a/datus/storage/rdb/sqlite_backend.py
+++ b/datus/storage/rdb/sqlite_backend.py
@@ -233,6 +233,10 @@ class SqliteRdbDatabase(RdbDatabase):
             with self._auto_conn() as conn:
                 # Migrate missing columns on existing tables before running DDL
                 self._migrate_missing_columns(conn, table_def)
+                # Rebuild table if inline constraints differ from the definition.
+                # Must run after _migrate_missing_columns so newly added columns
+                # are included in the data copy.
+                self._migrate_constraints(conn, table_def)
                 for stmt in ddl_statements:
                     conn.execute(stmt)
         except DatusException:
@@ -259,6 +263,80 @@ class SqliteRdbDatabase(RdbDatabase):
                 col_ddl = _sqlite_col_ddl(col)
                 conn.execute(f"ALTER TABLE {safe_table} ADD COLUMN {col_ddl}")
                 logger.info(f"Migrated: ALTER TABLE {safe_table} ADD COLUMN {col_ddl}")
+
+    @staticmethod
+    def _migrate_constraints(conn, table_def: TableDefinition) -> None:
+        """Rebuild the table when its UNIQUE constraints differ from the definition.
+
+        SQLite does not support ALTER TABLE DROP CONSTRAINT, so fixing a stale
+        inline constraint requires a full table rebuild: create a correctly
+        constrained temp table, copy all rows, drop the old table, rename.
+
+        Only UNIQUE constraints are compared; other constraint types are ignored.
+        The rebuild is skipped when the table does not yet exist (CREATE TABLE
+        will handle it) or when all desired constraints are already present.
+        """
+        # Nothing to check if the definition declares no constraints.
+        if not table_def.constraints:
+            return
+
+        # Validate the table name before embedding it in SQL — prevents injection.
+        safe_table = _safe_ident(table_def.table_name)
+
+        # PRAGMA table_info returns one row per column; zero rows means the table
+        # doesn't exist yet, so CREATE TABLE (run after this) will handle it.
+        cursor = conn.execute(f"PRAGMA table_info({safe_table})")
+        existing_cols = [row[1] for row in cursor.fetchall()]
+        if not existing_cols:
+            return  # table doesn't exist yet
+
+        # Read the original CREATE TABLE statement SQLite stored when the table
+        # was first created. This is the only way to inspect inline constraints
+        # because SQLite has no information_schema or constraint catalog.
+        cursor = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            (table_def.table_name,),
+        )
+        row = cursor.fetchone()
+        if not row or not row[0]:
+            return
+
+        # Normalize constraint strings to uppercase with no whitespace so that
+        # formatting differences don't cause false mismatches, e.g.
+        # "UNIQUE( parent_id, name )" and "UNIQUE(parent_id,name)" are equal.
+        def _norm(fragments):
+            return {re.sub(r"\s+", "", f.upper()) for f in fragments}
+
+        # Extract UNIQUE constraints from the TableDefinition (what we want).
+        desired = _norm(c for c in table_def.constraints if re.match(r"\s*UNIQUE", c, re.IGNORECASE))
+        # Extract UNIQUE constraints from the stored CREATE statement (what the DB has).
+        existing = _norm(re.findall(r"UNIQUE\s*\([^)]+\)", row[0], re.IGNORECASE))
+
+        # Constraints already match — nothing to do (fresh install or already migrated).
+        if existing == desired:
+            return
+
+        logger.info(f"Rebuilding '{table_def.table_name}': constraints {existing} -> {desired}")
+
+        tmp = f"{table_def.table_name}_migration_tmp"
+        safe_tmp = _safe_ident(tmp)
+
+        # Only transfer columns that exist in both the old table and the new definition.
+        # This safely handles columns that may have been added by _migrate_missing_columns.
+        new_col_names = {col.name for col in table_def.columns}
+        transfer_cols = ", ".join(c for c in existing_cols if c in new_col_names)
+
+        # Build DDL for the temp table using the new definition (correct constraints).
+        col_parts = [_sqlite_col_ddl(col) for col in table_def.columns] + list(table_def.constraints)
+        col_ddl = ",\n".join(f"    {p}" for p in col_parts)
+
+        # Four-step atomic rebuild — all inside the same transaction, so a crash
+        # between steps rolls back and leaves the original table untouched.
+        conn.execute(f"CREATE TABLE {safe_tmp} (\n{col_ddl}\n)")
+        conn.execute(f"INSERT INTO {safe_tmp} ({transfer_cols}) SELECT {transfer_cols} FROM {safe_table}")
+        conn.execute(f"DROP TABLE {safe_table}")
+        conn.execute(f"ALTER TABLE {safe_tmp} RENAME TO {safe_table}")
+        logger.info(f"Table '{table_def.table_name}' rebuilt with updated constraints")
 
     @contextmanager
     def transaction(self) -> Iterator[None]:

--- a/tests/unit_tests/storage/rdb/test_sqlite_backend.py
+++ b/tests/unit_tests/storage/rdb/test_sqlite_backend.py
@@ -413,3 +413,126 @@ class TestSqliteRdbBackendConnect:
         assert db_a.db_file != db_b.db_file
         assert db_a.db_file == os.path.join(str(tmp_path), "proj_a", "datus_db", "test.db")
         assert db_b.db_file == os.path.join(str(tmp_path), "proj_b", "datus_db", "test.db")
+
+
+class TestMigrateConstraints:
+    """Tests for _migrate_constraints table-rebuild migration."""
+
+    def _make_db(self, tmp_path, name="migrate_constraints.db"):
+        return SqliteRdbDatabase(os.path.join(str(tmp_path), name))
+
+    def _old_def(self):
+        """Table definition with the stale UNIQUE(parent_id, name) constraint."""
+        return TableDefinition(
+            table_name="nodes",
+            columns=[
+                ColumnDef(name="node_id", col_type="INTEGER", primary_key=True, autoincrement=True),
+                ColumnDef(name="parent_id", col_type="INTEGER"),
+                ColumnDef(name="name", col_type="TEXT", nullable=False),
+            ],
+            constraints=["UNIQUE(parent_id, name)"],
+        )
+
+    def _new_def(self):
+        """Table definition with the correct UNIQUE(parent_id, name, datasource_id) constraint."""
+        return TableDefinition(
+            table_name="nodes",
+            columns=[
+                ColumnDef(name="node_id", col_type="INTEGER", primary_key=True, autoincrement=True),
+                ColumnDef(name="parent_id", col_type="INTEGER"),
+                ColumnDef(name="name", col_type="TEXT", nullable=False),
+                ColumnDef(name="datasource_id", col_type="TEXT", default=""),
+            ],
+            constraints=["UNIQUE(parent_id, name, datasource_id)"],
+        )
+
+    def test_noop_when_table_missing(self, tmp_path):
+        """Skip rebuild when table does not exist yet."""
+        db = self._make_db(tmp_path)
+        import sqlite3
+
+        conn = sqlite3.connect(db.db_file)
+        SqliteRdbDatabase._migrate_constraints(conn, self._new_def())
+        conn.close()
+        # No error and no table created (CREATE TABLE is not our job here).
+        conn2 = sqlite3.connect(db.db_file)
+        cursor = conn2.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        assert cursor.fetchall() == []
+        conn2.close()
+
+    def test_noop_when_constraints_match(self, tmp_path):
+        """Skip rebuild when the live table already has the correct constraints."""
+        db = self._make_db(tmp_path)
+        new_def = self._new_def()
+        table = db.ensure_table(new_def)
+
+        @dataclass
+        class _Node:
+            node_id: int = None
+            parent_id: int = None
+            name: str = ""
+            datasource_id: str = ""
+
+        table.insert(_Node(parent_id=1, name="x", datasource_id="ds1"))
+
+        # Second ensure_table must not wipe data.
+        table2 = db.ensure_table(new_def)
+        rows = table2.query(_Node)
+        assert len(rows) == 1
+        assert rows[0].name == "x"
+
+    def test_rebuilds_stale_constraint_and_preserves_data(self, tmp_path):
+        """Rebuild replaces UNIQUE(parent_id, name) with UNIQUE(parent_id, name, datasource_id).
+
+        Existing rows must be preserved; after the rebuild, inserting two rows
+        that share (parent_id, name) but differ on datasource_id must succeed.
+        """
+        db = self._make_db(tmp_path)
+
+        @dataclass
+        class _OldNode:
+            node_id: int = None
+            parent_id: int = None
+            name: str = ""
+
+        @dataclass
+        class _NewNode:
+            node_id: int = None
+            parent_id: int = None
+            name: str = ""
+            datasource_id: str = ""
+
+        # Create table with old schema and seed a row.
+        old_table = db.ensure_table(self._old_def())
+        old_table.insert(_OldNode(parent_id=1, name="finance"))
+
+        # Upgrade: add datasource_id column + fix constraint.
+        new_table = db.ensure_table(self._new_def())
+
+        # Existing row must survive the rebuild.
+        rows = new_table.query(_NewNode)
+        assert len(rows) == 1
+        assert rows[0].name == "finance"
+
+        # Now two rows with same (parent_id, name) but different datasource_id must be accepted.
+        new_table.insert(_NewNode(parent_id=1, name="revenue", datasource_id="ds1"))
+        new_table.insert(_NewNode(parent_id=1, name="revenue", datasource_id="ds2"))
+        rows = new_table.query(_NewNode, where={"name": "revenue"})
+        assert len(rows) == 2
+
+    def test_old_constraint_still_blocks_same_datasource(self, tmp_path):
+        """After rebuild, inserting duplicate (parent_id, name, datasource_id) must still fail."""
+        db = self._make_db(tmp_path)
+        db.ensure_table(self._old_def())
+        new_table = db.ensure_table(self._new_def())
+
+        @dataclass
+        class _NewNode:
+            node_id: int = None
+            parent_id: int = None
+            name: str = ""
+            datasource_id: str = ""
+
+        new_table.insert(_NewNode(parent_id=1, name="dup", datasource_id="ds1"))
+        with pytest.raises(UniqueViolationError):
+            new_table.insert(_NewNode(parent_id=1, name="dup", datasource_id="ds1"))


### PR DESCRIPTION
## Why

PR #493 (Storage 2.0) changed the `subject_nodes` unique constraint from `UNIQUE(parent_id, name)` to `UNIQUE(parent_id, name, datasource_id)` to allow the same node name to exist under different datasources. However, SQLite does not support `ALTER TABLE DROP CONSTRAINT`, so existing databases retained the old constraint even after upgrading. The existing `_migrate_missing_columns` migration correctly added the `datasource_id` column but had no way to fix the stale constraint. As a result, any cross-datasource insert with a duplicate `(parent_id, name)` pair would fail with `UNIQUE constraint failed` on upgraded databases.

Fixes #507.

## Solution

Add `_migrate_constraints()` to `SqliteRdbDatabase`, called from `ensure_table()` after `_migrate_missing_columns()`. The method:

1. Reads the table's original `CREATE TABLE` statement from `sqlite_master`
2. Extracts and normalizes all `UNIQUE(...)` constraints from it
3. Compares against the desired constraints in `TableDefinition`
4. If they differ, performs a full table rebuild: `CREATE TABLE tmp → INSERT SELECT → DROP old → RENAME`

The rebuild is atomic (runs inside the same transaction as the rest of `ensure_table`) and is a no-op on fresh installs where the constraint is already correct. `_migrate_missing_columns` runs first so newly added columns are included in the data copy during rebuild.

## Test Cases

Added `TestMigrateConstraints` to `tests/unit_tests/storage/rdb/test_sqlite_backend.py` with 4 unit tests:

- `test_noop_when_table_missing` — no rebuild attempted on an empty database
- `test_noop_when_constraints_match` — no rebuild when constraint is already correct; existing data survives
- `test_rebuilds_stale_constraint_and_preserves_data` — full upgrade path: old DB is rebuilt, data is preserved, cross-datasource inserts now succeed
- `test_old_constraint_still_blocks_same_datasource` — new constraint still rejects true duplicates after rebuild

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database table constraint handling to properly rebuild tables when constraint requirements change while preserving existing data.

* **Tests**
  * Added test coverage for constraint migration scenarios to ensure data integrity during table rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->