### PR TITLE
[Tool] Close docs-driven harness nightly coverage gaps (#921 #922 #923 #924)

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -14,6 +14,25 @@ layers:
   weekly_benchmark:
     description: Quality and retrieval signal for benchmarked product scenarios.
 gap_issue: https://github.com/Datus-ai/Datus-agent/issues/910
+docs_coverage_policy:
+  description: >
+    Every page in the mkdocs nav must either be referenced by a flow's docs: list
+    or be excluded here with a rationale. validate_coverage_map.py fails when a nav
+    page is neither, so new documented user-facing surfaces cannot be added without
+    a conscious coverage decision.
+  exclude:
+    - path: docs/index.md
+      reason: Documentation site landing page, not a user-facing flow.
+    - path: docs/develop/README.md
+      reason: Contributor/development guide, not a product flow.
+    - path: docs/release_notes.md
+      reason: Release notes, not a user-facing flow.
+    - path: docs/configuration/introduction.md
+      reason: Configuration section overview, not a discrete flow.
+    - path: docs/knowledge_base/introduction.md
+      reason: Knowledge base section overview, not a discrete flow.
+    - path: docs/metricflow/introduction.md
+      reason: MetricFlow section overview; the semantic layer flow owns the concrete pages.
 flow_groups:
   onboarding:
     description: First-run and documented bootstrap flows.
@@ -149,6 +168,8 @@ flow_groups:
           - docs/cli/model_command.md
           - docs/cli/language_command.md
           - docs/cli/effort_command.md
+          - docs/cli/plan_mode.md
+          - docs/configuration/compact.md
         entrypoints:
           - "CLI: datus"
           - "CLI slash commands: /model, /language, /effort"
@@ -472,6 +493,7 @@ flow_groups:
           - docs/knowledge_base/ext_knowledge.md
           - docs/subagent/gen_semantic_model.md
           - docs/subagent/gen_metrics.md
+          - docs/configuration/semantic_layer.md
         entrypoints:
           - CLI bootstrap
           - Gen semantic model subagent
@@ -641,6 +663,7 @@ flow_groups:
           - docs/subagent/gen_table.md
           - docs/subagent/gen_visual_report.md
           - docs/subagent/gen_visual_dashboard.md
+          - docs/configuration/schedulers.md
         entrypoints:
           - Gen dashboard subagent
           - Scheduler subagent

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -44,8 +44,15 @@ flow_groups:
               - tests/unit_tests/cli/test_core_entrypoint_acceptance.py::test_quickstart_documented_repl_entrypoints_stay_routable
               - tests/unit_tests/cli/test_interactive_init.py
           nightly:
-            status: gap
-            notes: Full quickstart/tutorial replay is tracked separately.
+            status: covered
+            nodeids:
+              - tests/integration/cli/test_quickstart_smoke.py
+              - tests/integration/cli/test_quickstart_smoke.py::TestQuickstartChatInitialization::test_chat_node_exposes_sql_tools_on_quickstart_datasource
+              - tests/integration/cli/test_quickstart_smoke.py::TestQuickstartChatSmoke::test_quickstart_natural_language_question_answered_with_sql
+            notes: >
+              Nightly smoke exercises the documented quickstart chat path (natural-language
+              question answered with real-LLM SQL generation on a local datasource). Full
+              guided tutorial replay remains tracked by the gap issue.
           weekly_benchmark:
             status: not_applicable
         gaps:
@@ -83,8 +90,11 @@ flow_groups:
               - tests/integration/tools/test_bi_dashboard.py
               - tests/integration/tools/test_bi_grafana.py
           weekly_benchmark:
-            status: gap
-            notes: Benchmark currently focuses on Baisheng query quality, not BI bootstrap quality.
+            status: not_applicable
+            notes: >
+              Scoped out: the weekly benchmark measures query/retrieval quality (Baisheng),
+              not BI bootstrap artifact quality. bootstrap-bi is validated by nightly, not by
+              weekly benchmark, until a deliberate artifact-quality scoring design exists (#921).
         gaps:
           - https://github.com/Datus-ai/Datus-agent/issues/910
 
@@ -266,8 +276,12 @@ flow_groups:
               - tests/unit_tests/gateway/adapters/test_feishu.py
               - tests/unit_tests/gateway/adapters/test_slack.py
           nightly:
-            status: gap
-            notes: Requires representative Slack/Feishu smoke or documented manual gate.
+            status: manual
+            notes: >
+              Scoped out of automated nightly: live Slack/Feishu smoke needs real workspace/tenant
+              credentials and Socket Mode/WebSocket connections, classified as an external dependency.
+              Adapter parsing, rich-text rendering, and runtime routing are covered deterministically;
+              end-to-end channel delivery is validated by manual release QA.
           weekly_benchmark:
             status: not_applicable
         gaps:
@@ -391,9 +405,18 @@ flow_groups:
               - tests/unit_tests/tools/func_tool/test_context_search.py
               - tests/integration/tools/test_context_search.py
           nightly:
-            status: partial
+            status: covered
             nodeids:
               - tests/integration/tools/test_context_search.py
+              - tests/integration/tools/test_context_injection.py
+              - tests/integration/tools/test_context_injection.py::TestContextRetrievalInjection::test_search_knowledge_returns_seeded_entry
+              - tests/integration/tools/test_context_injection.py::TestContextRetrievalInjection::test_list_subject_tree_nests_all_sources
+              - tests/integration/tools/test_context_injection.py::TestContextInjectionRealLLM::test_context_tools_wired_into_node
+              - tests/integration/tools/test_context_injection.py::TestContextInjectionRealLLM::test_execute_stream_invokes_context_tools
+            notes: >
+              Catalog/semantic, subject-tree, historical reference SQL, external knowledge, and
+              fuzzy-search retrieval are each exercised, plus a real-LLM check that the SQL-generation
+              node wires in and invokes the context-search tools during generation.
           weekly_benchmark:
             status: covered
             notes: Baisheng weekly benchmark measures query quality under contextual retrieval.
@@ -647,14 +670,29 @@ flow_groups:
               - tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
               - tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
           nightly:
-            status: partial
+            status: covered
             nodeids:
               - tests/integration/agent/test_gen_dashboard_agentic.py
               - tests/integration/agent/test_scheduler_agentic.py
               - tests/integration/tools/test_bi_grafana.py
+              - tests/integration/agent/test_gen_table_agentic.py
+              - tests/integration/agent/test_gen_table_agentic.py::TestGenTableAgenticRealLLM::test_execute_stream_creates_table
+              - tests/integration/agent/test_gen_job_agentic.py
+              - tests/integration/agent/test_gen_job_agentic.py::TestGenJobAgenticRealLLM::test_execute_stream_runs_single_db_etl
+              - tests/integration/agent/test_gen_visual_report_agentic.py
+              - tests/integration/agent/test_gen_visual_report_agentic.py::TestGenVisualReportAgenticRealLLM::test_execute_stream_builds_report
+              - tests/integration/agent/test_gen_visual_dashboard_agentic.py
+              - tests/integration/agent/test_gen_visual_dashboard_agentic.py::TestGenVisualDashboardAgenticRealLLM::test_execute_stream_builds_dashboard
+            notes: >
+              Real-LLM smoke now covers gen_table (CTAS), gen_job (single-DB ETL on an isolated
+              SQLite copy), gen_visual_report, and gen_visual_dashboard in addition to the existing
+              dashboard/scheduler/Grafana paths. gen_job cross-DB transfer stays in the unit tier.
           weekly_benchmark:
-            status: gap
-            notes: Artifact quality scoring is not part of the current weekly benchmark.
+            status: not_applicable
+            notes: >
+              Scoped out: data-product subagents are artifact-generation paths. Nightly is the right
+              layer for real-dependency artifact smoke; weekly benchmark stays out until a deliberate
+              artifact-quality scoring design exists (#923).
         gaps:
           - https://github.com/Datus-ai/Datus-agent/issues/910
 
@@ -683,7 +721,15 @@ flow_groups:
               - tests/unit_tests/agent/test_workflow.py
               - tests/unit_tests/agent/node/test_node_factory.py
           nightly:
-            status: gap
+            status: covered
+            nodeids:
+              - tests/integration/agent/test_custom_subagent_agentic.py
+              - tests/integration/agent/test_custom_subagent_agentic.py::TestCustomSubagentResolution::test_factory_builds_gen_sql_node_for_custom_subagent
+              - tests/integration/agent/test_custom_subagent_agentic.py::TestCustomSubagentRealLLM::test_custom_subagent_executes_query
+            notes: >
+              A config-defined custom subagent (custom name + node_class + system_prompt) resolves
+              through the node factory, exposes the configured tools, and routes a real-LLM query to
+              completion.
           weekly_benchmark:
             status: not_applicable
         gaps:
@@ -756,7 +802,16 @@ flow_groups:
               - tests/unit_tests/cli/test_skill_commands.py
               - tests/unit_tests/tools/permission/test_profiles.py
           nightly:
-            status: gap
+            status: covered
+            nodeids:
+              - tests/integration/tools/test_skill.py
+              - tests/integration/tools/test_skill_execution.py
+              - tests/integration/tools/test_skill_execution.py::TestLocalSkillDiscoveryAndExecutionGate::test_skill_func_tool_exposes_execution_tools
+              - tests/integration/tools/test_skill_execution.py::TestRealLLMSkillExecution::test_agent_invokes_local_skill
+            notes: >
+              Local skill discovery, permission filtering, and real-LLM skill execution are covered.
+              Marketplace install/update/remove/publish requires the external Town Backend and is
+              classified as an external dependency, not a nightly gap.
           weekly_benchmark:
             status: not_applicable
         gaps:
@@ -789,7 +844,16 @@ flow_groups:
               - tests/unit_tests/agent/node/test_agentic_node_inherited_memory.py
               - tests/unit_tests/tools/func_tool/test_memory_filesystem_tools.py
           nightly:
-            status: gap
+            status: covered
+            nodeids:
+              - tests/integration/agent/test_auto_memory_agentic.py
+              - tests/integration/agent/test_auto_memory_agentic.py::TestAutoMemoryLoadAndInherit::test_chat_node_loads_own_memory_into_prompt
+              - tests/integration/agent/test_auto_memory_agentic.py::TestAutoMemoryRealLLM::test_loaded_memory_present_in_real_run
+            notes: >
+              Memory load, workspace isolation, and parent inheritance are covered, including a
+              real-LLM run that confirms loaded memory reaches the prompt. The LLM-driven
+              remember/forget/correct write lifecycle is scoped out: no such write tools exist yet
+              (memory filesystem tools are read-only); tracked for when the lifecycle ships.
           weekly_benchmark:
             status: not_applicable
         gaps:
@@ -826,7 +890,15 @@ flow_groups:
               - tests/unit_tests/agent/test_workflow_runner.py
               - tests/integration/api/test_api.py
           nightly:
-            status: gap
+            status: covered
+            nodeids:
+              - tests/integration/agent/test_workflow_orchestration.py
+              - tests/integration/agent/test_workflow_orchestration.py::TestWorkflowGraphAssembly::test_gen_sql_agentic_plan_is_multi_node
+              - tests/integration/agent/test_workflow_orchestration.py::TestWorkflowOrchestrationRealLLM::test_gen_sql_agentic_workflow_completes
+            notes: >
+              A multi-node workflow (gen_sql -> execute_sql -> output) is assembled and run end-to-end
+              through WorkflowRunner.run_stream with a real LLM, asserting multiple node executions and
+              successful completion with persisted state.
           weekly_benchmark:
             status: not_applicable
         gaps:
@@ -844,11 +916,16 @@ flow_groups:
           - Documented VSCode integration remains tracked as an external/editor surface.
         coverage:
           pr_acceptance:
-            status: gap
+            status: external
+            notes: VSCode integration is driven by a remote IDE front-end that owns its own runtime.
           merge_queue:
-            status: gap
+            status: external
+            notes: VSCode integration is driven by a remote IDE front-end that owns its own runtime.
           nightly:
-            status: gap
+            status: external
+            notes: >
+              Scoped out: the VSCode extension is a remote IDE front-end with no stable headless
+              automation path; tracked as an external editor surface rather than an automated flow.
           weekly_benchmark:
             status: not_applicable
         gaps:

--- a/ci/harness/validate_coverage_map.py
+++ b/ci/harness/validate_coverage_map.py
@@ -246,6 +246,111 @@ def validate_flow(repo_root: Path, flow_ref: FlowRef, errors: list[str]) -> None
         errors.append(f"{flow_id}: quality-sensitive flow must have benchmark coverage or an explicit gap issue")
 
 
+class _NavLoader(yaml.SafeLoader):
+    """YAML loader that tolerates mkdocs custom tags (e.g. ``!ENV``, emoji)."""
+
+
+# mkdocs.yml carries Python/emoji and ``!ENV`` tags outside the ``nav`` tree.
+# We only need the nav strings, so ignore every custom tag rather than fail.
+_NavLoader.add_multi_constructor("", lambda loader, tag_suffix, node: None)
+
+
+def collect_nav_pages(node: Any, pages: set[str]) -> None:
+    """Recursively collect ``docs/``-relative ``.md`` page paths from an mkdocs nav tree."""
+    if isinstance(node, str):
+        if node.endswith(".md"):
+            pages.add(f"docs/{node}")
+    elif isinstance(node, list):
+        for item in node:
+            collect_nav_pages(item, pages)
+    elif isinstance(node, dict):
+        for value in node.values():
+            collect_nav_pages(value, pages)
+
+
+def load_nav_pages(repo_root: Path, nav_path: str, errors: list[str]) -> set[str]:
+    """Parse the mkdocs nav file and return the set of documented page paths.
+
+    Paths are normalized to be ``docs/``-prefixed so they match the flow ``docs:``
+    convention used elsewhere in the coverage map.
+    """
+    full_path = repo_root / nav_path
+    if not full_path.exists():
+        errors.append(f"docs_coverage: navigation file does not exist: {nav_path}")
+        return set()
+    try:
+        config = yaml.load(full_path.read_text(encoding="utf-8"), Loader=_NavLoader)  # noqa: S506 - custom safe loader.
+    except yaml.YAMLError as exc:
+        errors.append(f"docs_coverage: failed to parse navigation file {nav_path}: {exc}")
+        return set()
+    pages: set[str] = set()
+    collect_nav_pages((config or {}).get("nav", []), pages)
+    return pages
+
+
+def validate_docs_coverage(
+    repo_root: Path,
+    coverage_map: dict[str, Any],
+    flows: list[FlowRef],
+    errors: list[str],
+) -> None:
+    """Fail when a documented nav page is neither owned by a flow nor explicitly excluded.
+
+    This closes the drift between ``mkdocs.yml`` and the coverage map: a new
+    documented user-facing page must either be referenced by some flow's ``docs:``
+    list or be listed under ``docs_coverage_policy.exclude`` with a rationale.
+
+    Enforcement is opt-in via the presence of a ``docs_coverage_policy`` block, so
+    synthetic/minimal maps without the policy are unaffected.
+    """
+    if "docs_coverage_policy" not in coverage_map:
+        return
+
+    source = coverage_map.get("source")
+    nav_path = source.get("docs_navigation") if isinstance(source, dict) else None
+    if not isinstance(nav_path, str):
+        return  # source.docs_navigation is validated separately.
+
+    nav_pages = load_nav_pages(repo_root, nav_path, errors)
+    if not nav_pages:
+        return
+
+    referenced = {doc for flow_ref in flows for doc in (flow_ref.flow.get("docs") or []) if isinstance(doc, str)}
+
+    policy = coverage_map.get("docs_coverage_policy") or {}
+    if not isinstance(policy, dict):
+        errors.append("docs_coverage_policy: must be a mapping")
+        policy = {}
+    raw_excludes = policy.get("exclude") or []
+    if not isinstance(raw_excludes, list):
+        errors.append("docs_coverage_policy.exclude: must be a list")
+        raw_excludes = []
+
+    excluded: set[str] = set()
+    for index, entry in enumerate(raw_excludes):
+        if not isinstance(entry, dict):
+            errors.append(f"docs_coverage_policy.exclude[{index}]: must be a mapping with path and reason")
+            continue
+        path = entry.get("path")
+        reason = entry.get("reason")
+        if not isinstance(path, str) or not path:
+            errors.append(f"docs_coverage_policy.exclude[{index}].path: required non-empty string is missing")
+            continue
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(f"docs_coverage_policy.exclude[{path}].reason: required rationale is missing")
+        if path not in nav_pages:
+            errors.append(f"docs_coverage_policy.exclude: stale entry not in mkdocs nav: {path}")
+        if path in referenced:
+            errors.append(f"docs_coverage_policy.exclude: redundant entry already owned by a flow: {path}")
+        excluded.add(path)
+
+    for page in sorted(nav_pages - referenced - excluded):
+        errors.append(
+            f"docs_coverage: {page} is in mkdocs nav but no flow references it and it is not in "
+            "docs_coverage_policy.exclude (add it to a flow's docs: list or exclude it with a rationale)"
+        )
+
+
 def validate_coverage_map(
     repo_root: Path,
     coverage_map: dict[str, Any],
@@ -288,6 +393,8 @@ def validate_coverage_map(
             errors.append(f"{flow_ref.flow_id}: duplicate flow id")
         seen_ids.add(flow_ref.flow_id)
         validate_flow(repo_root, flow_ref, errors)
+
+    validate_docs_coverage(repo_root, coverage_map, flows, errors)
 
     if check_github_issues:
         issue_refs = sorted(

--- a/tests/integration/agent/test_auto_memory_agentic.py
+++ b/tests/integration/agent/test_auto_memory_agentic.py
@@ -1,0 +1,187 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Nightly coverage for the extension flow ``extension.auto_memory``.
+
+Source-reality note (verified): there are no remember / forget / correct LLM
+tools — ``datus/tools/func_tool/memory_filesystem_tools.py`` is read-only
+glob/grep/read. So this file covers the parts of auto memory that are actually
+implemented:
+
+1. Memory LOAD — a MEMORY.md written into a memory-enabled node's workspace
+   memory dir (``{project_root}/.datus/memory/{node}/MEMORY.md``) is loaded and
+   injected (writable branch) into that node's system prompt.
+2. Memory inheritance — a built-in subagent that has no memory file of its own
+   (``memory_enabled is False``) inherits the parent's MEMORY.md in read-only
+   mode when the ``inherited_memory`` contextvar is active (the path used when a
+   custom subagent is launched via the ``task`` tool).
+3. Workspace isolation — a sibling node without its own MEMORY.md does not pick
+   up another node's memory.
+4. Real-LLM smoke — a memory-enabled chat node whose MEMORY.md carries a
+   distinctive instruction runs end-to-end and the loaded memory is present in
+   the prompt it sends.
+
+The remember/forget/correct write lifecycle is reported scoped-out (no tool
+support) and is intentionally not tested here.
+"""
+
+import os
+
+import pytest
+
+from datus.agent.node.chat_agentic_node import ChatAgenticNode
+from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+from datus.configuration.inherited_memory_overrides import inherited_memory
+from datus.configuration.node_type import NodeType
+from datus.schemas.action_history import ActionHistoryManager, ActionStatus
+from datus.schemas.chat_agentic_node_models import ChatNodeInput
+from datus.utils.loggings import get_logger
+from datus.utils.memory_loader import MEMORY_BASE_DIR, MEMORY_FILENAME, has_memory
+
+logger = get_logger(__name__)
+
+CHAT_MEMORY_MARKER = "Always prefer CTEs over nested subqueries in generated SQL."
+CUSTOM_AGENT = "nightly_memory_agent"
+CUSTOM_MEMORY_MARKER = "Revenue is computed from the net_amount column."
+
+
+def _write_memory(workspace_root, node_name, content):
+    """Seed a MEMORY.md for ``node_name`` under the workspace memory dir."""
+    from pathlib import Path
+
+    mem_dir = Path(workspace_root) / MEMORY_BASE_DIR / node_name
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    mem_file = mem_dir / MEMORY_FILENAME
+    mem_file.write_text(content, encoding="utf-8")
+    return mem_file
+
+
+def _isolated_config(nightly_agent_config, tmp_path):
+    """Point the (function-scoped) config's project_root at an isolated tmp dir.
+
+    Memory is resolved from ``project_root``; using tmp_path keeps each test's
+    seeded MEMORY.md from colliding with the real project or other tests.
+    ``project_root`` is a read-only property over ``_project_root``, so the
+    backing field is set directly on this function-scoped config.
+    """
+    from pathlib import Path
+
+    nightly_agent_config._project_root = Path(tmp_path).resolve()
+    return nightly_agent_config
+
+
+@pytest.mark.nightly
+class TestAutoMemoryLoadAndInherit:
+    """Deterministic memory load + inheritance behavior."""
+
+    def test_chat_node_loads_own_memory_into_prompt(self, nightly_agent_config, tmp_path):
+        config = _isolated_config(nightly_agent_config, tmp_path)
+        _write_memory(str(tmp_path), "chat", f"# Memory\n\n## SQL style\n- {CHAT_MEMORY_MARKER}\n")
+
+        node = ChatAgenticNode(
+            node_id="nightly_mem_chat",
+            description="chat memory load",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=config,
+        )
+        assert node.memory_enabled is True, "chat node must be memory-enabled"
+
+        prompt = node._get_system_prompt()
+        assert CHAT_MEMORY_MARKER in prompt, "Loaded chat MEMORY.md content must appear in the system prompt"
+        # Writable branch renders Save instructions for memory-enabled nodes.
+        assert "**Save**" in prompt, "Memory-enabled chat node must render the writable memory block"
+
+    def test_builtin_subagent_inherits_parent_memory_readonly(self, nightly_agent_config, tmp_path):
+        config = _isolated_config(nightly_agent_config, tmp_path)
+        _write_memory(str(tmp_path), "chat", f"# Memory\n\n## Domain\n- {CUSTOM_MEMORY_MARKER}\n")
+
+        node = GenSQLAgenticNode(
+            node_id="nightly_mem_inherit",
+            description="gen_sql inherits chat memory",
+            node_type=NodeType.TYPE_GEN_SQL,
+            agent_config=config,
+            node_name="gen_sql",
+            execution_mode="workflow",
+        )
+        assert node.memory_enabled is False, "built-in gen_sql must not own a memory file"
+        assert has_memory("gen_sql") is False
+
+        # Without inheritance active, gen_sql renders no memory section.
+        base_prompt = node._inject_memory_context("BASE PROMPT")
+        assert base_prompt == "BASE PROMPT", "gen_sql must not load memory without an active inheritance override"
+
+        # With inheritance active (the task-tool path), it reads chat's memory read-only.
+        with inherited_memory("gen_sql", "chat"):
+            inherited_prompt = node._inject_memory_context("BASE PROMPT")
+        assert CUSTOM_MEMORY_MARKER in inherited_prompt, "Inherited parent memory content must appear read-only"
+        assert "read-only inheritance from chat" in inherited_prompt, "Inherited block must be marked read-only"
+        assert "**Save**" not in inherited_prompt, "Read-only inheritance must NOT render writable Save instructions"
+
+    def test_custom_agent_memory_is_workspace_isolated(self, nightly_agent_config, tmp_path):
+        config = _isolated_config(nightly_agent_config, tmp_path)
+        # Seed memory only for the custom agent, not for chat.
+        _write_memory(str(tmp_path), CUSTOM_AGENT, f"# Memory\n\n## Domain\n- {CUSTOM_MEMORY_MARKER}\n")
+
+        custom_node = GenSQLAgenticNode(
+            node_id="nightly_mem_custom",
+            description="custom memory agent",
+            node_type=NodeType.TYPE_GEN_SQL,
+            agent_config=config,
+            node_name=CUSTOM_AGENT,
+            execution_mode="workflow",
+        )
+        assert custom_node.memory_enabled is True, "custom (non-builtin) subagent must be memory-enabled"
+        custom_prompt = custom_node._get_system_prompt()
+        assert CUSTOM_MEMORY_MARKER in custom_prompt, "Custom agent must load its own MEMORY.md"
+
+        chat_node = ChatAgenticNode(
+            node_id="nightly_mem_chat_isolated",
+            description="chat without own memory",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=config,
+        )
+        chat_prompt = chat_node._get_system_prompt()
+        assert CUSTOM_MEMORY_MARKER not in chat_prompt, (
+            "chat node must NOT see the custom agent's memory (per-node workspace isolation)"
+        )
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestAutoMemoryRealLLM:
+    """Real-LLM run of a memory-enabled node whose MEMORY.md is loaded."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_loaded_memory_present_in_real_run(self, nightly_agent_config, tmp_path):
+        """N924-MEM: chat node runs end-to-end with its MEMORY.md loaded into the prompt."""
+        config = _isolated_config(nightly_agent_config, tmp_path)
+        _write_memory(str(tmp_path), "chat", f"# Memory\n\n## SQL style\n- {CHAT_MEMORY_MARKER}\n")
+
+        node = ChatAgenticNode(
+            node_id="nightly_mem_chat_llm",
+            description="chat memory real run",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=config,
+        )
+        # The loaded memory must be wired into the system prompt the node sends.
+        assert CHAT_MEMORY_MARKER in node._get_system_prompt(), "Memory must be loaded before the run"
+
+        node.input = ChatNodeInput(
+            user_message="How many schools are there in Alameda county?",
+            database="california_schools",
+            max_turns=15,
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        assert len(actions) >= 2, f"Expected at least 2 actions, got {len(actions)}"
+        assert actions[-1].status == ActionStatus.SUCCESS, (
+            f"Memory-enabled chat run should end SUCCESS, got {actions[-1].status}: {actions[-1].output}"
+        )

--- a/tests/integration/agent/test_auto_memory_agentic.py
+++ b/tests/integration/agent/test_auto_memory_agentic.py
@@ -150,7 +150,7 @@ class TestAutoMemoryLoadAndInherit:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestAutoMemoryRealLLM:
     """Real-LLM run of a memory-enabled node whose MEMORY.md is loaded."""
 

--- a/tests/integration/agent/test_custom_subagent_agentic.py
+++ b/tests/integration/agent/test_custom_subagent_agentic.py
@@ -1,0 +1,140 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Nightly coverage for the extension flow ``subagents.custom_subagents``.
+
+A custom (config-defined) subagent is declared in ``agent_config.agentic_nodes``
+under a non-builtin name, backed by a chosen ``node_class`` (here ``gen_sql``),
+with its own ``system_prompt`` and ``agent_description``. These tests verify:
+
+1. The node factory resolves the custom subagent name to the correct node class
+   (driven by ``node_class``), threads the custom name through as ``node_name``,
+   and the resolved node exposes the tools configured for it.
+2. ``_resolve_node_class_type`` returns the configured ``node_class`` so the
+   ``task`` tool path (``NODE_CLASS_MAP``) and the factory agree on the runtime
+   class.
+3. A real-LLM end-to-end run routes a simple data question through the custom
+   subagent and reports ``ActionStatus.SUCCESS``.
+
+The deterministic tests run on every nightly; the real-LLM execute test is
+additionally gated behind ``product_e2e`` and ``DEEPSEEK_API_KEY``.
+"""
+
+import copy
+import os
+
+import pytest
+
+from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+from datus.agent.node.node_factory import (
+    _resolve_node_class_type,
+    create_interactive_node,
+    resolve_node_name,
+)
+from datus.schemas.action_history import ActionHistoryManager, ActionStatus
+from datus.schemas.gen_sql_agentic_node_models import GenSQLNodeInput
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+CUSTOM_SUBAGENT_NAME = "nightly_custom_sql"
+CUSTOM_SYSTEM_PROMPT = "gen_sql"
+CUSTOM_DESCRIPTION = "Nightly custom SQL subagent for california_schools"
+
+
+def _config_with_custom_subagent(base_config):
+    """Return a config copy with a custom subagent injected into agentic_nodes.
+
+    The agentic_nodes mapping is deep-copied first so the injected definition
+    never leaks into the shared configuration_manager cache used by other tests.
+    """
+    config = base_config
+    config.agentic_nodes = copy.deepcopy(config.agentic_nodes)
+    config.agentic_nodes[CUSTOM_SUBAGENT_NAME] = {
+        "model": "deepseek",
+        "node_class": "gen_sql",
+        "system_prompt": CUSTOM_SYSTEM_PROMPT,
+        "prompt_language": "en",
+        "max_turns": 30,
+        "tools": "db_tools.*, context_search_tools.*, filesystem_tools.*",
+        "agent_description": CUSTOM_DESCRIPTION,
+    }
+    return config
+
+
+@pytest.mark.nightly
+class TestCustomSubagentResolution:
+    """Deterministic resolution of a config-defined custom subagent."""
+
+    def test_resolve_node_class_type_returns_configured_class(self, nightly_agent_config):
+        config = _config_with_custom_subagent(nightly_agent_config)
+        resolved = _resolve_node_class_type(CUSTOM_SUBAGENT_NAME, config)
+        assert resolved == "gen_sql", f"Expected node_class 'gen_sql', got {resolved!r}"
+
+    def test_resolve_node_name_matches_custom_name(self):
+        assert resolve_node_name(CUSTOM_SUBAGENT_NAME) == CUSTOM_SUBAGENT_NAME
+
+    def test_factory_builds_gen_sql_node_for_custom_subagent(self, nightly_agent_config):
+        config = _config_with_custom_subagent(nightly_agent_config)
+        node = create_interactive_node(
+            CUSTOM_SUBAGENT_NAME,
+            config,
+            execution_mode="workflow",
+        )
+
+        assert isinstance(node, GenSQLAgenticNode), f"Expected GenSQLAgenticNode, got {type(node).__name__}"
+        assert node.get_node_name() == CUSTOM_SUBAGENT_NAME, (
+            f"Custom subagent must keep its alias as node name, got {node.get_node_name()!r}"
+        )
+        assert node.execution_mode == "workflow"
+
+    def test_custom_subagent_exposes_configured_tools(self, nightly_agent_config):
+        config = _config_with_custom_subagent(nightly_agent_config)
+        node = create_interactive_node(
+            CUSTOM_SUBAGENT_NAME,
+            config,
+            execution_mode="workflow",
+        )
+
+        tool_names = {tool.name for tool in node.tools}
+        # db_tools.* expands to at least read_query (SQL execution against the DB).
+        assert "read_query" in tool_names, f"Expected read_query from db_tools.*, got: {sorted(tool_names)}"
+        # filesystem_tools.* expands to file reads used for reference SQL discovery.
+        assert "read_file" in tool_names, f"Expected read_file from filesystem_tools.*, got: {sorted(tool_names)}"
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestCustomSubagentRealLLM:
+    """Real-LLM execution routed through the config-defined custom subagent."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_custom_subagent_executes_query(self, nightly_agent_config):
+        """N924-CS: A simple data question routed through the custom subagent succeeds."""
+        config = _config_with_custom_subagent(nightly_agent_config)
+        node = create_interactive_node(
+            CUSTOM_SUBAGENT_NAME,
+            config,
+            execution_mode="workflow",
+        )
+        assert isinstance(node, GenSQLAgenticNode), f"Expected GenSQLAgenticNode, got {type(node).__name__}"
+        assert node.get_node_name() == CUSTOM_SUBAGENT_NAME
+
+        node.input = GenSQLNodeInput(
+            user_message="How many schools are there in Alameda county?",
+            database="california_schools",
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        assert len(actions) >= 2, f"Expected at least 2 actions, got {len(actions)}"
+        assert actions[-1].status == ActionStatus.SUCCESS, (
+            f"Custom subagent run should end SUCCESS, got {actions[-1].status}: {actions[-1].output}"
+        )

--- a/tests/integration/agent/test_custom_subagent_agentic.py
+++ b/tests/integration/agent/test_custom_subagent_agentic.py
@@ -47,10 +47,11 @@ CUSTOM_DESCRIPTION = "Nightly custom SQL subagent for california_schools"
 def _config_with_custom_subagent(base_config):
     """Return a config copy with a custom subagent injected into agentic_nodes.
 
-    The agentic_nodes mapping is deep-copied first so the injected definition
-    never leaks into the shared configuration_manager cache used by other tests.
+    The config and its agentic_nodes mapping are deep-copied first so the injected
+    definition never leaks into the shared configuration_manager cache used by
+    other tests.
     """
-    config = base_config
+    config = copy.deepcopy(base_config)
     config.agentic_nodes = copy.deepcopy(config.agentic_nodes)
     config.agentic_nodes[CUSTOM_SUBAGENT_NAME] = {
         "model": "deepseek",
@@ -107,7 +108,7 @@ class TestCustomSubagentResolution:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestCustomSubagentRealLLM:
     """Real-LLM execution routed through the config-defined custom subagent."""
 

--- a/tests/integration/agent/test_gen_job_agentic.py
+++ b/tests/integration/agent/test_gen_job_agentic.py
@@ -1,0 +1,200 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Nightly integration tests for GenJobAgenticNode (issue #923).
+
+Expands nightly coverage for the data-product ``gen_job`` subagent.
+
+Two tiers:
+* A deterministic ``@pytest.mark.nightly`` init test asserting the DDL/DML +
+  cross-DB tool surface — no LLM call.
+* A real-LLM ``@pytest.mark.product_e2e`` test driving ``execute_stream`` for a
+  single-database ETL scenario (CREATE TABLE + INSERT ... SELECT) on an
+  ISOLATED SQLite copy.
+
+Scope note: ``gen_job`` absorbed the migration subagent and can drive cross-DB
+transfers, but a clean second writable warehouse cannot be arranged
+deterministically in the nightly environment. Per the issue guidance, this
+smoke is intentionally scoped to a single-DB DDL/DML job on the isolated SQLite
+copy. The cross-DB ``transfer_query_result`` path stays covered by the unit
+tier.
+
+Isolation mirrors the gen_table test: copy the shared
+``california_schools.sqlite`` to a tmp dir, repoint every datasource whose URI
+is that shared file to the copy, then clear the DBManager CLI cache. This
+guarantees the DDL/DML lands on the copy regardless of which datasource name the
+LLM routes to.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.tools.db_tools import db_manager as _db_manager
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def _table_names(db_path: Path) -> set[str]:
+    """Return the set of user table names in a SQLite file."""
+    con = sqlite3.connect(str(db_path))
+    try:
+        rows = con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    finally:
+        con.close()
+    return {r[0] for r in rows}
+
+
+def _row_count(db_path: Path, table: str) -> int:
+    """Return the row count of a table in a SQLite file."""
+    con = sqlite3.connect(str(db_path))
+    try:
+        return int(con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+    finally:
+        con.close()
+
+
+def _isolate_shared_sqlite(nightly_agent_config, tmp_dir: Path) -> Path:
+    """Copy the shared benchmark SQLite file and repoint every datasource at it.
+
+    The loaded acceptance config exposes the same physical
+    ``california_schools.sqlite`` under several datasource names (``bird_school``
+    plus the glob-discovered ``california_schools``). A gen_job ETL may route its
+    DDL/DML to any of them by name, so isolating only the selected datasource is
+    not enough — a stray ``datasource='california_schools'`` would still hit the
+    shared file and corrupt data shared with other nightly agents.
+
+    This repoints *all* datasources whose URI is the shared file to a per-test
+    writable copy, then clears the DBManager CLI cache so no connector bound to
+    the original path survives. Returns the path to the writable copy.
+    """
+    base = nightly_agent_config.services.datasources["bird_school"]
+    shared_uri = base.uri
+    src = shared_uri.replace("sqlite:///", "")
+    assert os.path.exists(src), f"source sqlite db not found: {src}"
+
+    dst = tmp_dir / "california_schools.sqlite"
+    shutil.copy2(src, dst)
+    dst_uri = f"sqlite:///{dst}"
+
+    repointed = 0
+    for cfg in nightly_agent_config.services.datasources.values():
+        if cfg.uri == shared_uri:
+            cfg.uri = dst_uri
+            repointed += 1
+    assert repointed >= 1, "expected at least one datasource pointing at the shared sqlite file"
+
+    _db_manager._cli_cache.clear()
+
+    nightly_agent_config.current_datasource = "bird_school"
+    return dst
+
+
+@pytest.fixture
+def isolated_job_config(nightly_agent_config, tmp_path):
+    """nightly_agent_config repointed at a per-test writable SQLite copy.
+
+    Yields ``(config, db_path)`` so tests can both drive the node and
+    introspect the isolated database after the run.
+    """
+    db_path = _isolate_shared_sqlite(nightly_agent_config, tmp_path)
+    yield nightly_agent_config, db_path
+    # Evict the copy-bound DBManager so the next test rebuilds against its own
+    # path instead of reusing a connector pinned to this (now-deleted) tmp file.
+    _db_manager._cli_cache.clear()
+
+
+@pytest.mark.nightly
+class TestGenJobAgenticInit:
+    """Deterministic node-construction coverage (no LLM)."""
+
+    def test_node_initialization(self, nightly_agent_config):
+        """Node initializes with the expected DDL/DML + migration tool surface."""
+        node = GenJobAgenticNode(
+            agent_config=nightly_agent_config,
+            execution_mode="workflow",
+        )
+
+        assert node.get_node_name() == "gen_job", f"unexpected node name: {node.get_node_name()}"
+        assert node.NODE_NAME == "gen_job", f"unexpected NODE_NAME: {node.NODE_NAME}"
+        assert node.ACTION_TYPE == "gen_job_response", f"unexpected ACTION_TYPE: {node.ACTION_TYPE}"
+        assert node.execution_mode == "workflow", f"unexpected execution mode: {node.execution_mode}"
+
+        tool_names = [tool.name for tool in node.tools]
+        assert "execute_ddl" in tool_names, f"missing execute_ddl, got: {tool_names}"
+        assert "execute_write" in tool_names, f"missing execute_write, got: {tool_names}"
+        assert "transfer_query_result" in tool_names, f"missing transfer_query_result, got: {tool_names}"
+        assert "read_query" in tool_names, f"missing read_query, got: {tool_names}"
+
+        logger.info("gen_job node initialized with %d tools: %s", len(node.tools), tool_names)
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestGenJobAgenticRealLLM:
+    """Real-LLM smoke for a single-DB gen_job ETL on an isolated SQLite copy."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_execute_stream_runs_single_db_etl(self, isolated_job_config):
+        """LLM creates a target table and loads it from schools; last action SUCCESS."""
+        config, db_path = isolated_job_config
+        tables_before = _table_names(db_path)
+
+        node = GenJobAgenticNode(
+            agent_config=config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(
+            user_message=(
+                "Build a single-database ETL job inside this SQLite database. "
+                "Create a new table named nightly_job_school_summary with one integer "
+                "column total_schools, then load it by inserting a single row: the total "
+                "number of rows in the schools table (INSERT INTO ... SELECT COUNT(*) FROM schools). "
+                "Use execute_ddl for the CREATE TABLE and execute_write for the INSERT. "
+                "This is an explicit, non-destructive request targeting a brand-new table."
+            ),
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+            logger.info("Action: role=%s status=%s type=%s", action.role, action.status, action.action_type)
+
+        assert len(actions) >= 2, f"expected at least 2 actions, got {len(actions)}"
+        assert actions[0].role == ActionRole.USER, f"first action role was {actions[0].role}"
+        assert actions[0].status == ActionStatus.PROCESSING, f"first action status was {actions[0].status}"
+
+        last = actions[-1]
+        assert last.status == ActionStatus.SUCCESS, f"last action should be SUCCESS, got {last.status}: {last.output}"
+        assert last.action_type == "gen_job_response", (
+            f"last action_type should be gen_job_response, got {last.action_type}"
+        )
+
+        # The ETL output must land in the ISOLATED copy: a new table was created
+        # and it holds at least one loaded row. Name-agnostic so the smoke stays
+        # robust to LLM identifier choices while still proving DDL + DML ran.
+        tables_after = _table_names(db_path)
+        new_tables = tables_after - tables_before
+        assert new_tables, f"no new table created in isolated db; before={tables_before}, after={tables_after}"
+
+        created = sorted(new_tables)[0]
+        query_result = node.db_func_tool.read_query(f"SELECT COUNT(*) AS n FROM {created}")
+        assert query_result.success == 1, f"job target table {created!r} not queryable: {query_result}"
+        # The ETL INSERT loaded rows, so the target table is non-empty. We read
+        # the count back through SQLite directly (the connector result is a
+        # compressed envelope) to assert a concrete, deterministic row count.
+        loaded_rows = _row_count(db_path, created)
+        assert loaded_rows >= 1, f"ETL target table {created!r} has no loaded rows: {loaded_rows}"

--- a/tests/integration/agent/test_gen_job_agentic.py
+++ b/tests/integration/agent/test_gen_job_agentic.py
@@ -55,11 +55,16 @@ def _table_names(db_path: Path) -> set[str]:
     return {r[0] for r in rows}
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier so LLM-chosen table names are interpolated safely."""
+    return '"' + name.replace('"', '""') + '"'
+
+
 def _row_count(db_path: Path, table: str) -> int:
     """Return the row count of a table in a SQLite file."""
     con = sqlite3.connect(str(db_path))
     try:
-        return int(con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+        return int(con.execute(f"SELECT COUNT(*) FROM {_quote_ident(table)}").fetchone()[0])
     finally:
         con.close()
 
@@ -141,7 +146,7 @@ class TestGenJobAgenticInit:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestGenJobAgenticRealLLM:
     """Real-LLM smoke for a single-DB gen_job ETL on an isolated SQLite copy."""
 
@@ -191,7 +196,7 @@ class TestGenJobAgenticRealLLM:
         assert new_tables, f"no new table created in isolated db; before={tables_before}, after={tables_after}"
 
         created = sorted(new_tables)[0]
-        query_result = node.db_func_tool.read_query(f"SELECT COUNT(*) AS n FROM {created}")
+        query_result = node.db_func_tool.read_query(f"SELECT COUNT(*) AS n FROM {_quote_ident(created)}")
         assert query_result.success == 1, f"job target table {created!r} not queryable: {query_result}"
         # The ETL INSERT loaded rows, so the target table is non-empty. We read
         # the count back through SQLite directly (the connector result is a

--- a/tests/integration/agent/test_gen_table_agentic.py
+++ b/tests/integration/agent/test_gen_table_agentic.py
@@ -1,0 +1,182 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Nightly integration tests for GenTableAgenticNode (issue #923).
+
+Expands nightly coverage for the data-product ``gen_table`` subagent.
+
+Two tiers:
+* A deterministic ``@pytest.mark.nightly`` init test that builds the node and
+  asserts the expected DDL/DB tool surface — no LLM call.
+* A real-LLM ``@pytest.mark.product_e2e`` test that drives ``execute_stream``
+  end to end. The LLM authors and executes a ``CREATE TABLE`` against an
+  ISOLATED SQLite copy so the shared benchmark database is never mutated and
+  concurrent nightly agents cannot race on the same file.
+
+Isolation strategy: copy the shared ``california_schools.sqlite`` to a tmp dir,
+repoint every datasource whose URI is that shared file (``bird_school`` plus the
+glob-discovered ``california_schools``) to the copy, then clear the DBManager
+CLI cache so no connector bound to the original path survives. This guarantees
+the DDL lands on the copy regardless of which datasource name the LLM routes to.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.tools.db_tools import db_manager as _db_manager
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def _table_names(db_path: Path) -> set[str]:
+    """Return the set of user table names in a SQLite file."""
+    con = sqlite3.connect(str(db_path))
+    try:
+        rows = con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    finally:
+        con.close()
+    return {r[0] for r in rows}
+
+
+def _isolate_shared_sqlite(nightly_agent_config, tmp_dir: Path) -> Path:
+    """Copy the shared benchmark SQLite file and repoint every datasource at it.
+
+    The loaded acceptance config exposes the same physical
+    ``california_schools.sqlite`` under several datasource names (``bird_school``
+    plus the glob-discovered ``california_schools``). The LLM may route a DDL to
+    any of them by name, so isolating only the selected datasource is not enough
+    — a stray ``datasource='california_schools'`` would still hit the shared
+    file and corrupt data shared with other nightly agents.
+
+    This repoints *all* datasources whose URI is the shared file to a per-test
+    writable copy, then clears the DBManager CLI cache so no connector bound to
+    the original path survives. Returns the path to the writable copy.
+    """
+    base = nightly_agent_config.services.datasources["bird_school"]
+    shared_uri = base.uri
+    src = shared_uri.replace("sqlite:///", "")
+    assert os.path.exists(src), f"source sqlite db not found: {src}"
+
+    dst = tmp_dir / "california_schools.sqlite"
+    shutil.copy2(src, dst)
+    dst_uri = f"sqlite:///{dst}"
+
+    repointed = 0
+    for cfg in nightly_agent_config.services.datasources.values():
+        if cfg.uri == shared_uri:
+            cfg.uri = dst_uri
+            repointed += 1
+    assert repointed >= 1, "expected at least one datasource pointing at the shared sqlite file"
+
+    # Drop any DBManager cached against the original path so connectors rebind
+    # to the copy on next use.
+    _db_manager._cli_cache.clear()
+
+    nightly_agent_config.current_datasource = "bird_school"
+    return dst
+
+
+@pytest.fixture
+def isolated_table_config(nightly_agent_config, tmp_path):
+    """nightly_agent_config repointed at a per-test writable SQLite copy.
+
+    Yields ``(config, db_path)`` so tests can both drive the node and
+    introspect the isolated database after the run.
+    """
+    db_path = _isolate_shared_sqlite(nightly_agent_config, tmp_path)
+    yield nightly_agent_config, db_path
+    # Evict the copy-bound DBManager so the next test rebuilds against its own
+    # path instead of reusing a connector pinned to this (now-deleted) tmp file.
+    _db_manager._cli_cache.clear()
+
+
+@pytest.mark.nightly
+class TestGenTableAgenticInit:
+    """Deterministic node-construction coverage (no LLM)."""
+
+    def test_node_initialization(self, nightly_agent_config):
+        """Node initializes with the expected DDL + DB tool surface."""
+        node = GenTableAgenticNode(
+            agent_config=nightly_agent_config,
+            execution_mode="workflow",
+        )
+
+        assert node.get_node_name() == "gen_table", f"unexpected node name: {node.get_node_name()}"
+        assert node.NODE_NAME == "gen_table", f"unexpected NODE_NAME: {node.NODE_NAME}"
+        assert node.ACTION_TYPE == "gen_table_response", f"unexpected ACTION_TYPE: {node.ACTION_TYPE}"
+        assert node.execution_mode == "workflow", f"unexpected execution mode: {node.execution_mode}"
+
+        tool_names = [tool.name for tool in node.tools]
+        assert "execute_ddl" in tool_names, f"missing execute_ddl, got: {tool_names}"
+        assert "list_tables" in tool_names, f"missing list_tables, got: {tool_names}"
+        assert "describe_table" in tool_names, f"missing describe_table, got: {tool_names}"
+        assert "read_query" in tool_names, f"missing read_query, got: {tool_names}"
+
+        logger.info("gen_table node initialized with %d tools: %s", len(node.tools), tool_names)
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestGenTableAgenticRealLLM:
+    """Real-LLM smoke for the gen_table DDL path on an isolated SQLite copy."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_execute_stream_creates_table(self, isolated_table_config):
+        """LLM authors + executes CREATE TABLE; last action is SUCCESS."""
+        config, db_path = isolated_table_config
+        tables_before = _table_names(db_path)
+
+        node = GenTableAgenticNode(
+            agent_config=config,
+            execution_mode="workflow",
+        )
+        node.input = SemanticNodeInput(
+            user_message=(
+                "Create a new summary table named nightly_school_counts that stores, "
+                "per county, the number of schools. Read it from the schools table "
+                "(group by the County column). Use a CREATE TABLE ... AS SELECT statement "
+                "and execute it with the execute_ddl tool. This is an explicit, "
+                "non-destructive create request."
+            ),
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+            logger.info("Action: role=%s status=%s type=%s", action.role, action.status, action.action_type)
+
+        assert len(actions) >= 2, f"expected at least 2 actions, got {len(actions)}"
+        assert actions[0].role == ActionRole.USER, f"first action role was {actions[0].role}"
+        assert actions[0].status == ActionStatus.PROCESSING, f"first action status was {actions[0].status}"
+
+        last = actions[-1]
+        assert last.status == ActionStatus.SUCCESS, f"last action should be SUCCESS, got {last.status}: {last.output}"
+        assert last.action_type == "gen_table_response", (
+            f"last action_type should be gen_table_response, got {last.action_type}"
+        )
+
+        # The DDL must have landed in the ISOLATED copy: exactly the new table(s)
+        # the run created appear, and at least one is non-empty/queryable. The
+        # assertion is name-agnostic so it stays robust to the LLM choosing a
+        # slightly different identifier while still proving a real CREATE TABLE ran.
+        tables_after = _table_names(db_path)
+        new_tables = tables_after - tables_before
+        assert new_tables, f"no new table created in isolated db; before={tables_before}, after={tables_after}"
+
+        created = sorted(new_tables)[0]
+        query_result = node.db_func_tool.read_query(f"SELECT COUNT(*) AS n FROM {created}")
+        assert query_result.success == 1, f"created table {created!r} not queryable: {query_result}"

--- a/tests/integration/agent/test_gen_table_agentic.py
+++ b/tests/integration/agent/test_gen_table_agentic.py
@@ -49,6 +49,11 @@ def _table_names(db_path: Path) -> set[str]:
     return {r[0] for r in rows}
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier so LLM-chosen table names are interpolated safely."""
+    return '"' + name.replace('"', '""') + '"'
+
+
 def _isolate_shared_sqlite(nightly_agent_config, tmp_dir: Path) -> Path:
     """Copy the shared benchmark SQLite file and repoint every datasource at it.
 
@@ -128,7 +133,7 @@ class TestGenTableAgenticInit:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestGenTableAgenticRealLLM:
     """Real-LLM smoke for the gen_table DDL path on an isolated SQLite copy."""
 
@@ -178,5 +183,5 @@ class TestGenTableAgenticRealLLM:
         assert new_tables, f"no new table created in isolated db; before={tables_before}, after={tables_after}"
 
         created = sorted(new_tables)[0]
-        query_result = node.db_func_tool.read_query(f"SELECT COUNT(*) AS n FROM {created}")
+        query_result = node.db_func_tool.read_query(f"SELECT COUNT(*) AS n FROM {_quote_ident(created)}")
         assert query_result.success == 1, f"created table {created!r} not queryable: {query_result}"

--- a/tests/integration/agent/test_gen_visual_dashboard_agentic.py
+++ b/tests/integration/agent/test_gen_visual_dashboard_agentic.py
@@ -1,0 +1,127 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Nightly integration tests for GenVisualDashboardAgenticNode (issue #923).
+
+Expands nightly coverage for the data-product ``gen_visual_dashboard`` subagent.
+
+Two tiers:
+* A deterministic ``@pytest.mark.nightly`` init test asserting the filesystem +
+  DB tool surface — no LLM call.
+* A real-LLM ``@pytest.mark.product_e2e`` test driving ``execute_stream`` end to
+  end. The LLM authors a parameterized React-JSX dashboard bundle (query
+  templates + render/app.jsx + manifest) against california_schools and
+  finalizes it with ``validate_render``; the run must end SUCCESS and surface
+  the compiled HTML via a ``dashboard_html_path`` action.
+
+Artifacts are written under ``project_root``, which this test redirects to a
+per-test tmp dir so the repository tree is never polluted and concurrent
+nightly agents cannot collide on the same ``dashboards/`` directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
+from datus.configuration.node_type import NodeType
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.gen_visual_dashboard_models import GenVisualDashboardNodeInput
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def _make_node(agent_config, execution_mode="workflow"):
+    return GenVisualDashboardAgenticNode(
+        node_id="gen_visual_dashboard_node",
+        description="Nightly visual dashboard node",
+        node_type=NodeType.TYPE_GEN_VISUAL_DASHBOARD,
+        agent_config=agent_config,
+        node_name="gen_visual_dashboard",
+        execution_mode=execution_mode,
+    )
+
+
+@pytest.fixture
+def dashboard_project_config(nightly_agent_config, tmp_path):
+    """nightly_agent_config with project_root redirected to a tmp workspace."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    # ``project_root`` is a read-only property over ``_project_root``; repointing
+    # the backing field redirects all dashboard artifacts into the tmp workspace.
+    nightly_agent_config._project_root = workspace
+    return nightly_agent_config
+
+
+@pytest.mark.nightly
+class TestGenVisualDashboardAgenticInit:
+    """Deterministic node-construction coverage (no LLM)."""
+
+    def test_node_initialization(self, nightly_agent_config):
+        """Node initializes with the expected filesystem + DB tool surface."""
+        node = _make_node(nightly_agent_config)
+
+        assert node.get_node_name() == "gen_visual_dashboard", f"unexpected node name: {node.get_node_name()}"
+        assert node.NODE_NAME == "gen_visual_dashboard", f"unexpected NODE_NAME: {node.NODE_NAME}"
+        assert node.execution_mode == "workflow", f"unexpected execution mode: {node.execution_mode}"
+
+        tool_names = [tool.name for tool in node.tools]
+        assert "read_file" in tool_names, f"missing read_file, got: {tool_names}"
+        assert "write_file" in tool_names, f"missing write_file, got: {tool_names}"
+        assert "edit_file" in tool_names, f"missing edit_file, got: {tool_names}"
+        assert "list_tables" in tool_names, f"missing list_tables, got: {tool_names}"
+
+        logger.info("gen_visual_dashboard node initialized with %d tools: %s", len(node.tools), tool_names)
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestGenVisualDashboardAgenticRealLLM:
+    """Real-LLM smoke for the gen_visual_dashboard artifact path."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_execute_stream_builds_dashboard(self, dashboard_project_config):
+        """LLM authors + validates a dashboard bundle; last action SUCCESS."""
+        node = _make_node(dashboard_project_config, execution_mode="workflow")
+        node.input = GenVisualDashboardNodeInput(
+            user_message=(
+                "Build a small dashboard titled 'County Schools Overview'. Author one "
+                "parameterized query template that returns the number of schools per county "
+                "from the schools table (group by County, order by the count descending). "
+                "Declare a '-- @datus-params' header (it may take no parameters). Render a "
+                "simple bar chart of county vs school count. Start a new dashboard, save the "
+                "query template, author render/app.jsx, then call validate_render to finalize."
+            ),
+            database="california_schools",
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+            logger.info("Action: role=%s status=%s type=%s", action.role, action.status, action.action_type)
+
+        assert len(actions) >= 2, f"expected at least 2 actions, got {len(actions)}"
+        assert actions[0].role == ActionRole.USER, f"first action role was {actions[0].role}"
+        assert actions[0].status == ActionStatus.PROCESSING, f"first action status was {actions[0].status}"
+
+        last = actions[-1]
+        assert last.status == ActionStatus.SUCCESS, f"last action should be SUCCESS, got {last.status}: {last.output}"
+
+        result = last.output
+        assert isinstance(result, dict), f"final output should be a dict, got {type(result)}"
+        assert result["success"] is True, f"dashboard run did not succeed: {result.get('error')}"
+        assert result["dashboard_slug"], f"dashboard_slug should be populated, got {result.get('dashboard_slug')}"
+
+        # CLI mode compiles a standalone HTML and surfaces its path in the stream.
+        path_actions = [a for a in actions if a.action_type == "dashboard_html_path"]
+        assert len(path_actions) == 1, f"expected exactly one dashboard_html_path action, got {len(path_actions)}"
+        html_path = path_actions[0].output["html_path"]
+        assert Path(html_path).is_file(), f"compiled dashboard HTML missing on disk: {html_path}"

--- a/tests/integration/agent/test_gen_visual_dashboard_agentic.py
+++ b/tests/integration/agent/test_gen_visual_dashboard_agentic.py
@@ -81,7 +81,7 @@ class TestGenVisualDashboardAgenticInit:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestGenVisualDashboardAgenticRealLLM:
     """Real-LLM smoke for the gen_visual_dashboard artifact path."""
 

--- a/tests/integration/agent/test_gen_visual_report_agentic.py
+++ b/tests/integration/agent/test_gen_visual_report_agentic.py
@@ -1,0 +1,126 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Nightly integration tests for GenVisualReportAgenticNode (issue #923).
+
+Expands nightly coverage for the data-product ``gen_visual_report`` subagent.
+
+Two tiers:
+* A deterministic ``@pytest.mark.nightly`` init test asserting the filesystem +
+  DB tool surface — no LLM call.
+* A real-LLM ``@pytest.mark.product_e2e`` test driving ``execute_stream`` end to
+  end. The LLM authors a React-JSX report bundle (queries + render/app.jsx +
+  manifest) against the california_schools data and finalizes it with
+  ``validate_render``; the run must end SUCCESS and surface the compiled HTML
+  via a ``report_html_path`` action.
+
+Artifacts are written under ``project_root``, which this test redirects to a
+per-test tmp dir so the repository tree is never polluted and concurrent
+nightly agents cannot collide on the same ``reports/`` directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from datus.agent.node.gen_visual_report_agentic_node import GenVisualReportAgenticNode
+from datus.configuration.node_type import NodeType
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.gen_visual_report_models import GenVisualReportNodeInput
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def _make_node(agent_config, execution_mode="workflow"):
+    return GenVisualReportAgenticNode(
+        node_id="gen_visual_report_node",
+        description="Nightly visual report node",
+        node_type=NodeType.TYPE_GEN_VISUAL_REPORT,
+        agent_config=agent_config,
+        node_name="gen_visual_report",
+        execution_mode=execution_mode,
+    )
+
+
+@pytest.fixture
+def report_project_config(nightly_agent_config, tmp_path):
+    """nightly_agent_config with project_root redirected to a tmp workspace."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    # ``project_root`` is a read-only property over ``_project_root``; repointing
+    # the backing field redirects all report artifacts into the tmp workspace.
+    nightly_agent_config._project_root = workspace
+    return nightly_agent_config
+
+
+@pytest.mark.nightly
+class TestGenVisualReportAgenticInit:
+    """Deterministic node-construction coverage (no LLM)."""
+
+    def test_node_initialization(self, nightly_agent_config):
+        """Node initializes with the expected filesystem + DB tool surface."""
+        node = _make_node(nightly_agent_config)
+
+        assert node.get_node_name() == "gen_visual_report", f"unexpected node name: {node.get_node_name()}"
+        assert node.NODE_NAME == "gen_visual_report", f"unexpected NODE_NAME: {node.NODE_NAME}"
+        assert node.execution_mode == "workflow", f"unexpected execution mode: {node.execution_mode}"
+
+        tool_names = [tool.name for tool in node.tools]
+        assert "read_file" in tool_names, f"missing read_file, got: {tool_names}"
+        assert "write_file" in tool_names, f"missing write_file, got: {tool_names}"
+        assert "edit_file" in tool_names, f"missing edit_file, got: {tool_names}"
+        assert "list_tables" in tool_names, f"missing list_tables, got: {tool_names}"
+
+        logger.info("gen_visual_report node initialized with %d tools: %s", len(node.tools), tool_names)
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestGenVisualReportAgenticRealLLM:
+    """Real-LLM smoke for the gen_visual_report artifact path."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_execute_stream_builds_report(self, report_project_config):
+        """LLM authors + validates a report bundle; last action SUCCESS."""
+        node = _make_node(report_project_config, execution_mode="workflow")
+        node.input = GenVisualReportNodeInput(
+            user_message=(
+                "Build a small visual report titled 'Schools by County'. Write one query "
+                "that returns the number of schools per county from the schools table "
+                "(group by County, order by the count descending, limit 10). Render a simple "
+                "bar chart of county vs school count. Start a new report, save the query, "
+                "author render/app.jsx, then call validate_render to finalize."
+            ),
+            database="california_schools",
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+            logger.info("Action: role=%s status=%s type=%s", action.role, action.status, action.action_type)
+
+        assert len(actions) >= 2, f"expected at least 2 actions, got {len(actions)}"
+        assert actions[0].role == ActionRole.USER, f"first action role was {actions[0].role}"
+        assert actions[0].status == ActionStatus.PROCESSING, f"first action status was {actions[0].status}"
+
+        last = actions[-1]
+        assert last.status == ActionStatus.SUCCESS, f"last action should be SUCCESS, got {last.status}: {last.output}"
+
+        result = last.output
+        assert isinstance(result, dict), f"final output should be a dict, got {type(result)}"
+        assert result["success"] is True, f"report run did not succeed: {result.get('error')}"
+        assert result["report_slug"], f"report_slug should be populated, got {result.get('report_slug')}"
+
+        # CLI mode compiles a standalone HTML and surfaces its path in the stream.
+        path_actions = [a for a in actions if a.action_type == "report_html_path"]
+        assert len(path_actions) == 1, f"expected exactly one report_html_path action, got {len(path_actions)}"
+        html_path = path_actions[0].output["html_path"]
+        assert Path(html_path).is_file(), f"compiled report HTML missing on disk: {html_path}"

--- a/tests/integration/agent/test_gen_visual_report_agentic.py
+++ b/tests/integration/agent/test_gen_visual_report_agentic.py
@@ -81,7 +81,7 @@ class TestGenVisualReportAgenticInit:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestGenVisualReportAgenticRealLLM:
     """Real-LLM smoke for the gen_visual_report artifact path."""
 

--- a/tests/integration/agent/test_workflow_orchestration.py
+++ b/tests/integration/agent/test_workflow_orchestration.py
@@ -1,0 +1,137 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Nightly coverage for the extension flow ``extension.workflow_orchestration``.
+
+Drives a real multi-node workflow end-to-end through ``WorkflowRunner`` against
+a real LLM and the bundled california_schools SQLite database. The
+``gen_sql_agentic`` builtin plan is a genuine multi-node graph
+(``gen_sql -> execute_sql -> output``) whose agentic ``gen_sql`` node performs
+its own schema discovery via ``db_tools.*`` — so it exercises cross-node
+orchestration without depending on a prebuilt embedding/KB store (which the
+``schema_linking``-first plans require and which is not provisioned in this
+nightly environment).
+
+Assertions:
+- The deterministic test confirms the runner assembles the expected multi-node
+  graph from the plan (no LLM needed).
+- The real-LLM streaming test asserts the runner emits its lifecycle actions
+  (init -> per-node execution -> completion), advances through more than one
+  node, and finishes with the completion action marked SUCCESS.
+"""
+
+import argparse
+import os
+
+import pytest
+
+from datus.agent.workflow_runner import WorkflowRunner
+from datus.schemas.action_history import ActionHistoryManager, ActionStatus
+from datus.schemas.node_models import SqlTask
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def _make_args(max_steps=20, workflow="gen_sql_agentic"):
+    return argparse.Namespace(
+        max_steps=max_steps,
+        workflow=workflow,
+        load_cp=None,
+        debug=False,
+        # Must be a concrete bool: the agentic gen_sql node (first node of this
+        # plan) builds GenSQLNodeInput(plan_mode=...) which rejects None.
+        plan_mode=False,
+    )
+
+
+def _make_sql_task():
+    return SqlTask(
+        id="nightly_wf_orchestration",
+        datasource="bird_school",
+        database_type="sqlite",
+        task="How many schools are there in Alameda county?",
+        database_name="california_schools",
+    )
+
+
+@pytest.mark.nightly
+class TestWorkflowGraphAssembly:
+    """Deterministic: the runner builds the expected multi-node gen_sql_agentic graph."""
+
+    def test_gen_sql_agentic_plan_is_multi_node(self, nightly_agent_config):
+        runner = WorkflowRunner(
+            args=_make_args(),
+            agent_config=nightly_agent_config,
+            run_id="nightly-wf-assembly",
+        )
+        runner.initialize_workflow(_make_sql_task())
+
+        from datus.agent.workflow import Workflow
+
+        assert isinstance(runner.workflow, Workflow), (
+            f"Runner must initialize a Workflow, got {type(runner.workflow).__name__}"
+        )
+        node_types = [n.type for n in runner.workflow.nodes.values()]
+        assert len(node_types) >= 3, f"gen_sql_agentic plan should assemble a multi-node graph, got {node_types}"
+        # The plan contains a gen_sql node, executes SQL, and ends in an output node.
+        type_strs = [str(t) for t in node_types]
+        assert any("gen_sql" in t for t in type_strs), (
+            f"gen_sql_agentic plan should contain a gen_sql node, got {type_strs}"
+        )
+        assert any("execute_sql" in t for t in type_strs), (
+            f"gen_sql_agentic plan should contain an execute_sql node, got {type_strs}"
+        )
+        assert any("output" in t for t in type_strs), (
+            f"gen_sql_agentic plan should contain an output node, got {type_strs}"
+        )
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestWorkflowOrchestrationRealLLM:
+    """Real-LLM multi-node workflow execution via WorkflowRunner."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_gen_sql_agentic_workflow_completes(self, nightly_agent_config):
+        """N924-WF: run a multi-node gen_sql_agentic workflow end-to-end with a real LLM."""
+        runner = WorkflowRunner(
+            args=_make_args(max_steps=20),
+            agent_config=nightly_agent_config,
+            run_id="nightly-wf-real",
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in runner.run_stream(
+            sql_task=_make_sql_task(),
+            check_storage=False,
+            action_history_manager=action_manager,
+        ):
+            actions.append(action)
+
+        action_ids = [a.action_id for a in actions]
+        assert "workflow_initialization" in action_ids, f"Missing init action, got: {action_ids}"
+        assert "workflow_completion" in action_ids, f"Missing completion action, got: {action_ids}"
+
+        # The runner emits one node_execution_* action per node it drives; a
+        # multi-node graph must produce more than one.
+        node_exec_actions = [a for a in actions if a.action_type == "node_execution"]
+        assert len(node_exec_actions) >= 2, (
+            f"Multi-node workflow should execute >=2 nodes, got {len(node_exec_actions)}: "
+            f"{[a.action_id for a in node_exec_actions]}"
+        )
+
+        # The final completion action must report success.
+        completion_actions = [a for a in actions if a.action_id == "workflow_completion"]
+        final_completion = completion_actions[-1]
+        assert final_completion.status == ActionStatus.SUCCESS, (
+            f"Workflow completion should be SUCCESS, got {final_completion.status}: {final_completion.output}"
+        )
+        assert final_completion.output.get("workflow_saved") is True, (
+            f"Completed workflow should be persisted, output: {final_completion.output}"
+        )

--- a/tests/integration/agent/test_workflow_orchestration.py
+++ b/tests/integration/agent/test_workflow_orchestration.py
@@ -35,7 +35,7 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 
-def _make_args(max_steps=20, workflow="gen_sql_agentic"):
+def _make_args(max_steps: int = 20, workflow: str = "gen_sql_agentic") -> argparse.Namespace:
     return argparse.Namespace(
         max_steps=max_steps,
         workflow=workflow,
@@ -47,7 +47,7 @@ def _make_args(max_steps=20, workflow="gen_sql_agentic"):
     )
 
 
-def _make_sql_task():
+def _make_sql_task() -> SqlTask:
     return SqlTask(
         id="nightly_wf_orchestration",
         datasource="bird_school",
@@ -91,7 +91,7 @@ class TestWorkflowGraphAssembly:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestWorkflowOrchestrationRealLLM:
     """Real-LLM multi-node workflow execution via WorkflowRunner."""
 

--- a/tests/integration/agent/test_workflow_orchestration.py
+++ b/tests/integration/agent/test_workflow_orchestration.py
@@ -61,7 +61,7 @@ def _make_sql_task() -> SqlTask:
 class TestWorkflowGraphAssembly:
     """Deterministic: the runner builds the expected multi-node gen_sql_agentic graph."""
 
-    def test_gen_sql_agentic_plan_is_multi_node(self, nightly_agent_config):
+    def test_gen_sql_agentic_plan_is_multi_node(self, nightly_agent_config) -> None:
         runner = WorkflowRunner(
             args=_make_args(),
             agent_config=nightly_agent_config,
@@ -97,7 +97,7 @@ class TestWorkflowOrchestrationRealLLM:
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(300)
-    async def test_gen_sql_agentic_workflow_completes(self, nightly_agent_config):
+    async def test_gen_sql_agentic_workflow_completes(self, nightly_agent_config) -> None:
         """N924-WF: run a multi-node gen_sql_agentic workflow end-to-end with a real LLM."""
         runner = WorkflowRunner(
             args=_make_args(max_steps=20),

--- a/tests/integration/cli/test_quickstart_smoke.py
+++ b/tests/integration/cli/test_quickstart_smoke.py
@@ -1,0 +1,110 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Nightly smoke test for the documented quickstart chat path.
+
+Exercises the core promise of docs/getting_started/Quickstart.md and
+docs/cli/chat_command.md: a fresh user asks a natural-language data question
+through the chat/agent path and gets a successful answer backed by SQL, on a
+local SQLite datasource.
+
+Covers the coverage-map flow ``onboarding.quickstart`` (GitHub issue #921).
+
+The chat path is exercised via ChatAgenticNode (the node behind the CLI ``/``
+chat command), mirroring the real-LLM invocation pattern used in
+tests/integration/agent/test_chat_agentic.py and
+tests/integration/agent/test_sql_summary_agentic.py. Tests reuse the
+``nightly_agent_config`` fixture (datasource ``bird_school``) from
+tests/integration/conftest.py.
+"""
+
+import os
+
+import pytest
+
+from datus.agent.node.chat_agentic_node import ChatAgenticNode
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.chat_agentic_node_models import ChatNodeInput
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Database (read) tools the quickstart chat path must expose so a fresh user's
+# natural-language question can be answered with SQL against a local datasource.
+EXPECTED_DB_TOOLS = ("read_query", "list_tables", "describe_table")
+
+
+@pytest.mark.nightly
+class TestQuickstartChatInitialization:
+    """Deterministic checks for the quickstart chat node (no LLM)."""
+
+    def test_chat_node_exposes_sql_tools_on_quickstart_datasource(self, nightly_agent_config):
+        """The chat node initializes with the SQL read tools the quickstart relies on."""
+        node = ChatAgenticNode(
+            node_id="quickstart_smoke_init",
+            description="Quickstart smoke initialization check",
+            node_type="chat",
+            agent_config=nightly_agent_config,
+        )
+
+        assert node.get_node_name() == "chat", f"Expected node name 'chat', got '{node.get_node_name()}'"
+
+        tool_names = [tool.name for tool in node.tools]
+        for expected in EXPECTED_DB_TOOLS:
+            assert expected in tool_names, f"Missing quickstart SQL tool '{expected}', got: {tool_names}"
+
+        logger.info(f"Quickstart chat node initialized with {len(tool_names)} tools: {tool_names}")
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+class TestQuickstartChatSmoke:
+    """Real-LLM end-to-end smoke for the documented quickstart chat path."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    @pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+    async def test_quickstart_natural_language_question_answered_with_sql(self, nightly_agent_config):
+        """A fresh NL question is answered successfully and is backed by a SQL read."""
+        node = ChatAgenticNode(
+            node_id="quickstart_smoke_e2e",
+            description="Quickstart smoke end-to-end check",
+            node_type="chat",
+            agent_config=nightly_agent_config,
+        )
+
+        node.input = ChatNodeInput(
+            user_message="How many schools are there?",
+            max_turns=15,
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+            logger.info(f"Action: role={action.role}, status={action.status}, type={action.action_type}")
+
+        assert len(actions) >= 2, f"Expected at least 2 actions (user + result), got {len(actions)}"
+
+        assert actions[0].role == ActionRole.USER, f"First action should be USER, got {actions[0].role}"
+
+        final_action = actions[-1]
+        assert final_action.status == ActionStatus.SUCCESS, (
+            f"Final action should be SUCCESS, got {final_action.status}: {final_action.output}"
+        )
+
+        successful_tool_actions = [
+            action for action in actions if action.role == ActionRole.TOOL and action.status == ActionStatus.SUCCESS
+        ]
+        assert len(successful_tool_actions) >= 1, (
+            f"Quickstart answer must be backed by at least one successful TOOL action, "
+            f"got tool actions: {[(a.action_type, a.status) for a in actions if a.role == ActionRole.TOOL]}"
+        )
+
+        sql_read_actions = [a for a in successful_tool_actions if "query" in a.action_type.lower()]
+        assert len(sql_read_actions) >= 1, (
+            f"Quickstart answer must execute a SQL read tool, "
+            f"successful tool action types: {[a.action_type for a in successful_tool_actions]}"
+        )

--- a/tests/integration/cli/test_quickstart_smoke.py
+++ b/tests/integration/cli/test_quickstart_smoke.py
@@ -65,7 +65,7 @@ class TestQuickstartChatSmoke:
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(300)
-    @pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+    @pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
     async def test_quickstart_natural_language_question_answered_with_sql(self, nightly_agent_config):
         """A fresh NL question is answered successfully and is backed by a SQL read."""
         node = ChatAgenticNode(

--- a/tests/integration/tools/test_context_injection.py
+++ b/tests/integration/tools/test_context_injection.py
@@ -275,7 +275,7 @@ class TestContextRetrievalInjection:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestContextInjectionRealLLM:
     """Injection-layer coverage: context tools are wired into and invoked by gen_sql."""
 
@@ -304,7 +304,11 @@ class TestContextInjectionRealLLM:
     @pytest.mark.asyncio
     @pytest.mark.timeout(300)
     async def test_execute_stream_invokes_context_tools(self, nightly_agent_config):
-        """End-to-end: the node runs to SUCCESS and invokes at least one tool."""
+        """End-to-end: the node runs to SUCCESS and invokes a context-search tool.
+
+        Proving context injection means proving a context-search tool was actually
+        called during generation, not merely that some (e.g. db schema) tool ran.
+        """
         _seed_all_context_sources(nightly_agent_config)
 
         node = self._build_node(nightly_agent_config)
@@ -325,9 +329,22 @@ class TestContextInjectionRealLLM:
 
         assert len(actions) >= 2, f"Should have at least 2 actions, got {len(actions)}"
 
-        tool_actions = [a for a in actions if a.role == ActionRole.TOOL]
-        assert len(tool_actions) >= 1, (
-            f"At least one TOOL action expected, got {len(tool_actions)}. Action roles: {[a.role for a in actions]}"
+        # A TOOL action's action_type is the tool name, so we can assert that a
+        # context-search tool (not just any tool) was invoked during generation.
+        context_tool_names = {
+            "search_reference_sql",
+            "get_reference_sql",
+            "search_metrics",
+            "get_metrics",
+            "search_knowledge",
+            "get_knowledge",
+            "search_semantic_objects",
+            "list_subject_tree",
+        }
+        invoked_tools = {a.action_type for a in actions if a.role == ActionRole.TOOL}
+        assert invoked_tools & context_tool_names, (
+            "Expected at least one context-search tool to be invoked during SQL generation, "
+            f"but only these tools were called: {sorted(invoked_tools)}"
         )
 
         assert actions[-1].status == ActionStatus.SUCCESS, (

--- a/tests/integration/tools/test_context_injection.py
+++ b/tests/integration/tools/test_context_injection.py
@@ -1,0 +1,335 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Nightly coverage for the data_access.context_injection flow (issue #922).
+
+This module proves each context source can be RETRIEVED and INJECTED into the
+SQL-generation path:
+
+* Retrieval layer (no LLM): self-seed catalog/schema-metadata (semantic objects),
+  subject-tree, historical/reference SQL, metrics, and external knowledge via the
+  RAG ``upsert_batch`` / ``after_init`` APIs, then assert ``ContextSearchTools``
+  surfaces them through ``search_knowledge`` / ``get_knowledge`` /
+  ``list_subject_tree`` and fuzzy (semantic + FTS) search.
+* Injection layer (real LLM): construct ``GenSQLAgenticNode`` from the
+  ``nightly_agent_config`` fixture, assert the context-search tools are wired into
+  ``node.tools``, then run the node end-to-end against the seeded reference SQL and
+  assert a tool action occurred and the run succeeded.
+
+Modelled after tests/integration/tools/test_context_search.py (retrieval) and
+tests/integration/agent/test_gen_metrics_agentic.py (execute_stream).
+"""
+
+import os
+
+import pytest
+from pandas import Timestamp
+
+from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+from datus.configuration.agent_config import AgentConfig
+from datus.configuration.node_type import NodeType
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.gen_sql_agentic_node_models import GenSQLNodeInput
+from datus.storage.ext_knowledge.store import ExtKnowledgeRAG
+from datus.storage.metric.store import MetricRAG, build_metric_id
+from datus.storage.reference_sql.store import ReferenceSqlRAG
+from datus.storage.semantic_model.store import SemanticModelRAG
+from datus.tools.func_tool.context_search import ContextSearchTools
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Shared subject hierarchy so every seeded context source lands under the same
+# subject-tree branch and ``list_subject_tree`` can nest them together.
+SUBJECT_PATH = ["california_schools", "context_injection"]
+
+
+# ── Seed payload builders ─────────────────────────────────────────────────
+
+
+def _metric_items():
+    """A metric whose business name is 'school_count' (used for fuzzy search)."""
+    name = "school_count"
+    return [
+        {
+            "id": build_metric_id(SUBJECT_PATH, name),
+            "subject_path": SUBJECT_PATH,
+            "semantic_model_name": "nightly_injection_school",
+            "name": name,
+            "description": (
+                "Total number of schools / campuses in the California schools dataset, "
+                "supporting county-level campus counting and enrollment analysis."
+            ),
+            "metric_type": "simple",
+            "measure_expr": "COUNT(*)",
+            "base_measures": ["school_count"],
+            "dimensions": ["county", "charter"],
+            "entities": [],
+            "catalog_name": "",
+            "database_name": "",
+            "schema_name": "",
+            "sql": "SELECT COUNT(*) AS school_count FROM schools",
+            "yaml_path": "tests/data/metrics/nightly_injection_school_count.yml",
+        }
+    ]
+
+
+def _reference_sql_items():
+    """Reference SQL counting Fresno charter schools (drives the injection run)."""
+    return [
+        {
+            "id": "nightly_injection_ref_sql_fresno_charter",
+            "subject_path": SUBJECT_PATH,
+            "name": "fresno_charter_school_count",
+            "sql": ("SELECT COUNT(*) AS school_count FROM schools WHERE County = 'Fresno' AND Charter = 1"),
+            "comment": "Deterministic reference SQL seed for context injection nightly tests.",
+            "summary": "Count charter schools located in Fresno county from the California schools dataset.",
+            "search_text": "school schools Fresno charter California county reference SQL count",
+            "filepath": "tests/data/reference_sql/nightly_injection_ref_sql_fresno_charter.sql",
+            "tags": "nightly,school,reference_sql,injection",
+        }
+    ]
+
+
+def _knowledge_items():
+    """External-knowledge entry describing the Charter flag semantics."""
+    return [
+        {
+            "subject_path": SUBJECT_PATH,
+            "name": "charter_flag_definition",
+            "search_text": "charter school definition flag Charter column meaning",
+            "explanation": (
+                "In the California schools dataset the Charter column equals 1 for charter "
+                "schools and 0 otherwise. Filter Charter = 1 to count charter campuses."
+            ),
+        }
+    ]
+
+
+def _semantic_objects():
+    """A table-kind semantic object so search_semantic_objects has catalog metadata."""
+    table_name = "schools"
+    return [
+        {
+            "id": f"table:nightly_injection.{table_name}",
+            "kind": "table",
+            "name": table_name,
+            "fq_name": f"california_schools.public.{table_name}",
+            "semantic_model_name": "nightly_injection_school",
+            "catalog_name": "",
+            "database_name": "california_schools",
+            "schema_name": "public",
+            "table_name": table_name,
+            "description": (
+                "California schools catalog table holding one row per school / campus, "
+                "including County and Charter attributes."
+            ),
+            "is_dimension": False,
+            "is_measure": False,
+            "is_entity_key": False,
+            "is_deprecated": False,
+            "expr": "",
+            "column_type": "",
+            "agg": "",
+            "create_metric": False,
+            "agg_time_dimension": "",
+            "is_partition": False,
+            "time_granularity": "",
+            "entity": "",
+            "yaml_path": "",
+            "updated_at": Timestamp.now().floor("ms"),
+        }
+    ]
+
+
+def _seed_all_context_sources(config: AgentConfig):
+    """Seed every context source against ``config`` and build indices.
+
+    Returns the constructed RAG stores so callers can introspect if needed.
+    """
+    metric_store = MetricRAG(config)
+    metric_store.upsert_batch(_metric_items())
+    metric_store.after_init()
+
+    reference_sql_store = ReferenceSqlRAG(config)
+    reference_sql_store.upsert_batch(_reference_sql_items())
+    reference_sql_store.after_init()
+
+    knowledge_store = ExtKnowledgeRAG(config)
+    knowledge_store.batch_upsert_knowledge(_knowledge_items())
+    knowledge_store.store.after_init()
+
+    semantic_store = SemanticModelRAG(config)
+    semantic_store.upsert_batch(_semantic_objects())
+    semantic_store.create_indices()
+
+    return metric_store, reference_sql_store, knowledge_store, semantic_store
+
+
+@pytest.fixture(scope="module")
+def seeded_context_data(agent_config: AgentConfig):
+    """Seed all context sources once for the retrieval-layer tests."""
+    return _seed_all_context_sources(agent_config)
+
+
+@pytest.mark.nightly
+class TestContextRetrievalInjection:
+    """Retrieval-layer coverage: each context source is searchable / fetchable."""
+
+    @pytest.fixture
+    def ctx_tools(self, agent_config: AgentConfig, seeded_context_data) -> ContextSearchTools:
+        return ContextSearchTools(agent_config)
+
+    def test_search_knowledge_returns_seeded_entry(self, ctx_tools):
+        """External knowledge: search_knowledge surfaces the seeded charter entry."""
+        assert ctx_tools.has_knowledge is True, "Seeded external knowledge should be detected"
+
+        result = ctx_tools.search_knowledge("what does the charter flag mean")
+
+        assert result.success == 1, f"search_knowledge should succeed, got error: {result.error}"
+        assert isinstance(result.result, list), f"Result should be a list, got {type(result.result)}"
+        assert len(result.result) >= 1, "Should surface at least the seeded knowledge entry"
+
+        names = [entry.get("name") for entry in result.result]
+        assert "charter_flag_definition" in names, f"Seeded knowledge name missing from results: {names}"
+
+    def test_get_knowledge_by_path(self, ctx_tools):
+        """External knowledge: get_knowledge fetches by full subject path + name."""
+        assert ctx_tools.has_knowledge is True, "Seeded external knowledge should be detected"
+
+        full_path = SUBJECT_PATH + ["charter_flag_definition"]
+        result = ctx_tools.get_knowledge(paths=[full_path])
+
+        assert result.success == 1, f"get_knowledge should succeed, got error: {result.error}"
+        assert isinstance(result.result, list), f"Result should be a list, got {type(result.result)}"
+        assert len(result.result) == 1, f"Should fetch exactly one entry for path {full_path}, got {result.result}"
+
+        entry = result.result[0]
+        assert entry.get("name") == "charter_flag_definition", f"Wrong entry returned: {entry}"
+        assert "Charter column equals 1" in entry.get("explanation", ""), (
+            f"Explanation should match seeded content, got: {entry.get('explanation')}"
+        )
+
+    def test_list_subject_tree_nests_all_sources(self, ctx_tools):
+        """Subject-tree: list_subject_tree returns the seeded entries nested by path."""
+        result = ctx_tools.list_subject_tree()
+
+        assert result.success == 1, f"list_subject_tree should succeed, got error: {result.error}"
+        assert isinstance(result.result, dict), f"Result should be a dict, got {type(result.result)}"
+
+        root, leaf_key = SUBJECT_PATH[0], SUBJECT_PATH[1]
+        assert root in result.result, f"Root subject '{root}' missing from tree: {list(result.result.keys())}"
+        leaf = result.result[root].get(leaf_key)
+        assert isinstance(leaf, dict), f"Leaf subject '{leaf_key}' missing under '{root}': {result.result[root]}"
+
+        assert "school_count" in leaf.get("metrics", []), f"Seeded metric not nested in subject tree: {leaf}"
+        assert "fresno_charter_school_count" in leaf.get("reference_sql", []), (
+            f"Seeded reference SQL not nested in subject tree: {leaf}"
+        )
+        assert "charter_flag_definition" in leaf.get("knowledge", []), (
+            f"Seeded knowledge not nested in subject tree: {leaf}"
+        )
+
+    def test_fuzzy_metric_search_surfaces_school_count(self, ctx_tools):
+        """Fuzzy search: a semantically-related query ('campus count') finds 'school_count'."""
+        assert ctx_tools.has_metrics is True, "Seeded metric should be detected"
+
+        result = ctx_tools.search_metrics("campus count")
+
+        assert result.success == 1, f"search_metrics should succeed, got error: {result.error}"
+        assert isinstance(result.result, list), f"Result should be a list, got {type(result.result)}"
+        assert len(result.result) >= 1, "Fuzzy query 'campus count' should still surface a seeded metric"
+
+        names = [m.get("name") for m in result.result]
+        assert "school_count" in names, f"Fuzzy 'campus count' query should surface 'school_count', got: {names}"
+
+    def test_fuzzy_reference_sql_search_surfaces_seed(self, ctx_tools):
+        """Fuzzy search: a related query surfaces the seeded Fresno charter reference SQL."""
+        assert ctx_tools.has_reference_sql is True, "Seeded reference SQL should be detected"
+
+        result = ctx_tools.search_reference_sql("charter schools in Fresno county")
+
+        assert result.success == 1, f"search_reference_sql should succeed, got error: {result.error}"
+        assert isinstance(result.result, list), f"Result should be a list, got {type(result.result)}"
+        assert len(result.result) >= 1, "Related query should surface a seeded reference SQL"
+
+        names = [r.get("name") for r in result.result]
+        assert "fresno_charter_school_count" in names, (
+            f"Related query should surface the seeded reference SQL, got: {names}"
+        )
+
+    def test_search_semantic_objects_surfaces_catalog_table(self, ctx_tools):
+        """Catalog/schema metadata: search_semantic_objects finds the seeded table object."""
+        assert ctx_tools.has_semantic_objects is True, "Seeded semantic object should be detected"
+
+        result = ctx_tools.search_semantic_objects("schools campus table")
+
+        assert result.success == 1, f"search_semantic_objects should succeed, got error: {result.error}"
+        assert isinstance(result.result, list), f"Result should be a list, got {type(result.result)}"
+        assert len(result.result) >= 1, "Should surface at least the seeded table object"
+
+        names = [obj.get("name") for obj in result.result]
+        assert "schools" in names, f"Seeded table 'schools' should be surfaced, got: {names}"
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestContextInjectionRealLLM:
+    """Injection-layer coverage: context tools are wired into and invoked by gen_sql."""
+
+    def _build_node(self, config: AgentConfig) -> GenSQLAgenticNode:
+        return GenSQLAgenticNode(
+            node_id="nightly_context_injection",
+            description="Nightly context injection node",
+            node_type=NodeType.TYPE_GEN_SQL,
+            agent_config=config,
+            node_name="gen_sql",
+            execution_mode="workflow",
+        )
+
+    def test_context_tools_wired_into_node(self, nightly_agent_config):
+        """Context-search tools are present in the gen_sql node's tool list."""
+        # Seed first so ContextSearchTools detects data and exposes the tools.
+        _seed_all_context_sources(nightly_agent_config)
+
+        node = self._build_node(nightly_agent_config)
+        tool_names = [t.name for t in node.tools]
+
+        assert "search_reference_sql" in tool_names, f"search_reference_sql missing from gen_sql tools: {tool_names}"
+        assert "search_metrics" in tool_names, f"search_metrics missing from gen_sql tools: {tool_names}"
+        assert "list_subject_tree" in tool_names, f"list_subject_tree missing from gen_sql tools: {tool_names}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_execute_stream_invokes_context_tools(self, nightly_agent_config):
+        """End-to-end: the node runs to SUCCESS and invokes at least one tool."""
+        _seed_all_context_sources(nightly_agent_config)
+
+        node = self._build_node(nightly_agent_config)
+
+        node.input = GenSQLNodeInput(
+            user_message=(
+                "How many charter schools are there in Fresno county? "
+                "Before writing SQL, call list_subject_tree and search_reference_sql to look up "
+                "any existing reference SQL for Fresno charter schools, and reuse it."
+            ),
+        )
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+            logger.info(f"Action: role={action.role}, status={action.status}, type={action.action_type}")
+
+        assert len(actions) >= 2, f"Should have at least 2 actions, got {len(actions)}"
+
+        tool_actions = [a for a in actions if a.role == ActionRole.TOOL]
+        assert len(tool_actions) >= 1, (
+            f"At least one TOOL action expected, got {len(tool_actions)}. Action roles: {[a.role for a in actions]}"
+        )
+
+        assert actions[-1].status == ActionStatus.SUCCESS, (
+            f"Last action should be SUCCESS, got {actions[-1].status}: {actions[-1].output}"
+        )

--- a/tests/integration/tools/test_skill_execution.py
+++ b/tests/integration/tools/test_skill_execution.py
@@ -80,7 +80,7 @@ class TestLocalSkillDiscoveryAndExecutionGate:
 
 @pytest.mark.nightly
 @pytest.mark.product_e2e
-@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+@pytest.mark.skipif(not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
 class TestRealLLMSkillExecution:
     """Real-LLM execution of an installed local skill via ChatAgenticNode.
 

--- a/tests/integration/tools/test_skill_execution.py
+++ b/tests/integration/tools/test_skill_execution.py
@@ -1,0 +1,139 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Nightly coverage for the extension flow ``extension.skills`` — the locally
+testable part: skill discovery + permission filtering + real-LLM execution of
+an installed *local* skill through an agentic node.
+
+Marketplace install / update / remove / publish require the external Town
+Backend and are reported scoped-out (no network in this suite).
+
+This file complements the existing tests/integration/tools/test_skill.py (which
+it does not modify):
+- ``TestLocalSkillDiscoveryAndExecutionGate`` is deterministic: it builds a
+  ChatAgenticNode wired with a SkillFuncTool and verifies the node actually
+  exposes the local skill-execution tools (``load_skill`` /
+  ``skill_execute_command``) and that permission filtering narrows the visible
+  skill set by pattern.
+- ``TestRealLLMSkillExecution`` is a real-LLM run: the agent is told to load a
+  local skill and execute one of its commands, and we assert the run reaches a
+  terminal status with the skill actually invoked.
+"""
+
+import os
+
+import pytest
+
+from datus.tools.permission.permission_manager import PermissionManager
+from datus.tools.skill_tools import SkillFuncTool, SkillManager
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+# ============================================================================
+# Deterministic: local skill discovery + permission filtering + tool exposure
+# ============================================================================
+
+
+@pytest.mark.nightly
+class TestLocalSkillDiscoveryAndExecutionGate:
+    """Local skill discovery, permission filtering, and node tool exposure.
+
+    Uses tests/data/skills (the same fixture set the existing skill suite uses)
+    via the shared ``agent_config`` fixture — no marketplace, no network.
+    """
+
+    def test_skill_func_tool_exposes_execution_tools(self, agent_config):
+        """A node wired with SkillFuncTool exposes the local execution tools."""
+        perm_manager = PermissionManager(global_config=agent_config.permissions_config)
+        manager = SkillManager(config=agent_config.skills_config, permission_manager=perm_manager)
+        func_tool = SkillFuncTool(manager=manager, node_name="school_all")
+
+        tool_names = {t.name for t in func_tool.available_tools()}
+        assert "load_skill" in tool_names, f"SkillFuncTool must expose load_skill, got: {sorted(tool_names)}"
+        assert "skill_execute_command" in tool_names, (
+            f"SkillFuncTool must expose skill_execute_command, got: {sorted(tool_names)}"
+        )
+
+    def test_permission_filtering_narrows_visible_skills(self, agent_config):
+        """The sql-* pattern only surfaces sql-* skills, never report/admin ones."""
+        perm_manager = PermissionManager(global_config=agent_config.permissions_config)
+        manager = SkillManager(config=agent_config.skills_config, permission_manager=perm_manager)
+
+        patterns = manager.parse_skill_patterns("sql-*")
+        available = manager.get_available_skills("school_sql", patterns=patterns)
+        names = {s.name for s in available}
+
+        assert "sql-analysis" in names, f"sql-* should include sql-analysis, got: {sorted(names)}"
+        assert "report-generator" not in names, f"sql-* must exclude report-generator, got: {sorted(names)}"
+        # admin-* is DENY in the test permissions config and must never surface.
+        assert "admin-tools" not in names, f"admin-tools must be denied, got: {sorted(names)}"
+
+
+# ============================================================================
+# Real-LLM: agent loads and executes an installed local skill
+# ============================================================================
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.skipif(not os.environ.get("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set")
+class TestRealLLMSkillExecution:
+    """Real-LLM execution of an installed local skill via ChatAgenticNode.
+
+    Reuses the ``llm_agent_config`` fixture (skips automatically when the
+    DEEPSEEK key, california_schools DB, or the local report-generator skill is
+    missing). No marketplace network is touched.
+    """
+
+    QUESTION = (
+        "Use load_skill to load the 'report-generator' skill, then use "
+        "skill_execute_command to run one of its commands to produce a short "
+        "report containing the text 'Alameda'. Keep it simple."
+    )
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(300)
+    async def test_agent_invokes_local_skill(self, llm_agent_config):
+        """N924-SKILL: the agent loads a local skill and reaches a terminal status."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+        from datus.schemas.action_history import ActionHistoryManager
+        from datus.schemas.chat_agentic_node_models import ChatNodeInput
+
+        node = ChatAgenticNode(
+            node_id="nightly_skill_exec",
+            description="local skill execution",
+            node_type="chat",
+            agent_config=llm_agent_config,
+        )
+        node.input = ChatNodeInput(
+            user_message=self.QUESTION,
+            database="california_schools",
+            max_turns=15,
+        )
+
+        assert isinstance(node.permission_manager, PermissionManager), (
+            f"Node must own a PermissionManager for skill gating, got {type(node.permission_manager).__name__}"
+        )
+        node.permission_manager.approve_for_session("skills", "*")
+
+        action_manager = ActionHistoryManager()
+        actions = []
+        async for action in node.execute_stream(action_manager):
+            actions.append(action)
+
+        all_actions = action_manager.get_actions()
+        assert len(all_actions) >= 2, f"Expected at least 2 actions, got {len(all_actions)}"
+
+        action_types = [a.action_type for a in all_actions]
+        action_messages = " ".join(a.messages for a in all_actions)
+        has_load_skill = "load_skill" in action_types or "load_skill" in action_messages
+        assert has_load_skill, f"Agent should invoke load_skill for a local skill. Action types: {action_types}"
+
+        final_action = all_actions[-1]
+        assert final_action.status in ("success", "failed"), (
+            f"Run must reach a terminal status, got {final_action.status}"
+        )

--- a/tests/unit_tests/ci/harness/test_validate_coverage_map.py
+++ b/tests/unit_tests/ci/harness/test_validate_coverage_map.py
@@ -135,3 +135,97 @@ def test_repo_coverage_map_is_valid():
 
     assert errors == []
     assert len(flows) >= 20
+
+
+def _docs_coverage_fixture(tmp_path: Path, *, nav_pages: list[str]) -> None:
+    """Materialize a tiny mkdocs.yml + docs tree under tmp_path for drift tests."""
+    docs_dir = tmp_path / "docs"
+    nav_entries = []
+    for page in nav_pages:
+        target = docs_dir / page
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# page\n", encoding="utf-8")
+        nav_entries.append({page.split("/")[-1]: page})
+    (tmp_path / "mkdocs.yml").write_text(yaml.safe_dump({"nav": nav_entries}), encoding="utf-8")
+
+
+def _docs_coverage_map(*, flow_docs: list[str], exclude: list[dict]) -> dict:
+    return {
+        "source": {"docs_navigation": "mkdocs.yml"},
+        "docs_coverage_policy": {"exclude": exclude},
+        "flow_groups": {"onboarding": {"flows": [{"id": "onboarding.quickstart", "docs": flow_docs}]}},
+    }
+
+
+def _flows(coverage_map: dict):
+    return validate_coverage_map.iter_flows(coverage_map, [])
+
+
+def test_docs_coverage_drift_unowned_nav_page_is_reported(tmp_path):
+    _docs_coverage_fixture(tmp_path, nav_pages=["a.md", "b.md"])
+    coverage_map = _docs_coverage_map(flow_docs=["docs/a.md"], exclude=[])
+
+    errors: list[str] = []
+    validate_coverage_map.validate_docs_coverage(tmp_path, coverage_map, _flows(coverage_map), errors)
+
+    assert any("docs/b.md is in mkdocs nav but no flow references it" in error for error in errors)
+    assert not any("docs/a.md" in error for error in errors)
+
+
+def test_docs_coverage_exclude_suppresses_drift(tmp_path):
+    _docs_coverage_fixture(tmp_path, nav_pages=["a.md", "b.md"])
+    coverage_map = _docs_coverage_map(
+        flow_docs=["docs/a.md"],
+        exclude=[{"path": "docs/b.md", "reason": "Section overview, not a flow."}],
+    )
+
+    errors: list[str] = []
+    validate_coverage_map.validate_docs_coverage(tmp_path, coverage_map, _flows(coverage_map), errors)
+
+    assert errors == []
+
+
+def test_docs_coverage_flow_reference_suppresses_drift(tmp_path):
+    _docs_coverage_fixture(tmp_path, nav_pages=["a.md", "b.md"])
+    coverage_map = _docs_coverage_map(flow_docs=["docs/a.md", "docs/b.md"], exclude=[])
+
+    errors: list[str] = []
+    validate_coverage_map.validate_docs_coverage(tmp_path, coverage_map, _flows(coverage_map), errors)
+
+    assert errors == []
+
+
+def test_docs_coverage_stale_exclude_is_reported(tmp_path):
+    _docs_coverage_fixture(tmp_path, nav_pages=["a.md"])
+    coverage_map = _docs_coverage_map(
+        flow_docs=["docs/a.md"],
+        exclude=[{"path": "docs/gone.md", "reason": "no longer documented"}],
+    )
+
+    errors: list[str] = []
+    validate_coverage_map.validate_docs_coverage(tmp_path, coverage_map, _flows(coverage_map), errors)
+
+    assert errors == ["docs_coverage_policy.exclude: stale entry not in mkdocs nav: docs/gone.md"]
+
+
+def test_docs_coverage_exclude_requires_reason(tmp_path):
+    _docs_coverage_fixture(tmp_path, nav_pages=["a.md", "b.md"])
+    coverage_map = _docs_coverage_map(flow_docs=["docs/a.md"], exclude=[{"path": "docs/b.md"}])
+
+    errors: list[str] = []
+    validate_coverage_map.validate_docs_coverage(tmp_path, coverage_map, _flows(coverage_map), errors)
+
+    assert any("reason: required rationale is missing" in error for error in errors)
+
+
+def test_docs_coverage_is_opt_in_without_policy(tmp_path):
+    _docs_coverage_fixture(tmp_path, nav_pages=["a.md", "b.md"])
+    coverage_map = {
+        "source": {"docs_navigation": "mkdocs.yml"},
+        "flow_groups": {"onboarding": {"flows": [{"id": "onboarding.quickstart", "docs": ["docs/a.md"]}]}},
+    }
+
+    errors: list[str] = []
+    validate_coverage_map.validate_docs_coverage(tmp_path, coverage_map, [], errors)
+
+    assert errors == []


### PR DESCRIPTION
## Why

The docs-driven core-flow coverage map (#910) still tracked several user-facing flows with `gap`/`partial` nightly status. This PR closes the child issues:

- #921 — Add nightly smoke for quickstart and bootstrap-bi entrypoints
- #922 — Strengthen nightly coverage for context injection
- #923 — Expand nightly coverage for data-product subagents
- #924 — Add nightly coverage for extension user flows

## Solution

Added real-dependency nightly integration tests (real LLM via deepseek, local SQLite, self-seeded RAG fixtures). Every real-LLM test is gated with `skipif` on `DEEPSEEK_API_KEY` and marked `nightly`/`product_e2e`, so the nightly harness reruns transient provider flakes and classifies failures cleanly.

- **#921 `onboarding.quickstart`** (gap → covered): `tests/integration/cli/test_quickstart_smoke.py` exercises the documented quickstart chat path end-to-end (natural-language question answered with real-LLM SQL on a local datasource). `onboarding.bootstrap_bi.weekly_benchmark` reclassified `not_applicable` — BI artifact quality is not a weekly-benchmark target.
- **#922 `data_access.context_injection`** (partial → covered): `tests/integration/tools/test_context_injection.py` covers catalog/semantic, subject-tree, reference-SQL, external-knowledge, and fuzzy retrieval, plus a real-LLM check that the SQL-generation node wires in and invokes the context-search tools during generation.
- **#923 `subagents.data_products`** (partial → covered): nightly smoke for `gen_table` (CTAS), `gen_job` (single-DB ETL on an isolated SQLite copy), `gen_visual_report`, and `gen_visual_dashboard`. `weekly_benchmark` reclassified `not_applicable` (no artifact-quality scoring design yet). gen_job cross-DB transfer stays in the unit tier.
- **#924 extension flows**: nightly for `custom_subagents` (config-defined subagent resolves + routes a real-LLM query), `auto_memory` (load + workspace isolation + parent inheritance + real-LLM load check), `workflow_orchestration` (multi-node gen_sql→execute_sql→output via `WorkflowRunner.run_stream`), and local `skills` (discovery + permission filtering + real-LLM execution). Scoped out with rationale in the coverage map: IM gateway Slack/Feishu (`manual` — needs real workspace/tenant credentials), VSCode (`external` — no stable headless automation path), skills marketplace (external Town Backend), and the remember/forget/correct memory write lifecycle (no write tools exist yet; memory filesystem tools are read-only).

`ci/harness/coverage-map.yml` is updated with the new nightly nodeids and status/rationale changes. `validate_coverage_map.py --strict` passes (all referenced nodeids resolve to real test functions).

## Test Cases

Added 10 nightly integration test files:

- `tests/integration/cli/test_quickstart_smoke.py`
- `tests/integration/tools/test_context_injection.py`
- `tests/integration/agent/test_gen_table_agentic.py`
- `tests/integration/agent/test_gen_job_agentic.py`
- `tests/integration/agent/test_gen_visual_report_agentic.py`
- `tests/integration/agent/test_gen_visual_dashboard_agentic.py`
- `tests/integration/agent/test_custom_subagent_agentic.py`
- `tests/integration/agent/test_auto_memory_agentic.py`
- `tests/integration/agent/test_workflow_orchestration.py`
- `tests/integration/tools/test_skill_execution.py`

Local verification (real LLM, deepseek-chat):
- New nightly suite: **31 passed, 1 skipped** (the skip is the real-LLM skill-execution test, gated on `~/.datus/skills/report-generator`, same as the existing nightly skill test; runs in CI where the skill is provisioned).
- PR CI harness (`ci/run-pr-tests.py upstream/main`): **303 passed, 0 failed**; diff coverage N/A (test/yaml-only diff).
- `ci/harness/validate_coverage_map.py --strict`: pass; harness validator unit test: 9 passed.
- `ruff format --check` + `ruff check`: clean; `ci/audit_tests.py` on the new files: **P0=0, P1=0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for auto-memory functionality, custom subagent configuration, multi-node workflow orchestration, and data/visualization generation capabilities.
  * Expanded test coverage for quickstart chat flows, context injection tools, and skill execution with permission management.
  * Updated coverage tracking for agentic features including memory management, subagents, skills, and dashboard/report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad nightly/product end-to-end and deterministic integration tests covering auto-memory, custom subagents, gen-job/gen-table/gen-visual-dashboard/gen-visual-report flows, workflow orchestration, quickstart chat, context injection, and skills execution; added coverage-map validation unit tests.
* **Documentation**
  * Enhanced docs-coverage validation and added explicit doc exclusions; updated coverage metadata and referenced documentation lists across multiple flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->