### PR TITLE
[BugFix] Scope datasource storage and harden metrics bootstrap

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -10,6 +10,7 @@ metrics generation with support for filesystem tools, generation tools,
 hooks, and metricflow MCP server integration.
 """
 
+import json
 from typing import Any, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
@@ -138,6 +139,37 @@ class GenMetricsAgenticNode(AgenticNode):
             self._setup_ask_user_tool()
 
         logger.info(f"Setup {len(self.tools)} tools for {self.NODE_NAME}: {[tool.name for tool in self.tools]}")
+
+    def _make_filesystem_tool(self, **kwargs):
+        from datus.configuration.inherited_memory_overrides import get_inherited_memory
+        from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
+
+        root_path = kwargs.pop("root_path", None) or self._resolve_workspace_root()
+        datus_home = kwargs.pop("datus_home", None)
+        if datus_home is None and self.agent_config is not None:
+            path_manager = getattr(self.agent_config, "path_manager", None)
+            if path_manager is not None:
+                try:
+                    datus_home = str(path_manager.datus_home)
+                except Exception:
+                    datus_home = None
+        strict = kwargs.pop("strict", None)
+        if strict is None:
+            strict = self._resolve_filesystem_strict()
+        current_node = kwargs.pop("current_node", None) or self.get_node_name()
+        inherited_memory_node = kwargs.pop("inherited_memory_node", None)
+        if inherited_memory_node is None:
+            inherited_memory_node = get_inherited_memory(current_node)
+        session_data_dir = kwargs.pop("session_data_dir", None) or self._resolve_session_data_dir()
+        return MetricFilesystemFuncTool(
+            root_path=root_path,
+            current_node=current_node,
+            datus_home=datus_home,
+            strict=strict,
+            inherited_memory_node=inherited_memory_node,
+            session_data_dir=session_data_dir,
+            **kwargs,
+        )
 
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
@@ -446,8 +478,113 @@ class GenMetricsAgenticNode(AgenticNode):
     def _set_metric_queryability_contracts_from_input(self, user_input: Optional[SemanticNodeInput]) -> None:
         if not user_input:
             return
-        contracts = extract_metric_queryability_contracts(getattr(user_input, "user_message", "") or "")
-        self.generation_evidence.set_metric_queryability_contracts(contracts)
+        user_message = getattr(user_input, "user_message", "") or ""
+        contracts = extract_metric_queryability_contracts(user_message)
+        candidate_plan = self._extract_precomputed_candidate_plan(user_message)
+        metric_aliases = self._metric_aliases_from_candidate_plan(candidate_plan)
+        blocked_sources = self._blocked_queryability_sources_from_candidate_plan(candidate_plan)
+        if blocked_sources:
+            contracts = [
+                contract
+                for contract in contracts
+                if not (self._source_name_set(contract.get("source")) & blocked_sources)
+            ]
+        self.generation_evidence.set_metric_queryability_contracts(contracts, metric_aliases=metric_aliases)
+
+    @classmethod
+    def _metric_aliases_from_user_message(cls, user_message: str) -> Dict[str, str]:
+        plan = cls._extract_precomputed_candidate_plan(user_message)
+        return cls._metric_aliases_from_candidate_plan(plan)
+
+    @classmethod
+    def _blocked_queryability_sources_from_user_message(cls, user_message: str) -> set[str]:
+        plan = cls._extract_precomputed_candidate_plan(user_message)
+        return cls._blocked_queryability_sources_from_candidate_plan(plan)
+
+    @staticmethod
+    def _extract_precomputed_candidate_plan(user_message: str) -> Dict[str, Any]:
+        marker = "## Precomputed Metric Candidate Plan JSON"
+        if marker not in user_message:
+            return {}
+        section = user_message.split(marker, 1)[1]
+        next_heading = section.find("\n\n## ")
+        if next_heading >= 0:
+            section = section[:next_heading]
+        json_start = min((idx for idx in (section.find("{"), section.find("[")) if idx >= 0), default=-1)
+        if json_start < 0:
+            return {}
+        payload = section[json_start:].strip()
+        try:
+            loaded = json.loads(payload)
+        except (TypeError, json.JSONDecodeError):
+            logger.debug("Failed to parse precomputed metric candidate plan JSON from gen_metrics prompt")
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    @staticmethod
+    def _metric_aliases_from_candidate_plan(candidate_plan: Dict[str, Any]) -> Dict[str, str]:
+        aliases: Dict[str, str] = {}
+
+        def add(alias: Any, canonical: Any) -> None:
+            if not isinstance(alias, str) or not isinstance(canonical, str):
+                return
+            alias = alias.strip()
+            canonical = canonical.strip()
+            if alias and canonical and alias != canonical:
+                aliases[alias] = canonical
+
+        for item in candidate_plan.get("metric_aliases") or []:
+            if not isinstance(item, dict):
+                continue
+            canonical = item.get("canonical_name") or item.get("name")
+            add(item.get("source_alias"), canonical)
+            add(item.get("candidate_name"), canonical)
+
+        for key in (
+            "direct_metric_candidates",
+            "derived_metric_candidates",
+            "metric_candidates",
+            "identity_metric_references",
+        ):
+            for candidate in candidate_plan.get(key) or []:
+                if not isinstance(candidate, dict):
+                    continue
+                canonical = candidate.get("name")
+                add(candidate.get("source_alias"), canonical)
+                for source_alias in candidate.get("source_aliases") or []:
+                    add(source_alias, canonical)
+                for candidate_name in candidate.get("candidate_names") or []:
+                    add(candidate_name, canonical)
+                for mapping in candidate.get("source_alias_mappings") or []:
+                    if not isinstance(mapping, dict):
+                        continue
+                    add(mapping.get("source_alias"), canonical)
+                    add(mapping.get("candidate_name"), canonical)
+        return aliases
+
+    @classmethod
+    def _blocked_queryability_sources_from_candidate_plan(cls, candidate_plan: Dict[str, Any]) -> set[str]:
+        blocked_sources: set[str] = set()
+        for item in candidate_plan.get("source_classifications") or []:
+            if not isinstance(item, dict):
+                continue
+            if item.get("classification") != "metric_plus_derived_datasource":
+                continue
+            blocked_sources.update(cls._source_name_set(item.get("source_sql_name")))
+
+        if blocked_sources:
+            return blocked_sources
+
+        for item in candidate_plan.get("blocked_direct_metric_candidates") or []:
+            if isinstance(item, dict):
+                blocked_sources.update(cls._source_name_set(item.get("source_sql_name")))
+        return blocked_sources
+
+    @staticmethod
+    def _source_name_set(value: Any) -> set[str]:
+        if not isinstance(value, str):
+            return set()
+        return {part.strip() for part in value.split(",") if part.strip()}
 
     def _finalize_metric_generation(
         self,
@@ -501,18 +638,26 @@ class GenMetricsAgenticNode(AgenticNode):
             raise RuntimeError(preflight_error)
 
         metric_names = self.generation_tools._extract_metric_names_from_file(abs_metric_file)
-        if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
+        metric_definitions = self.generation_tools._extract_metric_definitions_from_file(abs_metric_file)
+        required_metric_names = self.generation_tools._metric_names_requiring_dry_run(
+            metric_names,
+            metric_definitions,
+            self.generation_evidence.metric_sqls,
+        )
+        if required_metric_names and not self.generation_evidence.has_metric_dry_run(required_metric_names):
             if not getattr(self, "semantic_tools", None):
                 raise RuntimeError("Metric generation produced a metric_file, but query_metrics is unavailable.")
-            dry_run_result = self.semantic_tools.query_metrics(metrics=metric_names, dry_run=True)
-            self.generation_evidence.record_metric_dry_run(metric_names, dry_run_result)
+            dry_run_result = self.semantic_tools.query_metrics(metrics=required_metric_names, dry_run=True)
+            self.generation_evidence.record_metric_dry_run(required_metric_names, dry_run_result)
             if not self._tool_succeeded(dry_run_result):
                 raise RuntimeError(
                     "query_metrics(dry_run=True) failed for generated metric(s) "
-                    f"{', '.join(metric_names)}: {self._tool_error(dry_run_result)}"
+                    f"{', '.join(required_metric_names)}: {self._tool_error(dry_run_result)}"
                 )
-        if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
-            missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
+        if required_metric_names and not self.generation_evidence.has_required_queryability_dry_runs(
+            required_metric_names
+        ):
+            missing_contracts = self.generation_evidence.missing_queryability_contracts(required_metric_names)
             raise DatusException(
                 ErrorCode.COMMON_VALIDATION_FAILED,
                 "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions before "

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -424,7 +424,7 @@ class GenMetricsAgenticNode(AgenticNode):
             else:
                 response_content = str(ctx.last_successful_output)
 
-        semantic_model_file, metric_file, status, extracted_output = self._extract_metric_and_output_from_response(
+        semantic_model_files, metric_file, status, extracted_output = self._extract_metric_and_output_from_response(
             {"content": response_content}
         )
         if extracted_output:
@@ -434,7 +434,7 @@ class GenMetricsAgenticNode(AgenticNode):
             response_content = str(response_content) if response_content else ""
 
         self._finalize_metric_generation(
-            semantic_model_file=semantic_model_file,
+            semantic_model_files=semantic_model_files,
             metric_file=metric_file,
             status=status,
         )
@@ -585,7 +585,7 @@ class GenMetricsAgenticNode(AgenticNode):
 
     def _finalize_metric_generation(
         self,
-        semantic_model_file: Optional[str],
+        semantic_model_files: Optional[List[str]],
         metric_file: Optional[str],
         status: Optional[str],
     ) -> None:
@@ -627,9 +627,11 @@ class GenMetricsAgenticNode(AgenticNode):
                 )
 
         abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
-        abs_semantic_model_file = (
-            self._resolve_metric_artifact_path(semantic_model_file, "semantic") if semantic_model_file else ""
-        )
+        abs_semantic_model_files = [
+            self._resolve_metric_artifact_path(semantic_model_file, "semantic")
+            for semantic_model_file in (semantic_model_files or [])
+            if semantic_model_file
+        ]
         preflight_error = self.generation_tools._validate_metric_file_has_blocks(abs_metric_file)
         if preflight_error:
             raise RuntimeError(preflight_error)
@@ -665,7 +667,7 @@ class GenMetricsAgenticNode(AgenticNode):
 
         publish_result = self.generation_tools.end_metric_generation(
             metric_file=abs_metric_file,
-            semantic_model_file=abs_semantic_model_file,
+            semantic_model_files=abs_semantic_model_files,
         )
         if not self._tool_succeeded(publish_result):
             raise RuntimeError(f"Metric KB sync failed: {self._tool_error(publish_result)}")
@@ -673,12 +675,12 @@ class GenMetricsAgenticNode(AgenticNode):
 
     def _extract_metric_and_output_from_response(
         self, output: dict
-    ) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[Optional[List[str]], Optional[str], Optional[str], Optional[str]]:
         """
-        Extract semantic model file, metric file, status and formatted output from model response.
+        Extract semantic model files, metric file, status and formatted output from model response.
 
         Per prompt template requirements, LLM should return JSON format:
-        {"semantic_model_file": "path.yml", "metric_file": "path.yml",
+        {"semantic_model_files": ["path.yml"], "metric_file": "path.yml",
          "status": "generated" | "skipped", "output": "markdown text"}
 
         ``status`` is optional for backward compatibility; absent values are treated as ``"generated"``.
@@ -687,7 +689,7 @@ class GenMetricsAgenticNode(AgenticNode):
             output: Output dictionary from model generation
 
         Returns:
-            Tuple of (semantic_model_file, metric_file, status, output_string), each Optional[str].
+            Tuple of (semantic_model_files, metric_file, status, output_string).
         """
         try:
             from datus.utils.json_utils import strip_json_str
@@ -698,17 +700,22 @@ class GenMetricsAgenticNode(AgenticNode):
             # Case 1: content is already a dict (most common)
             if isinstance(content, dict):
                 output_text = content.get("output")
-                semantic_model_file = content.get("semantic_model_file")
+                semantic_model_files = content.get("semantic_model_files")
                 metric_file = content.get("metric_file")
                 status = content.get("status")
                 normalized_status = status.strip().lower() if isinstance(status, str) else None
 
                 if (metric_file and isinstance(metric_file, str)) or normalized_status:
                     logger.debug(
-                        f"Extracted from dict: semantic_model_file={semantic_model_file}, "
+                        f"Extracted from dict: semantic_model_files={semantic_model_files}, "
                         f"metric_file={metric_file}, status={normalized_status}"
                     )
-                    return semantic_model_file, metric_file, normalized_status, output_text
+                    return (
+                        semantic_model_files if isinstance(semantic_model_files, list) else [],
+                        metric_file,
+                        normalized_status,
+                        output_text,
+                    )
 
                 logger.warning(f"Dict format but missing expected keys or invalid format: {content.keys()}")
 
@@ -723,7 +730,7 @@ class GenMetricsAgenticNode(AgenticNode):
                         parsed = json_repair.loads(cleaned_json)
                         if isinstance(parsed, dict):
                             output_text = parsed.get("output")
-                            semantic_model_file = parsed.get("semantic_model_file")
+                            semantic_model_files = parsed.get("semantic_model_files")
                             metric_file = parsed.get("metric_file")
                             status = parsed.get("status")
                             normalized_status = status.strip().lower() if isinstance(status, str) else None
@@ -731,10 +738,15 @@ class GenMetricsAgenticNode(AgenticNode):
                             if (metric_file and isinstance(metric_file, str)) or normalized_status:
                                 logger.debug(
                                     f"Extracted from JSON string: "
-                                    f"semantic_model_file={semantic_model_file}, "
+                                    f"semantic_model_files={semantic_model_files}, "
                                     f"metric_file={metric_file}, status={normalized_status}"
                                 )
-                                return semantic_model_file, metric_file, normalized_status, output_text
+                                return (
+                                    semantic_model_files if isinstance(semantic_model_files, list) else [],
+                                    metric_file,
+                                    normalized_status,
+                                    output_text,
+                                )
 
                             logger.warning(f"Parsed JSON but missing expected keys or invalid format: {parsed.keys()}")
                     except Exception as e:

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -572,9 +572,6 @@ class GenMetricsAgenticNode(AgenticNode):
                 continue
             blocked_sources.update(cls._source_name_set(item.get("source_sql_name")))
 
-        if blocked_sources:
-            return blocked_sources
-
         for item in candidate_plan.get("blocked_direct_metric_candidates") or []:
             if isinstance(item, dict):
                 blocked_sources.update(cls._source_name_set(item.get("source_sql_name")))

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -339,6 +339,7 @@ def _classify_subject_paths(
         from datus.storage.metric.store import MetricRAG
         from datus.storage.reference_sql.store import ReferenceSqlRAG
         from datus.storage.registry import get_subject_tree_store
+        from datus.storage.scope import datasource_storage_namespace
         from datus.utils.reference_paths import split_reference_path
     except ImportError:
         logger.warning(
@@ -356,7 +357,7 @@ def _classify_subject_paths(
         return buckets
 
     try:
-        subject_tree = get_subject_tree_store(project=agent_config.project_name)
+        subject_tree = get_subject_tree_store(project=datasource_storage_namespace(agent_config, ds))
         metric_storage = MetricRAG(agent_config, datasource_id=ds).storage
         sql_storage = ReferenceSqlRAG(agent_config, datasource_id=ds).reference_sql_storage
         knowledge_storage = ExtKnowledgeRAG(agent_config, datasource_id=ds).store

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -40,8 +40,28 @@ class ExplorerService:
             agent_config: Agent configuration object
         """
         self.agent_config = agent_config
-        self.datasource_id = agent_config.current_datasource
+        self.datasource_id = ""
+        self._storage_init_error = ""
+        self.metric_rag = None
+        self.reference_sql_rag = None
+        self.knowledge_rag = None
+        self.semantic_model_rag = None
+        self.subject_tree_store = None
+        self._bind_storage_if_available()
         logger.info("ExplorerService initialized")
+
+    def _bind_storage_if_available(self) -> bool:
+        if self.datasource_id:
+            return True
+
+        from datus.storage.scope import resolve_datasource_scope
+
+        try:
+            datasource_id, storage_namespace = resolve_datasource_scope(self.agent_config)
+        except ValueError as exc:
+            self._storage_init_error = str(exc)
+            logger.warning("ExplorerService storage is unavailable without datasource: %s", exc)
+            return False
 
         from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
         from datus.storage.metric.store import MetricRAG
@@ -49,11 +69,18 @@ class ExplorerService:
         from datus.storage.registry import get_subject_tree_store
         from datus.storage.semantic_model.store import SemanticModelRAG
 
-        self.metric_rag = MetricRAG(agent_config, datasource_id=self.datasource_id)
-        self.reference_sql_rag = ReferenceSqlRAG(agent_config, datasource_id=self.datasource_id)
-        self.knowledge_rag = ExtKnowledgeRAG(agent_config, datasource_id=self.datasource_id)
-        self.semantic_model_rag = SemanticModelRAG(agent_config, datasource_id=self.datasource_id)
-        self.subject_tree_store = get_subject_tree_store(project=agent_config.project_name)
+        self.datasource_id = datasource_id
+        self.metric_rag = MetricRAG(self.agent_config, datasource_id=self.datasource_id)
+        self.reference_sql_rag = ReferenceSqlRAG(self.agent_config, datasource_id=self.datasource_id)
+        self.knowledge_rag = ExtKnowledgeRAG(self.agent_config, datasource_id=self.datasource_id)
+        self.semantic_model_rag = SemanticModelRAG(self.agent_config, datasource_id=self.datasource_id)
+        self.subject_tree_store = get_subject_tree_store(project=storage_namespace)
+        self._storage_init_error = ""
+        return True
+
+    def _require_datasource_bound(self) -> None:
+        if not self._bind_storage_if_available():
+            raise RuntimeError(self._storage_init_error or "datasource is required for explorer storage operations")
 
     def _gen_reference_sql_id(self, sql: str) -> str:
         """Generate a stable identifier for reference SQL entries."""
@@ -221,6 +248,10 @@ class ExplorerService:
 
             from datus.api.models.explorer_models import SubjectNodeType
 
+            if not self._bind_storage_if_available() or self.subject_tree_store is None:
+                logger.warning("Explorer subject list requested before datasource is bound; returning empty list")
+                return Result[SubjectListData](success=True, data=SubjectListData(subjects=[]))
+
             # Get tree structure from subject tree store
             tree_structure = self.subject_tree_store.get_tree_structure()
 
@@ -333,6 +364,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Creating directory at path: {request.subject_path}")
+            self._require_datasource_bound()
 
             # Use SubjectTreeStore to create or find the directory path
             # The last element in subject_path is the new directory name
@@ -372,6 +404,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Creating reference SQL '{request.name}' at path: {request.subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
 
             if not request.subject_path or not request.name:
@@ -427,6 +460,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Renaming {request.type} from {request.subject_path} to {request.new_subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
             from datus.api.models.explorer_models import SubjectNodeType
 
@@ -552,6 +586,7 @@ class ExplorerService:
             from datus.api.models.config_models import ErrorCode
 
             logger.info(f"Getting metric at path: {subject_path}")
+            self._require_datasource_bound()
 
             if not subject_path or len(subject_path) < 1:
                 return Result[MetricInfo](
@@ -615,6 +650,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Getting reference SQL at path: {subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
 
             if not subject_path or len(subject_path) < 1:
@@ -689,6 +725,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Editing reference SQL at path: {request.subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
 
             if not request.subject_path or len(request.subject_path) < 1:
@@ -765,6 +802,7 @@ class ExplorerService:
             from datus.cli.generation_hooks import GenerationHooks
 
             logger.info(f"Creating metric at parent path: {request.subject_path}")
+            self._require_datasource_bound()
 
             # subject_path is the parent directory
             parent_path = request.subject_path if request.subject_path else []
@@ -908,6 +946,7 @@ class ExplorerService:
             from datus.cli.generation_hooks import GenerationHooks
 
             logger.info(f"Editing metric at path: {request.subject_path}")
+            self._require_datasource_bound()
 
             if not request.subject_path or len(request.subject_path) < 1:
                 return Result[dict](
@@ -1053,6 +1092,7 @@ class ExplorerService:
             from datus.api.models.config_models import ErrorCode
 
             logger.info(f"Editing semantic model entry: {request.entry_id}")
+            self._require_datasource_bound()
 
             if not request.entry_id:
                 return Result[dict](
@@ -1097,6 +1137,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Creating knowledge '{request.name}' at path: {request.subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
 
             if not request.subject_path or not request.name:
@@ -1156,6 +1197,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Getting knowledge at path: {subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
 
             if not subject_path or len(subject_path) < 1:
@@ -1229,6 +1271,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Editing knowledge at path: {request.subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
 
             if not request.subject_path or len(request.subject_path) < 2:
@@ -1294,6 +1337,7 @@ class ExplorerService:
         """
         try:
             logger.info(f"Deleting {request.type} at path: {request.subject_path}")
+            self._require_datasource_bound()
             from datus.api.models.config_models import ErrorCode
             from datus.api.models.explorer_models import SubjectNodeType
 

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -41,6 +41,7 @@ class ExplorerService:
         """
         self.agent_config = agent_config
         self.datasource_id = ""
+        self.storage_namespace = ""
         self._storage_init_error = ""
         self.metric_rag = None
         self.reference_sql_rag = None
@@ -50,18 +51,29 @@ class ExplorerService:
         self._bind_storage_if_available()
         logger.info("ExplorerService initialized")
 
-    def _bind_storage_if_available(self) -> bool:
-        if self.datasource_id:
-            return True
+    def _clear_storage_binding(self, error: str = "") -> None:
+        self.datasource_id = ""
+        self.storage_namespace = ""
+        self.metric_rag = None
+        self.reference_sql_rag = None
+        self.knowledge_rag = None
+        self.semantic_model_rag = None
+        self.subject_tree_store = None
+        self._storage_init_error = error
 
+    def _bind_storage_if_available(self) -> bool:
         from datus.storage.scope import resolve_datasource_scope
+        from datus.utils.exceptions import DatusException
 
         try:
             datasource_id, storage_namespace = resolve_datasource_scope(self.agent_config)
-        except ValueError as exc:
-            self._storage_init_error = str(exc)
+        except DatusException as exc:
+            self._clear_storage_binding(str(exc))
             logger.warning("ExplorerService storage is unavailable without datasource: %s", exc)
             return False
+
+        if self.datasource_id == datasource_id and self.storage_namespace == storage_namespace:
+            return True
 
         from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
         from datus.storage.metric.store import MetricRAG
@@ -70,6 +82,7 @@ class ExplorerService:
         from datus.storage.semantic_model.store import SemanticModelRAG
 
         self.datasource_id = datasource_id
+        self.storage_namespace = storage_namespace
         self.metric_rag = MetricRAG(self.agent_config, datasource_id=self.datasource_id)
         self.reference_sql_rag = ReferenceSqlRAG(self.agent_config, datasource_id=self.datasource_id)
         self.knowledge_rag = ExtKnowledgeRAG(self.agent_config, datasource_id=self.datasource_id)

--- a/datus/cli/bootstrap_streams.py
+++ b/datus/cli/bootstrap_streams.py
@@ -358,8 +358,8 @@ async def stream_reference_sql(
 
     if build_mode == "overwrite":
         logger.info(
-            "[overwrite] Wiping reference_sql store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping reference_sql store for datasource '%s' before re-population",
+            agent_config.current_datasource,
         )
         storage.truncate()
         yield message_action("Reference SQL: cleared existing entries (overwrite mode).")
@@ -553,17 +553,15 @@ async def stream_metrics(
     *,
     datasource: str,
     success_story: str,
-    pool_size: int = 3,  # noqa: ARG001 - reserved; the underlying batch is single-LLM-call
+    pool_size: int = 5,
     build_mode: str = "incremental",
     subject_tree: Optional[List[str]] = None,
 ) -> AsyncGenerator[ActionHistory, None]:
     """Wrap :class:`GenMetricsAgenticNode` invocation as a ``gen_metrics`` task group.
 
-    ``pool_size`` is accepted for form parity with other tabs but the
-    underlying ``init_success_story_metrics_async`` invokes the LLM once
-    per CSV (single batch), so it is not currently consumed.
+    For metrics, ``pool_size`` controls SQL queries per generation batch. The
+    name is kept for CLI/TUI parity with other bootstrap components.
     """
-    del pool_size  # explicit parity; unused
     if not datasource:
         yield message_action("Metrics: --datasource is required, skipping.", status=ActionStatus.FAILED)
         return
@@ -583,6 +581,7 @@ async def stream_metrics(
             emit=emit,
             build_mode=build_mode,
             action_callback=on_action,
+            batch_size=max(1, int(pool_size)),
         )
 
     async def _inner(_mgr):

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -375,14 +375,14 @@ class GenerationHooks(AgentHooks):
         Handle end_metric_generation tool result.
 
         Args:
-            result: Tool result containing metric_file, optional semantic_model_file, and metric_sqls
+            result: Tool result containing metric_file, optional semantic_model_files, and metric_sqls
         """
         try:
             if not self._result_success(result):
                 logger.info(f"Skipping metric sync because generation tool failed: {result}")
                 return
 
-            metric_file, semantic_model_file, metric_sqls = self._extract_metric_generation_result(result)
+            metric_file, semantic_model_files, metric_sqls = self._extract_metric_generation_result(result)
 
             if not metric_file:
                 logger.warning(f"Could not extract metric_file from end_metric_generation result: {result}")
@@ -392,16 +392,19 @@ class GenerationHooks(AgentHooks):
             # workspace using the shared resolver. This applies the same containment
             # check (path traversal rejection) as the other generation kinds.
             metric_file = self._resolve_path(metric_file, "semantic")
-            semantic_model_file = self._resolve_path(semantic_model_file, "semantic")
+            semantic_model_files = [
+                resolved
+                for resolved in (self._resolve_path(path, "semantic") for path in semantic_model_files)
+                if resolved
+            ]
 
             logger.debug(
                 f"Processing metric generation: metric_file={metric_file}, "
-                f"semantic_model_file={semantic_model_file}, metric_sqls={list(metric_sqls.keys())}"
+                f"semantic_model_files={semantic_model_files}, metric_sqls={list(metric_sqls.keys())}"
             )
 
-            if semantic_model_file:
-                # Process both files together for proper association
-                await self._process_metric_with_semantic_model(semantic_model_file, metric_file, metric_sqls)
+            if semantic_model_files:
+                await self._process_metric_with_semantic_models(semantic_model_files, metric_file, metric_sqls)
             else:
                 # Process metric file alone (semantic model already exists in KB)
                 await self._process_single_file(metric_file, metric_sqls=metric_sqls, yaml_type="metric")
@@ -437,13 +440,13 @@ class GenerationHooks(AgentHooks):
 
     def _extract_metric_generation_result(self, result) -> tuple:
         """
-        Extract metric_file, semantic_model_file, and metric_sqls from tool result.
+        Extract metric_file, semantic_model_files, and metric_sqls from tool result.
 
         Args:
             result: Tool result (dict or FuncToolResult object)
 
         Returns:
-            Tuple of (metric_file, semantic_model_file, metric_sqls)
+            Tuple of (metric_file, semantic_model_files, metric_sqls)
         """
         # Debug: log raw result type and content
         logger.info(f"_extract_metric_generation_result raw result: type={type(result).__name__}, value={result}")
@@ -456,13 +459,15 @@ class GenerationHooks(AgentHooks):
 
         if isinstance(result_dict, dict):
             metric_file = result_dict.get("metric_file", "")
-            semantic_model_file = result_dict.get("semantic_model_file", "")
+            semantic_model_files = result_dict.get("semantic_model_files", [])
+            if not isinstance(semantic_model_files, list):
+                semantic_model_files = []
             metric_sqls = result_dict.get("metric_sqls", {})
             logger.info(f"Extracted from end_metric_generation: metric_sqls={metric_sqls}")
-            return metric_file, semantic_model_file, metric_sqls
+            return metric_file, semantic_model_files, metric_sqls
 
         logger.warning(f"Could not extract metric_generation_result from: {result}")
-        return "", "", {}
+        return "", [], {}
 
     async def _process_single_file(self, file_path: str, metric_sqls: dict = None, yaml_type: str = "semantic"):
         """
@@ -499,49 +504,34 @@ class GenerationHooks(AgentHooks):
     async def _process_metric_with_semantic_model(
         self, semantic_model_file: str, metric_file: str, metric_sqls: dict = None
     ):
+        await self._process_metric_with_semantic_models([semantic_model_file], metric_file, metric_sqls)
+
+    async def _process_metric_with_semantic_models(
+        self, semantic_model_files: list[str], metric_file: str, metric_sqls: dict = None
+    ):
         """
-        Process metric file along with its semantic model file.
-        Display both files and sync them together so metrics can reference semantic model data.
+        Process metric file after syncing all semantic model files it depends on.
 
         Args:
-            semantic_model_file: Path to the semantic model YAML file
+            semantic_model_files: Paths to semantic model YAML files
             metric_file: Path to the metric YAML file
             metric_sqls: Optional dict mapping metric names to generated SQL (from dry_run)
         """
-        # Check if files exist
-        if not os.path.exists(semantic_model_file):
-            logger.warning(f"Semantic model file {semantic_model_file} does not exist")
-            # Still try to process metric file alone
-            if os.path.exists(metric_file):
-                await self._process_single_file(metric_file, metric_sqls=metric_sqls, yaml_type="metric")
-            return
-
         if not os.path.exists(metric_file):
             logger.warning(f"Metric file {metric_file} does not exist")
-            # Still try to process semantic model file alone
-            await self._process_single_file(semantic_model_file)
+            for semantic_model_file in semantic_model_files:
+                if os.path.exists(semantic_model_file):
+                    await self._process_single_file(semantic_model_file)
             return
 
-        # Skip if both files have already been processed
-        if semantic_model_file in self.processed_files and metric_file in self.processed_files:
-            logger.info("Both files already processed, skipping")
-            return
+        existing_semantic_files = []
+        for semantic_model_file in semantic_model_files:
+            if not os.path.exists(semantic_model_file):
+                logger.warning(f"Semantic model file {semantic_model_file} does not exist")
+                continue
+            existing_semantic_files.append(semantic_model_file)
 
-        # Mark both files as processed
-        self.processed_files.add(semantic_model_file)
-        self.processed_files.add(metric_file)
-
-        # Read both files
-        with open(semantic_model_file, "r", encoding="utf-8") as f:
-            semantic_content = f.read()
-        with open(metric_file, "r", encoding="utf-8") as f:
-            metric_content = f.read()
-
-        if not semantic_content or not metric_content:
-            logger.warning("Empty content in semantic model or metric file")
-            return
-
-        await self._sync_generated_pair(semantic_model_file, metric_file, metric_sqls)
+        await self._sync_semantics_and_metric(existing_semantic_files, metric_file, metric_sqls)
 
     async def _handle_sql_summary_result(self, result):
         """
@@ -682,7 +672,7 @@ class GenerationHooks(AgentHooks):
             display_content: Deprecated. Kept for caller compatibility; ignored.
         """
         try:
-            await self._sync_semantic_and_metric(semantic_model_file, metric_file, metric_sqls)
+            await self._sync_semantics_and_metric([semantic_model_file], metric_file, metric_sqls)
 
         except InteractionCancelled:
             raise GenerationCancelledException("User interrupted")
@@ -798,19 +788,23 @@ class GenerationHooks(AgentHooks):
     async def _sync_semantic_and_metric(
         self, semantic_model_file: str, metric_file: str, metric_sqls: dict = None
     ) -> str:
+        return await self._sync_semantics_and_metric([semantic_model_file], metric_file, metric_sqls)
+
+    async def _sync_semantics_and_metric(
+        self, semantic_model_files: list[str], metric_file: str, metric_sqls: dict = None
+    ) -> str:
         """
-        Sync both semantic model and metric files to RAG storage.
-        Creates a combined YAML for syncing so metrics can reference semantic model data.
+        Sync semantic model files first, then sync the metric file by itself.
 
         Args:
-            semantic_model_file: Path to semantic model YAML file
+            semantic_model_files: Paths to semantic model YAML files
             metric_file: Path to metric YAML file
             metric_sqls: Optional dict mapping metric names to generated SQL (from dry_run)
 
         Returns:
             Markdown string describing the result
         """
-        files_info = f"- `{semantic_model_file}`\n- `{metric_file}`"
+        files_info = "\n".join([*(f"- `{path}`" for path in semantic_model_files), f"- `{metric_file}`"])
 
         if not self.agent_config:
             return (
@@ -821,53 +815,46 @@ class GenerationHooks(AgentHooks):
         try:
             loop = asyncio.get_event_loop()
 
-            # Load both YAML files
-            with open(semantic_model_file, "r", encoding="utf-8") as f:
-                semantic_docs = list(yaml.safe_load_all(f))
-            with open(metric_file, "r", encoding="utf-8") as f:
-                metric_docs = list(yaml.safe_load_all(f))
-
-            # Create a temporary combined YAML content
-            combined_docs = semantic_docs + metric_docs
-            temp_file = semantic_model_file + ".combined.tmp"
-
-            try:
-                # Write combined YAML to temp file
-                with open(temp_file, "w", encoding="utf-8") as f:
-                    yaml.safe_dump_all(combined_docs, f, allow_unicode=True, sort_keys=False)
-
-                # Sync the combined file - only sync metrics, not semantic objects (avoid duplicates)
-                result = await loop.run_in_executor(
+            for semantic_model_file in semantic_model_files:
+                semantic_result = await loop.run_in_executor(
                     None,
-                    lambda: GenerationHooks._sync_semantic_to_db(
-                        temp_file,
+                    lambda semantic_model_file=semantic_model_file: GenerationHooks._sync_semantic_to_db(
+                        semantic_model_file,
                         self.agent_config,
-                        include_semantic_objects=False,  # Semantic model already synced separately
-                        include_metrics=True,
-                        metric_sqls=metric_sqls,
-                        original_yaml_path=metric_file,  # Use original metric file path, not temp file
+                        include_semantic_objects=True,
+                        include_metrics=False,
                     ),
                 )
-
-                if result.get("success"):
-                    self.generation_evidence.mark_kb_sync("metric")
-                    result_content = "**Successfully synced semantic model and metrics to Knowledge Base**\n\n"
-                    message = result.get("message", "")
-                    if message:
-                        result_content += f"{message}\n\n"
-                    result_content += f"Files:\n{files_info}"
-                    return result_content
-                else:
-                    error = result.get("error", "Unknown error")
+                if not semantic_result.get("success"):
+                    error = semantic_result.get("error", "Unknown error")
                     return f"**Sync failed:** {error}\n\nYAMLs saved to files:\n{files_info}"
+                self.generation_evidence.mark_kb_sync("semantic")
 
-            finally:
-                # Clean up temp file
-                if os.path.exists(temp_file):
-                    os.remove(temp_file)
+            result = await loop.run_in_executor(
+                None,
+                lambda: GenerationHooks._sync_semantic_to_db(
+                    metric_file,
+                    self.agent_config,
+                    include_semantic_objects=False,
+                    include_metrics=True,
+                    metric_sqls=metric_sqls,
+                    original_yaml_path=metric_file,
+                ),
+            )
+
+            if result.get("success"):
+                self.generation_evidence.mark_kb_sync("metric")
+                result_content = "**Successfully synced semantic models and metrics to Knowledge Base**\n\n"
+                message = result.get("message", "")
+                if message:
+                    result_content += f"{message}\n\n"
+                result_content += f"Files:\n{files_info}"
+                return result_content
+            error = result.get("error", "Unknown error")
+            return f"**Sync failed:** {error}\n\nYAMLs saved to files:\n{files_info}"
 
         except Exception as e:
-            logger.error(f"Error syncing semantic and metric: {e}", exc_info=True)
+            logger.error(f"Error syncing semantic models and metric: {e}", exc_info=True)
             return f"**Sync error:** {e}\n\nYAMLs saved to files:\n{files_info}"
 
     def _is_sql_summary_tool_call(self, context) -> bool:
@@ -1181,6 +1168,65 @@ class GenerationHooks(AgentHooks):
                 for ident in data_source.get("identifiers", []):
                     process_column(ident, is_ent=True)
 
+            data_source_measure_names = {
+                str(measure.get("name", "")).strip()
+                for measure in (data_source or {}).get("measures", [])
+                if isinstance(measure, dict) and str(measure.get("name", "")).strip()
+            }
+
+            def _storage_rows(rows: Any) -> list[dict[str, Any]]:
+                if rows is None:
+                    return []
+                if hasattr(rows, "to_pylist"):
+                    rows = rows.to_pylist()
+                if isinstance(rows, dict):
+                    rows = [rows]
+                if not isinstance(rows, list):
+                    return []
+                return [row for row in rows if isinstance(row, dict)]
+
+            def _lookup_measure_row(measure_name: str) -> Optional[dict[str, Any]]:
+                if not measure_name:
+                    return None
+                rows = _storage_rows(
+                    semantic_rag.storage._search_all(
+                        where=And([eq("kind", "column"), eq("is_measure", True), eq("name", measure_name)]),
+                        select_fields=[
+                            "name",
+                            "table_name",
+                            "semantic_model_name",
+                            "catalog_name",
+                            "database_name",
+                            "schema_name",
+                        ],
+                    )
+                )
+                if not rows:
+                    return None
+                coordinates = {
+                    (
+                        row.get("catalog_name", ""),
+                        row.get("database_name", ""),
+                        row.get("schema_name", ""),
+                        row.get("table_name") or row.get("semantic_model_name", ""),
+                    )
+                    for row in rows
+                }
+                if len(coordinates) > 1:
+                    raise ValueError(
+                        f"Measure '{measure_name}' exists in multiple semantic models: "
+                        f"{sorted(str(coord) for coord in coordinates)}. "
+                        "Metric generation must disambiguate the source measure."
+                    )
+                return rows[0]
+
+            def _lookup_measure_context(base_measure_names: list[str]) -> Optional[dict[str, Any]]:
+                for measure_name in base_measure_names:
+                    row = _lookup_measure_row(measure_name)
+                    if row:
+                        return row
+                return None
+
             # 3. Process Metrics (Standard Metrics) - These go to MetricStorage
             if include_metrics:
                 for metric in metrics_list:
@@ -1194,15 +1240,13 @@ class GenerationHooks(AgentHooks):
                     m_type = metric.get("type", "")
 
                     # Parse tags for subject_path (domain/layer1/layer2)
-                    subject_path = []
+                    raw_subject_path = []
                     locked_meta = metric.get("locked_metadata", {})
                     if locked_meta:
                         tags = locked_meta.get("tags", [])
                         parsed_path = GenerationHooks._parse_subject_tree_from_tags(tags)
                         if parsed_path:
-                            subject_path = parsed_path
-
-                    subject_path = _normalize_metric_subject_path(agent_config, subject_path, table_name)
+                            raw_subject_path = parsed_path
 
                     # Extract type_params for measure_expr, base_measures
                     type_params = metric.get("type_params", {})
@@ -1281,8 +1325,40 @@ class GenerationHooks(AgentHooks):
                     # Extract dimensions and entities from data_source if available
                     dimensions = []
                     entities = []
-                    metric_table_name = table_name  # Track semantic model name for this metric
-                    if data_source:
+                    metric_table_name = ""
+                    metric_catalog_name = catalog_name
+                    metric_database_name = database_name
+                    metric_schema_name = schema_name
+
+                    measure_context = _lookup_measure_context(base_measures) if base_measures else None
+                    if measure_context:
+                        metric_table_name = measure_context.get("table_name") or measure_context.get(
+                            "semantic_model_name", ""
+                        )
+                        metric_catalog_name = measure_context.get("catalog_name", metric_catalog_name)
+                        metric_database_name = measure_context.get("database_name", metric_database_name)
+                        metric_schema_name = measure_context.get("schema_name", metric_schema_name)
+                        if metric_table_name:
+                            sm_result = semantic_rag.get_semantic_model(
+                                table_name=metric_table_name,
+                                select_fields=["dimensions", "identifiers"],
+                            )
+                            if sm_result:
+                                for dim in sm_result.get("dimensions", []):
+                                    dim_name = dim.get("name")
+                                    if dim_name:
+                                        dimensions.append(dim_name)
+                                for ident in sm_result.get("identifiers", []):
+                                    ident_name = ident.get("name")
+                                    if ident_name:
+                                        entities.append(ident_name)
+                                logger.debug(
+                                    f"Retrieved dims/ents from KB for metric {m_name} "
+                                    f"(table: {metric_table_name}): {len(dimensions)} dims, "
+                                    f"{len(entities)} ents"
+                                )
+                    elif data_source and (not base_measures or data_source_measure_names.intersection(base_measures)):
+                        metric_table_name = table_name
                         # Get dimension names
                         for dim in data_source.get("dimensions", []):
                             dim_name = dim.get("name")
@@ -1293,41 +1369,10 @@ class GenerationHooks(AgentHooks):
                             ident_name = ident.get("name")
                             if ident_name:
                                 entities.append(ident_name)
-                    elif base_measures:
-                        # Fallback: query dimensions/entities from Knowledge Base
-                        # when data_source is not in the same YAML file (multi-table scenario)
-                        try:
-                            # Find semantic model containing the first base measure
-                            measure_name = base_measures[0]
-                            # Query semantic objects to find the measure's table
-                            measure_objs = semantic_rag.storage._search_all(
-                                where=And([eq("kind", "column"), eq("is_measure", True), eq("name", measure_name)])
-                            ).to_pylist()
-                            if measure_objs:
-                                measure_table = measure_objs[0].get("table_name", "")
-                                if measure_table:
-                                    metric_table_name = measure_table
-                                    # Now query dimensions and entities for this table
-                                    sm_result = semantic_rag.get_semantic_model(
-                                        table_name=measure_table,
-                                        select_fields=["dimensions", "identifiers"],
-                                    )
-                                    if sm_result:
-                                        for dim in sm_result.get("dimensions", []):
-                                            dim_name = dim.get("name")
-                                            if dim_name:
-                                                dimensions.append(dim_name)
-                                        for ident in sm_result.get("identifiers", []):
-                                            ident_name = ident.get("name")
-                                            if ident_name:
-                                                entities.append(ident_name)
-                                        logger.debug(
-                                            f"Retrieved dims/ents from KB for metric {m_name} "
-                                            f"(table: {measure_table}): {len(dimensions)} dims, "
-                                            f"{len(entities)} ents"
-                                        )
-                        except Exception as e:
-                            logger.warning(f"Failed to query dimensions from KB for metric {m_name}: {e}")
+                    else:
+                        metric_table_name = table_name
+
+                    subject_path = _normalize_metric_subject_path(agent_config, raw_subject_path, metric_table_name)
 
                     # Build metric object for MetricStorage
                     metric_obj = {
@@ -1344,9 +1389,9 @@ class GenerationHooks(AgentHooks):
                         "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                         "updated_at": datetime.now().replace(microsecond=0),
                         # Database hierarchy
-                        "catalog_name": catalog_name,
-                        "database_name": database_name,
-                        "schema_name": schema_name,
+                        "catalog_name": metric_catalog_name,
+                        "database_name": metric_database_name,
+                        "schema_name": metric_schema_name,
                         # Generated SQL from dry_run
                         "sql": metric_sqls.get(m_name, "") if metric_sqls else "",
                         "yaml_path": yaml_path_to_store,

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -9,7 +9,7 @@ import asyncio
 import json
 import os
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import yaml
 from agents.lifecycle import AgentHooks
@@ -17,15 +17,63 @@ from datus_storage_base.conditions import And, eq
 
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
 from datus.configuration.agent_config import AgentConfig
-from datus.storage.metric.store import MetricRAG, build_metric_id
+from datus.storage.metric.store import MetricRAG, build_metric_id, metric_definition_conflict, normalize_metric_name
+from datus.storage.metric.subject_path import (
+    default_metric_subject_path,
+    normalize_metric_subject_path,
+)
 from datus.storage.reference_sql.store import ReferenceSqlRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
+from datus.storage.table_identity import build_semantic_table_identity
 from datus.tools.db_tools import connector_registry
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.utils.constants import DBType
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+
+def _deduplicate_metric_objects_by_name(metric_objects: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep metric names datasource-local and reject conflicting duplicate definitions."""
+
+    deduplicated: list[dict[str, Any]] = []
+    index_by_name: dict[str, int] = {}
+    for metric in metric_objects:
+        normalized = normalize_metric_name(metric.get("name"))
+        if not normalized:
+            continue
+        existing_index = index_by_name.get(normalized)
+        if existing_index is None:
+            index_by_name[normalized] = len(deduplicated)
+            deduplicated.append(metric)
+            continue
+
+        existing = deduplicated[existing_index]
+        conflict_field = metric_definition_conflict(existing, metric)
+        if conflict_field:
+            raise ValueError(
+                f"Metric name conflict within datasource for '{metric.get('name')}': "
+                f"field '{conflict_field}' differs in the same sync batch. "
+                "Metric names must be unique within a datasource."
+            )
+        deduplicated[existing_index] = metric
+    return deduplicated
+
+
+def _default_metric_subject_path(agent_config: AgentConfig, table_name: str) -> list[str]:
+    datasource = str(getattr(agent_config, "current_datasource", "") or "").strip()
+    return default_metric_subject_path(datasource, table_name)
+
+
+def _normalize_metric_subject_path(
+    agent_config: AgentConfig,
+    subject_path: Optional[list[str]],
+    table_name: str,
+) -> list[str]:
+    if not subject_path:
+        return _default_metric_subject_path(agent_config, table_name)
+    datasource = str(getattr(agent_config, "current_datasource", "") or "").strip()
+    return normalize_metric_subject_path(subject_path, datasource=datasource, table_name=table_name)
 
 
 class GenerationCancelledException(Exception):
@@ -967,6 +1015,7 @@ class GenerationHooks(AgentHooks):
 
             current_db_config = agent_config.current_db_config()
             table_name = ""
+            table_identity = ""
 
             # Get database hierarchy info
             # Prioritize explicitly passed parameters, then fallback to current db config
@@ -1018,15 +1067,22 @@ class GenerationHooks(AgentHooks):
                 if not connector_registry.support_schema(agent_config.db_type):
                     schema_name = ""
 
-                # Build fully qualified name (excluding empty parts)
-                fq_parts = [p for p in [catalog_name, database_name, schema_name, table_name] if p]
-                table_fq_name = ".".join(fq_parts)
+                table_identity = build_semantic_table_identity(
+                    {
+                        "catalog_name": catalog_name,
+                        "database_name": database_name,
+                        "schema_name": schema_name,
+                        "table_name": table_name,
+                    },
+                    agent_config.db_type,
+                )
+                table_fq_name = table_identity
 
             # 2. Create and store semantic objects (table/columns) only when requested
             if data_source and include_semantic_objects:
                 # --- A. Table Object ---
                 table_obj = {
-                    "id": f"table:{table_name}",
+                    "id": f"table:{table_identity}",
                     "kind": "table",
                     "name": table_name,
                     "fq_name": table_fq_name,
@@ -1056,7 +1112,7 @@ class GenerationHooks(AgentHooks):
                     "entity": "",
                 }
                 semantic_objects.append(table_obj)
-                synced_items.append(f"table:{table_name}")
+                synced_items.append(f"table:{table_identity}")
 
                 # --- B. Column Objects (Measures & Dimensions & Identifiers) ---
 
@@ -1078,7 +1134,7 @@ class GenerationHooks(AgentHooks):
                         time_granularity = type_params.get("time_granularity", "")
 
                     col_obj = {
-                        "id": f"column:{table_name}.{col_name}",
+                        "id": f"column:{table_identity}.{col_name}",
                         "kind": "column",
                         "name": col_name,
                         "fq_name": f"{table_fq_name}.{col_name}",
@@ -1146,9 +1202,7 @@ class GenerationHooks(AgentHooks):
                         if parsed_path:
                             subject_path = parsed_path
 
-                    # If no subject_path found, use default path with semantic_model_name
-                    if not subject_path:
-                        subject_path = ["Metrics", table_name if table_name else "Unknown"]
+                    subject_path = _normalize_metric_subject_path(agent_config, subject_path, table_name)
 
                     # Extract type_params for measure_expr, base_measures
                     type_params = metric.get("type_params", {})
@@ -1299,6 +1353,9 @@ class GenerationHooks(AgentHooks):
                     }
                     metric_objects.append(metric_obj)
                     synced_items.append(f"metric:{m_name}")
+
+            if metric_objects:
+                metric_objects = _deduplicate_metric_objects_by_name(metric_objects)
 
             # Store all objects using upsert (update if id exists, insert if not)
             all_objects = semantic_objects + metric_objects

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1220,12 +1220,32 @@ class GenerationHooks(AgentHooks):
                     )
                 return rows[0]
 
-            def _lookup_measure_context(base_measure_names: list[str]) -> Optional[dict[str, Any]]:
+            def _measure_coordinate(row: dict[str, Any]) -> tuple[str, str, str, str]:
+                return (
+                    str(row.get("catalog_name") or ""),
+                    str(row.get("database_name") or ""),
+                    str(row.get("schema_name") or ""),
+                    str(row.get("table_name") or row.get("semantic_model_name") or ""),
+                )
+
+            def _measure_context_label(row: dict[str, Any]) -> str:
+                return ".".join(part for part in _measure_coordinate(row) if part)
+
+            def _common_context_value(rows: list[dict[str, Any]], field: str, default: str = "") -> str:
+                values = {str(row.get(field) or "") for row in rows}
+                return values.pop() if len(values) == 1 else default
+
+            def _lookup_measure_contexts(base_measure_names: list[str]) -> list[dict[str, Any]]:
+                contexts: list[dict[str, Any]] = []
+                seen_coordinates: set[tuple[str, str, str, str]] = set()
                 for measure_name in base_measure_names:
                     row = _lookup_measure_row(measure_name)
                     if row:
-                        return row
-                return None
+                        coordinate = _measure_coordinate(row)
+                        if coordinate not in seen_coordinates:
+                            seen_coordinates.add(coordinate)
+                            contexts.append(row)
+                return contexts
 
             # 3. Process Metrics (Standard Metrics) - These go to MetricStorage
             if include_metrics:
@@ -1330,31 +1350,49 @@ class GenerationHooks(AgentHooks):
                     metric_database_name = database_name
                     metric_schema_name = schema_name
 
-                    measure_context = _lookup_measure_context(base_measures) if base_measures else None
-                    if measure_context:
-                        metric_table_name = measure_context.get("table_name") or measure_context.get(
-                            "semantic_model_name", ""
-                        )
-                        metric_catalog_name = measure_context.get("catalog_name", metric_catalog_name)
-                        metric_database_name = measure_context.get("database_name", metric_database_name)
-                        metric_schema_name = measure_context.get("schema_name", metric_schema_name)
-                        if metric_table_name:
+                    measure_contexts = _lookup_measure_contexts(base_measures) if base_measures else []
+                    if measure_contexts:
+                        if len(measure_contexts) == 1:
+                            measure_context = measure_contexts[0]
+                            metric_table_name = measure_context.get("table_name") or measure_context.get(
+                                "semantic_model_name", ""
+                            )
+                        else:
+                            metric_table_name = ",".join(
+                                _measure_context_label(context) for context in measure_contexts
+                            )
+                        metric_catalog_name = _common_context_value(measure_contexts, "catalog_name")
+                        metric_database_name = _common_context_value(measure_contexts, "database_name")
+                        metric_schema_name = _common_context_value(measure_contexts, "schema_name")
+                        seen_dimensions: set[str] = set()
+                        seen_entities: set[str] = set()
+                        for measure_context in measure_contexts:
+                            context_table_name = measure_context.get("table_name") or measure_context.get(
+                                "semantic_model_name", ""
+                            )
+                            if not context_table_name:
+                                continue
                             sm_result = semantic_rag.get_semantic_model(
-                                table_name=metric_table_name,
+                                catalog_name=measure_context.get("catalog_name", ""),
+                                database_name=measure_context.get("database_name", ""),
+                                schema_name=measure_context.get("schema_name", ""),
+                                table_name=context_table_name,
                                 select_fields=["dimensions", "identifiers"],
                             )
                             if sm_result:
                                 for dim in sm_result.get("dimensions", []):
                                     dim_name = dim.get("name")
-                                    if dim_name:
+                                    if dim_name and dim_name not in seen_dimensions:
+                                        seen_dimensions.add(dim_name)
                                         dimensions.append(dim_name)
                                 for ident in sm_result.get("identifiers", []):
                                     ident_name = ident.get("name")
-                                    if ident_name:
+                                    if ident_name and ident_name not in seen_entities:
+                                        seen_entities.add(ident_name)
                                         entities.append(ident_name)
                                 logger.debug(
                                     f"Retrieved dims/ents from KB for metric {m_name} "
-                                    f"(table: {metric_table_name}): {len(dimensions)} dims, "
+                                    f"(table: {context_table_name}): {len(dimensions)} dims, "
                                     f"{len(entities)} ents"
                                 )
                     elif data_source and (not base_measures or data_source_measure_names.intersection(base_measures)):

--- a/datus/cli/init_util.py
+++ b/datus/cli/init_util.py
@@ -92,14 +92,6 @@ def init_metrics(
         console = Console(log_path=False)
     try:
         if build_model == "overwrite":
-            from datus.storage.backend_holder import create_vector_connection
-
-            db = create_vector_connection(agent_config.project_name)
-            try:
-                db.drop_table("metrics", ignore_missing=True)
-                logger.info("Dropped existing metrics table")
-            finally:
-                db.close()
             agent_config.save_storage_config("metric")
 
         # Create StreamOutputManager
@@ -194,19 +186,11 @@ def init_semantic_model(
 
     try:
         if build_mode == "overwrite":
-            from datus.storage.backend_holder import create_vector_connection
-
-            db = create_vector_connection(agent_config.project_name)
-            try:
-                db.drop_table("semantic_model", ignore_missing=True)
-                logger.info("Dropped existing semantic_model table")
-            finally:
-                db.close()
             # Clear the datasource-scoped semantic_models directory (YAML files).
             semantic_yaml_dir = agent_config.path_manager.semantic_model_path(agent_config.current_datasource)
             if semantic_yaml_dir.exists() and not safe_rmtree(
                 semantic_yaml_dir,
-                f"project semantic YAML directory (shared by all databases in {agent_config.project_name!r})",
+                f"semantic YAML directory for datasource {agent_config.current_datasource!r}",
                 force=force,
             ):
                 console.print("[yellow]Cancelled by user[/yellow]")

--- a/datus/cli/interactive_init.py
+++ b/datus/cli/interactive_init.py
@@ -726,15 +726,6 @@ def init_metadata_and_log_result(datasource_name: str, config_path: str, console
         try:
             if kb_update_strategy == "overwrite":
                 agent_config.save_storage_config("database")
-                from datus.storage.backend_holder import create_vector_connection
-
-                db = create_vector_connection(agent_config.project_name)
-                try:
-                    db.drop_table("schema_metadata", ignore_missing=True)
-                    db.drop_table("schema_value", ignore_missing=True)
-                    logger.info("Dropped existing schema_metadata and schema_value tables")
-                finally:
-                    db.close()
             else:
                 agent_config.check_init_storage_config("database")
 
@@ -815,15 +806,7 @@ def do_init_sql_and_log_result(
 
         if kb_update_strategy == "overwrite":
             agent_config.save_storage_config("reference_sql")
-
-            from datus.storage.backend_holder import create_vector_connection
-
-            db = create_vector_connection(agent_config.project_name)
-            try:
-                db.drop_table("reference_sql", ignore_missing=True)
-                logger.info("Dropped existing reference_sql table")
-            finally:
-                db.close()
+            ReferenceSqlRAG(agent_config).truncate()
             # Also clear the sql_summaries directory (YAML files)
             sql_summary_dir = agent_config.path_manager.sql_summary_path()
             if sql_summary_dir.exists() and not safe_rmtree(sql_summary_dir, "SQL summary directory", force=force):

--- a/datus/main.py
+++ b/datus/main.py
@@ -227,7 +227,10 @@ def create_parser() -> argparse.ArgumentParser:
         "--pool_size",
         type=int,
         default=4,
-        help="Number of threads to initialize bootstrap-kb, default is 4",
+        help=(
+            "Bootstrap concurrency/batch size, default is 4. For metrics, this controls "
+            "SQL queries per gen_metrics batch."
+        ),
     )
     bootstrap_parser.add_argument(
         "--success_story",

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.1.j2
@@ -187,11 +187,11 @@ If `query_metrics(dry_run=True)` fails for any metric, fix the YAML and rerun
 
 ### Step 11: Complete Generation
 
-After validation succeeds and SQLs are collected, prefer calling `end_metric_generation` tool with the metric SQLs as a JSON string so publish errors are caught while you can still fix files. If you forget this tool, the host will still use the final JSON `metric_file` to validate, dry-run, and publish the generated metrics before reporting success. `metric_file` and `semantic_model_file` use the same `{{ kind_subdir }}/` prefix you wrote to:
+After validation succeeds and SQLs are collected, prefer calling `end_metric_generation` tool with the metric SQLs as a JSON string so publish errors are caught while you can still fix files. If you forget this tool, the host will still use the final JSON `metric_file` to validate, dry-run, and publish the generated metrics before reporting success. `metric_file` and `semantic_model_files` use the same `{{ kind_subdir }}/` prefix you wrote to:
 ```
 end_metric_generation(
     metric_file="{{ kind_subdir }}/metrics/users_metrics.yml",
-    semantic_model_file="{{ kind_subdir }}/users.yml",
+    semantic_model_files=["{{ kind_subdir }}/users.yml"],
     metric_sqls_json='{"metric1": "SELECT ...", "metric2": "SELECT ..."}'
 )
 ```
@@ -206,14 +206,14 @@ end_metric_generation(
 
 ```json
 {
-  "semantic_model_file": "{{ kind_subdir }}/users.yml",
+  "semantic_model_files": ["{{ kind_subdir }}/users.yml"],
   "metric_file": "{{ kind_subdir }}/metrics/users_metrics.yml",
   "status": "generated",
   "output": "markdown summary of extracted measures and generated metrics"
 }
 ```
 
-- `semantic_model_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/users.yml"`
+- `semantic_model_files`: List of semantic model paths using the semantic model prefix. Include every semantic model file newly created or updated for this metric batch, e.g. `["{{ kind_subdir }}/users.yml"]`.
 - `metric_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/metrics/users_metrics.yml"`
 - `status`: One of `"generated"` (at least one new metric was created and is ready to publish via `end_metric_generation` or the host fallback) or `"skipped"` (every requested metric already existed and was skipped — set `metric_file` to `null` in this case).
 - `output`: Brief summary message
@@ -221,7 +221,7 @@ end_metric_generation(
 If every requested metric already exists, return:
 ```json
 {
-  "semantic_model_file": null,
+  "semantic_model_files": [],
   "metric_file": null,
   "status": "skipped",
   "output": "All requested metrics already exist; no new metric was generated."

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -92,7 +92,7 @@ Before generating metrics, verify that semantic models exist for all involved ta
 ### Step 3: Define Metrics
 
 **For SQL-based input:**
-- Call `list_metrics()` first and build `existing_metric_catalog_json` with exact metric `name`, `type`, `description` when available, and `subject_path` when available.
+- If the prompt already includes `Existing Metric Catalog JSON`, use that structured catalog directly. Otherwise call `list_metrics()` first and build `existing_metric_catalog_json` with exact metric `name`, `type`, `description` when available, `subject_path` when available, and structured compatibility fields such as base measures, dimensions, entities, and semantic model when available.
 - Call `analyze_metric_candidates_from_history` for provided historical SQL before writing files, passing `existing_metric_catalog_json`.
 - Restrict filesystem reads/writes/reuse to `{{ kind_subdir }}/...`. Do not read, reuse, edit, or sync YAML files from sibling datasource directories; they are outside the active `{{ current_datasource }}` MetricFlow adapter scope.
 - Preserve final business output expressions as metric candidates.
@@ -108,8 +108,9 @@ Before generating metrics, verify that semantic models exist for all involved ta
 - Preserve output time grain from `time_grain_evidence`. If SQL projects a day-grain field such as `CURDATE() AS part_dt` or `DATE(create_time) AS part_dt`, expose the same day-grain time dimension instead of using raw `create_time` as the primary time dimension.
 - Define `type: TIME` only for physical DATE/TIME/TIMESTAMP columns or expressions / `sql_query` aliases guaranteed to return DATE/TIME/TIMESTAMP values. Do not use numeric surrogate keys such as `*_date_sk`, `*_date_key`, `*_dt_key`, or integer YYYYMMDD keys as TIME dimensions; join/convert to a real date first.
 - Preserve `post_aggregation_constraints` such as HAVING clauses as query constraints, metric usage notes, or later derived data sources. Do not silently drop them or push them into base measures.
-- Treat `derived_metric_candidates` as second-stage metrics over existing or newly generated metrics. Generate non-derived metrics first, validate, refresh `list_metrics`, then generate derived metrics only when every referenced metric exists.
-- Treat `identity_metric_references` as evidence that the SQL selected an existing metric without a new formula. Do not generate a new metric for those references.
+	- Treat `derived_metric_candidates` as second-stage metrics over existing or newly generated metrics. Generate non-derived metrics first, validate, refresh `list_metrics`, then generate derived metrics only when every referenced metric exists.
+	- Treat `identity_metric_references` as evidence that the SQL selected an existing metric without a new formula. Do not generate a new metric for those references.
+	- When the candidate plan includes `metric_aliases` or `source_alias_mappings`, use the canonical metric name from that mapping for generation, dry-run, and final JSON. Do not create a second metric only because a later SQL uses a different alias for the same formula.
 
 **For natural language input:**
 - Identify metric type: simple counting+filter, aggregation+filter, ratio, expr, derived, or cumulative
@@ -144,7 +145,7 @@ Skip any metric that already exists — do NOT update or overwrite.
   Bare filenames are silently normalized by the host but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also tolerated.
   Never pass paths from a sibling datasource directory such as `subject/semantic_models/other_datasource/...`.
 
-1. **Write files**: Use `write_file` to save metric YAML (and semantic model if newly created)
+1. **Write files**: Use `write_file` to save metric YAML (and semantic model if newly created). If the semantic model file already exists, read and preserve its existing identifiers, measures, dimensions, `sql_table`, and `sql_query`; add only missing fields needed by the new metrics. If the metrics YAML already exists, read it first and preserve all existing `metric:` entries; append only missing new metrics and never rewrite the file with a smaller subset.
 2. **Validate (MUST PASS)**: Use `validate_semantic` — if validation fails, fix errors with `edit_file` and retry until it **passes**. Do NOT proceed to Step 6 until validation passes.
 3. **Dry-run SQL**: Use `query_metrics(metrics=["metric_name"], dry_run=True)` to generate SQL. If the source SQL groups by dimensions or a time grain, also dry-run the generated metric set with matching `dimensions` / `time_granularity` from that source query. For a source SQL with multiple output metrics, either dry-run all corresponding generated metrics together with the same grouped dimensions/time grain, or dry-run each generated metric separately with those same grouped arguments. Use `get_dimensions` to find the exact generated dimension names; if a grouped source dimension cannot be queried, fix the semantic model joins/dimensions and retry.
 

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -139,7 +139,7 @@ Skip any metric that already exists — do NOT update or overwrite.
 
 ### Step 5: Write, Validate, and Dry-Run
 
-**File paths**: All `write_file` / `edit_file` / `read_file` calls — and the `metric_file` / `semantic_model_file` arguments to `end_metric_generation` — should include the `{{ kind_subdir }}/` prefix:
+**File paths**: All `write_file` / `edit_file` / `read_file` calls — and the `metric_file` / `semantic_model_files` arguments to `end_metric_generation` — should include the `{{ kind_subdir }}/` prefix:
   - Semantic model: `{{ kind_subdir }}/{table_name}.yml`
   - Metric file: `{{ kind_subdir }}/metrics/{table_name}_metrics.yml`
   Bare filenames are silently normalized by the host but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also tolerated.
@@ -161,7 +161,8 @@ Review each generated metric yourself:
 ### Step 7: Batch Sync to Knowledge Base
 
 After all generated metrics pass validation and dry-run SQL:
-- You MUST call `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` ONCE to sync them to Knowledge Base and catch publish errors while you can still fix files
+- You MUST call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` ONCE to sync them to Knowledge Base and catch publish errors while you can still fix files
+- `semantic_model_files` must include every semantic model file newly created or updated for this batch. If one metric file contains metrics backed by multiple tables, include all affected semantic model files.
 - Do not rely on the final JSON host fallback. The host fallback is only a last-resort guard when the tool call was accidentally missed.
 - If no metrics were generated, do NOT call `end_metric_generation`
 
@@ -176,14 +177,14 @@ After all generated metrics pass validation and dry-run SQL:
 
 ```json
 {
-  "semantic_model_file": "{{ kind_subdir }}/{table_name}.yml",
+  "semantic_model_files": ["{{ kind_subdir }}/{table_name}.yml"],
   "metric_file": "{{ kind_subdir }}/metrics/{table_name}_metrics.yml",
   "status": "generated",
   "output": "markdown summary of the metric definition"
 }
 ```
 
-- `semantic_model_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/users.yml"`
+- `semantic_model_files`: List of semantic model paths using the semantic model prefix, e.g. `["{{ kind_subdir }}/users.yml"]`. Include all newly created or updated semantic model files used by the metric file.
 - `metric_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/metrics/users_metrics.yml"`
 - `status`: One of `"generated"` (at least one new metric was created and synced via `end_metric_generation`) or `"skipped"` (every requested metric already existed and was skipped per Step 4 — set `metric_file` to `null` in this case).
 - `output`: Brief summary message
@@ -192,7 +193,7 @@ After all generated metrics pass validation and dry-run SQL:
 If every requested metric already exists, return:
 ```json
 {
-  "semantic_model_file": null,
+  "semantic_model_files": [],
   "metric_file": null,
   "status": "skipped",
   "output": "All requested metrics already exist; no new metric was generated."

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -206,7 +206,7 @@ Use when: non-equi JOINs, > 2 hop joins, subqueries, LATERAL/CROSS joins, comple
 - Metric file: `subject/semantic_models/<current_datasource>/metrics/{table_name}_metrics.yml`
 
 Bare filenames are silently normalized by the host, but the prefixed form is preferred for clarity. Absolute paths are also tolerated.
-Do not read, edit, or pass `metric_file` / `semantic_model_file` paths from another datasource directory such as `subject/semantic_models/other_datasource/...`.
+Do not read, edit, or pass `metric_file` / `semantic_model_files` paths from another datasource directory such as `subject/semantic_models/other_datasource/...`.
 
 1. **Check existing**: Call `check_semantic_object_exists(name="{metric_name}", kind="metric")` for each metric confirmed in Phase 1. If it already exists, inform the user and skip it.
 
@@ -230,7 +230,8 @@ Do not read, edit, or pass `metric_file` / `semantic_model_file` paths from anot
 
 After all generated metrics have passed validation and dry-run:
 - Collect all generated metrics and their dry-run SQLs into `metric_sqls_json`
-- You MUST call `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` **ONCE** to sync them to Knowledge Base while you can still fix publish errors
+- You MUST call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` **ONCE** to sync them to Knowledge Base while you can still fix publish errors
+- `semantic_model_files` must include every semantic model file newly created or updated for this batch. If one metric file contains metrics backed by multiple tables, include all affected semantic model files.
 - Do not rely on the final JSON host fallback. The host fallback is only a last-resort guard when the tool call was accidentally missed.
 - If no metrics were generated, do NOT call `end_metric_generation`
 

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -17,11 +17,16 @@ Guide the user through metric generation using natural language business descrip
 
 ## Phase 0: Discovery — Scan Existing Assets
 
-Before anything else, call `list_metrics()` to get all metrics already in the knowledge base. Build an existing metric catalog JSON array with each metric's exact `name`, `type`, `description` when available, and `subject_path` when available. Use this throughout the remaining phases to:
+If the user prompt already includes `Existing Metric Catalog JSON`, treat it as the Phase 0 catalog loaded by the bootstrap host. Do not call `list_metrics()` just to rediscover existing metrics. Otherwise, before anything else, call `list_metrics()` to get all metrics already in the knowledge base. Build an existing metric catalog JSON array with each metric's exact `name`, `type`, `description` when available, `subject_path` when available, and structured compatibility fields such as base measures, dimensions, entities, and semantic model when available. Use this throughout the remaining phases to:
 - **Skip redundant work** — don't recreate metrics that already exist
 - **Reuse existing measures** — reference measures from existing models instead of creating duplicates
 - **Detect conflicts** — warn the user if a proposed metric name collides with an existing one
 - **Enable derived/ratio metrics** — know which metrics can serve as building blocks for more complex definitions
+
+Metric names are datasource-local business keys. Within the current datasource, every persisted `metric.name` must be unique; `subject_tree` is only a display/classification path and must not be used to create a second metric with the same name. If a proposed name already exists:
+- Reuse or skip it when it has the same business definition.
+- In interactive mode, ask the user before replacing or renaming a conflicting definition.
+- In batch/bootstrap mode, infer a more specific English snake_case business name from the SQL/question/table context when the same name would mean a different calculation.
 
 Only inspect and edit semantic model YAML files under the current datasource directory shown in the system prompt, such as `subject/semantic_models/<current_datasource>/...`. Do not reuse or sync YAML files from sibling datasource directories; those files are outside the active MetricFlow adapter scope.
 
@@ -71,7 +76,7 @@ If the user skips, proceed to Step 1c using only table structure and the user's 
 
 **Step 1-batch-b: Mine metric candidates from SQL ASTs**
 
-Call `analyze_metric_candidates_from_history` with all parsed SQL queries and `existing_metric_catalog_json` from Phase 0. Use its output to preserve final business metric expressions and their dependencies:
+If the user prompt already includes `Precomputed Metric Candidate Plan JSON`, use that as the result of batch metric candidate mining for the current SQL batch. Do not call `analyze_metric_candidates_from_history` again unless the supplied JSON is malformed or clearly insufficient. Otherwise, call `analyze_metric_candidates_from_history` with all parsed SQL queries and `existing_metric_catalog_json` from Phase 0. Use its output to preserve final business metric expressions and their dependencies:
 
 1. **Preserve final output metrics** — SQL aliases and final SELECT expressions are the primary metric candidates.
 2. **Keep base measures as dependencies** — base measures support the final metric but do not replace it.
@@ -83,9 +88,10 @@ Call `analyze_metric_candidates_from_history` with all parsed SQL queries and `e
 8. **Preserve SQL time grain** — if `time_grain_evidence` is present, expose an equivalent time dimension in any derived data source. Do not replace a projected date such as `CURDATE() AS part_dt` or `DATE(create_time) AS part_dt` with raw `create_time` as the primary time dimension.
    Define `type: TIME` only for physical DATE/TIME/TIMESTAMP columns or SQL expressions / `sql_query` aliases guaranteed to return DATE/TIME/TIMESTAMP values. Numeric surrogate keys such as `*_date_sk`, `*_date_key`, `*_dt_key`, or integer YYYYMMDD keys must be identifiers or categorical dimensions unless converted to a real date.
 9. **Preserve post-aggregation constraints** — if `post_aggregation_constraints` is present, keep each HAVING/post-aggregation condition as a query constraint, metric usage note, or later derived data source. Do not silently drop it or push it into a base measure.
-10. **Cross-reference with Phase 0** — remove any candidate that already exists in the knowledge base.
+10. **Cross-reference with Phase 0** — remove any candidate that already exists in the knowledge base with the same definition; rename candidates whose name collides with a different existing definition.
 11. **Separate derived metrics** — treat `derived_metric_candidates` as second-stage metrics over existing metrics. Do not mix them into base semantic model or measure generation.
 12. **Ignore passthrough references** — entries in `identity_metric_references` show existing metrics selected without new business formula; do not generate new metrics for them.
+13. **Honor alias mappings** — when the plan includes `metric_aliases` or `source_alias_mappings`, use the `canonical_name` as the generated/reused metric name. Do not generate a second metric just because another SQL uses a different alias for the same formula.
 
 **Step 1-batch-c: Business metric principle**
 
@@ -204,16 +210,18 @@ Do not read, edit, or pass `metric_file` / `semantic_model_file` paths from anot
 
 1. **Check existing**: Call `check_semantic_object_exists(name="{metric_name}", kind="metric")` for each metric confirmed in Phase 1. If it already exists, inform the user and skip it.
 
-2. **Write metric YAML**: Use `write_file` to save each metric definition to `subject/semantic_models/<current_datasource>/metrics/{table_name}_metrics.yml`.
+2. **Update semantic model safely**: When a semantic model YAML already exists, read it first and preserve all existing identifiers, measures, dimensions, `sql_table`, and `sql_query`. Add only missing measures/dimensions needed by the new metric. Never rewrite an existing semantic model with a smaller subset of columns.
+
+3. **Write metric YAML**: Use `write_file` to save each metric definition to `subject/semantic_models/<current_datasource>/metrics/{table_name}_metrics.yml`. If the metrics YAML already exists, read it first and preserve all existing `metric:` entries; append only missing new metrics. Do not rewrite the file with a smaller subset, and do not delete existing metric YAML entries just because they already exist in the KB catalog.
    - For `measure_proxy`, keep `type_params.measure` as a string measure name.
    - For filtered metrics, add a dedicated conditional measure to the semantic model first, then reference that measure from the metric YAML.
    - Each generated metric must be an explicit named top-level `metric:` YAML document. Do not emit unnamed `metric:` blocks or wrap metrics inside another object.
 
-3. **Validate (MUST PASS)**: Call `validate_semantic` to check the metric YAML.
+4. **Validate (MUST PASS)**: Call `validate_semantic` to check the metric YAML.
    - If validation fails, fix errors with `edit_file` and retry until it **passes**.
    - **Do NOT proceed to Phase 4 until validation passes.** No exceptions.
 
-4. **Dry-run SQL**: Call `query_metrics(metrics=["{metric_name}"], dry_run=True)` to generate the SQL.
+5. **Dry-run SQL**: Call `query_metrics(metrics=["{metric_name}"], dry_run=True)` to generate the SQL.
    - If the source SQL groups by dimensions or a time grain, also dry-run the generated metric set with matching `dimensions` / `time_granularity` from that source query.
    - Use `get_dimensions` to find exact generated dimension names; if a grouped source dimension cannot be queried, fix the semantic model joins/dimensions and retry.
    - Collect the SQL into a dict: `{"{metric_name}": "SELECT ..."}`
@@ -238,11 +246,13 @@ Phase 1 confirms the generation scope; validation plus dry-run are the acceptanc
 
 4. **Check before creating**: ALWAYS call `check_semantic_object_exists(name="{metric_name}", kind="metric")` before writing a new metric. If the metric already exists, skip it.
 
-5. **Verify names after validation**: After `validate_semantic` succeeds and the adapter reloads, call `list_metrics` to see the exact metric names available. Use these exact names when calling `query_metrics`.
+5. **Do not use subject path to disambiguate metric names**: `revenue` under `Finance` and `revenue` under `Sales` are still the same datasource-local metric name. If the calculations differ, choose clearer names such as `finance_revenue` and `sales_revenue`.
 
-6. **Every metric needs explicit YAML**: Whether it's a simple aggregation, filtered variant, ratio, expr, derived, or cumulative — write a `metric:` entry in the metrics YAML file so it can be persisted and discovered later.
+6. **Verify names after validation**: After `validate_semantic` succeeds and the adapter reloads, call `list_metrics` to see the exact metric names available. Use these exact names when calling `query_metrics`.
 
-7. **Derived metrics are second-stage**: Generate non-derived metrics first, validate them, refresh the metric catalog with `list_metrics`, then generate `derived_metric_candidates` only when every referenced metric exists in the refreshed catalog or was generated earlier in the same batch.
+7. **Every metric needs explicit YAML**: Whether it's a simple aggregation, filtered variant, ratio, expr, derived, or cumulative — write a `metric:` entry in the metrics YAML file so it can be persisted and discovered later.
+
+8. **Derived metrics are second-stage**: Generate non-derived metrics first, validate them, refresh the metric catalog with `list_metrics`, then generate `derived_metric_candidates` only when every referenced metric exists in the refreshed catalog or was generated earlier in the same batch.
 
 ## Important Rules
 

--- a/datus/storage/backend_holder.py
+++ b/datus/storage/backend_holder.py
@@ -4,10 +4,10 @@
 
 """Global backend singleton — manages RDB and vector backend instances.
 
-Backends are stateless with respect to project: ``initialize()`` only carries
-backend-wide configuration (data_dir, isolation), while the active project
-identifier is passed at ``connect()`` time by the ``create_*`` helpers. This
-lets one backend instance serve many projects.
+Backends are stateless with respect to storage namespace: ``initialize()`` only
+carries backend-wide configuration (data_dir, isolation), while the active
+namespace is passed at ``connect()`` time by the ``create_*`` helpers. This lets
+one backend instance serve many namespaces.
 """
 
 import threading
@@ -38,8 +38,8 @@ def init_backends(
 ) -> None:
     """Initialize storage backends from configuration.
 
-    Should be called once during application startup. The per-call project
-    identifier is not stored here — it is passed to ``create_rdb_for_store``
+    Should be called once during application startup. The per-call storage
+    namespace is not stored here — it is passed to ``create_rdb_for_store``
     / ``create_vector_connection`` at lookup time.
 
     Args:
@@ -122,15 +122,15 @@ def get_isolation_type() -> str:
 
 
 def create_rdb_for_store(store_db_name: str, project: str) -> RdbDatabase:
-    """Create an RDB database handle for *store_db_name* scoped to *project*.
+    """Create an RDB database handle for *store_db_name* scoped to a namespace.
 
     The backend singleton is reused; ``connect()`` produces a per-store,
-    per-project database handle. ``project`` is a path component (PHYSICAL
-    isolation) and must be non-empty.
+    per-namespace database handle. ``project`` is the legacy parameter name for
+    that namespace and must be non-empty.
 
     Args:
         store_db_name: Logical store name (e.g. ``"subject_tree"``).
-        project: Project identifier; must be non-empty.
+        project: Backend storage namespace; must be non-empty.
 
     Raises:
         DatusException: when ``project`` is empty.
@@ -145,12 +145,11 @@ def create_rdb_for_store(store_db_name: str, project: str) -> RdbDatabase:
 
 
 def create_vector_connection(project: str) -> VectorDatabase:
-    """Create a vector db connection scoped to *project*.
+    """Create a vector db connection scoped to a backend namespace.
 
     Args:
-        project: Project identifier passed to the backend's ``connect()``
-            first argument; the backend uses it as a path component for
-            per-project isolation. Must be non-empty.
+        project: Legacy parameter name for the namespace passed to the
+            backend's ``connect()`` first argument. Must be non-empty.
 
     Raises:
         DatusException: when ``project`` is empty.

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -47,8 +47,8 @@ class StorageBase:
             db: Optional pre-created VectorDatabase connection.
                 If provided, it is used directly instead of opening a new
                 connection bound to the active project. Stores that need
-                a composite-project scope (e.g. ``DocumentStore``) pass
-                their own ``db`` built from the desired project.
+                a composite backend namespace (e.g. ``DocumentStore``) pass
+                their own ``db`` built from the desired namespace.
         """
         if db is not None:
             self.db: VectorDatabase = db
@@ -245,12 +245,36 @@ class BaseEmbeddingStore(StorageBase):
     def truncate_scoped(self) -> None:
         """Delete all rows visible to the current connection.
 
-        With PHYSICAL-only isolation this is equivalent to ``truncate()``
-        (drops the whole table); the method is retained as a stable alias
-        for call sites that previously relied on row-scoped deletion under
-        LOGICAL isolation.
+        Physical isolation gives each namespace its own table/database, so a
+        scoped truncate can drop the table. Logical isolation shares tables
+        across namespaces and only supports ``delete(None)`` when the backend
+        explicitly declares that it injects the current datasource filter.
         """
-        self.truncate()
+        from datus.storage.backend_holder import get_isolation_type
+
+        if get_isolation_type() != "logical":
+            self.truncate()
+            return
+
+        with self._table_lock:
+            table = self._open_existing_table_for_read()
+            if table is None:
+                return
+            if not getattr(table, "supports_logical_scoped_delete_all", False):
+                raise DatusException(
+                    ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                    message_args={
+                        "operation": "truncate_scoped",
+                        "table_name": self.table_name,
+                        "error_message": (
+                            "logical isolation requires a vector table that declares "
+                            "supports_logical_scoped_delete_all=True"
+                        ),
+                    },
+                )
+            table.delete(None)
+            self._shared.table = None
+            self._shared.initialized = False
 
     def _ensure_table(self, schema: Optional[pa.Schema] = None):
         if self.db.table_exists(self.table_name):

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -11,7 +11,9 @@ from typing import Any, Dict, List, Optional
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.registry import get_storage
+from datus.storage.scope import resolve_datasource_scope
 from datus.storage.semantic_model.store import SemanticModelStorage
+from datus.storage.table_identity import build_semantic_table_identity
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -25,9 +27,9 @@ class CatalogUpdater:
 
     def __init__(self, agent_config: AgentConfig, datasource_id: Optional[str] = None):
         self._agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
         self.semantic_model_storage = get_storage(
-            SemanticModelStorage, "semantic_model", project=agent_config.project_name
+            SemanticModelStorage, "semantic_model", project=self.storage_namespace
         )
 
     def _parse_json_field(self, value: Any) -> Optional[List[Dict[str, Any]]]:
@@ -44,13 +46,18 @@ class CatalogUpdater:
                 return None
         return None
 
+    def _table_identity(self, values: Dict[str, Any]) -> str:
+        agent_config = getattr(self, "_agent_config", None)
+        return build_semantic_table_identity(values, getattr(agent_config, "db_type", None))
+
     def update_semantic_model(self, old_values: Dict[str, Any], update_values: Dict[str, Any]):
         table_name = old_values.get("table_name", "")
         semantic_model_name = old_values.get("semantic_model_name", "")
+        table_identity = self._table_identity(old_values)
 
         # 1. Update table-level record (description)
         if "description" in update_values:
-            entry_id = f"table:{table_name}"
+            entry_id = f"table:{table_identity}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, {"description": update_values["description"]})
             except DatusException as e:
@@ -69,6 +76,7 @@ class CatalogUpdater:
             update_values.get("dimensions"),
             "is_dimension",
             {"description", "expr", "column_type", "is_partition", "time_granularity"},
+            table_identity=table_identity,
         )
         self._update_columns(
             table_name,
@@ -77,6 +85,7 @@ class CatalogUpdater:
             update_values.get("measures"),
             "is_measure",
             {"description", "expr", "agg", "create_metric", "agg_time_dimension"},
+            table_identity=table_identity,
         )
         self._update_columns(
             table_name,
@@ -85,6 +94,7 @@ class CatalogUpdater:
             update_values.get("identifiers"),
             "is_entity_key",
             {"description", "expr", "column_type", "entity"},
+            table_identity=table_identity,
         )
 
     def _update_columns(
@@ -95,6 +105,7 @@ class CatalogUpdater:
         new_columns: Any,
         kind_field: str,
         allowed_fields: set,
+        table_identity: str = "",
     ):
         """Update column-level records by matching old and new values."""
         old_list = self._parse_json_field(old_columns) or []
@@ -123,7 +134,7 @@ class CatalogUpdater:
             if not changed:
                 continue
 
-            entry_id = f"column:{table_name}.{col_name}"
+            entry_id = f"column:{table_identity or table_name}.{col_name}"
             try:
                 self.semantic_model_storage.update_entry(entry_id, changed)
             except DatusException as e:

--- a/datus/storage/ext_knowledge/ext_knowledge_init.py
+++ b/datus/storage/ext_knowledge/ext_knowledge_init.py
@@ -193,8 +193,8 @@ async def init_success_story_knowledge_async(
         from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
 
         logger.info(
-            "[overwrite] Wiping ext_knowledge store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping ext_knowledge store for datasource '%s' before re-population",
+            agent_config.current_datasource,
         )
         ExtKnowledgeRAG(agent_config).truncate()
     elif build_mode == "incremental":

--- a/datus/storage/ext_knowledge/store.py
+++ b/datus/storage/ext_knowledge/store.py
@@ -309,9 +309,10 @@ class ExtKnowledgeRAG:
     ):
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
+        from datus.storage.scope import resolve_datasource_scope
 
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
-        self.store = get_storage(ExtKnowledgeStore, "ext_knowledge", project=agent_config.project_name)
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
+        self.store = get_storage(ExtKnowledgeStore, "ext_knowledge", project=self.storage_namespace)
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.store, "ext_knowledge")
 
     def _sub_agent_conditions(self) -> List:

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -384,14 +384,110 @@ def _candidate_metric_names(candidate_plan: dict[str, Any]) -> list[str]:
     return names
 
 
+def _candidate_metric_items(candidate_plan: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates_by_name: dict[str, dict[str, Any]] = {}
+    ordered_names: list[str] = []
+    seen: set[str] = set()
+    for key in ("direct_metric_candidates", "derived_metric_candidates", "metric_candidates"):
+        for candidate in candidate_plan.get(key) or []:
+            if not isinstance(candidate, dict):
+                continue
+            name = str(candidate.get("name") or "").strip()
+            normalized = _normalize_metric_name(name)
+            if not normalized:
+                continue
+            if normalized not in seen:
+                seen.add(normalized)
+                ordered_names.append(normalized)
+                candidates_by_name[normalized] = candidate
+                continue
+            if not _candidate_has_definition_evidence(
+                candidates_by_name[normalized]
+            ) and _candidate_has_definition_evidence(candidate):
+                candidates_by_name[normalized] = candidate
+    return [candidates_by_name[name] for name in ordered_names]
+
+
+def _normalized_scalar(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalized_metric_type(value: Any) -> str:
+    metric_type = _normalized_scalar(value)
+    return "measure_proxy" if metric_type == "simple" else metric_type
+
+
+def _normalized_measure_names(value: Any) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(value, list):
+        return names
+    for item in value:
+        if isinstance(item, str):
+            name = item
+        elif isinstance(item, dict):
+            name = item.get("name") or item.get("measure") or item.get("expr")
+        else:
+            continue
+        normalized = _normalize_metric_name(name)
+        if normalized:
+            names.add(normalized)
+    return names
+
+
+def _candidate_has_definition_evidence(candidate: dict[str, Any]) -> bool:
+    return any(
+        candidate.get(field)
+        for field in (
+            "metric_type",
+            "type",
+            "semantic_model",
+            "semantic_model_name",
+            "base_measures",
+            "referenced_metrics",
+        )
+    )
+
+
+def _candidate_matches_existing_metric(candidate: dict[str, Any], existing: dict[str, Any]) -> bool:
+    if not _candidate_has_definition_evidence(candidate):
+        return False
+
+    candidate_type = _normalized_metric_type(candidate.get("metric_type") or candidate.get("type"))
+    existing_type = _normalized_metric_type(existing.get("type") or existing.get("metric_type"))
+    if candidate_type and existing_type and candidate_type != existing_type:
+        return False
+
+    candidate_semantic_model = _normalized_scalar(
+        candidate.get("semantic_model_name") or candidate.get("semantic_model")
+    )
+    existing_semantic_model = _normalized_scalar(existing.get("semantic_model_name") or existing.get("semantic_model"))
+    if candidate_semantic_model and existing_semantic_model and candidate_semantic_model != existing_semantic_model:
+        return False
+
+    candidate_measures = _normalized_measure_names(candidate.get("base_measures"))
+    if not candidate_measures and candidate.get("referenced_metrics"):
+        candidate_measures = _normalized_measure_names(candidate.get("referenced_metrics"))
+    existing_measures = _normalized_measure_names(existing.get("base_measures"))
+    if candidate_measures and existing_measures and candidate_measures != existing_measures:
+        return False
+
+    return True
+
+
 def _all_candidate_metrics_satisfied(
     candidate_plan: dict[str, Any], existing_metric_catalog: list[dict[str, Any]]
 ) -> bool:
-    candidate_names = _candidate_metric_names(candidate_plan)
-    if not candidate_names:
+    candidates = _candidate_metric_items(candidate_plan)
+    if not candidates:
         return False
-    existing_names = {_normalize_metric_name(item.get("name")) for item in existing_metric_catalog if item.get("name")}
-    return all(_normalize_metric_name(name) in existing_names for name in candidate_names)
+    existing_by_name = {
+        _normalize_metric_name(item.get("name")): item for item in existing_metric_catalog if item.get("name")
+    }
+    for candidate in candidates:
+        existing = existing_by_name.get(_normalize_metric_name(candidate.get("name")))
+        if not existing or not _candidate_matches_existing_metric(candidate, existing):
+            return False
+    return True
 
 
 async def _generate_metrics_batch(

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -27,6 +27,7 @@ from datus.storage.knowledge_provenance import (
     is_knowledge_provenance_enabled,
 )
 from datus.storage.semantic_model.auto_create import (
+    agent_config_dialect,
     ensure_semantic_models_exist,
     extract_table_sql_evidence,
     extract_tables_from_sql_list,
@@ -189,8 +190,208 @@ def _sync_metric_provenance(
         return 0
 
 
-DEFAULT_METRICS_BATCH_SIZE = 1
-METRICS_RESPONSE_ACTION_TYPE = f"{GenMetricsAgenticNode.NODE_NAME}_response"
+DEFAULT_METRICS_BATCH_SIZE = 5
+METRICS_NODE_NAME = "gen_metrics"
+METRICS_RESPONSE_ACTION_TYPE = f"{METRICS_NODE_NAME}_response"
+
+
+def _json_dump_compact(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _normalize_metric_name(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _source_names(value: Any) -> set[str]:
+    if not value:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        raw_values = value
+    else:
+        raw_values = str(value).split(",")
+    return {str(item).strip() for item in raw_values if str(item).strip()}
+
+
+def _source_scoped_items(items: Any, batch_sources: set[str]) -> list[dict[str, Any]]:
+    if not isinstance(items, list):
+        return []
+
+    scoped: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_sources = _source_names(item.get("source_sql_name") or item.get("source") or item.get("sql_name"))
+        if not item_sources or item_sources & batch_sources:
+            scoped.append(item)
+    return scoped
+
+
+def _build_existing_metric_catalog(agent_config: AgentConfig) -> list[dict[str, Any]]:
+    """Load existing metrics once for the whole bootstrap run."""
+    from datus.storage.metric.store import MetricRAG
+
+    try:
+        rows = MetricRAG(agent_config).search_all_metrics()
+    except Exception as exc:  # pragma: no cover - defensive; generation can proceed without catalog hints
+        logger.warning("Failed to load existing metric catalog; continuing without it: %s", exc)
+        return []
+
+    catalog: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        name = str(row.get("name") or "").strip()
+        if not name:
+            continue
+        normalized = _normalize_metric_name(name)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        catalog.append(
+            {
+                "name": name,
+                "type": row.get("metric_type") or row.get("type") or "",
+                "description": row.get("description") or "",
+                "subject_path": row.get("subject_path") or [],
+                "semantic_model": row.get("semantic_model_name") or "",
+                "semantic_model_name": row.get("semantic_model_name") or "",
+                "base_measures": row.get("base_measures") or [],
+                "dimensions": row.get("dimensions") or [],
+                "entities": row.get("entities") or [],
+            }
+        )
+    return catalog
+
+
+def _build_sql_to_table_lineage(sql_entries: list[dict[str, Any]], agent_config: AgentConfig) -> list[dict[str, Any]]:
+    from datus.utils.sql_utils import extract_table_names
+
+    lineage: list[dict[str, Any]] = []
+    dialect = agent_config_dialect(agent_config)
+    for entry in sql_entries:
+        sql = str(entry.get("sql") or "").strip()
+        if not sql:
+            continue
+        try:
+            tables = sorted(extract_table_names(sql, dialect=dialect, ignore_empty=True))
+        except Exception as exc:
+            lineage.append({"source_sql_name": entry.get("name"), "tables": [], "error": str(exc)})
+            continue
+        lineage.append({"source_sql_name": entry.get("name"), "tables": tables})
+    return lineage
+
+
+def _build_candidate_plan(
+    sql_entries: list[dict[str, Any]],
+    existing_metric_catalog_json: str,
+    agent_config: AgentConfig,
+) -> dict[str, Any]:
+    """Run SQL metric candidate extraction once before launching gen_metrics agents."""
+    from types import SimpleNamespace
+
+    from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
+
+    if not sql_entries:
+        return {
+            "available": True,
+            "metric_candidates": [],
+            "direct_metric_candidates": [],
+            "derived_metric_candidates": [],
+            "base_measures": [],
+            "non_metric_evidence": [],
+            "identity_metric_references": [],
+            "parse_errors": [],
+            "query_classification": "manual_review_required",
+            "source_classifications": [],
+            "derived_datasource_recommendations": [],
+            "blocked_direct_metric_candidates": [],
+            "literal_mappings": [],
+            "time_grain_evidence": [],
+            "post_aggregation_constraints": [],
+            "modeling_plan": {},
+            "summary": "Found 0 metric candidates and 0 base measures from 0 SQL queries",
+            "sql_to_table_lineage": [],
+        }
+
+    try:
+        discovery = SemanticDiscoveryTools(SimpleNamespace(agent_config=agent_config, sub_agent_name=METRICS_NODE_NAME))
+        result = discovery.analyze_metric_candidates_from_history(
+            sql_entries_json=_json_dump_compact(sql_entries),
+            existing_metric_catalog_json=existing_metric_catalog_json,
+            sample_sql_queries=len(sql_entries),
+        )
+        if not result.success:
+            logger.warning("Metric candidate extraction failed: %s", result.error)
+            return {
+                "available": False,
+                "error": result.error or "metric candidate extraction failed",
+                "sql_to_table_lineage": _build_sql_to_table_lineage(sql_entries, agent_config),
+            }
+        plan = dict(result.result or {})
+        plan["available"] = True
+        plan["sql_to_table_lineage"] = _build_sql_to_table_lineage(sql_entries, agent_config)
+        return plan
+    except Exception as exc:  # pragma: no cover - defensive; agent can still infer from SQL prompt
+        logger.warning("Metric candidate extraction raised; continuing without a candidate plan: %s", exc)
+        return {
+            "available": False,
+            "error": str(exc),
+            "sql_to_table_lineage": _build_sql_to_table_lineage(sql_entries, agent_config),
+        }
+
+
+def _candidate_plan_for_sources(candidate_plan: dict[str, Any], batch_sources: set[str]) -> dict[str, Any]:
+    if not candidate_plan or not candidate_plan.get("available"):
+        return candidate_plan or {}
+
+    scoped = dict(candidate_plan)
+    for key in (
+        "metric_candidates",
+        "direct_metric_candidates",
+        "derived_metric_candidates",
+        "base_measures",
+        "non_metric_evidence",
+        "identity_metric_references",
+        "source_classifications",
+        "derived_datasource_recommendations",
+        "blocked_direct_metric_candidates",
+        "metric_aliases",
+        "literal_mappings",
+        "time_grain_evidence",
+        "post_aggregation_constraints",
+        "sql_to_table_lineage",
+    ):
+        scoped[key] = _source_scoped_items(candidate_plan.get(key), batch_sources)
+
+    scoped["summary"] = (
+        f"Batch candidate plan for {len(batch_sources)} SQL source(s): "
+        f"{len(scoped.get('direct_metric_candidates') or [])} direct, "
+        f"{len(scoped.get('derived_metric_candidates') or [])} derived, "
+        f"{len(scoped.get('blocked_direct_metric_candidates') or [])} blocked direct candidate(s)."
+    )
+    return scoped
+
+
+def _candidate_metric_names(candidate_plan: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for key in ("direct_metric_candidates", "derived_metric_candidates", "metric_candidates"):
+        for candidate in candidate_plan.get(key) or []:
+            if not isinstance(candidate, dict):
+                continue
+            name = str(candidate.get("name") or "").strip()
+            if name and name not in names:
+                names.append(name)
+    return names
+
+
+def _all_candidate_metrics_satisfied(
+    candidate_plan: dict[str, Any], existing_metric_catalog: list[dict[str, Any]]
+) -> bool:
+    candidate_names = _candidate_metric_names(candidate_plan)
+    if not candidate_names:
+        return False
+    existing_names = {_normalize_metric_name(item.get("name")) for item in existing_metric_catalog if item.get("name")}
+    return all(_normalize_metric_name(name) in existing_names for name in candidate_names)
 
 
 async def _generate_metrics_batch(
@@ -201,11 +402,30 @@ async def _generate_metrics_batch(
     extra_instructions: Optional[str],
     event_helper: BatchEventHelper,
     action_callback: Optional[Callable[["ActionHistory"], None]],
+    candidate_plan_json: Optional[str] = None,
+    existing_metric_catalog_json: Optional[str] = None,
 ) -> tuple[bool, str, Optional[dict[str, Any]]]:
     """Process a single batch of SQL queries for metrics extraction."""
     batch_message = "Analyze the following SQL queries and extract core metrics:\n\n" + "\n\n---\n\n".join(
         batch_queries
     )
+
+    if existing_metric_catalog_json:
+        batch_message += (
+            "\n\n## Existing Metric Catalog JSON\n"
+            "This catalog was loaded once by the bootstrap host before this batch. "
+            "Use it as the initial metric catalog; do not call list_metrics only to rediscover existing metrics.\n"
+            f"{existing_metric_catalog_json}"
+        )
+
+    if candidate_plan_json:
+        batch_message += (
+            "\n\n## Precomputed Metric Candidate Plan JSON\n"
+            "This plan was mined once from the full success-story SQL set before this batch. "
+            "Use it as Phase 1 metric-candidate evidence; do not call analyze_metric_candidates_from_history again "
+            "unless this JSON is malformed or insufficient for the requested generation.\n"
+            f"{candidate_plan_json}"
+        )
 
     if extra_instructions:
         batch_message = f"{batch_message}\n\n## Additional Instructions\n{extra_instructions}"
@@ -305,7 +525,7 @@ async def init_success_story_metrics_async(
         build_mode: ``"overwrite"`` (default) regenerates unconditionally;
             ``"incremental"`` skips the LLM call when the metric store
             already contains entries.
-        batch_size: Number of SQL queries per batch (default 1).
+        batch_size: Number of SQL queries per batch (default 5).
     """
     if batch_size <= 0:
         from datus.utils.exceptions import DatusException, ErrorCode
@@ -320,29 +540,13 @@ async def init_success_story_metrics_async(
         from datus.storage.metric.store import MetricRAG
 
         logger.info(
-            "[overwrite] Wiping metrics store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping metrics store for datasource '%s' before re-population",
+            agent_config.current_datasource,
         )
         MetricRAG(agent_config).truncate()
         cleared_provenance = _clear_metric_provenance(agent_config)
         if cleared_provenance:
             logger.info("Cleared %d stale metric provenance row(s)", cleared_provenance)
-    elif build_mode == "incremental":
-        from datus.storage.metric.init_utils import exists_metrics
-        from datus.storage.metric.store import MetricRAG
-
-        existing = exists_metrics(MetricRAG(agent_config), build_mode)
-        if existing:
-            logger.info(
-                "Metrics incremental skip: %d existing metric(s) found, no LLM call.",
-                len(existing),
-            )
-            event_helper.task_completed(
-                total_items=len(existing),
-                completed_items=len(existing),
-                failed_items=0,
-            )
-            return True, "", {"skipped": True, "existing": len(existing)}
 
     df = pd.read_csv(success_story)
 
@@ -350,9 +554,16 @@ async def init_success_story_metrics_async(
     event_helper.task_started(total_items=len(df), success_story=success_story)
 
     # Step 0: Check and create missing semantic models
-    success_story_records = [
-        {"sql": row["sql"], "question": row.get("question")} for _, row in df.iterrows() if row.get("sql")
-    ]
+    success_story_records = []
+    sql_entries: list[dict[str, Any]] = []
+    for idx, row in df.iterrows():
+        sql = row.get("sql")
+        if not sql:
+            continue
+        question = row.get("question")
+        success_story_records.append({"sql": sql, "question": question})
+        sql_entries.append({"name": f"sql_{idx + 1}", "sql": sql, "question": question})
+
     sql_list = [record["sql"] for record in success_story_records]
     all_tables = extract_tables_from_sql_list(sql_list, agent_config)
 
@@ -366,6 +577,7 @@ async def init_success_story_metrics_async(
             agent_config,
             emit=None,
             sql_evidence_by_table=sql_evidence_by_table,
+            batch_mode=True,
         )
 
         if not success:
@@ -379,6 +591,15 @@ async def init_success_story_metrics_async(
         if error:
             logger.warning(f"Semantic model generation had partial failures: {error}")
 
+    existing_metric_catalog = _build_existing_metric_catalog(agent_config)
+    existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
+    candidate_plan = _build_candidate_plan(sql_entries, existing_metric_catalog_json, agent_config)
+    logger.info(
+        "Prepared metric bootstrap context: existing_metrics=%d, candidate_plan_available=%s",
+        len(existing_metric_catalog),
+        candidate_plan.get("available"),
+    )
+
     # Build query records for all rows. Optional source-context columns are only
     # used by benchmark provenance mode and do not affect normal bootstrap data.
     all_query_records: list[dict[str, Any]] = []
@@ -387,6 +608,7 @@ async def init_success_story_metrics_async(
         question = row["question"]
         all_query_records.append(
             {
+                "source_sql_name": f"sql_{idx + 1}",
                 "query": f"Query {idx + 1}:\nQuestion: {question}\nSQL:\n{sql}",
                 "source": _source_provenance_from_row(row, idx, success_story),
             }
@@ -406,13 +628,63 @@ async def init_success_story_metrics_async(
     failed_batches: list[tuple[int, str]] = []
     merged_result: Optional[dict[str, Any]] = None
     provenance_entries = 0
+    skipped_batches = 0
 
     for batch_idx, batch_records in enumerate(batches):
         batch_queries = [record["query"] for record in batch_records]
+        batch_sources = {record["source_sql_name"] for record in batch_records}
+        batch_candidate_plan = _candidate_plan_for_sources(candidate_plan, batch_sources)
+        batch_candidate_plan_json = _json_dump_compact(batch_candidate_plan) if batch_candidate_plan else ""
         source_entries = [record["source"] for record in batch_records if record.get("source")]
         metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
 
         logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
+
+        if build_mode == "incremental" and _all_candidate_metrics_satisfied(
+            batch_candidate_plan,
+            existing_metric_catalog,
+        ):
+            skipped_batches += 1
+            completed_batches += 1
+            skipped_names = _candidate_metric_names(batch_candidate_plan)
+            logger.info(
+                "Skipping metrics batch %d/%d: all %d candidate metric(s) already exist",
+                batch_idx + 1,
+                total_batches,
+                len(skipped_names),
+            )
+            if event_helper:
+                event_helper.item_processing(
+                    item_id=f"batch-{batch_idx}",
+                    action_name="gen_metrics_skip",
+                    status=ActionStatus.SUCCESS.value,
+                    messages=(
+                        f"Skipped metrics batch {batch_idx + 1}/{total_batches}: "
+                        f"existing metrics already satisfy candidates {skipped_names}"
+                    ),
+                    output={
+                        "skipped": True,
+                        "skipped_metric_candidates": skipped_names,
+                        "batch_index": batch_idx,
+                    },
+                )
+
+            batch_result = {
+                "skipped_batches": 1,
+                "skipped_queries": len(batch_records),
+                "skipped_metric_candidates": skipped_names,
+            }
+            if merged_result is None:
+                merged_result = batch_result
+            elif isinstance(merged_result, dict):
+                for key, value in batch_result.items():
+                    if key in merged_result and isinstance(merged_result[key], list) and isinstance(value, list):
+                        merged_result[key].extend(value)
+                    elif key in merged_result and isinstance(merged_result[key], int) and isinstance(value, int):
+                        merged_result[key] += value
+                    elif key not in merged_result:
+                        merged_result[key] = value
+            continue
 
         success, error, batch_result = await _generate_metrics_batch(
             batch_queries,
@@ -422,6 +694,8 @@ async def init_success_story_metrics_async(
             extra_instructions,
             event_helper,
             action_callback,
+            candidate_plan_json=batch_candidate_plan_json,
+            existing_metric_catalog_json=existing_metric_catalog_json,
         )
 
         if success and batch_result is not None:
@@ -446,6 +720,18 @@ async def init_success_story_metrics_async(
                         merged_result[key] += value
                     elif key not in merged_result:
                         merged_result[key] = value
+            if batch_idx + 1 < total_batches:
+                existing_metric_catalog = _build_existing_metric_catalog(agent_config)
+                existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
+                candidate_plan = _build_candidate_plan(sql_entries, existing_metric_catalog_json, agent_config)
+                logger.info(
+                    "Refreshed metric bootstrap context after batch %d/%d: "
+                    "existing_metrics=%d, candidate_plan_available=%s",
+                    batch_idx + 1,
+                    total_batches,
+                    len(existing_metric_catalog),
+                    candidate_plan.get("available"),
+                )
             logger.info(f"Batch {batch_idx + 1}/{total_batches} completed successfully")
         else:
             failed_batches.append((batch_idx, error))
@@ -463,8 +749,9 @@ async def init_success_story_metrics_async(
         partial_error = "; ".join(f"batch {i + 1}: {e}" for i, e in failed_batches)
         logger.warning(f"Metrics extraction partially succeeded: {partial_error}")
 
-    if isinstance(merged_result, dict) and provenance_entries:
-        merged_result["provenance_entries"] = provenance_entries
+    if isinstance(merged_result, dict):
+        if provenance_entries:
+            merged_result["provenance_entries"] = provenance_entries
 
     logger.info(f"Metrics extraction completed: {completed_batches}/{total_batches} batch(es) succeeded")
     event_helper.task_completed(
@@ -495,7 +782,7 @@ def init_success_story_metrics(
         emit: Optional callback to stream BatchEvent progress events
         extra_instructions: Optional extra instructions for the LLM
         build_mode: Forwarded to :func:`init_success_story_metrics_async`.
-        batch_size: Number of SQL queries per batch (default 1).
+        batch_size: Number of SQL queries per batch (default 5).
     """
     with suppress_keyboard_input():
         return asyncio.run(

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -17,11 +17,51 @@ from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
 
+METRIC_ID_PREFIX = "metric:"
+_METRIC_DEFINITION_FIELDS = ("semantic_model_name", "metric_type", "measure_expr", "base_measures")
+
+
+def normalize_metric_name(value: Any) -> str:
+    """Return the datasource-local business key used for metric names."""
+
+    return str(value or "").strip().lower()
+
 
 def build_metric_id(subject_path: List[str], name: str) -> str:
-    """Build the stable business key for a metric."""
-    subject_path_str = "/".join(subject_path)
-    return f"metric:{subject_path_str}.{name}"
+    """Build the stable business key for a metric.
+
+    ``subject_path`` is kept in the signature for existing call sites, but the
+    metric identity must not change when the metric is moved in the subject tree.
+    Datasource isolation is handled by the storage namespace.
+    """
+
+    metric_name = str(name or "").strip()
+    if not metric_name:
+        raise ValueError("metric name is required")
+    return f"{METRIC_ID_PREFIX}{metric_name}"
+
+
+def _normalize_definition_value(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple, set)):
+        return tuple(sorted(str(item).strip() for item in value if str(item).strip()))
+    return str(value).strip()
+
+
+def metric_definition_conflict(existing: Dict[str, Any], incoming: Dict[str, Any]) -> Optional[str]:
+    """Return the first conflicting core definition field, if any.
+
+    Empty values are treated as unknowns so legacy rows can be completed without
+    blocking a safe upsert.
+    """
+
+    for field in _METRIC_DEFINITION_FIELDS:
+        existing_value = _normalize_definition_value(existing.get(field))
+        incoming_value = _normalize_definition_value(incoming.get(field))
+        if existing_value and incoming_value and existing_value != incoming_value:
+            return field
+    return None
 
 
 class MetricStorage(BaseSubjectEmbeddingStore):
@@ -39,7 +79,7 @@ class MetricStorage(BaseSubjectEmbeddingStore):
                 base_schema_columns()  # Provides: name, subject_id, created_at
                 + [
                     # -- Identity & Basic Info --
-                    pa.field("id", pa.string()),  # Unique ID: "metric:Metrics/orders.dau"
+                    pa.field("id", pa.string()),  # Datasource-local ID: "metric:dau"
                     pa.field("semantic_model_name", pa.string()),  # Source semantic model
                     # -- Retrieval Fields --
                     pa.field("description", pa.string()),  # For LLM reading (RAG) and vector search
@@ -83,6 +123,11 @@ class MetricStorage(BaseSubjectEmbeddingStore):
     def batch_store_metrics(self, metrics: List[Dict[str, Any]]) -> None:
         """Store multiple metrics in the database efficiently.
 
+        Existing legacy rows whose id embedded a subject path are reconciled by
+        metric name before upsert: same definitions are removed in favor of the
+        datasource-local id, and conflicting definitions raise instead of
+        creating duplicate business keys.
+
         Args:
             metrics: List of dictionaries containing metric data with required fields:
                 - subject_path: List[str] - Subject hierarchy path for each metric (e.g., ['Finance', 'Revenue', 'Q1'])
@@ -94,14 +139,9 @@ class MetricStorage(BaseSubjectEmbeddingStore):
         if not metrics:
             return
 
-        # Validate all metrics have required subject_path
-        for metric in metrics:
-            subject_path = metric.get("subject_path")
-            if not subject_path:
-                raise ValueError("subject_path is required in metric data")
-
-        # Use base class batch_store method
-        self.batch_store(metrics)
+        prepared = self._prepare_metrics_for_write(metrics, check_existing=True)
+        if prepared:
+            self.batch_upsert(prepared, on_column="id")
 
     def batch_upsert_metrics(self, metrics: List[Dict[str, Any]]) -> None:
         """Upsert multiple metrics (update if id exists, insert if not).
@@ -109,20 +149,82 @@ class MetricStorage(BaseSubjectEmbeddingStore):
         Args:
             metrics: List of dictionaries containing metric data with required fields:
                 - subject_path: List[str] - Subject hierarchy path for each metric
-                - id: str - Unique identifier for the metric (e.g., "metric:Metrics/orders.dau")
+                - id: str - Unique identifier for the metric (e.g., "metric:dau")
                 - Other fields same as batch_store_metrics
         """
         if not metrics:
             return
 
-        # Validate all metrics have required subject_path
+        prepared = self._prepare_metrics_for_write(metrics, check_existing=True)
+        if prepared:
+            self.batch_upsert(prepared, on_column="id")
+
+    def _prepare_metrics_for_write(
+        self,
+        metrics: List[Dict[str, Any]],
+        check_existing: bool = False,
+    ) -> List[Dict[str, Any]]:
+        prepared: List[Dict[str, Any]] = []
+        index_by_name: Dict[str, int] = {}
+
         for metric in metrics:
             subject_path = metric.get("subject_path")
             if not subject_path:
                 raise ValueError("subject_path is required in metric data")
 
-        # Use base class batch_upsert method
-        self.batch_upsert(metrics, on_column="id")
+            name = str(metric.get("name") or "").strip()
+            if not name:
+                raise ValueError("metric name is required in metric data")
+
+            normalized_name = normalize_metric_name(name)
+            updated = dict(metric)
+            updated["name"] = name
+            updated["id"] = build_metric_id(subject_path, name)
+
+            existing_index = index_by_name.get(normalized_name)
+            if existing_index is not None:
+                existing_metric = prepared[existing_index]
+                conflict_field = metric_definition_conflict(existing_metric, updated)
+                if conflict_field:
+                    raise ValueError(
+                        f"Metric name conflict within datasource for '{name}': "
+                        f"field '{conflict_field}' differs in the same write batch. "
+                        "Metric names must be unique within a datasource."
+                    )
+                prepared[existing_index] = updated
+                continue
+
+            index_by_name[normalized_name] = len(prepared)
+            prepared.append(updated)
+
+        if check_existing and prepared:
+            self._reject_existing_metric_name_conflicts(prepared)
+
+        return prepared
+
+    def _reject_existing_metric_name_conflicts(self, metrics: List[Dict[str, Any]]) -> None:
+        names = {normalize_metric_name(metric.get("name")) for metric in metrics}
+        fields = ["id", "name", *_METRIC_DEFINITION_FIELDS]
+        existing_rows = self._search_all(select_fields=fields).to_pylist()
+
+        stale_duplicate_ids: List[str] = []
+        for existing in existing_rows:
+            existing_name = normalize_metric_name(existing.get("name"))
+            if existing_name not in names:
+                continue
+            incoming = next(metric for metric in metrics if normalize_metric_name(metric.get("name")) == existing_name)
+            conflict_field = metric_definition_conflict(existing, incoming)
+            if conflict_field:
+                raise ValueError(
+                    f"Metric name conflict within datasource for '{incoming['name']}': "
+                    f"existing metric id '{existing.get('id')}' has a different '{conflict_field}'. "
+                    "Choose a more specific metric name or update the existing metric explicitly."
+                )
+            if existing.get("id") and existing.get("id") != incoming.get("id"):
+                stale_duplicate_ids.append(str(existing["id"]))
+
+        if stale_duplicate_ids:
+            self._delete_rows(in_("id", stale_duplicate_ids))
 
     def _search_metrics_internal(
         self,
@@ -504,11 +606,12 @@ class MetricRAG:
     ):
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
+        from datus.storage.scope import resolve_datasource_scope
 
         self.agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
         self._provenance_enabled = is_knowledge_provenance_enabled(agent_config)
-        self.storage: MetricStorage = get_storage(MetricStorage, "metric", project=agent_config.project_name)
+        self.storage: MetricStorage = get_storage(MetricStorage, "metric", project=self.storage_namespace)
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.storage, "metrics")
 
     def _sub_agent_conditions(self) -> List:

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -139,9 +139,11 @@ class MetricStorage(BaseSubjectEmbeddingStore):
         if not metrics:
             return
 
-        prepared = self._prepare_metrics_for_write(metrics, check_existing=True)
+        prepared, stale_duplicate_ids = self._prepare_metrics_for_write(metrics, check_existing=True)
         if prepared:
             self.batch_upsert(prepared, on_column="id")
+        if stale_duplicate_ids:
+            self._delete_rows(in_("id", stale_duplicate_ids))
 
     def batch_upsert_metrics(self, metrics: List[Dict[str, Any]]) -> None:
         """Upsert multiple metrics (update if id exists, insert if not).
@@ -155,15 +157,17 @@ class MetricStorage(BaseSubjectEmbeddingStore):
         if not metrics:
             return
 
-        prepared = self._prepare_metrics_for_write(metrics, check_existing=True)
+        prepared, stale_duplicate_ids = self._prepare_metrics_for_write(metrics, check_existing=True)
         if prepared:
             self.batch_upsert(prepared, on_column="id")
+        if stale_duplicate_ids:
+            self._delete_rows(in_("id", stale_duplicate_ids))
 
     def _prepare_metrics_for_write(
         self,
         metrics: List[Dict[str, Any]],
         check_existing: bool = False,
-    ) -> List[Dict[str, Any]]:
+    ) -> tuple[List[Dict[str, Any]], List[str]]:
         prepared: List[Dict[str, Any]] = []
         index_by_name: Dict[str, int] = {}
 
@@ -197,12 +201,13 @@ class MetricStorage(BaseSubjectEmbeddingStore):
             index_by_name[normalized_name] = len(prepared)
             prepared.append(updated)
 
+        stale_duplicate_ids: List[str] = []
         if check_existing and prepared:
-            self._reject_existing_metric_name_conflicts(prepared)
+            stale_duplicate_ids = self._find_stale_existing_metric_ids(prepared)
 
-        return prepared
+        return prepared, stale_duplicate_ids
 
-    def _reject_existing_metric_name_conflicts(self, metrics: List[Dict[str, Any]]) -> None:
+    def _find_stale_existing_metric_ids(self, metrics: List[Dict[str, Any]]) -> List[str]:
         names = {normalize_metric_name(metric.get("name")) for metric in metrics}
         fields = ["id", "name", *_METRIC_DEFINITION_FIELDS]
         existing_rows = self._search_all(select_fields=fields).to_pylist()
@@ -223,8 +228,7 @@ class MetricStorage(BaseSubjectEmbeddingStore):
             if existing.get("id") and existing.get("id") != incoming.get("id"):
                 stale_duplicate_ids.append(str(existing["id"]))
 
-        if stale_duplicate_ids:
-            self._delete_rows(in_("id", stale_duplicate_ids))
+        return stale_duplicate_ids
 
     def _search_metrics_internal(
         self,

--- a/datus/storage/metric/subject_path.py
+++ b/datus/storage/metric/subject_path.py
@@ -1,0 +1,75 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Helpers for normalizing metric subject paths."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+GENERIC_METRIC_SUBJECT_ROOTS = {"metrics", "metric", "unknown"}
+
+
+def default_metric_subject_path(datasource: str = "", table_name: str = "") -> list[str]:
+    datasource = str(datasource or "").strip()
+    table = str(table_name or "Unknown").strip() or "Unknown"
+    if datasource:
+        return [datasource, table]
+    return ["Metrics", table]
+
+
+def normalize_metric_subject_path(
+    subject_path: Optional[Iterable[str]],
+    *,
+    datasource: str = "",
+    table_name: str = "",
+) -> list[str]:
+    """Normalize generated metric subject paths without rewriting business roots.
+
+    The datasource is a storage scope, so generic roots such as ``Metrics`` should
+    not become a parallel top-level subject tree under a datasource-scoped run.
+    Generated paths also commonly include the datasource twice
+    (``ac_manage/ac_manage/activity``); collapse only that exact duplicate root.
+    """
+
+    parts = [str(part).strip() for part in subject_path or [] if str(part).strip()]
+    if not parts:
+        return default_metric_subject_path(datasource, table_name)
+
+    datasource = str(datasource or "").strip()
+    if not datasource:
+        return parts
+
+    first = _normalize_part(parts[0])
+    if first in GENERIC_METRIC_SUBJECT_ROOTS:
+        tail = parts[1:]
+    elif _same_part(parts[0], datasource):
+        tail = parts[1:]
+    else:
+        return parts
+
+    while tail and _same_part(tail[0], datasource):
+        tail = tail[1:]
+
+    if not tail:
+        tail = [str(table_name or "Unknown").strip() or "Unknown"]
+    return [datasource, *tail]
+
+
+def normalize_metric_subject_tree_tag(tag: str, *, datasource: str = "", table_name: str = "") -> str:
+    prefix = "subject_tree:"
+    if not isinstance(tag, str) or not tag.startswith(prefix):
+        return tag
+    path = tag.split(prefix, 1)[1].strip()
+    parts = [part.strip() for part in path.split("/") if part.strip()]
+    normalized = normalize_metric_subject_path(parts, datasource=datasource, table_name=table_name)
+    return f"{prefix} {'/'.join(normalized)}"
+
+
+def _same_part(left: str, right: str) -> bool:
+    return _normalize_part(left) == _normalize_part(right)
+
+
+def _normalize_part(value: str) -> str:
+    return str(value or "").strip().lower()

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -438,13 +438,12 @@ class ReferenceSqlRAG:
     ):
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
+        from datus.storage.scope import resolve_datasource_scope
 
         self.agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
         self._provenance_enabled = is_knowledge_provenance_enabled(agent_config)
-        self.reference_sql_storage = get_storage(
-            ReferenceSqlStorage, "reference_sql", project=agent_config.project_name
-        )
+        self.reference_sql_storage = get_storage(ReferenceSqlStorage, "reference_sql", project=self.storage_namespace)
         self._sub_agent_filter = _build_sub_agent_filter(
             agent_config, sub_agent_name, self.reference_sql_storage, "sqls"
         )

--- a/datus/storage/reference_template/reference_template_init.py
+++ b/datus/storage/reference_template/reference_template_init.py
@@ -431,8 +431,8 @@ async def init_reference_template_async(
 
     if build_mode == "overwrite":
         logger.info(
-            "[overwrite] Wiping reference_template store for project '%s' before re-population",
-            global_config.project_name,
+            "[overwrite] Wiping reference_template store for datasource '%s' before re-population",
+            global_config.current_datasource,
         )
         storage.truncate()
 

--- a/datus/storage/reference_template/store.py
+++ b/datus/storage/reference_template/store.py
@@ -194,10 +194,11 @@ class ReferenceTemplateRAG:
     ):
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
+        from datus.storage.scope import resolve_datasource_scope
 
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
         self.reference_template_storage = get_storage(
-            ReferenceTemplateStorage, "reference_template", project=agent_config.project_name
+            ReferenceTemplateStorage, "reference_template", project=self.storage_namespace
         )
         self._sub_agent_filter = _build_sub_agent_filter(
             agent_config, sub_agent_name, self.reference_template_storage, "templates"

--- a/datus/storage/registry.py
+++ b/datus/storage/registry.py
@@ -3,11 +3,12 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 """
-Storage registry with per-project LRU cache.
+Storage registry with per-namespace LRU cache.
 
-Each (factory, project) pair gets its own storage instance with an isolated
-VectorDatabase connection. Project isolation is PHYSICAL: each project gets
-its own directory under ``{data_dir}/{project}/``.
+Each (factory, namespace) pair gets its own storage instance with an isolated
+VectorDatabase connection. The public argument is still named ``project`` for
+backward compatibility, but datasource-bound stores pass a datasource-scoped
+storage namespace here.
 """
 
 from __future__ import annotations
@@ -65,7 +66,7 @@ def get_storage_defaults() -> Dict[str, Any]:
 
 @lru_cache(maxsize=128)
 def _get_storage_cached(factory_name: str, embedding_model_conf_name: str, project: str) -> BaseEmbeddingStore:
-    """LRU-cached storage creation, keyed by (factory, embedding model, project)."""
+    """LRU-cached storage creation, keyed by (factory, embedding model, namespace)."""
     from datus.storage.backend_holder import create_vector_connection
     from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore
 
@@ -89,11 +90,11 @@ def get_storage(
     embedding_model_conf_name: str,
     project: str,
 ) -> BaseEmbeddingStore:
-    """Return a storage instance scoped to *project*.
+    """Return a storage instance scoped to a backend namespace.
 
-    Project isolation is PHYSICAL: each project gets a per-project directory
-    under ``{data_dir}/{project}/``. ``project`` must be non-empty and is
-    forwarded to the backend ``connect()`` call.
+    The argument is named ``project`` for API compatibility, but callers may
+    pass either a project namespace or a datasource-scoped namespace. It must be
+    non-empty and is forwarded to the backend ``connect()`` call.
 
     Uses an LRU cache (maxsize=128) so that inactive projects are evicted.
     Global defaults set via ``configure_storage_defaults()`` are
@@ -113,7 +114,7 @@ def _get_subject_tree_cached(project: str) -> "SubjectTreeStore":
 
 
 def get_subject_tree_store(project: str) -> "SubjectTreeStore":
-    """Return a SubjectTreeStore instance (LRU-cached per project)."""
+    """Return a SubjectTreeStore instance (LRU-cached per backend namespace)."""
     return _get_subject_tree_cached(project)
 
 
@@ -121,6 +122,7 @@ def preload_all_storages(
     project: str,
     data_dir: str = "",
     config: Optional[StorageBackendConfig] = None,
+    datasource: Optional[str] = None,
     **defaults: Any,
 ) -> None:
     """One-stop initialization: backends + defaults + all storage singletons.
@@ -129,13 +131,15 @@ def preload_all_storages(
     eager loading of every storage singleton into a single call.
 
     Args:
-        project: Project identifier for per-project isolation, forwarded
-            to every storage factory.  Must be non-empty.
+        project: Workspace project name. Must be non-empty.
         data_dir: Root data directory for file-based backends (e.g.
             ``~/.datus/data``).  Passed to ``init_backends()``.
         config: Storage backend configuration. Controls which RDB
             (sqlite/postgresql) and vector (lance) backends are used.
             Defaults to sqlite + lance if omitted.
+        datasource: Optional datasource to preload datasource-scoped KB stores.
+            When omitted, datasource-scoped stores are left lazy to avoid
+            creating project-scope tables that runtime RAG wrappers never use.
         **defaults: Deployment-level defaults forwarded to
             ``configure_storage_defaults()`` and then to every
             storage constructor (e.g. ``table_prefix="tb_"``).
@@ -168,21 +172,34 @@ def preload_all_storages(
     if defaults:
         configure_storage_defaults(**defaults)
 
-    # 3. Eagerly create all storage singletons
+    if not datasource:
+        logger.info("Storage backends initialized; datasource-scoped stores will be created lazily")
+        return
+
+    from types import SimpleNamespace
+
+    from datus.storage.scope import datasource_storage_namespace
+
+    storage_namespace = datasource_storage_namespace(
+        SimpleNamespace(project_name=project, current_datasource=datasource),
+        datasource,
+    )
+
+    # 3. Eagerly create datasource-scoped storage singletons
     from datus.storage.ext_knowledge.store import ExtKnowledgeStore
     from datus.storage.metric.store import MetricStorage
     from datus.storage.reference_sql.store import ReferenceSqlStorage
     from datus.storage.schema_metadata.store import SchemaStorage, SchemaValueStorage
     from datus.storage.semantic_model.store import SemanticModelStorage
 
-    get_storage(SchemaStorage, "database", project=project)
-    get_storage(SchemaValueStorage, "database", project=project)
-    get_storage(SemanticModelStorage, "semantic_model", project=project)
-    get_storage(MetricStorage, "metric", project=project)
-    get_storage(ReferenceSqlStorage, "reference_sql", project=project)
-    get_storage(ExtKnowledgeStore, "ext_knowledge", project=project)
-    get_subject_tree_store(project=project)
-    logger.info("All storage singletons pre-loaded")
+    get_storage(SchemaStorage, "database", project=storage_namespace)
+    get_storage(SchemaValueStorage, "database", project=storage_namespace)
+    get_storage(SemanticModelStorage, "semantic_model", project=storage_namespace)
+    get_storage(MetricStorage, "metric", project=storage_namespace)
+    get_storage(ReferenceSqlStorage, "reference_sql", project=storage_namespace)
+    get_storage(ExtKnowledgeStore, "ext_knowledge", project=storage_namespace)
+    get_subject_tree_store(project=storage_namespace)
+    logger.info("Datasource-scoped storage singletons pre-loaded for datasource=%s", datasource)
 
 
 def clear_storage_registry() -> None:

--- a/datus/storage/schema_metadata/local_init.py
+++ b/datus/storage/schema_metadata/local_init.py
@@ -45,8 +45,8 @@ async def init_local_schema_async(
         agent_config: Agent configuration
         db_manager: Database manager
         build_mode: "overwrite" wipes the schema+value tables for the
-            entire project (across ALL datasources sharing this project)
-            before re-populating with the current ``--datasource``;
+            current datasource storage namespace before re-populating with the
+            current ``--datasource``;
             "incremental" leaves existing rows in place.
         table_type: Which object types to initialise
         init_catalog_name: Optional catalog filter
@@ -56,8 +56,8 @@ async def init_local_schema_async(
     """
     if build_mode == "overwrite":
         logger.info(
-            "[overwrite] Wiping schema metadata store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping schema metadata store for datasource '%s' before re-population",
+            agent_config.current_datasource,
         )
         table_lineage_store.truncate()
 

--- a/datus/storage/schema_metadata/store.py
+++ b/datus/storage/schema_metadata/store.py
@@ -240,10 +240,11 @@ class SchemaWithValueRAG:
     ):
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
+        from datus.storage.scope import resolve_datasource_scope
 
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
-        self.schema_store = get_storage(SchemaStorage, "database", project=agent_config.project_name)
-        self.value_store = get_storage(SchemaValueStorage, "database", project=agent_config.project_name)
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
+        self.schema_store = get_storage(SchemaStorage, "database", project=self.storage_namespace)
+        self.value_store = get_storage(SchemaValueStorage, "database", project=self.storage_namespace)
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.schema_store, "tables")
 
     def _sub_agent_conditions(self) -> list:

--- a/datus/storage/scope.py
+++ b/datus/storage/scope.py
@@ -1,0 +1,120 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Helpers for deriving backend storage namespaces.
+
+The storage registry still names its routing argument ``project`` for backward
+compatibility, but datasource-bound KB stores need a narrower backend namespace
+than the workspace project.  These helpers keep that derivation centralized.
+
+Datasource-scoped KB stores use ``datasource_storage_namespace()`` so storage,
+subject tree rows, and vector rows do not leak across datasources in the same
+workspace project. Project-scoped stores use the project namespace directly or
+compose their own explicit sub-namespace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from datus.configuration.agent_config import AgentConfig
+
+# Informational classification used by tests and maintainers. Runtime routing
+# still goes through the helper functions below.
+DATASOURCE_SCOPED_KB_STORES = frozenset(
+    {
+        "ext_knowledge",
+        "metric",
+        "reference_sql",
+        "reference_template",
+        "schema_metadata",
+        "semantic_model",
+        "subject_tree",
+    }
+)
+PROJECT_SCOPED_STORES = frozenset(
+    {
+        "document",
+        "feedback",
+        "knowledge_provenance",
+        "task",
+    }
+)
+
+_SAFE_NAMESPACE_RE = re.compile(r"[^A-Za-z0-9_]")
+_MAX_NAMESPACE_LEN = 200
+_HASH_LEN = 8
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()[:_HASH_LEN]
+
+
+def safe_storage_namespace_token(value: object, fallback: str = "default") -> str:
+    """Return a backend-safe namespace token.
+
+    The token is intentionally stricter than filesystem path segments so it also
+    works for PostgreSQL schema names in physical isolation mode.
+    """
+
+    raw = str(value or "").strip()
+    normalized = _SAFE_NAMESPACE_RE.sub("_", raw)
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    if not normalized:
+        normalized = fallback
+    if not (normalized[0].isalpha() or normalized[0] == "_"):
+        normalized = f"n_{normalized}"
+
+    needs_digest = normalized != raw or len(normalized) > _MAX_NAMESPACE_LEN
+    digest = _hash(raw or fallback)
+    if len(normalized) > _MAX_NAMESPACE_LEN:
+        keep = _MAX_NAMESPACE_LEN - _HASH_LEN - 1
+        normalized = f"{normalized[:keep]}_{digest}"
+    elif needs_digest:
+        suffix = f"_{digest}"
+        if len(normalized) + len(suffix) > _MAX_NAMESPACE_LEN:
+            keep = _MAX_NAMESPACE_LEN - len(suffix)
+            normalized = normalized[:keep]
+        normalized = f"{normalized}{suffix}"
+    return normalized
+
+
+def project_storage_namespace(agent_config: "AgentConfig") -> str:
+    """Return the backend namespace for project-scoped storage."""
+
+    return safe_storage_namespace_token(getattr(agent_config, "project_name", ""), fallback="project")
+
+
+def resolve_datasource_id(agent_config: "AgentConfig", datasource: Optional[str] = None) -> str:
+    """Return the datasource id required by datasource-scoped KB storage."""
+
+    datasource_name = datasource if datasource is not None else getattr(agent_config, "current_datasource", "")
+    datasource_id = str(datasource_name or "").strip()
+    if not datasource_id:
+        raise ValueError("datasource is required for datasource-scoped storage")
+    return datasource_id
+
+
+def resolve_datasource_scope(agent_config: "AgentConfig", datasource: Optional[str] = None) -> tuple[str, str]:
+    """Return ``(datasource_id, storage_namespace)`` for datasource-scoped KB storage."""
+
+    datasource_id = resolve_datasource_id(agent_config, datasource)
+    return datasource_id, datasource_storage_namespace(agent_config, datasource_id)
+
+
+def datasource_storage_namespace(agent_config: "AgentConfig", datasource: Optional[str] = None) -> str:
+    """Return the backend namespace for datasource-scoped KB storage."""
+
+    project = project_storage_namespace(agent_config)
+    datasource_name = resolve_datasource_id(agent_config, datasource)
+    ds_token = safe_storage_namespace_token(datasource_name, fallback="datasource")
+    namespace = f"{project}__ds__{ds_token}"
+    if len(namespace) <= _MAX_NAMESPACE_LEN:
+        return namespace
+    digest = _hash(namespace)
+    keep = _MAX_NAMESPACE_LEN - _HASH_LEN - 1
+    return f"{namespace[:keep]}_{digest}"

--- a/datus/storage/scope.py
+++ b/datus/storage/scope.py
@@ -20,6 +20,8 @@ import hashlib
 import re
 from typing import TYPE_CHECKING, Optional
 
+from datus.utils.exceptions import DatusException, ErrorCode
+
 if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
 
@@ -95,7 +97,10 @@ def resolve_datasource_id(agent_config: "AgentConfig", datasource: Optional[str]
     datasource_name = datasource if datasource is not None else getattr(agent_config, "current_datasource", "")
     datasource_id = str(datasource_name or "").strip()
     if not datasource_id:
-        raise ValueError("datasource is required for datasource-scoped storage")
+        raise DatusException(
+            ErrorCode.STORAGE_INVALID_ARGUMENT,
+            message_args={"error_message": "datasource is required for datasource-scoped storage"},
+        )
     return datasource_id
 
 

--- a/datus/storage/semantic_model/auto_create.py
+++ b/datus/storage/semantic_model/auto_create.py
@@ -6,6 +6,7 @@
 
 import asyncio
 from collections import defaultdict
+from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Set
 
 from datus.configuration.agent_config import AgentConfig
@@ -34,7 +35,7 @@ def extract_tables_from_sql_list(
     from datus.utils.sql_utils import extract_table_names
 
     all_tables = set()
-    dialect = agent_config.db_type
+    dialect = agent_config_dialect(agent_config)
 
     for sql in sql_list:
         if sql and sql.strip():
@@ -88,7 +89,7 @@ def extract_table_sql_evidence(
     from datus.utils.sql_utils import extract_table_names
 
     evidence_by_key: dict[str, list[str]] = defaultdict(list)
-    dialect = agent_config.db_type
+    dialect = agent_config_dialect(agent_config)
 
     for idx, record in enumerate(records, 1):
         sql = str(record.get("sql") or "").strip()
@@ -121,11 +122,11 @@ def _lookup_sql_evidence(table: str, sql_evidence_by_table: Optional[dict[str, l
     return []
 
 
-def _agent_config_dialect(agent_config: AgentConfig) -> str:
+def agent_config_dialect(agent_config: AgentConfig) -> str:
     raw = getattr(agent_config, "db_type", "")
     raw = getattr(raw, "value", raw)
     if isinstance(raw, str) and raw:
-        return raw
+        return _normalize_dialect(raw)
 
     try:
         db_config = agent_config.current_db_config()
@@ -133,13 +134,20 @@ def _agent_config_dialect(agent_config: AgentConfig) -> str:
         return ""
     raw = getattr(db_config, "type", "")
     raw = getattr(raw, "value", raw)
-    return raw if isinstance(raw, str) else ""
+    return _normalize_dialect(raw) if isinstance(raw, str) else ""
+
+
+def _normalize_dialect(raw: str) -> str:
+    dialect = raw.strip().lower()
+    if dialect == "postgres":
+        return "postgresql"
+    return dialect
 
 
 def _resolved_table_target(table: str, agent_config: AgentConfig, current_db_config: object) -> dict[str, str]:
     from datus.utils.sql_utils import parse_table_name_parts
 
-    dialect = _agent_config_dialect(agent_config)
+    dialect = agent_config_dialect(agent_config)
     parsed = parse_table_name_parts(table, dialect=dialect or "snowflake")
     table_name = parsed.get("table_name") or str(table).split(".")[-1]
 
@@ -208,6 +216,24 @@ def find_missing_semantic_models(
 
             # Exact match on table name (case insensitive)
             exists = any(obj.get("name", "").lower() == table_name.lower() for obj in result)
+            if exists and not _semantic_model_yaml_exists(table_name, agent_config):
+                logger.info("Semantic model store has table %s but YAML file is missing; recreating", table_name)
+                try:
+                    current_db_config = agent_config.current_db_config()
+                    target = _resolved_table_target(table_fq_name, agent_config, current_db_config)
+                    semantic_rag.delete_semantic_model_for_table(
+                        table_name=target["table_name"],
+                        catalog_name=target["catalog_name"],
+                        database_name=target["database_name"],
+                        schema_name=target["schema_name"],
+                    )
+                except Exception as delete_error:
+                    logger.warning(
+                        "Failed to delete stale semantic model objects for %s: %s",
+                        table_name,
+                        delete_error,
+                    )
+                exists = False
 
             if not exists:
                 missing.append(table_fq_name)
@@ -216,6 +242,28 @@ def find_missing_semantic_models(
             missing.append(table_fq_name)
 
     return missing
+
+
+def _semantic_model_yaml_exists(table_name: str, agent_config: AgentConfig) -> bool:
+    """Return False only when the expected datasource YAML path is known and absent."""
+
+    try:
+        path_manager = getattr(agent_config, "path_manager", None)
+        if path_manager is None or not hasattr(path_manager, "semantic_model_path"):
+            return True
+        datasource = str(getattr(agent_config, "current_datasource", "") or "").strip()
+        base_path = path_manager.semantic_model_path(datasource)
+        if not isinstance(base_path, (str, Path)):
+            return True
+        semantic_dir = Path(base_path)
+    except Exception as exc:
+        logger.debug("Could not resolve semantic model YAML path for %s: %s", table_name, exc)
+        return True
+
+    safe_table_name = str(table_name or "").strip()
+    if not safe_table_name:
+        return True
+    return any((semantic_dir / f"{safe_table_name}{suffix}").exists() for suffix in (".yml", ".yaml"))
 
 
 async def create_semantic_model_for_table(
@@ -305,11 +353,106 @@ async def create_semantic_model_for_table(
         return False, str(e)
 
 
+def _format_batch_semantic_model_prompt(
+    tables: Sequence[str],
+    agent_config: AgentConfig,
+    current_db_config: object,
+    sql_evidence_by_table: Optional[dict[str, list[str]]] = None,
+) -> str:
+    table_targets = []
+    for idx, table in enumerate(tables, 1):
+        table_targets.append(
+            f"Table {idx}: {table}\n{_format_table_target_for_prompt(table, agent_config, current_db_config)}"
+        )
+
+    user_message = (
+        "Generate semantic models for the following related tables in one workflow.\n\n"
+        "Target table coordinates:\n\n"
+        + "\n\n".join(table_targets)
+        + "\n\nWhen calling database tools, pass the namespace fields separately exactly as shown above; "
+        "do not collapse a schema name into the database argument.\n"
+        "Write all required semantic model files before validation, then validate and publish them together."
+    )
+
+    evidence_sections = []
+    for table in tables:
+        evidence = _lookup_sql_evidence(table, sql_evidence_by_table)
+        if evidence:
+            evidence_sections.append(f"Evidence for {table}:\n" + "\n\n".join(evidence))
+    if evidence_sections:
+        user_message += (
+            "\n\nSuccess-story SQL evidence grouped by table. Use these queries as primary modeling evidence, "
+            "preserving joins that derive business dimensions or real time columns:\n\n"
+            + "\n\n".join(evidence_sections)
+        )
+
+    return user_message
+
+
+async def create_semantic_models_for_tables_batch(
+    tables: List[str],
+    agent_config: AgentConfig,
+    emit: Optional[Callable] = None,
+    sql_evidence_by_table: Optional[dict[str, list[str]]] = None,
+) -> tuple[bool, str]:
+    """Create multiple semantic models with one agent run."""
+    if not tables:
+        return True, ""
+
+    from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+    from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+
+    try:
+        current_db_config = agent_config.current_db_config()
+        user_message = _format_batch_semantic_model_prompt(
+            tables,
+            agent_config,
+            current_db_config,
+            sql_evidence_by_table=sql_evidence_by_table,
+        )
+    except Exception as e:
+        error = f"Error preparing batch semantic model input: {e}"
+        logger.error(error, exc_info=True)
+        return False, error
+
+    semantic_input = SemanticNodeInput(
+        user_message=user_message,
+        catalog=getattr(current_db_config, "catalog", "") or "",
+        database=getattr(current_db_config, "database", "") or "",
+        db_schema=getattr(current_db_config, "schema", "") or "",
+    )
+
+    semantic_node = GenSemanticModelAgenticNode(
+        agent_config=agent_config,
+        execution_mode="workflow",
+    )
+    semantic_node.input = semantic_input
+
+    action_history_manager = ActionHistoryManager()
+    try:
+        terminal_error = None
+        async for action in semantic_node.execute_stream(action_history_manager):
+            if emit:
+                emit(action)
+            action_type = getattr(action, "action_type", "")
+            if action.status == ActionStatus.FAILED and action_type == "error":
+                terminal_error = action.messages or "Semantic model generation failed"
+                logger.error(terminal_error)
+                continue
+        if terminal_error:
+            return False, terminal_error
+        return True, ""
+    except Exception as e:
+        logger.error(f"Error creating semantic models for tables {tables}: {e}", exc_info=True)
+        return False, str(e)
+
+
 async def create_semantic_models_for_tables(
     tables: List[str],
     agent_config: AgentConfig,
     emit: Optional[Callable] = None,
     sql_evidence_by_table: Optional[dict[str, list[str]]] = None,
+    batch_mode: bool = False,
 ) -> tuple[List[str], List[tuple[str, str]]]:
     """
     Create semantic models for the specified tables, processing each table
@@ -321,6 +464,8 @@ async def create_semantic_models_for_tables(
         emit: Optional progress callback
         sql_evidence_by_table: Optional mapping of table lookup key to
             success-story SQL evidence.
+        batch_mode: When True, try one multi-table agent run first and fall
+            back to per-table generation for any table still missing.
 
     Returns:
         (succeeded_tables, failed_tables) where failed_tables is a list of
@@ -331,8 +476,37 @@ async def create_semantic_models_for_tables(
 
     succeeded: List[str] = []
     failed: List[tuple[str, str]] = []
+    fallback_tables = list(tables)
 
-    for table in tables:
+    if batch_mode and len(tables) > 1:
+        logger.info("Creating semantic models for %d tables in one batch: %s", len(tables), tables)
+        batch_success, batch_error = await create_semantic_models_for_tables_batch(
+            tables,
+            agent_config,
+            emit,
+            sql_evidence_by_table=sql_evidence_by_table,
+        )
+        if batch_success:
+            still_missing = set(find_missing_semantic_models(set(tables), agent_config))
+            succeeded = [table for table in tables if table not in still_missing]
+            fallback_tables = [table for table in tables if table in still_missing]
+            if succeeded:
+                logger.info("Batch-created semantic models for: %s", succeeded)
+            if not fallback_tables:
+                return succeeded, []
+            logger.warning(
+                "Batch semantic model generation completed but %d table(s) are still missing; "
+                "falling back to per-table generation for: %s",
+                len(fallback_tables),
+                fallback_tables,
+            )
+        else:
+            logger.warning(
+                "Batch semantic model generation failed; falling back to per-table generation: %s",
+                batch_error,
+            )
+
+    for table in fallback_tables:
         logger.info(f"Creating semantic model for table: {table}")
         sql_evidence = _lookup_sql_evidence(table, sql_evidence_by_table)
         if sql_evidence:
@@ -362,6 +536,7 @@ def create_semantic_models_for_tables_sync(
     agent_config: AgentConfig,
     emit: Optional[Callable] = None,
     sql_evidence_by_table: Optional[dict[str, list[str]]] = None,
+    batch_mode: bool = False,
 ) -> tuple[List[str], List[tuple[str, str]]]:
     """
     Synchronous wrapper for create_semantic_models_for_tables.
@@ -369,9 +544,12 @@ def create_semantic_models_for_tables_sync(
     Returns:
         (succeeded_tables, failed_tables)
     """
-    if sql_evidence_by_table is None:
-        return asyncio.run(create_semantic_models_for_tables(tables, agent_config, emit))
-    return asyncio.run(create_semantic_models_for_tables(tables, agent_config, emit, sql_evidence_by_table))
+    kwargs = {}
+    if sql_evidence_by_table is not None:
+        kwargs["sql_evidence_by_table"] = sql_evidence_by_table
+    if batch_mode:
+        kwargs["batch_mode"] = True
+    return asyncio.run(create_semantic_models_for_tables(tables, agent_config, emit, **kwargs))
 
 
 async def ensure_semantic_models_exist(
@@ -379,6 +557,7 @@ async def ensure_semantic_models_exist(
     agent_config: AgentConfig,
     emit: Optional[Callable] = None,
     sql_evidence_by_table: Optional[dict[str, list[str]]] = None,
+    batch_mode: bool = False,
 ) -> tuple[bool, str, List[str]]:
     """
     Check and create missing semantic models. Processes each table independently
@@ -390,6 +569,8 @@ async def ensure_semantic_models_exist(
         emit: Optional progress callback
         sql_evidence_by_table: Optional mapping of table lookup key to
             success-story SQL evidence.
+        batch_mode: When True, create missing models with one multi-table
+            agent run when possible, then fall back per table for misses.
 
     Returns:
         (success, error_message, created_tables) — success is True when at
@@ -404,15 +585,17 @@ async def ensure_semantic_models_exist(
 
     logger.info(f"Found {len(missing_tables)} tables without semantic models: {missing_tables}")
 
+    create_kwargs = {}
     if sql_evidence_by_table is not None:
-        succeeded, failed = await create_semantic_models_for_tables(
-            missing_tables,
-            agent_config,
-            emit,
-            sql_evidence_by_table=sql_evidence_by_table,
-        )
-    else:
-        succeeded, failed = await create_semantic_models_for_tables(missing_tables, agent_config, emit)
+        create_kwargs["sql_evidence_by_table"] = sql_evidence_by_table
+    if batch_mode:
+        create_kwargs["batch_mode"] = True
+    succeeded, failed = await create_semantic_models_for_tables(
+        missing_tables,
+        agent_config,
+        emit,
+        **create_kwargs,
+    )
 
     if succeeded:
         logger.info(f"Successfully created semantic models for: {succeeded}")

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -98,8 +98,8 @@ async def init_success_story_semantic_model_async(
         from datus.storage.semantic_model.store import SemanticModelRAG
 
         logger.info(
-            "[overwrite] Wiping semantic_model store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping semantic_model store for datasource '%s' before re-population",
+            agent_config.current_datasource,
         )
         SemanticModelRAG(agent_config).truncate()
 

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -19,6 +19,47 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _strip_identifier_quotes(value: str) -> str:
+    value = value.strip()
+    while len(value) >= 2 and (
+        (value[0] == value[-1] and value[0] in {'"', "'", "`"}) or (value[0] == "[" and value[-1] == "]")
+    ):
+        value = value[1:-1].strip()
+    return value
+
+
+def _identifier_variants(value: str) -> List[str]:
+    """Return common exact-match variants for SQL identifiers."""
+
+    if not value:
+        return []
+    raw = _strip_identifier_quotes(value)
+    parts = [_strip_identifier_quotes(part) for part in raw.split(".") if part.strip()]
+    candidates = [raw]
+    if parts:
+        candidates.append(parts[-1])
+        candidates.append(".".join(parts))
+
+    expanded: List[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        expanded.extend([candidate, candidate.lower(), candidate.upper()])
+
+    seen = set()
+    result: List[str] = []
+    for candidate in expanded:
+        if candidate not in seen:
+            seen.add(candidate)
+            result.append(candidate)
+    return result
+
+
+def _normalized_identifier(value: str) -> str:
+    parts = [_strip_identifier_quotes(part) for part in str(value or "").split(".") if part.strip()]
+    return ".".join(parts).lower()
+
+
 class SemanticModelStorage(BaseEmbeddingStore):
     """Storage for field-level semantic objects (tables, columns) - excluding metrics."""
 
@@ -270,10 +311,11 @@ class SemanticModelRAG:
     ):
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
+        from datus.storage.scope import resolve_datasource_scope
 
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
         self.storage: SemanticModelStorage = get_storage(
-            SemanticModelStorage, "semantic_model", project=agent_config.project_name
+            SemanticModelStorage, "semantic_model", project=self.storage_namespace
         )
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.storage, "tables")
 
@@ -287,6 +329,93 @@ class SemanticModelRAG:
     def truncate(self) -> None:
         """Delete all semantic model data for this datasource."""
         self.storage.truncate_scoped()
+
+    def delete_semantic_model_for_table(
+        self,
+        table_name: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> int:
+        """Delete table and child semantic objects for one stored table coordinate.
+
+        The delete path first resolves the stored table row, then deletes rows
+        by that row's persisted catalog/database/schema/table fields. This keeps
+        the deletion aligned with the original sync path, including dialect
+        defaults such as an injected catalog.
+        """
+        if not table_name:
+            logger.warning("delete_semantic_model_for_table called without table_name")
+            return 0
+
+        base_conds = self._sub_agent_conditions()
+        table_rows = self.storage._search_all(
+            where=And([eq("kind", "table")] + base_conds),
+            select_fields=["name", "fq_name", "catalog_name", "database_name", "schema_name", "table_name"],
+        ).to_pylist()
+
+        target_norms = {_normalized_identifier(candidate) for candidate in _identifier_variants(table_name)}
+        candidates = [
+            row
+            for row in table_rows
+            if target_norms
+            & {
+                _normalized_identifier(row.get("name", "")),
+                _normalized_identifier(row.get("fq_name", "")),
+                _normalized_identifier(row.get("table_name", "")),
+            }
+        ]
+
+        def _matches_hierarchy(row: Dict[str, Any]) -> bool:
+            checks = (
+                ("catalog_name", catalog_name),
+                ("database_name", database_name),
+                ("schema_name", schema_name),
+            )
+            return all(
+                not expected or _normalized_identifier(row.get(field, "")) == _normalized_identifier(expected)
+                for field, expected in checks
+            )
+
+        matched_rows = [row for row in candidates if _matches_hierarchy(row)]
+        if not matched_rows and not any((catalog_name, database_name, schema_name)):
+            matched_rows = candidates
+
+        identities = {
+            (
+                row.get("catalog_name") or "",
+                row.get("database_name") or "",
+                row.get("schema_name") or "",
+                row.get("table_name") or row.get("name") or table_name,
+            )
+            for row in matched_rows
+        }
+        if not identities:
+            return 0
+        if len(identities) > 1 and not any((catalog_name, database_name, schema_name)):
+            logger.warning(
+                "Refusing broad semantic model delete for %s because multiple stored table coordinates matched",
+                table_name,
+            )
+            return 0
+
+        deleted_count = 0
+        for catalog, database, schema, stored_table in identities:
+            conditions = [
+                eq("table_name", stored_table),
+                eq("catalog_name", catalog),
+                eq("database_name", database),
+                eq("schema_name", schema),
+            ] + base_conds
+            where = And(conditions)
+            count = self.storage._count_rows(where=where)
+            if count:
+                self.storage._delete_rows(where)
+                deleted_count += count
+
+        if deleted_count:
+            logger.info("Deleted %d stale semantic object(s) for table %s", deleted_count, table_name)
+        return deleted_count
 
     def get_semantic_model(
         self,
@@ -303,34 +432,61 @@ class SemanticModelRAG:
 
         base_conds = self._sub_agent_conditions()
 
-        # Build filter conditions
-        table_conds = [eq("kind", "table"), eq("table_name", table_name)] + base_conds
-        if catalog_name:
-            table_conds.append(eq("catalog_name", catalog_name))
-        if database_name:
-            table_conds.append(eq("database_name", database_name))
-        if schema_name:
-            table_conds.append(eq("schema_name", schema_name))
+        def _hierarchy_conds() -> List:
+            conditions = []
+            if catalog_name:
+                conditions.append(eq("catalog_name", catalog_name))
+            if database_name:
+                conditions.append(eq("database_name", database_name))
+            if schema_name:
+                conditions.append(eq("schema_name", schema_name))
+            return conditions
 
-        table_objs = self.storage._search_all(where=And(table_conds)).to_pylist()
+        def _search_exact(field: str, value: str, include_hierarchy: bool = True) -> List[Dict[str, Any]]:
+            conditions = [eq("kind", "table"), eq(field, value)] + base_conds
+            if include_hierarchy:
+                conditions.extend(_hierarchy_conds())
+            return self.storage._search_all(where=And(conditions)).to_pylist()
 
-        # Fallback 1: broad match
+        table_objs: List[Dict[str, Any]] = []
+        table_candidates = _identifier_variants(table_name)
+        fq_candidate_values = []
+        explicit_fq = ".".join(part for part in [catalog_name, database_name, schema_name, table_name] if part)
+        if explicit_fq:
+            fq_candidate_values.extend(_identifier_variants(explicit_fq))
+        fq_candidate_values.extend(candidate for candidate in _identifier_variants(table_name) if "." in candidate)
+
+        for candidate in table_candidates:
+            table_objs = _search_exact("table_name", candidate, include_hierarchy=True)
+            if table_objs:
+                break
+        if not table_objs:
+            for candidate in fq_candidate_values:
+                table_objs = _search_exact("fq_name", candidate, include_hierarchy=False)
+                if table_objs:
+                    break
+
+        # Fallback 1: broad exact match without hierarchy filters.
         if not table_objs and (catalog_name or database_name or schema_name):
             logger.debug(f"Semantic model not found for {table_name} with full filters, trying broad match.")
-            broad_conds = [
-                eq("kind", "table"),
-                eq("table_name", table_name),
-            ] + base_conds
-            table_objs = self.storage._search_all(where=And(broad_conds)).to_pylist()
+            for candidate in table_candidates:
+                table_objs = _search_exact("table_name", candidate, include_hierarchy=False)
+                if table_objs:
+                    break
 
-        # Fallback 2: case-insensitive
+        # Fallback 2: normalized Python-side match for quoted/FQN/case variants.
         if not table_objs:
-            if table_name.lower() != table_name:
-                lower_conds = [
-                    eq("kind", "table"),
-                    eq("table_name", table_name.lower()),
-                ] + base_conds
-                table_objs = self.storage._search_all(where=And(lower_conds)).to_pylist()
+            target_norms = {_normalized_identifier(candidate) for candidate in table_candidates + fq_candidate_values}
+            all_tables = self.storage._search_all(where=And([eq("kind", "table")] + base_conds)).to_pylist()
+            for obj in all_tables:
+                obj_norms = {
+                    _normalized_identifier(obj.get("table_name", "")),
+                    _normalized_identifier(obj.get("name", "")),
+                    _normalized_identifier(obj.get("fq_name", "")),
+                }
+                if target_norms & obj_norms:
+                    table_objs = [obj]
+                    break
 
         if not table_objs:
             return None

--- a/datus/storage/subject_manager.py
+++ b/datus/storage/subject_manager.py
@@ -16,6 +16,7 @@ from datus.storage.ext_knowledge import ExtKnowledgeStore
 from datus.storage.metric import MetricStorage
 from datus.storage.reference_sql import ReferenceSqlStorage
 from datus.storage.registry import get_storage
+from datus.storage.scope import resolve_datasource_scope
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -26,13 +27,13 @@ class SubjectUpdater:
 
     def __init__(self, agent_config: AgentConfig, datasource_id: Optional[str] = None):
         self._agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
-        self.metrics_storage: MetricStorage = get_storage(MetricStorage, "metric", project=agent_config.project_name)
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
+        self.metrics_storage: MetricStorage = get_storage(MetricStorage, "metric", project=self.storage_namespace)
         self.reference_sql_storage: ReferenceSqlStorage = get_storage(
-            ReferenceSqlStorage, "reference_sql", project=agent_config.project_name
+            ReferenceSqlStorage, "reference_sql", project=self.storage_namespace
         )
         self.ext_knowledge_storage: ExtKnowledgeStore = get_storage(
-            ExtKnowledgeStore, "ext_knowledge", project=agent_config.project_name
+            ExtKnowledgeStore, "ext_knowledge", project=self.storage_namespace
         )
 
     def update_metrics_detail(self, subject_path: List[str], name: str, update_values: Dict[str, Any]):

--- a/datus/storage/subject_tree/store.py
+++ b/datus/storage/subject_tree/store.py
@@ -81,9 +81,10 @@ class SubjectTreeStore:
         """Initialize SubjectTreeStore.
 
         Args:
-            project: Project identifier used by the underlying RDB backend for
-                isolation. Must be non-empty; the backend rejects empty
-                identifiers.
+            project: Backend storage namespace used by the underlying RDB
+                backend for isolation. Must be non-empty; the backend rejects
+                empty identifiers. Datasource-scoped KB callers pass
+                ``datasource_storage_namespace(...)`` here.
 
         Reads ``table_prefix``, ``extra_fields``, and ``scope_indices`` from
         the storage registry defaults (set via ``configure_storage_defaults()``).
@@ -676,7 +677,8 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
     ):
         # ``project`` is injected by the storage registry; pop it before forwarding
         # so BaseEmbeddingStore (which has a strict signature) doesn't reject it.
-        # Falls back to the active path_manager for callers that bypass the registry.
+        # Direct low-level constructors are test/backward-compatible paths and
+        # use a reserved subject-tree namespace instead of the bare project.
         project = kwargs.pop("project", None)
 
         super().__init__(
@@ -693,9 +695,11 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         from datus.storage.registry import get_subject_tree_store
 
         if not project:
+            from datus.storage.scope import safe_storage_namespace_token
             from datus.utils.path_manager import get_path_manager
 
-            project = get_path_manager().project_name
+            base_project = safe_storage_namespace_token(get_path_manager().project_name, fallback="project")
+            project = f"{base_project}__direct_subject_tree"
 
         self.subject_tree = get_subject_tree_store(project=project)
 

--- a/datus/storage/table_identity.py
+++ b/datus/storage/table_identity.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping
 
 from datus.tools.db_tools import connector_registry
 from datus.utils.constants import DBType
+from datus.utils.exceptions import DatusException, ErrorCode
 
 
 def _dialect_value(db_type: Any) -> str:
@@ -23,7 +24,10 @@ def build_semantic_table_identity(values: Mapping[str, Any], db_type: Any) -> st
     table_name = str(values.get("table_name") or "").strip()
     dialect = _dialect_value(db_type)
     if not dialect:
-        raise ValueError("db_type is required to build semantic table identity")
+        raise DatusException(
+            ErrorCode.STORAGE_INVALID_ARGUMENT,
+            message_args={"error_message": "db_type is required to build semantic table identity"},
+        )
 
     sqlite_value = _dialect_value(DBType.SQLITE)
     parts = [

--- a/datus/storage/table_identity.py
+++ b/datus/storage/table_identity.py
@@ -1,0 +1,37 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Shared semantic-object identity helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from datus.tools.db_tools import connector_registry
+from datus.utils.constants import DBType
+
+
+def _dialect_value(db_type: Any) -> str:
+    raw = getattr(db_type, "value", db_type)
+    return str(raw or "").strip()
+
+
+def build_semantic_table_identity(values: Mapping[str, Any], db_type: Any) -> str:
+    """Build the table identity used by semantic table/column storage ids."""
+
+    table_name = str(values.get("table_name") or "").strip()
+    dialect = _dialect_value(db_type)
+    if not dialect:
+        raise ValueError("db_type is required to build semantic table identity")
+
+    sqlite_value = _dialect_value(DBType.SQLITE)
+    parts = [
+        values.get("catalog_name", "") if connector_registry.support_catalog(dialect) else "",
+        values.get("database_name", "")
+        if connector_registry.support_database(dialect) or dialect == sqlite_value
+        else "",
+        values.get("schema_name", "") if connector_registry.support_schema(dialect) else "",
+        table_name,
+    ]
+    return ".".join(str(part).strip() for part in parts if str(part).strip()) or table_name

--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -16,14 +16,14 @@ logger = get_logger(__name__)
 
 
 def normalize_null(value):
-    """Convert string 'null', 'None', empty, or whitespace-only values to None for LLM compatibility.
+    """Convert string 'null', 'None', empty, or placeholder values to None for LLM compatibility.
 
-    LLMs sometimes output the string 'null' / 'None' / '' instead of JSON null.
+    LLMs sometimes output the string 'null' / 'None' / '' / '-' instead of JSON null.
     This function normalizes such values to Python None.
     """
     if value is None:
         return None
-    if isinstance(value, str) and value.strip().lower() in ("null", "none", ""):
+    if isinstance(value, str) and value.strip().lower() in ("null", "none", "", "-"):
         return None
     return value
 

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -146,12 +146,33 @@ class DBFuncTool:
         self.schema_rag = SchemaWithValueRAG(agent_config, sub_agent_name) if agent_config else None
         self._field_order = self._determine_field_order()
         self._scoped_patterns = self._load_scoped_patterns(scoped_tables)
-        self._describe_table_cache: Dict[tuple[str, str, str, str, str], FuncToolResult] = {}
+        self._describe_table_cache: Dict[tuple[str, str, str, str, str, str], FuncToolResult] = {}
 
         self._semantic_storage = SemanticModelRAG(agent_config, sub_agent_name) if agent_config else None
         self.has_schema = self.schema_rag and self.schema_rag.schema_store.table_size() > 0
 
         self.has_semantic_models = self._semantic_storage and self._semantic_storage.get_size() > 0
+
+    def _semantic_model_cache_token(self) -> str:
+        """Return a small fingerprint for semantic enrichment used by describe_table."""
+
+        if not self.has_semantic_models or not self._semantic_storage:
+            return ""
+        try:
+            rows = self._semantic_storage.search_all(select_fields=["id", "updated_at"])
+        except Exception as exc:
+            logger.debug("Failed to fingerprint semantic model cache state: %s", exc)
+            return "semantic:unknown"
+        latest = ""
+        count = 0
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            count += 1
+            updated_at = str(row.get("updated_at") or "")
+            if updated_at > latest:
+                latest = updated_at
+        return f"semantic:{count}:{latest}"
 
     def _init_single_db_connector(self, connector: BaseSqlConnector):
         # Legacy single connector mode
@@ -985,6 +1006,7 @@ class DBFuncTool:
                 coordinate.database,
                 coordinate.schema,
                 coordinate.table,
+                self._semantic_model_cache_token(),
             )
             cached = self._describe_table_cache.get(cache_key)
             if cached is not None:

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -146,6 +146,7 @@ class DBFuncTool:
         self.schema_rag = SchemaWithValueRAG(agent_config, sub_agent_name) if agent_config else None
         self._field_order = self._determine_field_order()
         self._scoped_patterns = self._load_scoped_patterns(scoped_tables)
+        self._describe_table_cache: Dict[tuple[str, str, str, str, str], FuncToolResult] = {}
 
         self._semantic_storage = SemanticModelRAG(agent_config, sub_agent_name) if agent_config else None
         self.has_schema = self.schema_rag and self.schema_rag.schema_store.table_size() > 0
@@ -977,6 +978,18 @@ class DBFuncTool:
                 database=database,
                 schema=schema_name,
             )
+            source = datasource or self._default_datasource or ""
+            cache_key = (
+                str(source),
+                coordinate.catalog,
+                coordinate.database,
+                coordinate.schema,
+                coordinate.table,
+            )
+            cached = self._describe_table_cache.get(cache_key)
+            if cached is not None:
+                logger.debug("describe_table cache hit: %s", cache_key)
+                return cached.model_copy(deep=True)
 
             if not self._table_matches_scope(coordinate):
                 error_msg = f"Table '{table_name}' is outside the scoped context."
@@ -1067,7 +1080,9 @@ class DBFuncTool:
                     logger.warning(f"Failed to get semantic model for {table_name}: {e}")
 
             logger.info(f"describe_table succeeded for {table_name}, returning {len(columns)} columns")
-            return FuncToolResult(result=result_data)
+            result = FuncToolResult(result=result_data)
+            self._describe_table_cache[cache_key] = result.model_copy(deep=True)
+            return result
 
         except Exception as e:
             import traceback
@@ -1273,6 +1288,7 @@ class DBFuncTool:
         try:
             result = connector.execute_ddl(cleaned)
             if result.success:
+                self._describe_table_cache.clear()
                 # Commit to release locks (critical for SQLAlchemy-based connectors)
                 if hasattr(connector, "connection") and hasattr(connector.connection, "commit"):
                     connector.connection.commit()

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -53,9 +53,11 @@ class GenerationEvidence:
     metric_dry_run_queries: List[Dict[str, Any]] = field(default_factory=list)
     metric_sqls: Dict[str, str] = field(default_factory=dict)
     metric_queryability_contracts: List[Dict[str, Any]] = field(default_factory=list)
+    metric_aliases: Dict[str, str] = field(default_factory=dict)
     semantic_kb_sync_passed: bool = False
     metric_kb_sync_passed: bool = False
     generic_kb_sync_passed: bool = False
+    storage_revision: int = 0
 
     @property
     def kb_sync_passed(self) -> bool:
@@ -67,12 +69,33 @@ class GenerationEvidence:
         if _result_success(result) and valid:
             self.validation_passed = True
 
-    def set_metric_queryability_contracts(self, contracts: Optional[Iterable[Dict[str, Any]]]) -> None:
-        self.metric_queryability_contracts = [
-            contract
-            for contract in (contracts or [])
-            if isinstance(contract, dict) and (contract.get("dimension_hints") or contract.get("time_group_hints"))
-        ]
+    def set_metric_queryability_contracts(
+        self,
+        contracts: Optional[Iterable[Dict[str, Any]]],
+        metric_aliases: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.metric_aliases = _normalized_metric_alias_map(metric_aliases or {})
+        self.metric_queryability_contracts = []
+        for contract in contracts or []:
+            if not isinstance(contract, dict) or not (
+                contract.get("dimension_hints") or contract.get("time_group_hints")
+            ):
+                continue
+            normalized_contract = dict(contract)
+            metric_hints = []
+            alias_rewrites = {}
+            for hint in contract.get("metric_hints") or []:
+                if not isinstance(hint, str) or not hint.strip():
+                    continue
+                canonical = _canonical_metric_hint(hint, self.metric_aliases)
+                metric_hints.append(canonical)
+                if canonical != hint:
+                    alias_rewrites[hint] = canonical
+            if metric_hints:
+                normalized_contract["metric_hints"] = _deduplicate_preserve_order(metric_hints)
+            if alias_rewrites:
+                normalized_contract["metric_alias_rewrites"] = alias_rewrites
+            self.metric_queryability_contracts.append(normalized_contract)
 
     def record_metric_dry_run(
         self,
@@ -90,10 +113,15 @@ class GenerationEvidence:
         metrics_list = [m for m in metric_candidates if isinstance(m, str) and m]
         self.metric_dry_run_metrics.update(metrics_list)
         dimensions_list = [d for d in dimension_candidates if isinstance(d, str) and d]
+        explicit_time_granularity = isinstance(time_granularity, str) and bool(_normalize_time_grain(time_granularity))
+        normalized_time_granularity = (
+            time_granularity if explicit_time_granularity else _time_grain_from_dimensions(dimensions_list)
+        )
         dry_run_query = {
             "metrics": metrics_list,
             "dimensions": dimensions_list,
-            "time_granularity": time_granularity if isinstance(time_granularity, str) else None,
+            "time_granularity": normalized_time_granularity,
+            "time_granularity_explicit": explicit_time_granularity,
         }
         self.metric_dry_run_queries.append(dry_run_query)
         metadata = _metadata_from_result(result)
@@ -120,6 +148,8 @@ class GenerationEvidence:
                 self.metric_sqls[metrics_list[0]] = sql
             else:
                 self.metric_sqls["__query_metrics_dry_run__"] = sql
+                for metric_name in metrics_list:
+                    self.metric_sqls.setdefault(metric_name, sql)
 
     def has_metric_dry_run(self, metric_names: Optional[Iterable[str]] = None) -> bool:
         names = {m for m in (metric_names or []) if isinstance(m, str) and m}
@@ -184,6 +214,7 @@ class GenerationEvidence:
             if (
                 _looks_time_dimension(hint)
                 and time_granularity
+                and dry_run.get("time_granularity_explicit") is True
                 and any(_is_metric_time_dimension(dimension) for dimension in dimensions)
             ):
                 continue
@@ -197,6 +228,7 @@ class GenerationEvidence:
             self.semantic_kb_sync_passed = True
         else:
             self.generic_kb_sync_passed = True
+        self.storage_revision += 1
 
 
 _GENERIC_DIMENSION_TOKENS = {"id", "key", "name", "dim", "dimension", "value"}
@@ -223,6 +255,35 @@ def _name_tokens(value: str) -> Set[str]:
 
 def _normalize_name(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", str(value).strip().lower()).strip("_")
+
+
+def _deduplicate_preserve_order(values: Iterable[str]) -> List[str]:
+    result: List[str] = []
+    seen: Set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _normalized_metric_alias_map(metric_aliases: Dict[str, str]) -> Dict[str, str]:
+    normalized: Dict[str, str] = {}
+    for alias, canonical in metric_aliases.items():
+        if not isinstance(alias, str) or not isinstance(canonical, str):
+            continue
+        alias = alias.strip()
+        canonical = canonical.strip()
+        if not alias or not canonical:
+            continue
+        normalized[alias] = canonical
+        normalized[_normalize_name(alias)] = canonical
+    return normalized
+
+
+def _canonical_metric_hint(hint: str, metric_aliases: Dict[str, str]) -> str:
+    return metric_aliases.get(hint) or metric_aliases.get(_normalize_name(hint)) or hint
 
 
 def _semantic_tokens(value: str) -> Set[str]:
@@ -307,16 +368,23 @@ def _dimension_matches_expr_hint(dimension: str, expr_hint: Dict[str, str]) -> b
 
 def _dry_run_satisfies_time_group(dry_run: Dict[str, Any], time_hint: Dict[str, str]) -> bool:
     grain = _normalize_time_grain(time_hint.get("grain", ""))
-    dry_run_grain = _normalize_time_grain(dry_run.get("time_granularity"))
+    dimensions = [d for d in dry_run.get("dimensions", []) if isinstance(d, str)]
+    dry_run_grain = _normalize_time_grain(dry_run.get("time_granularity")) or _time_grain_from_dimensions(dimensions)
     if not grain or dry_run_grain != grain:
         return False
 
-    dimensions = [d for d in dry_run.get("dimensions", []) if isinstance(d, str)]
     base_expr = time_hint.get("base_expr", "")
     if base_expr and any(_time_base_dimension_matches(dimension, base_expr) for dimension in dimensions):
         return True
 
     sql = dry_run.get("sql", "")
+    if (
+        isinstance(sql, str)
+        and base_expr
+        and _sql_contains_base_expr_text(sql, base_expr)
+        and (not dimensions or any(_is_metric_time_dimension(dimension) for dimension in dimensions))
+    ):
+        return True
     if not isinstance(sql, str) or not _sql_contains_time_group(sql, base_expr, grain):
         return False
     return True
@@ -325,6 +393,22 @@ def _dry_run_satisfies_time_group(dry_run: Dict[str, Any], time_hint: Dict[str, 
 def _normalize_time_grain(value: Any) -> str:
     text = str(value or "").strip().strip("'\"").lower()
     return text if text in _TIME_GRAINS else ""
+
+
+def _time_grain_from_dimensions(dimensions: Iterable[str]) -> Optional[str]:
+    for dimension in dimensions:
+        grain = _dimension_time_grain(dimension)
+        if grain:
+            return grain
+    return None
+
+
+def _dimension_time_grain(dimension: str) -> str:
+    text = str(dimension or "").strip().lower()
+    if "__" not in text:
+        return ""
+    grain = re.sub(r"[^a-z0-9]+", "", text.rsplit("__", 1)[-1])
+    return grain if grain in _TIME_GRAINS else ""
 
 
 def _time_base_dimension_matches(dimension: str, base_expr: str) -> bool:
@@ -349,6 +433,18 @@ def _sql_contains_time_group(sql: str, base_expr: str, grain: str) -> bool:
             if _time_trunc_expression_matches(expr, normalized_base, grain):
                 return True
     return False
+
+
+def _sql_contains_base_expr_text(sql: str, base_expr: str) -> bool:
+    normalized_sql = _normalize_sql_text(sql)
+    normalized_base = _normalize_sql_text(base_expr)
+    if normalized_base and normalized_base in normalized_sql:
+        return True
+    leaf = _last_identifier(base_expr)
+    normalized_leaf = _normalize_sql_text(leaf)
+    return bool(
+        normalized_leaf and re.search(rf"(?<![a-z0-9_]){re.escape(normalized_leaf)}(?![a-z0-9_])", normalized_sql)
+    )
 
 
 def _sql_contains_expression(sql: str, expression: str) -> bool:

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -4,7 +4,8 @@
 
 # -*- coding: utf-8 -*-
 import os
-from typing import Dict, List, Optional
+from collections.abc import Iterable
+from typing import Any, Dict, List, Optional
 
 import yaml
 from agents import Tool
@@ -20,6 +21,36 @@ from datus.utils.loggings import get_logger
 from datus.utils.path_manager import get_path_manager
 
 logger = get_logger(__name__)
+
+
+def _rows_to_dicts(rows: Any) -> List[Dict[str, Any]]:
+    """Normalize storage row containers to a list of dictionaries."""
+
+    if rows is None:
+        return []
+    if hasattr(rows, "to_pylist"):
+        rows = rows.to_pylist()
+    if isinstance(rows, dict):
+        return [rows]
+    if isinstance(rows, list):
+        iterable: Iterable[Any] = rows
+    elif isinstance(rows, tuple):
+        iterable = rows
+    elif isinstance(rows, Iterable) and not isinstance(rows, (str, bytes)):
+        iterable = rows
+    else:
+        return []
+    return [row for row in iterable if isinstance(row, dict)]
+
+
+def _is_supported_row_container(rows: Any) -> bool:
+    if rows is None:
+        return True
+    if hasattr(rows, "to_pylist"):
+        return True
+    if isinstance(rows, (dict, list, tuple)):
+        return True
+    return isinstance(rows, Iterable) and not isinstance(rows, (str, bytes))
 
 
 class GenerationTools:
@@ -75,8 +106,9 @@ class GenerationTools:
             dict: Check results containing existence status and details.
         """
         try:
+            normalized_kind = str(kind or "").strip().lower()
             cache_key = (
-                str(kind or "").strip().lower(),
+                normalized_kind,
                 str(object_name or "").strip().lower(),
                 str(table_context or "").strip().lower(),
             )
@@ -90,17 +122,17 @@ class GenerationTools:
 
             found_object = None
 
-            if kind == "table":
+            if normalized_kind == "table":
                 table_index = self._get_semantic_table_object_index()
                 for candidate in _identifier_variants(object_name):
                     found_object = table_index.get(candidate) or table_index.get(_normalized_identifier(candidate))
                     if found_object:
                         break
-            elif kind == "metric":
+            elif normalized_kind == "metric":
                 # Exact match for metric using SQL WHERE condition
                 storage = self.metric_rag.storage
                 where = eq("name", target_name)
-                results = storage.search_all(where=where, select_fields=["id", "name"])
+                results = _rows_to_dicts(storage.search_all(where=where, select_fields=["id", "name"]))
                 if results:
                     found_object = results[0]
             else:
@@ -108,7 +140,7 @@ class GenerationTools:
                 storage = self.semantic_rag.storage
                 results = storage.search_objects(
                     query_text=object_name,
-                    kinds=[kind],
+                    kinds=[normalized_kind],
                     table_name=table_context if table_context else None,
                     top_n=5,
                 )
@@ -119,7 +151,7 @@ class GenerationTools:
                 elif "." in object_name:
                     target_table = object_name.rsplit(".", 1)[0].lower()
 
-                for obj in results:
+                for obj in _rows_to_dicts(results):
                     name_match = obj.get("name", "").lower() == target_name
                     if target_table:
                         table_match = obj.get("table_name", "").lower() == target_table
@@ -136,14 +168,16 @@ class GenerationTools:
                         "exists": True,
                         "id": found_object.get("id"),
                         "name": found_object.get("name"),
-                        "kind": found_object.get("kind") or kind,
-                        "message": f"Object '{object_name}' ({kind}) already exists.",
+                        "kind": found_object.get("kind") or normalized_kind,
+                        "message": f"Object '{object_name}' ({normalized_kind}) already exists.",
                     }
                 )
                 self._semantic_object_exists_cache[cache_key] = result.model_copy(deep=True)
                 return result
 
-            result = FuncToolResult(result={"exists": False, "message": f"No {kind} found for '{object_name}'"})
+            result = FuncToolResult(
+                result={"exists": False, "message": f"No {normalized_kind} found for '{object_name}'"}
+            )
             self._semantic_object_exists_cache[cache_key] = result.model_copy(deep=True)
             return result
 
@@ -171,12 +205,8 @@ class GenerationTools:
         storage = self.semantic_rag.storage
         select_fields = ["id", "name", "kind", "table_name", "fq_name"]
         rows = storage.search_all(where=And([eq("kind", "table")]), select_fields=select_fields)
-        if hasattr(rows, "to_pylist"):
-            rows = rows.to_pylist()
         index: Dict[str, Dict[str, object]] = {}
-        for obj in rows if isinstance(rows, list) else []:
-            if not isinstance(obj, dict):
-                continue
+        for obj in _rows_to_dicts(rows):
             for field in ("name", "table_name", "fq_name"):
                 value = str(obj.get(field) or "").strip()
                 if not value:
@@ -648,12 +678,11 @@ class GenerationTools:
         except Exception as exc:
             logger.warning("Failed to load existing metric names before publish dry-run gating: %s", exc)
             return None
-        if not isinstance(rows, list):
+        if not _is_supported_row_container(rows):
             return None
+        normalized_rows = _rows_to_dicts(rows)
         names = set()
-        for row in rows:
-            if not isinstance(row, dict):
-                continue
+        for row in normalized_rows:
             normalized = normalize_metric_name(row.get("name"))
             if normalized:
                 names.add(normalized)
@@ -671,12 +700,11 @@ class GenerationTools:
         except Exception as exc:
             logger.warning("Failed to check existing metric name conflicts before sync: %s", exc)
             return None
-        if not isinstance(rows, list):
+        if not _is_supported_row_container(rows):
             return None
+        normalized_rows = _rows_to_dicts(rows)
 
-        for row in rows:
-            if not isinstance(row, dict):
-                continue
+        for row in normalized_rows:
             normalized = normalize_metric_name(row.get("name"))
             if normalized:
                 existing_by_name.setdefault(normalized, []).append(row)

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -11,8 +11,8 @@ from agents import Tool
 from datus_storage_base.conditions import And, eq
 
 from datus.configuration.agent_config import AgentConfig
-from datus.storage.metric.store import MetricRAG
-from datus.storage.semantic_model.store import SemanticModelRAG
+from datus.storage.metric.store import MetricRAG, metric_definition_conflict, normalize_metric_name
+from datus.storage.semantic_model.store import SemanticModelRAG, _identifier_variants, _normalized_identifier
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.metric_queryability import summarize_queryability_contracts
@@ -35,6 +35,8 @@ class GenerationTools:
         self.generation_evidence = generation_evidence or GenerationEvidence()
         self.metric_rag = MetricRAG(agent_config)
         self.semantic_rag = SemanticModelRAG(agent_config)
+        self._semantic_object_exists_cache: Dict[tuple[str, str, str], FuncToolResult] = {}
+        self._semantic_table_object_index: Optional[Dict[str, Dict[str, object]]] = None
 
     def available_tools(self) -> List[Tool]:
         """
@@ -73,18 +75,27 @@ class GenerationTools:
             dict: Check results containing existence status and details.
         """
         try:
+            cache_key = (
+                str(kind or "").strip().lower(),
+                str(object_name or "").strip().lower(),
+                str(table_context or "").strip().lower(),
+            )
+            cached = self._semantic_object_exists_cache.get(cache_key)
+            if cached is not None:
+                logger.debug("check_semantic_object_exists cache hit: %s", cache_key)
+                return cached.model_copy(deep=True)
+
             # Extract the final segment as target name (e.g., "public.orders" -> "orders")
-            target_name = object_name.split(".")[-1].lower()
+            target_name = object_name.split(".")[-1].strip('`"[]').lower()
 
             found_object = None
 
             if kind == "table":
-                # Exact match for table using SQL WHERE condition
-                storage = self.semantic_rag.storage
-                where = And([eq("kind", "table"), eq("name", target_name)])
-                results = storage.search_all(where=where, select_fields=["id", "name", "kind"])
-                if results:
-                    found_object = results[0]
+                table_index = self._get_semantic_table_object_index()
+                for candidate in _identifier_variants(object_name):
+                    found_object = table_index.get(candidate) or table_index.get(_normalized_identifier(candidate))
+                    if found_object:
+                        break
             elif kind == "metric":
                 # Exact match for metric using SQL WHERE condition
                 storage = self.metric_rag.storage
@@ -120,7 +131,7 @@ class GenerationTools:
                         break
 
             if found_object:
-                return FuncToolResult(
+                result = FuncToolResult(
                     result={
                         "exists": True,
                         "id": found_object.get("id"),
@@ -129,8 +140,12 @@ class GenerationTools:
                         "message": f"Object '{object_name}' ({kind}) already exists.",
                     }
                 )
+                self._semantic_object_exists_cache[cache_key] = result.model_copy(deep=True)
+                return result
 
-            return FuncToolResult(result={"exists": False, "message": f"No {kind} found for '{object_name}'"})
+            result = FuncToolResult(result={"exists": False, "message": f"No {kind} found for '{object_name}'"})
+            self._semantic_object_exists_cache[cache_key] = result.model_copy(deep=True)
+            return result
 
         except Exception as e:
             logger.error(f"Error checking semantic object existence: {e}")
@@ -146,6 +161,35 @@ class GenerationTools:
     ) -> FuncToolResult:
         """Legacy wrapper for checking table existence."""
         return self.check_semantic_object_exists(table_name, kind="table")
+
+    def _get_semantic_table_object_index(self) -> Dict[str, Dict[str, object]]:
+        """Load table semantic objects once and index all identifier variants."""
+
+        if self._semantic_table_object_index is not None:
+            return self._semantic_table_object_index
+
+        storage = self.semantic_rag.storage
+        select_fields = ["id", "name", "kind", "table_name", "fq_name"]
+        rows = storage.search_all(where=And([eq("kind", "table")]), select_fields=select_fields)
+        if hasattr(rows, "to_pylist"):
+            rows = rows.to_pylist()
+        index: Dict[str, Dict[str, object]] = {}
+        for obj in rows if isinstance(rows, list) else []:
+            if not isinstance(obj, dict):
+                continue
+            for field in ("name", "table_name", "fq_name"):
+                value = str(obj.get(field) or "").strip()
+                if not value:
+                    continue
+                for variant in _identifier_variants(value):
+                    if variant:
+                        index.setdefault(variant, obj)
+                    normalized = _normalized_identifier(variant)
+                    if normalized:
+                        index.setdefault(normalized, obj)
+
+        self._semantic_table_object_index = index
+        return index
 
     def end_semantic_model_generation(self, semantic_model_files: List[str]) -> FuncToolResult:
         """
@@ -179,6 +223,8 @@ class GenerationTools:
             logger.info(
                 f"Semantic model generation completed for {len(semantic_model_files)} files: {semantic_model_files}"
             )
+            self._semantic_object_exists_cache.clear()
+            self._semantic_table_object_index = None
 
             return FuncToolResult(
                 result={
@@ -322,12 +368,25 @@ class GenerationTools:
                     },
                 )
             metric_names = self._extract_metric_names_from_file(abs_metric)
-            if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
+            metric_definitions = self._extract_metric_definitions_from_file(abs_metric)
+            conflict_error = self._validate_metric_name_conflicts(metric_definitions)
+            if conflict_error:
+                return FuncToolResult(
+                    success=0,
+                    error=conflict_error,
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_file": semantic_model_file,
+                        "metric_sqls": metric_sqls,
+                    },
+                )
+            required_metric_names = self._metric_names_requiring_dry_run(metric_names, metric_definitions, metric_sqls)
+            if required_metric_names and not self.generation_evidence.has_metric_dry_run(required_metric_names):
                 return FuncToolResult(
                     success=0,
                     error=(
                         "query_metrics(dry_run=True) must pass for generated metric(s): "
-                        f"{', '.join(metric_names)}. Run a dry-run query for these metric names, "
+                        f"{', '.join(required_metric_names)}. Run a dry-run query for these metric names, "
                         "fix any issues, and retry end_metric_generation."
                     ),
                     result={
@@ -336,8 +395,10 @@ class GenerationTools:
                         "metric_sqls": metric_sqls,
                     },
                 )
-            if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
-                missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
+            if required_metric_names and not self.generation_evidence.has_required_queryability_dry_runs(
+                required_metric_names
+            ):
+                missing_contracts = self.generation_evidence.missing_queryability_contracts(required_metric_names)
                 contract_summary = summarize_queryability_contracts(missing_contracts)
                 return FuncToolResult(
                     success=0,
@@ -372,6 +433,8 @@ class GenerationTools:
             self.generation_evidence.mark_kb_sync("metric")
             if sync_result.get("semantic_synced"):
                 self.generation_evidence.mark_kb_sync("semantic")
+            self._semantic_object_exists_cache.clear()
+            self._semantic_table_object_index = None
 
             return FuncToolResult(
                 result={
@@ -409,6 +472,8 @@ class GenerationTools:
                 "(separated by `---`)."
             )
         saw_metric_block = False
+        seen_names: Dict[str, str] = {}
+        saw_named_metric = False
         for doc in docs:
             if isinstance(doc, dict) and "metric" in doc:
                 saw_metric_block = True
@@ -416,7 +481,18 @@ class GenerationTools:
                 if isinstance(metric, dict):
                     name = metric.get("name")
                     if isinstance(name, str) and name.strip():
-                        return None
+                        saw_named_metric = True
+                        metric_name = name.strip()
+                        normalized = normalize_metric_name(metric_name)
+                        if normalized in seen_names:
+                            return (
+                                f"Metric file {metric_file!r} declares duplicate metric.name '{metric_name}'. "
+                                "Metric names must be unique within a datasource; merge identical definitions "
+                                "or choose a more specific business name."
+                            )
+                        seen_names[normalized] = metric_name
+        if saw_named_metric:
+            return None
         if saw_metric_block:
             return (
                 f"Metric file {metric_file!r} contains `metric:` YAML blocks, "
@@ -452,6 +528,173 @@ class GenerationTools:
             if isinstance(name, str) and name:
                 names.append(name)
         return names
+
+    @staticmethod
+    def _extract_metric_definitions_from_file(metric_file: str) -> List[Dict[str, object]]:
+        """Return lightweight metric definitions for pre-sync conflict checks."""
+        try:
+            with open(metric_file, "r", encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+        except (OSError, yaml.YAMLError):
+            return []
+
+        definitions: List[Dict[str, object]] = []
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            metric = doc.get("metric")
+            if not isinstance(metric, dict):
+                continue
+            name = metric.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            metric_type = str(metric.get("type") or "").strip()
+            type_params = metric.get("type_params") if isinstance(metric.get("type_params"), dict) else {}
+            measure_expr = ""
+            base_measures: List[str] = []
+
+            if metric_type == "measure_proxy":
+                measure = type_params.get("measure")
+                if isinstance(measure, str):
+                    measure_expr = measure
+                    base_measures.append(measure)
+                elif isinstance(measure, dict):
+                    measure_name = measure.get("name")
+                    if isinstance(measure_name, str) and measure_name.strip():
+                        measure_expr = measure_name
+                        base_measures.append(measure_name)
+            elif metric_type == "ratio":
+                for key in ("numerator", "denominator"):
+                    ref = type_params.get(key)
+                    if isinstance(ref, str) and ref.strip():
+                        base_measures.append(ref)
+                    elif isinstance(ref, dict):
+                        ref_name = ref.get("name")
+                        if isinstance(ref_name, str) and ref_name.strip():
+                            base_measures.append(ref_name)
+            elif metric_type in {"expr", "cumulative"}:
+                for ref in type_params.get("measures") or []:
+                    if isinstance(ref, str) and ref.strip():
+                        base_measures.append(ref)
+                    elif isinstance(ref, dict):
+                        ref_name = ref.get("name")
+                        if isinstance(ref_name, str) and ref_name.strip():
+                            base_measures.append(ref_name)
+                if metric_type == "expr" and type_params.get("expr"):
+                    measure_expr = str(type_params["expr"])
+            elif metric_type == "derived":
+                for ref in type_params.get("metrics") or []:
+                    if isinstance(ref, str) and ref.strip():
+                        base_measures.append(ref)
+                    elif isinstance(ref, dict):
+                        ref_name = ref.get("name")
+                        if isinstance(ref_name, str) and ref_name.strip():
+                            base_measures.append(ref_name)
+                if type_params.get("expr"):
+                    measure_expr = str(type_params["expr"])
+
+            definitions.append(
+                {
+                    "name": name.strip(),
+                    "metric_type": metric_type,
+                    "measure_expr": measure_expr,
+                    "base_measures": base_measures,
+                }
+            )
+        return definitions
+
+    def _metric_names_requiring_dry_run(
+        self,
+        metric_names: List[str],
+        metric_definitions: List[Dict[str, object]],
+        metric_sqls: Optional[Dict[str, str]] = None,
+    ) -> List[str]:
+        """Return the subset of a metric file that must be dry-run before publish.
+
+        Batch generation often appends new metrics to an existing metrics YAML file.
+        Requiring every historical metric in that file to be re-dry-run makes later
+        batches slower and brittle. We still require all new metric names, and any
+        metric name that the current run produced SQL evidence for.
+        """
+        if not metric_names:
+            return []
+
+        by_normalized_name = {normalize_metric_name(name): name for name in metric_names if normalize_metric_name(name)}
+        required = set()
+        for name in metric_sqls or {}:
+            normalized = normalize_metric_name(name)
+            if normalized and not normalized.startswith("__") and normalized in by_normalized_name:
+                required.add(normalized)
+        for name in self.generation_evidence.metric_dry_run_metrics:
+            normalized = normalize_metric_name(name)
+            if normalized in by_normalized_name:
+                required.add(normalized)
+
+        existing_names = self._existing_metric_names()
+        if existing_names is None:
+            return metric_names
+        for definition in metric_definitions:
+            normalized = normalize_metric_name(definition.get("name"))
+            if normalized and normalized not in existing_names:
+                required.add(normalized)
+
+        if not required:
+            return []
+        return [name for normalized, name in by_normalized_name.items() if normalized in required]
+
+    def _existing_metric_names(self) -> Optional[set[str]]:
+        try:
+            rows = self.metric_rag.search_all_metrics(select_fields=["name"])
+        except Exception as exc:
+            logger.warning("Failed to load existing metric names before publish dry-run gating: %s", exc)
+            return None
+        if not isinstance(rows, list):
+            return None
+        names = set()
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            normalized = normalize_metric_name(row.get("name"))
+            if normalized:
+                names.add(normalized)
+        return names
+
+    def _validate_metric_name_conflicts(self, metric_definitions: List[Dict[str, object]]) -> Optional[str]:
+        if not metric_definitions:
+            return None
+
+        existing_by_name: Dict[str, List[Dict[str, object]]] = {}
+        try:
+            rows = self.metric_rag.search_all_metrics(
+                select_fields=["id", "name", "semantic_model_name", "metric_type", "measure_expr", "base_measures"]
+            )
+        except Exception as exc:
+            logger.warning("Failed to check existing metric name conflicts before sync: %s", exc)
+            return None
+        if not isinstance(rows, list):
+            return None
+
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            normalized = normalize_metric_name(row.get("name"))
+            if normalized:
+                existing_by_name.setdefault(normalized, []).append(row)
+
+        for incoming in metric_definitions:
+            normalized = normalize_metric_name(incoming.get("name"))
+            if not normalized:
+                continue
+            for existing in existing_by_name.get(normalized, []):
+                conflict_field = metric_definition_conflict(existing, incoming)
+                if conflict_field:
+                    return (
+                        f"Metric name conflict within this datasource for '{incoming.get('name')}': "
+                        f"existing metric id '{existing.get('id')}' has a different '{conflict_field}'. "
+                        "Metric names must be unique within a datasource; choose a more specific name "
+                        "or update the existing metric explicitly."
+                    )
+        return None
 
     def _sync_metric_to_db(
         self,

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -268,7 +268,10 @@ class GenerationTools:
             return FuncToolResult(success=0, error=f"Failed to complete generation: {str(e)}")
 
     def end_metric_generation(
-        self, metric_file: str, semantic_model_file: str = "", metric_sqls_json: str = ""
+        self,
+        metric_file: str,
+        semantic_model_files: Optional[List[str]] = None,
+        metric_sqls_json: str = "",
     ) -> FuncToolResult:
         """
         Complete metric generation process and automatically sync to Knowledge Base.
@@ -283,10 +286,9 @@ class GenerationTools:
                 the live ``agent_config.current_datasource``. Absolute paths are only
                 accepted when they resolve inside the Knowledge Base semantic-model
                 sandbox.
-            semantic_model_file: Path to the primary semantic model file that defines
-                the measure(s) used by this metric. Optional — provide this if the
-                semantic model was newly created or updated. Same relative/absolute
-                rules as ``metric_file``.
+            semantic_model_files: Paths to semantic model files that were newly
+                created or updated and define the measure(s) used by this metric
+                batch. Same relative/absolute rules as ``metric_file``.
             metric_sqls_json: JSON string mapping metric names to their generated SQL (from query_metrics dry_run).
                               Example: '{"revenue_total": "SELECT SUM(revenue) FROM orders GROUP BY date"}'
 
@@ -316,7 +318,7 @@ class GenerationTools:
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files or [],
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -331,7 +333,7 @@ class GenerationTools:
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files or [],
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -341,7 +343,7 @@ class GenerationTools:
 
             logger.info(
                 f"Metric generation completed: metric_file={metric_file}, "
-                f"semantic_model_file={semantic_model_file}, "
+                f"semantic_model_files={semantic_model_files or []}, "
                 f"metric_sqls={metric_sqls}"
             )
 
@@ -358,24 +360,38 @@ class GenerationTools:
                 return resolve_kb_sandbox_path(path, kind, subject_root) or ""
 
             abs_metric = _resolve(metric_file, "metric")
-            abs_semantic = _resolve(semantic_model_file, "semantic")
+            semantic_model_files = semantic_model_files or []
+            if not isinstance(semantic_model_files, list):
+                return FuncToolResult(
+                    success=0,
+                    error="semantic_model_files must be a list of semantic model YAML paths",
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_files": semantic_model_files,
+                        "metric_sqls": metric_sqls,
+                    },
+                )
+            abs_semantic_files: List[str] = []
+            for semantic_model_file in semantic_model_files:
+                abs_semantic = _resolve(semantic_model_file, "semantic")
+                if not abs_semantic:
+                    return FuncToolResult(
+                        success=0,
+                        error=f"semantic_model_files contains path outside Knowledge Base sandbox: {semantic_model_file!r}",
+                        result={
+                            "metric_file": metric_file,
+                            "semantic_model_files": semantic_model_files,
+                            "metric_sqls": metric_sqls,
+                        },
+                    )
+                abs_semantic_files.append(abs_semantic)
             if not abs_metric:
                 return FuncToolResult(
                     success=0,
                     error=f"metric_file escapes Knowledge Base sandbox: {metric_file!r}",
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
-                        "metric_sqls": metric_sqls,
-                    },
-                )
-            if semantic_model_file and not abs_semantic:
-                return FuncToolResult(
-                    success=0,
-                    error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}",
-                    result={
-                        "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -393,7 +409,7 @@ class GenerationTools:
                     error=preflight_error,
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -406,7 +422,7 @@ class GenerationTools:
                     error=conflict_error,
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -421,7 +437,7 @@ class GenerationTools:
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -439,14 +455,14 @@ class GenerationTools:
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                         "queryability_contracts": missing_contracts,
                     },
                 )
 
             # Auto-sync to Knowledge Base
-            sync_result = self._sync_metric_to_db(abs_metric, abs_semantic, metric_sqls)
+            sync_result = self._sync_metric_to_db(abs_metric, abs_semantic_files, metric_sqls)
 
             if not sync_result.get("success"):
                 return FuncToolResult(
@@ -454,7 +470,7 @@ class GenerationTools:
                     error=f"Metric file written but KB sync failed: {sync_result.get('error', 'unknown')}",
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                         "sync": sync_result,
                     },
@@ -470,7 +486,7 @@ class GenerationTools:
                 result={
                     "message": "Metric generation completed and synced to Knowledge Base",
                     "metric_file": metric_file,
-                    "semantic_model_file": semantic_model_file,
+                    "semantic_model_files": semantic_model_files,
                     "metric_sqls": metric_sqls,
                     "sync": sync_result,
                 }
@@ -727,17 +743,17 @@ class GenerationTools:
     def _sync_metric_to_db(
         self,
         metric_file: str,
-        semantic_model_file: Optional[str] = None,
+        semantic_model_files: Optional[List[str]] = None,
         metric_sqls: Optional[Dict[str, str]] = None,
     ) -> dict:
         """
-        Sync metric (and optionally semantic model) to Knowledge Base.
+        Sync metric and any updated semantic models to Knowledge Base.
 
         Reuses GenerationHooks._sync_semantic_to_db() static method.
 
         Args:
             metric_file: Absolute path to metric YAML file
-            semantic_model_file: Optional absolute path to semantic model YAML file
+            semantic_model_files: Optional absolute paths to semantic model YAML files
             metric_sqls: Optional dict mapping metric names to generated SQL
 
         Returns:
@@ -749,60 +765,34 @@ class GenerationTools:
             if not os.path.exists(metric_file):
                 return {"success": False, "error": f"Metric file not found: {metric_file}"}
 
-            if semantic_model_file and os.path.exists(semantic_model_file):
-                # Combine semantic model + metric into a temp file for sync
-                with open(semantic_model_file, "r", encoding="utf-8") as f:
-                    semantic_docs = list(yaml.safe_load_all(f))
-                with open(metric_file, "r", encoding="utf-8") as f:
-                    metric_docs = list(yaml.safe_load_all(f))
-
-                combined_docs = semantic_docs + metric_docs
-                import tempfile
-
-                fd, temp_file = tempfile.mkstemp(
-                    suffix=".combined.tmp",
-                    dir=os.path.dirname(semantic_model_file),
-                )
-                try:
-                    os.close(fd)
-                    with open(temp_file, "w", encoding="utf-8") as f:
-                        yaml.safe_dump_all(combined_docs, f, allow_unicode=True, sort_keys=False)
-
-                    # First: sync semantic objects from the semantic model file
-                    sem_result = GenerationHooks._sync_semantic_to_db(
-                        semantic_model_file,
-                        self.agent_config,
-                        include_semantic_objects=True,
-                        include_metrics=False,
-                    )
-                    if not sem_result.get("success"):
-                        return sem_result
-                    # Then: sync metrics from combined file
-                    result = GenerationHooks._sync_semantic_to_db(
-                        temp_file,
-                        self.agent_config,
-                        include_semantic_objects=False,
-                        include_metrics=True,
-                        metric_sqls=metric_sqls,
-                        original_yaml_path=metric_file,
-                    )
-                    if result.get("success"):
-                        result["semantic_synced"] = True
-                finally:
-                    if os.path.exists(temp_file):
-                        os.remove(temp_file)
-            else:
-                # Sync metric file alone
-                result = GenerationHooks._sync_semantic_to_db(
-                    metric_file,
+            synced_semantic_files: List[str] = []
+            for semantic_model_file in semantic_model_files or []:
+                if not os.path.exists(semantic_model_file):
+                    return {
+                        "success": False,
+                        "error": f"Semantic model file not found: {semantic_model_file}",
+                    }
+                sem_result = GenerationHooks._sync_semantic_to_db(
+                    semantic_model_file,
                     self.agent_config,
-                    include_semantic_objects=False,
-                    include_metrics=True,
-                    metric_sqls=metric_sqls,
-                    original_yaml_path=metric_file,
+                    include_semantic_objects=True,
+                    include_metrics=False,
                 )
-                if result.get("success"):
-                    result["semantic_synced"] = False
+                if not sem_result.get("success"):
+                    return sem_result
+                synced_semantic_files.append(semantic_model_file)
+
+            result = GenerationHooks._sync_semantic_to_db(
+                metric_file,
+                self.agent_config,
+                include_semantic_objects=False,
+                include_metrics=True,
+                metric_sqls=metric_sqls,
+                original_yaml_path=metric_file,
+            )
+            if result.get("success"):
+                result["semantic_synced"] = bool(synced_semantic_files)
+                result["semantic_model_files_synced"] = synced_semantic_files
 
             if result.get("success"):
                 logger.info(f"Successfully synced metric to KB: {result.get('message')}")

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -75,17 +75,36 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
         return None
 
     def edit_file(self, path: str, old_string: str, new_string: str) -> FuncToolResult:  # type: ignore[override]
+        resolved = self._classify(path)
+        policy_error = self._reject_write_policy(resolved)
+        if policy_error is not None:
+            return policy_error
+        target_path = resolved.resolved
+        original_content: Optional[str] = None
+        should_restore = self._is_semantic_yaml_path(target_path) and target_path.exists() and target_path.is_file()
+        if should_restore:
+            try:
+                original_content = target_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                return FuncToolResult(success=0, error=f"Cannot read YAML file before edit: {exc}")
+
         result = super().edit_file(path, old_string, new_string)
         if not result.success:
             return result
 
-        resolved = self._classify(path)
-        target_path = resolved.resolved
         if not self._is_semantic_yaml_path(target_path) or not target_path.exists():
             return result
 
         postprocess_result = self._postprocess_yaml_file(target_path)
         if not postprocess_result.success:
+            if original_content is not None:
+                try:
+                    target_path.write_text(original_content, encoding="utf-8")
+                except OSError as exc:
+                    return FuncToolResult(
+                        success=0,
+                        error=f"{postprocess_result.error}; additionally failed to restore original file: {exc}",
+                    )
             return postprocess_result
         return result
 
@@ -99,6 +118,11 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
         if not preprocess_result.success:
             return preprocess_result
         normalized_content = str(preprocess_result.result or "")
+
+        try:
+            list(yaml.safe_load_all(normalized_content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot normalize invalid edited YAML file: {exc}")
 
         if self._is_metric_file_path(target_path):
             normalize_result = self._normalize_metric_subject_tree_tags(target_path, normalized_content)
@@ -199,8 +223,16 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
 
         existing_idx, existing_doc, existing_ds = self._find_data_source_doc(existing_docs)
         _, incoming_doc, incoming_ds = self._find_data_source_doc(incoming_docs)
-        if existing_ds is None or incoming_ds is None:
-            return FuncToolResult(result=incoming_content)
+        if existing_ds is None:
+            return FuncToolResult(
+                success=0,
+                error="Cannot merge existing semantic model YAML without a data_source document.",
+            )
+        if incoming_ds is None:
+            return FuncToolResult(
+                success=0,
+                error="Cannot merge semantic model YAML update without a data_source document.",
+            )
 
         merged_ds, error = self._merge_data_sources(existing_ds, incoming_ds)
         if error:
@@ -272,6 +304,11 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
             name = normalize_metric_name(metric.get("name") if metric else "")
             if name and metric is not None:
                 existing_by_name[name] = (idx, metric)
+        if not existing_by_name:
+            return FuncToolResult(
+                success=0,
+                error="Cannot merge existing metric YAML without metric documents.",
+            )
 
         saw_incoming_metric = False
         for incoming_doc in incoming_docs:
@@ -305,7 +342,10 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
             existing_by_name[incoming_name] = (existing_idx, merged_metric)
 
         if not saw_incoming_metric:
-            return FuncToolResult(result=incoming_content)
+            return FuncToolResult(
+                success=0,
+                error="Cannot merge metric YAML update without metric documents.",
+            )
 
         merged_content = yaml.safe_dump_all(existing_docs, allow_unicode=True, sort_keys=False)
         return self._normalize_metric_subject_tree_tags(target_path, merged_content)

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -1,0 +1,467 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from datus.storage.metric.store import normalize_metric_name
+from datus.storage.metric.subject_path import normalize_metric_subject_tree_tag
+from datus.tools.func_tool.base import FuncToolResult
+from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
+from datus.tools.func_tool.fs_path_policy import PathZone, ResolvedPath
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+class MetricFilesystemFuncTool(FilesystemFuncTool):
+    """Filesystem tool variant for metric generation.
+
+    Metric batches may update the same semantic model file several times. A
+    plain write would replace the whole file and can accidentally drop measures
+    or dimensions created by an earlier batch. For existing semantic model YAML
+    files, convert overwrite attempts into a structure-aware merge.
+    """
+
+    def write_file(self, path: str, content: str, file_type: str = "") -> FuncToolResult:  # type: ignore[override]
+        resolved = self._classify(path)
+        policy_error = self._reject_write_policy(resolved)
+        if policy_error is not None:
+            return policy_error
+        target_path = resolved.resolved
+        preprocess_result = self._preprocess_yaml_content(target_path, content)
+        if not preprocess_result.success:
+            return preprocess_result
+        content = str(preprocess_result.result or "")
+
+        if self._is_metric_file_path(target_path):
+            if not self._should_merge_metric_file(target_path):
+                normalize_result = self._normalize_metric_subject_tree_tags(target_path, content)
+                if not normalize_result.success:
+                    return normalize_result
+                content = str(normalize_result.result or "")
+                return super().write_file(path, content, file_type)
+            merge_result = self._merge_metric_content(target_path, content)
+            if not merge_result.success:
+                return merge_result
+            merged_content = str(merge_result.result or "")
+            result = super().write_file(path, merged_content, file_type)
+            if result.success:
+                result.result = f"Metric file merged successfully: {resolved.display}"
+            return result
+
+        if not self._should_merge_semantic_model(target_path):
+            return super().write_file(path, content, file_type)
+
+        merge_result = self._merge_semantic_model_content(target_path, content)
+        if not merge_result.success:
+            return merge_result
+        merged_content = str(merge_result.result or "")
+        result = super().write_file(path, merged_content, file_type)
+        if result.success:
+            result.result = f"Semantic model merged successfully: {resolved.display}"
+        return result
+
+    def _reject_write_policy(self, resolved: ResolvedPath) -> Optional[FuncToolResult]:
+        if resolved.zone == PathZone.HIDDEN:
+            return self._not_found(resolved)
+        if self.strict and resolved.zone == PathZone.EXTERNAL:
+            return self._strict_reject(resolved)
+        if resolved.read_only:
+            return self._read_only_reject(resolved)
+        return None
+
+    def edit_file(self, path: str, old_string: str, new_string: str) -> FuncToolResult:  # type: ignore[override]
+        result = super().edit_file(path, old_string, new_string)
+        if not result.success:
+            return result
+
+        resolved = self._classify(path)
+        target_path = resolved.resolved
+        if not self._is_semantic_yaml_path(target_path) or not target_path.exists():
+            return result
+
+        postprocess_result = self._postprocess_yaml_file(target_path)
+        if not postprocess_result.success:
+            return postprocess_result
+        return result
+
+    def _postprocess_yaml_file(self, target_path: Path) -> FuncToolResult:
+        try:
+            content = target_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return FuncToolResult(success=0, error=f"Cannot read edited YAML file: {exc}")
+
+        preprocess_result = self._preprocess_yaml_content(target_path, content)
+        if not preprocess_result.success:
+            return preprocess_result
+        normalized_content = str(preprocess_result.result or "")
+
+        if self._is_metric_file_path(target_path):
+            normalize_result = self._normalize_metric_subject_tree_tags(target_path, normalized_content)
+            if not normalize_result.success:
+                return normalize_result
+            normalized_content = str(normalize_result.result or "")
+
+        if normalized_content != content:
+            try:
+                target_path.write_text(normalized_content, encoding="utf-8")
+            except OSError as exc:
+                return FuncToolResult(success=0, error=f"Cannot normalize edited YAML file: {exc}")
+        return FuncToolResult(result=normalized_content)
+
+    def _should_merge_semantic_model(self, target_path: Path) -> bool:
+        if not target_path.exists() or not target_path.is_file():
+            return False
+        if target_path.suffix.lower() not in {".yml", ".yaml"}:
+            return False
+        parts = target_path.parts
+        if "subject" not in parts or "semantic_models" not in parts:
+            return False
+        subject_idx = parts.index("subject")
+        if len(parts) <= subject_idx + 1 or parts[subject_idx + 1] != "semantic_models":
+            return False
+        return "metrics" not in parts[subject_idx + 2 : -1]
+
+    def _should_merge_metric_file(self, target_path: Path) -> bool:
+        if not target_path.exists() or not target_path.is_file():
+            return False
+        return self._is_metric_file_path(target_path)
+
+    def _is_metric_file_path(self, target_path: Path) -> bool:
+        if target_path.suffix.lower() not in {".yml", ".yaml"}:
+            return False
+        parts = target_path.parts
+        if "subject" not in parts or "semantic_models" not in parts:
+            return False
+        subject_idx = parts.index("subject")
+        if len(parts) <= subject_idx + 1 or parts[subject_idx + 1] != "semantic_models":
+            return False
+        return "metrics" in parts[subject_idx + 2 : -1]
+
+    def _is_semantic_yaml_path(self, target_path: Path) -> bool:
+        if target_path.suffix.lower() not in {".yml", ".yaml"}:
+            return False
+        parts = target_path.parts
+        if "subject" not in parts or "semantic_models" not in parts:
+            return False
+        subject_idx = parts.index("subject")
+        return len(parts) > subject_idx + 1 and parts[subject_idx + 1] == "semantic_models"
+
+    def _preprocess_yaml_content(self, target_path: Path, content: str) -> FuncToolResult:
+        if not self._is_semantic_yaml_path(target_path):
+            return FuncToolResult(result=content)
+        repaired = self._repair_invalid_yaml_single_quote_escapes(content)
+        return FuncToolResult(result=repaired)
+
+    @staticmethod
+    def _repair_invalid_yaml_single_quote_escapes(content: str) -> str:
+        repaired = content
+        changed = False
+        for _ in range(20):
+            try:
+                list(yaml.safe_load_all(repaired))
+                return repaired if changed else content
+            except yaml.YAMLError as exc:
+                if "unknown escape character" not in str(exc) or "'" not in str(exc):
+                    return content
+                offset = MetricFilesystemFuncTool._yaml_error_offset(repaired, getattr(exc, "problem_mark", None))
+                if offset is None or offset <= 0:
+                    return content
+                if repaired[offset] != "'" or repaired[offset - 1] != "\\":
+                    return content
+                repaired = repaired[: offset - 1] + repaired[offset:]
+                changed = True
+        return content
+
+    @staticmethod
+    def _yaml_error_offset(content: str, mark: object) -> Optional[int]:
+        line = getattr(mark, "line", None)
+        column = getattr(mark, "column", None)
+        if not isinstance(line, int) or not isinstance(column, int) or line < 0 or column < 0:
+            return None
+        lines = content.splitlines(keepends=True)
+        if line >= len(lines) or column >= len(lines[line]):
+            return None
+        return sum(len(item) for item in lines[:line]) + column
+
+    def _merge_semantic_model_content(self, target_path: Path, incoming_content: str) -> FuncToolResult:
+        try:
+            existing_docs = list(yaml.safe_load_all(target_path.read_text(encoding="utf-8")))
+            incoming_docs = list(yaml.safe_load_all(incoming_content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot merge invalid semantic model YAML: {exc}")
+        except OSError as exc:
+            return FuncToolResult(success=0, error=f"Cannot read existing semantic model file: {exc}")
+
+        existing_idx, existing_doc, existing_ds = self._find_data_source_doc(existing_docs)
+        _, incoming_doc, incoming_ds = self._find_data_source_doc(incoming_docs)
+        if existing_ds is None or incoming_ds is None:
+            return FuncToolResult(result=incoming_content)
+
+        merged_ds, error = self._merge_data_sources(existing_ds, incoming_ds)
+        if error:
+            return FuncToolResult(success=0, error=error)
+
+        merged_doc = dict(existing_doc or {})
+        merged_doc["data_source"] = merged_ds
+        existing_docs[existing_idx] = merged_doc
+        merged_content = yaml.safe_dump_all(existing_docs, allow_unicode=True, sort_keys=False)
+        return self._normalize_metric_subject_tree_tags(target_path, merged_content)
+
+    def _normalize_metric_subject_tree_tags(self, target_path: Path, content: str) -> FuncToolResult:
+        try:
+            docs = list(yaml.safe_load_all(content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot normalize invalid metric YAML: {exc}")
+
+        datasource, table_name = self._metric_scope_from_path(target_path)
+        changed = False
+        for doc in docs:
+            metric = self._metric_from_doc(doc)
+            if metric is None:
+                continue
+            locked_metadata = metric.get("locked_metadata")
+            if not isinstance(locked_metadata, dict):
+                continue
+            tags = locked_metadata.get("tags")
+            if not isinstance(tags, list):
+                continue
+            normalized_tags = []
+            for tag in tags:
+                normalized = (
+                    normalize_metric_subject_tree_tag(tag, datasource=datasource, table_name=table_name)
+                    if isinstance(tag, str)
+                    else tag
+                )
+                normalized_tags.append(normalized)
+                changed = changed or normalized != tag
+            locked_metadata["tags"] = normalized_tags
+
+        if not changed:
+            return FuncToolResult(result=content)
+        return FuncToolResult(result=yaml.safe_dump_all(docs, allow_unicode=True, sort_keys=False))
+
+    @staticmethod
+    def _metric_scope_from_path(target_path: Path) -> Tuple[str, str]:
+        parts = list(target_path.parts)
+        datasource = ""
+        if "semantic_models" in parts:
+            idx = parts.index("semantic_models")
+            if len(parts) > idx + 1:
+                datasource = parts[idx + 1]
+        stem = target_path.stem
+        table_name = stem[: -len("_metrics")] if stem.endswith("_metrics") else stem
+        return datasource, table_name or "Unknown"
+
+    def _merge_metric_content(self, target_path: Path, incoming_content: str) -> FuncToolResult:
+        try:
+            existing_docs = list(yaml.safe_load_all(target_path.read_text(encoding="utf-8")))
+            incoming_docs = list(yaml.safe_load_all(incoming_content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot merge invalid metric YAML: {exc}")
+        except OSError as exc:
+            return FuncToolResult(success=0, error=f"Cannot read existing metric file: {exc}")
+
+        existing_by_name: Dict[str, Tuple[int, Dict[str, Any]]] = {}
+        for idx, doc in enumerate(existing_docs):
+            metric = self._metric_from_doc(doc)
+            name = normalize_metric_name(metric.get("name") if metric else "")
+            if name and metric is not None:
+                existing_by_name[name] = (idx, metric)
+
+        saw_incoming_metric = False
+        for incoming_doc in incoming_docs:
+            incoming_metric = self._metric_from_doc(incoming_doc)
+            incoming_name = normalize_metric_name(incoming_metric.get("name") if incoming_metric else "")
+            if not incoming_name or incoming_metric is None:
+                continue
+            saw_incoming_metric = True
+            existing_entry = existing_by_name.get(incoming_name)
+            if existing_entry is None:
+                existing_by_name[incoming_name] = (len(existing_docs), incoming_metric)
+                existing_docs.append(incoming_doc)
+                continue
+
+            existing_idx, existing_metric = existing_entry
+            conflict_field = self._metric_definition_conflict(existing_metric, incoming_metric)
+            if conflict_field:
+                metric_name = incoming_metric.get("name") or existing_metric.get("name") or incoming_name
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        f"Refusing to overwrite metric '{metric_name}': field '{conflict_field}' differs. "
+                        "Metric names must be unique within a datasource; preserve the existing definition "
+                        "or choose a new metric name."
+                    ),
+                )
+            merged_metric = self._merge_metric_fields(existing_metric, incoming_metric)
+            merged_doc = dict(existing_docs[existing_idx] or {})
+            merged_doc["metric"] = merged_metric
+            existing_docs[existing_idx] = merged_doc
+            existing_by_name[incoming_name] = (existing_idx, merged_metric)
+
+        if not saw_incoming_metric:
+            return FuncToolResult(result=incoming_content)
+
+        merged_content = yaml.safe_dump_all(existing_docs, allow_unicode=True, sort_keys=False)
+        return self._normalize_metric_subject_tree_tags(target_path, merged_content)
+
+    @staticmethod
+    def _metric_from_doc(doc: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(doc, dict):
+            return None
+        metric = doc.get("metric")
+        return metric if isinstance(metric, dict) else None
+
+    @staticmethod
+    def _merge_metric_fields(existing: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+        merged = dict(existing)
+        for field, value in incoming.items():
+            if field not in merged or merged.get(field) in (None, "", []):
+                merged[field] = value
+        return merged
+
+    @classmethod
+    def _metric_definition_conflict(cls, existing: Dict[str, Any], incoming: Dict[str, Any]) -> str:
+        for field in ("type", "type_params"):
+            existing_value = existing.get(field)
+            incoming_value = incoming.get(field)
+            if existing_value in (None, "", []) or incoming_value in (None, "", []):
+                continue
+            if cls._stable_yaml_value(existing_value) != cls._stable_yaml_value(incoming_value):
+                return field
+        return ""
+
+    @staticmethod
+    def _stable_yaml_value(value: Any) -> str:
+        return yaml.safe_dump(value, allow_unicode=True, sort_keys=True)
+
+    @staticmethod
+    def _find_data_source_doc(docs: List[Any]) -> Tuple[int, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        for idx, doc in enumerate(docs):
+            if isinstance(doc, dict) and isinstance(doc.get("data_source"), dict):
+                return idx, doc, doc["data_source"]
+        return -1, None, None
+
+    def _merge_data_sources(
+        self,
+        existing_ds: Dict[str, Any],
+        incoming_ds: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], str]:
+        existing_name = str(existing_ds.get("name") or "").strip()
+        incoming_name = str(incoming_ds.get("name") or "").strip()
+        if existing_name and incoming_name and existing_name != incoming_name:
+            return {}, (
+                f"Refusing to overwrite semantic model '{existing_name}' with data_source '{incoming_name}'. "
+                "Use a separate file for a different data_source."
+            )
+
+        merged = dict(existing_ds)
+        for field in ("name", "description"):
+            if not merged.get(field) and incoming_ds.get(field):
+                merged[field] = incoming_ds[field]
+
+        for field in ("sql_table", "sql_query"):
+            error = self._merge_stable_scalar(merged, incoming_ds, field, existing_name or incoming_name)
+            if error:
+                return {}, error
+
+        for field, conflict_fields in (
+            ("identifiers", ("type", "expr")),
+            ("measures", ("agg", "expr", "filter", "agg_params", "non_additive_dimension")),
+            ("dimensions", ("type", "expr", "type_params")),
+        ):
+            merged_items, error = self._merge_named_items(
+                field,
+                merged.get(field) or [],
+                incoming_ds.get(field) or [],
+                conflict_fields,
+                existing_name or incoming_name,
+            )
+            if error:
+                return {}, error
+            if merged_items:
+                merged[field] = merged_items
+
+        for field, value in incoming_ds.items():
+            if field in {"name", "description", "sql_table", "sql_query", "identifiers", "measures", "dimensions"}:
+                continue
+            if field not in merged:
+                merged[field] = value
+
+        return merged, ""
+
+    @staticmethod
+    def _merge_stable_scalar(
+        merged: Dict[str, Any],
+        incoming: Dict[str, Any],
+        field: str,
+        data_source_name: str,
+    ) -> str:
+        existing_value = merged.get(field)
+        incoming_value = incoming.get(field)
+        if not existing_value and incoming_value:
+            merged[field] = incoming_value
+            return ""
+        if existing_value and incoming_value and existing_value != incoming_value:
+            return (
+                f"Refusing to change data_source '{data_source_name}' field '{field}' from "
+                f"{existing_value!r} to {incoming_value!r}. Edit intentionally or write a new data_source file."
+            )
+        return ""
+
+    def _merge_named_items(
+        self,
+        section: str,
+        existing_items: List[Any],
+        incoming_items: List[Any],
+        conflict_fields: Tuple[str, ...],
+        data_source_name: str,
+    ) -> Tuple[List[Dict[str, Any]], str]:
+        merged: List[Dict[str, Any]] = [dict(item) for item in existing_items if isinstance(item, dict)]
+        index_by_name = {
+            str(item.get("name") or "").strip(): idx
+            for idx, item in enumerate(merged)
+            if str(item.get("name") or "").strip()
+        }
+
+        for raw_item in incoming_items:
+            if not isinstance(raw_item, dict):
+                continue
+            item = dict(raw_item)
+            name = str(item.get("name") or "").strip()
+            if not name:
+                continue
+            existing_idx = index_by_name.get(name)
+            if existing_idx is None:
+                index_by_name[name] = len(merged)
+                merged.append(item)
+                continue
+
+            existing = merged[existing_idx]
+            conflict_field = self._named_item_conflict(existing, item, conflict_fields)
+            if conflict_field:
+                return [], (
+                    f"Refusing to overwrite {section[:-1]} '{name}' in data_source '{data_source_name}': "
+                    f"field '{conflict_field}' differs. Preserve the existing definition or choose a new name."
+                )
+            for field, value in item.items():
+                if field not in existing or existing.get(field) in (None, "", []):
+                    existing[field] = value
+
+        return merged, ""
+
+    @staticmethod
+    def _named_item_conflict(existing: Dict[str, Any], incoming: Dict[str, Any], fields: Tuple[str, ...]) -> str:
+        for field in fields:
+            existing_value = existing.get(field)
+            incoming_value = incoming.get(field)
+            if existing_value in (None, "", []) or incoming_value in (None, "", []):
+                continue
+            if existing_value != incoming_value:
+                return field
+        return ""

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -953,6 +953,8 @@ class SemanticDiscoveryTools:
         for node in expr.walk():
             if not isinstance(node, exp.Literal):
                 continue
+            if not self._is_business_literal_node(node):
+                continue
             item = {
                 "source_sql_name": source_name,
                 "clause": clause,
@@ -966,6 +968,46 @@ class SemanticDiscoveryTools:
                 item["alias"] = alias
             mappings.append(item)
         return mappings
+
+    @staticmethod
+    def _is_business_literal_node(node: Any) -> bool:
+        """Return true for literals that represent business values, not function syntax."""
+        from sqlglot import expressions as exp
+
+        comparison_classes = tuple(
+            cls
+            for cls in (
+                getattr(exp, "EQ", None),
+                getattr(exp, "NEQ", None),
+                getattr(exp, "GT", None),
+                getattr(exp, "GTE", None),
+                getattr(exp, "LT", None),
+                getattr(exp, "LTE", None),
+                getattr(exp, "In", None),
+                getattr(exp, "Between", None),
+                getattr(exp, "Like", None),
+                getattr(exp, "ILike", None),
+                getattr(exp, "RegexpLike", None),
+            )
+            if cls is not None
+        )
+
+        parent = getattr(node, "parent", None)
+        child = node
+        while parent is not None:
+            if isinstance(parent, exp.Func):
+                return False
+            if isinstance(parent, comparison_classes):
+                return True
+            if isinstance(parent, exp.If) and getattr(child, "arg_key", "") == "true":
+                return True
+            if isinstance(parent, exp.Case) and getattr(child, "arg_key", "") == "default":
+                return True
+            if isinstance(parent, (exp.Select, exp.Where, exp.Having)):
+                return False
+            child = parent
+            parent = getattr(parent, "parent", None)
+        return False
 
     def _time_grain_from_projection(self, projection: Any, source_name: str) -> Optional[Dict[str, Any]]:
         """Return time-dimension evidence from projected date expressions."""

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -10,6 +10,7 @@ including table relationships, column usage evidence, and metric candidates
 mined from historical SQL.
 """
 
+import json
 from typing import Any, Dict, List, Optional
 
 from agents import Tool
@@ -41,6 +42,7 @@ class SemanticDiscoveryTools:
         self.db_tool = db_tool
         self.agent_config = db_tool.agent_config
         self.sub_agent_name = db_tool.sub_agent_name
+        self._result_cache: dict[tuple[str, str], FuncToolResult] = {}
 
     @classmethod
     def _aggregate_classes(cls):
@@ -66,6 +68,22 @@ class SemanticDiscoveryTools:
         for bound_method in methods_to_convert:
             bound_tools.append(trans_to_function_tool(bound_method))
         return bound_tools
+
+    @staticmethod
+    def _cache_key(tool_name: str, payload: dict[str, Any]) -> tuple[str, str]:
+        return (tool_name, json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str))
+
+    def _get_cached_result(self, tool_name: str, payload: dict[str, Any]) -> Optional[FuncToolResult]:
+        cached = self._result_cache.get(self._cache_key(tool_name, payload))
+        if cached is not None:
+            logger.debug("%s cache hit", tool_name)
+            return cached.model_copy(deep=True)
+        return None
+
+    def _cache_success(self, tool_name: str, payload: dict[str, Any], result: FuncToolResult) -> FuncToolResult:
+        if result.success in (1, True):
+            self._result_cache[self._cache_key(tool_name, payload)] = result.model_copy(deep=True)
+        return result
 
     def analyze_table_relationships(
         self,
@@ -110,6 +128,15 @@ class SemanticDiscoveryTools:
                 "summary": "Found 3 relationships across 3 tables"
             }
         """
+        cache_payload = {
+            "tables": tables,
+            "catalog": catalog,
+            "database": database,
+            "schema_name": schema_name,
+            "sample_sql_queries": sample_sql_queries,
+        }
+        if cached := self._get_cached_result("analyze_table_relationships", cache_payload):
+            return cached
         try:
             relationships = []
 
@@ -129,11 +156,15 @@ class SemanticDiscoveryTools:
             # Deduplicate and sort by confidence
             deduplicated = self._deduplicate_relationships(relationships)
 
-            return FuncToolResult(
-                result={
-                    "relationships": deduplicated,
-                    "summary": f"Found {len(deduplicated)} relationships across {len(tables)} tables",
-                }
+            return self._cache_success(
+                "analyze_table_relationships",
+                cache_payload,
+                FuncToolResult(
+                    result={
+                        "relationships": deduplicated,
+                        "summary": f"Found {len(deduplicated)} relationships across {len(tables)} tables",
+                    }
+                ),
             )
 
         except Exception as e:
@@ -164,6 +195,14 @@ class SemanticDiscoveryTools:
                 {"table_name": "customers", "definition": "CREATE TABLE ...", ...}
             ]
         """
+        cache_payload = {
+            "tables": tables,
+            "catalog": catalog,
+            "database": database,
+            "schema_name": schema_name,
+        }
+        if cached := self._get_cached_result("get_multiple_tables_ddl", cache_payload):
+            return cached
         try:
             results = []
             for table in tables:
@@ -173,7 +212,7 @@ class SemanticDiscoveryTools:
                 else:
                     results.append({"table_name": table, "error": ddl_result.error})
 
-            return FuncToolResult(result=results)
+            return self._cache_success("get_multiple_tables_ddl", cache_payload, FuncToolResult(result=results))
         except Exception as e:
             return FuncToolResult(success=0, error=str(e))
 
@@ -227,6 +266,16 @@ class SemanticDiscoveryTools:
                 "summary": "Analyzed 2 columns from 50 SQL queries"
             }
         """
+        cache_payload = {
+            "table_name": table_name,
+            "columns": columns,
+            "catalog": catalog,
+            "database": database,
+            "schema_name": schema_name,
+            "sample_sql_queries": sample_sql_queries,
+        }
+        if cached := self._get_cached_result("analyze_column_usage_patterns", cache_payload):
+            return cached
         try:
             if not self.agent_config:
                 return FuncToolResult(
@@ -381,11 +430,15 @@ class SemanticDiscoveryTools:
 
             logger.info(f"Analyzed {len(result_patterns)} columns with usage patterns")
 
-            return FuncToolResult(
-                result={
-                    "column_patterns": result_patterns,
-                    "summary": f"Analyzed {len(result_patterns)} columns from {len(search_results)} SQL queries",
-                }
+            return self._cache_success(
+                "analyze_column_usage_patterns",
+                cache_payload,
+                FuncToolResult(
+                    result={
+                        "column_patterns": result_patterns,
+                        "summary": f"Analyzed {len(result_patterns)} columns from {len(search_results)} SQL queries",
+                    }
+                ),
             )
 
         except Exception as e:
@@ -429,6 +482,16 @@ class SemanticDiscoveryTools:
             derived_metric_candidates, base_measures, identity_metric_references,
             non_metric_evidence, parse_errors, and summary.
         """
+        cache_payload = {
+            "sql_queries": sql_queries,
+            "sql_entries_json": sql_entries_json,
+            "query_text": query_text,
+            "tables": tables,
+            "sample_sql_queries": sample_sql_queries,
+            "existing_metric_catalog_json": existing_metric_catalog_json,
+        }
+        if cached := self._get_cached_result("analyze_metric_candidates_from_history", cache_payload):
+            return cached
         try:
             entries = self._load_metric_mining_entries(
                 sql_queries, sql_entries_json, query_text, tables, sample_sql_queries
@@ -463,8 +526,9 @@ class SemanticDiscoveryTools:
                 entry_has_non_metric_evidence = False
                 entry_has_metric_evidence = False
                 modeling_analysis = self._analyze_query_modeling(parsed_expressions, source_name)
-                if modeling_analysis["derived_datasource_recommendations"]:
-                    derived_datasource_recommendations.extend(modeling_analysis["derived_datasource_recommendations"])
+                modeling_recommendations = modeling_analysis["derived_datasource_recommendations"]
+                if modeling_recommendations:
+                    derived_datasource_recommendations.extend(modeling_recommendations)
                 preservation_evidence = self._extract_semantic_preservation_evidence(
                     parsed_expressions,
                     source_name,
@@ -520,7 +584,7 @@ class SemanticDiscoveryTools:
                 classification = self._classify_source_query(
                     has_candidates=bool(entry_candidates),
                     has_non_metric_evidence=entry_has_non_metric_evidence,
-                    derived_datasource_recommendations=modeling_analysis["derived_datasource_recommendations"],
+                    derived_datasource_recommendations=modeling_recommendations,
                 )
                 source_classifications.append(
                     {
@@ -532,9 +596,7 @@ class SemanticDiscoveryTools:
                 if classification == "metric_plus_derived_datasource":
                     for candidate in entry_candidates:
                         blocked = dict(candidate)
-                        blocked["block_reason"] = (
-                            "aggregation over ranked/windowed result; create the recommended derived data source first"
-                        )
+                        blocked["block_reason"] = self._blocked_direct_metric_reason(modeling_recommendations)
                         blocked_direct_metric_candidates.append(blocked)
 
             candidates = sorted(
@@ -554,31 +616,36 @@ class SemanticDiscoveryTools:
                 and not self._is_blocked_direct_candidate(candidate, blocked_direct_metric_candidates)
             ]
             modeling_plan = self._build_modeling_plan(derived_datasource_recommendations)
-            return FuncToolResult(
-                result={
-                    "metric_candidates": candidates,
-                    "direct_metric_candidates": direct_candidates,
-                    "derived_metric_candidates": derived_candidates,
-                    "base_measures": measures,
-                    "non_metric_evidence": non_metric_evidence,
-                    "identity_metric_references": identity_metric_references,
-                    "parse_errors": parse_errors,
-                    "query_classification": self._overall_query_classification(
-                        source_classifications=source_classifications,
-                        parse_errors=parse_errors,
-                    ),
-                    "source_classifications": source_classifications,
-                    "derived_datasource_recommendations": derived_datasource_recommendations,
-                    "blocked_direct_metric_candidates": blocked_direct_metric_candidates,
-                    "literal_mappings": literal_mappings,
-                    "time_grain_evidence": time_grain_evidence,
-                    "post_aggregation_constraints": post_aggregation_constraints,
-                    "modeling_plan": modeling_plan,
-                    "summary": (
-                        f"Found {len(candidates)} metric candidates and {len(measures)} base measures "
-                        f"from {len(entries)} SQL queries"
-                    ),
-                }
+            return self._cache_success(
+                "analyze_metric_candidates_from_history",
+                cache_payload,
+                FuncToolResult(
+                    result={
+                        "metric_candidates": candidates,
+                        "direct_metric_candidates": direct_candidates,
+                        "derived_metric_candidates": derived_candidates,
+                        "base_measures": measures,
+                        "non_metric_evidence": non_metric_evidence,
+                        "identity_metric_references": identity_metric_references,
+                        "parse_errors": parse_errors,
+                        "query_classification": self._overall_query_classification(
+                            source_classifications=source_classifications,
+                            parse_errors=parse_errors,
+                        ),
+                        "source_classifications": source_classifications,
+                        "derived_datasource_recommendations": derived_datasource_recommendations,
+                        "blocked_direct_metric_candidates": blocked_direct_metric_candidates,
+                        "metric_aliases": self._metric_aliases_for_candidates(candidates),
+                        "literal_mappings": literal_mappings,
+                        "time_grain_evidence": time_grain_evidence,
+                        "post_aggregation_constraints": post_aggregation_constraints,
+                        "modeling_plan": modeling_plan,
+                        "summary": (
+                            f"Found {len(candidates)} metric candidates and {len(measures)} base measures "
+                            f"from {len(entries)} SQL queries"
+                        ),
+                    }
+                ),
             )
         except Exception as e:
             logger.exception("Error analyzing metric candidates from history")
@@ -601,6 +668,15 @@ class SemanticDiscoveryTools:
             return "cohort_or_dataset_only"
         return "manual_review_required"
 
+    def _blocked_direct_metric_reason(self, recommendations: List[Dict[str, Any]]) -> str:
+        """Explain why a candidate should not be emitted as a direct metric."""
+        recommendation_types = {rec.get("recommendation_type", "ranked_window") for rec in recommendations}
+        if "post_aggregation" in recommendation_types:
+            return "post-aggregation filtering must be preserved in a derived data source before defining metrics"
+        if "ranked_window" in recommendation_types:
+            return "aggregation over ranked/windowed result; create the recommended derived data source first"
+        return "complex SQL should be modeled as a derived data source before defining direct metrics"
+
     def _overall_query_classification(
         self,
         source_classifications: List[Dict[str, Any]],
@@ -622,12 +698,43 @@ class SemanticDiscoveryTools:
         """Build high-level modeling steps for complex SQL patterns."""
         plans = []
         for rec in recommendations:
+            recommendation_type = rec.get("recommendation_type", "ranked_window")
+            if recommendation_type == "post_aggregation":
+                plans.append(
+                    {
+                        "source_sql_name": rec.get("source_sql_name", ""),
+                        "classification": "metric_plus_derived_datasource",
+                        "recommendation_type": recommendation_type,
+                        "steps": [
+                            {
+                                "step": "create_derived_datasource",
+                                "description": (
+                                    "Create a sql_query data source or materialized view that preserves the "
+                                    "post-aggregation filter before MetricFlow metrics are defined."
+                                ),
+                                "datasource": rec.get("name", ""),
+                                "post_aggregation_constraints": rec.get("post_aggregation_constraints", []),
+                                "source_query": rec.get("source_query", ""),
+                            },
+                            {
+                                "step": "define_final_metric",
+                                "description": (
+                                    "Define metrics over the derived data source output columns instead of pushing "
+                                    "the HAVING predicate into a base measure."
+                                ),
+                                "generated_columns": rec.get("generated_columns", []),
+                            },
+                        ],
+                    }
+                )
+                continue
             rank_alias = rec.get("rank_alias") or "rank_value"
             rank_filter = rec.get("rank_filters") or []
             plans.append(
                 {
                     "source_sql_name": rec.get("source_sql_name", ""),
                     "classification": "metric_plus_derived_datasource",
+                    "recommendation_type": recommendation_type,
                     "steps": [
                         {
                             "step": "define_base_metrics",
@@ -660,7 +767,9 @@ class SemanticDiscoveryTools:
         recommendations: List[Dict[str, Any]] = []
         for parsed in parsed_expressions:
             cte_projection_map = self._cte_projection_map(parsed)
+            named_select_ids = set()
             for cte_name, select in self._iter_cte_selects(parsed):
+                named_select_ids.add(id(select))
                 recommendations.extend(
                     self._ranked_datasource_recommendations(
                         source_name=source_name,
@@ -670,7 +779,19 @@ class SemanticDiscoveryTools:
                         cte_projection_map=cte_projection_map,
                     )
                 )
+                recommendation = self._post_aggregation_datasource_recommendation(
+                    source_name=source_name,
+                    select_name=cte_name,
+                    select=select,
+                )
+                if recommendation:
+                    self._append_unique(
+                        recommendations,
+                        recommendation,
+                        ["source_sql_name", "name", "recommendation_type", "source_query"],
+                    )
             for subquery_name, select in self._iter_inline_subquery_selects(parsed):
+                named_select_ids.add(id(select))
                 recommendations.extend(
                     self._ranked_datasource_recommendations(
                         source_name=source_name,
@@ -680,10 +801,36 @@ class SemanticDiscoveryTools:
                         cte_projection_map=cte_projection_map,
                     )
                 )
+                recommendation = self._post_aggregation_datasource_recommendation(
+                    source_name=source_name,
+                    select_name=subquery_name,
+                    select=select,
+                )
+                if recommendation:
+                    self._append_unique(
+                        recommendations,
+                        recommendation,
+                        ["source_sql_name", "name", "recommendation_type", "source_query"],
+                    )
+            for select in self._iter_selects(parsed):
+                if id(select) in named_select_ids:
+                    continue
+                recommendation = self._post_aggregation_datasource_recommendation(
+                    source_name=source_name,
+                    select_name=f"{source_name}_post_aggregation",
+                    select=select,
+                )
+                if recommendation:
+                    self._append_unique(
+                        recommendations,
+                        recommendation,
+                        ["source_sql_name", "name", "recommendation_type", "source_query"],
+                    )
 
         reason = ""
         if recommendations:
-            reason = "rank/window output is filtered or aggregated downstream; model it as a derived data source first"
+            reasons = sorted({rec.get("reason", "") for rec in recommendations if rec.get("reason")})
+            reason = "; ".join(reasons) or "complex SQL should be modeled as a derived data source first"
         return {
             "derived_datasource_recommendations": recommendations,
             "classification_reason": reason,
@@ -705,6 +852,12 @@ class SemanticDiscoveryTools:
                     literal_mapping = self._literal_mapping_from_projection(projection, source_name)
                     if literal_mapping:
                         self._append_unique(literal_mappings, literal_mapping, ["source_sql_name", "alias", "value"])
+                    for item in self._literal_mappings_from_projection_expression(projection, source_name):
+                        self._append_unique(
+                            literal_mappings,
+                            item,
+                            ["source_sql_name", "clause", "value", "predicate"],
+                        )
 
                     time_projection = self._time_grain_from_projection(projection, source_name)
                     if time_projection:
@@ -717,6 +870,12 @@ class SemanticDiscoveryTools:
                 where = select.args.get("where")
                 predicate = getattr(where, "this", None)
                 if predicate is not None:
+                    for item in self._literal_mappings_from_expression(predicate, source_name, "WHERE"):
+                        self._append_unique(
+                            literal_mappings,
+                            item,
+                            ["source_sql_name", "clause", "value", "predicate"],
+                        )
                     for item in self._time_grain_from_filter(predicate, source_name):
                         self._append_unique(
                             time_grain_evidence,
@@ -727,6 +886,12 @@ class SemanticDiscoveryTools:
                 having = select.args.get("having")
                 having_predicate = getattr(having, "this", None)
                 if having_predicate is not None:
+                    for item in self._literal_mappings_from_expression(having_predicate, source_name, "HAVING"):
+                        self._append_unique(
+                            literal_mappings,
+                            item,
+                            ["source_sql_name", "clause", "value", "predicate"],
+                        )
                     post_aggregation = {
                         "source_sql_name": source_name,
                         "constraint": having_predicate.sql(),
@@ -762,6 +927,45 @@ class SemanticDiscoveryTools:
             "projection": projection.sql(),
             "preservation_rule": "preserve literal values verbatim; only MetricFlow object names may be normalized",
         }
+
+    def _literal_mappings_from_projection_expression(self, projection: Any, source_name: str) -> List[Dict[str, Any]]:
+        """Return literal evidence from CASE projections without treating function arguments as business literals."""
+        from sqlglot import expressions as exp
+
+        expr = projection.this if isinstance(projection, exp.Alias) else projection
+        if not list(expr.find_all(exp.Case)):
+            return []
+        alias = projection.alias if isinstance(projection, exp.Alias) else projection.alias_or_name
+        return self._literal_mappings_from_expression(expr, source_name, "SELECT", alias=alias or "")
+
+    def _literal_mappings_from_expression(
+        self,
+        expr: Any,
+        source_name: str,
+        clause: str,
+        alias: str = "",
+    ) -> List[Dict[str, Any]]:
+        """Return literal evidence that must remain stable in SQL modeling."""
+        from sqlglot import expressions as exp
+
+        mappings = []
+        predicate_sql = expr.sql()
+        for node in expr.walk():
+            if not isinstance(node, exp.Literal):
+                continue
+            item = {
+                "source_sql_name": source_name,
+                "clause": clause,
+                "value": str(node.this),
+                "expression": node.sql(),
+                "predicate": predicate_sql,
+                "literal_type": "string" if node.is_string else "numeric",
+                "preservation_rule": "preserve literal values verbatim; only MetricFlow object names may be normalized",
+            }
+            if alias:
+                item["alias"] = alias
+            mappings.append(item)
+        return mappings
 
     def _time_grain_from_projection(self, projection: Any, source_name: str) -> Optional[Dict[str, Any]]:
         """Return time-dimension evidence from projected date expressions."""
@@ -971,6 +1175,7 @@ class SemanticDiscoveryTools:
                     {
                         "source_sql_name": source_name,
                         "name": cte_name,
+                        "recommendation_type": "ranked_window",
                         "source_cte": cte_name,
                         "reason": "rank-like window output is filtered downstream",
                         "rank_alias": self._safe_name(rank_alias),
@@ -989,6 +1194,38 @@ class SemanticDiscoveryTools:
                     }
                 )
         return recommendations
+
+    def _post_aggregation_datasource_recommendation(
+        self,
+        source_name: str,
+        select_name: str,
+        select: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Recommend a derived data source when HAVING filters aggregate results."""
+        having = select.args.get("having")
+        predicate = getattr(having, "this", None)
+        if predicate is None:
+            return None
+
+        aggregate_classes = self._aggregate_classes()
+        has_aggregate_output = any(list(projection.find_all(*aggregate_classes)) for projection in select.expressions)
+        has_aggregate_predicate = bool(list(predicate.find_all(*aggregate_classes)))
+        if not has_aggregate_output and not has_aggregate_predicate:
+            return None
+
+        return {
+            "source_sql_name": source_name,
+            "name": self._safe_name(select_name or f"{source_name}_post_aggregation"),
+            "recommendation_type": "post_aggregation",
+            "reason": "HAVING/post-aggregation constraint filters aggregated rows",
+            "post_aggregation_constraints": [predicate.sql()],
+            "generated_columns": [
+                self._safe_name(projection.alias or projection.alias_or_name)
+                for projection in select.expressions
+                if (projection.alias or projection.alias_or_name)
+            ],
+            "source_query": select.sql(),
+        }
 
     def _is_rank_like_window(self, window: Any) -> bool:
         """Return true for ranking windows that should become derived data sources."""
@@ -1207,12 +1444,26 @@ class SemanticDiscoveryTools:
             if not name:
                 continue
             normalized_name = self._normalize_identifier(name)
-            catalog[normalized_name] = {
+            catalog_item = {
                 "name": name,
                 "type": item.get("type") or item.get("metric_type") or "",
                 "description": item.get("description") or "",
                 "subject_path": item.get("subject_path") or item.get("path") or "",
             }
+            for field in (
+                "base_measures",
+                "dimensions",
+                "entities",
+                "semantic_model",
+                "semantic_model_name",
+                "measures",
+                "query_grain",
+                "unit",
+                "format",
+            ):
+                if item.get(field):
+                    catalog_item[field] = item[field]
+            catalog[normalized_name] = catalog_item
         return catalog
 
     def _parse_sql(self, sql_text: str):
@@ -1298,7 +1549,8 @@ class SemanticDiscoveryTools:
 
         score_reasons = []
         confidence = "medium"
-        requires_name_translation = self._requires_name_translation(alias)
+        name_translation_reason = self._name_translation_reason(alias)
+        requires_name_translation = bool(name_translation_reason)
         if alias:
             score_reasons.append("final SELECT alias provides metric name evidence")
             if requires_name_translation:
@@ -1321,6 +1573,7 @@ class SemanticDiscoveryTools:
             "expression": expr.sql(),
             "source_alias": alias or "",
             "requires_name_translation": requires_name_translation,
+            "name_translation_reason": name_translation_reason,
             "name_source": "expression_fallback"
             if requires_name_translation
             else ("source_alias" if alias else "expression"),
@@ -1388,6 +1641,19 @@ class SemanticDiscoveryTools:
                 "description": metric.get("description", ""),
                 "subject_path": metric.get("subject_path", ""),
             }
+            for field in (
+                "base_measures",
+                "dimensions",
+                "entities",
+                "semantic_model",
+                "semantic_model_name",
+                "measures",
+                "query_grain",
+                "unit",
+                "format",
+            ):
+                if metric.get(field):
+                    item[field] = metric[field]
             items.append({key: value for key, value in item.items() if value})
         return items
 
@@ -1421,16 +1687,27 @@ class SemanticDiscoveryTools:
             "filter": "",
             "source_alias": alias or "",
             "requires_name_translation": self._requires_name_translation(alias),
+            "name_translation_reason": self._name_translation_reason(alias),
             "source_count": 1,
         }
 
     def _merge_metric_candidate(self, candidates: Dict[str, Dict[str, Any]], candidate: Dict[str, Any]) -> None:
-        """Merge metric candidates with the same normalized name, type, and formula."""
+        """Merge metric candidates with the same type and formula while retaining alias evidence."""
+        self._initialize_metric_candidate_aliases(candidate)
         key = self._metric_candidate_merge_key(candidate)
         existing = candidates.get(key)
         if not existing:
             candidates[key] = candidate
             return
+
+        if self._candidate_name_is_better(candidate, existing):
+            previous_name = existing.get("name", "")
+            existing["name"] = candidate.get("name", previous_name)
+            existing["name_source"] = candidate.get("name_source", existing.get("name_source", ""))
+            existing["requires_name_translation"] = candidate.get("requires_name_translation", False)
+            existing["name_translation_reason"] = candidate.get("name_translation_reason", "")
+            if previous_name:
+                self._append_unique_value(existing, "candidate_names", previous_name)
 
         existing["source_count"] += 1
         existing["source_sql_name"] = ", ".join(
@@ -1438,16 +1715,24 @@ class SemanticDiscoveryTools:
         )
         for field in ("dimensions", "filters", "tables", "score_reasons"):
             existing[field] = sorted(set(existing.get(field, []) + candidate.get(field, [])))
+        for field in ("source_aliases", "candidate_names"):
+            for value in candidate.get(field, []):
+                self._append_unique_value(existing, field, value)
+        for alias_mapping in candidate.get("source_alias_mappings", []):
+            self._append_unique(
+                existing["source_alias_mappings"],
+                alias_mapping,
+                ["source_alias", "candidate_name", "source_sql_name"],
+            )
         for measure in candidate.get("base_measures", []):
-            self._append_unique(existing["base_measures"], measure, ["name", "agg", "expr", "filter"])
+            self._append_unique(existing["base_measures"], measure, ["agg", "expr", "filter"])
         for metric in candidate.get("referenced_metrics", []):
             self._append_unique(existing["referenced_metrics"], metric, ["name", "type", "subject_path"])
 
     def _metric_candidate_merge_key(self, candidate: Dict[str, Any]) -> str:
-        """Build a stable candidate identity without collapsing distinct formulas."""
+        """Build a stable candidate identity without letting aliases split identical formulas."""
         return "::".join(
             [
-                candidate.get("name", ""),
                 candidate.get("metric_type", ""),
                 self._metric_candidate_formula_signature(candidate),
             ]
@@ -1457,17 +1742,79 @@ class SemanticDiscoveryTools:
         """Return a deterministic signature for a metric expression and its measures."""
         measure_parts = []
         for measure in candidate.get("base_measures", []):
-            measure_parts.append("|".join(str(measure.get(field, "")) for field in ("name", "agg", "expr", "filter")))
-        return "||".join([candidate.get("expression", ""), *sorted(measure_parts)])
+            measure_parts.append("|".join(str(measure.get(field, "")) for field in ("agg", "expr", "filter")))
+        filter_part = "&&".join(sorted(str(filter_expr) for filter_expr in candidate.get("filters", []) if filter_expr))
+        return "||".join([candidate.get("expression", ""), filter_part, *sorted(measure_parts)])
 
     def _merge_base_measure(self, measures: Dict[str, Dict[str, Any]], measure: Dict[str, Any]) -> None:
         """Merge repeated base measure evidence."""
-        key = f"{measure['name']}::{measure['agg']}::{measure['expr']}::{measure.get('filter', '')}"
+        key = f"{measure['agg']}::{measure['expr']}::{measure.get('filter', '')}"
         existing = measures.get(key)
         if not existing:
             measures[key] = dict(measure)
             return
         existing["source_count"] += 1
+
+    def _initialize_metric_candidate_aliases(self, candidate: Dict[str, Any]) -> None:
+        """Attach source alias/name evidence used by later bootstrap batches."""
+        source_alias = str(candidate.get("source_alias") or "").strip()
+        candidate_name = str(candidate.get("name") or "").strip()
+        source_sql_name = str(candidate.get("source_sql_name") or "").strip()
+        candidate.setdefault("source_aliases", [])
+        candidate.setdefault("candidate_names", [])
+        candidate.setdefault("source_alias_mappings", [])
+        if source_alias:
+            self._append_unique_value(candidate, "source_aliases", source_alias)
+        if candidate_name:
+            self._append_unique_value(candidate, "candidate_names", candidate_name)
+        if source_alias or candidate_name:
+            self._append_unique(
+                candidate["source_alias_mappings"],
+                {
+                    "source_alias": source_alias,
+                    "candidate_name": candidate_name,
+                    "source_sql_name": source_sql_name,
+                    "requires_name_translation": bool(candidate.get("requires_name_translation")),
+                },
+                ["source_alias", "candidate_name", "source_sql_name"],
+            )
+
+    def _candidate_name_is_better(self, candidate: Dict[str, Any], existing: Dict[str, Any]) -> bool:
+        """Prefer business aliases over generated fallbacks when formula evidence is identical."""
+        existing_requires_translation = bool(existing.get("requires_name_translation"))
+        candidate_requires_translation = bool(candidate.get("requires_name_translation"))
+        if existing_requires_translation and not candidate_requires_translation:
+            return True
+        return False
+
+    def _metric_aliases_for_candidates(self, candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return source alias -> canonical metric name mappings for queryability checks."""
+        aliases: List[Dict[str, Any]] = []
+        for candidate in candidates:
+            canonical_name = str(candidate.get("name") or "").strip()
+            if not canonical_name:
+                continue
+            for mapping in candidate.get("source_alias_mappings", []):
+                if not isinstance(mapping, dict):
+                    continue
+                source_alias = str(mapping.get("source_alias") or "").strip()
+                candidate_name = str(mapping.get("candidate_name") or "").strip()
+                source_sql_name = str(mapping.get("source_sql_name") or "").strip()
+                if not source_alias and not candidate_name:
+                    continue
+                if source_alias == canonical_name and candidate_name == canonical_name:
+                    continue
+                self._append_unique(
+                    aliases,
+                    {
+                        "source_alias": source_alias,
+                        "candidate_name": candidate_name,
+                        "canonical_name": canonical_name,
+                        "source_sql_name": source_sql_name,
+                    },
+                    ["source_alias", "candidate_name", "canonical_name", "source_sql_name"],
+                )
+        return aliases
 
     def _extract_join_relationships_from_sql(
         self, sql_text: str, tables_lower_map: Dict[str, str]
@@ -1554,7 +1901,7 @@ class SemanticDiscoveryTools:
         """Convert a SQL alias/expression into a MetricFlow-compatible snake_case name."""
         import re
 
-        value = raw.strip().strip('"`[]').lower()
+        value = str(raw or "").strip().strip('"`[]').lower()
         value = re.sub(r"[^a-z0-9]+", "_", value).strip("_")
         if not value:
             value = "metric_candidate"
@@ -1570,7 +1917,7 @@ class SemanticDiscoveryTools:
         `source_alias` plus SQL/question context to choose the final business
         metric name.
         """
-        if alias:
+        if alias and not self._requires_name_translation(alias):
             alias_name = self._safe_name(alias)
             if alias_name != "metric_candidate":
                 return alias_name
@@ -1578,9 +1925,35 @@ class SemanticDiscoveryTools:
 
     def _requires_name_translation(self, alias: str) -> bool:
         """Return true when the original SQL alias should be named by the LLM."""
+        return bool(self._name_translation_reason(alias))
+
+    def _name_translation_reason(self, alias: str) -> str:
+        """Explain why a SQL alias is only technical evidence, not a final metric name."""
+        import re
+
         if not alias:
-            return False
-        return self._safe_name(alias) == "metric_candidate"
+            return ""
+        raw_alias = str(alias).strip().strip('"`[]')
+        safe_alias = self._safe_name(raw_alias)
+        if safe_alias == "metric_candidate":
+            return "source alias contains no MetricFlow-safe name tokens"
+        if raw_alias and raw_alias[0].isdigit():
+            return "source alias starts with a digit and needs a MetricFlow-safe business name"
+
+        tokens = [token for token in safe_alias.split("_") if token]
+        has_numeric_token = any(token.isdigit() for token in tokens)
+        alpha_tokens = [token for token in tokens if token.isalpha()]
+        compact_alias = safe_alias.replace("_", "")
+        short_prefix_with_ordinal = (
+            has_numeric_token
+            and len(alpha_tokens) <= 1
+            and sum(len(token) for token in alpha_tokens) <= 4
+            and bool(alpha_tokens)
+        )
+        compact_short_prefix_with_ordinal = bool(re.fullmatch(r"[a-z]{1,4}\d+", compact_alias))
+        if short_prefix_with_ordinal or compact_short_prefix_with_ordinal:
+            return "source alias looks like a generated short prefix plus ordinal"
+        return ""
 
     def _name_from_expression(self, expr: Any) -> str:
         """Derive a deterministic MetricFlow-safe name from a SQL expression."""
@@ -1629,6 +2002,14 @@ class SemanticDiscoveryTools:
         if all(tuple(existing.get(field) for field in key_fields) != key for existing in items):
             items.append(dict(item))
 
+    def _append_unique_value(self, item: Dict[str, Any], field: str, value: str) -> None:
+        """Append a scalar string to a list field once."""
+        if not value:
+            return
+        values = item.setdefault(field, [])
+        if value not in values:
+            values.append(value)
+
     def _is_blocked_direct_candidate(
         self,
         candidate: Dict[str, Any],
@@ -1637,9 +2018,7 @@ class SemanticDiscoveryTools:
         """Return true if any source merged into the candidate requires derived modeling first."""
         candidate_sources = self._source_sql_name_set(candidate.get("source_sql_name", ""))
         for blocked in blocked_candidates:
-            if blocked.get("name") != candidate.get("name") or blocked.get("metric_type") != candidate.get(
-                "metric_type"
-            ):
+            if blocked.get("metric_type") != candidate.get("metric_type"):
                 continue
             if self._metric_candidate_formula_signature(blocked) != self._metric_candidate_formula_signature(candidate):
                 continue

--- a/datus/tools/semantic_tools/storage_sync.py
+++ b/datus/tools/semantic_tools/storage_sync.py
@@ -29,14 +29,18 @@ logger = get_logger(__name__)
 class SemanticStorageManager:
     """Manages sync between semantic adapters and unified storage."""
 
-    def __init__(self, agent_config: AgentConfig):
+    def __init__(self, agent_config: AgentConfig, datasource_id: Optional[str] = None):
         """
         Initialize storage manager.
 
         Args:
             agent_config: Agent configuration
+            datasource_id: Explicit datasource scope for all synced stores
         """
+        from datus.storage.scope import resolve_datasource_scope
+
         self.agent_config = agent_config
+        self.datasource_id, self.storage_namespace = resolve_datasource_scope(agent_config, datasource_id)
         self.semantic_model_store: Optional[SemanticModelStorage] = None
         self.metric_store: Optional[MetricStorage] = None
         self.subject_tree_store: Optional[SubjectTreeStore] = None
@@ -46,7 +50,7 @@ class SemanticStorageManager:
         if self.semantic_model_store is None:
             from datus.storage.semantic_model.store import SemanticModelRAG
 
-            rag = SemanticModelRAG(self.agent_config)
+            rag = SemanticModelRAG(self.agent_config, datasource_id=self.datasource_id)
             self.semantic_model_store = rag.storage
         return self.semantic_model_store
 
@@ -55,7 +59,7 @@ class SemanticStorageManager:
         if self.metric_store is None:
             from datus.storage.metric.store import MetricRAG
 
-            rag = MetricRAG(self.agent_config)
+            rag = MetricRAG(self.agent_config, datasource_id=self.datasource_id)
             self.metric_store = rag.storage
         return self.metric_store
 
@@ -64,7 +68,7 @@ class SemanticStorageManager:
         if self.subject_tree_store is None:
             from datus.storage.registry import get_subject_tree_store
 
-            self.subject_tree_store = get_subject_tree_store(project=self.agent_config.project_name)
+            self.subject_tree_store = get_subject_tree_store(project=self.storage_namespace)
         return self.subject_tree_store
 
     def store_semantic_model(

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -61,6 +61,7 @@ class TestGenMetricsAgenticNodeInit:
     def test_metrics_has_tools(self, real_agent_config, mock_llm_create):
         """Test that the node has filesystem and generation tools."""
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
 
         node = GenMetricsAgenticNode(
             agent_config=real_agent_config,
@@ -78,6 +79,7 @@ class TestGenMetricsAgenticNodeInit:
 
         # Tool instances should be initialized
         assert isinstance(node.filesystem_func_tool, FilesystemFuncTool)
+        assert isinstance(node.filesystem_func_tool, MetricFilesystemFuncTool)
         assert isinstance(node.generation_tools, GenerationTools)
 
     def test_metrics_max_turns(self, real_agent_config, mock_llm_create):
@@ -123,6 +125,35 @@ class TestGenMetricsAgenticNodeInit:
         assert "check_semantic_object_exists" in semantic_names
         assert "db_tools" in mapping
         assert "filesystem_tools" in mapping
+
+    def test_metric_aliases_from_precomputed_candidate_plan(self):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        user_message = """
+        Query 1:
+        SELECT COUNT(*) AS new_ip_activity_count FROM activity GROUP BY dt
+
+        ## Precomputed Metric Candidate Plan JSON
+        Use this plan.
+        {"metric_aliases":[{"source_alias":"new_ip_activity_count","candidate_name":"new_ip_activity_count","canonical_name":"new_and_ip_activity_count","source_sql_name":"sql_1"}]}
+        """
+
+        assert GenMetricsAgenticNode._metric_aliases_from_user_message(user_message) == {
+            "new_ip_activity_count": "new_and_ip_activity_count"
+        }
+
+    def test_blocked_queryability_sources_from_candidate_plan(self):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        user_message = """
+        Query 1:
+        SELECT request_name, COUNT(*) AS activity_count FROM activity GROUP BY request_name HAVING COUNT(*) > 1
+
+        ## Precomputed Metric Candidate Plan JSON
+        {"source_classifications":[{"source_sql_name":"sql_1","classification":"metric_plus_derived_datasource"}]}
+        """
+
+        assert GenMetricsAgenticNode._blocked_queryability_sources_from_user_message(user_message) == {"sql_1"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -566,14 +566,14 @@ class TestExtractMetricAndOutputFromResponse:
         node = _make_node(real_agent_config, mock_llm_create)
         output = {
             "content": {
-                "semantic_model_file": "model.yml",
+                "semantic_model_files": ["model.yml"],
                 "metric_file": "revenue_metrics.yml",
                 "output": "Generated successfully",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file == "revenue_metrics.yml"
-        assert sem_model == "model.yml"
+        assert sem_models == ["model.yml"]
         assert status is None
         assert out == "Generated successfully"
 
@@ -581,14 +581,15 @@ class TestExtractMetricAndOutputFromResponse:
         node = _make_node(real_agent_config, mock_llm_create)
         content = json.dumps(
             {
-                "semantic_model_file": "model.yml",
+                "semantic_model_files": ["model.yml"],
                 "metric_file": "sales_metrics.yml",
                 "output": "Done",
             }
         )
         output = {"content": content}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file == "sales_metrics.yml"
+        assert sem_models == ["model.yml"]
         assert status is None
         assert out == "Done"
 
@@ -596,14 +597,14 @@ class TestExtractMetricAndOutputFromResponse:
         node = _make_node(real_agent_config, mock_llm_create)
         output = {
             "content": {
-                "semantic_model_file": "model.yml",
+                "semantic_model_files": ["model.yml"],
                 "metric_file": None,
                 "status": "skipped",
                 "output": "All requested metrics already exist; skipped per Step 4.",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
-        assert sem_model == "model.yml"
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_models == ["model.yml"]
         assert metric_file is None
         assert status == "skipped"
         assert out.startswith("All requested metrics already exist")
@@ -612,14 +613,14 @@ class TestExtractMetricAndOutputFromResponse:
         node = _make_node(real_agent_config, mock_llm_create)
         output = {
             "content": {
-                "semantic_model_file": "model.yml",
+                "semantic_model_files": ["model.yml"],
                 "metric_file": None,
                 "status": "generated",
                 "output": "Generated successfully.",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
-        assert sem_model == "model.yml"
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_models == ["model.yml"]
         assert metric_file is None
         assert status == "generated"
         assert out == "Generated successfully."
@@ -628,14 +629,14 @@ class TestExtractMetricAndOutputFromResponse:
         node = _make_node(real_agent_config, mock_llm_create)
         output = {
             "content": {
-                "semantic_model_file": "model.yml",
+                "semantic_model_files": ["model.yml"],
                 "metric_file": None,
                 "status": "done",
                 "output": "Done.",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
-        assert sem_model == "model.yml"
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_models == ["model.yml"]
         assert metric_file is None
         assert status == "done"
         assert out == "Done."
@@ -644,14 +645,15 @@ class TestExtractMetricAndOutputFromResponse:
         node = _make_node(real_agent_config, mock_llm_create)
         content = json.dumps(
             {
-                "semantic_model_file": "model.yml",
+                "semantic_model_files": ["model.yml"],
                 "metric_file": None,
                 "status": "skipped",
                 "output": "Skipped: metric already exists.",
             }
         )
         output = {"content": content}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_models == ["model.yml"]
         assert metric_file is None
         assert status == "skipped"
         assert out == "Skipped: metric already exists."
@@ -659,24 +661,26 @@ class TestExtractMetricAndOutputFromResponse:
     def test_returns_none_quad_on_empty_content(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": ""}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file is None
-        assert sem_model is None
+        assert sem_models is None
         assert status is None
         assert out is None
 
     def test_returns_none_quad_on_dict_missing_metric_file(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": {"some_key": "some_value"}}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file is None
+        assert sem_models is None
         assert status is None
 
     def test_returns_none_quad_on_invalid_json(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": "not json at all !!!"}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_models, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file is None
+        assert sem_models is None
         assert status is None
 
 
@@ -858,7 +862,7 @@ class TestExecuteStreamGenMetricsError:
                 build_simple_response(
                     json.dumps(
                         {
-                            "semantic_model_file": reported_semantic_path,
+                            "semantic_model_files": [reported_semantic_path],
                             "metric_file": reported_metric_path,
                             "status": "generated",
                             "output": "Generated metrics.",
@@ -897,7 +901,7 @@ class TestExecuteStreamGenMetricsError:
         node.semantic_tools.query_metrics.assert_called_once_with(metrics=["orders_total"], dry_run=True)
         node.generation_tools.end_metric_generation.assert_called_once_with(
             metric_file=str(metric_path),
-            semantic_model_file=str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml"),
+            semantic_model_files=[str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml")],
         )
 
     def test_final_metric_publish_requires_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):
@@ -931,7 +935,7 @@ class TestExecuteStreamGenMetricsError:
         node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
 
         with pytest.raises(DatusException, match="source SQL group-by dimensions"):
-            node._finalize_metric_generation(reported_semantic_path, reported_metric_path, "generated")
+            node._finalize_metric_generation([reported_semantic_path], reported_metric_path, "generated")
 
         node.semantic_tools.query_metrics.assert_called_once_with(metrics=["revenue_total"], dry_run=True)
         node.generation_tools.end_metric_generation.assert_not_called()
@@ -967,11 +971,11 @@ class TestExecuteStreamGenMetricsError:
         )
         node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
 
-        node._finalize_metric_generation(reported_semantic_path, reported_metric_path, "generated")
+        node._finalize_metric_generation([reported_semantic_path], reported_metric_path, "generated")
 
         node.generation_tools.end_metric_generation.assert_called_once_with(
             metric_file=str(metric_path),
-            semantic_model_file=str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml"),
+            semantic_model_files=[str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml")],
         )
 
     @pytest.mark.asyncio
@@ -993,7 +997,7 @@ class TestExecuteStreamGenMetricsError:
                 build_simple_response(
                     json.dumps(
                         {
-                            "semantic_model_file": None,
+                            "semantic_model_files": [],
                             "metric_file": str(outside),
                             "status": "generated",
                             "output": "Generated metrics.",
@@ -1051,7 +1055,7 @@ class TestExecuteStreamGenMetricsError:
                 build_simple_response(
                     json.dumps(
                         {
-                            "semantic_model_file": "orders.yml",
+                            "semantic_model_files": ["orders.yml"],
                             "metric_file": None,
                             "status": "skipped",
                             "output": "All requested metrics already exist; nothing generated.",
@@ -1085,7 +1089,7 @@ class TestExecuteStreamGenMetricsError:
                 build_simple_response(
                     json.dumps(
                         {
-                            "semantic_model_file": "orders.yml",
+                            "semantic_model_files": ["orders.yml"],
                             "metric_file": "orders_metrics.yml",
                             "status": "skipped",
                             "output": "Metric already exists; reused existing definition.",
@@ -1120,7 +1124,7 @@ class TestExecuteStreamGenMetricsError:
                 build_simple_response(
                     json.dumps(
                         {
-                            "semantic_model_file": "orders.yml",
+                            "semantic_model_files": ["orders.yml"],
                             "metric_file": None,
                             "status": "generated",
                             "output": "Generated metrics.",
@@ -1157,7 +1161,7 @@ class TestExecuteStreamGenMetricsError:
                 build_simple_response(
                     json.dumps(
                         {
-                            "semantic_model_file": "orders.yml",
+                            "semantic_model_files": ["orders.yml"],
                             "metric_file": None,
                             "status": "done",
                             "output": "Done.",

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -155,6 +155,22 @@ class TestGenMetricsAgenticNodeInit:
 
         assert GenMetricsAgenticNode._blocked_queryability_sources_from_user_message(user_message) == {"sql_1"}
 
+    def test_blocked_queryability_sources_merges_classification_and_blocked_candidates(self):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        candidate_plan = {
+            "source_classifications": [
+                {"source_sql_name": "sql_1", "classification": "metric_plus_derived_datasource"}
+            ],
+            "blocked_direct_metric_candidates": [{"source_sql_name": "sql_2, sql_3"}],
+        }
+
+        assert GenMetricsAgenticNode._blocked_queryability_sources_from_candidate_plan(candidate_plan) == {
+            "sql_1",
+            "sql_2",
+            "sql_3",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Execution Tests

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -1211,13 +1211,14 @@ class TestGenMetricsNonInteractiveBridge:
 
     def test_workflow_mode_compose_hooks_is_non_interactive(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.permission.permission_hooks import CompositeHooks, PermissionHooks
 
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         # Workflow mode may now compose CompositeHooks (permission + compact)
         # because multi-turn history is enabled for all modes. Validate the
         # permission gate via ``node.permission_hooks`` instead of the bundle.
         hooks = node._compose_hooks()
-        assert hooks is not None
-        assert node.permission_hooks is not None
+        assert isinstance(hooks, CompositeHooks)
+        assert isinstance(node.permission_hooks, PermissionHooks)
         assert node.permission_hooks.non_interactive is True
         assert node.permission_manager.active_profile == "dangerous"

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -69,6 +69,28 @@ class TestExplorerServiceInit:
         assert result.success is True
         assert svc.datasource_id == original_datasource
 
+    async def test_bound_service_rebinds_when_datasource_changes(self, real_agent_config):
+        svc = ExplorerService(agent_config=real_agent_config)
+        first_namespace = svc.storage_namespace
+
+        real_agent_config.current_datasource = "another_datasource"
+        await svc.get_subject_list()
+
+        assert svc.datasource_id == "another_datasource"
+        assert svc.storage_namespace != first_namespace
+
+    async def test_bound_service_unbinds_when_datasource_is_cleared(self, real_agent_config):
+        svc = ExplorerService(agent_config=real_agent_config)
+        assert svc.datasource_id
+
+        real_agent_config.current_datasource = ""
+        result = await svc.get_subject_list()
+
+        assert result.success is True
+        assert result.data.subjects == []
+        assert svc.datasource_id == ""
+        assert svc.subject_tree_store is None
+
 
 @pytest.mark.asyncio
 class TestExplorerServiceGetSubjectList:

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -69,16 +69,22 @@ class TestExplorerServiceInit:
         assert result.success is True
         assert svc.datasource_id == original_datasource
 
+    @pytest.mark.asyncio
     async def test_bound_service_rebinds_when_datasource_changes(self, real_agent_config):
         svc = ExplorerService(agent_config=real_agent_config)
         first_namespace = svc.storage_namespace
 
+        original_datasource = real_agent_config.current_datasource
+        real_agent_config.services.datasources["another_datasource"] = real_agent_config.services.datasources[
+            original_datasource
+        ]
         real_agent_config.current_datasource = "another_datasource"
         await svc.get_subject_list()
 
         assert svc.datasource_id == "another_datasource"
         assert svc.storage_namespace != first_namespace
 
+    @pytest.mark.asyncio
     async def test_bound_service_unbinds_when_datasource_is_cleared(self, real_agent_config):
         svc = ExplorerService(agent_config=real_agent_config)
         assert svc.datasource_id

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -44,6 +44,31 @@ class TestExplorerServiceInit:
         svc = ExplorerService(agent_config=real_agent_config)
         assert isinstance(svc.subject_tree_store, SubjectTreeStore)
 
+    @pytest.mark.asyncio
+    async def test_init_without_datasource_does_not_raise(self, real_agent_config):
+        """Explorer can be constructed before a workflow binds a datasource."""
+        real_agent_config.current_datasource = ""
+
+        svc = ExplorerService(agent_config=real_agent_config)
+
+        assert svc.datasource_id == ""
+        assert svc.subject_tree_store is None
+        result = await svc.get_subject_list()
+        assert result.success is True
+        assert result.data.subjects == []
+
+    @pytest.mark.asyncio
+    async def test_unbound_service_rebinds_when_datasource_becomes_available(self, real_agent_config):
+        original_datasource = real_agent_config.current_datasource
+        real_agent_config.current_datasource = ""
+        svc = ExplorerService(agent_config=real_agent_config)
+
+        real_agent_config.current_datasource = original_datasource
+        result = await svc.create_directory(CreateDirectoryInput(subject_path=["late_bound"]))
+
+        assert result.success is True
+        assert svc.datasource_id == original_datasource
+
 
 @pytest.mark.asyncio
 class TestExplorerServiceGetSubjectList:

--- a/tests/unit_tests/cli/test_core_entrypoint_acceptance.py
+++ b/tests/unit_tests/cli/test_core_entrypoint_acceptance.py
@@ -193,6 +193,7 @@ async def test_bootstrap_semantic_model_and_metrics_streams_orchestrate_fake_hel
         emit,
         build_mode,
         action_callback,
+        batch_size,
     ):
         calls.append(
             (
@@ -201,6 +202,7 @@ async def test_bootstrap_semantic_model_and_metrics_streams_orchestrate_fake_hel
                 success_story,
                 tuple(subject_tree or ()),
                 build_mode,
+                batch_size,
             )
         )
         action_callback(_action("metrics artifact persisted", action_type="metrics_saved"))
@@ -238,7 +240,7 @@ async def test_bootstrap_semantic_model_and_metrics_streams_orchestrate_fake_hel
 
     assert calls == [
         ("semantic", "local", "/tmp/story.csv", "overwrite"),
-        ("metrics", "local", "/tmp/story.csv", ("Sales", "Orders"), "incremental"),
+        ("metrics", "local", "/tmp/story.csv", ("Sales", "Orders"), "incremental", 5),
     ]
     assert any(action.action_type == "semantic_model_saved" for action in semantic_actions)
     assert any(action.action_type == "metrics_saved" for action in metrics_actions)

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -1075,8 +1075,8 @@ class TestSyncReferenceTemplateToDb:
 
 @pytest.mark.asyncio
 class TestProcessMetricWithSemanticModel:
-    async def test_semantic_missing_tries_metric_alone(self, hooks):
-        hooks._process_single_file = AsyncMock()
+    async def test_semantic_missing_syncs_metric_without_semantic_context(self, hooks):
+        hooks._sync_semantics_and_metric = AsyncMock()
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as mf:
             mf.write("metric: revenue\n")
             metric_path = mf.name
@@ -1087,7 +1087,7 @@ class TestProcessMetricWithSemanticModel:
             )
         finally:
             os.unlink(metric_path)
-        hooks._process_single_file.assert_awaited_once_with(metric_path, metric_sqls=None, yaml_type="metric")
+        hooks._sync_semantics_and_metric.assert_awaited_once_with([], metric_path, None)
 
     async def test_metric_missing_tries_semantic_alone(self, hooks):
         hooks._process_single_file = AsyncMock()
@@ -1105,31 +1105,16 @@ class TestProcessMetricWithSemanticModel:
 
     async def test_both_missing_does_nothing(self, hooks):
         hooks._process_single_file = AsyncMock()
+        hooks._sync_semantics_and_metric = AsyncMock()
         await hooks._process_metric_with_semantic_model(
             semantic_model_file="/nonexistent/sem.yaml",
             metric_file="/nonexistent/metric.yaml",
         )
         hooks._process_single_file.assert_not_called()
-
-    async def test_both_already_processed_skipped(self, hooks):
-        hooks._sync_generated_pair = AsyncMock()
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as sf:
-            sf.write("data_source:\n  name: orders\n")
-            sem_path = sf.name
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as mf:
-            mf.write("metric: revenue\n")
-            metric_path = mf.name
-        hooks.processed_files.add(sem_path)
-        hooks.processed_files.add(metric_path)
-        try:
-            await hooks._process_metric_with_semantic_model(sem_path, metric_path)
-        finally:
-            os.unlink(sem_path)
-            os.unlink(metric_path)
-        hooks._sync_generated_pair.assert_not_called()
+        hooks._sync_semantics_and_metric.assert_not_called()
 
     async def test_happy_path_auto_syncs_pair(self, hooks):
-        hooks._sync_generated_pair = AsyncMock()
+        hooks._sync_semantics_and_metric = AsyncMock()
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as sf:
             sf.write("data_source:\n  name: orders\n")
             sem_path = sf.name
@@ -1141,28 +1126,11 @@ class TestProcessMetricWithSemanticModel:
         finally:
             os.unlink(sem_path)
             os.unlink(metric_path)
-        hooks._sync_generated_pair.assert_awaited_once()
-        assert sem_path in hooks.processed_files
-        assert metric_path in hooks.processed_files
-
-    async def test_empty_content_returns_early(self, hooks):
-        hooks._sync_generated_pair = AsyncMock()
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as sf:
-            sf.write("")
-            sem_path = sf.name
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as mf:
-            mf.write("metric: revenue\n")
-            metric_path = mf.name
-        try:
-            await hooks._process_metric_with_semantic_model(sem_path, metric_path)
-        finally:
-            os.unlink(sem_path)
-            os.unlink(metric_path)
-        hooks._sync_generated_pair.assert_not_called()
+        hooks._sync_semantics_and_metric.assert_awaited_once_with([sem_path], metric_path, None)
 
     async def test_sync_error_propagates(self, hooks):
-        """Exception in _sync_generated_pair propagates to caller."""
-        hooks._sync_generated_pair = AsyncMock(side_effect=RuntimeError("broker down"))
+        """Exception in _sync_semantics_and_metric propagates to caller."""
+        hooks._sync_semantics_and_metric = AsyncMock(side_effect=RuntimeError("broker down"))
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as sf:
             sf.write("data_source:\n  name: orders\n")
             sem_path = sf.name
@@ -1176,20 +1144,6 @@ class TestProcessMetricWithSemanticModel:
             os.unlink(sem_path)
             os.unlink(metric_path)
 
-    async def test_read_error_propagates(self, hooks, tmp_path):
-        """Unreadable file raises OSError."""
-        sem_dir = tmp_path / "not_a_file"
-        sem_dir.mkdir()
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as mf:
-            mf.write("metric: revenue\n")
-            metric_path = mf.name
-        try:
-            # sem_dir is a directory, open() will raise
-            with pytest.raises(IsADirectoryError):
-                await hooks._process_metric_with_semantic_model(str(sem_dir), metric_path)
-        finally:
-            os.unlink(metric_path)
-
 
 # ---------------------------------------------------------------------------
 # Tests: _sync_generated_pair
@@ -1201,19 +1155,19 @@ class TestSyncGeneratedPair:
     async def test_auto_syncs_both_files(self, hooks):
         """Pair sync goes directly to storage."""
         hooks.broker.request = AsyncMock()
-        hooks._sync_semantic_and_metric = AsyncMock(return_value="Synced OK")
+        hooks._sync_semantics_and_metric = AsyncMock(return_value="Synced OK")
 
         await hooks._sync_generated_pair(
             semantic_model_file="/tmp/sem.yaml",
             metric_file="/tmp/met.yaml",
         )
 
-        hooks._sync_semantic_and_metric.assert_awaited_once_with("/tmp/sem.yaml", "/tmp/met.yaml", None)
+        hooks._sync_semantics_and_metric.assert_awaited_once_with(["/tmp/sem.yaml"], "/tmp/met.yaml", None)
         hooks.broker.request.assert_not_awaited()
 
     async def test_display_content_is_ignored(self, hooks):
         hooks.broker.request = AsyncMock()
-        hooks._sync_semantic_and_metric = AsyncMock(return_value="Synced OK")
+        hooks._sync_semantics_and_metric = AsyncMock(return_value="Synced OK")
 
         await hooks._sync_generated_pair(
             semantic_model_file="/tmp/sem.yaml",
@@ -1221,11 +1175,11 @@ class TestSyncGeneratedPair:
             display_content="ignored",
         )
 
-        hooks._sync_semantic_and_metric.assert_awaited_once_with("/tmp/sem.yaml", "/tmp/met.yaml", None)
+        hooks._sync_semantics_and_metric.assert_awaited_once_with(["/tmp/sem.yaml"], "/tmp/met.yaml", None)
         hooks.broker.request.assert_not_awaited()
 
     async def test_sync_error_propagates(self, hooks):
-        hooks._sync_semantic_and_metric = AsyncMock(side_effect=RuntimeError("sync failed"))
+        hooks._sync_semantics_and_metric = AsyncMock(side_effect=RuntimeError("sync failed"))
 
         with pytest.raises(RuntimeError, match="sync failed"):
             await hooks._sync_generated_pair(
@@ -1526,6 +1480,119 @@ metric:
         assert captured_metric[0]["base_measures"] == ["order_count"]
         assert captured_metric[0]["measure_expr"] == "order_count WHERE status = 'completed'"
 
+    def test_metric_context_resolves_from_base_measure_not_combined_data_source(self, agent_config, tmp_path):
+        yaml_file = tmp_path / "metrics.yml"
+        yaml_file.write_text(
+            """
+data_source:
+  name: LINEITEM
+  sql_table: SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.LINEITEM
+  measures:
+    - name: discounted_revenue
+      agg: SUM
+      expr: l_extendedprice
+  dimensions:
+    - name: ship_date
+      type: TIME
+      expr: l_shipdate
+---
+metric:
+  name: discounted_revenue
+  description: "Discounted lineitem revenue"
+  type: measure_proxy
+  type_params:
+    measure: discounted_revenue
+---
+metric:
+  name: order_count
+  description: "Orders count"
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""",
+            encoding="utf-8",
+        )
+
+        captured_metric = []
+        mock_semantic_rag = MagicMock()
+        mock_metric_rag = MagicMock()
+        mock_metric_rag.upsert_batch = lambda objects: captured_metric.extend(objects)
+
+        rows_by_measure = {
+            "discounted_revenue": [
+                {
+                    "name": "discounted_revenue",
+                    "table_name": "LINEITEM",
+                    "semantic_model_name": "LINEITEM",
+                    "catalog_name": "",
+                    "database_name": "SNOWFLAKE_SAMPLE_DATA",
+                    "schema_name": "TPCH_SF1",
+                }
+            ],
+            "order_count": [
+                {
+                    "name": "order_count",
+                    "table_name": "ORDERS",
+                    "semantic_model_name": "ORDERS",
+                    "catalog_name": "",
+                    "database_name": "SNOWFLAKE_SAMPLE_DATA",
+                    "schema_name": "TPCH_SF1",
+                }
+            ],
+        }
+
+        def _measure_name_from_condition(where):
+            for node in getattr(where, "nodes", []):
+                if getattr(node, "field", "") == "name":
+                    return getattr(node, "value", "")
+            return ""
+
+        def _search_measures(where=None, select_fields=None):
+            return rows_by_measure.get(_measure_name_from_condition(where), [])
+
+        def _semantic_model_for_table(table_name=None, select_fields=None):
+            if table_name == "LINEITEM":
+                return {
+                    "dimensions": [{"name": "ship_date"}],
+                    "identifiers": [{"name": "order_key"}],
+                }
+            if table_name == "ORDERS":
+                return {
+                    "dimensions": [{"name": "order_date"}],
+                    "identifiers": [{"name": "customer_key"}],
+                }
+            return {}
+
+        mock_semantic_rag.storage._search_all.side_effect = _search_measures
+        mock_semantic_rag.get_semantic_model.side_effect = _semantic_model_for_table
+        db_config = MagicMock()
+        db_config.catalog = ""
+        db_config.database = "SNOWFLAKE_SAMPLE_DATA"
+        db_config.schema = "TPCH_SF1"
+        agent_config.current_db_config.return_value = db_config
+
+        with (
+            patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.cli.generation_hooks.MetricRAG", return_value=mock_metric_rag),
+        ):
+            result = GenerationHooks._sync_semantic_to_db(
+                file_path=str(yaml_file),
+                agent_config=agent_config,
+                include_semantic_objects=False,
+                include_metrics=True,
+            )
+
+        assert result["success"], f"Sync failed: {result.get('error')}"
+        captured_by_name = {metric["name"]: metric for metric in captured_metric}
+        assert captured_by_name["discounted_revenue"]["semantic_model_name"] == "LINEITEM"
+        assert captured_by_name["discounted_revenue"]["dimensions"] == ["ship_date"]
+        assert captured_by_name["discounted_revenue"]["entities"] == ["order_key"]
+        assert captured_by_name["order_count"]["semantic_model_name"] == "ORDERS"
+        assert captured_by_name["order_count"]["database_name"] == "SNOWFLAKE_SAMPLE_DATA"
+        assert captured_by_name["order_count"]["schema_name"] == "TPCH_SF1"
+        assert captured_by_name["order_count"]["dimensions"] == ["order_date"]
+        assert captured_by_name["order_count"]["entities"] == ["customer_key"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: _sync_semantic_to_db actionable error for empty metric-only sync
@@ -1647,7 +1714,7 @@ class TestHandleEndMetricGeneration:
     async def test_failed_tool_result_skips_sync(self, hooks):
         hooks._extract_metric_generation_result = MagicMock()
         hooks._process_single_file = AsyncMock()
-        hooks._process_metric_with_semantic_model = AsyncMock()
+        hooks._process_metric_with_semantic_models = AsyncMock()
         result = FuncToolResult(
             success=0,
             error="query_metrics dry-run must pass",
@@ -1658,34 +1725,34 @@ class TestHandleEndMetricGeneration:
 
         hooks._extract_metric_generation_result.assert_not_called()
         hooks._process_single_file.assert_not_called()
-        hooks._process_metric_with_semantic_model.assert_not_called()
+        hooks._process_metric_with_semantic_models.assert_not_called()
 
     async def test_missing_metric_file_warns_and_returns(self, hooks):
-        hooks._extract_metric_generation_result = MagicMock(return_value=(None, None, {}))
+        hooks._extract_metric_generation_result = MagicMock(return_value=(None, [], {}))
         hooks._process_single_file = AsyncMock()
-        hooks._process_metric_with_semantic_model = AsyncMock()
+        hooks._process_metric_with_semantic_models = AsyncMock()
         await hooks._handle_end_metric_generation({"result": {}})
         hooks._process_single_file.assert_not_awaited()
-        hooks._process_metric_with_semantic_model.assert_not_awaited()
+        hooks._process_metric_with_semantic_models.assert_not_awaited()
 
     async def test_resolves_relative_paths_via_resolve_path(self, hooks):
-        """Relative metric_file and semantic_model_file must be resolved through _resolve_path."""
+        """Relative metric_file and semantic_model_files must be resolved through _resolve_path."""
         hooks._extract_metric_generation_result = MagicMock(
-            return_value=("metrics/orders.yml", "semantic/orders.yml", {"m": "SELECT 1"})
+            return_value=("metrics/orders.yml", ["semantic/orders.yml"], {"m": "SELECT 1"})
         )
-        hooks._process_metric_with_semantic_model = AsyncMock()
+        hooks._process_metric_with_semantic_models = AsyncMock()
         hooks._resolve_path = MagicMock(side_effect=lambda p, k: f"/ws/sm/{p}" if p else p)
 
         await hooks._handle_end_metric_generation({"result": {"metric_file": "metrics/orders.yml"}})
 
         hooks._resolve_path.assert_any_call("metrics/orders.yml", "semantic")
         hooks._resolve_path.assert_any_call("semantic/orders.yml", "semantic")
-        hooks._process_metric_with_semantic_model.assert_awaited_once_with(
-            "/ws/sm/semantic/orders.yml", "/ws/sm/metrics/orders.yml", {"m": "SELECT 1"}
+        hooks._process_metric_with_semantic_models.assert_awaited_once_with(
+            ["/ws/sm/semantic/orders.yml"], "/ws/sm/metrics/orders.yml", {"m": "SELECT 1"}
         )
 
     async def test_no_semantic_model_falls_back_to_single_file(self, hooks):
-        hooks._extract_metric_generation_result = MagicMock(return_value=("metrics/orders.yml", None, {"m": "SQL"}))
+        hooks._extract_metric_generation_result = MagicMock(return_value=("metrics/orders.yml", [], {"m": "SQL"}))
         hooks._process_single_file = AsyncMock()
         hooks._resolve_path = MagicMock(side_effect=lambda p, k: f"/ws/sm/{p}" if p else p)
 
@@ -1698,7 +1765,7 @@ class TestHandleEndMetricGeneration:
         )
 
     async def test_cancelled_exception_absorbed(self, hooks):
-        hooks._extract_metric_generation_result = MagicMock(return_value=("m.yml", None, {}))
+        hooks._extract_metric_generation_result = MagicMock(return_value=("m.yml", [], {}))
         hooks._resolve_path = MagicMock(side_effect=lambda p, k: p)
         hooks._process_single_file = AsyncMock(side_effect=GenerationCancelledException("user-cancel"))
         await hooks._handle_end_metric_generation({"result": {}})

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -25,6 +25,7 @@ import pytest
 from datus.cli.generation_hooks import (
     GenerationCancelledException,
     GenerationHooks,
+    _normalize_metric_subject_path,
     normalize_kb_relative_path,
     resolve_kb_sandbox_path,
 )
@@ -92,6 +93,36 @@ class TestGenerationHooksInit:
     def test_init_no_config(self, broker):
         h = GenerationHooks(broker=broker)
         assert h.agent_config is None
+
+    def test_normalizes_generic_metric_subject_root_to_datasource(self, agent_config):
+        assert _normalize_metric_subject_path(agent_config, ["Metrics", "orders"], "orders") == [
+            "test_ns",
+            "orders",
+        ]
+
+    def test_normalizes_generic_metric_subject_root_with_datasource_tail(self, agent_config):
+        assert _normalize_metric_subject_path(agent_config, ["Metrics", "test_ns", "orders"], "orders") == [
+            "test_ns",
+            "orders",
+        ]
+
+    def test_collapses_duplicate_datasource_metric_subject_root(self, agent_config):
+        assert _normalize_metric_subject_path(agent_config, ["test_ns", "test_ns", "orders"], "orders") == [
+            "test_ns",
+            "orders",
+        ]
+
+    def test_keeps_business_metric_subject_root(self, agent_config):
+        assert _normalize_metric_subject_path(agent_config, ["finance", "orders"], "orders") == [
+            "finance",
+            "orders",
+        ]
+
+    def test_keeps_uncategorized_business_metric_subject_root(self, agent_config):
+        assert _normalize_metric_subject_path(agent_config, ["Uncategorized", "orders"], "orders") == [
+            "Uncategorized",
+            "orders",
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -1247,6 +1278,24 @@ class TestParseSubjectTreeFromTags:
         assert result == ["Finance", "Revenue"]
 
 
+class TestDefaultMetricSubjectPath:
+    def test_uses_current_datasource(self):
+        from datus.cli.generation_hooks import _default_metric_subject_path
+
+        config = MagicMock()
+        config.current_datasource = "ac_manage"
+
+        assert _default_metric_subject_path(config, "orders") == ["ac_manage", "orders"]
+
+    def test_keeps_project_fallback_without_datasource(self):
+        from datus.cli.generation_hooks import _default_metric_subject_path
+
+        config = MagicMock()
+        config.current_datasource = ""
+
+        assert _default_metric_subject_path(config, "orders") == ["Metrics", "orders"]
+
+
 # ---------------------------------------------------------------------------
 # Tests: _sync_semantic_to_db — boolean coercion
 # ---------------------------------------------------------------------------
@@ -1372,7 +1421,7 @@ class TestSyncSemanticToDbBooleanCoercion:
 
 
 class TestSyncSemanticToDbMetricReferenceNormalization:
-    def test_metric_id_includes_subject_path_to_avoid_same_name_collision(self, agent_config, tmp_path):
+    def test_metric_name_is_datasource_local_and_subject_path_is_classification(self, agent_config, tmp_path):
         yaml_file = tmp_path / "metrics.yml"
         yaml_file.write_text(
             """
@@ -1418,10 +1467,9 @@ metric:
             )
 
         assert result["success"], f"Sync failed: {result.get('error')}"
-        assert len(captured_metric) == 2
-        assert captured_metric[0]["id"] == "metric:Commerce/Orders/Average_Order_Value.average_gross_order_value"
-        assert captured_metric[1]["id"] == "metric:Finance/Orders/Average_Order_Value.average_gross_order_value"
-        assert captured_metric[0]["id"] != captured_metric[1]["id"]
+        assert len(captured_metric) == 1
+        assert captured_metric[0]["id"] == "metric:average_gross_order_value"
+        assert captured_metric[0]["subject_path"] == ["Finance", "Orders", "Average_Order_Value"]
 
     def test_measure_proxy_nested_measure_is_stored_as_string(self, agent_config, tmp_path):
         yaml_file = tmp_path / "metrics.yml"

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -1550,7 +1550,9 @@ metric:
         def _search_measures(where=None, select_fields=None):
             return rows_by_measure.get(_measure_name_from_condition(where), [])
 
-        def _semantic_model_for_table(table_name=None, select_fields=None):
+        def _semantic_model_for_table(
+            catalog_name="", database_name="", schema_name="", table_name=None, select_fields=None
+        ):
             if table_name == "LINEITEM":
                 return {
                     "dimensions": [{"name": "ship_date"}],
@@ -1592,6 +1594,114 @@ metric:
         assert captured_by_name["order_count"]["schema_name"] == "TPCH_SF1"
         assert captured_by_name["order_count"]["dimensions"] == ["order_date"]
         assert captured_by_name["order_count"]["entities"] == ["customer_key"]
+        mock_semantic_rag.get_semantic_model.assert_any_call(
+            catalog_name="",
+            database_name="SNOWFLAKE_SAMPLE_DATA",
+            schema_name="TPCH_SF1",
+            table_name="ORDERS",
+            select_fields=["dimensions", "identifiers"],
+        )
+
+    def test_multi_measure_metric_keeps_all_measure_contexts(self, agent_config, tmp_path):
+        yaml_file = tmp_path / "metrics.yml"
+        yaml_file.write_text(
+            """
+metric:
+  name: revenue_per_order
+  description: "Discounted revenue per order."
+  type: ratio
+  type_params:
+    numerator: discounted_revenue
+    denominator: order_count
+""",
+            encoding="utf-8",
+        )
+
+        captured_metric = []
+        mock_semantic_rag = MagicMock()
+        mock_metric_rag = MagicMock()
+        mock_metric_rag.upsert_batch = lambda objects: captured_metric.extend(objects)
+
+        rows_by_measure = {
+            "discounted_revenue": [
+                {
+                    "name": "discounted_revenue",
+                    "table_name": "LINEITEM",
+                    "semantic_model_name": "LINEITEM",
+                    "catalog_name": "",
+                    "database_name": "SNOWFLAKE_SAMPLE_DATA",
+                    "schema_name": "TPCH_SF1",
+                }
+            ],
+            "order_count": [
+                {
+                    "name": "order_count",
+                    "table_name": "ORDERS",
+                    "semantic_model_name": "ORDERS",
+                    "catalog_name": "",
+                    "database_name": "SNOWFLAKE_SAMPLE_DATA",
+                    "schema_name": "TPCH_SF1",
+                }
+            ],
+        }
+
+        def _measure_name_from_condition(where):
+            for node in getattr(where, "nodes", []):
+                if getattr(node, "field", "") == "name":
+                    return getattr(node, "value", "")
+            return ""
+
+        def _search_measures(where=None, select_fields=None):
+            return rows_by_measure.get(_measure_name_from_condition(where), [])
+
+        def _semantic_model_for_table(
+            catalog_name="", database_name="", schema_name="", table_name=None, select_fields=None
+        ):
+            if table_name == "LINEITEM":
+                assert database_name == "SNOWFLAKE_SAMPLE_DATA"
+                assert schema_name == "TPCH_SF1"
+                return {
+                    "dimensions": [{"name": "ship_date"}],
+                    "identifiers": [{"name": "order_key"}],
+                }
+            if table_name == "ORDERS":
+                assert database_name == "SNOWFLAKE_SAMPLE_DATA"
+                assert schema_name == "TPCH_SF1"
+                return {
+                    "dimensions": [{"name": "order_date"}],
+                    "identifiers": [{"name": "customer_key"}],
+                }
+            return {}
+
+        mock_semantic_rag.storage._search_all.side_effect = _search_measures
+        mock_semantic_rag.get_semantic_model.side_effect = _semantic_model_for_table
+        db_config = MagicMock()
+        db_config.catalog = ""
+        db_config.database = "SNOWFLAKE_SAMPLE_DATA"
+        db_config.schema = "TPCH_SF1"
+        agent_config.current_db_config.return_value = db_config
+
+        with (
+            patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.cli.generation_hooks.MetricRAG", return_value=mock_metric_rag),
+        ):
+            result = GenerationHooks._sync_semantic_to_db(
+                file_path=str(yaml_file),
+                agent_config=agent_config,
+                include_semantic_objects=False,
+                include_metrics=True,
+            )
+
+        assert result["success"], f"Sync failed: {result.get('error')}"
+        assert len(captured_metric) == 1
+        metric = captured_metric[0]
+        assert metric["semantic_model_name"] == (
+            "SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.LINEITEM,SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.ORDERS"
+        )
+        assert metric["database_name"] == "SNOWFLAKE_SAMPLE_DATA"
+        assert metric["schema_name"] == "TPCH_SF1"
+        assert metric["dimensions"] == ["ship_date", "order_date"]
+        assert metric["entities"] == ["order_key", "customer_key"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -18,7 +18,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -1658,15 +1658,11 @@ metric:
             catalog_name="", database_name="", schema_name="", table_name=None, select_fields=None
         ):
             if table_name == "LINEITEM":
-                assert database_name == "SNOWFLAKE_SAMPLE_DATA"
-                assert schema_name == "TPCH_SF1"
                 return {
                     "dimensions": [{"name": "ship_date"}],
                     "identifiers": [{"name": "order_key"}],
                 }
             if table_name == "ORDERS":
-                assert database_name == "SNOWFLAKE_SAMPLE_DATA"
-                assert schema_name == "TPCH_SF1"
                 return {
                     "dimensions": [{"name": "order_date"}],
                     "identifiers": [{"name": "customer_key"}],
@@ -1702,6 +1698,22 @@ metric:
         assert metric["schema_name"] == "TPCH_SF1"
         assert metric["dimensions"] == ["ship_date", "order_date"]
         assert metric["entities"] == ["order_key", "customer_key"]
+        assert mock_semantic_rag.get_semantic_model.call_args_list == [
+            call(
+                catalog_name="",
+                database_name="SNOWFLAKE_SAMPLE_DATA",
+                schema_name="TPCH_SF1",
+                table_name="LINEITEM",
+                select_fields=["dimensions", "identifiers"],
+            ),
+            call(
+                catalog_name="",
+                database_name="SNOWFLAKE_SAMPLE_DATA",
+                schema_name="TPCH_SF1",
+                table_name="ORDERS",
+                select_fields=["dimensions", "identifiers"],
+            ),
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -13,6 +13,7 @@ from datus.storage.metric.metric_init import (
     BIZ_NAME,
     DEFAULT_METRICS_BATCH_SIZE,
     _action_status_value,
+    _all_candidate_metrics_satisfied,
     _extract_metric_artifact_ids,
     _generate_metrics_batch,
     _source_provenance_from_row,
@@ -1278,16 +1279,23 @@ class TestBatchSplitting:
         rows = [{"question": "revenue", "sql": "SELECT SUM(revenue) AS total_revenue FROM orders"}]
         candidate_plan = {
             "available": True,
-            "direct_metric_candidates": [{"name": "total_revenue", "source_sql_name": "sql_1"}],
+            "direct_metric_candidates": [
+                {
+                    "name": "total_revenue",
+                    "source_sql_name": "sql_1",
+                    "metric_type": "measure_proxy",
+                    "base_measures": [{"name": "total_revenue"}],
+                }
+            ],
             "derived_metric_candidates": [],
-            "metric_candidates": [{"name": "total_revenue", "source_sql_name": "sql_1"}],
+            "metric_candidates": [],
         }
 
         with (
             patch("datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value=[]),
             patch(
                 "datus.storage.metric.metric_init._build_existing_metric_catalog",
-                return_value=[{"name": "total_revenue", "type": "measure_proxy"}],
+                return_value=[{"name": "total_revenue", "type": "measure_proxy", "base_measures": ["total_revenue"]}],
             ) as catalog_builder,
             patch(
                 "datus.storage.metric.metric_init._build_candidate_plan", return_value=candidate_plan
@@ -1308,3 +1316,30 @@ class TestBatchSplitting:
         catalog_builder.assert_called_once_with(mock_config)
         plan_builder.assert_called_once()
         node_factory.assert_not_called()
+
+    def test_candidate_metrics_satisfied_requires_definition_match(self):
+        candidate_plan = {
+            "direct_metric_candidates": [
+                {
+                    "name": "total_revenue",
+                    "metric_type": "measure_proxy",
+                    "base_measures": [{"name": "total_revenue"}],
+                }
+            ]
+        }
+
+        assert (
+            _all_candidate_metrics_satisfied(
+                candidate_plan,
+                [{"name": "total_revenue", "type": "measure_proxy", "base_measures": ["total_revenue"]}],
+            )
+            is True
+        )
+        assert (
+            _all_candidate_metrics_satisfied(
+                candidate_plan,
+                [{"name": "total_revenue", "type": "ratio", "base_measures": ["total_revenue"]}],
+            )
+            is False
+        )
+        assert _all_candidate_metrics_satisfied({"direct_metric_candidates": [{"name": "total_revenue"}]}, []) is False

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -506,13 +506,14 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
             )
 
         assert success is True
-        rag_factory.assert_called_once_with(mock_config)
+        assert rag_factory.call_count == 2
+        rag_factory.assert_any_call(mock_config)
         fake_rag_instance.truncate.assert_called_once_with()
         mock_exists.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_incremental_does_not_call_truncate(self):
-        """build_mode='incremental' must not call truncate; it consults exists_metrics instead."""
+        """build_mode='incremental' must not call truncate or whole-store exists probe."""
         from unittest.mock import patch
 
         import pandas as pd
@@ -561,7 +562,7 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
 
         assert success is True
         fake_rag_instance.truncate.assert_not_called()
-        mock_exists.assert_called_once()
+        mock_exists.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -672,7 +673,7 @@ class TestMetricProvenanceHelpers:
 @pytest.mark.ci
 class TestDefaultMetricsBatchSize:
     def test_default_batch_size(self):
-        assert DEFAULT_METRICS_BATCH_SIZE == 1
+        assert DEFAULT_METRICS_BATCH_SIZE == 5
 
 
 # ---------------------------------------------------------------------------
@@ -895,6 +896,55 @@ class TestGenerateMetricsBatch:
         assert ok is False
         assert "connection lost" in err
 
+    @pytest.mark.asyncio
+    async def test_prompt_includes_precomputed_catalog_and_candidate_plan(self):
+        from unittest.mock import patch
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.schemas.batch_events import BatchEventHelper
+
+        captured = {}
+
+        class MockNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+
+            async def execute_stream(self, _ahm):
+                captured["message"] = self.input.user_message
+                action = MagicMock()
+                action.status = ActionStatus.SUCCESS
+                action.action_type = "gen_metrics_response"
+                action.output = {"metrics": ["revenue"]}
+                action.messages = "ok"
+                yield action
+
+        mock_config = MagicMock()
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+
+        with (
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", MockNode),
+        ):
+            ok, err, _ = await _generate_metrics_batch(
+                ["Query 1:\nQuestion: q?\nSQL:\nSELECT SUM(revenue) AS revenue FROM orders"],
+                0,
+                mock_config,
+                None,
+                None,
+                BatchEventHelper("test", None),
+                None,
+                candidate_plan_json='{"direct_metric_candidates":[{"name":"revenue"}]}',
+                existing_metric_catalog_json='[{"name":"orders"}]',
+            )
+
+        assert ok is True
+        assert err == ""
+        assert "Existing Metric Catalog JSON" in captured["message"]
+        assert "Precomputed Metric Candidate Plan JSON" in captured["message"]
+        assert "do not call analyze_metric_candidates_from_history again" in captured["message"]
+
 
 # ---------------------------------------------------------------------------
 # init_success_story_metrics_async — batch splitting & partial failure
@@ -975,6 +1025,121 @@ class TestBatchSplitting:
         assert ok is True
         assert err == ""
         assert len(result["metrics"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_refreshes_existing_metric_catalog_between_batches(self):
+        from unittest.mock import patch
+
+        import pandas as pd
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        captured_messages = []
+        call_count = {"n": 0}
+
+        class MockNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+
+            async def execute_stream(self, _ahm):
+                captured_messages.append(self.input.user_message)
+                batch_idx = call_count["n"]
+                call_count["n"] += 1
+                action = MagicMock()
+                action.status = ActionStatus.SUCCESS
+                action.action_type = "gen_metrics_response"
+                action.output = {"metrics": [f"m{batch_idx}"]}
+                action.messages = "ok"
+                yield action
+
+        catalog_snapshots = [
+            [],
+            [{"name": "first_metric"}],
+            [{"name": "first_metric"}, {"name": "second_metric"}],
+        ]
+
+        def fake_catalog(_agent_config):
+            if catalog_snapshots:
+                return catalog_snapshots.pop(0)
+            return [{"name": "first_metric"}, {"name": "second_metric"}]
+
+        def fake_candidate_plan(_sql_entries, _catalog_json, _agent_config):
+            return {"available": True, "direct_metric_candidates": [], "metric_candidates": []}
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+        rows = [
+            {"question": "q1", "sql": "SELECT COUNT(*) AS first_metric FROM orders"},
+            {"question": "q2", "sql": "SELECT COUNT(*) AS second_metric FROM orders"},
+        ]
+
+        with (
+            patch("datus.storage.metric.store.MetricRAG", MagicMock()),
+            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value=[]),
+            patch("datus.storage.metric.metric_init._build_existing_metric_catalog", side_effect=fake_catalog),
+            patch("datus.storage.metric.metric_init._build_candidate_plan", side_effect=fake_candidate_plan),
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", MockNode),
+            patch("datus.storage.metric.metric_init.pd.read_csv", return_value=pd.DataFrame(rows)),
+        ):
+            ok, err, result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="dummy.csv",
+                batch_size=1,
+            )
+
+        assert ok is True
+        assert err == ""
+        assert result["metrics"] == ["m0", "m1"]
+        assert len(captured_messages) == 2
+        assert '"first_metric"' in captured_messages[1]
+
+    @pytest.mark.asyncio
+    async def test_metrics_bootstrap_uses_batch_semantic_model_creation(self):
+        """Metrics bootstrap asks semantic model auto-create to batch missing tables."""
+        from unittest.mock import AsyncMock, patch
+
+        import pandas as pd
+
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        MockNode = self._make_node_factory()
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_prompt_manager = MagicMock()
+        mock_prompt_manager.get_latest_version.return_value = "1.0"
+        ensure_semantic = AsyncMock(return_value=(True, "", ["orders", "customers"]))
+
+        rows = [{"question": "revenue", "sql": "SELECT SUM(amount) FROM orders"}]
+
+        with (
+            patch(
+                "datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value={"orders", "customers"}
+            ),
+            patch("datus.storage.metric.metric_init.extract_table_sql_evidence", return_value={"orders": ["sql"]}),
+            patch("datus.storage.metric.metric_init.ensure_semantic_models_exist", ensure_semantic),
+            patch("datus.storage.metric.metric_init._build_existing_metric_catalog", return_value=[]),
+            patch("datus.storage.metric.metric_init._build_candidate_plan", return_value={"available": False}),
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_prompt_manager),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", MockNode),
+            patch("datus.storage.metric.metric_init.pd.read_csv", return_value=pd.DataFrame(rows)),
+        ):
+            ok, err, result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="dummy.csv",
+            )
+
+        assert ok is True
+        assert err == ""
+        assert result["metrics"] == ["m0"]
+        ensure_semantic.assert_awaited_once()
+        assert ensure_semantic.await_args.kwargs["batch_mode"] is True
 
     @pytest.mark.asyncio
     async def test_partial_batch_failure_continues(self):
@@ -1096,3 +1261,50 @@ class TestBatchSplitting:
         sig = inspect.signature(init_success_story_metrics)
         assert "batch_size" in sig.parameters
         assert sig.parameters["batch_size"].default == DEFAULT_METRICS_BATCH_SIZE
+
+    @pytest.mark.asyncio
+    async def test_incremental_skips_batch_when_candidates_already_exist(self):
+        """A fully satisfied candidate plan skips gen_metrics without creating an agent node."""
+        from unittest.mock import patch
+
+        import pandas as pd
+
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+
+        rows = [{"question": "revenue", "sql": "SELECT SUM(revenue) AS total_revenue FROM orders"}]
+        candidate_plan = {
+            "available": True,
+            "direct_metric_candidates": [{"name": "total_revenue", "source_sql_name": "sql_1"}],
+            "derived_metric_candidates": [],
+            "metric_candidates": [{"name": "total_revenue", "source_sql_name": "sql_1"}],
+        }
+
+        with (
+            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list", return_value=[]),
+            patch(
+                "datus.storage.metric.metric_init._build_existing_metric_catalog",
+                return_value=[{"name": "total_revenue", "type": "measure_proxy"}],
+            ) as catalog_builder,
+            patch(
+                "datus.storage.metric.metric_init._build_candidate_plan", return_value=candidate_plan
+            ) as plan_builder,
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode") as node_factory,
+            patch("datus.storage.metric.metric_init.pd.read_csv", return_value=pd.DataFrame(rows)),
+        ):
+            ok, err, result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="dummy.csv",
+                build_mode="incremental",
+            )
+
+        assert ok is True
+        assert err == ""
+        assert result["skipped_batches"] == 1
+        assert result["skipped_metric_candidates"] == ["total_revenue"]
+        catalog_builder.assert_called_once_with(mock_config)
+        plan_builder.assert_called_once()
+        node_factory.assert_not_called()

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -228,6 +228,30 @@ class TestBatchUpsertMetricsValidation:
         assert rows[0]["id"] == build_metric_id([], "test_metric_1")
         assert rows[0]["name"] == "test_metric_1"
 
+    def test_batch_upsert_metrics_keeps_legacy_duplicate_when_upsert_fails(
+        self, metric_storage: MetricStorage, monkeypatch
+    ):
+        legacy = _make_metric(1, subject_path=["Finance", "Revenue"])
+        legacy["id"] = "metric:Finance/Revenue.test_metric_1"
+        canonical = _make_metric(1, subject_path=["Sales", "Revenue"])
+
+        legacy_row = dict(legacy)
+        legacy_row["subject_node_id"] = metric_storage.subject_tree.find_or_create_path(legacy["subject_path"])
+        legacy_row.pop("subject_path", None)
+        metric_storage.store_batch([legacy_row])
+
+        def fail_upsert(*_args, **_kwargs):
+            raise RuntimeError("upsert failed")
+
+        monkeypatch.setattr(metric_storage, "batch_upsert", fail_upsert)
+
+        with pytest.raises(RuntimeError, match="upsert failed"):
+            metric_storage.batch_upsert_metrics([canonical])
+
+        rows = metric_storage.search_all_metrics(select_fields=["id", "name"])
+        assert len(rows) == 1
+        assert rows[0]["id"] == "metric:Finance/Revenue.test_metric_1"
+
 
 # ---------------------------------------------------------------------------
 # YAML deletion logic in delete_metric

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 
 from datus.storage.embedding_models import get_metric_embedding_model
-from datus.storage.metric.store import MetricStorage
+from datus.storage.metric.store import MetricStorage, build_metric_id
 
 
 @pytest.fixture
@@ -137,6 +137,26 @@ class TestBatchStoreMetricsValidation:
         with pytest.raises(ValueError, match="subject_path is required"):
             metric_storage.batch_store_metrics([bad_metric])
 
+    def test_batch_store_metrics_normalizes_id_from_metric_name(self, metric_storage: MetricStorage):
+        metric = _make_metric(1)
+        metric["id"] = "metric:wrong_id"
+
+        metric_storage.batch_store_metrics([metric])
+
+        rows = metric_storage.search_all_metrics(select_fields=["id", "name"])
+        assert len(rows) == 1
+        assert rows[0]["id"] == build_metric_id([], "test_metric_1")
+        assert rows[0]["name"] == "test_metric_1"
+
+    def test_batch_store_metrics_rejects_same_batch_name_conflict(self, metric_storage: MetricStorage):
+        first = _make_metric(1, subject_path=["Finance"])
+        second = _make_metric(2, subject_path=["Sales"])
+        second["name"] = first["name"]
+        second["measure_expr"] = "SUM(other_col)"
+
+        with pytest.raises(ValueError, match="Metric name conflict within datasource"):
+            metric_storage.batch_store_metrics([first, second])
+
 
 # ---------------------------------------------------------------------------
 # batch_upsert_metrics validation
@@ -162,6 +182,51 @@ class TestBatchUpsertMetricsValidation:
         }
         with pytest.raises(ValueError, match="subject_path is required"):
             metric_storage.batch_upsert_metrics([bad_metric])
+
+    def test_batch_upsert_metrics_allows_same_definition_update(self, metric_storage: MetricStorage):
+        original = _make_metric(1, subject_path=["Finance", "Revenue"])
+        updated = _make_metric(1, subject_path=["Sales", "Revenue"])
+        updated["description"] = "Updated display text"
+
+        metric_storage.batch_upsert_metrics([original])
+        metric_storage.batch_upsert_metrics([updated])
+
+        rows = metric_storage.search_all_metrics(select_fields=["id", "name", "description"])
+        assert len(rows) == 1
+        assert rows[0]["id"] == build_metric_id([], "test_metric_1")
+        assert rows[0]["description"] == "Updated display text"
+        assert rows[0]["subject_path"] == ["Sales", "Revenue"]
+
+    def test_batch_upsert_metrics_rejects_existing_name_conflict(self, metric_storage: MetricStorage):
+        original = _make_metric(1, subject_path=["Finance", "Revenue"])
+        conflicting = _make_metric(2, subject_path=["Sales", "Revenue"])
+        conflicting["name"] = original["name"]
+        conflicting["measure_expr"] = "SUM(net_revenue)"
+
+        metric_storage.batch_upsert_metrics([original])
+
+        with pytest.raises(ValueError, match="existing metric id"):
+            metric_storage.batch_upsert_metrics([conflicting])
+
+        rows = metric_storage.search_all_metrics(select_fields=["name", "measure_expr"])
+        assert len(rows) == 1
+        assert rows[0]["measure_expr"] == original["measure_expr"]
+
+    def test_batch_upsert_metrics_removes_same_definition_legacy_duplicate(self, metric_storage: MetricStorage):
+        legacy = _make_metric(1, subject_path=["Finance", "Revenue"])
+        legacy["id"] = "metric:Finance/Revenue.test_metric_1"
+        canonical = _make_metric(1, subject_path=["Sales", "Revenue"])
+
+        legacy_row = dict(legacy)
+        legacy_row["subject_node_id"] = metric_storage.subject_tree.find_or_create_path(legacy["subject_path"])
+        legacy_row.pop("subject_path", None)
+        metric_storage.store_batch([legacy_row])
+        metric_storage.batch_upsert_metrics([canonical])
+
+        rows = metric_storage.search_all_metrics(select_fields=["id", "name"])
+        assert len(rows) == 1
+        assert rows[0]["id"] == build_metric_id([], "test_metric_1")
+        assert rows[0]["name"] == "test_metric_1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/semantic_model/test_auto_create.py
+++ b/tests/unit_tests/storage/semantic_model/test_auto_create.py
@@ -176,6 +176,34 @@ class TestFindMissingSemanticModels:
         assert result == []
 
     @patch("datus.storage.semantic_model.store.SemanticModelRAG")
+    def test_store_hit_but_yaml_missing_is_missing(self, MockRAG, tmp_path):
+        """A stale store row should not suppress YAML regeneration."""
+        from datus.storage.semantic_model.auto_create import find_missing_semantic_models
+
+        semantic_dir = tmp_path / "subject" / "semantic_models" / "ac_manage"
+        semantic_dir.mkdir(parents=True)
+        config = MagicMock()
+        config.db_type = "starrocks"
+        config.current_datasource = "ac_manage"
+        config.path_manager.semantic_model_path.return_value = semantic_dir
+        config.current_db_config.return_value.catalog = "default_catalog"
+        config.current_db_config.return_value.database = "ac_manage"
+        config.current_db_config.return_value.schema = ""
+        mock_rag = MagicMock()
+        MockRAG.return_value = mock_rag
+        mock_rag.storage.search_objects.return_value = [{"name": "users"}]
+
+        result = find_missing_semantic_models({"users"}, config)
+
+        assert result == ["users"]
+        mock_rag.delete_semantic_model_for_table.assert_called_once_with(
+            table_name="users",
+            catalog_name="default_catalog",
+            database_name="ac_manage",
+            schema_name="",
+        )
+
+    @patch("datus.storage.semantic_model.store.SemanticModelRAG")
     def test_missing_models_detected(self, MockRAG):
         """When semantic models are missing, should return those table names."""
         from datus.storage.semantic_model.auto_create import find_missing_semantic_models
@@ -676,6 +704,62 @@ class TestCreateSemanticModelsForTables:
         assert succeeded == ["catalog_sales", "date_dim"]
         assert failed == []
         assert calls == {"catalog_sales": ["catalog SQL"], "date_dim": ["date SQL"]}
+
+    @pytest.mark.asyncio
+    async def test_batch_mode_uses_one_agent_when_all_models_created(self, monkeypatch):
+        """Batch mode returns after one multi-table generation when all tables now exist."""
+        from datus.storage.semantic_model import auto_create
+
+        batch_calls = []
+
+        async def mock_batch(tables, config, emit=None, sql_evidence_by_table=None):
+            batch_calls.append(list(tables))
+            return True, ""
+
+        async def mock_single(table, config, emit=None, related_tables=None, sql_evidence=None):
+            raise AssertionError("single-table fallback should not run")
+
+        monkeypatch.setattr(auto_create, "create_semantic_models_for_tables_batch", mock_batch)
+        monkeypatch.setattr(auto_create, "find_missing_semantic_models", lambda tables, config: [])
+        monkeypatch.setattr(auto_create, "create_semantic_model_for_table", mock_single)
+
+        succeeded, failed = await auto_create.create_semantic_models_for_tables(
+            ["users", "orders"],
+            MagicMock(),
+            batch_mode=True,
+        )
+
+        assert batch_calls == [["users", "orders"]]
+        assert succeeded == ["users", "orders"]
+        assert failed == []
+
+    @pytest.mark.asyncio
+    async def test_batch_mode_falls_back_only_for_remaining_missing_models(self, monkeypatch):
+        """Batch mode keeps created models and falls back per table only for misses."""
+        from datus.storage.semantic_model import auto_create
+
+        single_calls = []
+
+        async def mock_batch(tables, config, emit=None, sql_evidence_by_table=None):
+            return True, ""
+
+        async def mock_single(table, config, emit=None, related_tables=None, sql_evidence=None):
+            single_calls.append(table)
+            return True, ""
+
+        monkeypatch.setattr(auto_create, "create_semantic_models_for_tables_batch", mock_batch)
+        monkeypatch.setattr(auto_create, "find_missing_semantic_models", lambda tables, config: ["orders"])
+        monkeypatch.setattr(auto_create, "create_semantic_model_for_table", mock_single)
+
+        succeeded, failed = await auto_create.create_semantic_models_for_tables(
+            ["users", "orders"],
+            MagicMock(),
+            batch_mode=True,
+        )
+
+        assert single_calls == ["orders"]
+        assert succeeded == ["users", "orders"]
+        assert failed == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -902,6 +902,58 @@ class TestSemanticModelRAGTruncate:
         assert sem_rag.get_size() == 0
 
 
+class TestSemanticModelRAGDeleteSemanticModelForTable:
+    """Tests for table-scoped semantic model deletion."""
+
+    def test_delete_semantic_model_for_table_deletes_table_and_children(self, sem_rag):
+        orders = _make_table_object("orders", catalog_name="default", database_name="sales", schema_name="public")
+        orders["id"] = "table:sales.public.orders"
+        amount = _make_column_object(
+            "orders",
+            "amount",
+            catalog_name="default",
+            database_name="sales",
+            schema_name="public",
+            is_measure=True,
+            agg="SUM",
+        )
+        amount["id"] = "column:sales.public.orders.amount"
+        customers = _make_table_object("customers", catalog_name="default", database_name="sales", schema_name="public")
+        customers["id"] = "table:sales.public.customers"
+
+        sem_rag.store_batch([orders, amount, customers])
+
+        deleted = sem_rag.delete_semantic_model_for_table(
+            table_name="orders",
+            catalog_name="default",
+            database_name="sales",
+            schema_name="public",
+        )
+
+        rows = sem_rag.storage.search_all(select_fields=["id"])
+        assert deleted == 2
+        assert {row["id"] for row in rows} == {"table:sales.public.customers"}
+
+    def test_delete_semantic_model_for_table_respects_hierarchy(self, sem_rag):
+        sales_orders = _make_table_object("orders", catalog_name="default", database_name="sales", schema_name="public")
+        sales_orders["id"] = "table:sales.public.orders"
+        ops_orders = _make_table_object("orders", catalog_name="default", database_name="ops", schema_name="public")
+        ops_orders["id"] = "table:ops.public.orders"
+
+        sem_rag.store_batch([sales_orders, ops_orders])
+
+        deleted = sem_rag.delete_semantic_model_for_table(
+            table_name="orders",
+            catalog_name="default",
+            database_name="sales",
+            schema_name="public",
+        )
+
+        rows = sem_rag.storage.search_all(select_fields=["id"])
+        assert deleted == 1
+        assert {row["id"] for row in rows} == {"table:ops.public.orders"}
+
+
 # ============================================================
 # SemanticModelRAG.create_indices
 # ============================================================

--- a/tests/unit_tests/storage/test_base_truncate_scoped.py
+++ b/tests/unit_tests/storage/test_base_truncate_scoped.py
@@ -1,0 +1,61 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from datus.storage.base import BaseEmbeddingStore
+from datus.utils.exceptions import DatusException
+
+
+def _store_with_table(table):
+    store = object.__new__(BaseEmbeddingStore)
+    store._shared = SimpleNamespace(table=table, initialized=True)
+    store._table_lock = MagicMock()
+    store.db = Mock()
+    store.table_name = "metrics"
+    return store
+
+
+def test_truncate_scoped_physical_delegates_to_truncate():
+    store = _store_with_table(Mock())
+    store.truncate = Mock()
+
+    with patch("datus.storage.backend_holder.get_isolation_type", return_value="physical"):
+        store.truncate_scoped()
+
+    store.truncate.assert_called_once_with()
+
+
+def test_truncate_scoped_logical_deletes_visible_rows_without_drop():
+    table = Mock()
+    table.supports_logical_scoped_delete_all = True
+    store = _store_with_table(table)
+    store.truncate = Mock()
+
+    with patch("datus.storage.backend_holder.get_isolation_type", return_value="logical"):
+        store.truncate_scoped()
+
+    table.delete.assert_called_once_with(None)
+    store.db.drop_table.assert_not_called()
+    store.truncate.assert_not_called()
+    assert store._shared.table is None
+    assert store._shared.initialized is False
+
+
+def test_truncate_scoped_logical_requires_scoped_delete_support():
+    table = Mock()
+    table.supports_logical_scoped_delete_all = False
+    store = _store_with_table(table)
+    store.truncate = Mock()
+
+    with patch("datus.storage.backend_holder.get_isolation_type", return_value="logical"):
+        with pytest.raises(DatusException, match="supports_logical_scoped_delete_all"):
+            store.truncate_scoped()
+
+    table.delete.assert_not_called()
+    store.db.drop_table.assert_not_called()
+    store.truncate.assert_not_called()

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -5,8 +5,12 @@
 """Tests for datus/storage/catalog_manager.py — CatalogUpdater pure logic methods."""
 
 import json
+from types import SimpleNamespace
+
+import pytest
 
 from datus.storage.catalog_manager import CatalogUpdater
+from datus.storage.table_identity import build_semantic_table_identity
 from datus.utils.exceptions import DatusException, ErrorCode
 
 
@@ -116,6 +120,7 @@ class TestUpdateColumnsFieldMapping:
         obj = object.__new__(CatalogUpdater)
         obj.datasource_id = "test_datasource"
         obj.semantic_model_storage = fake_storage
+        obj._agent_config = SimpleNamespace(db_type="sqlite")
         return obj
 
     def test_type_to_column_type_mapping_detects_change(self):
@@ -233,6 +238,7 @@ class TestUpdateColumnsMethod:
         """Create a bare CatalogUpdater for pure method tests."""
         obj = object.__new__(CatalogUpdater)
         obj.datasource_id = "test_datasource"
+        obj._agent_config = SimpleNamespace(db_type="sqlite")
         return obj
 
     def test_update_columns_skips_items_without_name(self):
@@ -417,6 +423,7 @@ class TestUpdateSemanticModel:
         """Create a bare CatalogUpdater for tests."""
         obj = object.__new__(CatalogUpdater)
         obj.datasource_id = "test_datasource"
+        obj._agent_config = SimpleNamespace(db_type="sqlite")
         return obj
 
     def test_update_semantic_model_description(self):
@@ -462,6 +469,34 @@ class TestUpdateSemanticModel:
         updater.update_semantic_model(old_values, update_values)
 
         assert any(entry_id == "table:orders" for entry_id, _ in calls)
+
+    def test_update_semantic_model_schema_less_dialect_omits_schema_from_identity(self):
+        updater = self._make_updater()
+        updater._agent_config = SimpleNamespace(db_type="starrocks")
+        calls = []
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater.semantic_model_storage = FakeStorage()
+
+        updater.update_semantic_model(
+            {
+                "database_name": "analytics",
+                "schema_name": "ignored_schema",
+                "table_name": "orders",
+                "semantic_model_name": "orders",
+            },
+            {"description": "Updated description"},
+        )
+
+        assert any(entry_id == "table:analytics.orders" for entry_id, _ in calls)
+        assert all("ignored_schema" not in entry_id for entry_id, _ in calls)
+
+    def test_build_semantic_table_identity_requires_db_type(self):
+        with pytest.raises(ValueError, match="db_type is required"):
+            build_semantic_table_identity({"table_name": "orders"}, "")
 
     def test_update_semantic_model_description_value_error_handled(self):
         """DatusException from update_entry for table is caught and does not raise."""

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -495,8 +495,12 @@ class TestUpdateSemanticModel:
         assert all("ignored_schema" not in entry_id for entry_id, _ in calls)
 
     def test_build_semantic_table_identity_requires_db_type(self):
-        with pytest.raises(ValueError, match="db_type is required"):
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        with pytest.raises(DatusException) as exc:
             build_semantic_table_identity({"table_name": "orders"}, "")
+        assert exc.value.code == ErrorCode.STORAGE_INVALID_ARGUMENT
+        assert "db_type is required" in str(exc.value)
 
     def test_update_semantic_model_description_value_error_handled(self):
         """DatusException from update_entry for table is caught and does not raise."""

--- a/tests/unit_tests/storage/test_rag_datasource_isolation.py
+++ b/tests/unit_tests/storage/test_rag_datasource_isolation.py
@@ -2,28 +2,13 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Tests for RAG classes in PHYSICAL isolation mode.
-
-In Storage 3.0, datasource_id isolation is handled at the backend level:
-- PHYSICAL mode (CLI default): each datasource gets its own directory via
-  init_backends(datasource=...).  All RAG instances within one process share
-  the same storage — isolation is per-process, not per-RAG.
-- LOGICAL mode (SaaS): backend auto-injects datasource_id column for
-  within-process multi-tenant filtering.
-
-LOGICAL isolation is tested at the LanceDB backend level in
-tests/unit_tests/storage/vector/test_lance_backend.py
-(TestLanceVectorTableLogicalIsolation).
-
-This file tests that RAG classes work correctly in PHYSICAL mode
-(single shared storage, no cross-datasource filtering).
-"""
+"""Tests for datasource-scoped RAG storage namespaces."""
 
 from typing import Any, Dict
 
 import pyarrow as pa
 
-from datus.storage.metric.store import MetricRAG
+from datus.storage.metric.store import MetricRAG, build_metric_id
 from datus.storage.semantic_model.store import SemanticModelRAG
 
 # ---------------------------------------------------------------------------
@@ -78,11 +63,7 @@ def _make_metric(suffix: str = "a") -> Dict[str, Any]:
 
 
 class TestRAGPhysicalModeSharedStorage:
-    """In PHYSICAL mode, all RAG instances share the same storage.
-
-    This verifies that store_batch/search_all work correctly when
-    multiple RAGs use the same underlying storage.
-    """
+    """RAGs can store and retrieve data inside one datasource namespace."""
 
     def test_semantic_model_store_and_search(self, real_agent_config):
         """SemanticModelRAG can store and retrieve data."""
@@ -122,3 +103,115 @@ class TestRAGPhysicalModeSharedStorage:
         # Upsert same id — should not increase count
         rag.upsert_batch([m])
         assert rag.get_metrics_size() == initial_size
+
+
+class TestDatasourceScopedNamespaces:
+    """Datasource-bound KB stores must not share project-level storage."""
+
+    def _add_datasource_alias(self, agent_config, datasource: str) -> None:
+        agent_config.services.datasources[datasource] = agent_config.services.datasources[
+            agent_config.current_datasource
+        ]
+
+    def test_namespace_helper_sanitizes_project_and_datasource(self, real_agent_config):
+        from datus.storage.scope import datasource_storage_namespace
+
+        self._add_datasource_alias(real_agent_config, "Sales DB/2026")
+        namespace = datasource_storage_namespace(real_agent_config, "Sales DB/2026")
+
+        assert "__ds__" in namespace
+        assert "/" not in namespace
+        assert " " not in namespace
+        assert "-" not in namespace
+
+    def test_metric_id_does_not_depend_on_subject_path(self):
+        assert build_metric_id(["Finance"], "total_revenue") == build_metric_id(["Sales"], "total_revenue")
+
+    def test_rag_wrappers_use_datasource_scoped_namespace(self, real_agent_config):
+        from datus.storage.scope import datasource_storage_namespace, project_storage_namespace
+
+        expected_namespace = datasource_storage_namespace(real_agent_config)
+        project_namespace = project_storage_namespace(real_agent_config)
+
+        metric_rag = MetricRAG(real_agent_config)
+        semantic_rag = SemanticModelRAG(real_agent_config)
+
+        assert metric_rag.storage_namespace == expected_namespace
+        assert semantic_rag.storage_namespace == expected_namespace
+        assert metric_rag.storage_namespace != project_namespace
+        assert semantic_rag.storage_namespace != project_namespace
+
+    def test_metric_storage_isolated_by_datasource(self, real_agent_config):
+        ds_a = real_agent_config.current_datasource
+        ds_b = "other_datasource"
+        self._add_datasource_alias(real_agent_config, ds_b)
+
+        rag_a = MetricRAG(real_agent_config)
+        rag_a.store_batch([_make_metric("a")])
+        assert rag_a.get_metrics_size() == 1
+        assert rag_a.storage.get_subject_tree_flat() == ["Finance", "Finance/Revenue"]
+
+        real_agent_config.current_datasource = ds_b
+        rag_b = MetricRAG(real_agent_config)
+        assert rag_b.search_all_metrics() == []
+        assert rag_b.storage.get_subject_tree_flat() == []
+
+        rag_b.store_batch([_make_metric("b")])
+        assert rag_b.get_metrics_size() == 1
+
+        real_agent_config.current_datasource = ds_a
+        rag_a_again = MetricRAG(real_agent_config)
+        assert [row["name"] for row in rag_a_again.search_all_metrics()] == ["total_revenue_a"]
+        rag_a_again.truncate()
+        assert rag_a_again.search_all_metrics() == []
+
+        real_agent_config.current_datasource = ds_b
+        assert [row["name"] for row in MetricRAG(real_agent_config).search_all_metrics()] == ["total_revenue_b"]
+
+    def test_same_metric_name_can_exist_in_different_datasources(self, real_agent_config):
+        ds_a = real_agent_config.current_datasource
+        ds_b = "same_metric_other_datasource"
+        self._add_datasource_alias(real_agent_config, ds_b)
+
+        metric_a = _make_metric("a")
+        metric_a["name"] = "total_revenue"
+        metric_a["id"] = build_metric_id(metric_a["subject_path"], metric_a["name"])
+        metric_a["measure_expr"] = "SUM(revenue_a)"
+        metric_a["base_measures"] = ["revenue_a"]
+        metric_b = _make_metric("b")
+        metric_b["name"] = "total_revenue"
+        metric_b["id"] = build_metric_id(metric_b["subject_path"], metric_b["name"])
+        metric_b["measure_expr"] = "SUM(net_revenue)"
+        metric_b["base_measures"] = ["net_revenue"]
+
+        MetricRAG(real_agent_config).store_batch([metric_a])
+
+        real_agent_config.current_datasource = ds_b
+        MetricRAG(real_agent_config).store_batch([metric_b])
+
+        assert [row["measure_expr"] for row in MetricRAG(real_agent_config).search_all_metrics()] == [
+            "SUM(net_revenue)"
+        ]
+
+        real_agent_config.current_datasource = ds_a
+        assert [row["measure_expr"] for row in MetricRAG(real_agent_config).search_all_metrics()] == ["SUM(revenue_a)"]
+
+    def test_semantic_model_storage_isolated_by_datasource(self, real_agent_config):
+        ds_a = real_agent_config.current_datasource
+        ds_b = "semantic_other_datasource"
+        self._add_datasource_alias(real_agent_config, ds_b)
+
+        rag_a = SemanticModelRAG(real_agent_config)
+        rag_a.store_batch([_make_table_object("a")])
+        assert [row["table_name"] for row in rag_a.search_all()] == ["orders_a"]
+
+        real_agent_config.current_datasource = ds_b
+        rag_b = SemanticModelRAG(real_agent_config)
+        assert rag_b.search_all() == []
+        rag_b.store_batch([_make_table_object("b")])
+
+        real_agent_config.current_datasource = ds_a
+        assert [row["table_name"] for row in SemanticModelRAG(real_agent_config).search_all()] == ["orders_a"]
+
+        real_agent_config.current_datasource = ds_b
+        assert [row["table_name"] for row in SemanticModelRAG(real_agent_config).search_all()] == ["orders_b"]

--- a/tests/unit_tests/storage/test_registry_cache.py
+++ b/tests/unit_tests/storage/test_registry_cache.py
@@ -23,7 +23,7 @@ class _FakeEmbeddingModel:
 
 
 class TestGetStorageLRUCache:
-    """Tests for per-project LRU caching in get_storage()."""
+    """Tests for per-namespace LRU caching in get_storage()."""
 
     def test_same_project_returns_cached(self, reset_global_singletons):
         """get_storage with same factory+project returns the same instance."""
@@ -85,11 +85,12 @@ class TestGetStorageLRUCache:
             clear_storage_registry()
             assert _get_storage_cached.cache_info().currsize == 0
 
-    def test_subject_store_binds_subject_tree_by_requested_project(self, reset_global_singletons):
-        """Subject stores created via get_storage() bind the requested project's subject tree."""
+    def test_subject_store_binds_subject_tree_by_requested_namespace(self, reset_global_singletons):
+        """Subject stores created via get_storage() bind the requested namespace's subject tree."""
         from datus.storage.metric.store import MetricStorage
         from datus.storage.registry import get_storage
 
+        namespace = "my_project__ds__sales"
         project_tree = MagicMock(name="project_tree")
 
         with (
@@ -98,29 +99,45 @@ class TestGetStorageLRUCache:
             patch("datus.storage.backend_holder.get_vector_backend") as mock_backend,
         ):
             mock_backend.return_value = MagicMock()
-            store = get_storage(MetricStorage, "metric", project="my_project")
+            store = get_storage(MetricStorage, "metric", project=namespace)
 
         assert store.subject_tree is project_tree
-        assert call("my_project") in mock_tree.call_args_list
+        assert call(namespace) in mock_tree.call_args_list
 
 
 class TestPreloadAllStorages:
     """Tests for preload_all_storages() with project."""
 
-    def test_preload_forwards_project(self, reset_global_singletons):
-        """preload_all_storages forwards project to both init_backends and get_storage."""
+    def test_preload_without_datasource_does_not_create_datasource_scoped_stores(self, reset_global_singletons):
+        """preload_all_storages does not warm datasource-scoped stores at project scope."""
         from datus.storage.registry import preload_all_storages
 
         with (
             patch("datus.storage.registry.get_storage") as mock_get_storage,
             patch("datus.storage.backend_holder.init_backends") as mock_init,
-            patch("datus.storage.registry.get_subject_tree_store"),
+            patch("datus.storage.registry.get_subject_tree_store") as mock_subject_tree,
         ):
             preload_all_storages(data_dir="/tmp/test", project="my_project")
             mock_init.assert_called_once_with(config=None, data_dir="/tmp/test")
-            # All get_storage calls receive project as a kwarg.
-            for call_args in mock_get_storage.call_args_list:
-                assert call_args.kwargs.get("project") == "my_project"
+            mock_get_storage.assert_not_called()
+            mock_subject_tree.assert_not_called()
+
+    def test_preload_with_datasource_forwards_datasource_namespace(self, reset_global_singletons):
+        """preload_all_storages warms datasource-scoped stores only under datasource namespace."""
+        from datus.storage.registry import preload_all_storages
+
+        with (
+            patch("datus.storage.registry.get_storage") as mock_get_storage,
+            patch("datus.storage.backend_holder.init_backends"),
+            patch("datus.storage.registry.get_subject_tree_store") as mock_subject_tree,
+        ):
+            preload_all_storages(data_dir="/tmp/test", project="my_project", datasource="sales db")
+
+        assert mock_get_storage.call_args_list
+        for call_args in mock_get_storage.call_args_list:
+            assert call_args.kwargs.get("project").startswith("my_project__ds__sales_db_")
+        mock_subject_tree.assert_called_once()
+        assert mock_subject_tree.call_args.kwargs.get("project").startswith("my_project__ds__sales_db_")
 
     def test_preload_applies_defaults(self, reset_global_singletons):
         """preload_all_storages applies deployment defaults."""
@@ -139,8 +156,8 @@ class TestPreloadAllStorages:
 class TestBackendHolderConfigPropagation:
     """Tests for config propagation in backend_holder.
 
-    Backends are stateless w.r.t. project: ``initialize()`` only carries
-    backend-wide settings (``data_dir``, ``isolation``). The project
+    Backends are stateless w.r.t. namespace: ``initialize()`` only carries
+    backend-wide settings (``data_dir``, ``isolation``). The namespace
     identifier is passed to ``connect()`` via ``create_*`` helpers, not
     injected into backend config.
     """

--- a/tests/unit_tests/storage/test_storage_scope.py
+++ b/tests/unit_tests/storage/test_storage_scope.py
@@ -1,0 +1,52 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for centralized storage namespace derivation."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from datus.storage.scope import (
+    DATASOURCE_SCOPED_KB_STORES,
+    PROJECT_SCOPED_STORES,
+    datasource_storage_namespace,
+    project_storage_namespace,
+    safe_storage_namespace_token,
+)
+
+
+def test_safe_storage_namespace_token_normalizes_and_hashes_unsafe_values():
+    token = safe_storage_namespace_token("Sales DB/2026")
+
+    assert token.startswith("Sales_DB_2026_")
+    assert "/" not in token
+    assert " " not in token
+    assert token != "Sales_DB_2026"
+
+
+def test_safe_storage_namespace_token_prefixes_digit_start():
+    assert safe_storage_namespace_token("2026-prod").startswith("n_2026_prod_")
+
+
+def test_datasource_namespace_combines_project_and_datasource():
+    cfg = SimpleNamespace(project_name="workspace", current_datasource="sales db")
+
+    namespace = datasource_storage_namespace(cfg)
+
+    assert namespace.startswith("workspace__ds__sales_db_")
+    assert namespace != project_storage_namespace(cfg)
+
+
+def test_datasource_namespace_without_datasource_raises():
+    cfg = SimpleNamespace(project_name="workspace", current_datasource="")
+
+    with pytest.raises(ValueError, match="datasource is required"):
+        datasource_storage_namespace(cfg)
+
+
+def test_storage_scope_classification_documents_kb_and_project_stores():
+    assert {"metric", "semantic_model", "reference_sql", "subject_tree"} <= DATASOURCE_SCOPED_KB_STORES
+    assert {"task", "feedback", "document"} <= PROJECT_SCOPED_STORES
+    assert DATASOURCE_SCOPED_KB_STORES.isdisjoint(PROJECT_SCOPED_STORES)

--- a/tests/unit_tests/storage/test_storage_scope.py
+++ b/tests/unit_tests/storage/test_storage_scope.py
@@ -15,6 +15,7 @@ from datus.storage.scope import (
     project_storage_namespace,
     safe_storage_namespace_token,
 )
+from datus.utils.exceptions import DatusException, ErrorCode
 
 
 def test_safe_storage_namespace_token_normalizes_and_hashes_unsafe_values():
@@ -42,8 +43,10 @@ def test_datasource_namespace_combines_project_and_datasource():
 def test_datasource_namespace_without_datasource_raises():
     cfg = SimpleNamespace(project_name="workspace", current_datasource="")
 
-    with pytest.raises(ValueError, match="datasource is required"):
+    with pytest.raises(DatusException) as exc:
         datasource_storage_namespace(cfg)
+    assert exc.value.code == ErrorCode.STORAGE_INVALID_ARGUMENT
+    assert "datasource is required" in str(exc.value)
 
 
 def test_storage_scope_classification_documents_kb_and_project_stores():

--- a/tests/unit_tests/tools/db_tools/test_db_func_tools.py
+++ b/tests/unit_tests/tools/db_tools/test_db_func_tools.py
@@ -456,6 +456,26 @@ class TestDBFuncTool:
             catalog_name="", database_name="test_db", schema_name="test_schema", table_name="users"
         )
 
+    def test_describe_table_reuses_cached_result(self, db_func_tool, mock_connector):
+        """Repeated describe_table calls for the same coordinate should not hit the connector again."""
+        first = db_func_tool.describe_table(table_name="users")
+        second = db_func_tool.describe_table(table_name="users")
+
+        assert first.success == 1
+        assert second.success == 1
+        assert first.result == second.result
+        mock_connector.get_schema.assert_called_once()
+
+    def test_execute_ddl_success_clears_describe_table_cache(self, db_func_tool, mock_connector):
+        db_func_tool.describe_table(table_name="users")
+        assert db_func_tool._describe_table_cache
+        mock_connector.execute_ddl.return_value = FuncToolResult(result={"ok": True})
+
+        result = db_func_tool.execute_ddl("ALTER TABLE users ADD COLUMN status TEXT")
+
+        assert result.success == 1
+        assert db_func_tool._describe_table_cache == {}
+
     def test_describe_table_scope_validation(self, mock_connector):
         """describe_table should block tables outside scoped set."""
         tool = DBFuncTool(mock_connector, scoped_tables={"db1.schema1.orders"})

--- a/tests/unit_tests/tools/db_tools/test_db_func_tools.py
+++ b/tests/unit_tests/tools/db_tools/test_db_func_tools.py
@@ -476,6 +476,29 @@ class TestDBFuncTool:
         assert result.success == 1
         assert db_func_tool._describe_table_cache == {}
 
+    def test_describe_table_cache_tracks_semantic_model_fingerprint(self, db_func_tool, mock_connector):
+        db_func_tool.has_semantic_models = True
+        db_func_tool._semantic_storage = Mock()
+        db_func_tool._semantic_storage.search_all.side_effect = [
+            [{"id": "table:orders", "updated_at": "2026-01-01 00:00:00"}],
+            [{"id": "table:orders", "updated_at": "2026-01-02 00:00:00"}],
+        ]
+        db_func_tool._get_semantic_model = Mock(
+            side_effect=[
+                {"semantic_model_name": "orders", "description": "old", "dimensions": []},
+                {"semantic_model_name": "orders", "description": "new", "dimensions": []},
+            ]
+        )
+
+        first = db_func_tool.describe_table(table_name="orders")
+        second = db_func_tool.describe_table(table_name="orders")
+
+        assert first.success == 1
+        assert second.success == 1
+        assert first.result["table"]["description"] == "old"
+        assert second.result["table"]["description"] == "new"
+        assert mock_connector.get_schema.call_count == 2
+
     def test_describe_table_scope_validation(self, mock_connector):
         """describe_table should block tables outside scoped set."""
         tool = DBFuncTool(mock_connector, scoped_tables={"db1.schema1.orders"})

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -3,7 +3,6 @@
 """Unit tests for GenerationTools - CI level, zero external dependencies."""
 
 import json
-import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -273,7 +272,7 @@ class TestEndMetricGeneration:
             result = generation_tools.end_metric_generation(metric_file="/path/semantic_models/metric.yaml")
         assert result.success == 1
         assert result.result["metric_file"] == "/path/semantic_models/metric.yaml"
-        assert result.result["semantic_model_file"] == ""
+        assert result.result["semantic_model_files"] == []
         assert result.result["metric_sqls"] == {}
         assert result.result["sync"]["success"] is True
 
@@ -283,10 +282,10 @@ class TestEndMetricGeneration:
         with p1, p2, p3:
             result = generation_tools.end_metric_generation(
                 metric_file="/path/semantic_models/metric.yaml",
-                semantic_model_file="/path/semantic_models/model.yaml",
+                semantic_model_files=["/path/semantic_models/model.yaml"],
             )
         assert result.success == 1
-        assert result.result["semantic_model_file"] == "/path/semantic_models/model.yaml"
+        assert result.result["semantic_model_files"] == ["/path/semantic_models/model.yaml"]
 
     def test_success_with_metric_sqls_json(self, generation_tools):
         self._mark_ready_to_publish(generation_tools)
@@ -647,8 +646,8 @@ class TestSyncMetricToDb:
             original_yaml_path=str(metric_file),
         )
 
-    def test_metric_with_semantic_model_combines_files(self, generation_tools, tmp_path):
-        """When both metric and semantic model files exist, combine into temp file."""
+    def test_metric_with_semantic_models_syncs_semantics_then_metric(self, generation_tools, tmp_path):
+        """When semantic model files exist, sync them before the metric file."""
         metric_file = tmp_path / "metric.yaml"
         metric_file.write_text("metric:\n  name: revenue\n  type: simple\n")
         semantic_file = tmp_path / "model.yaml"
@@ -656,7 +655,7 @@ class TestSyncMetricToDb:
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.return_value = {"success": True, "message": "synced"}
-            result = generation_tools._sync_metric_to_db(str(metric_file), str(semantic_file), {"rev": "SELECT 1"})
+            result = generation_tools._sync_metric_to_db(str(metric_file), [str(semantic_file)], {"rev": "SELECT 1"})
 
         assert result["success"] is True
         assert result["semantic_synced"] is True
@@ -666,13 +665,13 @@ class TestSyncMetricToDb:
         sem_call = mock_sync.call_args_list[0]
         assert sem_call.kwargs.get("include_semantic_objects") is True
         assert sem_call.kwargs.get("include_metrics") is False
-        # Second call: sync metrics from combined temp file
+        # Second call: sync metrics from metric file alone
         metric_call = mock_sync.call_args_list[1]
-        actual_temp_path = metric_call[0][0]
-        assert not os.path.exists(actual_temp_path), f"Temp file should be cleaned up: {actual_temp_path}"
+        assert metric_call[0][0] == str(metric_file)
         assert metric_call.kwargs.get("include_semantic_objects") is False
         assert metric_call.kwargs.get("include_metrics") is True
         assert metric_call.kwargs.get("metric_sqls") == {"rev": "SELECT 1"}
+        assert metric_call.kwargs.get("original_yaml_path") == str(metric_file)
 
     def test_semantic_sync_failure_aborts_metric_sync(self, generation_tools, tmp_path):
         """When semantic object sync fails, metric sync is skipped and failure propagated."""
@@ -683,33 +682,25 @@ class TestSyncMetricToDb:
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.return_value = {"success": False, "error": "semantic sync failed"}
-            result = generation_tools._sync_metric_to_db(str(metric_file), str(semantic_file))
+            result = generation_tools._sync_metric_to_db(str(metric_file), [str(semantic_file)])
 
         assert result["success"] is False
         assert result["error"] == "semantic sync failed"
         # Only called once (semantic sync), metric sync was skipped
         assert mock_sync.call_count == 1
 
-    def test_semantic_model_not_exists_falls_through(self, generation_tools, tmp_path):
-        """When semantic_model_file path provided but file doesn't exist, sync metric alone."""
+    def test_semantic_model_not_exists_fails_before_metric_sync(self, generation_tools, tmp_path):
+        """When a declared semantic model path is missing, fail before syncing metrics."""
         metric_file = tmp_path / "metric.yaml"
         metric_file.write_text("metric:\n  name: revenue\n")
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.return_value = {"success": True, "message": "ok"}
-            result = generation_tools._sync_metric_to_db(str(metric_file), "/nonexistent/model.yaml")
+            result = generation_tools._sync_metric_to_db(str(metric_file), ["/nonexistent/model.yaml"])
 
-        assert result["success"] is True
-        assert result["semantic_synced"] is False
-        # Should call with metric file directly (not combined)
-        mock_sync.assert_called_once_with(
-            str(metric_file),
-            generation_tools.agent_config,
-            include_semantic_objects=False,
-            include_metrics=True,
-            metric_sqls=None,
-            original_yaml_path=str(metric_file),
-        )
+        assert result["success"] is False
+        assert "Semantic model file not found" in result["error"]
+        mock_sync.assert_not_called()
 
     def test_sync_failure_propagated(self, generation_tools, tmp_path):
         """Sync failure result is returned as-is."""
@@ -735,8 +726,8 @@ class TestSyncMetricToDb:
         assert result["success"] is False
         assert "connection lost" in result["error"]
 
-    def test_temp_file_cleaned_on_sync_exception(self, generation_tools, tmp_path):
-        """Temp combined file is cleaned up even when sync raises."""
+    def test_exception_during_semantic_sync_returns_failure(self, generation_tools, tmp_path):
+        """Exception during semantic sync is caught and returned as failure dict."""
         metric_file = tmp_path / "metric.yaml"
         metric_file.write_text("metric:\n  name: revenue\n")
         semantic_file = tmp_path / "model.yaml"
@@ -744,11 +735,10 @@ class TestSyncMetricToDb:
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.side_effect = RuntimeError("boom")
-            result = generation_tools._sync_metric_to_db(str(metric_file), str(semantic_file))
+            result = generation_tools._sync_metric_to_db(str(metric_file), [str(semantic_file)])
 
         assert result["success"] is False
-        # Temp file should still be cleaned up
-        assert not (tmp_path / "model.yaml.combined.tmp").exists()
+        assert "boom" in result["error"]
 
 
 class TestGenerateSqlSummaryId:

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -11,6 +11,14 @@ import pytest
 from datus.tools.func_tool.base import FuncToolResult
 
 
+class FakeRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def to_pylist(self):
+        return list(self._rows)
+
+
 @pytest.fixture
 def mock_agent_config():
     return Mock()
@@ -71,6 +79,31 @@ class TestCheckSemanticObjectExists:
         mock_storage = Mock()
         generation_tools.metric_rag.storage = mock_storage
         mock_storage.search_all.return_value = [{"id": "m1", "name": "revenue"}]
+
+        with patch("datus.tools.func_tool.generation_tools.eq"):
+            result = generation_tools.check_semantic_object_exists("revenue", kind="metric")
+
+        assert result.success == 1
+        assert result.result["exists"] is True
+
+    def test_kind_is_normalized_for_control_flow_and_cache(self, generation_tools):
+        mock_storage = Mock()
+        generation_tools.semantic_rag.storage = mock_storage
+        mock_storage.search_all.return_value = [{"id": "t1", "name": "orders", "kind": "table"}]
+
+        with patch("datus.tools.func_tool.generation_tools.And"), patch("datus.tools.func_tool.generation_tools.eq"):
+            first = generation_tools.check_semantic_object_exists("orders", kind="Table")
+            second = generation_tools.check_semantic_object_exists("orders", kind="table")
+
+        assert first.success == 1
+        assert first.result["exists"] is True
+        assert second.result == first.result
+        mock_storage.search_all.assert_called_once()
+
+    def test_metric_found_with_arrow_like_rows(self, generation_tools):
+        mock_storage = Mock()
+        generation_tools.metric_rag.storage = mock_storage
+        mock_storage.search_all.return_value = FakeRows([{"id": "m1", "name": "revenue"}])
 
         with patch("datus.tools.func_tool.generation_tools.eq"):
             result = generation_tools.check_semantic_object_exists("revenue", kind="metric")
@@ -733,3 +766,39 @@ class TestGenerateSqlSummaryId:
             result = generation_tools.generate_sql_summary_id("SELECT 1")
         assert result.success == 0
         assert "hash error" in result.error
+
+
+class TestMetricPreflightRows:
+    def test_existing_metric_names_accepts_arrow_like_rows(self, generation_tools):
+        generation_tools.metric_rag.search_all_metrics.return_value = FakeRows([{"name": "revenue"}])
+
+        assert generation_tools._existing_metric_names() == {"revenue"}
+
+    def test_validate_metric_name_conflicts_accepts_arrow_like_rows(self, generation_tools):
+        generation_tools.metric_rag.search_all_metrics.return_value = FakeRows(
+            [
+                {
+                    "id": "metric:revenue",
+                    "name": "revenue",
+                    "semantic_model_name": "orders",
+                    "metric_type": "measure_proxy",
+                    "measure_expr": "revenue",
+                    "base_measures": ["revenue"],
+                }
+            ]
+        )
+
+        error = generation_tools._validate_metric_name_conflicts(
+            [
+                {
+                    "name": "revenue",
+                    "semantic_model_name": "orders",
+                    "metric_type": "ratio",
+                    "measure_expr": "revenue / orders",
+                    "base_measures": ["revenue", "orders"],
+                }
+            ]
+        )
+
+        assert error is not None
+        assert "Metric name conflict" in error

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -89,6 +89,19 @@ class TestCheckSemanticObjectExists:
         assert result.success == 1
         assert result.result["exists"] is False
 
+    def test_check_semantic_object_exists_reuses_cached_result(self, generation_tools):
+        mock_storage = Mock()
+        generation_tools.metric_rag.storage = mock_storage
+        mock_storage.search_all.return_value = [{"id": "m1", "name": "revenue"}]
+
+        with patch("datus.tools.func_tool.generation_tools.eq"):
+            first = generation_tools.check_semantic_object_exists("revenue", kind="metric")
+            second = generation_tools.check_semantic_object_exists("revenue", kind="metric")
+
+        assert first.success == 1
+        assert second.result == first.result
+        mock_storage.search_all.assert_called_once()
+
     def test_column_found_with_table_context(self, generation_tools):
         mock_storage = Mock()
         generation_tools.semantic_rag.storage = mock_storage
@@ -343,6 +356,7 @@ class TestEndMetricGenerationPreflight:
     def test_accepts_file_with_metric_block(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
         generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue_total")
+        generation_tools.metric_rag.search_all_metrics.return_value = []
         good = tmp_path / "semantic_models" / "good_metric.yml"
         good.parent.mkdir(parents=True, exist_ok=True)
         good.write_text("metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
@@ -353,9 +367,50 @@ class TestEndMetricGenerationPreflight:
             result = generation_tools.end_metric_generation(metric_file=str(good))
         assert result.success == 1
 
+    def test_only_new_metrics_in_cumulative_file_require_dry_run(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        generation_tools.generation_evidence.metric_dry_run_metrics.add("new_order_count")
+        generation_tools.metric_rag.search_all_metrics.return_value = [
+            {
+                "id": "metric:old_revenue",
+                "name": "old_revenue",
+                "metric_type": "measure_proxy",
+                "measure_expr": "old_revenue",
+                "base_measures": ["old_revenue"],
+                "semantic_model_name": "orders",
+            }
+        ]
+        metric_file = tmp_path / "semantic_models" / "orders_metrics.yml"
+        metric_file.parent.mkdir(parents=True, exist_ok=True)
+        metric_file.write_text(
+            "metric:\n"
+            "  name: old_revenue\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: old_revenue\n"
+            "---\n"
+            "metric:\n"
+            "  name: new_order_count\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: new_order_count\n"
+        )
+
+        with (
+            self._patch_path_resolution(generation_tools, tmp_path),
+            patch.object(generation_tools, "_sync_metric_to_db", return_value={"success": True, "message": "ok"}),
+        ):
+            result = generation_tools.end_metric_generation(
+                metric_file=str(metric_file),
+                metric_sqls_json=json.dumps({"new_order_count": "SELECT 1"}),
+            )
+
+        assert result.success == 1
+
     def test_rejects_missing_grouped_queryability_dry_run(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
         generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue_total")
+        generation_tools.metric_rag.search_all_metrics.return_value = []
         generation_tools.generation_evidence.set_metric_queryability_contracts(
             [
                 {
@@ -380,6 +435,7 @@ class TestEndMetricGenerationPreflight:
 
     def test_accepts_grouped_queryability_dry_run(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
+        generation_tools.metric_rag.search_all_metrics.return_value = []
         generation_tools.generation_evidence.set_metric_queryability_contracts(
             [
                 {
@@ -406,6 +462,7 @@ class TestEndMetricGenerationPreflight:
 
     def test_rejects_metric_not_covered_by_dry_run(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
+        generation_tools.metric_rag.search_all_metrics.return_value = []
         good = tmp_path / "semantic_models" / "good_metric.yml"
         good.parent.mkdir(parents=True, exist_ok=True)
         good.write_text("metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
@@ -416,6 +473,35 @@ class TestEndMetricGenerationPreflight:
             result = generation_tools.end_metric_generation(metric_file=str(good))
         assert result.success == 0
         assert "revenue_total" in result.error
+        sync_mock.assert_not_called()
+
+    def test_rejects_existing_metric_name_conflict_before_sync(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue_total")
+        generation_tools.metric_rag.search_all_metrics.return_value = [
+            {
+                "id": "metric:revenue_total",
+                "name": "revenue_total",
+                "metric_type": "measure_proxy",
+                "measure_expr": "gross_revenue",
+                "base_measures": ["gross_revenue"],
+                "semantic_model_name": "orders",
+            }
+        ]
+        conflicting = tmp_path / "semantic_models" / "conflicting_metric.yml"
+        conflicting.parent.mkdir(parents=True, exist_ok=True)
+        conflicting.write_text(
+            "metric:\n  name: revenue_total\n  type: measure_proxy\n  type_params:\n    measure: net_revenue\n"
+        )
+
+        with (
+            self._patch_path_resolution(generation_tools, tmp_path),
+            patch.object(generation_tools, "_sync_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(conflicting))
+
+        assert result.success == 0
+        assert "Metric name conflict within this datasource" in result.error
         sync_mock.assert_not_called()
 
     def test_rejects_out_of_sandbox_metric_path_before_reading(self, generation_tools, tmp_path):
@@ -480,6 +566,15 @@ class TestValidateMetricFileHasBlocks:
         f = tmp_path / "multi.yml"
         f.write_text("metric:\n  name: a\n  type: measure_proxy\n---\nmetric:\n  name: b\n  type: measure_proxy\n")
         assert GenerationTools._validate_metric_file_has_blocks(str(f)) is None
+
+    def test_returns_error_for_duplicate_metric_names(self, tmp_path):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        f = tmp_path / "duplicates.yml"
+        f.write_text("metric:\n  name: revenue\n---\nmetric:\n  name: Revenue\n")
+        msg = GenerationTools._validate_metric_file_has_blocks(str(f))
+        assert msg is not None
+        assert "duplicate metric.name" in msg
 
     def test_data_source_only_is_rejected(self, tmp_path):
         """A file with only `data_source:` (no `metric:`) is not a metric file."""

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -605,7 +605,7 @@ class TestValidateMetricFileHasBlocks:
         f = tmp_path / "duplicates.yml"
         f.write_text("metric:\n  name: revenue\n---\nmetric:\n  name: Revenue\n")
         msg = GenerationTools._validate_metric_file_has_blocks(str(f))
-        assert msg is not None
+        assert isinstance(msg, str)
         assert "duplicate metric.name" in msg
 
     def test_data_source_only_is_rejected(self, tmp_path):
@@ -615,7 +615,8 @@ class TestValidateMetricFileHasBlocks:
         f = tmp_path / "ds.yml"
         f.write_text("data_source:\n  name: orders\n")
         msg = GenerationTools._validate_metric_file_has_blocks(str(f))
-        assert msg is not None and "no `metric:` YAML blocks" in msg
+        assert isinstance(msg, str)
+        assert "no `metric:` YAML blocks" in msg
 
 
 class TestSyncMetricToDb:
@@ -790,5 +791,5 @@ class TestMetricPreflightRows:
             ]
         )
 
-        assert error is not None
+        assert isinstance(error, str)
         assert "Metric name conflict" in error

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -85,6 +85,31 @@ data_source:
         assert "Refusing to overwrite measure 'order_count'" in result.error
         assert target.read_text(encoding="utf-8") == original
 
+    def test_write_file_rejects_semantic_merge_without_incoming_data_source(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        original = """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+""".lstrip()
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/orders.yml",
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "without a data_source document" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
     def test_write_file_merges_existing_metric_file(self, tmp_path):
         project = tmp_path / "project"
         target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
@@ -184,6 +209,32 @@ metric:
 
         assert result.success == 0
         assert "Refusing to overwrite metric 'order_count'" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_write_file_rejects_metric_merge_without_incoming_metric(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        original = """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip()
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            """
+data_source:
+  name: orders
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "without metric documents" in result.error
         assert target.read_text(encoding="utf-8") == original
 
     def test_write_file_strict_external_path_is_rejected_before_merge(self, tmp_path, monkeypatch):
@@ -369,3 +420,27 @@ metric:
         assert result.success == 1
         docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
         assert docs[0]["metric"]["locked_metadata"]["tags"][1] == "subject_tree: ac_manage/orders"
+
+    def test_edit_file_restores_original_when_yaml_postprocess_fails(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        original = """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip()
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.edit_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            "measure: order_count",
+            "measure: [",
+        )
+
+        assert result.success == 0
+        assert "invalid edited YAML" in result.error
+        assert target.read_text(encoding="utf-8") == original

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -1,0 +1,371 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+import yaml
+
+from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
+
+
+class TestMetricFilesystemFuncTool:
+    def test_write_file_merges_existing_semantic_model(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: order_count
+      agg: COUNT
+      expr: "1"
+  dimensions:
+    - name: ds
+      type: TIME
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/orders.yml",
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: paid_order_count
+      agg: SUM
+      expr: "CASE WHEN status = 'paid' THEN 1 ELSE 0 END"
+""".lstrip(),
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        data_source = docs[0]["data_source"]
+        assert [measure["name"] for measure in data_source["measures"]] == [
+            "order_count",
+            "paid_order_count",
+        ]
+        assert data_source["dimensions"][0]["name"] == "ds"
+
+    def test_write_file_rejects_conflicting_measure_overwrite(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        original = """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: order_count
+      agg: COUNT
+      expr: "1"
+""".lstrip()
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/orders.yml",
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: order_count
+      agg: SUM
+      expr: amount
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "Refusing to overwrite measure 'order_count'" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_write_file_merges_existing_metric_file(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            """
+metric:
+  name: paid_order_count
+  type: measure_proxy
+  type_params:
+    measure: paid_order_count
+""".lstrip(),
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        assert [doc["metric"]["name"] for doc in docs] == ["order_count", "paid_order_count"]
+
+    def test_write_file_normalizes_subject_tree_tags_after_metric_merge(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+  locked_metadata:
+    tags:
+      - Metrics
+      - "subject_tree: Metrics/ac_manage/orders"
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            """
+metric:
+  name: paid_order_count
+  type: measure_proxy
+  type_params:
+    measure: paid_order_count
+  locked_metadata:
+    tags:
+      - ac_manage
+      - "subject_tree: ac_manage/ac_manage/orders"
+""".lstrip(),
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        assert docs[0]["metric"]["locked_metadata"]["tags"][1] == "subject_tree: ac_manage/orders"
+        assert docs[1]["metric"]["locked_metadata"]["tags"][1] == "subject_tree: ac_manage/orders"
+
+    def test_write_file_rejects_conflicting_metric_overwrite(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        original = """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip()
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            """
+metric:
+  name: order_count
+  type: ratio
+  type_params:
+    numerator: paid_order_count
+    denominator: order_count
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "Refusing to overwrite metric 'order_count'" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_write_file_strict_external_path_is_rejected_before_merge(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        target = tmp_path / "outside" / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics", strict=True)
+
+        def fail_if_called(*_args, **_kwargs):
+            pytest.fail("external file was read before strict path rejection")
+
+        monkeypatch.setattr(tool, "_merge_metric_content", fail_if_called)
+
+        result = tool.write_file(
+            str(target),
+            """
+metric:
+  name: paid_order_count
+  type: measure_proxy
+  type_params:
+    measure: paid_order_count
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "outside workspace" in result.error
+
+    def test_write_file_normalizes_metric_subject_tree_tags(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+  locked_metadata:
+    tags:
+      - Metrics
+      - "subject_tree: Metrics/ac_manage/orders"
+---
+metric:
+  name: paid_order_count
+  type: measure_proxy
+  type_params:
+    measure: paid_order_count
+  locked_metadata:
+    tags:
+      - ac_manage
+      - "subject_tree: ac_manage/ac_manage/orders"
+""".lstrip(),
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        assert docs[0]["metric"]["locked_metadata"]["tags"][1] == "subject_tree: ac_manage/orders"
+
+    def test_edit_file_repairs_overescaped_sql_quotes_in_semantic_model(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: paid_order_count
+      agg: SUM
+      expr: "CASE WHEN status = 'paid' THEN 1 END"
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.edit_file(
+            "subject/semantic_models/ac_manage/orders.yml",
+            "status = 'paid'",
+            "status = \\'paid\\'",
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        measure = docs[0]["data_source"]["measures"][0]
+        assert measure["expr"] == "CASE WHEN status = 'paid' THEN 1 END"
+
+    def test_write_file_repairs_overescaped_sql_quotes_before_merge(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: order_count
+      agg: COUNT
+      expr: "1"
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/orders.yml",
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: paid_order_count
+      agg: SUM
+      expr: "CASE WHEN status = \\'paid\\' THEN 1 END"
+""".lstrip(),
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        measures = {measure["name"]: measure for measure in docs[0]["data_source"]["measures"]}
+        assert measures["paid_order_count"]["expr"] == "CASE WHEN status = 'paid' THEN 1 END"
+
+    def test_quote_escape_repair_only_touches_yaml_error_location(self):
+        content = """
+data_source:
+  name: orders
+  sql_query: |
+    SELECT '\\'' AS literal_value
+  measures:
+    - name: paid_order_count
+      agg: SUM
+      expr: "CASE WHEN status = \\'paid\\' THEN 1 END"
+""".lstrip()
+
+        repaired = MetricFilesystemFuncTool._repair_invalid_yaml_single_quote_escapes(content)
+
+        docs = list(yaml.safe_load_all(repaired))
+        data_source = docs[0]["data_source"]
+        assert data_source["measures"][0]["expr"] == "CASE WHEN status = 'paid' THEN 1 END"
+        assert "SELECT '\\'' AS literal_value" in data_source["sql_query"]
+
+    def test_edit_file_normalizes_metric_subject_tree_tags(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+  locked_metadata:
+    tags:
+      - ac_manage
+      - "subject_tree: ac_manage/orders"
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.edit_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            "subject_tree: ac_manage/orders",
+            "subject_tree: ac_manage/ac_manage/orders",
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        assert docs[0]["metric"]["locked_metadata"]["tags"][1] == "subject_tree: ac_manage/orders"

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -990,3 +990,6 @@ class TestAnalyzeMetricCandidatesFromHistory:
             and "DATE_TRUNC('WEEK'" in item["expression"]
             for item in time_evidence
         )
+        literal_values = {item.get("value") for item in result.result["literal_mappings"]}
+        assert "MONTH" not in literal_values
+        assert "WEEK" not in literal_values

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -52,6 +52,17 @@ class TestGetMultipleTablesDDL:
         assert result.success == 1
         assert len(result.result) == 2
 
+    def test_reuses_cached_ddl_result(self):
+        db_tool = _make_db_tool()
+        db_tool.get_table_ddl.return_value = FuncToolResult(success=1, result={"definition": "CREATE TABLE t (id INT)"})
+        tools = _make_tools(db_tool)
+
+        first = tools.get_multiple_tables_ddl(["orders"])
+        second = tools.get_multiple_tables_ddl(["orders"])
+
+        assert first.result == second.result
+        db_tool.get_table_ddl.assert_called_once()
+
     def test_partial_failure(self):
         db_tool = _make_db_tool()
 
@@ -495,8 +506,12 @@ class TestAnalyzeMetricCandidatesFromHistory:
         result = tools.analyze_metric_candidates_from_history(
             sql_queries=["SELECT revenue / ad_spend AS roas FROM metric_table"],
             existing_metric_catalog_json=(
-                '[{"name": "revenue", "type": "measure_proxy", "subject_path": "finance"}, '
-                '{"name": "ad_spend", "type": "measure_proxy", "subject_path": "finance"}]'
+                '[{"name": "revenue", "type": "measure_proxy", "subject_path": "finance", '
+                '"base_measures": ["total_revenue"], "dimensions": ["dt"], "entities": ["account_id"], '
+                '"semantic_model": "orders"}, '
+                '{"name": "ad_spend", "type": "measure_proxy", "subject_path": "finance", '
+                '"base_measures": ["total_ad_spend"], "dimensions": ["dt"], "entities": ["account_id"], '
+                '"semantic_model": "ads"}]'
             ),
         )
 
@@ -506,8 +521,24 @@ class TestAnalyzeMetricCandidatesFromHistory:
         assert result.result["direct_metric_candidates"] == []
         assert result.result["derived_metric_candidates"] == [candidate]
         assert candidate["referenced_metrics"] == [
-            {"name": "ad_spend", "type": "measure_proxy", "subject_path": "finance"},
-            {"name": "revenue", "type": "measure_proxy", "subject_path": "finance"},
+            {
+                "name": "ad_spend",
+                "type": "measure_proxy",
+                "subject_path": "finance",
+                "base_measures": ["total_ad_spend"],
+                "dimensions": ["dt"],
+                "entities": ["account_id"],
+                "semantic_model": "ads",
+            },
+            {
+                "name": "revenue",
+                "type": "measure_proxy",
+                "subject_path": "finance",
+                "base_measures": ["total_revenue"],
+                "dimensions": ["dt"],
+                "entities": ["account_id"],
+                "semantic_model": "orders",
+            },
         ]
 
     def test_existing_metric_passthrough_is_identity_reference_not_derived_candidate(self):
@@ -600,6 +631,27 @@ class TestAnalyzeMetricCandidatesFromHistory:
         assert candidates[0]["name"] == "revenue"
         assert candidates[0]["source_count"] == 2
 
+    def test_same_formula_with_different_aliases_is_merged_with_alias_mapping(self):
+        tools = _make_tools()
+        result = tools.analyze_metric_candidates_from_history(
+            sql_queries=[
+                "SELECT COUNT(DISTINCT ip) AS new_and_ip_activity_count FROM activity WHERE ac_tag = '1,5'",
+                "SELECT COUNT(DISTINCT ip) AS new_ip_activity_count FROM activity WHERE ac_tag = '1,5'",
+            ]
+        )
+
+        candidates = result.result["metric_candidates"]
+        assert len(candidates) == 1
+        assert candidates[0]["name"] == "new_and_ip_activity_count"
+        assert candidates[0]["source_count"] == 2
+        assert candidates[0]["candidate_names"] == ["new_and_ip_activity_count", "new_ip_activity_count"]
+        assert {
+            "source_alias": "new_ip_activity_count",
+            "candidate_name": "new_ip_activity_count",
+            "canonical_name": "new_and_ip_activity_count",
+            "source_sql_name": "sql_2",
+        } in result.result["metric_aliases"]
+
     def test_same_alias_with_different_formulas_are_not_merged(self):
         tools = _make_tools()
         result = tools.analyze_metric_candidates_from_history(
@@ -673,6 +725,19 @@ class TestAnalyzeMetricCandidatesFromHistory:
         assert candidate["name_source"] == "expression_fallback"
         assert candidate["name"] == "count_distinct_user_id"
 
+    def test_low_information_ascii_alias_requires_business_name_translation(self):
+        tools = _make_tools()
+        result = tools.analyze_metric_candidates_from_history(
+            sql_queries=["SELECT COUNT(DISTINCT user_id) AS co_0 FROM orders"]
+        )
+
+        candidate = result.result["metric_candidates"][0]
+        assert candidate["source_alias"] == "co_0"
+        assert candidate["requires_name_translation"] is True
+        assert candidate["name_translation_reason"] == "source alias looks like a generated short prefix plus ordinal"
+        assert candidate["name_source"] == "expression_fallback"
+        assert candidate["name"] == "count_distinct_user_id"
+
     def test_ranked_window_blocks_direct_metric_and_recommends_datasource(self):
         tools = _make_tools()
         result = tools.analyze_metric_candidates_from_history(
@@ -726,6 +791,51 @@ class TestAnalyzeMetricCandidatesFromHistory:
                 "reason": "post-aggregation constraint must be preserved as a query filter or later derived data source",
             }
         ]
+
+    def test_having_blocks_direct_metric_and_recommends_post_aggregation_datasource(self):
+        tools = _make_tools()
+        result = tools.analyze_metric_candidates_from_history(
+            sql_queries=[
+                """
+                SELECT store_id, SUM(amount) AS high_revenue
+                FROM orders
+                WHERE status = 'paid'
+                GROUP BY store_id
+                HAVING SUM(amount) >= 100
+                """
+            ]
+        )
+
+        assert result.result["query_classification"] == "metric_plus_derived_datasource"
+        assert result.result["direct_metric_candidates"] == []
+        assert result.result["blocked_direct_metric_candidates"][0]["name"] == "high_revenue"
+        assert (
+            result.result["blocked_direct_metric_candidates"][0]["block_reason"]
+            == "post-aggregation filtering must be preserved in a derived data source before defining metrics"
+        )
+        recommendation = result.result["derived_datasource_recommendations"][0]
+        assert recommendation["recommendation_type"] == "post_aggregation"
+        assert recommendation["post_aggregation_constraints"] == ["SUM(amount) >= 100"]
+        assert recommendation["generated_columns"] == ["store_id", "high_revenue"]
+        assert result.result["modeling_plan"][0]["recommendation_type"] == "post_aggregation"
+        assert {
+            "source_sql_name": "sql_1",
+            "clause": "WHERE",
+            "value": "paid",
+            "expression": "'paid'",
+            "predicate": "status = 'paid'",
+            "literal_type": "string",
+            "preservation_rule": "preserve literal values verbatim; only MetricFlow object names may be normalized",
+        } in result.result["literal_mappings"]
+        assert {
+            "source_sql_name": "sql_1",
+            "clause": "HAVING",
+            "value": "100",
+            "expression": "100",
+            "predicate": "SUM(amount) >= 100",
+            "literal_type": "numeric",
+            "preservation_rule": "preserve literal values verbatim; only MetricFlow object names may be normalized",
+        } in result.result["literal_mappings"]
 
     def test_inline_ranked_subquery_blocks_direct_metric_and_recommends_datasource(self):
         tools = _make_tools()

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -48,7 +48,11 @@ class TestGenerationEvidence:
         evidence.record_metric_dry_run(["revenue", "cost"], result)
 
         assert evidence.metric_dry_run_passed is True
-        assert evidence.metric_sqls == {"__query_metrics_dry_run__": "SELECT 1"}
+        assert evidence.metric_sqls == {
+            "__query_metrics_dry_run__": "SELECT 1",
+            "revenue": "SELECT 1",
+            "cost": "SELECT 1",
+        }
         assert evidence.has_metric_dry_run(["revenue", "cost"]) is True
 
     def test_dry_run_success_without_sql_metadata_records_coverage(self):
@@ -82,6 +86,101 @@ class TestGenerationEvidence:
         evidence.record_metric_dry_run(["revenue_total"], result, dimensions=["customer__segment_name"])
 
         assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is True
+
+    def test_queryability_contract_rewrites_metric_alias_to_canonical_name(self):
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["new_ip_activity_count"],
+                    "dimension_hints": ["activity_date"],
+                }
+            ],
+            metric_aliases={"new_ip_activity_count": "new_and_ip_activity_count"},
+        )
+        result = FuncToolResult(success=1, result={"metadata": {"sql": "SELECT 1"}})
+
+        evidence.record_metric_dry_run(
+            ["new_and_ip_activity_count"],
+            result,
+            dimensions=["activity_date"],
+        )
+
+        assert evidence.metric_queryability_contracts[0]["metric_hints"] == ["new_and_ip_activity_count"]
+        assert evidence.metric_queryability_contracts[0]["metric_alias_rewrites"] == {
+            "new_ip_activity_count": "new_and_ip_activity_count"
+        }
+        assert evidence.has_required_queryability_dry_runs(["new_and_ip_activity_count"]) is True
+
+    def test_queryability_contract_accepts_metric_time_grain_dimension(self):
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["activity_count"],
+                    "dimension_hints": ["start_month"],
+                    "time_group_hints": [
+                        {
+                            "alias": "start_month",
+                            "base_expr": "start_date",
+                            "grain": "month",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        evidence.record_metric_dry_run(
+            ["activity_count"],
+            FuncToolResult(
+                success=1,
+                result={
+                    "metadata": {
+                        "sql": (
+                            "SELECT DATE_FORMAT(start_date, '%Y-%m-01') AS metric_time__month, "
+                            "COUNT(DISTINCT ac_code) AS activity_count FROM activity GROUP BY "
+                            "DATE_FORMAT(start_date, '%Y-%m-01')"
+                        )
+                    }
+                },
+            ),
+            dimensions=["metric_time__month"],
+        )
+
+        assert evidence.metric_dry_run_queries[0]["time_granularity"] == "month"
+        assert evidence.has_required_queryability_dry_runs(["activity_count"]) is True
+
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["activity_count"],
+                    "dimension_hints": ["start_month"],
+                    "time_group_hints": [{"alias": "start_month", "base_expr": "start_date", "grain": "month"}],
+                }
+            ]
+        )
+        evidence.record_metric_dry_run(
+            ["activity_count"],
+            FuncToolResult(
+                success=1,
+                result={
+                    "metadata": {
+                        "sql": (
+                            "SELECT DATE_FORMAT(start_date, '%Y-%m-01') AS metric_time__month, "
+                            "COUNT(DISTINCT ac_code) AS activity_count FROM activity GROUP BY "
+                            "DATE_FORMAT(start_date, '%Y-%m-01')"
+                        )
+                    }
+                },
+            ),
+            time_granularity="month",
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["activity_count"]) is True
 
     def test_queryability_contract_accepts_split_grouped_dry_runs_for_source_metrics(self):
         contract = {
@@ -715,7 +814,7 @@ class TestNormalizeNull:
 
     @pytest.mark.parametrize(
         "value",
-        [None, "null", "None", "NULL", "Null", "NONE", "none", "", "  ", "\t"],
+        [None, "null", "None", "NULL", "Null", "NONE", "none", "", "  ", "\t", "-"],
     )
     def test_null_variants_return_none(self, value):
         assert normalize_null(value) is None
@@ -1042,6 +1141,7 @@ class TestQueryMetricsCompression:
                 "metrics": ["revenue"],
                 "dimensions": ["customer_segment"],
                 "time_granularity": "month",
+                "time_granularity_explicit": True,
                 "sql": "SELECT SUM(revenue) AS revenue FROM orders",
             }
         ]

--- a/tests/unit_tests/tools/semantic_tools/test_storage_sync.py
+++ b/tests/unit_tests/tools/semantic_tools/test_storage_sync.py
@@ -13,6 +13,8 @@ from datus.tools.semantic_tools.storage_sync import SemanticStorageManager
 
 def _make_manager():
     mock_config = MagicMock()
+    mock_config.project_name = "test_project"
+    mock_config.current_datasource = "test_datasource"
     return SemanticStorageManager(agent_config=mock_config)
 
 
@@ -34,11 +36,24 @@ def _make_metric(name="revenue", path=None, description="Total revenue"):
 class TestSemanticStorageManagerInit:
     def test_init_sets_agent_config(self):
         mock_config = MagicMock()
+        mock_config.project_name = "test_project"
+        mock_config.current_datasource = "test_datasource"
         manager = SemanticStorageManager(agent_config=mock_config)
         assert manager.agent_config is mock_config
+        assert manager.datasource_id == "test_datasource"
         assert manager.semantic_model_store is None
         assert manager.metric_store is None
         assert manager.subject_tree_store is None
+
+    def test_init_accepts_explicit_datasource_id(self):
+        mock_config = MagicMock()
+        mock_config.project_name = "test_project"
+        mock_config.current_datasource = "wrong_datasource"
+
+        manager = SemanticStorageManager(agent_config=mock_config, datasource_id="target_datasource")
+
+        assert manager.datasource_id == "target_datasource"
+        assert manager.storage_namespace == "test_project__ds__target_datasource"
 
 
 class TestEnsureSemanticModelStore:
@@ -55,6 +70,7 @@ class TestEnsureSemanticModelStore:
 
         assert store is mock_expected_store
         assert manager.semantic_model_store is mock_expected_store
+        mock_rag_class.assert_called_once_with(manager.agent_config, datasource_id="test_datasource")
 
     def test_returns_existing_store_on_second_call(self):
         manager = _make_manager()
@@ -79,6 +95,7 @@ class TestEnsureMetricStore:
 
         assert store is mock_expected_store
         assert manager.metric_store is mock_expected_store
+        mock_rag_class.assert_called_once_with(manager.agent_config, datasource_id="test_datasource")
 
     def test_returns_existing_store_on_second_call(self):
         manager = _make_manager()
@@ -93,10 +110,11 @@ class TestEnsureSubjectTreeStore:
         manager = _make_manager()
         mock_store = MagicMock()
 
-        with patch("datus.storage.registry.get_subject_tree_store", return_value=mock_store):
+        with patch("datus.storage.registry.get_subject_tree_store", return_value=mock_store) as mock_get_tree:
             store = manager._ensure_subject_tree_store()
 
         assert store is mock_store
+        mock_get_tree.assert_called_once_with(project="test_project__ds__test_datasource")
 
     def test_returns_existing_on_second_call(self):
         manager = _make_manager()
@@ -372,14 +390,14 @@ class TestStoreMetric:
         stored = mock_store.batch_store_metrics.call_args[0][0]
         assert stored[0]["subject_path"] == ["Finance", "Q1"]
 
-    def test_metric_id_includes_subject_path(self):
+    def test_metric_id_is_independent_of_subject_path(self):
         manager = _make_manager()
         mock_store = MagicMock()
         with patch.object(manager, "_ensure_metric_store", return_value=mock_store):
             manager.store_metric({"name": "revenue"}, subject_path=["Finance", "Revenue"])
 
         stored = mock_store.batch_store_metrics.call_args[0][0]
-        assert "Finance/Revenue.revenue" in stored[0]["id"]
+        assert stored[0]["id"] == "metric:revenue"
 
     def test_metric_type_defaults_to_simple(self):
         manager = _make_manager()


### PR DESCRIPTION
## Summary
- Scope datasource-specific KB stores by datasource namespace and prevent unscoped overwrite/truncate paths.
- Harden metrics bootstrap for existing metric reuse, complex SQL candidate planning, queryability validation, stale semantic model cleanup, and DeepSeek/agent response handling.
- Fix review follow-ups: Explorer no-datasource startup, metric filesystem strict-mode read-before-write gating, scoped YAML escape repair, subject-path normalization, semantic table identity, and legacy metric id reconciliation.

Fixes #955
Fixes #956
Fixes #957
Fixes #958

## Validation
- `uv run ruff check datus/api/services/explorer_service.py datus/tools/func_tool/metric_filesystem_tools.py datus/storage/metric/subject_path.py datus/storage/table_identity.py datus/storage/catalog_manager.py datus/storage/metric/store.py tests/unit_tests/api/services/test_explorer_service.py tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py tests/unit_tests/cli/test_generation_hooks.py tests/unit_tests/storage/test_catalog_manager.py tests/unit_tests/storage/metric/test_store.py`
- `uv run pytest tests/unit_tests/api/services/test_explorer_service.py tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py tests/unit_tests/cli/test_generation_hooks.py::TestGenerationHooksInit tests/unit_tests/storage/test_catalog_manager.py tests/unit_tests/storage/metric/test_store.py` (`165 passed`)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **New Features**
  * Added datasource-scoped storage isolation for metrics, semantic models, and reference content
  * Introduced metric batching with improved catalog reuse and incremental batch optimization
  * Added semantic model batch generation support for faster initialization
  * Implemented intelligent YAML merging for metric and semantic model files with conflict detection

* **Bug Fixes**
  * Fixed metric identity calculations to be datasource-local and subject-path independent
  * Corrected semantic model storage isolation across datasources
  * Improved stale metric duplicate handling during updates

* **Improvements**
  * Added caching for semantic object and metric-candidate lookups
  * Enhanced metric subject path normalization and validation
  * Strengthened metric conflict detection and definition validation
  * Optimized metric dry-run validation with improved queryability contract handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datasource-scoped storage namespaces; larger metrics batch size (default 5) with incremental skipping, batch semantic-model creation, and plural semantic_model_files in responses.

* **Bug Fixes**
  * Metric IDs are datasource-local (not tied to subject path); stale duplicate metrics removed and conflicting overwrites prevented.

* **Improvements**
  * Safer, structure-aware YAML merges for semantics/metrics; metric alias handling and blocked-source support from embedded candidate plans; targeted dry-run/queryability checks and caching for discovery.

* **Documentation**
  * Updated prompts and skill guide to reflect reuse, safe-update, and new response/flow conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->