### PR TITLE
[Doc] upgrade version to 0.3.3 and add release notes (backport #953)

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,24 @@
 
 ## 0.3
 
+### 0.3.3
+
+**New Features**
+
+- **Automatic Session Compaction** - Long conversations now clean up context automatically, reducing interruptions when the context fills up. As a conversation grows, older tool-call records are archived to disk while the active task stays in context; near the limit (about 90%), Datus summarizes the session and keeps the run moving. The `/compact` command also shows progress and a summary panel, with full history persisted for restore and review. [#871](https://github.com/Datus-ai/Datus-agent/pull/871) [#919](https://github.com/Datus-ai/Datus-agent/pull/919) [#933](https://github.com/Datus-ai/Datus-agent/pull/933) [docs](configuration/compact.md)
+- **Live Token Usage** - Model responses now show newly used and cumulative tokens as they stream, while the status bar tracks current context usage and total capacity. Usage history is saved with the session for restore, cost review, and context audits. [#920](https://github.com/Datus-ai/Datus-agent/pull/920)
+
+**Enhancements**
+
+- **Snowflake Key-Pair Authentication** - Snowflake setups with MFA can now use RSA key-pair authentication instead of passwords. Configure `private_key_file`, optional `private_key_file_pwd`, and `role`; the same credentials are used for SQL execution and MetricFlow metric generation, validation, and querying, with credentials redacted from logs. [#926](https://github.com/Datus-ai/Datus-agent/pull/926) [datus-db-adapters#66](https://github.com/Datus-ai/datus-db-adapters/pull/66) [datus-db-adapters#67](https://github.com/Datus-ai/datus-db-adapters/pull/67) [datus-semantic-adapter#25](https://github.com/Datus-ai/datus-semantic-adapter/pull/25) [docs](configuration/datasources.md)
+- **Offline Embedding Fallback** - Datus no longer stalls on embedding model downloads in offline, intranet, or Hugging Face-blocked environments. Context search and `@` reference autocomplete temporarily degrade with diagnostics for the model name, cache path, environment variables, and fix steps; database tools and normal chat continue to work. The docs also cover pre-caching models or using an OpenAI-compatible embedding service for offline deployments. [#870](https://github.com/Datus-ai/Datus-agent/pull/870)
+- **Codex Prompt Cache Optimization** - When using the ChatGPT subscription-backed Codex backend, multi-step runs can now reuse prompt cache like the official client, reducing wait time and token cost. [#918](https://github.com/Datus-ai/Datus-agent/pull/918)
+- **Multi-Turn `datus -p` and `--resume`** - Print mode can now restore and continue a specific session. Use `datus -p '...' --resume <session_id>` to continue from the command line; REPL and API chat also support `--resume` for existing sessions. [#914](https://github.com/Datus-ai/Datus-agent/pull/914)
+
+**Bug Fixes**
+
+- **Custom Ask Subagents Honor Tool Whitelists** - `ask_report` / `ask_dashboard` now only see tools allowed by the subagent's `tools` whitelist. Unauthorized database, bash, and skill tools are no longer exposed to the model, and prompts no longer include the full chat tool directory, reducing unauthorized-tool and context-pollution risk. [#877](https://github.com/Datus-ai/Datus-agent/pull/877) [#878](https://github.com/Datus-ai/Datus-agent/pull/878) [#881](https://github.com/Datus-ai/Datus-agent/pull/881)
+
 ### 0.3.2
 
 **New Features**
@@ -353,4 +371,3 @@ skipped
 **Datus-cli**
 
 - Enhanced !reason and !gen_semantic_model commands for a more agentic and intuitive experience.
-

--- a/docs/release_notes.zh.md
+++ b/docs/release_notes.zh.md
@@ -2,6 +2,24 @@
 
 ## 0.3
 
+### 0.3.3
+
+**新功能**
+
+- **会话自动压缩** - 长对话现在可以自动整理上下文，减少因上下文占满而中断的情况。对话变长时，较早的工具调用记录会归档到磁盘，当前任务仍保留在上下文中；接近上限（约 90%）时，会生成会话摘要并继续运行。`/compact` 也新增了进度提示和摘要面板，完整历史会持久化保存，方便恢复和回溯。[#871](https://github.com/Datus-ai/Datus-agent/pull/871) [#919](https://github.com/Datus-ai/Datus-agent/pull/919) [#933](https://github.com/Datus-ai/Datus-agent/pull/933) [文档](configuration/compact.zh.md)
+- **实时 Token 用量** - 模型响应时会实时显示本次新增与累计 token 数；状态栏同步展示当前上下文占用和总容量。用量历史会随会话保存，恢复会话或审计成本时都能查看。[#920](https://github.com/Datus-ai/Datus-agent/pull/920)
+
+**增强**
+
+- **Snowflake 密钥对认证** - Snowflake 启用 MFA 后，可改用 RSA 密钥对认证，不必依赖密码连接。配置 `private_key_file`、可选的 `private_key_file_pwd` 和 `role` 后，同一套认证信息会用于 SQL 执行，以及 MetricFlow 指标生成、校验和查询；日志中的凭据会自动脱敏。[#926](https://github.com/Datus-ai/Datus-agent/pull/926) [datus-db-adapters#66](https://github.com/Datus-ai/datus-db-adapters/pull/66) [datus-db-adapters#67](https://github.com/Datus-ai/datus-db-adapters/pull/67) [datus-semantic-adapter#25](https://github.com/Datus-ai/datus-semantic-adapter/pull/25) [文档](configuration/datasources.zh.md)
+- **离线 Embedding 降级** - 离线、内网或无法访问 Hugging Face 时，Datus 不再卡在 embedding 模型下载上。上下文搜索和 `@` 引用补全会临时降级，并提示模型名、缓存路径、相关环境变量和修复方法；数据库工具和普通聊天仍可继续使用。文档也补充了预先缓存模型、或改用 OpenAI 兼容 embedding 服务的离线部署方案。[#870](https://github.com/Datus-ai/Datus-agent/pull/870)
+- **Codex 缓存策略优化** - 使用 ChatGPT 订阅版 Codex 后端时，多步运行现在可以像官方客户端一样复用 prompt 缓存，降低等待时间和 token 成本。[#918](https://github.com/Datus-ai/Datus-agent/pull/918)
+- **`datus -p` 与 `--resume` 支持多轮对话** - Print 模式现在也能恢复并继续指定会话。通过 `datus -p '...' --resume <session_id>` 即可在命令行中接续对话；REPL 与 API chat 也支持用 `--resume` 恢复既有会话。[#914](https://github.com/Datus-ai/Datus-agent/pull/914)
+
+**Bug 修复**
+
+- **自定义 Ask 子代理遵守工具白名单** - `ask_report` / `ask_dashboard` 现在只会看到子代理 `tools` 白名单中允许的工具。未授权的数据库、bash、skill 工具不再暴露给模型，prompt 也不再混入完整聊天工具目录，减少越权调用和上下文污染风险。[#877](https://github.com/Datus-ai/Datus-agent/pull/877) [#878](https://github.com/Datus-ai/Datus-agent/pull/878) [#881](https://github.com/Datus-ai/Datus-agent/pull/881)
+
 ### 0.3.2
 
 **新功能**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Project basic information configuration, required.
 [project]
 name = "datus-agent"
-version = "0.3.3rc2"
+version = "0.3.3"
 description = "AI-powered SQL Agent for data engineering (Compiled Version)"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Why

Manual backport of #953 to `release/0.3.3`. The automated mergify backport (#967) was auto-closed because of a cherry-pick conflict in `pyproject.toml`: #953 bumped the version from `0.3.1` → `0.3.3` on `main`, but `release/0.3.3` already carried `0.3.3rc2` (from the `0.3.3rc2` release-prep commit), so the patch context did not match.

## Solution

Cherry-picked `62c8b55` ([Doc] upgrade version to 0.3.3 and add release notes, #953) onto `release/0.3.3`. The two release-notes docs applied cleanly; the only conflict was the version line in `pyproject.toml`, resolved to the final release version `0.3.3` (dropping the `rc2` suffix).

## Test Cases

Docs/version-only change — no integration or nightly tests added. The change is limited to `pyproject.toml` version string and `docs/release_notes*.md` content.
