### PR TITLE
[BugFix] Scope datasource storage and harden metrics bootstrap

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -370,7 +370,10 @@ class Agent:
                 if action_name not in seen:
                     seen.add(action_name)
                     print(f"  {action_name}:", flush=True)
-            self._print_stream_lines(payload.get("output", {}).get("raw_output"), indent="    ", prefix="")
+            raw_output = payload.get("output", {}).get("raw_output")
+            if isinstance(raw_output, str) and len(raw_output) > 500:
+                raw_output = raw_output[:500] + "\n... (truncated)"
+            self._print_stream_lines(raw_output, indent="    ", prefix="")
             # Check for semantic model output
             output = payload.get("output")
             if isinstance(output, dict):

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -10,6 +10,7 @@ metrics generation with support for filesystem tools, generation tools,
 hooks, and metricflow MCP server integration.
 """
 
+import json
 from typing import Any, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
@@ -138,6 +139,37 @@ class GenMetricsAgenticNode(AgenticNode):
             self._setup_ask_user_tool()
 
         logger.info(f"Setup {len(self.tools)} tools for {self.NODE_NAME}: {[tool.name for tool in self.tools]}")
+
+    def _make_filesystem_tool(self, **kwargs):
+        from datus.configuration.inherited_memory_overrides import get_inherited_memory
+        from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
+
+        root_path = kwargs.pop("root_path", None) or self._resolve_workspace_root()
+        datus_home = kwargs.pop("datus_home", None)
+        if datus_home is None and self.agent_config is not None:
+            path_manager = getattr(self.agent_config, "path_manager", None)
+            if path_manager is not None:
+                try:
+                    datus_home = str(path_manager.datus_home)
+                except Exception:
+                    datus_home = None
+        strict = kwargs.pop("strict", None)
+        if strict is None:
+            strict = self._resolve_filesystem_strict()
+        current_node = kwargs.pop("current_node", None) or self.get_node_name()
+        inherited_memory_node = kwargs.pop("inherited_memory_node", None)
+        if inherited_memory_node is None:
+            inherited_memory_node = get_inherited_memory(current_node)
+        session_data_dir = kwargs.pop("session_data_dir", None) or self._resolve_session_data_dir()
+        return MetricFilesystemFuncTool(
+            root_path=root_path,
+            current_node=current_node,
+            datus_home=datus_home,
+            strict=strict,
+            inherited_memory_node=inherited_memory_node,
+            session_data_dir=session_data_dir,
+            **kwargs,
+        )
 
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
@@ -392,7 +424,7 @@ class GenMetricsAgenticNode(AgenticNode):
             else:
                 response_content = str(ctx.last_successful_output)
 
-        semantic_model_file, metric_file, status, extracted_output = self._extract_metric_and_output_from_response(
+        semantic_model_files, metric_file, status, extracted_output = self._extract_metric_and_output_from_response(
             {"content": response_content}
         )
         if extracted_output:
@@ -402,7 +434,7 @@ class GenMetricsAgenticNode(AgenticNode):
             response_content = str(response_content) if response_content else ""
 
         self._finalize_metric_generation(
-            semantic_model_file=semantic_model_file,
+            semantic_model_files=semantic_model_files,
             metric_file=metric_file,
             status=status,
         )
@@ -446,12 +478,114 @@ class GenMetricsAgenticNode(AgenticNode):
     def _set_metric_queryability_contracts_from_input(self, user_input: Optional[SemanticNodeInput]) -> None:
         if not user_input:
             return
-        contracts = extract_metric_queryability_contracts(getattr(user_input, "user_message", "") or "")
-        self.generation_evidence.set_metric_queryability_contracts(contracts)
+        user_message = getattr(user_input, "user_message", "") or ""
+        contracts = extract_metric_queryability_contracts(user_message)
+        candidate_plan = self._extract_precomputed_candidate_plan(user_message)
+        metric_aliases = self._metric_aliases_from_candidate_plan(candidate_plan)
+        blocked_sources = self._blocked_queryability_sources_from_candidate_plan(candidate_plan)
+        if blocked_sources:
+            contracts = [
+                contract
+                for contract in contracts
+                if not (self._source_name_set(contract.get("source")) & blocked_sources)
+            ]
+        self.generation_evidence.set_metric_queryability_contracts(contracts, metric_aliases=metric_aliases)
+
+    @classmethod
+    def _metric_aliases_from_user_message(cls, user_message: str) -> Dict[str, str]:
+        plan = cls._extract_precomputed_candidate_plan(user_message)
+        return cls._metric_aliases_from_candidate_plan(plan)
+
+    @classmethod
+    def _blocked_queryability_sources_from_user_message(cls, user_message: str) -> set[str]:
+        plan = cls._extract_precomputed_candidate_plan(user_message)
+        return cls._blocked_queryability_sources_from_candidate_plan(plan)
+
+    @staticmethod
+    def _extract_precomputed_candidate_plan(user_message: str) -> Dict[str, Any]:
+        marker = "## Precomputed Metric Candidate Plan JSON"
+        if marker not in user_message:
+            return {}
+        section = user_message.split(marker, 1)[1]
+        next_heading = section.find("\n\n## ")
+        if next_heading >= 0:
+            section = section[:next_heading]
+        json_start = min((idx for idx in (section.find("{"), section.find("[")) if idx >= 0), default=-1)
+        if json_start < 0:
+            return {}
+        payload = section[json_start:].strip()
+        try:
+            loaded = json.loads(payload)
+        except (TypeError, json.JSONDecodeError):
+            logger.debug("Failed to parse precomputed metric candidate plan JSON from gen_metrics prompt")
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    @staticmethod
+    def _metric_aliases_from_candidate_plan(candidate_plan: Dict[str, Any]) -> Dict[str, str]:
+        aliases: Dict[str, str] = {}
+
+        def add(alias: Any, canonical: Any) -> None:
+            if not isinstance(alias, str) or not isinstance(canonical, str):
+                return
+            alias = alias.strip()
+            canonical = canonical.strip()
+            if alias and canonical and alias != canonical:
+                aliases[alias] = canonical
+
+        for item in candidate_plan.get("metric_aliases") or []:
+            if not isinstance(item, dict):
+                continue
+            canonical = item.get("canonical_name") or item.get("name")
+            add(item.get("source_alias"), canonical)
+            add(item.get("candidate_name"), canonical)
+
+        for key in (
+            "direct_metric_candidates",
+            "derived_metric_candidates",
+            "metric_candidates",
+            "identity_metric_references",
+        ):
+            for candidate in candidate_plan.get(key) or []:
+                if not isinstance(candidate, dict):
+                    continue
+                canonical = candidate.get("name")
+                add(candidate.get("source_alias"), canonical)
+                for source_alias in candidate.get("source_aliases") or []:
+                    add(source_alias, canonical)
+                for candidate_name in candidate.get("candidate_names") or []:
+                    add(candidate_name, canonical)
+                for mapping in candidate.get("source_alias_mappings") or []:
+                    if not isinstance(mapping, dict):
+                        continue
+                    add(mapping.get("source_alias"), canonical)
+                    add(mapping.get("candidate_name"), canonical)
+        return aliases
+
+    @classmethod
+    def _blocked_queryability_sources_from_candidate_plan(cls, candidate_plan: Dict[str, Any]) -> set[str]:
+        blocked_sources: set[str] = set()
+        for item in candidate_plan.get("source_classifications") or []:
+            if not isinstance(item, dict):
+                continue
+            if item.get("classification") != "metric_plus_derived_datasource":
+                continue
+            blocked_sources.update(cls._source_name_set(item.get("source_sql_name")))
+
+        for item in candidate_plan.get("blocked_direct_metric_candidates") or []:
+            if isinstance(item, dict):
+                blocked_sources.update(cls._source_name_set(item.get("source_sql_name")))
+        return blocked_sources
+
+    @staticmethod
+    def _source_name_set(value: Any) -> set[str]:
+        if not isinstance(value, str):
+            return set()
+        return {part.strip() for part in value.split(",") if part.strip()}
 
     def _finalize_metric_generation(
         self,
-        semantic_model_file: Optional[str],
+        semantic_model_files: Optional[List[str] | str],
         metric_file: Optional[str],
         status: Optional[str],
     ) -> None:
@@ -493,26 +627,40 @@ class GenMetricsAgenticNode(AgenticNode):
                 )
 
         abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
-        abs_semantic_model_file = (
-            self._resolve_metric_artifact_path(semantic_model_file, "semantic") if semantic_model_file else ""
-        )
+        if isinstance(semantic_model_files, str):
+            semantic_model_file_candidates = [semantic_model_files]
+        else:
+            semantic_model_file_candidates = semantic_model_files or []
+        abs_semantic_model_files = [
+            self._resolve_metric_artifact_path(semantic_model_file, "semantic")
+            for semantic_model_file in semantic_model_file_candidates
+            if semantic_model_file
+        ]
         preflight_error = self.generation_tools._validate_metric_file_has_blocks(abs_metric_file)
         if preflight_error:
             raise RuntimeError(preflight_error)
 
         metric_names = self.generation_tools._extract_metric_names_from_file(abs_metric_file)
-        if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
+        metric_definitions = self.generation_tools._extract_metric_definitions_from_file(abs_metric_file)
+        required_metric_names = self.generation_tools._metric_names_requiring_dry_run(
+            metric_names,
+            metric_definitions,
+            self.generation_evidence.metric_sqls,
+        )
+        if required_metric_names and not self.generation_evidence.has_metric_dry_run(required_metric_names):
             if not getattr(self, "semantic_tools", None):
                 raise RuntimeError("Metric generation produced a metric_file, but query_metrics is unavailable.")
-            dry_run_result = self.semantic_tools.query_metrics(metrics=metric_names, dry_run=True)
-            self.generation_evidence.record_metric_dry_run(metric_names, dry_run_result)
+            dry_run_result = self.semantic_tools.query_metrics(metrics=required_metric_names, dry_run=True)
+            self.generation_evidence.record_metric_dry_run(required_metric_names, dry_run_result)
             if not self._tool_succeeded(dry_run_result):
                 raise RuntimeError(
                     "query_metrics(dry_run=True) failed for generated metric(s) "
-                    f"{', '.join(metric_names)}: {self._tool_error(dry_run_result)}"
+                    f"{', '.join(required_metric_names)}: {self._tool_error(dry_run_result)}"
                 )
-        if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
-            missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
+        if required_metric_names and not self.generation_evidence.has_required_queryability_dry_runs(
+            required_metric_names
+        ):
+            missing_contracts = self.generation_evidence.missing_queryability_contracts(required_metric_names)
             raise DatusException(
                 ErrorCode.COMMON_VALIDATION_FAILED,
                 "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions before "
@@ -523,7 +671,7 @@ class GenMetricsAgenticNode(AgenticNode):
 
         publish_result = self.generation_tools.end_metric_generation(
             metric_file=abs_metric_file,
-            semantic_model_file=abs_semantic_model_file,
+            semantic_model_files=abs_semantic_model_files,
         )
         if not self._tool_succeeded(publish_result):
             raise RuntimeError(f"Metric KB sync failed: {self._tool_error(publish_result)}")
@@ -531,12 +679,12 @@ class GenMetricsAgenticNode(AgenticNode):
 
     def _extract_metric_and_output_from_response(
         self, output: dict
-    ) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[Optional[List[str]], Optional[str], Optional[str], Optional[str]]:
         """
-        Extract semantic model file, metric file, status and formatted output from model response.
+        Extract semantic model files, metric file, status and formatted output from model response.
 
         Per prompt template requirements, LLM should return JSON format:
-        {"semantic_model_file": "path.yml", "metric_file": "path.yml",
+        {"semantic_model_files": ["path.yml"], "metric_file": "path.yml",
          "status": "generated" | "skipped", "output": "markdown text"}
 
         ``status`` is optional for backward compatibility; absent values are treated as ``"generated"``.
@@ -545,7 +693,7 @@ class GenMetricsAgenticNode(AgenticNode):
             output: Output dictionary from model generation
 
         Returns:
-            Tuple of (semantic_model_file, metric_file, status, output_string), each Optional[str].
+            Tuple of (semantic_model_files, metric_file, status, output_string).
         """
         try:
             from datus.utils.json_utils import strip_json_str
@@ -556,17 +704,17 @@ class GenMetricsAgenticNode(AgenticNode):
             # Case 1: content is already a dict (most common)
             if isinstance(content, dict):
                 output_text = content.get("output")
-                semantic_model_file = content.get("semantic_model_file")
+                semantic_model_files = self._normalize_semantic_model_files(content)
                 metric_file = content.get("metric_file")
                 status = content.get("status")
                 normalized_status = status.strip().lower() if isinstance(status, str) else None
 
                 if (metric_file and isinstance(metric_file, str)) or normalized_status:
                     logger.debug(
-                        f"Extracted from dict: semantic_model_file={semantic_model_file}, "
+                        f"Extracted from dict: semantic_model_files={semantic_model_files}, "
                         f"metric_file={metric_file}, status={normalized_status}"
                     )
-                    return semantic_model_file, metric_file, normalized_status, output_text
+                    return semantic_model_files, metric_file, normalized_status, output_text
 
                 logger.warning(f"Dict format but missing expected keys or invalid format: {content.keys()}")
 
@@ -581,7 +729,7 @@ class GenMetricsAgenticNode(AgenticNode):
                         parsed = json_repair.loads(cleaned_json)
                         if isinstance(parsed, dict):
                             output_text = parsed.get("output")
-                            semantic_model_file = parsed.get("semantic_model_file")
+                            semantic_model_files = self._normalize_semantic_model_files(parsed)
                             metric_file = parsed.get("metric_file")
                             status = parsed.get("status")
                             normalized_status = status.strip().lower() if isinstance(status, str) else None
@@ -589,10 +737,10 @@ class GenMetricsAgenticNode(AgenticNode):
                             if (metric_file and isinstance(metric_file, str)) or normalized_status:
                                 logger.debug(
                                     f"Extracted from JSON string: "
-                                    f"semantic_model_file={semantic_model_file}, "
+                                    f"semantic_model_files={semantic_model_files}, "
                                     f"metric_file={metric_file}, status={normalized_status}"
                                 )
-                                return semantic_model_file, metric_file, normalized_status, output_text
+                                return semantic_model_files, metric_file, normalized_status, output_text
 
                             logger.warning(f"Parsed JSON but missing expected keys or invalid format: {parsed.keys()}")
                     except Exception as e:
@@ -604,3 +752,23 @@ class GenMetricsAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Unexpected error extracting metric_file: {e}", exc_info=True)
             return None, None, None, None
+
+    @staticmethod
+    def _normalize_semantic_model_files(content: Dict[str, Any]) -> List[str]:
+        raw_files = content.get("semantic_model_files")
+        if raw_files is None:
+            raw_files = content.get("semantic_model_file")
+        if isinstance(raw_files, str):
+            candidates = [raw_files]
+        elif isinstance(raw_files, list):
+            candidates = raw_files
+        else:
+            candidates = []
+        result: List[str] = []
+        for item in candidates:
+            if not isinstance(item, str):
+                continue
+            value = item.strip()
+            if value and value not in result:
+                result.append(value)
+        return result

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -354,7 +354,7 @@ def _classify_subject_paths(
         return buckets
 
     try:
-        subject_tree = get_subject_tree_store(project=agent_config.project_name)
+        subject_tree = get_subject_tree_store(project=agent_config.project_name, datasource_id=ds)
         metric_storage = MetricRAG(agent_config, datasource_id=ds).storage
         sql_storage = ReferenceSqlRAG(agent_config, datasource_id=ds).reference_sql_storage
     except Exception:

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -63,7 +63,13 @@ class DatasourceService:
             return self.semantic_rag
         self.current_datasource = self.agent_config.current_datasource
         if not self.current_datasource:
-            raise ValueError("No datasource is selected")
+            from datus.utils.exceptions import DatusException
+            from datus.utils.exceptions import ErrorCode as StorageErrorCode
+
+            raise DatusException(
+                StorageErrorCode.STORAGE_INVALID_ARGUMENT,
+                message_args={"error_message": "No datasource is selected"},
+            )
         self.semantic_rag = SemanticModelRAG(self.agent_config, datasource_id=self.current_datasource)
         return self.semantic_rag
 

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -50,11 +50,22 @@ class DatasourceService:
 
         self.db_manager = DBManager(agent_config.datasource_configs)
         self.current_datasource = agent_config.current_datasource
-        self.semantic_rag = SemanticModelRAG(self.agent_config)
+        self.semantic_rag = SemanticModelRAG(self.agent_config) if self.current_datasource else None
 
         self.current_db_connector = None
         self.current_db_name = None
         self._initialize_connection()
+
+    def _ensure_semantic_rag(self) -> SemanticModelRAG:
+        """Create semantic model storage only after a datasource is selected."""
+
+        if self.semantic_rag is not None:
+            return self.semantic_rag
+        self.current_datasource = self.agent_config.current_datasource
+        if not self.current_datasource:
+            raise ValueError("No datasource is selected")
+        self.semantic_rag = SemanticModelRAG(self.agent_config, datasource_id=self.current_datasource)
+        return self.semantic_rag
 
     def _get_database_type(self, database_name: Optional[str] = None) -> tuple[str, str]:
         """
@@ -398,7 +409,7 @@ class DatasourceService:
         table_name = name_parts["table_name"]
 
         # Get semantic model using SemanticMetricsRAG
-        semantic_model = self.semantic_rag.get_semantic_model(
+        semantic_model = self._ensure_semantic_rag().get_semantic_model(
             catalog_name=catalog_name,
             database_name=database_name,
             schema_name=schema_name,

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -61,6 +61,16 @@ class ExplorerService:
             datasource_id=self.datasource_id,
         )
 
+    def _require_datasource(self) -> None:
+        """Raise if no datasource is bound to this service instance."""
+        if not self.datasource_id:
+            from datus.utils.exceptions import DatusException, ErrorCode
+
+            raise DatusException(
+                ErrorCode.STORAGE_INVALID_ARGUMENT,
+                message_args={"error_message": "No datasource is selected; select a datasource first"},
+            )
+
     def _gen_reference_sql_id(self, sql: str) -> str:
         """Generate a stable identifier for reference SQL entries."""
         from datus.storage.reference_sql.init_utils import gen_reference_sql_id
@@ -319,6 +329,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             logger.info(f"Creating directory at path: {request.subject_path}")
 
             # Use SubjectTreeStore to create or find the directory path
@@ -358,6 +369,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             logger.info(f"Creating reference SQL '{request.name}' at path: {request.subject_path}")
             from datus.api.models.config_models import ErrorCode
 
@@ -413,6 +425,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             logger.info(f"Renaming {request.type} from {request.subject_path} to {request.new_subject_path}")
             from datus.api.models.config_models import ErrorCode
             from datus.api.models.explorer_models import SubjectNodeType
@@ -672,6 +685,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             logger.info(f"Editing reference SQL at path: {request.subject_path}")
             from datus.api.models.config_models import ErrorCode
 
@@ -744,6 +758,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             import yaml
 
             from datus.api.models.config_models import ErrorCode
@@ -887,6 +902,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             import yaml
 
             from datus.api.models.config_models import ErrorCode
@@ -1035,6 +1051,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             from datus.api.models.config_models import ErrorCode
 
             logger.info(f"Editing semantic model entry: {request.entry_id}")
@@ -1087,6 +1104,7 @@ class ExplorerService:
             Result[dict]
         """
         try:
+            self._require_datasource()
             logger.info(f"Deleting {request.type} at path: {request.subject_path}")
             from datus.api.models.config_models import ErrorCode
             from datus.api.models.explorer_models import SubjectNodeType

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -37,8 +37,16 @@ class ExplorerService:
             agent_config: Agent configuration object
         """
         self.agent_config = agent_config
-        self.datasource_id = agent_config.current_datasource
+        self.datasource_id = str(agent_config.current_datasource or "").strip()
         logger.info("ExplorerService initialized")
+
+        self.metric_rag = None
+        self.reference_sql_rag = None
+        self.semantic_model_rag = None
+        self.subject_tree_store = None
+        if not self.datasource_id:
+            logger.info("ExplorerService initialized without datasource; subject tree is empty until one is selected")
+            return
 
         from datus.storage.metric.store import MetricRAG
         from datus.storage.reference_sql.store import ReferenceSqlRAG
@@ -48,7 +56,10 @@ class ExplorerService:
         self.metric_rag = MetricRAG(agent_config, datasource_id=self.datasource_id)
         self.reference_sql_rag = ReferenceSqlRAG(agent_config, datasource_id=self.datasource_id)
         self.semantic_model_rag = SemanticModelRAG(agent_config, datasource_id=self.datasource_id)
-        self.subject_tree_store = get_subject_tree_store(project=agent_config.project_name)
+        self.subject_tree_store = get_subject_tree_store(
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
+        )
 
     def _gen_reference_sql_id(self, sql: str) -> str:
         """Generate a stable identifier for reference SQL entries."""
@@ -209,6 +220,9 @@ class ExplorerService:
             logger.info("Getting subject list")
 
             from datus.api.models.explorer_models import SubjectNodeType
+
+            if self.subject_tree_store is None:
+                return Result[SubjectListData](success=True, data=SubjectListData(subjects=[]))
 
             # Get tree structure from subject tree store
             tree_structure = self.subject_tree_store.get_tree_structure()
@@ -684,6 +698,7 @@ class ExplorerService:
                 subject_path=parent_path,
                 name=sql_name,
                 update_values=update_values,
+                extra_conditions=self.reference_sql_rag._sub_agent_conditions(),
             )
 
             logger.info(f"Successfully updated reference SQL: {sql_name}")
@@ -1041,6 +1056,7 @@ class ExplorerService:
             self.semantic_model_rag.storage.update_entry(
                 entry_id=request.entry_id,
                 update_values=request.update_values,
+                extra_conditions=self.semantic_model_rag._sub_agent_conditions(),
             )
 
             logger.info(f"Successfully updated semantic model entry: {request.entry_id}")

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -544,6 +544,7 @@ class ExplorerService:
             Result[MetricInfo] with metric name and YAML content
         """
         try:
+            self._require_datasource()
             import yaml
 
             from datus.api.models.config_models import ErrorCode
@@ -611,6 +612,7 @@ class ExplorerService:
             Result[GetReferenceSQLData] with SQL details
         """
         try:
+            self._require_datasource()
             logger.info(f"Getting reference SQL at path: {subject_path}")
             from datus.api.models.config_models import ErrorCode
 

--- a/datus/cli/bootstrap_streams.py
+++ b/datus/cli/bootstrap_streams.py
@@ -358,8 +358,8 @@ async def stream_reference_sql(
 
     if build_mode == "overwrite":
         logger.info(
-            "[overwrite] Wiping reference_sql store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping reference_sql rows for datasource '%s' before re-population",
+            storage.datasource_id,
         )
         storage.truncate()
         yield message_action("Reference SQL: cleared existing entries (overwrite mode).")

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1146,7 +1146,14 @@ class GenerationHooks(AgentHooks):
                             measure_name = base_measures[0]
                             # Query semantic objects to find the measure's table
                             measure_objs = semantic_rag.storage._search_all(
-                                where=And([eq("kind", "column"), eq("is_measure", True), eq("name", measure_name)])
+                                where=And(
+                                    [
+                                        eq("kind", "column"),
+                                        eq("is_measure", True),
+                                        eq("name", measure_name),
+                                    ]
+                                    + semantic_rag._sub_agent_conditions()
+                                )
                             ).to_pylist()
                             if measure_objs:
                                 measure_table = measure_objs[0].get("table_name", "")

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -97,6 +97,8 @@ Before generating metrics, verify that semantic models exist for all involved ta
 - Restrict filesystem reads/writes/reuse to `{{ kind_subdir }}/...`. Do not read, reuse, edit, or sync YAML files from sibling datasource directories; they are outside the active `{{ current_datasource }}` MetricFlow adapter scope.
 - Preserve final business output expressions as metric candidates.
 - Parse aggregations (SUM, COUNT, AVG, etc.) → dependency measures
+- Support aggregations that only feed another final KPI should be added/reused as semantic-model measures, not published as separate top-level metrics unless the user question or candidate plan identifies them as final KPIs.
+- Treat `support_measure_candidates` as dependency or comparison measures only. Do not publish a `metric:` block for them; add/reuse the measure only when another generated metric needs it.
 - Parse GROUP BY → dimensions
 - Deduplicate only the underlying measure definition when the aggregation/expression is identical
 - Preserve separate metrics when filters or business semantics differ (e.g., paid revenue vs refunded revenue)
@@ -138,7 +140,7 @@ Skip any metric that already exists — do NOT update or overwrite.
 
 ### Step 5: Write, Validate, and Dry-Run
 
-**File paths**: All `write_file` / `edit_file` / `read_file` calls — and the `metric_file` / `semantic_model_file` arguments to `end_metric_generation` — should include the `{{ kind_subdir }}/` prefix:
+**File paths**: All `write_file` / `edit_file` / `read_file` calls — and the `metric_file` / `semantic_model_files` arguments to `end_metric_generation` — should include the `{{ kind_subdir }}/` prefix:
   - Semantic model: `{{ kind_subdir }}/{table_name}.yml`
   - Metric file: `{{ kind_subdir }}/metrics/{table_name}_metrics.yml`
   Bare filenames are silently normalized by the host but the prefixed form is preferred so subsequent reads use the same path. Absolute paths are also tolerated.
@@ -160,7 +162,7 @@ Review each generated metric yourself:
 ### Step 7: Batch Sync to Knowledge Base
 
 After all generated metrics pass validation and dry-run SQL:
-- You MUST call `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` ONCE to sync them to Knowledge Base and catch publish errors while you can still fix files
+- You MUST call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` ONCE to sync them to Knowledge Base and catch publish errors while you can still fix files
 - Do not rely on the final JSON host fallback. The host fallback is only a last-resort guard when the tool call was accidentally missed.
 - If no metrics were generated, do NOT call `end_metric_generation`
 
@@ -175,14 +177,14 @@ After all generated metrics pass validation and dry-run SQL:
 
 ```json
 {
-  "semantic_model_file": "{{ kind_subdir }}/{table_name}.yml",
+  "semantic_model_files": ["{{ kind_subdir }}/{table_name}.yml"],
   "metric_file": "{{ kind_subdir }}/metrics/{table_name}_metrics.yml",
   "status": "generated",
   "output": "markdown summary of the metric definition"
 }
 ```
 
-- `semantic_model_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/users.yml"`
+- `semantic_model_files`: List of paths using the semantic model prefix, e.g. `["{{ kind_subdir }}/users.yml"]`; use an empty array when no semantic model file was changed
 - `metric_file`: Path using the semantic model prefix, e.g. `"{{ kind_subdir }}/metrics/users_metrics.yml"`
 - `status`: One of `"generated"` (at least one new metric was created and synced via `end_metric_generation`) or `"skipped"` (every requested metric already existed and was skipped per Step 4 — set `metric_file` to `null` in this case).
 - `output`: Brief summary message
@@ -191,7 +193,7 @@ After all generated metrics pass validation and dry-run SQL:
 If every requested metric already exists, return:
 ```json
 {
-  "semantic_model_file": null,
+  "semantic_model_files": [],
   "metric_file": null,
   "status": "skipped",
   "output": "All requested metrics already exist; no new metric was generated."
@@ -362,7 +364,7 @@ metric:
 {% else %}1. **Proceed carefully**: If required input is missing or ambiguous, stop and explain what information is needed.
 {% endif %}
 2. **Skill-first**: Always check for and load matching skills before proceeding
-3. **Preserve final output expressions**: Historical SQL aliases and final SELECT expressions are metric candidates; base measures are dependencies
+3. **Preserve final output expressions**: Historical SQL aliases and final SELECT expressions are metric candidates; base measures are dependencies, not automatically separate metrics
 4. **COUNT requires `expr: "1"`**: Never use `expr: {column}` with `agg: COUNT`
 5. **Primary time dimension correctness**: Every metric data_source needs one primary `type: TIME` dimension when a reliable DATE/TIME/TIMESTAMP column or expression exists. Do not force a primary TIME dimension from numeric surrogate keys; use a `sql_query` join to a date dimension or an explicit date conversion first.
 6. **Validate**: Always validate before completing

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -86,6 +86,8 @@ Call `analyze_metric_candidates_from_history` with all parsed SQL queries and `e
 10. **Cross-reference with Phase 0** — remove any candidate that already exists in the knowledge base.
 11. **Separate derived metrics** — treat `derived_metric_candidates` as second-stage metrics over existing metrics. Do not mix them into base semantic model or measure generation.
 12. **Ignore passthrough references** — entries in `identity_metric_references` show existing metrics selected without new business formula; do not generate new metrics for them.
+13. **Do not promote support measures** — a SELECT projection that only supports another final KPI, such as a denominator, row count, or intermediate aggregation, may be added as a semantic-model measure. Do not also wrap it as a top-level business metric unless the user question or candidate plan identifies it as a final KPI.
+14. **Respect `support_measure_candidates`** — these are dependency or comparison measures, not direct metrics. You may add them to a semantic model only if a generated metric needs them, but do not publish a `metric:` block for them.
 
 **Step 1-batch-c: Business metric principle**
 
@@ -93,6 +95,7 @@ From N SQL queries, propose a focused set of business metrics. Ask yourself for 
 - Is this a final output a business user would recognize as a KPI?
 - Are its base measures complete enough to validate and dry-run?
 - Should the evidence be a metric, or only a filter/dimension/segment/view definition?
+- Is this alias only a supporting count/sum used by another final output? If yes, create or reuse the measure but do not publish a separate metric for it.
 - Does the tool say the metric depends on a ranked/windowed CTE or other derived data source? If yes, generate the derived data source first instead of forcing a direct metric.
 - Are SQL literals, output time grain, and HAVING/post-aggregation constraints preserved from the tool evidence?
 
@@ -200,7 +203,7 @@ Use when: non-equi JOINs, > 2 hop joins, subqueries, LATERAL/CROSS joins, comple
 - Metric file: `subject/semantic_models/<current_datasource>/metrics/{table_name}_metrics.yml`
 
 Bare filenames are silently normalized by the host, but the prefixed form is preferred for clarity. Absolute paths are also tolerated.
-Do not read, edit, or pass `metric_file` / `semantic_model_file` paths from another datasource directory such as `subject/semantic_models/other_datasource/...`.
+Do not read, edit, or pass `metric_file` / `semantic_model_files` paths from another datasource directory such as `subject/semantic_models/other_datasource/...`.
 
 1. **Check existing**: Call `check_semantic_object_exists(name="{metric_name}", kind="metric")` for each metric confirmed in Phase 1. If it already exists, inform the user and skip it.
 
@@ -222,7 +225,7 @@ Do not read, edit, or pass `metric_file` / `semantic_model_file` paths from anot
 
 After all generated metrics have passed validation and dry-run:
 - Collect all generated metrics and their dry-run SQLs into `metric_sqls_json`
-- You MUST call `end_metric_generation(metric_file, semantic_model_file, metric_sqls_json)` **ONCE** to sync them to Knowledge Base while you can still fix publish errors
+- You MUST call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` **ONCE** to sync them to Knowledge Base while you can still fix publish errors
 - Do not rely on the final JSON host fallback. The host fallback is only a last-resort guard when the tool call was accidentally missed.
 - If no metrics were generated, do NOT call `end_metric_generation`
 
@@ -243,6 +246,8 @@ Phase 1 confirms the generation scope; validation plus dry-run are the acceptanc
 6. **Every metric needs explicit YAML**: Whether it's a simple aggregation, filtered variant, ratio, expr, derived, or cumulative — write a `metric:` entry in the metrics YAML file so it can be persisted and discovered later.
 
 7. **Derived metrics are second-stage**: Generate non-derived metrics first, validate them, refresh the metric catalog with `list_metrics`, then generate `derived_metric_candidates` only when every referenced metric exists in the refreshed catalog or was generated earlier in the same batch.
+
+8. **Support measures are not always metrics**: Add support measures needed for ratios, expressions, filters, and validation, but do not publish each support measure as a separate metric unless it is itself a requested/final business KPI.
 
 ## Important Rules
 

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -14,6 +14,12 @@ import pyarrow as pa
 from datus_storage_base.conditions import WhereExpr
 from datus_storage_base.vector.base import VectorDatabase, VectorTable
 
+from datus.storage.datasource_scope import (
+    DATASOURCE_ID_COLUMN,
+    STORAGE_KEY_COLUMN,
+    build_storage_key,
+    datasource_condition,
+)
 from datus.storage.embedding_models import EmbeddingModel
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -83,6 +89,7 @@ class BaseEmbeddingStore(StorageBase):
         extra_fields: Optional[List[pa.Field]] = None,
         default_values: Optional[Dict[str, Any]] = None,
         scope_indices: Optional[List[str]] = None,
+        datasource_scoped: bool = False,
     ):
         super().__init__(db=db)
         self.model = embedding_model
@@ -94,16 +101,22 @@ class BaseEmbeddingStore(StorageBase):
         # Append extra fields to schema if provided
         if schema is not None and extra_fields:
             schema = pa.schema(list(schema) + extra_fields)
-        # Ensure datasource_id field exists for subject-tree-based stores
-        # (needed for RDB subject tree lookups even in PHYSICAL isolation mode)
-        if schema is not None:
+        # Datasource-scoped shared tables keep the physical namespace at the
+        # project level and isolate rows by datasource_id/storage_key.
+        if datasource_scoped and schema is not None:
             existing_names = {f.name for f in schema}
-            if "datasource_id" not in existing_names:
-                schema = pa.schema(list(schema) + [pa.field("datasource_id", pa.string())])
+            extra_scope_fields = []
+            if DATASOURCE_ID_COLUMN not in existing_names:
+                extra_scope_fields.append(pa.field(DATASOURCE_ID_COLUMN, pa.string()))
+            if "id" in existing_names and STORAGE_KEY_COLUMN not in existing_names:
+                extra_scope_fields.append(pa.field(STORAGE_KEY_COLUMN, pa.string()))
+            if extra_scope_fields:
+                schema = pa.schema(list(schema) + extra_scope_fields)
         self._schema = schema
         self._unique_columns = unique_columns
         self._default_values: Dict[str, Any] = dict(default_values) if default_values else {}
         self._scope_indices: List[str] = list(scope_indices or [])
+        self._datasource_scoped = datasource_scoped
         # Delay table initialization until first use.
         self._shared = _SharedTableState()
         self._table_lock = Lock()
@@ -143,6 +156,7 @@ class BaseEmbeddingStore(StorageBase):
         if not self.db.table_exists(self.table_name):
             return None
         self.table = self.db.open_table(self.table_name)
+        self._ensure_persisted_scope_columns()
         return self.table
 
     def _empty_result(self, select_fields: Optional[List[str]] = None) -> pa.Table:
@@ -165,12 +179,51 @@ class BaseEmbeddingStore(StorageBase):
 
     def _apply_default_values(self, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Fill in default values for rows that are missing them."""
-        if not self._default_values:
-            return data
+        schema_names = set(self._schema.names) if self._datasource_scoped and self._schema is not None else set()
         for row in data:
+            if DATASOURCE_ID_COLUMN in schema_names:
+                row.setdefault(DATASOURCE_ID_COLUMN, "")
+            if STORAGE_KEY_COLUMN in schema_names and row.get("id") not in (None, ""):
+                row.setdefault(STORAGE_KEY_COLUMN, build_storage_key(row.get(DATASOURCE_ID_COLUMN, ""), row["id"]))
             for k, v in self._default_values.items():
                 row.setdefault(k, v)
         return data
+
+    def _scope_column_migration_exprs(self) -> Dict[str, str]:
+        """Return default SQL expressions for missing row-scope columns."""
+
+        if not self._datasource_scoped or self._schema is None:
+            return {}
+        schema_names = set(self._schema.names)
+        exprs: Dict[str, str] = {}
+        if DATASOURCE_ID_COLUMN in schema_names:
+            exprs[DATASOURCE_ID_COLUMN] = "''"
+        if STORAGE_KEY_COLUMN in schema_names and "id" in schema_names:
+            exprs[STORAGE_KEY_COLUMN] = "'legacy:' || id"
+        return exprs
+
+    def _ensure_persisted_scope_columns(self) -> None:
+        """Best-effort migration for existing vector tables missing scope columns."""
+
+        if self.table is None:
+            return
+        ensure_columns = getattr(self.table, "ensure_columns", None)
+        if ensure_columns is None:
+            return
+        exprs = self._scope_column_migration_exprs()
+        if not exprs:
+            return
+        try:
+            ensure_columns(exprs)
+        except Exception as exc:
+            raise DatusException(
+                ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                message_args={
+                    "operation": "ensure_scope_columns",
+                    "table_name": self.table_name,
+                    "error_message": str(exc),
+                },
+            ) from exc
 
     def _search_all(
         self, where: WhereExpr = None, select_fields: Optional[List[str]] = None, limit: Optional[int] = None
@@ -243,14 +296,24 @@ class BaseEmbeddingStore(StorageBase):
             self._shared.initialized = False
 
     def truncate_scoped(self) -> None:
-        """Delete all rows visible to the current connection.
+        """Legacy full-table truncate alias.
 
-        With PHYSICAL-only isolation this is equivalent to ``truncate()``
-        (drops the whole table); the method is retained as a stable alias
-        for call sites that previously relied on row-scoped deletion under
-        LOGICAL isolation.
+        Datasource-scoped overwrite paths must call ``delete_datasource_rows``
+        instead of this method.
         """
         self.truncate()
+
+    def delete_datasource_rows(self, datasource_id: str) -> None:
+        """Delete rows for one datasource without dropping the project table."""
+
+        if not self._datasource_scoped:
+            raise DatusException(
+                ErrorCode.STORAGE_INVALID_ARGUMENT,
+                message_args={
+                    "error_message": f"table '{self.table_name}' is not datasource-scoped",
+                },
+            )
+        self._delete_rows(datasource_condition(datasource_id))
 
     def _ensure_table(self, schema: Optional[pa.Schema] = None):
         if self.db.table_exists(self.table_name):
@@ -276,6 +339,7 @@ class BaseEmbeddingStore(StorageBase):
                     ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
                     message_args={"operation": "create_table", "table_name": self.table_name, "error_message": str(e)},
                 ) from e
+        self._ensure_persisted_scope_columns()
 
     def create_vector_index(
         self,

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -181,12 +181,12 @@ class BaseEmbeddingStore(StorageBase):
         """Fill in default values for rows that are missing them."""
         schema_names = set(self._schema.names) if self._datasource_scoped and self._schema is not None else set()
         for row in data:
+            for k, v in self._default_values.items():
+                row.setdefault(k, v)
             if DATASOURCE_ID_COLUMN in schema_names:
                 row.setdefault(DATASOURCE_ID_COLUMN, "")
             if STORAGE_KEY_COLUMN in schema_names and row.get("id") not in (None, ""):
                 row.setdefault(STORAGE_KEY_COLUMN, build_storage_key(row.get(DATASOURCE_ID_COLUMN, ""), row["id"]))
-            for k, v in self._default_values.items():
-                row.setdefault(k, v)
         return data
 
     def _scope_column_migration_exprs(self) -> Dict[str, str]:

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -10,6 +10,7 @@ import json
 from typing import Any, Dict, List, Optional
 
 from datus.configuration.agent_config import AgentConfig
+from datus.storage.datasource_scope import datasource_condition, resolve_datasource_id
 from datus.storage.registry import get_storage
 from datus.storage.semantic_model.store import SemanticModelStorage
 from datus.utils.exceptions import DatusException, ErrorCode
@@ -25,10 +26,23 @@ class CatalogUpdater:
 
     def __init__(self, agent_config: AgentConfig, datasource_id: Optional[str] = None):
         self._agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self.semantic_model_storage = get_storage(
-            SemanticModelStorage, "semantic_model", project=agent_config.project_name
+            SemanticModelStorage,
+            "semantic_model",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
         )
+        self._scope_conditions = [datasource_condition(self.datasource_id)]
+
+    def _update_entry(self, entry_id: str, changes: Dict[str, Any]) -> None:
+        """Update one semantic object, adding datasource scope when initialized normally."""
+
+        scope_conditions = getattr(self, "_scope_conditions", None)
+        if scope_conditions:
+            self.semantic_model_storage.update_entry(entry_id, changes, extra_conditions=scope_conditions)
+            return
+        self.semantic_model_storage.update_entry(entry_id, changes)
 
     def _parse_json_field(self, value: Any) -> Optional[List[Dict[str, Any]]]:
         """Parse JSON string or return list directly."""
@@ -52,7 +66,7 @@ class CatalogUpdater:
         if "description" in update_values:
             entry_id = f"table:{table_name}"
             try:
-                self.semantic_model_storage.update_entry(entry_id, {"description": update_values["description"]})
+                self._update_entry(entry_id, {"description": update_values["description"]})
             except DatusException as e:
                 if e.code == ErrorCode.STORAGE_ENTRY_NOT_FOUND:
                     logger.warning(f"Table entry not found: {entry_id}")
@@ -125,7 +139,7 @@ class CatalogUpdater:
 
             entry_id = f"column:{table_name}.{col_name}"
             try:
-                self.semantic_model_storage.update_entry(entry_id, changed)
+                self._update_entry(entry_id, changed)
             except DatusException as e:
                 if e.code == ErrorCode.STORAGE_ENTRY_NOT_FOUND:
                     logger.warning(f"Column entry not found: {entry_id}")

--- a/datus/storage/datasource_scope.py
+++ b/datus/storage/datasource_scope.py
@@ -60,7 +60,10 @@ def build_storage_key(datasource_id: str, business_id: Any) -> str:
 
     row_id = str(business_id or "").strip()
     if not row_id:
-        raise ValueError("business id is required to build storage_key")
+        raise DatusException(
+            ErrorCode.STORAGE_INVALID_ARGUMENT,
+            message_args={"error_message": "business id is required to build storage_key"},
+        )
     datasource = str(datasource_id or "").strip()
     if datasource:
         return f"{datasource}:{row_id}"

--- a/datus/storage/datasource_scope.py
+++ b/datus/storage/datasource_scope.py
@@ -1,0 +1,85 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Row-level datasource scoping helpers for project-scoped storage.
+
+Physical storage namespaces remain project-scoped. Datasource isolation is
+represented by columns inside each shared project table.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+
+from datus_storage_base.conditions import Node, and_, eq
+
+from datus.utils.exceptions import DatusException, ErrorCode
+
+if TYPE_CHECKING:
+    from datus.configuration.agent_config import AgentConfig
+
+DATASOURCE_ID_COLUMN = "datasource_id"
+STORAGE_KEY_COLUMN = "storage_key"
+LEGACY_DATASOURCE_ID = ""
+LEGACY_STORAGE_KEY_PREFIX = "legacy:"
+
+
+def resolve_datasource_id(agent_config: "AgentConfig", datasource_id: Optional[str] = None) -> str:
+    """Return the datasource id required by datasource-scoped KB stores."""
+
+    raw_value = datasource_id if datasource_id is not None else getattr(agent_config, "current_datasource", "")
+    resolved = str(raw_value or "").strip()
+    if not resolved:
+        raise DatusException(
+            ErrorCode.STORAGE_INVALID_ARGUMENT,
+            message_args={"error_message": "datasource is required for datasource-scoped storage"},
+        )
+    return resolved
+
+
+def datasource_condition(datasource_id: str) -> Node:
+    """Build a WHERE condition for the datasource row scope."""
+
+    return eq(DATASOURCE_ID_COLUMN, datasource_id)
+
+
+def combine_conditions(conditions: Iterable[Optional[Node]]) -> Optional[Node]:
+    """Combine non-empty conditions with AND."""
+
+    active = [condition for condition in conditions if condition is not None]
+    if not active:
+        return None
+    if len(active) == 1:
+        return active[0]
+    return and_(*active)
+
+
+def build_storage_key(datasource_id: str, business_id: Any) -> str:
+    """Build an internal datasource-scoped unique key for vector upserts."""
+
+    row_id = str(business_id or "").strip()
+    if not row_id:
+        raise ValueError("business id is required to build storage_key")
+    datasource = str(datasource_id or "").strip()
+    if datasource:
+        return f"{datasource}:{row_id}"
+    return f"{LEGACY_STORAGE_KEY_PREFIX}{row_id}"
+
+
+def add_datasource_scope_to_rows(
+    rows: List[Dict[str, Any]],
+    datasource_id: str,
+    *,
+    id_field: str = "id",
+) -> List[Dict[str, Any]]:
+    """Return copies of rows with datasource_id and storage_key populated."""
+
+    scoped_rows: List[Dict[str, Any]] = []
+    for row in rows:
+        scoped = dict(row)
+        scoped[DATASOURCE_ID_COLUMN] = datasource_id
+        if id_field and scoped.get(id_field) not in (None, ""):
+            scoped[STORAGE_KEY_COLUMN] = build_storage_key(datasource_id, scoped[id_field])
+        scoped_rows.append(scoped)
+    return scoped_rows

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -189,8 +189,339 @@ def _sync_metric_provenance(
         return 0
 
 
-DEFAULT_METRICS_BATCH_SIZE = 1
-METRICS_RESPONSE_ACTION_TYPE = f"{GenMetricsAgenticNode.NODE_NAME}_response"
+DEFAULT_METRICS_BATCH_SIZE = 5
+METRICS_NODE_NAME = GenMetricsAgenticNode.NODE_NAME
+METRICS_RESPONSE_ACTION_TYPE = f"{METRICS_NODE_NAME}_response"
+
+
+def _json_dump_compact(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _normalize_metric_name(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _source_names(value: Any) -> set[str]:
+    if not value:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        raw_values = value
+    else:
+        raw_values = str(value).split(",")
+    return {str(item).strip() for item in raw_values if str(item).strip()}
+
+
+def _source_scoped_items(items: Any, batch_sources: set[str]) -> list[dict[str, Any]]:
+    if not isinstance(items, list):
+        return []
+
+    scoped: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_sources = _source_names(item.get("source_sql_name") or item.get("source") or item.get("sql_name"))
+        if not item_sources or item_sources & batch_sources:
+            scoped.append(item)
+    return scoped
+
+
+def _agent_config_dialect(agent_config: AgentConfig) -> str:
+    try:
+        current_db_config = agent_config.current_db_config()
+    except Exception:
+        return "snowflake"
+    value = getattr(current_db_config, "db_type", "") or getattr(current_db_config, "dialect", "") or ""
+    return value if isinstance(value, str) and value.strip() else "snowflake"
+
+
+def _build_existing_metric_catalog(agent_config: AgentConfig) -> list[dict[str, Any]]:
+    """Load existing metrics once for the bootstrap run."""
+    from datus.storage.metric.store import MetricRAG
+
+    try:
+        rows = MetricRAG(agent_config).search_all_metrics()
+    except Exception as exc:  # pragma: no cover - defensive; generation can proceed without catalog hints
+        logger.warning("Failed to load existing metric catalog; continuing without it: %s", exc)
+        return []
+
+    catalog: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        name = str(row.get("name") or "").strip()
+        if not name:
+            continue
+        normalized = _normalize_metric_name(name)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        catalog.append(
+            {
+                "name": name,
+                "type": row.get("metric_type") or row.get("type") or "",
+                "description": row.get("description") or "",
+                "subject_path": row.get("subject_path") or [],
+                "semantic_model": row.get("semantic_model_name") or "",
+                "semantic_model_name": row.get("semantic_model_name") or "",
+                "base_measures": row.get("base_measures") or [],
+                "dimensions": row.get("dimensions") or [],
+                "entities": row.get("entities") or [],
+            }
+        )
+    return catalog
+
+
+def _final_metric_count(agent_config: AgentConfig) -> int:
+    catalog = _build_existing_metric_catalog(agent_config)
+    return len(catalog)
+
+
+def _build_sql_to_table_lineage(sql_entries: list[dict[str, Any]], agent_config: AgentConfig) -> list[dict[str, Any]]:
+    from datus.utils.sql_utils import extract_table_names
+
+    lineage: list[dict[str, Any]] = []
+    dialect = _agent_config_dialect(agent_config)
+    for entry in sql_entries:
+        sql = str(entry.get("sql") or "").strip()
+        if not sql:
+            continue
+        try:
+            tables = sorted(extract_table_names(sql, dialect=dialect, ignore_empty=True))
+        except Exception as exc:
+            lineage.append({"source_sql_name": entry.get("name"), "tables": [], "error": str(exc)})
+            continue
+        lineage.append({"source_sql_name": entry.get("name"), "tables": tables})
+    return lineage
+
+
+def _build_candidate_plan(
+    sql_entries: list[dict[str, Any]],
+    existing_metric_catalog_json: str,
+    agent_config: AgentConfig,
+) -> dict[str, Any]:
+    """Run SQL metric candidate extraction once before launching gen_metrics agents."""
+    from types import SimpleNamespace
+
+    from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
+
+    if not sql_entries:
+        return {
+            "available": True,
+            "metric_candidates": [],
+            "direct_metric_candidates": [],
+            "derived_metric_candidates": [],
+            "base_measures": [],
+            "support_measure_candidates": [],
+            "non_metric_evidence": [],
+            "identity_metric_references": [],
+            "parse_errors": [],
+            "query_classification": "manual_review_required",
+            "source_classifications": [],
+            "derived_datasource_recommendations": [],
+            "blocked_direct_metric_candidates": [],
+            "literal_mappings": [],
+            "time_grain_evidence": [],
+            "post_aggregation_constraints": [],
+            "modeling_plan": {},
+            "summary": "Found 0 metric candidates and 0 base measures from 0 SQL queries",
+            "sql_to_table_lineage": [],
+        }
+
+    try:
+        discovery = SemanticDiscoveryTools(SimpleNamespace(agent_config=agent_config, sub_agent_name=METRICS_NODE_NAME))
+        result = discovery.analyze_metric_candidates_from_history(
+            sql_entries_json=_json_dump_compact(sql_entries),
+            existing_metric_catalog_json=existing_metric_catalog_json,
+            sample_sql_queries=len(sql_entries),
+        )
+        if not result.success:
+            logger.warning("Metric candidate extraction failed: %s", result.error)
+            return {
+                "available": False,
+                "error": result.error or "metric candidate extraction failed",
+                "sql_to_table_lineage": _build_sql_to_table_lineage(sql_entries, agent_config),
+            }
+        plan = dict(result.result or {})
+        plan["available"] = True
+        plan["sql_to_table_lineage"] = _build_sql_to_table_lineage(sql_entries, agent_config)
+        return plan
+    except Exception as exc:  # pragma: no cover - defensive; agent can still infer from SQL prompt
+        logger.warning("Metric candidate extraction raised; continuing without a candidate plan: %s", exc)
+        return {
+            "available": False,
+            "error": str(exc),
+            "sql_to_table_lineage": _build_sql_to_table_lineage(sql_entries, agent_config),
+        }
+
+
+def _candidate_plan_for_sources(candidate_plan: dict[str, Any], batch_sources: set[str]) -> dict[str, Any]:
+    if not candidate_plan or not candidate_plan.get("available"):
+        return candidate_plan or {}
+
+    scoped = dict(candidate_plan)
+    for key in (
+        "metric_candidates",
+        "direct_metric_candidates",
+        "derived_metric_candidates",
+        "base_measures",
+        "support_measure_candidates",
+        "non_metric_evidence",
+        "identity_metric_references",
+        "source_classifications",
+        "derived_datasource_recommendations",
+        "blocked_direct_metric_candidates",
+        "metric_aliases",
+        "literal_mappings",
+        "time_grain_evidence",
+        "post_aggregation_constraints",
+        "sql_to_table_lineage",
+    ):
+        scoped[key] = _source_scoped_items(candidate_plan.get(key), batch_sources)
+
+    scoped["summary"] = (
+        f"Batch candidate plan for {len(batch_sources)} SQL source(s): "
+        f"{len(scoped.get('direct_metric_candidates') or [])} direct, "
+        f"{len(scoped.get('derived_metric_candidates') or [])} derived, "
+        f"{len(scoped.get('blocked_direct_metric_candidates') or [])} blocked direct candidate(s)."
+    )
+    return scoped
+
+
+def _candidate_metric_names(candidate_plan: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for key in ("direct_metric_candidates", "derived_metric_candidates", "metric_candidates"):
+        for candidate in candidate_plan.get(key) or []:
+            if not isinstance(candidate, dict):
+                continue
+            name = str(candidate.get("name") or "").strip()
+            if name and name not in names:
+                names.append(name)
+    return names
+
+
+def _batch_has_no_metric_candidates(batch_candidate_plan: dict[str, Any]) -> bool:
+    """Return True when the batch candidate plan has no actionable metric candidates.
+
+    Skipping the LLM call is safe when the plan is available, there are zero
+    direct/derived candidates, and there IS non-metric or identity-reference
+    evidence (i.e. the SQL was analysed but produced nothing metric-worthy).
+    """
+    if not batch_candidate_plan or not batch_candidate_plan.get("available"):
+        return False
+    if _candidate_metric_names(batch_candidate_plan):
+        return False
+    has_evidence = bool(
+        batch_candidate_plan.get("non_metric_evidence")
+        or batch_candidate_plan.get("identity_metric_references")
+        or batch_candidate_plan.get("derived_datasource_recommendations")
+    )
+    return has_evidence
+
+
+def _candidate_metric_items(candidate_plan: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates_by_name: dict[str, dict[str, Any]] = {}
+    ordered_names: list[str] = []
+    seen: set[str] = set()
+    for key in ("direct_metric_candidates", "derived_metric_candidates", "metric_candidates"):
+        for candidate in candidate_plan.get(key) or []:
+            if not isinstance(candidate, dict):
+                continue
+            name = str(candidate.get("name") or "").strip()
+            normalized = _normalize_metric_name(name)
+            if not normalized:
+                continue
+            if normalized not in seen:
+                seen.add(normalized)
+                ordered_names.append(normalized)
+                candidates_by_name[normalized] = candidate
+                continue
+            if not _candidate_has_definition_evidence(
+                candidates_by_name[normalized]
+            ) and _candidate_has_definition_evidence(candidate):
+                candidates_by_name[normalized] = candidate
+    return [candidates_by_name[name] for name in ordered_names]
+
+
+def _normalized_scalar(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalized_metric_type(value: Any) -> str:
+    metric_type = _normalized_scalar(value)
+    return "measure_proxy" if metric_type == "simple" else metric_type
+
+
+def _normalized_measure_names(value: Any) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(value, list):
+        return names
+    for item in value:
+        if isinstance(item, str):
+            name = item
+        elif isinstance(item, dict):
+            name = item.get("name") or item.get("measure") or item.get("expr")
+        else:
+            continue
+        normalized = _normalize_metric_name(name)
+        if normalized:
+            names.add(normalized)
+    return names
+
+
+def _candidate_has_definition_evidence(candidate: dict[str, Any]) -> bool:
+    return any(
+        candidate.get(field)
+        for field in (
+            "metric_type",
+            "type",
+            "semantic_model",
+            "semantic_model_name",
+            "base_measures",
+            "referenced_metrics",
+        )
+    )
+
+
+def _candidate_matches_existing_metric(candidate: dict[str, Any], existing: dict[str, Any]) -> bool:
+    if not _candidate_has_definition_evidence(candidate):
+        return False
+
+    candidate_type = _normalized_metric_type(candidate.get("metric_type") or candidate.get("type"))
+    existing_type = _normalized_metric_type(existing.get("type") or existing.get("metric_type"))
+    if candidate_type and existing_type and candidate_type != existing_type:
+        return False
+
+    candidate_semantic_model = _normalized_scalar(
+        candidate.get("semantic_model_name") or candidate.get("semantic_model")
+    )
+    existing_semantic_model = _normalized_scalar(existing.get("semantic_model_name") or existing.get("semantic_model"))
+    if candidate_semantic_model and existing_semantic_model and candidate_semantic_model != existing_semantic_model:
+        return False
+
+    candidate_measures = _normalized_measure_names(candidate.get("base_measures"))
+    if not candidate_measures and candidate.get("referenced_metrics"):
+        candidate_measures = _normalized_measure_names(candidate.get("referenced_metrics"))
+    existing_measures = _normalized_measure_names(existing.get("base_measures"))
+    if candidate_measures and existing_measures and candidate_measures != existing_measures:
+        return False
+
+    return True
+
+
+def _all_candidate_metrics_satisfied(
+    candidate_plan: dict[str, Any], existing_metric_catalog: list[dict[str, Any]]
+) -> bool:
+    candidates = _candidate_metric_items(candidate_plan)
+    if not candidates:
+        return False
+    existing_by_name = {
+        _normalize_metric_name(item.get("name")): item for item in existing_metric_catalog if item.get("name")
+    }
+    for candidate in candidates:
+        existing = existing_by_name.get(_normalize_metric_name(candidate.get("name")))
+        if not existing or not _candidate_matches_existing_metric(candidate, existing):
+            return False
+    return True
 
 
 async def _generate_metrics_batch(
@@ -201,11 +532,30 @@ async def _generate_metrics_batch(
     extra_instructions: Optional[str],
     event_helper: BatchEventHelper,
     action_callback: Optional[Callable[["ActionHistory"], None]],
+    candidate_plan_json: Optional[str] = None,
+    existing_metric_catalog_json: Optional[str] = None,
 ) -> tuple[bool, str, Optional[dict[str, Any]]]:
     """Process a single batch of SQL queries for metrics extraction."""
     batch_message = "Analyze the following SQL queries and extract core metrics:\n\n" + "\n\n---\n\n".join(
         batch_queries
     )
+
+    if existing_metric_catalog_json:
+        batch_message += (
+            "\n\n## Existing Metric Catalog JSON\n"
+            "This catalog was loaded once by the bootstrap host before this batch. "
+            "Use it as the initial metric catalog; do not call list_metrics only to rediscover existing metrics.\n"
+            f"{existing_metric_catalog_json}"
+        )
+
+    if candidate_plan_json:
+        batch_message += (
+            "\n\n## Precomputed Metric Candidate Plan JSON\n"
+            "This plan was mined once from the full success-story SQL set before this batch. "
+            "Use it as Phase 1 metric-candidate evidence; do not call analyze_metric_candidates_from_history again "
+            "unless this JSON is malformed or insufficient for the requested generation.\n"
+            f"{candidate_plan_json}"
+        )
 
     if extra_instructions:
         batch_message = f"{batch_message}\n\n## Additional Instructions\n{extra_instructions}"
@@ -305,7 +655,7 @@ async def init_success_story_metrics_async(
         build_mode: ``"overwrite"`` (default) regenerates unconditionally;
             ``"incremental"`` skips the LLM call when the metric store
             already contains entries.
-        batch_size: Number of SQL queries per batch (default 1).
+        batch_size: Number of SQL queries per batch (default 5).
     """
     if batch_size <= 0:
         from datus.utils.exceptions import DatusException, ErrorCode
@@ -319,30 +669,15 @@ async def init_success_story_metrics_async(
     if build_mode == "overwrite":
         from datus.storage.metric.store import MetricRAG
 
+        metric_rag = MetricRAG(agent_config)
         logger.info(
-            "[overwrite] Wiping metrics store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping metrics rows for datasource '%s' before re-population",
+            metric_rag.datasource_id,
         )
-        MetricRAG(agent_config).truncate()
+        metric_rag.truncate()
         cleared_provenance = _clear_metric_provenance(agent_config)
         if cleared_provenance:
             logger.info("Cleared %d stale metric provenance row(s)", cleared_provenance)
-    elif build_mode == "incremental":
-        from datus.storage.metric.init_utils import exists_metrics
-        from datus.storage.metric.store import MetricRAG
-
-        existing = exists_metrics(MetricRAG(agent_config), build_mode)
-        if existing:
-            logger.info(
-                "Metrics incremental skip: %d existing metric(s) found, no LLM call.",
-                len(existing),
-            )
-            event_helper.task_completed(
-                total_items=len(existing),
-                completed_items=len(existing),
-                failed_items=0,
-            )
-            return True, "", {"skipped": True, "existing": len(existing)}
 
     df = pd.read_csv(success_story)
 
@@ -350,9 +685,15 @@ async def init_success_story_metrics_async(
     event_helper.task_started(total_items=len(df), success_story=success_story)
 
     # Step 0: Check and create missing semantic models
-    success_story_records = [
-        {"sql": row["sql"], "question": row.get("question")} for _, row in df.iterrows() if row.get("sql")
-    ]
+    success_story_records = []
+    sql_entries: list[dict[str, Any]] = []
+    for idx, row in df.iterrows():
+        sql = row.get("sql")
+        if not sql:
+            continue
+        question = row.get("question")
+        success_story_records.append({"sql": sql, "question": question})
+        sql_entries.append({"name": f"sql_{idx + 1}", "sql": sql, "question": question})
     sql_list = [record["sql"] for record in success_story_records]
     all_tables = extract_tables_from_sql_list(sql_list, agent_config)
 
@@ -379,6 +720,15 @@ async def init_success_story_metrics_async(
         if error:
             logger.warning(f"Semantic model generation had partial failures: {error}")
 
+    existing_metric_catalog = _build_existing_metric_catalog(agent_config)
+    existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
+    candidate_plan = _build_candidate_plan(sql_entries, existing_metric_catalog_json, agent_config)
+    logger.info(
+        "Prepared metric bootstrap context: existing_metrics=%d, candidate_plan_available=%s",
+        len(existing_metric_catalog),
+        candidate_plan.get("available"),
+    )
+
     # Build query records for all rows. Optional source-context columns are only
     # used by benchmark provenance mode and do not affect normal bootstrap data.
     all_query_records: list[dict[str, Any]] = []
@@ -387,6 +737,7 @@ async def init_success_story_metrics_async(
         question = row["question"]
         all_query_records.append(
             {
+                "source_sql_name": f"sql_{idx + 1}",
                 "query": f"Query {idx + 1}:\nQuestion: {question}\nSQL:\n{sql}",
                 "source": _source_provenance_from_row(row, idx, success_story),
             }
@@ -406,13 +757,108 @@ async def init_success_story_metrics_async(
     failed_batches: list[tuple[int, str]] = []
     merged_result: Optional[dict[str, Any]] = None
     provenance_entries = 0
+    skipped_batches = 0
 
     for batch_idx, batch_records in enumerate(batches):
         batch_queries = [record["query"] for record in batch_records]
+        batch_sources = {record["source_sql_name"] for record in batch_records}
+        batch_candidate_plan = _candidate_plan_for_sources(candidate_plan, batch_sources)
+        batch_candidate_plan_json = _json_dump_compact(batch_candidate_plan) if batch_candidate_plan else ""
         source_entries = [record["source"] for record in batch_records if record.get("source")]
         metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
 
         logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
+
+        if build_mode == "incremental" and _all_candidate_metrics_satisfied(
+            batch_candidate_plan,
+            existing_metric_catalog,
+        ):
+            skipped_batches += 1
+            completed_batches += 1
+            skipped_names = _candidate_metric_names(batch_candidate_plan)
+            logger.info(
+                "Skipping metrics batch %d/%d: all %d candidate metric(s) already exist",
+                batch_idx + 1,
+                total_batches,
+                len(skipped_names),
+            )
+            if event_helper:
+                event_helper.item_processing(
+                    item_id=f"batch-{batch_idx}",
+                    action_name="gen_metrics_skip",
+                    status=ActionStatus.SUCCESS.value,
+                    messages=(
+                        f"Skipped metrics batch {batch_idx + 1}/{total_batches}: "
+                        f"existing metrics already satisfy candidates {skipped_names}"
+                    ),
+                    output={
+                        "skipped": True,
+                        "skipped_metric_candidates": skipped_names,
+                        "batch_index": batch_idx,
+                    },
+                )
+
+            batch_result = {
+                "skipped_batches": 1,
+                "skipped_queries": len(batch_records),
+                "skipped_metric_candidates": skipped_names,
+            }
+            if merged_result is None:
+                merged_result = batch_result
+            elif isinstance(merged_result, dict):
+                for key, value in batch_result.items():
+                    if key in merged_result and isinstance(merged_result[key], list) and isinstance(value, list):
+                        merged_result[key].extend(value)
+                    elif key in merged_result and isinstance(merged_result[key], int) and isinstance(value, int):
+                        merged_result[key] += value
+                    elif key not in merged_result:
+                        merged_result[key] = value
+            continue
+
+        if _batch_has_no_metric_candidates(batch_candidate_plan):
+            skipped_batches += 1
+            completed_batches += 1
+            non_metric_count = len(batch_candidate_plan.get("non_metric_evidence") or [])
+            identity_count = len(batch_candidate_plan.get("identity_metric_references") or [])
+            logger.info(
+                "Skipping metrics batch %d/%d: no metric candidates (%d non-metric evidence, %d identity references)",
+                batch_idx + 1,
+                total_batches,
+                non_metric_count,
+                identity_count,
+            )
+            if event_helper:
+                event_helper.item_processing(
+                    item_id=f"batch-{batch_idx}",
+                    action_name="gen_metrics_skip",
+                    status=ActionStatus.SUCCESS.value,
+                    messages=(
+                        f"Skipped metrics batch {batch_idx + 1}/{total_batches}: "
+                        f"candidate plan contains no metric candidates "
+                        f"({non_metric_count} non-metric, {identity_count} identity ref)"
+                    ),
+                    output={
+                        "skipped": True,
+                        "skip_reason": "no_metric_candidates",
+                        "non_metric_evidence_count": non_metric_count,
+                        "identity_reference_count": identity_count,
+                        "batch_index": batch_idx,
+                    },
+                )
+
+            batch_result = {
+                "skipped_batches": 1,
+                "skipped_queries": len(batch_records),
+            }
+            if merged_result is None:
+                merged_result = batch_result
+            elif isinstance(merged_result, dict):
+                for key, value in batch_result.items():
+                    if key in merged_result and isinstance(merged_result[key], int) and isinstance(value, int):
+                        merged_result[key] += value
+                    elif key not in merged_result:
+                        merged_result[key] = value
+            continue
 
         success, error, batch_result = await _generate_metrics_batch(
             batch_queries,
@@ -422,6 +868,8 @@ async def init_success_story_metrics_async(
             extra_instructions,
             event_helper,
             action_callback,
+            candidate_plan_json=batch_candidate_plan_json,
+            existing_metric_catalog_json=existing_metric_catalog_json,
         )
 
         if success and batch_result is not None:
@@ -446,6 +894,18 @@ async def init_success_story_metrics_async(
                         merged_result[key] += value
                     elif key not in merged_result:
                         merged_result[key] = value
+            if batch_idx + 1 < total_batches:
+                existing_metric_catalog = _build_existing_metric_catalog(agent_config)
+                existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
+                candidate_plan = _build_candidate_plan(sql_entries, existing_metric_catalog_json, agent_config)
+                logger.info(
+                    "Refreshed metric bootstrap context after batch %d/%d: "
+                    "existing_metrics=%d, candidate_plan_available=%s",
+                    batch_idx + 1,
+                    total_batches,
+                    len(existing_metric_catalog),
+                    candidate_plan.get("available"),
+                )
             logger.info(f"Batch {batch_idx + 1}/{total_batches} completed successfully")
         else:
             failed_batches.append((batch_idx, error))
@@ -463,8 +923,14 @@ async def init_success_story_metrics_async(
         partial_error = "; ".join(f"batch {i + 1}: {e}" for i, e in failed_batches)
         logger.warning(f"Metrics extraction partially succeeded: {partial_error}")
 
-    if isinstance(merged_result, dict) and provenance_entries:
-        merged_result["provenance_entries"] = provenance_entries
+    if isinstance(merged_result, dict):
+        if provenance_entries:
+            merged_result["provenance_entries"] = provenance_entries
+        final_metrics_count = _final_metric_count(agent_config)
+        merged_result["metrics_count"] = final_metrics_count
+        merged_result["final_metrics_count"] = final_metrics_count
+        if skipped_batches:
+            merged_result["skipped_batches"] = skipped_batches
 
     logger.info(f"Metrics extraction completed: {completed_batches}/{total_batches} batch(es) succeeded")
     event_helper.task_completed(
@@ -495,7 +961,7 @@ def init_success_story_metrics(
         emit: Optional callback to stream BatchEvent progress events
         extra_instructions: Optional extra instructions for the LLM
         build_mode: Forwarded to :func:`init_success_story_metrics_async`.
-        batch_size: Number of SQL queries per batch (default 1).
+        batch_size: Number of SQL queries per batch (default 5).
     """
     with suppress_keyboard_input():
         return asyncio.run(

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -7,21 +7,62 @@ from typing import Any, Dict, List, Optional
 
 import pyarrow as pa
 import yaml
-from datus_storage_base.conditions import WhereExpr, in_
+from datus_storage_base.conditions import WhereExpr, and_, in_
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
+from datus.storage.datasource_scope import datasource_condition, resolve_datasource_id
 from datus.storage.knowledge_provenance import enrich_metric_results, is_knowledge_provenance_enabled
 from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore, base_schema_columns
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
 
+METRIC_ID_PREFIX = "metric:"
+_METRIC_DEFINITION_FIELDS = ("semantic_model_name", "metric_type", "measure_expr", "base_measures")
+
+
+def normalize_metric_name(value: Any) -> str:
+    """Return the datasource-local business key used for metric names."""
+
+    return str(value or "").strip().lower()
+
 
 def build_metric_id(subject_path: List[str], name: str) -> str:
-    """Build the stable business key for a metric."""
-    subject_path_str = "/".join(subject_path)
-    return f"metric:{subject_path_str}.{name}"
+    """Build the stable datasource-local business key for a metric.
+
+    ``subject_path`` is kept in the signature for existing call sites, but a
+    metric's identity must not change when it is moved in the subject tree.
+    Datasource isolation is handled by row-level storage scope.
+    """
+
+    metric_name = str(name or "").strip()
+    if not metric_name:
+        raise ValueError("metric name is required")
+    return f"{METRIC_ID_PREFIX}{metric_name}"
+
+
+def _normalize_definition_value(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple, set)):
+        return tuple(sorted(str(item).strip() for item in value if str(item).strip()))
+    return str(value).strip()
+
+
+def metric_definition_conflict(existing: Dict[str, Any], incoming: Dict[str, Any]) -> Optional[str]:
+    """Return the first conflicting core definition field, if any.
+
+    Empty values are treated as unknowns so legacy rows can be completed without
+    blocking a safe upsert.
+    """
+
+    for field in _METRIC_DEFINITION_FIELDS:
+        existing_value = _normalize_definition_value(existing.get(field))
+        incoming_value = _normalize_definition_value(incoming.get(field))
+        if existing_value and incoming_value and existing_value != incoming_value:
+            return field
+    return None
 
 
 class MetricStorage(BaseSubjectEmbeddingStore):
@@ -39,7 +80,7 @@ class MetricStorage(BaseSubjectEmbeddingStore):
                 base_schema_columns()  # Provides: name, subject_id, created_at
                 + [
                     # -- Identity & Basic Info --
-                    pa.field("id", pa.string()),  # Unique ID: "metric:Metrics/orders.dau"
+                    pa.field("id", pa.string()),  # Datasource-local ID: "metric:dau"
                     pa.field("semantic_model_name", pa.string()),  # Source semantic model
                     # -- Retrieval Fields --
                     pa.field("description", pa.string()),  # For LLM reading (RAG) and vector search
@@ -63,7 +104,7 @@ class MetricStorage(BaseSubjectEmbeddingStore):
             ),
             vector_source_name="description",
             vector_column_name="vector",
-            unique_columns=["id"],
+            unique_columns=["storage_key"],
             **kwargs,
         )
 
@@ -83,6 +124,11 @@ class MetricStorage(BaseSubjectEmbeddingStore):
     def batch_store_metrics(self, metrics: List[Dict[str, Any]]) -> None:
         """Store multiple metrics in the database efficiently.
 
+        Existing rows whose id embedded a subject path are reconciled by metric
+        name before upsert: equivalent definitions are removed in favor of the
+        datasource-local id, and conflicting definitions raise instead of
+        creating duplicate business keys.
+
         Args:
             metrics: List of dictionaries containing metric data with required fields:
                 - subject_path: List[str] - Subject hierarchy path for each metric (e.g., ['Finance', 'Revenue', 'Q1'])
@@ -94,14 +140,16 @@ class MetricStorage(BaseSubjectEmbeddingStore):
         if not metrics:
             return
 
-        # Validate all metrics have required subject_path
-        for metric in metrics:
-            subject_path = metric.get("subject_path")
-            if not subject_path:
-                raise ValueError("subject_path is required in metric data")
-
-        # Use base class batch_store method
-        self.batch_store(metrics)
+        prepared, stale_duplicate_ids = self._prepare_metrics_for_write(metrics, check_existing=True)
+        if prepared:
+            self.batch_upsert(prepared, on_column="storage_key")
+        if stale_duplicate_ids:
+            self._delete_rows(
+                and_(
+                    datasource_condition(self.datasource_id),
+                    in_("id", stale_duplicate_ids),
+                )
+            )
 
     def batch_upsert_metrics(self, metrics: List[Dict[str, Any]]) -> None:
         """Upsert multiple metrics (update if id exists, insert if not).
@@ -109,20 +157,92 @@ class MetricStorage(BaseSubjectEmbeddingStore):
         Args:
             metrics: List of dictionaries containing metric data with required fields:
                 - subject_path: List[str] - Subject hierarchy path for each metric
-                - id: str - Unique identifier for the metric (e.g., "metric:Metrics/orders.dau")
+                - id: str - Unique identifier for the metric (e.g., "metric:dau")
                 - Other fields same as batch_store_metrics
         """
         if not metrics:
             return
 
-        # Validate all metrics have required subject_path
+        prepared, stale_duplicate_ids = self._prepare_metrics_for_write(metrics, check_existing=True)
+        if prepared:
+            self.batch_upsert(prepared, on_column="storage_key")
+        if stale_duplicate_ids:
+            self._delete_rows(
+                and_(
+                    datasource_condition(self.datasource_id),
+                    in_("id", stale_duplicate_ids),
+                )
+            )
+
+    def _prepare_metrics_for_write(
+        self,
+        metrics: List[Dict[str, Any]],
+        check_existing: bool = False,
+    ) -> tuple[List[Dict[str, Any]], List[str]]:
+        prepared: List[Dict[str, Any]] = []
+        index_by_name: Dict[str, int] = {}
+
         for metric in metrics:
             subject_path = metric.get("subject_path")
             if not subject_path:
                 raise ValueError("subject_path is required in metric data")
 
-        # Use base class batch_upsert method
-        self.batch_upsert(metrics, on_column="id")
+            name = str(metric.get("name") or "").strip()
+            if not name:
+                raise ValueError("metric name is required in metric data")
+
+            normalized_name = normalize_metric_name(name)
+            updated = dict(metric)
+            updated["name"] = name
+            updated["id"] = build_metric_id(subject_path, name)
+
+            existing_index = index_by_name.get(normalized_name)
+            if existing_index is not None:
+                existing_metric = prepared[existing_index]
+                conflict_field = metric_definition_conflict(existing_metric, updated)
+                if conflict_field:
+                    raise ValueError(
+                        f"Metric name conflict within datasource for '{name}': "
+                        f"field '{conflict_field}' differs in the same write batch. "
+                        "Metric names must be unique within a datasource."
+                    )
+                prepared[existing_index] = updated
+                continue
+
+            index_by_name[normalized_name] = len(prepared)
+            prepared.append(updated)
+
+        stale_duplicate_ids: List[str] = []
+        if check_existing and prepared:
+            stale_duplicate_ids = self._find_stale_existing_metric_ids(prepared)
+
+        return prepared, stale_duplicate_ids
+
+    def _find_stale_existing_metric_ids(self, metrics: List[Dict[str, Any]]) -> List[str]:
+        names = {normalize_metric_name(metric.get("name")) for metric in metrics}
+        fields = ["id", "name", *_METRIC_DEFINITION_FIELDS]
+        existing_rows = self._search_all(
+            where=datasource_condition(self.datasource_id),
+            select_fields=fields,
+        ).to_pylist()
+
+        stale_duplicate_ids: List[str] = []
+        for existing in existing_rows:
+            existing_name = normalize_metric_name(existing.get("name"))
+            if existing_name not in names:
+                continue
+            incoming = next(metric for metric in metrics if normalize_metric_name(metric.get("name")) == existing_name)
+            conflict_field = metric_definition_conflict(existing, incoming)
+            if conflict_field:
+                raise ValueError(
+                    f"Metric name conflict within datasource for '{incoming['name']}': "
+                    f"existing metric id '{existing.get('id')}' has a different '{conflict_field}'. "
+                    "Choose a more specific metric name or update the existing metric explicitly."
+                )
+            if existing.get("id") and existing.get("id") != incoming.get("id"):
+                stale_duplicate_ids.append(str(existing["id"]))
+
+        return stale_duplicate_ids
 
     def _search_metrics_internal(
         self,
@@ -506,14 +626,19 @@ class MetricRAG:
         from datus.storage.registry import get_storage
 
         self.agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self._provenance_enabled = is_knowledge_provenance_enabled(agent_config)
-        self.storage: MetricStorage = get_storage(MetricStorage, "metric", project=agent_config.project_name)
+        self.storage: MetricStorage = get_storage(
+            MetricStorage,
+            "metric",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
+        )
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.storage, "metrics")
 
     def _sub_agent_conditions(self) -> List:
-        """Build sub-agent filter conditions (datasource_id handled by backend)."""
-        conditions = []
+        """Build datasource and sub-agent filter conditions."""
+        conditions = [datasource_condition(self.datasource_id)]
         if self._sub_agent_filter:
             conditions.append(self._sub_agent_filter)
         return conditions
@@ -547,7 +672,7 @@ class MetricRAG:
 
     def truncate(self) -> None:
         """Delete all metrics for this datasource."""
-        self.storage.truncate_scoped()
+        self.storage.delete_datasource_rows(self.datasource_id)
 
     def store_batch(self, metrics: List[Dict[str, Any]]):
         logger.info(f"store metrics: {metrics}")

--- a/datus/storage/metric/subject_path.py
+++ b/datus/storage/metric/subject_path.py
@@ -1,0 +1,69 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Helpers for normalizing metric subject paths."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+GENERIC_METRIC_SUBJECT_ROOTS = {"metrics", "metric", "unknown"}
+
+
+def default_metric_subject_path(datasource: str = "", table_name: str = "") -> list[str]:
+    datasource = str(datasource or "").strip()
+    table = str(table_name or "Unknown").strip() or "Unknown"
+    if datasource:
+        return [datasource, table]
+    return ["Metrics", table]
+
+
+def normalize_metric_subject_path(
+    subject_path: Optional[Iterable[str]],
+    *,
+    datasource: str = "",
+    table_name: str = "",
+) -> list[str]:
+    """Normalize generated metric subject paths without rewriting business roots."""
+
+    parts = [str(part).strip() for part in subject_path or [] if str(part).strip()]
+    if not parts:
+        return default_metric_subject_path(datasource, table_name)
+
+    datasource = str(datasource or "").strip()
+    if not datasource:
+        return parts
+
+    first = _normalize_part(parts[0])
+    if first in GENERIC_METRIC_SUBJECT_ROOTS:
+        tail = parts[1:]
+    elif _same_part(parts[0], datasource):
+        tail = parts[1:]
+    else:
+        return parts
+
+    while tail and _same_part(tail[0], datasource):
+        tail = tail[1:]
+
+    if not tail:
+        tail = [str(table_name or "Unknown").strip() or "Unknown"]
+    return [datasource, *tail]
+
+
+def normalize_metric_subject_tree_tag(tag: str, *, datasource: str = "", table_name: str = "") -> str:
+    prefix = "subject_tree:"
+    if not isinstance(tag, str) or not tag.startswith(prefix):
+        return tag
+    path = tag.split(prefix, 1)[1].strip()
+    parts = [part.strip() for part in path.split("/") if part.strip()]
+    normalized = normalize_metric_subject_path(parts, datasource=datasource, table_name=table_name)
+    return f"{prefix} {'/'.join(normalized)}"
+
+
+def _same_part(left: str, right: str) -> bool:
+    return _normalize_part(left) == _normalize_part(right)
+
+
+def _normalize_part(value: str) -> str:
+    return str(value or "").strip().lower()

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -10,6 +10,7 @@ import yaml
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
+from datus.storage.datasource_scope import datasource_condition, resolve_datasource_id
 from datus.storage.knowledge_provenance import enrich_reference_sql_results, is_knowledge_provenance_enabled
 from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore, base_schema_columns
 from datus.utils.loggings import get_logger
@@ -41,7 +42,7 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
                 ]
             ),
             vector_source_name="search_text",
-            unique_columns=["id"],
+            unique_columns=["storage_key"],
             **kwargs,
         )
 
@@ -116,7 +117,7 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
                 raise ValueError("subject_path is required in SQL item data")
 
         # Use base class batch_upsert method
-        self.batch_upsert(sql_items, on_column="id")
+        self.batch_upsert(sql_items, on_column="storage_key")
 
     def search_reference_sql(
         self,
@@ -440,18 +441,21 @@ class ReferenceSqlRAG:
         from datus.storage.registry import get_storage
 
         self.agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self._provenance_enabled = is_knowledge_provenance_enabled(agent_config)
         self.reference_sql_storage = get_storage(
-            ReferenceSqlStorage, "reference_sql", project=agent_config.project_name
+            ReferenceSqlStorage,
+            "reference_sql",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
         )
         self._sub_agent_filter = _build_sub_agent_filter(
             agent_config, sub_agent_name, self.reference_sql_storage, "sqls"
         )
 
     def _sub_agent_conditions(self) -> List:
-        """Build sub-agent filter conditions (datasource_id handled by backend)."""
-        conditions = []
+        """Build datasource and sub-agent filter conditions."""
+        conditions = [datasource_condition(self.datasource_id)]
         if self._sub_agent_filter:
             conditions.append(self._sub_agent_filter)
         return conditions
@@ -482,7 +486,7 @@ class ReferenceSqlRAG:
 
     def truncate(self) -> None:
         """Delete all reference SQL data for this datasource."""
-        self.reference_sql_storage.truncate_scoped()
+        self.reference_sql_storage.delete_datasource_rows(self.datasource_id)
 
     def store_batch(self, reference_sql_items: List[Dict[str, Any]]):
         """Store batch of reference SQL items."""

--- a/datus/storage/reference_template/reference_template_init.py
+++ b/datus/storage/reference_template/reference_template_init.py
@@ -431,8 +431,8 @@ async def init_reference_template_async(
 
     if build_mode == "overwrite":
         logger.info(
-            "[overwrite] Wiping reference_template store for project '%s' before re-population",
-            global_config.project_name,
+            "[overwrite] Wiping reference_template rows for datasource '%s' before re-population",
+            storage.datasource_id,
         )
         storage.truncate()
 

--- a/datus/storage/reference_template/store.py
+++ b/datus/storage/reference_template/store.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
+from datus.storage.datasource_scope import datasource_condition, resolve_datasource_id
 from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore, base_schema_columns
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -40,7 +41,7 @@ class ReferenceTemplateStorage(BaseSubjectEmbeddingStore):
                 ]
             ),
             vector_source_name="search_text",
-            unique_columns=["id"],
+            unique_columns=["storage_key"],
             **kwargs,
         )
 
@@ -112,7 +113,7 @@ class ReferenceTemplateStorage(BaseSubjectEmbeddingStore):
             if not subject_path:
                 raise DatusException(ErrorCode.COMMON_FIELD_REQUIRED, message_args={"field_name": "subject_path"})
 
-        self.batch_upsert(template_items, on_column="id")
+        self.batch_upsert(template_items, on_column="storage_key")
 
     def search_reference_templates(
         self,
@@ -195,24 +196,27 @@ class ReferenceTemplateRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self.reference_template_storage = get_storage(
-            ReferenceTemplateStorage, "reference_template", project=agent_config.project_name
+            ReferenceTemplateStorage,
+            "reference_template",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
         )
         self._sub_agent_filter = _build_sub_agent_filter(
             agent_config, sub_agent_name, self.reference_template_storage, "templates"
         )
 
     def _sub_agent_conditions(self) -> List:
-        """Build sub-agent filter conditions."""
-        conditions = []
+        """Build datasource and sub-agent filter conditions."""
+        conditions = [datasource_condition(self.datasource_id)]
         if self._sub_agent_filter:
             conditions.append(self._sub_agent_filter)
         return conditions
 
     def truncate(self) -> None:
         """Delete all reference template data for this datasource."""
-        self.reference_template_storage.truncate_scoped()
+        self.reference_template_storage.delete_datasource_rows(self.datasource_id)
 
     def store_batch(self, reference_template_items: List[Dict[str, Any]]):
         """Store batch of reference template items."""

--- a/datus/storage/registry.py
+++ b/datus/storage/registry.py
@@ -5,9 +5,9 @@
 """
 Storage registry with per-project LRU cache.
 
-Each (factory, project) pair gets its own storage instance with an isolated
-VectorDatabase connection. Project isolation is PHYSICAL: each project gets
-its own directory under ``{data_dir}/{project}/``.
+Each (factory, project, datasource_id) tuple gets its own storage wrapper.
+The underlying VectorDatabase connection remains project-scoped: each project
+gets its own directory under ``{data_dir}/{project}/``.
 """
 
 from __future__ import annotations
@@ -63,9 +63,14 @@ def get_storage_defaults() -> Dict[str, Any]:
     return dict(_storage_defaults)
 
 
-@lru_cache(maxsize=128)
-def _get_storage_cached(factory_name: str, embedding_model_conf_name: str, project: str) -> BaseEmbeddingStore:
-    """LRU-cached storage creation, keyed by (factory, embedding model, project)."""
+@lru_cache(maxsize=256)
+def _get_storage_cached(
+    factory_name: str,
+    embedding_model_conf_name: str,
+    project: str,
+    datasource_id: str,
+) -> BaseEmbeddingStore:
+    """LRU-cached storage creation, keyed by (factory, embedding model, project, datasource)."""
     from datus.storage.backend_holder import create_vector_connection
     from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore
 
@@ -79,6 +84,7 @@ def _get_storage_cached(factory_name: str, embedding_model_conf_name: str, proje
     # path_manager (which fails outside chat task threads).
     if isinstance(factory, type) and issubclass(factory, BaseSubjectEmbeddingStore):
         kwargs["project"] = project
+        kwargs["datasource_id"] = datasource_id
 
     store = factory(get_embedding_model(embedding_model_conf_name), **kwargs)
     return store
@@ -88,12 +94,14 @@ def get_storage(
     factory: Callable[..., BaseEmbeddingStore],
     embedding_model_conf_name: str,
     project: str,
+    datasource_id: str = "",
 ) -> BaseEmbeddingStore:
-    """Return a storage instance scoped to *project*.
+    """Return a storage instance scoped to *project* and datasource wrapper.
 
     Project isolation is PHYSICAL: each project gets a per-project directory
     under ``{data_dir}/{project}/``. ``project`` must be non-empty and is
-    forwarded to the backend ``connect()`` call.
+    forwarded to the backend ``connect()`` call. ``datasource_id`` only scopes
+    the returned wrapper; it is not part of the backend namespace.
 
     Uses an LRU cache (maxsize=128) so that inactive projects are evicted.
     Global defaults set via ``configure_storage_defaults()`` are
@@ -101,20 +109,20 @@ def get_storage(
     """
     with _registry_lock:
         _factory_registry[factory.__name__] = factory
-    return _get_storage_cached(factory.__name__, embedding_model_conf_name, project)
+    return _get_storage_cached(factory.__name__, embedding_model_conf_name, project, datasource_id or "")
 
 
-@lru_cache(maxsize=128)
-def _get_subject_tree_cached(project: str) -> "SubjectTreeStore":
+@lru_cache(maxsize=256)
+def _get_subject_tree_cached(project: str, datasource_id: str) -> "SubjectTreeStore":
     """LRU-cached SubjectTreeStore creation."""
     from datus.storage.subject_tree.store import SubjectTreeStore
 
-    return SubjectTreeStore(project=project)
+    return SubjectTreeStore(project=project, datasource_id=datasource_id)
 
 
-def get_subject_tree_store(project: str) -> "SubjectTreeStore":
-    """Return a SubjectTreeStore instance (LRU-cached per project)."""
-    return _get_subject_tree_cached(project)
+def get_subject_tree_store(project: str, datasource_id: str = "") -> "SubjectTreeStore":
+    """Return a SubjectTreeStore instance (LRU-cached per project/datasource)."""
+    return _get_subject_tree_cached(project, datasource_id or "")
 
 
 def preload_all_storages(
@@ -168,19 +176,7 @@ def preload_all_storages(
     if defaults:
         configure_storage_defaults(**defaults)
 
-    # 3. Eagerly create all storage singletons
-    from datus.storage.metric.store import MetricStorage
-    from datus.storage.reference_sql.store import ReferenceSqlStorage
-    from datus.storage.schema_metadata.store import SchemaStorage, SchemaValueStorage
-    from datus.storage.semantic_model.store import SemanticModelStorage
-
-    get_storage(SchemaStorage, "database", project=project)
-    get_storage(SchemaValueStorage, "database", project=project)
-    get_storage(SemanticModelStorage, "semantic_model", project=project)
-    get_storage(MetricStorage, "metric", project=project)
-    get_storage(ReferenceSqlStorage, "reference_sql", project=project)
-    get_subject_tree_store(project=project)
-    logger.info("All storage singletons pre-loaded")
+    logger.info("Storage backends initialized; datasource-scoped stores will be created lazily")
 
 
 def clear_storage_registry() -> None:

--- a/datus/storage/schema_metadata/local_init.py
+++ b/datus/storage/schema_metadata/local_init.py
@@ -56,8 +56,8 @@ async def init_local_schema_async(
     """
     if build_mode == "overwrite":
         logger.info(
-            "[overwrite] Wiping schema metadata store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping schema metadata rows for datasource '%s' before re-population",
+            table_lineage_store.datasource_id,
         )
         table_lineage_store.truncate()
 

--- a/datus/storage/schema_metadata/store.py
+++ b/datus/storage/schema_metadata/store.py
@@ -12,6 +12,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.schemas.base import TABLE_TYPE
 from datus.schemas.node_models import TableSchema, TableValue
 from datus.storage.base import BaseEmbeddingStore, WhereExpr
+from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
 from datus.storage.embedding_models import EmbeddingModel
 from datus.tools.db_tools import connector_registry
 from datus.utils.constants import DBType
@@ -67,6 +68,7 @@ class BaseMetadataStorage(BaseEmbeddingStore):
                 ]
             ),
             vector_source_name=vector_source_name,
+            datasource_scoped=True,
             **kwargs,
         )
 
@@ -241,14 +243,24 @@ class SchemaWithValueRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
-        self.schema_store = get_storage(SchemaStorage, "database", project=agent_config.project_name)
-        self.value_store = get_storage(SchemaValueStorage, "database", project=agent_config.project_name)
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
+        self.schema_store = get_storage(
+            SchemaStorage,
+            "database",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
+        )
+        self.value_store = get_storage(
+            SchemaValueStorage,
+            "database",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
+        )
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.schema_store, "tables")
 
     def _sub_agent_conditions(self) -> list:
-        """Build sub-agent filter conditions (datasource_id handled by backend)."""
-        conditions = []
+        """Build datasource and sub-agent filter conditions."""
+        conditions = [datasource_condition(self.datasource_id)]
         if self._sub_agent_filter:
             conditions.append(self._sub_agent_filter)
         return conditions
@@ -265,12 +277,12 @@ class SchemaWithValueRAG:
 
     def truncate(self) -> None:
         """Delete all schema metadata for this datasource."""
-        self.schema_store.truncate_scoped()
-        self.value_store.truncate_scoped()
+        self.schema_store.delete_datasource_rows(self.datasource_id)
+        self.value_store.delete_datasource_rows(self.datasource_id)
 
     def store_batch(self, schemas: List[Dict[str, Any]], values: List[Dict[str, Any]]):
         if schemas:
-            self.schema_store.store_batch(schemas)
+            self.schema_store.store_batch(add_datasource_scope_to_rows(schemas, self.datasource_id, id_field=""))
 
         if len(values) == 0:
             return
@@ -284,7 +296,7 @@ class SchemaWithValueRAG:
                 sample_rows = json2csv(sample_rows)
             item["sample_rows"] = sample_rows
             final_values.append(item)
-        self.value_store.store_batch(final_values)
+        self.value_store.store_batch(add_datasource_scope_to_rows(final_values, self.datasource_id, id_field=""))
 
         logger.debug(f"Batch stored {len(schemas)} schemas, {len(final_values)} values")
 
@@ -508,9 +520,12 @@ class SchemaWithValueRAG:
             table_name=table_name,
             table_type=table_type,
         )
-        if where_condition:
-            self.schema_store._delete_rows(where_condition)
-            self.value_store._delete_rows(where_condition)
+        if where_condition is None:
+            return
+        scoped_where = self._add_sub_agent_filter(where_condition)
+        if scoped_where:
+            self.schema_store._delete_rows(scoped_where)
+            self.value_store._delete_rows(scoped_where)
 
 
 def _build_where_clause(

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -97,11 +97,12 @@ async def init_success_story_semantic_model_async(
     if build_mode == "overwrite":
         from datus.storage.semantic_model.store import SemanticModelRAG
 
+        semantic_model_rag = SemanticModelRAG(agent_config)
         logger.info(
-            "[overwrite] Wiping semantic_model store for project '%s' before re-population",
-            agent_config.project_name,
+            "[overwrite] Wiping semantic_model rows for datasource '%s' before re-population",
+            semantic_model_rag.datasource_id,
         )
-        SemanticModelRAG(agent_config).truncate()
+        semantic_model_rag.truncate()
 
     # Build comprehensive context from all rows
     context_message = "Generate semantic models for the following SQL queries:\n\n"

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -10,6 +10,7 @@ import yaml
 from datus_storage_base.conditions import And, WhereExpr, eq, in_
 
 from datus.storage.base import BaseEmbeddingStore, EmbeddingModel
+from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -17,6 +18,45 @@ if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
 
 logger = get_logger(__name__)
+
+
+def _strip_identifier_quotes(value: str) -> str:
+    text = str(value or "").strip()
+    while len(text) >= 2 and (
+        (text[0] == text[-1] and text[0] in {'"', "'", "`"}) or (text[0] == "[" and text[-1] == "]")
+    ):
+        text = text[1:-1].strip()
+    return text
+
+
+def _identifier_variants(value: str) -> List[str]:
+    """Return common exact-match variants for SQL identifiers."""
+
+    parts = [_strip_identifier_quotes(part) for part in str(value or "").split(".") if part.strip()]
+    variants: List[str] = []
+    for start in range(len(parts)):
+        candidate = ".".join(parts[start:])
+        if candidate and candidate not in variants:
+            variants.append(candidate)
+    if parts:
+        leaf = parts[-1]
+        if leaf and leaf not in variants:
+            variants.append(leaf)
+    raw = _strip_identifier_quotes(value)
+    if raw and raw not in variants:
+        variants.append(raw)
+    lower_variants = []
+    for item in variants:
+        lowered = item.lower()
+        if lowered and lowered not in variants and lowered not in lower_variants:
+            lower_variants.append(lowered)
+    variants.extend(lower_variants)
+    return variants
+
+
+def _normalized_identifier(value: str) -> str:
+    parts = [_strip_identifier_quotes(part) for part in str(value or "").split(".") if part.strip()]
+    return ".".join(parts).lower()
 
 
 class SemanticModelStorage(BaseEmbeddingStore):
@@ -68,7 +108,8 @@ class SemanticModelStorage(BaseEmbeddingStore):
             ),
             vector_source_name="description",
             vector_column_name="vector",
-            unique_columns=["id"],
+            unique_columns=["storage_key"],
+            datasource_scoped=True,
             **kwargs,
         )
 
@@ -87,6 +128,7 @@ class SemanticModelStorage(BaseEmbeddingStore):
         kinds: Optional[List[str]] = None,
         table_name: Optional[str] = None,
         top_n: int = 10,
+        extra_conditions: Optional[List] = None,
     ) -> List[Dict[str, Any]]:
         """Search for semantic objects."""
         conditions = []
@@ -94,6 +136,8 @@ class SemanticModelStorage(BaseEmbeddingStore):
             conditions.append(in_("kind", kinds))
         if table_name:
             conditions.append(eq("table_name", table_name))
+        if extra_conditions:
+            conditions.extend(extra_conditions)
 
         where_clause = And(conditions) if conditions else None
 
@@ -130,7 +174,12 @@ class SemanticModelStorage(BaseEmbeddingStore):
         "entity": "entity",
     }
 
-    def update_entry(self, entry_id: str, update_values: Dict[str, Any]) -> bool:
+    def update_entry(
+        self,
+        entry_id: str,
+        update_values: Dict[str, Any],
+        extra_conditions: Optional[List] = None,
+    ) -> bool:
         """Update a semantic model entry by ID and sync changes to the YAML file.
 
         Args:
@@ -152,8 +201,13 @@ class SemanticModelStorage(BaseEmbeddingStore):
                 ErrorCode.STORAGE_INVALID_ARGUMENT, message_args={"error_message": "update_values must not be empty"}
             )
 
+        conditions = [eq("id", entry_id)]
+        if extra_conditions:
+            conditions.extend(extra_conditions)
+        where = And(conditions)
+
         entries = self._search_all(
-            where=eq("id", entry_id), select_fields=["id", "kind", "name", "table_name", "yaml_path"]
+            where=where, select_fields=["id", "kind", "name", "table_name", "yaml_path"]
         ).to_pylist()
         if not entries:
             raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
@@ -164,7 +218,7 @@ class SemanticModelStorage(BaseEmbeddingStore):
         # data_source name, so fall back to it when ``table_name`` is empty.
         data_source_name = entry.get("table_name") or entry["name"]
 
-        self.update(where=eq("id", entry_id), update_values=update_values)
+        self.update(where=where, update_values=update_values)
 
         if yaml_path:
             self._sync_semantic_update_to_yaml(yaml_path, entry["kind"], entry["name"], data_source_name, update_values)
@@ -271,22 +325,25 @@ class SemanticModelRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self.storage: SemanticModelStorage = get_storage(
-            SemanticModelStorage, "semantic_model", project=agent_config.project_name
+            SemanticModelStorage,
+            "semantic_model",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
         )
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.storage, "tables")
 
     def _sub_agent_conditions(self) -> list:
-        """Build sub-agent filter conditions (datasource_id handled by backend)."""
-        conditions = []
+        """Build datasource and sub-agent filter conditions."""
+        conditions = [datasource_condition(self.datasource_id)]
         if self._sub_agent_filter:
             conditions.append(self._sub_agent_filter)
         return conditions
 
     def truncate(self) -> None:
         """Delete all semantic model data for this datasource."""
-        self.storage.truncate_scoped()
+        self.storage.delete_datasource_rows(self.datasource_id)
 
     def get_semantic_model(
         self,
@@ -431,11 +488,11 @@ class SemanticModelRAG:
 
     def store_batch(self, objects: List[Dict[str, Any]]):
         """Store a batch of semantic model objects."""
-        self.storage.store_batch(objects)
+        self.storage.store_batch(add_datasource_scope_to_rows(objects, self.datasource_id))
 
     def upsert_batch(self, objects: List[Dict[str, Any]]):
         """Upsert a batch of semantic model objects (update if id exists, insert if not)."""
-        self.storage.upsert_batch(objects, on_column="id")
+        self.storage.upsert_batch(add_datasource_scope_to_rows(objects, self.datasource_id), on_column="storage_key")
 
     def create_indices(self):
         """Create indices for semantic model storage."""

--- a/datus/storage/subject_manager.py
+++ b/datus/storage/subject_manager.py
@@ -12,6 +12,7 @@ cross-datasource interference in multi-tenant setups.
 from typing import Any, Dict, List, Optional
 
 from datus.configuration.agent_config import AgentConfig
+from datus.storage.datasource_scope import resolve_datasource_id
 from datus.storage.metric import MetricStorage
 from datus.storage.reference_sql import ReferenceSqlStorage
 from datus.storage.registry import get_storage
@@ -25,10 +26,18 @@ class SubjectUpdater:
 
     def __init__(self, agent_config: AgentConfig, datasource_id: Optional[str] = None):
         self._agent_config = agent_config
-        self.datasource_id = datasource_id or agent_config.current_datasource or ""
-        self.metrics_storage: MetricStorage = get_storage(MetricStorage, "metric", project=agent_config.project_name)
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
+        self.metrics_storage: MetricStorage = get_storage(
+            MetricStorage,
+            "metric",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
+        )
         self.reference_sql_storage: ReferenceSqlStorage = get_storage(
-            ReferenceSqlStorage, "reference_sql", project=agent_config.project_name
+            ReferenceSqlStorage,
+            "reference_sql",
+            project=agent_config.project_name,
+            datasource_id=self.datasource_id,
         )
 
     def update_metrics_detail(self, subject_path: List[str], name: str, update_values: Dict[str, Any]):
@@ -40,7 +49,11 @@ class SubjectUpdater:
     def update_historical_sql(self, subject_path: List[str], name: str, update_values: Dict[str, Any]):
         if not update_values:
             return
-        self.reference_sql_storage.update_entry(subject_path, name, update_values)
+        self.reference_sql_storage.update_entry(
+            subject_path,
+            name,
+            update_values,
+        )
         logger.debug("Updated the reference SQL details in the main space successfully")
 
     def delete_metric(self, subject_path: List[str], name: str) -> Dict[str, Any]:

--- a/datus/storage/subject_tree/store.py
+++ b/datus/storage/subject_tree/store.py
@@ -14,6 +14,12 @@ from datus_storage_base.conditions import and_, in_, like
 from datus_storage_base.rdb.base import ColumnDef, IndexDef, TableDefinition, UniqueViolationError, WhereOp
 
 from datus.storage import BaseEmbeddingStore
+from datus.storage.datasource_scope import (
+    DATASOURCE_ID_COLUMN,
+    STORAGE_KEY_COLUMN,
+    build_storage_key,
+    datasource_condition,
+)
 from datus.storage.embedding_models import EmbeddingModel
 from datus.utils.loggings import get_logger
 
@@ -77,13 +83,14 @@ class SubjectTreeStore:
     Implements adjacency list model for tree structure.
     """
 
-    def __init__(self, project: str):
+    def __init__(self, project: str, datasource_id: str = ""):
         """Initialize SubjectTreeStore.
 
         Args:
             project: Project identifier used by the underlying RDB backend for
                 isolation. Must be non-empty; the backend rejects empty
                 identifiers.
+            datasource_id: Row-level datasource scope inside the project tree.
 
         Reads ``table_prefix``, ``extra_fields``, and ``scope_indices`` from
         the storage registry defaults (set via ``configure_storage_defaults()``).
@@ -115,6 +122,7 @@ class SubjectTreeStore:
                 if idx_name not in existing_idx_names:
                     table_def.indices = table_def.indices + [IndexDef(name=idx_name, columns=[col])]
 
+        self.datasource_id = str(datasource_id or "")
         self._rdb = create_rdb_for_store("subject_tree", project=project)
         self._table = self._rdb.ensure_table(table_def)
         self._migrate_null_parents()
@@ -168,6 +176,7 @@ class SubjectTreeStore:
                 description=description,
                 created_at=now,
                 updated_at=now,
+                datasource_id=self.datasource_id,
             )
             node_id = self._table.insert(record)
 
@@ -190,7 +199,7 @@ class SubjectTreeStore:
         Returns:
             Node dict or None if not found
         """
-        rows = self._table.query(SubjectNodeRecord, where={"node_id": node_id})
+        rows = self._table.query(SubjectNodeRecord, where={"node_id": node_id, "datasource_id": self.datasource_id})
         if rows:
             return _node_to_dict(rows[0])
         return None
@@ -259,7 +268,7 @@ class SubjectTreeStore:
         data["updated_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
         try:
-            self._table.update(data, where={"node_id": node_id})
+            self._table.update(data, where={"node_id": node_id, "datasource_id": self.datasource_id})
             logger.info(f"Updated node {node_id}")
             return True
         except UniqueViolationError as e:
@@ -290,9 +299,9 @@ class SubjectTreeStore:
             with self._rdb.transaction():
                 for descendant in descendants:
                     child_path = self.get_full_path(descendant["node_id"])
-                    self._table.delete(where={"node_id": descendant["node_id"]})
+                    self._table.delete(where={"node_id": descendant["node_id"], "datasource_id": self.datasource_id})
                     logger.info(f"Deleted child node {descendant['node_id']} ({child_path})")
-                self._table.delete(where={"node_id": node_id})
+                self._table.delete(where={"node_id": node_id, "datasource_id": self.datasource_id})
             logger.info(f"Deleted node {node_id} ({node_path})" + (" with cascade" if cascade else ""))
             return True
         except Exception as e:
@@ -304,7 +313,7 @@ class SubjectTreeStore:
     def get_children(self, parent_id: Optional[int]) -> List[Dict[str, Any]]:
         """Get direct children of a node."""
         db_parent_id = ROOT_PARENT_ID if parent_id is None else parent_id
-        where = {"parent_id": db_parent_id}
+        where = {"parent_id": db_parent_id, "datasource_id": self.datasource_id}
         rows = self._table.query(
             SubjectNodeRecord,
             where=where,
@@ -541,7 +550,7 @@ class SubjectTreeStore:
     def _find_child_by_name(self, parent_id: Optional[int], name: str) -> Optional[Dict[str, Any]]:
         """Find a child node by name under a specific parent."""
         db_parent_id = ROOT_PARENT_ID if parent_id is None else parent_id
-        where = {"parent_id": db_parent_id, "name": name}
+        where = {"parent_id": db_parent_id, "name": name, "datasource_id": self.datasource_id}
         rows = self._table.query(
             SubjectNodeRecord,
             where=where,
@@ -678,6 +687,8 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         # so BaseEmbeddingStore (which has a strict signature) doesn't reject it.
         # Falls back to the active path_manager for callers that bypass the registry.
         project = kwargs.pop("project", None)
+        datasource_id = kwargs.pop("datasource_id", "")
+        kwargs.setdefault("datasource_scoped", True)
 
         super().__init__(
             table_name=table_name,
@@ -697,7 +708,8 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
 
             project = get_path_manager().project_name
 
-        self.subject_tree = get_subject_tree_store(project=project)
+        self.datasource_id = str(datasource_id or "")
+        self.subject_tree = get_subject_tree_store(project=project, datasource_id=self.datasource_id)
 
     def batch_store(
         self,
@@ -728,6 +740,9 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
                 # Create new item dict without subject_path field and with subject_node_id
                 processed_item = item.copy()
                 processed_item[SUBJECT_ID_COLUMN_NAME] = subject_node_id
+                processed_item[DATASOURCE_ID_COLUMN] = self.datasource_id
+                if processed_item.get("id") not in (None, ""):
+                    processed_item[STORAGE_KEY_COLUMN] = build_storage_key(self.datasource_id, processed_item["id"])
                 processed_item.pop(SUBJECT_PATH_COLUMN_NAME, None)
 
                 # Auto-generate timestamp if needed
@@ -776,6 +791,9 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
                 # Create new item dict without subject_path field and with subject_node_id
                 processed_item = item.copy()
                 processed_item[SUBJECT_ID_COLUMN_NAME] = subject_node_id
+                processed_item[DATASOURCE_ID_COLUMN] = self.datasource_id
+                if processed_item.get("id") not in (None, ""):
+                    processed_item[STORAGE_KEY_COLUMN] = build_storage_key(self.datasource_id, processed_item["id"])
                 processed_item.pop(SUBJECT_PATH_COLUMN_NAME, None)
 
                 # Auto-generate timestamp if needed
@@ -822,7 +840,9 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
 
         results = []
         for path, name in path_filter:
-            conditions = additional_conditions.copy() if additional_conditions else []
+            conditions = [datasource_condition(self.datasource_id)]
+            if additional_conditions:
+                conditions.extend(additional_conditions)
 
             # Convert path to include all descendant node_ids if provided
             if path:
@@ -1038,12 +1058,20 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         self._ensure_table_ready()
         from datus_storage_base.conditions import and_, eq
 
-        where_condition = and_(eq(SUBJECT_ID_COLUMN_NAME, old_subject_node_id), eq("name", old_name))
+        where_condition = and_(
+            eq(SUBJECT_ID_COLUMN_NAME, old_subject_node_id),
+            eq("name", old_name),
+            datasource_condition(self.datasource_id),
+        )
 
         # Check for conflicts when both name and parent are changing
         if name_changed and parent_changed:
             # Check if target (new_subject_node_id + new_name) already exists
-            conflict_condition = and_(eq(SUBJECT_ID_COLUMN_NAME, new_subject_node_id), eq("name", new_name))
+            conflict_condition = and_(
+                eq(SUBJECT_ID_COLUMN_NAME, new_subject_node_id),
+                eq("name", new_name),
+                datasource_condition(self.datasource_id),
+            )
             existing_count = self._count_rows(conflict_condition)
             if existing_count > 0:
                 raise ValueError(
@@ -1132,7 +1160,11 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         self._ensure_table_ready()
         from datus_storage_base.conditions import and_, eq
 
-        conditions = [eq(SUBJECT_ID_COLUMN_NAME, subject_node_id), eq(NAME_COLUMN_NAME, name.strip())]
+        conditions = [
+            eq(SUBJECT_ID_COLUMN_NAME, subject_node_id),
+            eq(NAME_COLUMN_NAME, name.strip()),
+            datasource_condition(self.datasource_id),
+        ]
         if extra_conditions:
             conditions.extend(extra_conditions)
         where_condition = and_(*conditions)
@@ -1189,7 +1221,7 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
             self._ensure_table_ready()
 
             # Build where clause
-            conditions = [eq(SUBJECT_ID_COLUMN_NAME, node_id)]
+            conditions = [eq(SUBJECT_ID_COLUMN_NAME, node_id), datasource_condition(self.datasource_id)]
 
             if name:
                 conditions.append(eq(NAME_COLUMN_NAME, name))
@@ -1243,7 +1275,11 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         self._ensure_table_ready()
         from datus_storage_base.conditions import and_, eq
 
-        conditions = [eq(SUBJECT_ID_COLUMN_NAME, subject_node_id), eq(NAME_COLUMN_NAME, name)]
+        conditions = [
+            eq(SUBJECT_ID_COLUMN_NAME, subject_node_id),
+            eq(NAME_COLUMN_NAME, name),
+            datasource_condition(self.datasource_id),
+        ]
         if extra_conditions:
             conditions.extend(extra_conditions)
         where_condition = and_(*conditions)

--- a/datus/storage/vector/lance_backend.py
+++ b/datus/storage/vector/lance_backend.py
@@ -210,6 +210,13 @@ class LanceVectorTable(VectorTable):
     def create_scalar_index(self, column: str) -> None:
         self._table.create_scalar_index(column, replace=True)
 
+    def ensure_columns(self, expressions: Dict[str, str]) -> None:
+        """Add missing columns using Lance SQL expressions."""
+
+        missing = {name: expr for name, expr in expressions.items() if name not in self._table.schema.names}
+        if missing:
+            self._table.add_columns(missing)
+
     # -- Maintenance --
 
     def compact_files(self) -> None:

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -648,6 +648,55 @@ class FilesystemFuncTool(BaseTool):
 
         yield from walk_recursive(target_path)
 
+    @staticmethod
+    def _glob_part_has_magic(part: str) -> bool:
+        return any(ch in part for ch in "*?[{")
+
+    def _rescope_path_pattern_glob(self, pattern: str, path: str) -> tuple[str, str]:
+        """Treat path-like glob patterns as an explicit seed directory.
+
+        ``glob(pattern="subject/foo/*.yml", path=".")`` should search
+        ``subject/foo`` even when ``subject/`` is gitignored from a root walk.
+        """
+        if not pattern or os.path.isabs(pattern):
+            return pattern, path
+
+        normalized_pattern = pattern.replace("\\", "/")
+        if "/" not in normalized_pattern:
+            return pattern, path
+
+        parts = [part for part in normalized_pattern.split("/") if part not in ("", ".")]
+        if len(parts) <= 1:
+            return pattern, path
+
+        fixed_parts: List[str] = []
+        remainder_parts: List[str] = []
+        for idx, part in enumerate(parts):
+            if self._glob_part_has_magic(part):
+                remainder_parts = parts[idx:]
+                break
+            fixed_parts.append(part)
+        else:
+            fixed_parts = parts[:-1]
+            remainder_parts = parts[-1:]
+
+        if not fixed_parts or not remainder_parts:
+            return pattern, path
+
+        fixed_prefix = "/".join(fixed_parts)
+        remainder = "/".join(remainder_parts)
+        candidates = [fixed_prefix]
+        if path not in ("", ".", "./"):
+            candidates.append(os.path.join(path, fixed_prefix))
+
+        for candidate in candidates:
+            resolved = self._classify(candidate)
+            if resolved.zone == PathZone.HIDDEN:
+                continue
+            if resolved.resolved.exists() and resolved.resolved.is_dir():
+                return remainder, candidate
+        return pattern, path
+
     def glob(self, pattern: str, path: str = ".") -> FuncToolResult:
         """
         Find files matching a glob pattern.
@@ -666,6 +715,7 @@ class FilesystemFuncTool(BaseTool):
         """
         max_results = 200
         try:
+            pattern, path = self._rescope_path_pattern_glob(pattern, path)
             seed = self._classify(path)
             if seed.zone == PathZone.HIDDEN:
                 return FuncToolResult(result={"files": [], "truncated": False})

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -685,9 +685,10 @@ class FilesystemFuncTool(BaseTool):
 
         fixed_prefix = "/".join(fixed_parts)
         remainder = "/".join(remainder_parts)
-        candidates = [fixed_prefix]
+        candidates = []
         if path not in ("", ".", "./"):
             candidates.append(os.path.join(path, fixed_prefix))
+        candidates.append(fixed_prefix)
 
         for candidate in candidates:
             resolved = self._classify(candidate)

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -381,8 +381,9 @@ def _dry_run_satisfies_time_group(dry_run: Dict[str, Any], time_hint: Dict[str, 
     if (
         isinstance(sql, str)
         and base_expr
+        and dimensions
         and _sql_contains_base_expr_text(sql, base_expr)
-        and (not dimensions or any(_is_metric_time_dimension(dimension) for dimension in dimensions))
+        and any(_is_metric_time_dimension(dimension) for dimension in dimensions)
     ):
         return True
     if not isinstance(sql, str) or not _sql_contains_time_group(sql, base_expr, grain):

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -53,9 +53,11 @@ class GenerationEvidence:
     metric_dry_run_queries: List[Dict[str, Any]] = field(default_factory=list)
     metric_sqls: Dict[str, str] = field(default_factory=dict)
     metric_queryability_contracts: List[Dict[str, Any]] = field(default_factory=list)
+    metric_aliases: Dict[str, str] = field(default_factory=dict)
     semantic_kb_sync_passed: bool = False
     metric_kb_sync_passed: bool = False
     generic_kb_sync_passed: bool = False
+    storage_revision: int = 0
 
     @property
     def kb_sync_passed(self) -> bool:
@@ -67,12 +69,33 @@ class GenerationEvidence:
         if _result_success(result) and valid:
             self.validation_passed = True
 
-    def set_metric_queryability_contracts(self, contracts: Optional[Iterable[Dict[str, Any]]]) -> None:
-        self.metric_queryability_contracts = [
-            contract
-            for contract in (contracts or [])
-            if isinstance(contract, dict) and (contract.get("dimension_hints") or contract.get("time_group_hints"))
-        ]
+    def set_metric_queryability_contracts(
+        self,
+        contracts: Optional[Iterable[Dict[str, Any]]],
+        metric_aliases: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.metric_aliases = _normalized_metric_alias_map(metric_aliases or {})
+        self.metric_queryability_contracts = []
+        for contract in contracts or []:
+            if not isinstance(contract, dict) or not (
+                contract.get("dimension_hints") or contract.get("time_group_hints")
+            ):
+                continue
+            normalized_contract = dict(contract)
+            metric_hints = []
+            alias_rewrites = {}
+            for hint in contract.get("metric_hints") or []:
+                if not isinstance(hint, str) or not hint.strip():
+                    continue
+                canonical = _canonical_metric_hint(hint, self.metric_aliases)
+                metric_hints.append(canonical)
+                if canonical != hint:
+                    alias_rewrites[hint] = canonical
+            if metric_hints:
+                normalized_contract["metric_hints"] = _deduplicate_preserve_order(metric_hints)
+            if alias_rewrites:
+                normalized_contract["metric_alias_rewrites"] = alias_rewrites
+            self.metric_queryability_contracts.append(normalized_contract)
 
     def record_metric_dry_run(
         self,
@@ -90,10 +113,15 @@ class GenerationEvidence:
         metrics_list = [m for m in metric_candidates if isinstance(m, str) and m]
         self.metric_dry_run_metrics.update(metrics_list)
         dimensions_list = [d for d in dimension_candidates if isinstance(d, str) and d]
+        explicit_time_granularity = isinstance(time_granularity, str) and bool(_normalize_time_grain(time_granularity))
+        normalized_time_granularity = (
+            time_granularity if explicit_time_granularity else _time_grain_from_dimensions(dimensions_list)
+        )
         dry_run_query = {
             "metrics": metrics_list,
             "dimensions": dimensions_list,
-            "time_granularity": time_granularity if isinstance(time_granularity, str) else None,
+            "time_granularity": normalized_time_granularity,
+            "time_granularity_explicit": explicit_time_granularity,
         }
         self.metric_dry_run_queries.append(dry_run_query)
         metadata = _metadata_from_result(result)
@@ -146,12 +174,14 @@ class GenerationEvidence:
         ]
 
     def _contract_has_matching_dry_run(self, contract: Dict[str, Any], generated_metrics: Set[str]) -> bool:
-        required_metrics = {
-            name
-            for name in (contract.get("metric_hints") or [])
-            if isinstance(name, str) and (not generated_metrics or name in generated_metrics)
-        }
-        if not required_metrics:
+        metric_hints = {name for name in (contract.get("metric_hints") or []) if isinstance(name, str)}
+        if generated_metrics:
+            required_metrics = metric_hints & generated_metrics if metric_hints else generated_metrics
+            if metric_hints and not required_metrics:
+                return True
+        else:
+            required_metrics = metric_hints
+        if not required_metrics and not metric_hints:
             required_metrics = generated_metrics
 
         covered_metrics: Set[str] = set()
@@ -184,6 +214,7 @@ class GenerationEvidence:
             if (
                 _looks_time_dimension(hint)
                 and time_granularity
+                and dry_run.get("time_granularity_explicit") is True
                 and any(_is_metric_time_dimension(dimension) for dimension in dimensions)
             ):
                 continue
@@ -197,6 +228,7 @@ class GenerationEvidence:
             self.semantic_kb_sync_passed = True
         else:
             self.generic_kb_sync_passed = True
+        self.storage_revision += 1
 
 
 _GENERIC_DIMENSION_TOKENS = {"id", "key", "name", "dim", "dimension", "value"}
@@ -223,6 +255,35 @@ def _name_tokens(value: str) -> Set[str]:
 
 def _normalize_name(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", str(value).strip().lower()).strip("_")
+
+
+def _deduplicate_preserve_order(values: Iterable[str]) -> List[str]:
+    result: List[str] = []
+    seen: Set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _normalized_metric_alias_map(metric_aliases: Dict[str, str]) -> Dict[str, str]:
+    normalized: Dict[str, str] = {}
+    for alias, canonical in metric_aliases.items():
+        if not isinstance(alias, str) or not isinstance(canonical, str):
+            continue
+        alias = alias.strip()
+        canonical = canonical.strip()
+        if not alias or not canonical:
+            continue
+        normalized[alias] = canonical
+        normalized[_normalize_name(alias)] = canonical
+    return normalized
+
+
+def _canonical_metric_hint(hint: str, metric_aliases: Dict[str, str]) -> str:
+    return metric_aliases.get(hint) or metric_aliases.get(_normalize_name(hint)) or hint
 
 
 def _semantic_tokens(value: str) -> Set[str]:
@@ -307,16 +368,23 @@ def _dimension_matches_expr_hint(dimension: str, expr_hint: Dict[str, str]) -> b
 
 def _dry_run_satisfies_time_group(dry_run: Dict[str, Any], time_hint: Dict[str, str]) -> bool:
     grain = _normalize_time_grain(time_hint.get("grain", ""))
-    dry_run_grain = _normalize_time_grain(dry_run.get("time_granularity"))
+    dimensions = [d for d in dry_run.get("dimensions", []) if isinstance(d, str)]
+    dry_run_grain = _normalize_time_grain(dry_run.get("time_granularity")) or _time_grain_from_dimensions(dimensions)
     if not grain or dry_run_grain != grain:
         return False
 
-    dimensions = [d for d in dry_run.get("dimensions", []) if isinstance(d, str)]
     base_expr = time_hint.get("base_expr", "")
     if base_expr and any(_time_base_dimension_matches(dimension, base_expr) for dimension in dimensions):
         return True
 
     sql = dry_run.get("sql", "")
+    if (
+        isinstance(sql, str)
+        and base_expr
+        and _sql_contains_base_expr_text(sql, base_expr)
+        and (not dimensions or any(_is_metric_time_dimension(dimension) for dimension in dimensions))
+    ):
+        return True
     if not isinstance(sql, str) or not _sql_contains_time_group(sql, base_expr, grain):
         return False
     return True
@@ -325,6 +393,22 @@ def _dry_run_satisfies_time_group(dry_run: Dict[str, Any], time_hint: Dict[str, 
 def _normalize_time_grain(value: Any) -> str:
     text = str(value or "").strip().strip("'\"").lower()
     return text if text in _TIME_GRAINS else ""
+
+
+def _time_grain_from_dimensions(dimensions: Iterable[str]) -> Optional[str]:
+    for dimension in dimensions:
+        grain = _dimension_time_grain(dimension)
+        if grain:
+            return grain
+    return None
+
+
+def _dimension_time_grain(dimension: str) -> str:
+    text = str(dimension or "").strip().lower()
+    if "__" not in text:
+        return ""
+    grain = re.sub(r"[^a-z0-9]+", "", text.rsplit("__", 1)[-1])
+    return grain if grain in _TIME_GRAINS else ""
 
 
 def _time_base_dimension_matches(dimension: str, base_expr: str) -> bool:
@@ -349,6 +433,18 @@ def _sql_contains_time_group(sql: str, base_expr: str, grain: str) -> bool:
             if _time_trunc_expression_matches(expr, normalized_base, grain):
                 return True
     return False
+
+
+def _sql_contains_base_expr_text(sql: str, base_expr: str) -> bool:
+    normalized_sql = _normalize_sql_text(sql)
+    normalized_base = _normalize_sql_text(base_expr)
+    if normalized_base and normalized_base in normalized_sql:
+        return True
+    leaf = _last_identifier(base_expr)
+    normalized_leaf = _normalize_sql_text(leaf)
+    return bool(
+        normalized_leaf and re.search(rf"(?<![a-z0-9_]){re.escape(normalized_leaf)}(?![a-z0-9_])", normalized_sql)
+    )
 
 
 def _sql_contains_expression(sql: str, expression: str) -> bool:

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -4,15 +4,17 @@
 
 # -*- coding: utf-8 -*-
 import os
-from typing import Dict, List, Optional
+import tempfile
+from collections.abc import Iterable
+from typing import Any, Dict, List, Optional
 
 import yaml
 from agents import Tool
 from datus_storage_base.conditions import And, eq
 
 from datus.configuration.agent_config import AgentConfig
-from datus.storage.metric.store import MetricRAG
-from datus.storage.semantic_model.store import SemanticModelRAG
+from datus.storage.metric.store import MetricRAG, metric_definition_conflict, normalize_metric_name
+from datus.storage.semantic_model.store import SemanticModelRAG, _identifier_variants, _normalized_identifier
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.metric_queryability import summarize_queryability_contracts
@@ -20,6 +22,47 @@ from datus.utils.loggings import get_logger
 from datus.utils.path_manager import get_path_manager
 
 logger = get_logger(__name__)
+
+
+def _rows_to_dicts(rows: Any) -> List[Dict[str, Any]]:
+    """Normalize storage row containers to a list of dictionaries."""
+
+    if rows is None:
+        return []
+    if hasattr(rows, "to_pylist"):
+        rows = rows.to_pylist()
+    if isinstance(rows, dict):
+        return [rows]
+    if isinstance(rows, list):
+        iterable: Iterable[Any] = rows
+    elif isinstance(rows, tuple):
+        iterable = rows
+    elif isinstance(rows, Iterable) and not isinstance(rows, (str, bytes)):
+        iterable = rows
+    else:
+        return []
+    return [row for row in iterable if isinstance(row, dict)]
+
+
+def _is_supported_row_container(rows: Any) -> bool:
+    if rows is None:
+        return True
+    if hasattr(rows, "to_pylist"):
+        return True
+    if isinstance(rows, (dict, list, tuple)):
+        return True
+    return isinstance(rows, Iterable) and not isinstance(rows, (str, bytes))
+
+
+def _rag_scope_conditions(rag: Any) -> List[Any]:
+    method = getattr(rag, "_sub_agent_conditions", None)
+    if not callable(method):
+        return []
+    try:
+        conditions = method()
+    except Exception:
+        return []
+    return conditions if isinstance(conditions, list) else []
 
 
 class GenerationTools:
@@ -35,6 +78,8 @@ class GenerationTools:
         self.generation_evidence = generation_evidence or GenerationEvidence()
         self.metric_rag = MetricRAG(agent_config)
         self.semantic_rag = SemanticModelRAG(agent_config)
+        self._semantic_object_exists_cache: Dict[tuple[str, str, str], FuncToolResult] = {}
+        self._semantic_table_object_index: Optional[Dict[str, Dict[str, object]]] = None
 
     def available_tools(self) -> List[Tool]:
         """
@@ -73,23 +118,33 @@ class GenerationTools:
             dict: Check results containing existence status and details.
         """
         try:
+            normalized_kind = str(kind or "").strip().lower()
+            cache_key = (
+                normalized_kind,
+                str(object_name or "").strip().lower(),
+                str(table_context or "").strip().lower(),
+            )
+            cached = self._semantic_object_exists_cache.get(cache_key)
+            if cached is not None:
+                logger.debug("check_semantic_object_exists cache hit: %s", cache_key)
+                return cached.model_copy(deep=True)
+
             # Extract the final segment as target name (e.g., "public.orders" -> "orders")
-            target_name = object_name.split(".")[-1].lower()
+            target_name = object_name.split(".")[-1].strip('`"[]').lower()
 
             found_object = None
 
-            if kind == "table":
-                # Exact match for table using SQL WHERE condition
-                storage = self.semantic_rag.storage
-                where = And([eq("kind", "table"), eq("name", target_name)])
-                results = storage.search_all(where=where, select_fields=["id", "name", "kind"])
-                if results:
-                    found_object = results[0]
-            elif kind == "metric":
+            if normalized_kind == "table":
+                table_index = self._get_semantic_table_object_index()
+                for candidate in _identifier_variants(object_name):
+                    found_object = table_index.get(candidate) or table_index.get(_normalized_identifier(candidate))
+                    if found_object:
+                        break
+            elif normalized_kind == "metric":
                 # Exact match for metric using SQL WHERE condition
                 storage = self.metric_rag.storage
-                where = eq("name", target_name)
-                results = storage.search_all(where=where, select_fields=["id", "name"])
+                where = And([eq("name", target_name)] + _rag_scope_conditions(self.metric_rag))
+                results = _rows_to_dicts(storage.search_all(where=where, select_fields=["id", "name"]))
                 if results:
                     found_object = results[0]
             else:
@@ -97,9 +152,10 @@ class GenerationTools:
                 storage = self.semantic_rag.storage
                 results = storage.search_objects(
                     query_text=object_name,
-                    kinds=[kind],
+                    kinds=[normalized_kind],
                     table_name=table_context if table_context else None,
                     top_n=5,
+                    extra_conditions=_rag_scope_conditions(self.semantic_rag),
                 )
                 # Determine target table from explicit context or dotted name
                 target_table = None
@@ -108,7 +164,7 @@ class GenerationTools:
                 elif "." in object_name:
                     target_table = object_name.rsplit(".", 1)[0].lower()
 
-                for obj in results:
+                for obj in _rows_to_dicts(results):
                     name_match = obj.get("name", "").lower() == target_name
                     if target_table:
                         table_match = obj.get("table_name", "").lower() == target_table
@@ -120,17 +176,23 @@ class GenerationTools:
                         break
 
             if found_object:
-                return FuncToolResult(
+                result = FuncToolResult(
                     result={
                         "exists": True,
                         "id": found_object.get("id"),
                         "name": found_object.get("name"),
-                        "kind": found_object.get("kind") or kind,
-                        "message": f"Object '{object_name}' ({kind}) already exists.",
+                        "kind": found_object.get("kind") or normalized_kind,
+                        "message": f"Object '{object_name}' ({normalized_kind}) already exists.",
                     }
                 )
+                self._semantic_object_exists_cache[cache_key] = result.model_copy(deep=True)
+                return result
 
-            return FuncToolResult(result={"exists": False, "message": f"No {kind} found for '{object_name}'"})
+            result = FuncToolResult(
+                result={"exists": False, "message": f"No {normalized_kind} found for '{object_name}'"}
+            )
+            self._semantic_object_exists_cache[cache_key] = result.model_copy(deep=True)
+            return result
 
         except Exception as e:
             logger.error(f"Error checking semantic object existence: {e}")
@@ -146,6 +208,34 @@ class GenerationTools:
     ) -> FuncToolResult:
         """Legacy wrapper for checking table existence."""
         return self.check_semantic_object_exists(table_name, kind="table")
+
+    def _get_semantic_table_object_index(self) -> Dict[str, Dict[str, object]]:
+        """Load table semantic objects once and index all identifier variants."""
+
+        if self._semantic_table_object_index is not None:
+            return self._semantic_table_object_index
+
+        storage = self.semantic_rag.storage
+        select_fields = ["id", "name", "kind", "table_name", "fq_name"]
+        rows = storage.search_all(
+            where=And([eq("kind", "table")] + _rag_scope_conditions(self.semantic_rag)),
+            select_fields=select_fields,
+        )
+        index: Dict[str, Dict[str, object]] = {}
+        for obj in _rows_to_dicts(rows):
+            for field in ("name", "table_name", "fq_name"):
+                value = str(obj.get(field) or "").strip()
+                if not value:
+                    continue
+                for variant in _identifier_variants(value):
+                    if variant:
+                        index.setdefault(variant, obj)
+                    normalized = _normalized_identifier(variant)
+                    if normalized:
+                        index.setdefault(normalized, obj)
+
+        self._semantic_table_object_index = index
+        return index
 
     def end_semantic_model_generation(self, semantic_model_files: List[str]) -> FuncToolResult:
         """
@@ -179,6 +269,8 @@ class GenerationTools:
             logger.info(
                 f"Semantic model generation completed for {len(semantic_model_files)} files: {semantic_model_files}"
             )
+            self._semantic_object_exists_cache.clear()
+            self._semantic_table_object_index = None
 
             return FuncToolResult(
                 result={
@@ -192,7 +284,11 @@ class GenerationTools:
             return FuncToolResult(success=0, error=f"Failed to complete generation: {str(e)}")
 
     def end_metric_generation(
-        self, metric_file: str, semantic_model_file: str = "", metric_sqls_json: str = ""
+        self,
+        metric_file: str,
+        semantic_model_files: Optional[List[str]] = None,
+        metric_sqls_json: str = "",
+        semantic_model_file: str = "",
     ) -> FuncToolResult:
         """
         Complete metric generation process and automatically sync to Knowledge Base.
@@ -207,10 +303,9 @@ class GenerationTools:
                 the live ``agent_config.current_datasource``. Absolute paths are only
                 accepted when they resolve inside the Knowledge Base semantic-model
                 sandbox.
-            semantic_model_file: Path to the primary semantic model file that defines
-                the measure(s) used by this metric. Optional — provide this if the
-                semantic model was newly created or updated. Same relative/absolute
-                rules as ``metric_file``.
+            semantic_model_files: Paths to semantic model files that were newly
+                created or updated and define the measure(s) used by this metric
+                batch. Same relative/absolute rules as ``metric_file``.
             metric_sqls_json: JSON string mapping metric names to their generated SQL (from query_metrics dry_run).
                               Example: '{"revenue_total": "SELECT SUM(revenue) FROM orders GROUP BY date"}'
 
@@ -220,6 +315,10 @@ class GenerationTools:
         import json
 
         try:
+            if semantic_model_files is None and semantic_model_file:
+                semantic_model_files = [semantic_model_file]
+            semantic_model_files = semantic_model_files or []
+
             # Parse JSON string to dict
             metric_sqls: Dict[str, str] = {}
             if metric_sqls_json:
@@ -240,7 +339,7 @@ class GenerationTools:
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -255,7 +354,7 @@ class GenerationTools:
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -265,7 +364,7 @@ class GenerationTools:
 
             logger.info(
                 f"Metric generation completed: metric_file={metric_file}, "
-                f"semantic_model_file={semantic_model_file}, "
+                f"semantic_model_files={semantic_model_files}, "
                 f"metric_sqls={metric_sqls}"
             )
 
@@ -282,24 +381,40 @@ class GenerationTools:
                 return resolve_kb_sandbox_path(path, kind, subject_root) or ""
 
             abs_metric = _resolve(metric_file, "metric")
-            abs_semantic = _resolve(semantic_model_file, "semantic")
+            if not isinstance(semantic_model_files, list):
+                return FuncToolResult(
+                    success=0,
+                    error="semantic_model_files must be a list of semantic model YAML paths",
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_files": semantic_model_files,
+                        "metric_sqls": metric_sqls,
+                    },
+                )
+            abs_semantic_files: List[str] = []
+            for candidate_semantic_model_file in semantic_model_files:
+                abs_semantic = _resolve(candidate_semantic_model_file, "semantic")
+                if not abs_semantic:
+                    return FuncToolResult(
+                        success=0,
+                        error=(
+                            "semantic_model_files contains path outside Knowledge Base sandbox: "
+                            f"{candidate_semantic_model_file!r}"
+                        ),
+                        result={
+                            "metric_file": metric_file,
+                            "semantic_model_files": semantic_model_files,
+                            "metric_sqls": metric_sqls,
+                        },
+                    )
+                abs_semantic_files.append(abs_semantic)
             if not abs_metric:
                 return FuncToolResult(
                     success=0,
                     error=f"metric_file escapes Knowledge Base sandbox: {metric_file!r}",
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
-                        "metric_sqls": metric_sqls,
-                    },
-                )
-            if semantic_model_file and not abs_semantic:
-                return FuncToolResult(
-                    success=0,
-                    error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}",
-                    result={
-                        "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
@@ -317,27 +432,61 @@ class GenerationTools:
                     error=preflight_error,
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
             metric_names = self._extract_metric_names_from_file(abs_metric)
-            if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
+            metric_definitions = self._extract_metric_definitions_from_file(abs_metric)
+            metric_names_to_sync = self._metric_names_to_sync(metric_names, metric_sqls)
+            scoped_metric_names = self._filter_metric_names(metric_names, metric_names_to_sync)
+            scoped_metric_definitions = self._filter_metric_definitions(metric_definitions, metric_names_to_sync)
+            if metric_names_to_sync is not None and not scoped_metric_definitions:
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        "metric_sqls_json does not reference any metric declared in metric_file. "
+                        "Pass SQL entries for the metric names being published, or omit metric_sqls_json "
+                        "to publish the whole file."
+                    ),
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_files": semantic_model_files,
+                        "metric_sqls": metric_sqls,
+                    },
+                )
+            conflict_error = self._validate_metric_name_conflicts(scoped_metric_definitions)
+            if conflict_error:
+                return FuncToolResult(
+                    success=0,
+                    error=conflict_error,
+                    result={
+                        "metric_file": metric_file,
+                        "semantic_model_files": semantic_model_files,
+                        "metric_sqls": metric_sqls,
+                    },
+                )
+            required_metric_names = self._metric_names_requiring_dry_run(
+                scoped_metric_names, scoped_metric_definitions, metric_sqls
+            )
+            if required_metric_names and not self.generation_evidence.has_metric_dry_run(required_metric_names):
                 return FuncToolResult(
                     success=0,
                     error=(
                         "query_metrics(dry_run=True) must pass for generated metric(s): "
-                        f"{', '.join(metric_names)}. Run a dry-run query for these metric names, "
+                        f"{', '.join(required_metric_names)}. Run a dry-run query for these metric names, "
                         "fix any issues, and retry end_metric_generation."
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
                 )
-            if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
-                missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
+            if required_metric_names and not self.generation_evidence.has_required_queryability_dry_runs(
+                required_metric_names
+            ):
+                missing_contracts = self.generation_evidence.missing_queryability_contracts(required_metric_names)
                 contract_summary = summarize_queryability_contracts(missing_contracts)
                 return FuncToolResult(
                     success=0,
@@ -348,14 +497,19 @@ class GenerationTools:
                     ),
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                         "queryability_contracts": missing_contracts,
                     },
                 )
 
             # Auto-sync to Knowledge Base
-            sync_result = self._sync_metric_to_db(abs_metric, abs_semantic, metric_sqls)
+            sync_result = self._sync_metric_to_db(
+                abs_metric,
+                abs_semantic_files,
+                metric_sqls,
+                metric_names_to_sync=metric_names_to_sync,
+            )
 
             if not sync_result.get("success"):
                 return FuncToolResult(
@@ -363,7 +517,7 @@ class GenerationTools:
                     error=f"Metric file written but KB sync failed: {sync_result.get('error', 'unknown')}",
                     result={
                         "metric_file": metric_file,
-                        "semantic_model_file": semantic_model_file,
+                        "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                         "sync": sync_result,
                     },
@@ -372,12 +526,14 @@ class GenerationTools:
             self.generation_evidence.mark_kb_sync("metric")
             if sync_result.get("semantic_synced"):
                 self.generation_evidence.mark_kb_sync("semantic")
+            self._semantic_object_exists_cache.clear()
+            self._semantic_table_object_index = None
 
             return FuncToolResult(
                 result={
                     "message": "Metric generation completed and synced to Knowledge Base",
                     "metric_file": metric_file,
-                    "semantic_model_file": semantic_model_file,
+                    "semantic_model_files": semantic_model_files,
                     "metric_sqls": metric_sqls,
                     "sync": sync_result,
                 }
@@ -409,6 +565,8 @@ class GenerationTools:
                 "(separated by `---`)."
             )
         saw_metric_block = False
+        seen_names: Dict[str, str] = {}
+        saw_named_metric = False
         for doc in docs:
             if isinstance(doc, dict) and "metric" in doc:
                 saw_metric_block = True
@@ -416,7 +574,18 @@ class GenerationTools:
                 if isinstance(metric, dict):
                     name = metric.get("name")
                     if isinstance(name, str) and name.strip():
-                        return None
+                        saw_named_metric = True
+                        metric_name = name.strip()
+                        normalized = normalize_metric_name(metric_name)
+                        if normalized in seen_names:
+                            return (
+                                f"Metric file {metric_file!r} declares duplicate metric.name '{metric_name}'. "
+                                "Metric names must be unique within a datasource; merge identical definitions "
+                                "or choose a more specific business name."
+                            )
+                        seen_names[normalized] = metric_name
+        if saw_named_metric:
+            return None
         if saw_metric_block:
             return (
                 f"Metric file {metric_file!r} contains `metric:` YAML blocks, "
@@ -453,20 +622,248 @@ class GenerationTools:
                 names.append(name)
         return names
 
+    @staticmethod
+    def _extract_metric_definitions_from_file(metric_file: str) -> List[Dict[str, object]]:
+        """Return lightweight metric definitions for pre-sync conflict checks."""
+        try:
+            with open(metric_file, "r", encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+        except (OSError, yaml.YAMLError):
+            return []
+
+        definitions: List[Dict[str, object]] = []
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            metric = doc.get("metric")
+            if not isinstance(metric, dict):
+                continue
+            name = metric.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            metric_type = str(metric.get("type") or "").strip()
+            type_params = metric.get("type_params") if isinstance(metric.get("type_params"), dict) else {}
+            measure_expr = ""
+            base_measures: List[str] = []
+
+            if metric_type == "measure_proxy":
+                measure = type_params.get("measure")
+                if isinstance(measure, str):
+                    measure_expr = measure
+                    base_measures.append(measure)
+                elif isinstance(measure, dict):
+                    measure_name = measure.get("name")
+                    if isinstance(measure_name, str) and measure_name.strip():
+                        measure_expr = measure_name
+                        base_measures.append(measure_name)
+            elif metric_type == "ratio":
+                for key in ("numerator", "denominator"):
+                    ref = type_params.get(key)
+                    if isinstance(ref, str) and ref.strip():
+                        base_measures.append(ref)
+                    elif isinstance(ref, dict):
+                        ref_name = ref.get("name")
+                        if isinstance(ref_name, str) and ref_name.strip():
+                            base_measures.append(ref_name)
+            elif metric_type in {"expr", "cumulative"}:
+                for ref in type_params.get("measures") or []:
+                    if isinstance(ref, str) and ref.strip():
+                        base_measures.append(ref)
+                    elif isinstance(ref, dict):
+                        ref_name = ref.get("name")
+                        if isinstance(ref_name, str) and ref_name.strip():
+                            base_measures.append(ref_name)
+                if metric_type == "expr" and type_params.get("expr"):
+                    measure_expr = str(type_params["expr"])
+            elif metric_type == "derived":
+                for ref in type_params.get("metrics") or []:
+                    if isinstance(ref, str) and ref.strip():
+                        base_measures.append(ref)
+                    elif isinstance(ref, dict):
+                        ref_name = ref.get("name")
+                        if isinstance(ref_name, str) and ref_name.strip():
+                            base_measures.append(ref_name)
+                if type_params.get("expr"):
+                    measure_expr = str(type_params["expr"])
+
+            definitions.append(
+                {
+                    "name": name.strip(),
+                    "metric_type": metric_type,
+                    "measure_expr": measure_expr,
+                    "base_measures": base_measures,
+                }
+            )
+        return definitions
+
+    def _metric_names_requiring_dry_run(
+        self,
+        metric_names: List[str],
+        metric_definitions: List[Dict[str, object]],
+        metric_sqls: Optional[Dict[str, str]] = None,
+    ) -> List[str]:
+        """Return the subset of a metric file that must be dry-run before publish.
+
+        Batch generation appends new metrics to existing metrics YAML files. Later
+        batches should not have to re-dry-run every historical metric already in
+        that file; they only need to dry-run new metrics and metrics with SQL
+        evidence produced in this node run.
+        """
+        if not metric_names:
+            return []
+
+        by_normalized_name = {normalize_metric_name(name): name for name in metric_names if normalize_metric_name(name)}
+        required = set()
+        for name in metric_sqls or {}:
+            normalized = normalize_metric_name(name)
+            if normalized and not normalized.startswith("__") and normalized in by_normalized_name:
+                required.add(normalized)
+        for name in self.generation_evidence.metric_dry_run_metrics:
+            normalized = normalize_metric_name(name)
+            if normalized in by_normalized_name:
+                required.add(normalized)
+
+        existing_names = self._existing_metric_names()
+        if existing_names is None:
+            return metric_names
+        for definition in metric_definitions:
+            normalized = normalize_metric_name(definition.get("name"))
+            if normalized and normalized not in existing_names:
+                required.add(normalized)
+
+        if not required:
+            return []
+        return [name for normalized, name in by_normalized_name.items() if normalized in required]
+
+    @staticmethod
+    def _filter_metric_names(metric_names: List[str], metric_names_to_sync: Optional[set[str]]) -> List[str]:
+        if metric_names_to_sync is None:
+            return metric_names
+        return [name for name in metric_names if normalize_metric_name(name) in metric_names_to_sync]
+
+    @staticmethod
+    def _filter_metric_definitions(
+        metric_definitions: List[Dict[str, object]], metric_names_to_sync: Optional[set[str]]
+    ) -> List[Dict[str, object]]:
+        if metric_names_to_sync is None:
+            return metric_definitions
+        return [
+            definition
+            for definition in metric_definitions
+            if normalize_metric_name(definition.get("name")) in metric_names_to_sync
+        ]
+
+    @staticmethod
+    def _public_metric_sql_names(metric_sqls: Optional[Dict[str, str]]) -> set[str]:
+        names: set[str] = set()
+        for name in metric_sqls or {}:
+            raw_name = str(name or "").strip()
+            if not raw_name or raw_name.startswith("__"):
+                continue
+            normalized = normalize_metric_name(raw_name)
+            if normalized:
+                names.add(normalized)
+        return names
+
+    def _metric_names_to_sync(
+        self, metric_names: List[str], metric_sqls: Optional[Dict[str, str]]
+    ) -> Optional[set[str]]:
+        """Return the metric subset to publish, or None to publish the full file.
+
+        Later bootstrap batches often append one new metric to a file that already
+        contains older metrics. When the node provides metric_sqls_json, treat those
+        SQL keys as the current publish scope and avoid re-upserting historical
+        metrics from the same YAML file.
+        """
+
+        dry_run_names = {
+            normalized
+            for normalized in (normalize_metric_name(name) for name in self.generation_evidence.metric_dry_run_metrics)
+            if normalized
+        }
+        scope_names = self._public_metric_sql_names(metric_sqls) | dry_run_names
+        if not scope_names:
+            return None
+        if not metric_names:
+            return None
+
+        declared_names = {normalize_metric_name(name) for name in metric_names if normalize_metric_name(name)}
+        matched_names = scope_names & declared_names
+        if not matched_names:
+            return set()
+
+        existing_names = self._existing_metric_names()
+        if existing_names is not None:
+            new_names = matched_names - existing_names
+            if new_names:
+                return new_names
+        return matched_names
+
+    def _existing_metric_names(self) -> Optional[set[str]]:
+        try:
+            rows = self.metric_rag.search_all_metrics(select_fields=["name"])
+        except Exception as exc:
+            logger.warning("Failed to load existing metric names before publish dry-run gating: %s", exc)
+            return None
+        if not _is_supported_row_container(rows):
+            return None
+        names = set()
+        for row in _rows_to_dicts(rows):
+            normalized = normalize_metric_name(row.get("name"))
+            if normalized:
+                names.add(normalized)
+        return names
+
+    def _validate_metric_name_conflicts(self, metric_definitions: List[Dict[str, object]]) -> Optional[str]:
+        if not metric_definitions:
+            return None
+
+        existing_by_name: Dict[str, List[Dict[str, object]]] = {}
+        try:
+            rows = self.metric_rag.search_all_metrics(
+                select_fields=["id", "name", "semantic_model_name", "metric_type", "measure_expr", "base_measures"]
+            )
+        except Exception as exc:
+            logger.warning("Failed to check existing metric name conflicts before sync: %s", exc)
+            return None
+        if not _is_supported_row_container(rows):
+            return None
+
+        for row in _rows_to_dicts(rows):
+            normalized = normalize_metric_name(row.get("name"))
+            if normalized:
+                existing_by_name.setdefault(normalized, []).append(row)
+
+        for incoming in metric_definitions:
+            normalized = normalize_metric_name(incoming.get("name"))
+            if not normalized:
+                continue
+            for existing in existing_by_name.get(normalized, []):
+                conflict_field = metric_definition_conflict(existing, incoming)
+                if conflict_field:
+                    return (
+                        f"Metric name conflict within this datasource for '{incoming.get('name')}': "
+                        f"existing metric id '{existing.get('id')}' has a different '{conflict_field}'. "
+                        "Metric names must be unique within a datasource; choose a more specific name "
+                        "or update the existing metric explicitly."
+                    )
+        return None
+
     def _sync_metric_to_db(
         self,
         metric_file: str,
-        semantic_model_file: Optional[str] = None,
+        semantic_model_files: Optional[List[str]] = None,
         metric_sqls: Optional[Dict[str, str]] = None,
+        metric_names_to_sync: Optional[set[str]] = None,
     ) -> dict:
         """
-        Sync metric (and optionally semantic model) to Knowledge Base.
+        Sync metric and any updated semantic models to Knowledge Base.
 
         Reuses GenerationHooks._sync_semantic_to_db() static method.
 
         Args:
             metric_file: Absolute path to metric YAML file
-            semantic_model_file: Optional absolute path to semantic model YAML file
+            semantic_model_files: Optional absolute paths to semantic model YAML files
             metric_sqls: Optional dict mapping metric names to generated SQL
 
         Returns:
@@ -478,60 +875,48 @@ class GenerationTools:
             if not os.path.exists(metric_file):
                 return {"success": False, "error": f"Metric file not found: {metric_file}"}
 
-            if semantic_model_file and os.path.exists(semantic_model_file):
-                # Combine semantic model + metric into a temp file for sync
-                with open(semantic_model_file, "r", encoding="utf-8") as f:
-                    semantic_docs = list(yaml.safe_load_all(f))
-                with open(metric_file, "r", encoding="utf-8") as f:
-                    metric_docs = list(yaml.safe_load_all(f))
-
-                combined_docs = semantic_docs + metric_docs
-                import tempfile
-
-                fd, temp_file = tempfile.mkstemp(
-                    suffix=".combined.tmp",
-                    dir=os.path.dirname(semantic_model_file),
+            synced_semantic_files: List[str] = []
+            for semantic_model_file in semantic_model_files or []:
+                if not os.path.exists(semantic_model_file):
+                    return {
+                        "success": False,
+                        "error": f"Semantic model file not found: {semantic_model_file}",
+                    }
+                sem_result = GenerationHooks._sync_semantic_to_db(
+                    semantic_model_file,
+                    self.agent_config,
+                    include_semantic_objects=True,
+                    include_metrics=False,
                 )
-                try:
-                    os.close(fd)
-                    with open(temp_file, "w", encoding="utf-8") as f:
-                        yaml.safe_dump_all(combined_docs, f, allow_unicode=True, sort_keys=False)
+                if not sem_result.get("success"):
+                    return sem_result
+                synced_semantic_files.append(semantic_model_file)
 
-                    # First: sync semantic objects from the semantic model file
-                    sem_result = GenerationHooks._sync_semantic_to_db(
-                        semantic_model_file,
-                        self.agent_config,
-                        include_semantic_objects=True,
-                        include_metrics=False,
-                    )
-                    if not sem_result.get("success"):
-                        return sem_result
-                    # Then: sync metrics from combined file
-                    result = GenerationHooks._sync_semantic_to_db(
-                        temp_file,
-                        self.agent_config,
-                        include_semantic_objects=False,
-                        include_metrics=True,
-                        metric_sqls=metric_sqls,
-                        original_yaml_path=metric_file,
-                    )
-                    if result.get("success"):
-                        result["semantic_synced"] = True
-                finally:
-                    if os.path.exists(temp_file):
-                        os.remove(temp_file)
-            else:
-                # Sync metric file alone
+            sync_metric_file = metric_file
+            temp_metric_file = ""
+            sync_metric_sqls = metric_sqls
+            if metric_names_to_sync is not None:
+                sync_metric_file = self._write_filtered_metric_file(metric_file, metric_names_to_sync)
+                temp_metric_file = sync_metric_file if sync_metric_file != metric_file else ""
+                sync_metric_sqls = self._filter_metric_sqls(metric_sqls, metric_names_to_sync)
+
+            try:
                 result = GenerationHooks._sync_semantic_to_db(
-                    metric_file,
+                    sync_metric_file,
                     self.agent_config,
                     include_semantic_objects=False,
                     include_metrics=True,
-                    metric_sqls=metric_sqls,
+                    metric_sqls=sync_metric_sqls,
                     original_yaml_path=metric_file,
                 )
-                if result.get("success"):
-                    result["semantic_synced"] = False
+            finally:
+                if temp_metric_file and os.path.exists(temp_metric_file):
+                    os.remove(temp_metric_file)
+            if result.get("success"):
+                result["semantic_synced"] = bool(synced_semantic_files)
+                result["semantic_model_files_synced"] = synced_semantic_files
+                if metric_names_to_sync is not None:
+                    result["metric_names_synced"] = sorted(metric_names_to_sync)
 
             if result.get("success"):
                 logger.info(f"Successfully synced metric to KB: {result.get('message')}")
@@ -543,6 +928,46 @@ class GenerationTools:
         except Exception as e:
             logger.error(f"Error syncing metric to KB: {e}", exc_info=True)
             return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def _filter_metric_sqls(
+        metric_sqls: Optional[Dict[str, str]], metric_names_to_sync: set[str]
+    ) -> Optional[Dict[str, str]]:
+        if metric_sqls is None:
+            return None
+        filtered: Dict[str, str] = {}
+        for name, sql in metric_sqls.items():
+            normalized = normalize_metric_name(name)
+            if normalized in metric_names_to_sync:
+                filtered[name] = sql
+        return filtered
+
+    @staticmethod
+    def _write_filtered_metric_file(metric_file: str, metric_names_to_sync: set[str]) -> str:
+        with open(metric_file, "r", encoding="utf-8") as f:
+            docs = list(yaml.safe_load_all(f))
+
+        filtered_docs = []
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            metric = doc.get("metric")
+            if not isinstance(metric, dict):
+                continue
+            if normalize_metric_name(metric.get("name")) in metric_names_to_sync:
+                filtered_docs.append(doc)
+
+        if not filtered_docs:
+            raise ValueError("No matching metric definitions found for current publish scope")
+
+        fd, temp_path = tempfile.mkstemp(
+            prefix=".metric_publish_",
+            suffix=".yml",
+            dir=os.path.dirname(metric_file),
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.safe_dump_all(filtered_docs, f, allow_unicode=True, sort_keys=False)
+        return temp_path
 
     def generate_sql_summary_id(self, sql_query: str, comment: str = "") -> FuncToolResult:
         """

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -1,0 +1,495 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from datus.storage.metric.store import normalize_metric_name
+from datus.storage.metric.subject_path import normalize_metric_subject_tree_tag
+from datus.tools.func_tool.base import FuncToolResult
+from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
+from datus.tools.func_tool.fs_path_policy import PathZone, ResolvedPath
+
+
+class MetricFilesystemFuncTool(FilesystemFuncTool):
+    """Filesystem tool variant for MetricFlow YAML generation.
+
+    Batch metric generation often updates the same semantic model and metrics
+    files across several batches. Plain ``write_file`` replacement can drop
+    measures, dimensions, or metrics created by earlier batches, so existing
+    MetricFlow YAML files are merged structurally.
+    """
+
+    def write_file(self, path: str, content: str, file_type: str = "") -> FuncToolResult:  # type: ignore[override]
+        resolved = self._classify(path)
+        policy_error = self._reject_write_policy(resolved)
+        if policy_error is not None:
+            return policy_error
+
+        target_path = resolved.resolved
+        preprocess_result = self._preprocess_yaml_content(target_path, content)
+        if not preprocess_result.success:
+            return preprocess_result
+        content = str(preprocess_result.result or "")
+
+        if self._is_metric_file_path(target_path):
+            if not self._should_merge_metric_file(target_path):
+                normalize_result = self._normalize_metric_subject_tree_tags(target_path, content)
+                if not normalize_result.success:
+                    return normalize_result
+                content = str(normalize_result.result or "")
+                return super().write_file(path, content, file_type)
+
+            merge_result = self._merge_metric_content(target_path, content)
+            if not merge_result.success:
+                return merge_result
+            result = super().write_file(path, str(merge_result.result or ""), file_type)
+            if result.success:
+                result.result = f"Metric file merged successfully: {resolved.display}"
+            return result
+
+        if not self._should_merge_semantic_model(target_path):
+            return super().write_file(path, content, file_type)
+
+        merge_result = self._merge_semantic_model_content(target_path, content)
+        if not merge_result.success:
+            return merge_result
+        result = super().write_file(path, str(merge_result.result or ""), file_type)
+        if result.success:
+            result.result = f"Semantic model merged successfully: {resolved.display}"
+        return result
+
+    def edit_file(self, path: str, old_string: str, new_string: str) -> FuncToolResult:  # type: ignore[override]
+        resolved = self._classify(path)
+        policy_error = self._reject_write_policy(resolved)
+        if policy_error is not None:
+            return policy_error
+
+        target_path = resolved.resolved
+        original_content: Optional[str] = None
+        should_restore = self._is_semantic_yaml_path(target_path) and target_path.exists() and target_path.is_file()
+        if should_restore:
+            try:
+                original_content = target_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                return FuncToolResult(success=0, error=f"Cannot read YAML file before edit: {exc}")
+
+        result = super().edit_file(path, old_string, new_string)
+        if not result.success:
+            return result
+        if not self._is_semantic_yaml_path(target_path) or not target_path.exists():
+            return result
+
+        postprocess_result = self._postprocess_yaml_file(target_path)
+        if not postprocess_result.success:
+            if original_content is not None:
+                try:
+                    target_path.write_text(original_content, encoding="utf-8")
+                except OSError as exc:
+                    return FuncToolResult(
+                        success=0,
+                        error=f"{postprocess_result.error}; additionally failed to restore original file: {exc}",
+                    )
+            return postprocess_result
+        return result
+
+    def _reject_write_policy(self, resolved: ResolvedPath) -> Optional[FuncToolResult]:
+        if resolved.zone == PathZone.HIDDEN:
+            return self._not_found(resolved)
+        if self.strict and resolved.zone == PathZone.EXTERNAL:
+            return self._strict_reject(resolved)
+        if resolved.read_only:
+            return self._read_only_reject(resolved)
+        return None
+
+    def _postprocess_yaml_file(self, target_path: Path) -> FuncToolResult:
+        try:
+            content = target_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return FuncToolResult(success=0, error=f"Cannot read edited YAML file: {exc}")
+
+        preprocess_result = self._preprocess_yaml_content(target_path, content)
+        if not preprocess_result.success:
+            return preprocess_result
+        normalized_content = str(preprocess_result.result or "")
+
+        try:
+            list(yaml.safe_load_all(normalized_content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot normalize invalid edited YAML file: {exc}")
+
+        if self._is_metric_file_path(target_path):
+            normalize_result = self._normalize_metric_subject_tree_tags(target_path, normalized_content)
+            if not normalize_result.success:
+                return normalize_result
+            normalized_content = str(normalize_result.result or "")
+
+        if normalized_content != content:
+            try:
+                target_path.write_text(normalized_content, encoding="utf-8")
+            except OSError as exc:
+                return FuncToolResult(success=0, error=f"Cannot normalize edited YAML file: {exc}")
+        return FuncToolResult(result=normalized_content)
+
+    def _should_merge_semantic_model(self, target_path: Path) -> bool:
+        if not target_path.exists() or not target_path.is_file():
+            return False
+        if target_path.suffix.lower() not in {".yml", ".yaml"}:
+            return False
+        parts = target_path.parts
+        if "subject" not in parts or "semantic_models" not in parts:
+            return False
+        subject_idx = parts.index("subject")
+        if len(parts) <= subject_idx + 1 or parts[subject_idx + 1] != "semantic_models":
+            return False
+        return "metrics" not in parts[subject_idx + 2 : -1]
+
+    def _should_merge_metric_file(self, target_path: Path) -> bool:
+        return target_path.exists() and target_path.is_file() and self._is_metric_file_path(target_path)
+
+    def _is_metric_file_path(self, target_path: Path) -> bool:
+        if target_path.suffix.lower() not in {".yml", ".yaml"}:
+            return False
+        parts = target_path.parts
+        if "subject" not in parts or "semantic_models" not in parts:
+            return False
+        subject_idx = parts.index("subject")
+        if len(parts) <= subject_idx + 1 or parts[subject_idx + 1] != "semantic_models":
+            return False
+        return "metrics" in parts[subject_idx + 2 : -1]
+
+    def _is_semantic_yaml_path(self, target_path: Path) -> bool:
+        if target_path.suffix.lower() not in {".yml", ".yaml"}:
+            return False
+        parts = target_path.parts
+        if "subject" not in parts or "semantic_models" not in parts:
+            return False
+        subject_idx = parts.index("subject")
+        return len(parts) > subject_idx + 1 and parts[subject_idx + 1] == "semantic_models"
+
+    def _preprocess_yaml_content(self, target_path: Path, content: str) -> FuncToolResult:
+        if not self._is_semantic_yaml_path(target_path):
+            return FuncToolResult(result=content)
+        return FuncToolResult(result=self._repair_invalid_yaml_single_quote_escapes(content))
+
+    @staticmethod
+    def _repair_invalid_yaml_single_quote_escapes(content: str) -> str:
+        repaired = content
+        changed = False
+        for _ in range(20):
+            try:
+                list(yaml.safe_load_all(repaired))
+                return repaired if changed else content
+            except yaml.YAMLError as exc:
+                if "unknown escape character" not in str(exc) or "'" not in str(exc):
+                    return content
+                offset = MetricFilesystemFuncTool._yaml_error_offset(repaired, getattr(exc, "problem_mark", None))
+                if offset is None or offset <= 0:
+                    return content
+                if repaired[offset] != "'" or repaired[offset - 1] != "\\":
+                    return content
+                repaired = repaired[: offset - 1] + repaired[offset:]
+                changed = True
+        return content
+
+    @staticmethod
+    def _yaml_error_offset(content: str, mark: object) -> Optional[int]:
+        line = getattr(mark, "line", None)
+        column = getattr(mark, "column", None)
+        if not isinstance(line, int) or not isinstance(column, int) or line < 0 or column < 0:
+            return None
+        lines = content.splitlines(keepends=True)
+        if line >= len(lines) or column >= len(lines[line]):
+            return None
+        return sum(len(item) for item in lines[:line]) + column
+
+    def _merge_semantic_model_content(self, target_path: Path, incoming_content: str) -> FuncToolResult:
+        try:
+            existing_docs = list(yaml.safe_load_all(target_path.read_text(encoding="utf-8")))
+            incoming_docs = list(yaml.safe_load_all(incoming_content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot merge invalid semantic model YAML: {exc}")
+        except OSError as exc:
+            return FuncToolResult(success=0, error=f"Cannot read existing semantic model file: {exc}")
+
+        existing_idx, existing_doc, existing_ds = self._find_data_source_doc(existing_docs)
+        _, _, incoming_ds = self._find_data_source_doc(incoming_docs)
+        if existing_ds is None:
+            return FuncToolResult(
+                success=0,
+                error="Cannot merge existing semantic model YAML without a data_source document.",
+            )
+        if incoming_ds is None:
+            return FuncToolResult(
+                success=0,
+                error="Cannot merge semantic model YAML update without a data_source document.",
+            )
+
+        merged_ds, error = self._merge_data_sources(existing_ds, incoming_ds)
+        if error:
+            return FuncToolResult(success=0, error=error)
+
+        merged_doc = dict(existing_doc or {})
+        merged_doc["data_source"] = merged_ds
+        existing_docs[existing_idx] = merged_doc
+        merged_content = yaml.safe_dump_all(existing_docs, allow_unicode=True, sort_keys=False)
+        return self._normalize_metric_subject_tree_tags(target_path, merged_content)
+
+    def _merge_metric_content(self, target_path: Path, incoming_content: str) -> FuncToolResult:
+        try:
+            existing_docs = list(yaml.safe_load_all(target_path.read_text(encoding="utf-8")))
+            incoming_docs = list(yaml.safe_load_all(incoming_content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot merge invalid metric YAML: {exc}")
+        except OSError as exc:
+            return FuncToolResult(success=0, error=f"Cannot read existing metric file: {exc}")
+
+        existing_by_name: Dict[str, Tuple[int, Dict[str, Any]]] = {}
+        for idx, doc in enumerate(existing_docs):
+            metric = self._metric_from_doc(doc)
+            name = normalize_metric_name(metric.get("name") if metric else "")
+            if name and metric is not None:
+                existing_by_name[name] = (idx, metric)
+        if not existing_by_name:
+            return FuncToolResult(success=0, error="Cannot merge existing metric YAML without metric documents.")
+
+        saw_incoming_metric = False
+        for incoming_doc in incoming_docs:
+            incoming_metric = self._metric_from_doc(incoming_doc)
+            incoming_name = normalize_metric_name(incoming_metric.get("name") if incoming_metric else "")
+            if not incoming_name or incoming_metric is None:
+                continue
+            saw_incoming_metric = True
+            existing_entry = existing_by_name.get(incoming_name)
+            if existing_entry is None:
+                existing_by_name[incoming_name] = (len(existing_docs), incoming_metric)
+                existing_docs.append(incoming_doc)
+                continue
+
+            existing_idx, existing_metric = existing_entry
+            conflict_field = self._metric_definition_conflict(existing_metric, incoming_metric)
+            if conflict_field:
+                metric_name = incoming_metric.get("name") or existing_metric.get("name") or incoming_name
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        f"Refusing to overwrite metric '{metric_name}': field '{conflict_field}' differs. "
+                        "Metric names must be unique within a datasource; preserve the existing definition "
+                        "or choose a new metric name."
+                    ),
+                )
+            merged_metric = self._merge_metric_fields(existing_metric, incoming_metric)
+            merged_doc = dict(existing_docs[existing_idx] or {})
+            merged_doc["metric"] = merged_metric
+            existing_docs[existing_idx] = merged_doc
+            existing_by_name[incoming_name] = (existing_idx, merged_metric)
+
+        if not saw_incoming_metric:
+            return FuncToolResult(success=0, error="Cannot merge metric YAML update without metric documents.")
+
+        merged_content = yaml.safe_dump_all(existing_docs, allow_unicode=True, sort_keys=False)
+        return self._normalize_metric_subject_tree_tags(target_path, merged_content)
+
+    def _normalize_metric_subject_tree_tags(self, target_path: Path, content: str) -> FuncToolResult:
+        try:
+            docs = list(yaml.safe_load_all(content))
+        except yaml.YAMLError as exc:
+            return FuncToolResult(success=0, error=f"Cannot normalize invalid metric YAML: {exc}")
+
+        datasource, table_name = self._metric_scope_from_path(target_path)
+        changed = False
+        for doc in docs:
+            metric = self._metric_from_doc(doc)
+            if metric is None:
+                continue
+            locked_metadata = metric.get("locked_metadata")
+            if not isinstance(locked_metadata, dict):
+                continue
+            tags = locked_metadata.get("tags")
+            if not isinstance(tags, list):
+                continue
+            normalized_tags = []
+            for tag in tags:
+                normalized = (
+                    normalize_metric_subject_tree_tag(tag, datasource=datasource, table_name=table_name)
+                    if isinstance(tag, str)
+                    else tag
+                )
+                normalized_tags.append(normalized)
+                changed = changed or normalized != tag
+            locked_metadata["tags"] = normalized_tags
+
+        if not changed:
+            return FuncToolResult(result=content)
+        return FuncToolResult(result=yaml.safe_dump_all(docs, allow_unicode=True, sort_keys=False))
+
+    @staticmethod
+    def _metric_scope_from_path(target_path: Path) -> Tuple[str, str]:
+        parts = list(target_path.parts)
+        datasource = ""
+        if "semantic_models" in parts:
+            idx = parts.index("semantic_models")
+            if len(parts) > idx + 1:
+                datasource = parts[idx + 1]
+        stem = target_path.stem
+        table_name = stem[: -len("_metrics")] if stem.endswith("_metrics") else stem
+        return datasource, table_name or "Unknown"
+
+    @staticmethod
+    def _metric_from_doc(doc: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(doc, dict):
+            return None
+        metric = doc.get("metric")
+        return metric if isinstance(metric, dict) else None
+
+    @staticmethod
+    def _merge_metric_fields(existing: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+        merged = dict(existing)
+        for field, value in incoming.items():
+            if field not in merged or merged.get(field) in (None, "", []):
+                merged[field] = value
+        return merged
+
+    @classmethod
+    def _metric_definition_conflict(cls, existing: Dict[str, Any], incoming: Dict[str, Any]) -> str:
+        for field in ("type", "type_params"):
+            existing_value = existing.get(field)
+            incoming_value = incoming.get(field)
+            if existing_value in (None, "", []) or incoming_value in (None, "", []):
+                continue
+            if cls._stable_yaml_value(existing_value) != cls._stable_yaml_value(incoming_value):
+                return field
+        return ""
+
+    @staticmethod
+    def _stable_yaml_value(value: Any) -> str:
+        return yaml.safe_dump(value, allow_unicode=True, sort_keys=True)
+
+    @staticmethod
+    def _find_data_source_doc(docs: List[Any]) -> Tuple[int, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        for idx, doc in enumerate(docs):
+            if isinstance(doc, dict) and isinstance(doc.get("data_source"), dict):
+                return idx, doc, doc["data_source"]
+        return -1, None, None
+
+    def _merge_data_sources(
+        self,
+        existing_ds: Dict[str, Any],
+        incoming_ds: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], str]:
+        existing_name = str(existing_ds.get("name") or "").strip()
+        incoming_name = str(incoming_ds.get("name") or "").strip()
+        if existing_name and incoming_name and existing_name != incoming_name:
+            return {}, (
+                f"Refusing to overwrite semantic model '{existing_name}' with data_source '{incoming_name}'. "
+                "Use a separate file for a different data_source."
+            )
+
+        merged = dict(existing_ds)
+        for field in ("name", "description"):
+            if not merged.get(field) and incoming_ds.get(field):
+                merged[field] = incoming_ds[field]
+
+        for field in ("sql_table", "sql_query"):
+            error = self._merge_stable_scalar(merged, incoming_ds, field, existing_name or incoming_name)
+            if error:
+                return {}, error
+
+        for field, conflict_fields in (
+            ("identifiers", ("type", "expr")),
+            ("measures", ("agg", "expr", "filter", "agg_params", "non_additive_dimension")),
+            ("dimensions", ("type", "expr", "type_params")),
+        ):
+            merged_items, error = self._merge_named_items(
+                field,
+                merged.get(field) or [],
+                incoming_ds.get(field) or [],
+                conflict_fields,
+                existing_name or incoming_name,
+            )
+            if error:
+                return {}, error
+            if merged_items:
+                merged[field] = merged_items
+
+        for field, value in incoming_ds.items():
+            if field in {"name", "description", "sql_table", "sql_query", "identifiers", "measures", "dimensions"}:
+                continue
+            if field not in merged:
+                merged[field] = value
+
+        return merged, ""
+
+    @staticmethod
+    def _merge_stable_scalar(
+        merged: Dict[str, Any],
+        incoming: Dict[str, Any],
+        field: str,
+        data_source_name: str,
+    ) -> str:
+        existing_value = merged.get(field)
+        incoming_value = incoming.get(field)
+        if not existing_value and incoming_value:
+            merged[field] = incoming_value
+            return ""
+        if existing_value and incoming_value and existing_value != incoming_value:
+            return (
+                f"Refusing to change data_source '{data_source_name}' field '{field}' from "
+                f"{existing_value!r} to {incoming_value!r}. Edit intentionally or write a new data_source file."
+            )
+        return ""
+
+    def _merge_named_items(
+        self,
+        section: str,
+        existing_items: List[Any],
+        incoming_items: List[Any],
+        conflict_fields: Tuple[str, ...],
+        data_source_name: str,
+    ) -> Tuple[List[Dict[str, Any]], str]:
+        merged: List[Dict[str, Any]] = [dict(item) for item in existing_items if isinstance(item, dict)]
+        index_by_name = {
+            str(item.get("name") or "").strip(): idx
+            for idx, item in enumerate(merged)
+            if str(item.get("name") or "").strip()
+        }
+
+        for raw_item in incoming_items:
+            if not isinstance(raw_item, dict):
+                continue
+            item = dict(raw_item)
+            name = str(item.get("name") or "").strip()
+            if not name:
+                continue
+            existing_idx = index_by_name.get(name)
+            if existing_idx is None:
+                index_by_name[name] = len(merged)
+                merged.append(item)
+                continue
+
+            existing = merged[existing_idx]
+            conflict_field = self._named_item_conflict(existing, item, conflict_fields)
+            if conflict_field:
+                return [], (
+                    f"Refusing to overwrite {section[:-1]} '{name}' in data_source '{data_source_name}': "
+                    f"field '{conflict_field}' differs. Preserve the existing definition or choose a new name."
+                )
+            for field, value in item.items():
+                if field not in existing or existing.get(field) in (None, "", []):
+                    existing[field] = value
+
+        return merged, ""
+
+    @staticmethod
+    def _named_item_conflict(existing: Dict[str, Any], incoming: Dict[str, Any], fields: Tuple[str, ...]) -> str:
+        for field in fields:
+            existing_value = existing.get(field)
+            incoming_value = incoming.get(field)
+            if existing_value in (None, "", []) or incoming_value in (None, "", []):
+                continue
+            if existing_value != incoming_value:
+                return field
+        return ""

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -439,6 +439,7 @@ class SemanticDiscoveryTools:
             base_measures: Dict[str, Dict[str, Any]] = {}
             non_metric_evidence: List[Dict[str, Any]] = []
             identity_metric_references: List[Dict[str, Any]] = []
+            support_measure_candidates: List[Dict[str, Any]] = []
             parse_errors: List[Dict[str, Any]] = []
             source_classifications: List[Dict[str, Any]] = []
             derived_datasource_recommendations: List[Dict[str, Any]] = []
@@ -479,6 +480,7 @@ class SemanticDiscoveryTools:
                         select_tables = self._collect_tables(select)
                         filters = self._collect_filters(select)
                         dimensions = self._collect_dimensions(select)
+                        support_projection_aliases = self._support_measure_projection_aliases(select)
 
                         for projection in select.expressions:
                             candidate = self._candidate_from_projection(
@@ -494,6 +496,19 @@ class SemanticDiscoveryTools:
                             entry_has_metric_evidence = True
                             if candidate.get("evidence_kind") == "identity_metric_reference":
                                 identity_metric_references.append(candidate)
+                                continue
+                            if self._projection_alias_key(projection) in support_projection_aliases:
+                                support_candidate = dict(candidate)
+                                support_candidate["evidence_kind"] = "support_measure"
+                                support_candidate["reason"] = (
+                                    "COUNT(*) appears alongside a distinct business count; keep it as a "
+                                    "support/base measure instead of a published metric"
+                                )
+                                support_measure_candidates.append(support_candidate)
+                                for measure in support_candidate.get("base_measures", []):
+                                    measure = dict(measure)
+                                    measure["evidence_kind"] = "support_measure"
+                                    self._merge_base_measure(base_measures, measure)
                                 continue
                             found_candidate = True
                             entry_candidates.append(candidate)
@@ -560,6 +575,7 @@ class SemanticDiscoveryTools:
                     "direct_metric_candidates": direct_candidates,
                     "derived_metric_candidates": derived_candidates,
                     "base_measures": measures,
+                    "support_measure_candidates": support_measure_candidates,
                     "non_metric_evidence": non_metric_evidence,
                     "identity_metric_references": identity_metric_references,
                     "parse_errors": parse_errors,
@@ -1334,6 +1350,63 @@ class SemanticDiscoveryTools:
             "source_count": 1,
             "referenced_metrics": self._referenced_metric_items(referenced_metric_names, existing_metric_catalog),
         }
+
+    def _support_measure_projection_aliases(self, select: Any) -> set[str]:
+        """Return projection aliases that should stay as support measures only.
+
+        A common BI de-duplication query projects ``COUNT(*)`` next to
+        ``COUNT(DISTINCT business_key)`` to show raw rows versus deduplicated
+        business entities. In that shape, the row count is useful dependency
+        evidence but is usually not a standalone business metric.
+        """
+        aggregate_classes = self._aggregate_classes()
+        count_star_aliases: set[str] = set()
+        has_distinct_business_count = False
+
+        for projection in getattr(select, "expressions", []) or []:
+            expr = self._projection_expr(projection)
+            aggregates = list(expr.find_all(*aggregate_classes))
+            if len(aggregates) != 1 or not self._is_same_expression(expr, aggregates[0]):
+                continue
+            aggregate = aggregates[0]
+            if self._is_count_star(aggregate):
+                alias_key = self._projection_alias_key(projection)
+                if alias_key:
+                    count_star_aliases.add(alias_key)
+                continue
+            if self._is_count_distinct(aggregate):
+                has_distinct_business_count = True
+
+        if not has_distinct_business_count:
+            return set()
+        return count_star_aliases
+
+    def _projection_expr(self, projection: Any) -> Any:
+        """Return the expression represented by a SELECT projection."""
+        from sqlglot import expressions as exp
+
+        return projection.this if isinstance(projection, exp.Alias) else projection
+
+    def _projection_alias_key(self, projection: Any) -> str:
+        """Return the normalized key used to identify a projection alias."""
+        from sqlglot import expressions as exp
+
+        alias = projection.alias if isinstance(projection, exp.Alias) else projection.alias_or_name
+        return self._safe_name(alias or projection.sql())
+
+    def _is_count_star(self, aggregate: Any) -> bool:
+        """Return true for COUNT(*)."""
+        from sqlglot import expressions as exp
+
+        return isinstance(aggregate, exp.Count) and (aggregate.this is None or isinstance(aggregate.this, exp.Star))
+
+    def _is_count_distinct(self, aggregate: Any) -> bool:
+        """Return true for COUNT(DISTINCT ...)."""
+        from sqlglot import expressions as exp
+
+        return isinstance(aggregate, exp.Count) and (
+            isinstance(aggregate.this, exp.Distinct) or "DISTINCT" in aggregate.sql().upper()
+        )
 
     def _classify_metric_expression(
         self, expr: Any, name: str, aggregates: List[Any], columns: set, existing_metric_names: set

--- a/datus/tools/semantic_tools/storage_sync.py
+++ b/datus/tools/semantic_tools/storage_sync.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 from datus.configuration.agent_config import AgentConfig
+from datus.storage.datasource_scope import add_datasource_scope_to_rows, resolve_datasource_id
 from datus.storage.metric.store import MetricStorage, build_metric_id
 from datus.storage.semantic_model.store import SemanticModelStorage
 from datus.storage.subject_tree.store import SubjectTreeStore
@@ -37,6 +38,7 @@ class SemanticStorageManager:
             agent_config: Agent configuration
         """
         self.agent_config = agent_config
+        self.datasource_id = resolve_datasource_id(agent_config)
         self.semantic_model_store: Optional[SemanticModelStorage] = None
         self.metric_store: Optional[MetricStorage] = None
         self.subject_tree_store: Optional[SubjectTreeStore] = None
@@ -46,7 +48,7 @@ class SemanticStorageManager:
         if self.semantic_model_store is None:
             from datus.storage.semantic_model.store import SemanticModelRAG
 
-            rag = SemanticModelRAG(self.agent_config)
+            rag = SemanticModelRAG(self.agent_config, datasource_id=self.datasource_id)
             self.semantic_model_store = rag.storage
         return self.semantic_model_store
 
@@ -55,7 +57,7 @@ class SemanticStorageManager:
         if self.metric_store is None:
             from datus.storage.metric.store import MetricRAG
 
-            rag = MetricRAG(self.agent_config)
+            rag = MetricRAG(self.agent_config, datasource_id=self.datasource_id)
             self.metric_store = rag.storage
         return self.metric_store
 
@@ -64,7 +66,10 @@ class SemanticStorageManager:
         if self.subject_tree_store is None:
             from datus.storage.registry import get_subject_tree_store
 
-            self.subject_tree_store = get_subject_tree_store(project=self.agent_config.project_name)
+            self.subject_tree_store = get_subject_tree_store(
+                project=self.agent_config.project_name,
+                datasource_id=self.datasource_id,
+            )
         return self.subject_tree_store
 
     def store_semantic_model(
@@ -153,7 +158,7 @@ class SemanticStorageManager:
             "yaml_path": "",
             "updated_at": updated_at,
         }
-        store.batch_store([table_obj])
+        store.batch_store(add_datasource_scope_to_rows([table_obj], self.datasource_id))
 
         # Store dimensions
         dimensions = model_data.get("dimensions", [])
@@ -185,7 +190,7 @@ class SemanticStorageManager:
             }
             dim_objects.append(dim_obj)
         if dim_objects:
-            store.batch_store(dim_objects)
+            store.batch_store(add_datasource_scope_to_rows(dim_objects, self.datasource_id))
 
         # Store measures
         measures = model_data.get("measures", [])
@@ -217,7 +222,7 @@ class SemanticStorageManager:
             }
             measure_objects.append(measure_obj)
         if measure_objects:
-            store.batch_store(measure_objects)
+            store.batch_store(add_datasource_scope_to_rows(measure_objects, self.datasource_id))
 
         # Store identifiers (entity keys)
         identifiers = model_data.get("identifiers", [])
@@ -249,7 +254,7 @@ class SemanticStorageManager:
             }
             identifier_objects.append(identifier_obj)
         if identifier_objects:
-            store.batch_store(identifier_objects)
+            store.batch_store(add_datasource_scope_to_rows(identifier_objects, self.datasource_id))
 
         logger.info(
             f"Stored semantic model '{semantic_model_name}': "

--- a/docs/qa/metric-bootstrap-generation-qa.zh.md
+++ b/docs/qa/metric-bootstrap-generation-qa.zh.md
@@ -1,0 +1,346 @@
+# 指标生成与 Bootstrap KB QA 测试说明
+
+本文档用于 QA 验证当前分支的指标生成、批量 `bootstrap-kb`、MetricFlow YAML 合并、Datasource 行级隔离和失败回滚行为。
+
+## 当前实现状态
+
+本次实现聚焦 `gen_metrics` 和 `bootstrap-kb --components metrics` 的稳定性与可测性，目标是让普通聚合 SQL、复杂 SQL、已有指标复用和不可发布指标都能被正确处理。
+
+当前 `gen_metrics` 使用配置中的 `deepseek` 模型，配置位置为 `conf/agent.yml`：
+
+```yaml
+nodes:
+  gen_metrics:
+    model: deepseek
+```
+
+`deepseek` 的默认底层模型由 `conf/providers.yml` 决定，当前为 `deepseek-v4-pro`。
+
+## 主要改动范围
+
+### 1. SQL 指标候选抽取
+
+`analyze_metric_candidates_from_history` 现在会把 SQL 输出拆成更明确的几类：
+
+- `direct_metric_candidates`：可直接建模的业务指标，例如 `COUNT(DISTINCT ac_code)`、`AVG(sr_value)`、`MAX(sr_value)`。
+- `base_measures`：指标依赖的基础 measure。
+- `support_measure_candidates`：只作为辅助口径的 measure，不应发布成顶层 metric。
+- `derived_metric_candidates`：基于已有 metric 的二阶段指标，例如 MoM delta。
+- `identity_metric_references`：SQL 只是引用已有指标，不应重复生成。
+- `non_metric_evidence`：明细查询、过滤查询、Top-N/ROW_NUMBER 查询等非指标证据。
+- `derived_datasource_recommendations`：窗口函数、排名、复杂子查询等需要先建 derived data source 的场景。
+
+关键行为：
+
+- 普通聚合 SQL 仍按指标抽取。
+- `COUNT(*)` 单独出现时仍可作为直接指标。
+- 如果同一 SELECT 中同时有 `COUNT(*)` 和更明确的 `COUNT(DISTINCT ...)` 业务口径，`COUNT(*)` 会被降级为 support measure，避免生成 `product_row_count` 这类低价值指标。
+- `ROW_NUMBER()` / Top-N 明细查询不会硬套成普通指标，会归类为明细/derived datasource 场景。
+
+### 2. MetricFlow YAML 写入与合并
+
+新增了面向 MetricFlow YAML 的文件工具逻辑：
+
+- 写入已有 semantic model YAML 时，合并 `measures` / `dimensions` / `identifiers`，避免后续 batch 覆盖前面 batch 已写入的内容。
+- 写入已有 metric YAML 时，按 metric name 合并或追加，避免最后一个 batch 重新生成文件并丢失已有 metric。
+- 对 metric 文件中的 `subject_tree` tag 做 datasource 路径规范化。
+- YAML 单引号转义修复改为按 YAML 报错位置局部修复，避免全局替换破坏合法内容。
+- 严格模式下，文件读写会先做路径策略检查，再读取已有文件进行合并。
+
+### 3. 批量指标生成与 KB 同步
+
+`bootstrap-kb --components metrics` 现在按 batch 处理 SQL 后会刷新上下文：
+
+- 已生成的 metric 会进入后续 batch 的 existing metric catalog，后续 batch 不再重复生成。
+- `end_metric_generation` 根据本批新增 metric 作用域同步 KB，不再把同一个 metric 文件里已有 metric 重复计入。
+- combined dry-run SQL 不再被错误归属给所有 metric；如果一条 dry-run 覆盖多个新 metric，会按当前新增 metric 范围同步。
+- 最终 `metrics_count` 代表本次 datasource 下最终同步成功的唯一 metric 数，而不是每个 batch 的重复累计数。
+
+### 4. Datasource 行级隔离
+
+当前实现不再通过修改向量库目录来隔离 datasource，而是在同一 project 物理存储中增加行级 scope：
+
+- scoped 行增加 `datasource_id`。
+- scoped 行增加内部 upsert key `storage_key`，格式为 `{datasource_id}:{business_id}`。
+- 覆盖更新时按 datasource 删除对应行，不 drop 整张 project 表。
+- 没有 datasource 的 datasource-scoped storage 会 fail fast，避免写入 project 全局命名空间。
+- Explorer 等无 datasource 入口做了降级处理，避免因为未绑定 datasource 直接 500。
+- 旧数据兼容通过 best-effort scope 列补齐处理：旧行默认 `datasource_id=""`，`storage_key="legacy:{id}"`。
+
+## QA 环境准备
+
+### 必要配置
+
+确认 `conf/agent.yml` 中有可用的 StarRocks datasource，并且 `gen_metrics` 使用 `deepseek`：
+
+```bash
+rg -n "gen_metrics|model: deepseek|starrocks" conf/agent.yml conf/providers.yml
+```
+
+确认 StarRocks 中测试库和测试表已准备好。本地验证使用：
+
+- datasource：`starrocks`
+- database：`ac_manage`
+- table：`ac_manage.v_udata_ac_info`
+- time spine：`ac_manage.mf_time_spine`
+- success story：`seed_context.csv`
+
+如果 QA 环境没有 `seed_context.csv`，请使用测试包随附的同等 CSV；该文件需要覆盖以下三类 SQL：
+
+- 普通聚合 SQL：COUNT DISTINCT、条件计数、AVG、MAX、ratio。
+- 复杂 SQL：ROW_NUMBER / Top-N / 明细查询。
+- 已有 metric 复用：已有 `activity_count` 基础上识别 ratio、support measure、MoM derived candidate。
+
+### 建议清理
+
+为了保证从空 YAML 状态验证合并逻辑，运行前可清理当前 datasource 的本地 YAML：
+
+```bash
+rm -rf subject/semantic_models/starrocks
+```
+
+如果要验证 overwrite 的 storage 行级删除，请不要删除整个 `~/.datus/data/.../datus_db`，否则无法覆盖“同一 project 表内按 datasource 删除”的场景。
+
+## 主流程测试
+
+### 测试 1：指标 bootstrap 全流程
+
+执行：
+
+```bash
+uv run datus-agent bootstrap-kb \
+  --datasource starrocks \
+  --components metrics \
+  --kb_update_strategy overwrite \
+  --success_story seed_context.csv \
+  -y
+```
+
+预期结果：
+
+```text
+Final Result: {'status': 'success', 'message': 'metrics bootstrap completed, metrics_count=12', 'error': ''}
+```
+
+预期日志特征：
+
+- `Processing 28 SQL queries in 6 batch(es)`
+- `Batch 1/6 completed successfully` 到 `Batch 6/6 completed successfully`
+- `Metrics extraction completed: 6/6 batch(es) succeeded`
+- 不应出现最终失败：
+  - `All batch(es) failed`
+  - `No valid objects found to sync`
+  - `Metrics extraction completed but produced no output`
+
+### 测试 2：最终 YAML 内容
+
+执行：
+
+```bash
+uv run python - <<'PY'
+import glob, yaml
+
+total = 0
+for path in sorted(glob.glob("subject/semantic_models/starrocks/**/*.yml", recursive=True)):
+    docs = list(yaml.safe_load_all(open(path)))
+    metrics = []
+    measures = []
+    for doc in docs:
+        if isinstance(doc, dict) and isinstance(doc.get("metric"), dict):
+            metrics.append(doc["metric"].get("name"))
+        if isinstance(doc, dict) and isinstance(doc.get("data_source"), dict):
+            measures.extend([m.get("name") for m in doc["data_source"].get("measures") or []])
+    if metrics or measures:
+        print(path)
+        print("metrics_count:", len(metrics), metrics)
+        print("measures_count:", len(measures), measures)
+        total += len(metrics)
+print("TOTAL_METRICS", total)
+PY
+```
+
+预期最终 metric 共 12 个：
+
+```text
+activity_count
+avg_sr_value
+avg_first_day_sr
+delivery_activity_count
+high_sr_activity_count
+new_product_activity_count
+new_product_activity_ratio
+new_ip_activity_count
+delivery_activity_ratio
+major_activity_count
+max_sr_value
+avg_activity_days
+```
+
+预期 semantic model measures 共 10 个：
+
+```text
+activity_count
+avg_sr_value
+avg_first_day_sr
+delivery_activity_count
+high_sr_activity_count
+new_product_activity_count
+new_ip_activity_count
+major_activity_count
+max_sr_value
+avg_activity_days
+```
+
+以下内容不应出现在最终 YAML 中：
+
+```text
+product_row_count
+activity_count_mom_delta
+```
+
+### 测试 3：文件合并不覆盖
+
+重点观察批次 4、5、6 后的最终文件：
+
+- 批次 4 生成的 `avg_sr_value`、`avg_first_day_sr`、`high_sr_activity_count`、`new_product_activity_ratio` 应保留到最终文件。
+- 批次 5 追加的 `new_ip_activity_count`、`delivery_activity_ratio`、`major_activity_count`、`max_sr_value`、`avg_activity_days` 应保留。
+- 批次 6 不应因为 glob 为空或重新 `write_file` 覆盖 `v_udata_ac_info.yml` / `v_udata_ac_info_metrics.yml`。
+
+可用命令：
+
+```bash
+rg -n "Metric file merged successfully|Semantic model merged successfully|File written successfully" ~/.datus/logs/agent.$(date +%F).log
+```
+
+预期：
+
+- 已存在文件的后续写入应出现 `Metric file merged successfully` 或 `Semantic model merged successfully`。
+- 最终 metric 文件仍为 12 个 metric block。
+
+### 测试 4：support measure 不发布
+
+测试 SQL 中包含类似：
+
+```sql
+SELECT
+  COUNT(*) AS product_row_count,
+  COUNT(DISTINCT ac_code) AS activity_count
+FROM ac_manage.v_udata_ac_info
+...
+```
+
+预期：
+
+- `activity_count` 被识别为业务指标，且如果已存在则复用。
+- `product_row_count` 被识别为 `support_measure_candidates`。
+- 不生成 `metric: product_row_count`。
+- 如果没有指标依赖它，也不需要把它追加到 semantic model measures。
+
+### 测试 5：ROW_NUMBER / Top-N SQL 不硬套指标
+
+测试 SQL 中包含 `ROW_NUMBER() OVER (...)` 或排名过滤，例如每个渠道 SR 最高的活动。
+
+预期：
+
+- 不生成直接 metric。
+- 日志或模型输出应说明这是 detail ranking / derived datasource 场景。
+- 该 SQL 不应导致 `max_sr_value` 之外的错误 Top-N 指标被发布。
+
+### 测试 6：StarRocks MoM derived metric 失败回滚
+
+测试 SQL 中包含月环比逻辑，例如：
+
+```sql
+activity_count - LAG(activity_count) OVER (ORDER BY month)
+```
+
+当前预期行为：
+
+- 系统可以识别 `activity_count_mom_delta` 是 derived metric candidate。
+- 模型可能尝试用 MetricFlow `derived` + `offset_window` 表达。
+- 在 StarRocks 下，MetricFlow 生成的 offset SQL 可能出现重复列别名或无法解析别名，例如：
+
+```text
+Column 'activity_count' is ambiguous
+```
+
+验收标准：
+
+- dry-run/validation 失败后必须回滚。
+- 最终 YAML 不包含 `activity_count_mom_delta`。
+- KB 中不包含 `metric:activity_count_mom_delta`。
+- 整个 batch 应以 skipped/success 完成，不应让 bootstrap 失败。
+
+### 测试 7：metrics_count 不重复计数
+
+重复运行主流程命令。
+
+预期：
+
+- 最终仍为 `metrics_count=12`。
+- 不应因为多个 batch 重复 sync 同一个 metric 文件导致 `metrics_count` 大于最终 YAML metric 数。
+- 用 YAML 解析脚本得到 `TOTAL_METRICS 12`。
+
+## Storage 隔离测试
+
+### 测试 8：不同 datasource 不互相删除
+
+准备两个 datasource，例如 `starrocks` 和另一个测试 datasource，在同一个 project 下分别写入 metric KB。
+
+执行：
+
+```bash
+uv run datus-agent bootstrap-kb --datasource starrocks --components metrics --kb_update_strategy overwrite --success_story seed_context.csv -y
+```
+
+预期：
+
+- 只删除并重建 `datasource_id='starrocks'` 的 metric 行。
+- 其他 datasource 的 metric/semantic/reference rows 不被删除。
+- 向量库目录不应新增 `{project}__ds__{datasource}` 这类 datasource 拆分目录。
+
+### 测试 9：无 datasource 入口降级
+
+打开 Explorer 或调用无 datasource 上下文的 Explorer API。
+
+预期：
+
+- 不应返回 500。
+- 在无 datasource 绑定时，可以返回空列表或降级结果。
+- 一旦 datasource 绑定后，应能读取对应 datasource scope 下的数据。
+
+## 推荐回归测试命令
+
+执行当前改动相关单测：
+
+```bash
+uv run pytest -q \
+  tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py::TestAnalyzeMetricCandidatesFromHistory \
+  tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestGenerationEvidence \
+  tests/unit_tests/tools/func_tool/test_generation_tools.py \
+  tests/unit_tests/tools/func_tool/test_filesystem_tools.py::TestGlobSearch \
+  tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py \
+  tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py \
+  tests/unit_tests/storage/metric/test_metric_init.py
+```
+
+当前本地验证结果：
+
+```text
+200 passed
+```
+
+## 已知限制
+
+1. StarRocks 下 MetricFlow `derived` + `offset_window` 对同一个 metric 做环比时，生成 SQL 可能存在重复别名或别名不可解析问题。当前实现不绕过 MetricFlow 生成 SQL，而是要求 validation/dry-run 失败后不发布该 derived metric。
+2. `components=metrics` 只保证 metrics 相关 KB 行按 datasource overwrite；如果 QA 同时验证 semantic model storage，请使用 `--components semantic_model,metrics` 或对应全量流程。
+3. 当前不做 subject path 级别清理；overwrite 的隔离维度是 datasource。
+4. 旧向量表的 scope 字段补齐依赖后端支持 `ensure_columns`。如果后端不支持，需要重新 bootstrap 或执行后端迁移。
+
+## QA 结论模板
+
+验证通过时可记录：
+
+```text
+通过。bootstrap-kb metrics 在 StarRocks datasource 下 6/6 batch 成功，最终 metrics_count=12，YAML 中 12 个 metric 与 KB 计数一致。普通聚合、条件计数、AVG、MAX、ratio 均可生成；ROW_NUMBER Top-N 被识别为 derived datasource/detail 场景；product_row_count 未被发布；activity_count_mom_delta 在 StarRocks dry-run 失败后被回滚且未入库；overwrite 未出现跨 datasource 清理或文件覆盖丢失。
+```

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -526,7 +526,7 @@ class TestExtractMetricAndOutputFromResponse:
         }
         sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file == "revenue_metrics.yml"
-        assert sem_model == "model.yml"
+        assert sem_model == ["model.yml"]
         assert status is None
         assert out == "Generated successfully"
 
@@ -542,6 +542,7 @@ class TestExtractMetricAndOutputFromResponse:
         output = {"content": content}
         sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
         assert metric_file == "sales_metrics.yml"
+        assert sem_model == ["model.yml"]
         assert status is None
         assert out == "Done"
 
@@ -556,7 +557,7 @@ class TestExtractMetricAndOutputFromResponse:
             }
         }
         sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
-        assert sem_model == "model.yml"
+        assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "skipped"
         assert out.startswith("All requested metrics already exist")
@@ -572,7 +573,7 @@ class TestExtractMetricAndOutputFromResponse:
             }
         }
         sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
-        assert sem_model == "model.yml"
+        assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "generated"
         assert out == "Generated successfully."
@@ -588,7 +589,7 @@ class TestExtractMetricAndOutputFromResponse:
             }
         }
         sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
-        assert sem_model == "model.yml"
+        assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "done"
         assert out == "Done."
@@ -605,6 +606,7 @@ class TestExtractMetricAndOutputFromResponse:
         )
         output = {"content": content}
         sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "skipped"
         assert out == "Skipped: metric already exists."
@@ -850,7 +852,7 @@ class TestExecuteStreamGenMetricsError:
         node.semantic_tools.query_metrics.assert_called_once_with(metrics=["orders_total"], dry_run=True)
         node.generation_tools.end_metric_generation.assert_called_once_with(
             metric_file=str(metric_path),
-            semantic_model_file=str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml"),
+            semantic_model_files=[str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml")],
         )
 
     def test_final_metric_publish_requires_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):
@@ -924,7 +926,7 @@ class TestExecuteStreamGenMetricsError:
 
         node.generation_tools.end_metric_generation.assert_called_once_with(
             metric_file=str(metric_path),
-            semantic_model_file=str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml"),
+            semantic_model_files=[str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml")],
         )
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -1465,7 +1465,7 @@ class TestClassifySubjectPaths:
         monkeypatch.setattr(ReferenceSqlRAG, "__init__", fake_sql_init)
         monkeypatch.setattr(
             "datus.storage.registry.get_subject_tree_store",
-            lambda project: _StubTree(),
+            lambda project, datasource_id="": _StubTree(),
         )
 
         result = _classify_subject_paths(
@@ -1831,7 +1831,7 @@ class TestSubagentScopedContextRoundTrip:
         monkeypatch.setattr(ReferenceSqlRAG, "__init__", fake_sql_init)
         monkeypatch.setattr(
             "datus.storage.registry.get_subject_tree_store",
-            lambda project: _StubTree(),
+            lambda project, datasource_id="": _StubTree(),
         )
 
         # Seed an entry already bound to "finance" via scoped_context, then

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -32,6 +32,15 @@ class TestDatasourceServiceInit:
         svc = DatasourceService(agent_config=real_agent_config)
         assert isinstance(svc.db_manager, DBManager)
 
+    def test_init_without_datasource_defers_semantic_rag(self, real_agent_config):
+        """Init does not open datasource-scoped semantic storage before datasource selection."""
+        real_agent_config.current_datasource = ""
+
+        svc = DatasourceService(agent_config=real_agent_config)
+
+        assert svc.current_datasource == ""
+        assert svc.semantic_rag is None
+
 
 class TestDatabaseServiceGetDatabaseType:
     """Tests for _get_database_type helper."""

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -1,5 +1,7 @@
 """Tests for datus.api.services.explorer_service — catalog and subject tree."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from datus.api.models.base_models import Result
@@ -220,6 +222,35 @@ class TestExplorerServiceReferenceSql:
             )
         )
         assert result.success is True
+
+    async def test_edit_reference_sql_uses_sub_agent_conditions(self, real_agent_config):
+        """edit_reference_sql should preserve scoped-agent filters when updating storage."""
+        svc = ExplorerService(agent_config=real_agent_config)
+        marker_condition = object()
+        svc.reference_sql_rag._sub_agent_conditions = MagicMock(return_value=[marker_condition])
+        svc.reference_sql_rag.reference_sql_storage.update_entry = MagicMock(return_value=True)
+
+        result = await svc.edit_reference_sql(
+            ReferenceSQLInput(
+                subject_path=["edit_ref", "editable"],
+                name="editable",
+                sql="SELECT 2",
+                summary="updated",
+                search_text="updated",
+            )
+        )
+
+        assert result.success is True
+        svc.reference_sql_rag.reference_sql_storage.update_entry.assert_called_once_with(
+            subject_path=["edit_ref"],
+            name="editable",
+            update_values={
+                "sql": "SELECT 2",
+                "summary": "updated",
+                "search_text": "updated",
+            },
+            extra_conditions=[marker_condition],
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -1286,9 +1286,10 @@ metric:
 
         assert result["success"], f"Sync failed: {result.get('error')}"
         assert len(captured_metric) == 2
-        assert captured_metric[0]["id"] == "metric:Commerce/Orders/Average_Order_Value.average_gross_order_value"
-        assert captured_metric[1]["id"] == "metric:Finance/Orders/Average_Order_Value.average_gross_order_value"
-        assert captured_metric[0]["id"] != captured_metric[1]["id"]
+        assert captured_metric[0]["id"] == "metric:average_gross_order_value"
+        assert captured_metric[1]["id"] == "metric:average_gross_order_value"
+        assert captured_metric[0]["subject_path"] == ["Commerce", "Orders", "Average_Order_Value"]
+        assert captured_metric[1]["subject_path"] == ["Finance", "Orders", "Average_Order_Value"]
 
     def test_measure_proxy_nested_measure_is_stored_as_string(self, agent_config, tmp_path):
         yaml_file = tmp_path / "metrics.yml"

--- a/tests/unit_tests/storage/document/test_store.py
+++ b/tests/unit_tests/storage/document/test_store.py
@@ -138,6 +138,12 @@ class TestDocumentStoreInit:
     def test_table_name(self, doc_store):
         """Table name should be 'document'."""
         assert doc_store.table_name == "document"
+
+    def test_document_store_is_not_datasource_scoped(self, doc_store):
+        """Document storage is platform/version scoped, not datasource-scoped."""
+        schema_names = set(doc_store._schema.names)
+        assert "datasource_id" not in schema_names
+        assert "storage_key" not in schema_names
         assert doc_store.TABLE_NAME == "document"
 
     def test_vector_source_name(self, doc_store):

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -309,7 +309,7 @@ class TestInitSuccessStoryMetricsAsync:
 
         assert success is True
         assert error == ""
-        assert result == {"response": "done"}
+        assert result == {"response": "done", "metrics_count": 0, "final_metrics_count": 0}
 
     @pytest.mark.asyncio
     async def test_batch_flow_allows_recoverable_tool_failure(self):
@@ -360,7 +360,7 @@ class TestInitSuccessStoryMetricsAsync:
 
         assert success is True
         assert error == ""
-        assert result == {"response": "done"}
+        assert result == {"response": "done", "metrics_count": 0, "final_metrics_count": 0}
 
 
 # ---------------------------------------------------------------------------
@@ -506,13 +506,13 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
             )
 
         assert success is True
-        rag_factory.assert_called_once_with(mock_config)
+        rag_factory.assert_any_call(mock_config)
         fake_rag_instance.truncate.assert_called_once_with()
         mock_exists.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_incremental_does_not_call_truncate(self):
-        """build_mode='incremental' must not call truncate; it consults exists_metrics instead."""
+        """build_mode='incremental' must not call truncate."""
         from unittest.mock import patch
 
         import pandas as pd
@@ -561,7 +561,7 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
 
         assert success is True
         fake_rag_instance.truncate.assert_not_called()
-        mock_exists.assert_called_once()
+        mock_exists.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -672,7 +672,7 @@ class TestMetricProvenanceHelpers:
 @pytest.mark.ci
 class TestDefaultMetricsBatchSize:
     def test_default_batch_size(self):
-        assert DEFAULT_METRICS_BATCH_SIZE == 1
+        assert DEFAULT_METRICS_BATCH_SIZE == 5
 
 
 # ---------------------------------------------------------------------------
@@ -1084,7 +1084,7 @@ class TestBatchSplitting:
             )
 
         assert ok is True
-        assert result == {"metrics": ["m0"]}
+        assert result == {"metrics": ["m0"], "metrics_count": 0, "final_metrics_count": 0}
 
     @pytest.mark.asyncio
     async def test_batch_size_parameter_passed_through_sync(self):
@@ -1096,3 +1096,70 @@ class TestBatchSplitting:
         sig = inspect.signature(init_success_story_metrics)
         assert "batch_size" in sig.parameters
         assert sig.parameters["batch_size"].default == DEFAULT_METRICS_BATCH_SIZE
+
+
+class TestBatchHasNoMetricCandidates:
+    """Tests for _batch_has_no_metric_candidates early-skip logic."""
+
+    def test_returns_false_when_plan_unavailable(self):
+        from datus.storage.metric.metric_init import _batch_has_no_metric_candidates
+
+        assert _batch_has_no_metric_candidates({}) is False
+        assert _batch_has_no_metric_candidates({"available": False}) is False
+        assert _batch_has_no_metric_candidates(None) is False
+
+    def test_returns_false_when_direct_candidates_exist(self):
+        from datus.storage.metric.metric_init import _batch_has_no_metric_candidates
+
+        plan = {
+            "available": True,
+            "direct_metric_candidates": [{"name": "revenue"}],
+            "non_metric_evidence": [{"name": "detail_query"}],
+        }
+        assert _batch_has_no_metric_candidates(plan) is False
+
+    def test_returns_false_when_derived_candidates_exist(self):
+        from datus.storage.metric.metric_init import _batch_has_no_metric_candidates
+
+        plan = {
+            "available": True,
+            "derived_metric_candidates": [{"name": "mom_delta"}],
+            "non_metric_evidence": [{"name": "detail_query"}],
+        }
+        assert _batch_has_no_metric_candidates(plan) is False
+
+    def test_returns_true_when_only_non_metric_evidence(self):
+        from datus.storage.metric.metric_init import _batch_has_no_metric_candidates
+
+        plan = {
+            "available": True,
+            "direct_metric_candidates": [],
+            "derived_metric_candidates": [],
+            "non_metric_evidence": [{"name": "row_number_query"}],
+        }
+        assert _batch_has_no_metric_candidates(plan) is True
+
+    def test_returns_true_when_only_identity_references(self):
+        from datus.storage.metric.metric_init import _batch_has_no_metric_candidates
+
+        plan = {
+            "available": True,
+            "identity_metric_references": [{"name": "activity_count"}],
+        }
+        assert _batch_has_no_metric_candidates(plan) is True
+
+    def test_returns_true_when_only_derived_datasource_recommendations(self):
+        from datus.storage.metric.metric_init import _batch_has_no_metric_candidates
+
+        plan = {
+            "available": True,
+            "derived_datasource_recommendations": [{"sql_query": "SELECT ..."}],
+        }
+        assert _batch_has_no_metric_candidates(plan) is True
+
+    def test_returns_false_when_no_evidence_at_all(self):
+        """Available plan with zero candidates AND zero evidence should NOT skip."""
+        from datus.storage.metric.metric_init import _batch_has_no_metric_candidates
+
+        plan = {"available": True}
+        assert _batch_has_no_metric_candidates(plan) is False

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -1163,3 +1163,273 @@ class TestBatchHasNoMetricCandidates:
 
         plan = {"available": True}
         assert _batch_has_no_metric_candidates(plan) is False
+
+
+@pytest.mark.ci
+class TestSourceNames:
+    """Tests for _source_names helper."""
+
+    def test_empty_value_returns_empty_set(self):
+        from datus.storage.metric.metric_init import _source_names
+
+        assert _source_names("") == set()
+        assert _source_names(None) == set()
+        assert _source_names([]) == set()
+
+    def test_list_of_strings(self):
+        from datus.storage.metric.metric_init import _source_names
+
+        assert _source_names(["sql_1", "sql_2"]) == {"sql_1", "sql_2"}
+
+    def test_tuple_of_strings(self):
+        from datus.storage.metric.metric_init import _source_names
+
+        assert _source_names(("sql_1", "sql_2")) == {"sql_1", "sql_2"}
+
+    def test_set_of_strings(self):
+        from datus.storage.metric.metric_init import _source_names
+
+        assert _source_names({"sql_1"}) == {"sql_1"}
+
+    def test_comma_separated_string(self):
+        from datus.storage.metric.metric_init import _source_names
+
+        assert _source_names("sql_1, sql_2") == {"sql_1", "sql_2"}
+
+    def test_single_string(self):
+        from datus.storage.metric.metric_init import _source_names
+
+        assert _source_names("sql_1") == {"sql_1"}
+
+
+@pytest.mark.ci
+class TestSourceScopedItems:
+    """Tests for _source_scoped_items helper."""
+
+    def test_non_list_returns_empty(self):
+        from datus.storage.metric.metric_init import _source_scoped_items
+
+        assert _source_scoped_items(None, {"sql_1"}) == []
+        assert _source_scoped_items("not_a_list", {"sql_1"}) == []
+
+    def test_non_dict_items_skipped(self):
+        from datus.storage.metric.metric_init import _source_scoped_items
+
+        assert _source_scoped_items(["not_dict", 42], {"sql_1"}) == []
+
+    def test_item_without_source_always_included(self):
+        from datus.storage.metric.metric_init import _source_scoped_items
+
+        item = {"name": "m1"}
+        result = _source_scoped_items([item], {"sql_1"})
+        assert item in result
+
+    def test_item_with_matching_source_included(self):
+        from datus.storage.metric.metric_init import _source_scoped_items
+
+        item = {"name": "m1", "source_sql_name": "sql_1"}
+        result = _source_scoped_items([item], {"sql_1"})
+        assert item in result
+
+    def test_item_with_non_matching_source_excluded(self):
+        from datus.storage.metric.metric_init import _source_scoped_items
+
+        item = {"name": "m1", "source_sql_name": "sql_99"}
+        result = _source_scoped_items([item], {"sql_1"})
+        assert result == []
+
+    def test_uses_source_key_as_fallback(self):
+        from datus.storage.metric.metric_init import _source_scoped_items
+
+        item = {"name": "m1", "source": "sql_1"}
+        result = _source_scoped_items([item], {"sql_1"})
+        assert item in result
+
+
+@pytest.mark.ci
+class TestNormalizedScalar:
+    """Tests for _normalized_scalar helper."""
+
+    def test_strips_and_lowercases(self):
+        from datus.storage.metric.metric_init import _normalized_scalar
+
+        assert _normalized_scalar("  MeasureProxy  ") == "measureproxy"
+
+    def test_none_returns_empty(self):
+        from datus.storage.metric.metric_init import _normalized_scalar
+
+        assert _normalized_scalar(None) == ""
+
+    def test_empty_string(self):
+        from datus.storage.metric.metric_init import _normalized_scalar
+
+        assert _normalized_scalar("") == ""
+
+
+@pytest.mark.ci
+class TestNormalizedMetricType:
+    """Tests for _normalized_metric_type helper."""
+
+    def test_simple_mapped_to_measure_proxy(self):
+        from datus.storage.metric.metric_init import _normalized_metric_type
+
+        assert _normalized_metric_type("simple") == "measure_proxy"
+
+    def test_other_types_unchanged(self):
+        from datus.storage.metric.metric_init import _normalized_metric_type
+
+        assert _normalized_metric_type("ratio") == "ratio"
+        assert _normalized_metric_type("derived") == "derived"
+
+    def test_none_returns_empty(self):
+        from datus.storage.metric.metric_init import _normalized_metric_type
+
+        assert _normalized_metric_type(None) == ""
+
+
+@pytest.mark.ci
+class TestNormalizedMeasureNames:
+    """Tests for _normalized_measure_names helper."""
+
+    def test_non_list_returns_empty(self):
+        from datus.storage.metric.metric_init import _normalized_measure_names
+
+        assert _normalized_measure_names(None) == set()
+        assert _normalized_measure_names("not_a_list") == set()
+
+    def test_list_of_strings(self):
+        from datus.storage.metric.metric_init import _normalized_measure_names
+
+        assert _normalized_measure_names(["Revenue", "Cost"]) == {"revenue", "cost"}
+
+    def test_list_of_dicts_with_name_key(self):
+        from datus.storage.metric.metric_init import _normalized_measure_names
+
+        result = _normalized_measure_names([{"name": "Revenue"}, {"name": "Cost"}])
+        assert result == {"revenue", "cost"}
+
+    def test_list_of_dicts_with_measure_key(self):
+        from datus.storage.metric.metric_init import _normalized_measure_names
+
+        result = _normalized_measure_names([{"measure": "Revenue"}])
+        assert result == {"revenue"}
+
+    def test_ignores_non_string_non_dict_items(self):
+        from datus.storage.metric.metric_init import _normalized_measure_names
+
+        result = _normalized_measure_names([42, None, "revenue"])
+        assert result == {"revenue"}
+
+
+@pytest.mark.ci
+class TestCandidateHasDefinitionEvidence:
+    """Tests for _candidate_has_definition_evidence helper."""
+
+    def test_empty_candidate_returns_false(self):
+        from datus.storage.metric.metric_init import _candidate_has_definition_evidence
+
+        assert _candidate_has_definition_evidence({}) is False
+
+    def test_candidate_with_metric_type(self):
+        from datus.storage.metric.metric_init import _candidate_has_definition_evidence
+
+        assert _candidate_has_definition_evidence({"metric_type": "measure_proxy"}) is True
+
+    def test_candidate_with_semantic_model(self):
+        from datus.storage.metric.metric_init import _candidate_has_definition_evidence
+
+        assert _candidate_has_definition_evidence({"semantic_model": "orders"}) is True
+
+    def test_candidate_with_base_measures(self):
+        from datus.storage.metric.metric_init import _candidate_has_definition_evidence
+
+        assert _candidate_has_definition_evidence({"base_measures": ["order_count"]}) is True
+
+    def test_candidate_with_referenced_metrics(self):
+        from datus.storage.metric.metric_init import _candidate_has_definition_evidence
+
+        assert _candidate_has_definition_evidence({"referenced_metrics": ["revenue"]}) is True
+
+
+@pytest.mark.ci
+class TestCandidateMatchesExistingMetric:
+    """Tests for _candidate_matches_existing_metric helper."""
+
+    def test_no_definition_evidence_returns_false(self):
+        from datus.storage.metric.metric_init import _candidate_matches_existing_metric
+
+        assert _candidate_matches_existing_metric({}, {"name": "revenue", "type": "measure_proxy"}) is False
+
+    def test_matching_type_and_measures(self):
+        from datus.storage.metric.metric_init import _candidate_matches_existing_metric
+
+        candidate = {"metric_type": "measure_proxy", "base_measures": ["revenue_total"]}
+        existing = {"type": "measure_proxy", "base_measures": ["revenue_total"]}
+        assert _candidate_matches_existing_metric(candidate, existing) is True
+
+    def test_mismatched_metric_type_returns_false(self):
+        from datus.storage.metric.metric_init import _candidate_matches_existing_metric
+
+        candidate = {"metric_type": "ratio", "base_measures": ["a", "b"]}
+        existing = {"type": "measure_proxy", "base_measures": ["a"]}
+        assert _candidate_matches_existing_metric(candidate, existing) is False
+
+    def test_mismatched_semantic_model_returns_false(self):
+        from datus.storage.metric.metric_init import _candidate_matches_existing_metric
+
+        candidate = {"metric_type": "measure_proxy", "semantic_model_name": "orders"}
+        existing = {"type": "measure_proxy", "semantic_model_name": "customers"}
+        assert _candidate_matches_existing_metric(candidate, existing) is False
+
+    def test_mismatched_base_measures_returns_false(self):
+        from datus.storage.metric.metric_init import _candidate_matches_existing_metric
+
+        candidate = {"metric_type": "measure_proxy", "base_measures": ["revenue"]}
+        existing = {"type": "measure_proxy", "base_measures": ["cost"]}
+        assert _candidate_matches_existing_metric(candidate, existing) is False
+
+    def test_simple_type_normalized_to_measure_proxy(self):
+        from datus.storage.metric.metric_init import _candidate_matches_existing_metric
+
+        candidate = {"metric_type": "simple", "base_measures": ["revenue"]}
+        existing = {"type": "measure_proxy", "base_measures": ["revenue"]}
+        assert _candidate_matches_existing_metric(candidate, existing) is True
+
+
+@pytest.mark.ci
+class TestAllCandidateMetricsSatisfied:
+    """Tests for _all_candidate_metrics_satisfied helper."""
+
+    def test_empty_candidates_returns_false(self):
+        from datus.storage.metric.metric_init import _all_candidate_metrics_satisfied
+
+        assert _all_candidate_metrics_satisfied({}, []) is False
+
+    def test_candidate_not_in_existing_returns_false(self):
+        from datus.storage.metric.metric_init import _all_candidate_metrics_satisfied
+
+        plan = {"direct_metric_candidates": [{"name": "new_metric", "metric_type": "measure_proxy"}]}
+        assert _all_candidate_metrics_satisfied(plan, []) is False
+
+    def test_all_candidates_satisfied(self):
+        from datus.storage.metric.metric_init import _all_candidate_metrics_satisfied
+
+        plan = {
+            "direct_metric_candidates": [
+                {"name": "revenue_total", "metric_type": "measure_proxy", "base_measures": ["revenue"]}
+            ]
+        }
+        existing = [{"name": "revenue_total", "type": "measure_proxy", "base_measures": ["revenue"]}]
+        assert _all_candidate_metrics_satisfied(plan, existing) is True
+
+    def test_one_unsatisfied_returns_false(self):
+        from datus.storage.metric.metric_init import _all_candidate_metrics_satisfied
+
+        plan = {
+            "direct_metric_candidates": [
+                {"name": "revenue_total", "metric_type": "measure_proxy", "base_measures": ["revenue"]},
+                {"name": "new_metric", "metric_type": "measure_proxy", "base_measures": ["something"]},
+            ]
+        }
+        existing = [{"name": "revenue_total", "type": "measure_proxy", "base_measures": ["revenue"]}]
+        assert _all_candidate_metrics_satisfied(plan, existing) is False

--- a/tests/unit_tests/storage/metric/test_subject_path.py
+++ b/tests/unit_tests/storage/metric/test_subject_path.py
@@ -1,0 +1,130 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus.storage.metric.subject_path."""
+
+from datus.storage.metric.subject_path import (
+    GENERIC_METRIC_SUBJECT_ROOTS,
+    _normalize_part,
+    _same_part,
+    default_metric_subject_path,
+    normalize_metric_subject_path,
+    normalize_metric_subject_tree_tag,
+)
+
+
+class TestDefaultMetricSubjectPath:
+    def test_with_datasource_and_table(self):
+        assert default_metric_subject_path("myds", "orders") == ["myds", "orders"]
+
+    def test_without_datasource_uses_metrics_root(self):
+        assert default_metric_subject_path("", "orders") == ["Metrics", "orders"]
+
+    def test_none_datasource_uses_metrics_root(self):
+        assert default_metric_subject_path(None, "orders") == ["Metrics", "orders"]
+
+    def test_empty_table_becomes_unknown(self):
+        assert default_metric_subject_path("ds", "") == ["ds", "Unknown"]
+
+    def test_both_empty(self):
+        assert default_metric_subject_path("", "") == ["Metrics", "Unknown"]
+
+    def test_whitespace_datasource_treated_as_empty(self):
+        assert default_metric_subject_path("  ", "orders") == ["Metrics", "orders"]
+
+    def test_whitespace_table_becomes_unknown(self):
+        result = default_metric_subject_path("ds", "  ")
+        assert result == ["ds", "Unknown"]
+
+
+class TestNormalizeMetricSubjectPath:
+    def test_empty_parts_falls_back_to_default(self):
+        result = normalize_metric_subject_path([], datasource="ds", table_name="orders")
+        assert result == ["ds", "orders"]
+
+    def test_none_parts_falls_back_to_default(self):
+        result = normalize_metric_subject_path(None, datasource="ds", table_name="orders")
+        assert result == ["ds", "orders"]
+
+    def test_no_datasource_returns_parts_unchanged(self):
+        parts = ["Finance", "Revenue"]
+        result = normalize_metric_subject_path(parts)
+        assert result == ["Finance", "Revenue"]
+
+    def test_generic_root_replaced_with_datasource(self):
+        for root in GENERIC_METRIC_SUBJECT_ROOTS:
+            result = normalize_metric_subject_path([root, "Orders"], datasource="myds")
+            assert result[0] == "myds"
+            assert result[1] == "Orders"
+
+    def test_same_part_as_datasource_deduplicated(self):
+        result = normalize_metric_subject_path(["myds", "Revenue"], datasource="myds")
+        assert result == ["myds", "Revenue"]
+
+    def test_datasource_repeated_in_tail_stripped(self):
+        result = normalize_metric_subject_path(["myds", "myds", "Revenue"], datasource="myds")
+        assert result == ["myds", "Revenue"]
+
+    def test_non_generic_non_datasource_root_returned_as_is(self):
+        result = normalize_metric_subject_path(["Finance", "Revenue"], datasource="myds")
+        assert result == ["Finance", "Revenue"]
+
+    def test_empty_tail_after_strip_uses_table_name(self):
+        result = normalize_metric_subject_path(["metrics"], datasource="myds", table_name="orders")
+        assert result == ["myds", "orders"]
+
+    def test_empty_tail_after_strip_no_table_name_uses_unknown(self):
+        result = normalize_metric_subject_path(["metrics"], datasource="myds")
+        assert result == ["myds", "Unknown"]
+
+    def test_case_insensitive_datasource_match(self):
+        result = normalize_metric_subject_path(["MyDS", "Revenue"], datasource="myds")
+        assert result[0] == "myds"
+        assert result[1] == "Revenue"
+
+    def test_whitespace_only_parts_filtered(self):
+        result = normalize_metric_subject_path(["  ", "Finance"], datasource="ds", table_name="orders")
+        # "  " gets stripped to "" and filtered, so only "Finance" remains
+        assert result == ["Finance"]
+
+    def test_multiple_parts_preserved(self):
+        result = normalize_metric_subject_path(["metrics", "Finance", "Q1"], datasource="myds")
+        assert result == ["myds", "Finance", "Q1"]
+
+
+class TestNormalizeMetricSubjectTreeTag:
+    def test_non_string_input_returned_as_is(self):
+        assert normalize_metric_subject_tree_tag(42) == 42
+
+    def test_tag_without_prefix_returned_as_is(self):
+        assert normalize_metric_subject_tree_tag("some_tag") == "some_tag"
+
+    def test_tag_with_prefix_normalized(self):
+        result = normalize_metric_subject_tree_tag(
+            "subject_tree: metrics/Revenue", datasource="myds", table_name="orders"
+        )
+        assert result.startswith("subject_tree:")
+        assert "myds" in result
+        assert "Revenue" in result
+
+    def test_tag_with_prefix_no_datasource(self):
+        result = normalize_metric_subject_tree_tag("subject_tree: Finance/Revenue")
+        assert result == "subject_tree: Finance/Revenue"
+
+    def test_empty_path_parts_handled(self):
+        result = normalize_metric_subject_tree_tag("subject_tree: /Finance//Revenue/")
+        assert "Finance" in result
+        assert "Revenue" in result
+
+
+class TestHelpers:
+    def test_normalize_part_lowercases_and_strips(self):
+        assert _normalize_part("  MyValue  ") == "myvalue"
+
+    def test_normalize_part_empty(self):
+        assert _normalize_part("") == ""
+
+    def test_same_part_case_insensitive(self):
+        assert _same_part("MyDS", "myds") is True
+        assert _same_part("Finance", "Revenue") is False

--- a/tests/unit_tests/storage/reference_template/test_store.py
+++ b/tests/unit_tests/storage/reference_template/test_store.py
@@ -20,7 +20,7 @@ class TestReferenceTemplateStorage:
         call_kwargs = mock_super.call_args
         assert call_kwargs.kwargs["table_name"] == "reference_template"
         assert call_kwargs.kwargs["vector_source_name"] == "search_text"
-        assert call_kwargs.kwargs["unique_columns"] == ["id"]
+        assert call_kwargs.kwargs["unique_columns"] == ["storage_key"]
 
     @patch("datus.storage.reference_template.store.BaseSubjectEmbeddingStore.__init__", return_value=None)
     def test_create_indices(self, mock_super):
@@ -116,7 +116,7 @@ class TestReferenceTemplateStorage:
 
         items = [{"id": "abc", "template": "SELECT 1", "subject_path": ["Sales"]}]
         storage.batch_upsert_templates(items)
-        storage.batch_upsert.assert_called_once_with(items, on_column="id")
+        storage.batch_upsert.assert_called_once_with(items, on_column="storage_key")
 
     @patch("datus.storage.reference_template.store.BaseSubjectEmbeddingStore.__init__", return_value=None)
     def test_search_reference_templates(self, mock_super):
@@ -175,7 +175,7 @@ class TestReferenceTemplateRAG:
     def test_truncate(self, mock_get_storage, mock_filter):
         rag, mock_storage = self._create_rag(mock_get_storage)
         rag.truncate()
-        mock_storage.truncate_scoped.assert_called_once()
+        mock_storage.delete_datasource_rows.assert_called_once_with("test_ns")
 
     @patch("datus.storage.rag_scope._build_sub_agent_filter", return_value=None)
     @patch("datus.storage.registry.get_storage")

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -214,7 +214,7 @@ class TestSemanticModelStorageBatchOps:
     def test_upsert_batch_insert(self, sem_storage):
         """Upserting new objects should insert them."""
         table_obj = _make_table_object("products", description="Products catalog")
-        sem_storage.upsert_batch([table_obj], on_column="id")
+        sem_storage.upsert_batch([table_obj], on_column="storage_key")
         results = sem_storage.search_all()
         assert len(results) == 1
         assert results[0]["name"] == "products"
@@ -225,7 +225,7 @@ class TestSemanticModelStorageBatchOps:
         sem_storage.store_batch([table_obj])
 
         updated_obj = _make_table_object("products", description="Updated description")
-        sem_storage.upsert_batch([updated_obj], on_column="id")
+        sem_storage.upsert_batch([updated_obj], on_column="storage_key")
 
         results = sem_storage.search_all()
         assert len(results) == 1

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -331,7 +331,7 @@ class TestReadOnlyPathsWithoutEmbedding:
         result = store._search_all()
 
         assert result.num_rows == 0
-        assert result.column_names == ["name", "definition", "datasource_id"]
+        assert result.column_names == ["name", "definition"]
         assert db.open_table_calls == []
         assert store._shared.initialized is False
 

--- a/tests/unit_tests/storage/test_base_extensions.py
+++ b/tests/unit_tests/storage/test_base_extensions.py
@@ -87,11 +87,23 @@ class TestExtraFields:
             embedding_model=_FakeEmbeddingModel(),
             schema=schema,
         )
-        # datasource_id is auto-appended for subject tree compatibility
         schema_names = {f.name for f in store._schema}
         assert "id" in schema_names
         assert "text" in schema_names
+        assert "datasource_id" not in schema_names
+        assert "storage_key" not in schema_names
+
+    def test_datasource_scoped_schema_appends_scope_fields(self):
+        schema = _base_schema()
+        store = BaseEmbeddingStore(
+            table_name="test",
+            embedding_model=_FakeEmbeddingModel(),
+            schema=schema,
+            datasource_scoped=True,
+        )
+        schema_names = {f.name for f in store._schema}
         assert "datasource_id" in schema_names
+        assert "storage_key" in schema_names
 
     def test_extra_fields_are_appended(self):
         schema = _base_schema()
@@ -171,6 +183,34 @@ class TestDefaultValues:
         data = [{"id": "1", "text": "hello"}]
         result = store._apply_default_values(data)
         assert result[0]["workspace_id"] == "ws_123"
+        assert "datasource_id" not in result[0]
+        assert "storage_key" not in result[0]
+
+    def test_apply_default_values_fills_datasource_scope(self):
+        store = BaseEmbeddingStore(
+            table_name="test",
+            embedding_model=_FakeEmbeddingModel(),
+            schema=_base_schema(),
+            datasource_scoped=True,
+        )
+        data = [{"id": "1", "text": "hello", "datasource_id": "ds"}]
+        result = store._apply_default_values(data)
+        assert result[0]["datasource_id"] == "ds"
+        assert result[0]["storage_key"] == "ds:1"
+
+    def test_apply_default_values_ignores_scope_fields_when_not_datasource_scoped(self):
+        schema = pa.schema(list(_base_schema()) + [pa.field("datasource_id", pa.string())])
+        store = BaseEmbeddingStore(
+            table_name="test",
+            embedding_model=_FakeEmbeddingModel(),
+            schema=schema,
+        )
+        data = [{"id": "1", "text": "hello", "datasource_id": "business_value"}]
+
+        result = store._apply_default_values(data)
+
+        assert result[0]["datasource_id"] == "business_value"
+        assert "storage_key" not in result[0]
 
     def test_apply_default_values_does_not_overwrite_existing(self):
         store = BaseEmbeddingStore(
@@ -214,10 +254,10 @@ class TestDefaultValues:
 
 
 class TestTruncateScoped:
-    """Tests for truncate_scoped() — aliased to truncate() under PHYSICAL-only isolation."""
+    """Tests for truncate_scoped() as a legacy full-table truncate alias."""
 
     def test_truncate_scoped_drops_table(self):
-        """truncate_scoped() drops the entire table (alias for truncate())."""
+        """truncate_scoped() drops the entire table."""
         from unittest.mock import MagicMock
 
         store = BaseEmbeddingStore(

--- a/tests/unit_tests/storage/test_datasource_scope.py
+++ b/tests/unit_tests/storage/test_datasource_scope.py
@@ -1,0 +1,164 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus.storage.datasource_scope."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.storage.datasource_scope import (
+    DATASOURCE_ID_COLUMN,
+    LEGACY_STORAGE_KEY_PREFIX,
+    STORAGE_KEY_COLUMN,
+    add_datasource_scope_to_rows,
+    build_storage_key,
+    combine_conditions,
+    datasource_condition,
+    resolve_datasource_id,
+)
+from datus.utils.exceptions import DatusException
+
+
+class TestResolveDatasourceId:
+    def test_explicit_datasource_id_returned(self):
+        cfg = MagicMock()
+        cfg.current_datasource = "ignored"
+        assert resolve_datasource_id(cfg, datasource_id="my_ds") == "my_ds"
+
+    def test_falls_back_to_agent_config_current_datasource(self):
+        cfg = MagicMock()
+        cfg.current_datasource = "cfg_ds"
+        assert resolve_datasource_id(cfg) == "cfg_ds"
+
+    def test_strips_whitespace(self):
+        cfg = MagicMock()
+        cfg.current_datasource = "  ds  "
+        assert resolve_datasource_id(cfg) == "ds"
+
+    def test_raises_when_empty_after_strip(self):
+        cfg = MagicMock()
+        cfg.current_datasource = ""
+        with pytest.raises(DatusException):
+            resolve_datasource_id(cfg)
+
+    def test_raises_when_none_datasource_and_empty_config(self):
+        cfg = MagicMock()
+        cfg.current_datasource = None
+        with pytest.raises(DatusException):
+            resolve_datasource_id(cfg, datasource_id=None)
+
+    def test_raises_when_whitespace_only_explicit(self):
+        cfg = MagicMock()
+        cfg.current_datasource = "anything"
+        with pytest.raises(DatusException):
+            resolve_datasource_id(cfg, datasource_id="   ")
+
+
+class TestDatasourceCondition:
+    def test_returns_node(self):
+        node = datasource_condition("ds1")
+        assert node is not None
+
+    def test_different_ids_produce_different_conditions(self):
+        node_a = datasource_condition("ds_a")
+        node_b = datasource_condition("ds_b")
+        assert node_a != node_b
+
+
+class TestCombineConditions:
+    def test_empty_returns_none(self):
+        assert combine_conditions([]) is None
+
+    def test_all_none_returns_none(self):
+        assert combine_conditions([None, None]) is None
+
+    def test_single_non_none_returned_as_is(self):
+        cond = datasource_condition("ds1")
+        result = combine_conditions([None, cond, None])
+        assert result is cond
+
+    def test_two_conditions_returns_and_node(self):
+        cond_a = datasource_condition("ds_a")
+        cond_b = datasource_condition("ds_b")
+        result = combine_conditions([cond_a, cond_b])
+        assert result is not None
+        assert result is not cond_a
+        assert result is not cond_b
+
+    def test_three_conditions_combines(self):
+        conds = [datasource_condition(f"ds_{i}") for i in range(3)]
+        result = combine_conditions(conds)
+        assert result is not None
+
+
+class TestBuildStorageKey:
+    def test_with_datasource_and_business_id(self):
+        key = build_storage_key("my_ds", "row_123")
+        assert key == "my_ds:row_123"
+
+    def test_empty_datasource_uses_legacy_prefix(self):
+        key = build_storage_key("", "row_456")
+        assert key == f"{LEGACY_STORAGE_KEY_PREFIX}row_456"
+
+    def test_none_datasource_uses_legacy_prefix(self):
+        key = build_storage_key(None, "row_789")
+        assert key == f"{LEGACY_STORAGE_KEY_PREFIX}row_789"
+
+    def test_empty_business_id_raises(self):
+        with pytest.raises(Exception, match="business id is required"):
+            build_storage_key("ds", "")
+
+    def test_none_business_id_raises(self):
+        with pytest.raises(Exception, match="business id is required"):
+            build_storage_key("ds", None)
+
+    def test_whitespace_only_business_id_raises(self):
+        with pytest.raises(Exception, match="business id is required"):
+            build_storage_key("ds", "   ")
+
+    def test_integer_business_id_stringified(self):
+        key = build_storage_key("ds", 42)
+        assert key == "ds:42"
+
+
+class TestAddDatasourceScopeToRows:
+    def test_adds_datasource_id_column(self):
+        rows = [{"id": "r1", "name": "orders"}]
+        result = add_datasource_scope_to_rows(rows, "my_ds")
+        assert result[0][DATASOURCE_ID_COLUMN] == "my_ds"
+
+    def test_adds_storage_key_when_id_present(self):
+        rows = [{"id": "r1", "name": "orders"}]
+        result = add_datasource_scope_to_rows(rows, "my_ds")
+        assert result[0][STORAGE_KEY_COLUMN] == "my_ds:r1"
+
+    def test_no_storage_key_when_id_missing(self):
+        rows = [{"name": "orders"}]
+        result = add_datasource_scope_to_rows(rows, "my_ds")
+        assert STORAGE_KEY_COLUMN not in result[0]
+
+    def test_no_storage_key_when_id_is_empty_string(self):
+        rows = [{"id": "", "name": "orders"}]
+        result = add_datasource_scope_to_rows(rows, "my_ds")
+        assert STORAGE_KEY_COLUMN not in result[0]
+
+    def test_custom_id_field(self):
+        rows = [{"metric_id": "m1", "name": "revenue"}]
+        result = add_datasource_scope_to_rows(rows, "ds1", id_field="metric_id")
+        assert result[0][STORAGE_KEY_COLUMN] == "ds1:m1"
+
+    def test_original_rows_not_mutated(self):
+        rows = [{"id": "r1", "name": "orders"}]
+        add_datasource_scope_to_rows(rows, "my_ds")
+        assert DATASOURCE_ID_COLUMN not in rows[0]
+
+    def test_empty_rows_returns_empty(self):
+        assert add_datasource_scope_to_rows([], "ds") == []
+
+    def test_multiple_rows_all_scoped(self):
+        rows = [{"id": f"r{i}"} for i in range(3)]
+        result = add_datasource_scope_to_rows(rows, "ds")
+        assert all(r[DATASOURCE_ID_COLUMN] == "ds" for r in result)
+        assert [r[STORAGE_KEY_COLUMN] for r in result] == ["ds:r0", "ds:r1", "ds:r2"]

--- a/tests/unit_tests/storage/test_rag_datasource_isolation.py
+++ b/tests/unit_tests/storage/test_rag_datasource_isolation.py
@@ -2,21 +2,12 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Tests for RAG classes in PHYSICAL isolation mode.
+"""Datasource row-scope tests for RAG stores.
 
-In Storage 3.0, datasource_id isolation is handled at the backend level:
-- PHYSICAL mode (CLI default): each datasource gets its own directory via
-  init_backends(datasource=...).  All RAG instances within one process share
-  the same storage — isolation is per-process, not per-RAG.
-- LOGICAL mode (SaaS): backend auto-injects datasource_id column for
-  within-process multi-tenant filtering.
-
-LOGICAL isolation is tested at the LanceDB backend level in
-tests/unit_tests/storage/vector/test_lance_backend.py
-(TestLanceVectorTableLogicalIsolation).
-
-This file tests that RAG classes work correctly in PHYSICAL mode
-(single shared storage, no cross-datasource filtering).
+Physical storage remains project-scoped: every datasource in a project shares
+the same vector tables. RAG classes must therefore inject and filter by
+``datasource_id`` on every read/write/delete, while ``storage_key`` prevents
+same business ids from colliding across datasources.
 """
 
 from typing import Any, Dict
@@ -26,24 +17,21 @@ import pyarrow as pa
 from datus.storage.metric.store import MetricRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 
-# ---------------------------------------------------------------------------
-# Sample data helpers
-# ---------------------------------------------------------------------------
 
-
-def _make_table_object(suffix: str = "a") -> Dict[str, Any]:
+def _make_table_object(suffix: str = "a", description: str = "") -> Dict[str, Any]:
     """Return a minimal SemanticModelRAG-compatible table object."""
+
     return {
-        "id": f"table:orders_{suffix}",
+        "id": "table:orders",
         "kind": "table",
-        "name": f"orders_{suffix}",
-        "fq_name": f"analytics.public.orders_{suffix}",
-        "semantic_model_name": f"orders_{suffix}",
+        "name": "orders",
+        "fq_name": "analytics.public.orders",
+        "semantic_model_name": "orders",
         "catalog_name": "default",
         "database_name": "analytics",
         "schema_name": "public",
-        "table_name": f"orders_{suffix}",
-        "description": f"Order table {suffix}",
+        "table_name": "orders",
+        "description": description or f"Order table {suffix}",
         "is_dimension": False,
         "is_measure": False,
         "is_entity_key": False,
@@ -61,64 +49,77 @@ def _make_table_object(suffix: str = "a") -> Dict[str, Any]:
     }
 
 
-def _make_metric(suffix: str = "a") -> Dict[str, Any]:
+def _make_metric(description: str = "Total revenue metric") -> Dict[str, Any]:
     """Return a minimal MetricRAG-compatible metric object."""
+
     return {
-        "id": f"metric:total_revenue_{suffix}",
+        "id": "metric:Finance/Revenue.total_revenue",
         "subject_path": ["Finance", "Revenue"],
-        "name": f"total_revenue_{suffix}",
+        "name": "total_revenue",
         "semantic_model_name": "orders",
-        "description": f"Total revenue metric {suffix}",
+        "description": description,
     }
 
 
-# ---------------------------------------------------------------------------
-# PHYSICAL mode tests — shared storage within one process
-# ---------------------------------------------------------------------------
+def _rag_pair(real_agent_config, rag_cls):
+    rag_a = rag_cls(real_agent_config, datasource_id="ds_a")
+    rag_b = rag_cls(real_agent_config, datasource_id="ds_b")
+    return rag_a, rag_b
 
 
-class TestRAGPhysicalModeSharedStorage:
-    """In PHYSICAL mode, all RAG instances share the same storage.
+class TestRAGDatasourceRowScope:
+    def test_semantic_model_same_business_id_isolated_by_datasource(self, real_agent_config):
+        rag_a, rag_b = _rag_pair(real_agent_config, SemanticModelRAG)
 
-    This verifies that store_batch/search_all work correctly when
-    multiple RAGs use the same underlying storage.
-    """
+        rag_a.upsert_batch([_make_table_object(description="orders from ds_a")])
+        rag_b.upsert_batch([_make_table_object(description="orders from ds_b")])
 
-    def test_semantic_model_store_and_search(self, real_agent_config):
-        """SemanticModelRAG can store and retrieve data."""
-        rag = SemanticModelRAG(real_agent_config)
-        rag.store_batch([_make_table_object("x1"), _make_table_object("x2")])
-        results = rag.search_all()
-        assert len(results) == 2
+        results_a = rag_a.search_all()
+        results_b = rag_b.search_all()
 
-    def test_semantic_model_truncate(self, real_agent_config):
-        """SemanticModelRAG truncate clears data."""
-        rag = SemanticModelRAG(real_agent_config)
-        rag.store_batch([_make_table_object("trunc")])
-        assert rag.get_size() >= 1
-        rag.truncate()
-        assert rag.get_size() == 0
+        assert [row["description"] for row in results_a] == ["orders from ds_a"]
+        assert [row["description"] for row in results_b] == ["orders from ds_b"]
 
-    def test_metric_store_and_search(self, real_agent_config):
-        """MetricRAG can store and retrieve metrics."""
-        rag = MetricRAG(real_agent_config)
-        rag.store_batch([_make_metric("m1"), _make_metric("m2")])
-        results = rag.search_all_metrics()
-        assert len(results) >= 2
+    def test_semantic_model_truncate_deletes_only_current_datasource(self, real_agent_config):
+        rag_a, rag_b = _rag_pair(real_agent_config, SemanticModelRAG)
 
-    def test_metric_get_size(self, real_agent_config):
-        """MetricRAG.get_metrics_size returns correct count."""
-        rag = MetricRAG(real_agent_config)
-        rag.store_batch([_make_metric("sz1"), _make_metric("sz2")])
-        assert rag.get_metrics_size() >= 2
+        rag_a.upsert_batch([_make_table_object(description="orders from ds_a")])
+        rag_b.upsert_batch([_make_table_object(description="orders from ds_b")])
 
-    def test_metric_upsert_batch(self, real_agent_config):
-        """MetricRAG.upsert_batch updates existing and inserts new."""
-        rag = MetricRAG(real_agent_config)
-        m = _make_metric("ups")
-        rag.store_batch([m])
-        initial_size = rag.get_metrics_size()
+        rag_a.truncate()
 
-        # Upsert same id — should not increase count
-        rag.upsert_batch([m])
-        assert rag.get_metrics_size() == initial_size
+        assert rag_a.get_size() == 0
+        assert [row["description"] for row in rag_b.search_all()] == ["orders from ds_b"]
+
+    def test_metric_same_business_id_isolated_by_datasource(self, real_agent_config):
+        rag_a, rag_b = _rag_pair(real_agent_config, MetricRAG)
+
+        rag_a.upsert_batch([_make_metric("metric from ds_a")])
+        rag_b.upsert_batch([_make_metric("metric from ds_b")])
+
+        results_a = rag_a.search_all_metrics()
+        results_b = rag_b.search_all_metrics()
+
+        assert [row["description"] for row in results_a] == ["metric from ds_a"]
+        assert [row["description"] for row in results_b] == ["metric from ds_b"]
+
+    def test_metric_upsert_updates_only_current_datasource(self, real_agent_config):
+        rag_a, rag_b = _rag_pair(real_agent_config, MetricRAG)
+
+        rag_a.upsert_batch([_make_metric("metric from ds_a")])
+        rag_b.upsert_batch([_make_metric("metric from ds_b")])
+        rag_a.upsert_batch([_make_metric("updated metric from ds_a")])
+
+        assert [row["description"] for row in rag_a.search_all_metrics()] == ["updated metric from ds_a"]
+        assert [row["description"] for row in rag_b.search_all_metrics()] == ["metric from ds_b"]
+
+    def test_metric_truncate_deletes_only_current_datasource(self, real_agent_config):
+        rag_a, rag_b = _rag_pair(real_agent_config, MetricRAG)
+
+        rag_a.upsert_batch([_make_metric("metric from ds_a")])
+        rag_b.upsert_batch([_make_metric("metric from ds_b")])
+
+        rag_a.truncate()
+
+        assert rag_a.get_metrics_size() == 0
+        assert [row["description"] for row in rag_b.search_all_metrics()] == ["metric from ds_b"]

--- a/tests/unit_tests/storage/test_registry_cache.py
+++ b/tests/unit_tests/storage/test_registry_cache.py
@@ -98,29 +98,47 @@ class TestGetStorageLRUCache:
             patch("datus.storage.backend_holder.get_vector_backend") as mock_backend,
         ):
             mock_backend.return_value = MagicMock()
-            store = get_storage(MetricStorage, "metric", project="my_project")
+            store = get_storage(MetricStorage, "metric", project="my_project", datasource_id="ds1")
 
         assert store.subject_tree is project_tree
-        assert call("my_project") in mock_tree.call_args_list
+        assert call("my_project", "ds1") in mock_tree.call_args_list
+
+    def test_datasource_scopes_wrapper_not_backend_namespace(self, reset_global_singletons):
+        """Different datasource wrappers share the same project backend namespace."""
+        from datus.storage.registry import get_storage
+
+        def _factory(embedding_model, **kwargs):
+            return BaseEmbeddingStore(table_name="test", embedding_model=embedding_model, **kwargs)
+
+        backend = MagicMock()
+        backend.connect.return_value = MagicMock()
+        with (
+            patch("datus.storage.registry.get_embedding_model", return_value=_FakeEmbeddingModel()),
+            patch("datus.storage.backend_holder.get_vector_backend", return_value=backend),
+        ):
+            s1 = get_storage(_factory, "database", project="proj_1", datasource_id="ds_a")
+            s2 = get_storage(_factory, "database", project="proj_1", datasource_id="ds_b")
+
+        assert s1 is not s2
+        assert backend.connect.call_args_list == [call("proj_1"), call("proj_1")]
 
 
 class TestPreloadAllStorages:
     """Tests for preload_all_storages() with project."""
 
     def test_preload_forwards_project(self, reset_global_singletons):
-        """preload_all_storages forwards project to both init_backends and get_storage."""
+        """preload_all_storages initializes backends without opening datasource-scoped stores."""
         from datus.storage.registry import preload_all_storages
 
         with (
             patch("datus.storage.registry.get_storage") as mock_get_storage,
             patch("datus.storage.backend_holder.init_backends") as mock_init,
-            patch("datus.storage.registry.get_subject_tree_store"),
+            patch("datus.storage.registry.get_subject_tree_store") as mock_get_subject_tree_store,
         ):
             preload_all_storages(data_dir="/tmp/test", project="my_project")
             mock_init.assert_called_once_with(config=None, data_dir="/tmp/test")
-            # All get_storage calls receive project as a kwarg.
-            for call_args in mock_get_storage.call_args_list:
-                assert call_args.kwargs.get("project") == "my_project"
+            mock_get_storage.assert_not_called()
+            mock_get_subject_tree_store.assert_not_called()
 
     def test_preload_applies_defaults(self, reset_global_singletons):
         """preload_all_storages applies deployment defaults."""

--- a/tests/unit_tests/storage/test_storage_cache.py
+++ b/tests/unit_tests/storage/test_storage_cache.py
@@ -87,12 +87,12 @@ class TestGetStorage:
             b = get_storage(_DummyStore, "metric", project="test")
         assert a is not b
 
-    def test_different_datasources_not_in_key(self):
-        """get_storage ignores datasource — same factory always returns same instance."""
+    def test_different_datasources_get_distinct_wrappers(self):
+        """Datasource participates in the wrapper cache key."""
         with patch("datus.storage.registry.get_embedding_model", side_effect=_fake_get_embedding_model):
-            a = get_storage(_DummyStore, "metric", project="test")
-            b = get_storage(_DummyStore, "metric", project="test")
-        assert a is b
+            a = get_storage(_DummyStore, "metric", project="test", datasource_id="ds_a")
+            b = get_storage(_DummyStore, "metric", project="test", datasource_id="ds_b")
+        assert a is not b
 
 
 class TestConfigureStorageDefaults:

--- a/tests/unit_tests/storage/test_storage_integration_pyarrow.py
+++ b/tests/unit_tests/storage/test_storage_integration_pyarrow.py
@@ -83,11 +83,12 @@ class TestMetricRAGPyArrow:
         metric_storage = MetricStorage(embedding_model=get_metric_embedding_model())
         metric_storage.batch_store_metrics(sample_metrics_with_domain_layers)
 
-        # Mock cache for MetricRAG
+        # Mock cache for MetricRAG — datasource_id must match the storage default
         rag = MetricRAG.__new__(MetricRAG)
         rag.storage = metric_storage
-        rag.datasource_id = "test_datasource"
+        rag.datasource_id = metric_storage.datasource_id
         rag._sub_agent_filter = None
+        rag._provenance_enabled = False
 
         result = rag.search_all_metrics()
 

--- a/tests/unit_tests/storage/test_subject_manager.py
+++ b/tests/unit_tests/storage/test_subject_manager.py
@@ -14,6 +14,8 @@ from datus.storage.subject_manager import SubjectUpdater
 def _build_updater() -> SubjectUpdater:
     """Create a SubjectUpdater with all storage dependencies mocked."""
     mock_config = MagicMock()
+    mock_config.current_datasource = "test_ds"
+    mock_config.project_name = "test_project"
     mock_storage = MagicMock()
     with patch("datus.storage.subject_manager.get_storage", return_value=mock_storage):
         updater = SubjectUpdater(mock_config)
@@ -41,7 +43,9 @@ class TestUpdateMetricsDetail:
         updater = _build_updater()
         updater.update_metrics_detail(["Finance", "Revenue"], "dau", {"description": "daily active users"})
         updater.metrics_storage.update_entry.assert_called_once_with(
-            ["Finance", "Revenue"], "dau", {"description": "daily active users"}
+            ["Finance", "Revenue"],
+            "dau",
+            {"description": "daily active users"},
         )
 
 
@@ -66,7 +70,9 @@ class TestUpdateHistoricalSql:
         updater = _build_updater()
         updater.update_historical_sql(["Analytics"], "query_1", {"sql": "SELECT 1"})
         updater.reference_sql_storage.update_entry.assert_called_once_with(
-            ["Analytics"], "query_1", {"sql": "SELECT 1"}
+            ["Analytics"],
+            "query_1",
+            {"sql": "SELECT 1"},
         )
 
 
@@ -84,7 +90,10 @@ class TestDeleteMetric:
         updater = _build_updater()
         updater.metrics_storage.delete_metric.return_value = {"success": True, "message": "deleted"}
         result = updater.delete_metric(["Finance"], "old_metric")
-        updater.metrics_storage.delete_metric.assert_called_once_with(["Finance"], "old_metric")
+        updater.metrics_storage.delete_metric.assert_called_once_with(
+            ["Finance"],
+            "old_metric",
+        )
         assert result == {"success": True, "message": "deleted"}
 
 
@@ -103,7 +112,8 @@ class TestDeleteReferenceSql:
         updater.reference_sql_storage.delete_reference_sql.return_value = True
         result = updater.delete_reference_sql(["Analytics", "Reports"], "old_query")
         updater.reference_sql_storage.delete_reference_sql.assert_called_once_with(
-            ["Analytics", "Reports"], "old_query"
+            ["Analytics", "Reports"],
+            "old_query",
         )
         assert result is True
 

--- a/tests/unit_tests/storage/test_subject_tree_store.py
+++ b/tests/unit_tests/storage/test_subject_tree_store.py
@@ -846,6 +846,19 @@ class TestSubjectTreeDatasourceFields:
         node = store.create_node(None, "Finance")
         assert "datasource_id" in node
 
+    def test_same_project_different_datasources_have_independent_trees(self, storage_test_project):
+        """The same path can exist independently for two datasources in one project."""
+        store_a = SubjectTreeStore(project=storage_test_project, datasource_id="ds_a")
+        store_b = SubjectTreeStore(project=storage_test_project, datasource_id="ds_b")
 
-# Datasource isolation is now handled at the RDB layer (SqliteRdbDatabase).
-# See tests/unit_tests/storage/rdb/ for isolation tests.
+        node_a = store_a.create_node(None, "Finance")
+        node_b = store_b.create_node(None, "Finance")
+
+        assert node_a["node_id"] != node_b["node_id"]
+        assert store_a.get_tree_structure().keys() == {"Finance"}
+        assert store_b.get_tree_structure().keys() == {"Finance"}
+        assert store_a.get_node(node_b["node_id"]) is None
+        assert store_b.get_node(node_a["node_id"]) is None
+
+
+# Datasource isolation is row-level in the shared project tree.

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -455,6 +455,18 @@ class TestGlobSearch:
         assert "file.py" in names
         assert "other.py" not in names
 
+    def test_glob_path_like_pattern_searches_explicit_seed(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("subject/\n")
+        metrics_dir = tmp_path / "subject" / "semantic_models" / "starrocks" / "metrics"
+        metrics_dir.mkdir(parents=True)
+        (metrics_dir / "v_udata_ac_info_metrics.yml").write_text("metric: {}\n")
+
+        tool = _make_tool(str(tmp_path))
+        result = tool.glob("subject/semantic_models/starrocks/metrics/*.yml")
+
+        assert result.success == 1
+        assert result.result["files"] == ["subject/semantic_models/starrocks/metrics/v_udata_ac_info_metrics.yml"]
+
     def test_glob_truncation(self, tmp_path):
         """Results are truncated when exceeding max_results (200)."""
         for i in range(5):

--- a/tests/unit_tests/tools/func_tool/test_generation_evidence.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_evidence.py
@@ -1,0 +1,295 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus.tools.func_tool.generation_evidence."""
+
+from datus.tools.func_tool.generation_evidence import (
+    GenerationEvidence,
+    _deduplicate_preserve_order,
+    _metadata_from_result,
+    _normalized_metric_alias_map,
+    _result_payload,
+    _result_success,
+)
+
+
+class TestResultSuccess:
+    def test_dict_success_1(self):
+        assert _result_success({"success": 1}) is True
+
+    def test_dict_success_true(self):
+        assert _result_success({"success": True}) is True
+
+    def test_dict_success_0(self):
+        assert _result_success({"success": 0}) is False
+
+    def test_dict_no_success_key(self):
+        assert _result_success({}) is False
+
+    def test_object_with_success_attr(self):
+        class Obj:
+            success = 1
+
+        assert _result_success(Obj()) is True
+
+    def test_object_with_success_false(self):
+        class Obj:
+            success = False
+
+        assert _result_success(Obj()) is False
+
+    def test_plain_value_returns_false(self):
+        assert _result_success(None) is False
+        assert _result_success("str") is False
+        assert _result_success(42) is False
+
+
+class TestResultPayload:
+    def test_dict_returns_result_key(self):
+        assert _result_payload({"result": "payload"}) == "payload"
+
+    def test_dict_missing_result_key_returns_none(self):
+        assert _result_payload({}) is None
+
+    def test_object_with_result_attr(self):
+        class Obj:
+            result = "attr_payload"
+
+        assert _result_payload(Obj()) == "attr_payload"
+
+    def test_plain_returns_none(self):
+        assert _result_payload(None) is None
+
+
+class TestMetadataFromResult:
+    def test_extracts_metadata_from_dict_result(self):
+        result = {"result": {"metadata": {"sql": "SELECT 1"}}}
+        assert _metadata_from_result(result) == {"sql": "SELECT 1"}
+
+    def test_non_dict_metadata_returns_empty(self):
+        result = {"result": {"metadata": "not a dict"}}
+        assert _metadata_from_result(result) == {}
+
+    def test_no_metadata_key_returns_empty(self):
+        result = {"result": {}}
+        assert _metadata_from_result(result) == {}
+
+    def test_object_payload_with_metadata_attr(self):
+        class Payload:
+            metadata = {"key": "value"}
+
+        class Obj:
+            result = Payload()
+
+        assert _metadata_from_result(Obj()) == {"key": "value"}
+
+    def test_non_dict_object_metadata_returns_empty(self):
+        class Payload:
+            metadata = "not a dict"
+
+        class Obj:
+            result = Payload()
+
+        assert _metadata_from_result(Obj()) == {}
+
+
+class TestDeduplicatePreserveOrder:
+    def test_removes_duplicates(self):
+        assert _deduplicate_preserve_order(["a", "b", "a", "c"]) == ["a", "b", "c"]
+
+    def test_preserves_order(self):
+        assert _deduplicate_preserve_order(["c", "b", "a"]) == ["c", "b", "a"]
+
+    def test_empty(self):
+        assert _deduplicate_preserve_order([]) == []
+
+
+class TestNormalizedMetricAliasMap:
+    def test_maps_alias_to_canonical(self):
+        result = _normalized_metric_alias_map({"rev_total": "revenue_total"})
+        assert result["rev_total"] == "revenue_total"
+
+    def test_also_maps_normalized_alias(self):
+        result = _normalized_metric_alias_map({"Rev Total": "revenue_total"})
+        assert result.get("rev_total") == "revenue_total"
+
+    def test_skips_non_string_entries(self):
+        result = _normalized_metric_alias_map({1: "canonical", "alias": 2})
+        assert result == {}
+
+    def test_skips_empty_entries(self):
+        result = _normalized_metric_alias_map({"": "canonical", "alias": ""})
+        assert result == {}
+
+
+class TestGenerationEvidence:
+    def test_initial_state(self):
+        ev = GenerationEvidence()
+        assert ev.validation_passed is False
+        assert ev.metric_dry_run_passed is False
+        assert ev.kb_sync_passed is False
+        assert ev.storage_revision == 0
+
+    def test_kb_sync_passed_when_any_kind_set(self):
+        ev = GenerationEvidence()
+        ev.mark_kb_sync("metric")
+        assert ev.kb_sync_passed is True
+        assert ev.metric_kb_sync_passed is True
+        assert ev.storage_revision == 1
+
+    def test_kb_sync_semantic(self):
+        ev = GenerationEvidence()
+        ev.mark_kb_sync("semantic")
+        assert ev.semantic_kb_sync_passed is True
+
+    def test_kb_sync_generic(self):
+        ev = GenerationEvidence()
+        ev.mark_kb_sync()
+        assert ev.generic_kb_sync_passed is True
+
+    def test_record_validation_result_success(self):
+        ev = GenerationEvidence()
+        ev.record_validation_result({"success": 1, "result": {"valid": True}})
+        assert ev.validation_passed is True
+
+    def test_record_validation_result_not_valid(self):
+        ev = GenerationEvidence()
+        ev.record_validation_result({"success": 1, "result": {"valid": False}})
+        assert ev.validation_passed is False
+
+    def test_record_validation_result_failure(self):
+        ev = GenerationEvidence()
+        ev.record_validation_result({"success": 0, "result": {"valid": True}})
+        assert ev.validation_passed is False
+
+    def test_record_metric_dry_run_success(self):
+        ev = GenerationEvidence()
+        result = {"success": 1, "result": {"metadata": {}}}
+        ev.record_metric_dry_run(["revenue_total"], result)
+        assert ev.metric_dry_run_passed is True
+        assert "revenue_total" in ev.metric_dry_run_metrics
+
+    def test_record_metric_dry_run_failure_ignored(self):
+        ev = GenerationEvidence()
+        ev.record_metric_dry_run(["revenue_total"], {"success": 0})
+        assert ev.metric_dry_run_passed is False
+        assert "revenue_total" not in ev.metric_dry_run_metrics
+
+    def test_record_metric_dry_run_string_metrics(self):
+        ev = GenerationEvidence()
+        ev.record_metric_dry_run("revenue_total", {"success": 1, "result": {"metadata": {}}})
+        assert "revenue_total" in ev.metric_dry_run_metrics
+
+    def test_record_metric_dry_run_stores_sql_from_metadata(self):
+        ev = GenerationEvidence()
+        result = {"success": 1, "result": {"metadata": {"sql": "SELECT SUM(revenue)"}}}
+        ev.record_metric_dry_run(["revenue_total"], result)
+        assert ev.metric_sqls["revenue_total"] == "SELECT SUM(revenue)"
+
+    def test_record_metric_dry_run_stores_metric_sqls_dict(self):
+        ev = GenerationEvidence()
+        metric_sqls = {
+            "__query_metrics_dry_run__": "SELECT combined",
+            "revenue_total": "SELECT revenue",
+        }
+        result = {"success": 1, "result": {"metadata": {"metric_sqls": metric_sqls}}}
+        ev.record_metric_dry_run(["revenue_total"], result)
+        assert ev.metric_sqls["revenue_total"] == "SELECT revenue"
+        assert ev.metric_dry_run_queries[0].get("sql") == "SELECT combined"
+
+    def test_has_metric_dry_run_no_names(self):
+        ev = GenerationEvidence()
+        ev.metric_dry_run_passed = True
+        assert ev.has_metric_dry_run() is True
+
+    def test_has_metric_dry_run_with_names_subset(self):
+        ev = GenerationEvidence()
+        ev.metric_dry_run_passed = True
+        ev.metric_dry_run_metrics = {"a", "b"}
+        assert ev.has_metric_dry_run(["a"]) is True
+        assert ev.has_metric_dry_run(["a", "c"]) is False
+
+    def test_has_metric_dry_run_not_passed(self):
+        ev = GenerationEvidence()
+        ev.metric_dry_run_metrics = {"a"}
+        assert ev.has_metric_dry_run(["a"]) is False
+
+    def test_set_metric_queryability_contracts_filters_invalid(self):
+        ev = GenerationEvidence()
+        contracts = [
+            {"source": "s1", "dimension_hints": ["col_a"], "metric_hints": ["m1"]},
+            {"source": "s2"},  # no dimension_hints or time_group_hints — filtered
+        ]
+        ev.set_metric_queryability_contracts(contracts)
+        assert len(ev.metric_queryability_contracts) == 1
+        assert ev.metric_queryability_contracts[0]["source"] == "s1"
+
+    def test_set_metric_queryability_contracts_deduplicates_metric_hints(self):
+        ev = GenerationEvidence()
+        ev.set_metric_queryability_contracts([{"dimension_hints": ["col_a"], "metric_hints": ["m1", "m1", "m2"]}])
+        assert ev.metric_queryability_contracts[0]["metric_hints"] == ["m1", "m2"]
+
+    def test_set_metric_queryability_contracts_applies_alias_rewrites(self):
+        ev = GenerationEvidence()
+        ev.set_metric_queryability_contracts(
+            [{"dimension_hints": ["col_a"], "metric_hints": ["rev_alias"]}],
+            metric_aliases={"rev_alias": "revenue_total"},
+        )
+        hints = ev.metric_queryability_contracts[0]["metric_hints"]
+        assert "revenue_total" in hints
+        alias_rewrites = ev.metric_queryability_contracts[0].get("metric_alias_rewrites", {})
+        assert alias_rewrites.get("rev_alias") == "revenue_total"
+
+    def test_has_required_queryability_dry_runs_no_contracts(self):
+        ev = GenerationEvidence()
+        assert ev.has_required_queryability_dry_runs() is True
+
+    def test_missing_queryability_contracts_empty_when_satisfied(self):
+        ev = GenerationEvidence()
+        ev.set_metric_queryability_contracts([{"dimension_hints": ["col_a"], "metric_hints": ["revenue_total"]}])
+        ev.record_metric_dry_run(
+            ["revenue_total"],
+            {"success": 1, "result": {"metadata": {}}},
+            dimensions=["col_a"],
+        )
+        missing = ev.missing_queryability_contracts(["revenue_total"])
+        assert missing == []
+
+    def test_missing_queryability_contracts_nonempty_when_unsatisfied(self):
+        ev = GenerationEvidence()
+        ev.set_metric_queryability_contracts([{"dimension_hints": ["col_a"], "metric_hints": ["revenue_total"]}])
+        ev.metric_dry_run_passed = True
+        ev.metric_dry_run_metrics.add("revenue_total")
+        # No dry_run_queries at all -> contract not matched
+        missing = ev.missing_queryability_contracts(["revenue_total"])
+        assert len(missing) == 1
+
+    def test_record_metric_dry_run_time_granularity_explicit(self):
+        ev = GenerationEvidence()
+        result = {"success": 1, "result": {"metadata": {}}}
+        ev.record_metric_dry_run(["rev"], result, time_granularity="month")
+        query = ev.metric_dry_run_queries[0]
+        assert query["time_granularity"] == "month"
+        assert query["time_granularity_explicit"] is True
+
+    def test_record_metric_dry_run_time_granularity_from_dimensions(self):
+        ev = GenerationEvidence()
+        result = {"success": 1, "result": {"metadata": {}}}
+        ev.record_metric_dry_run(["rev"], result, dimensions=["metric_time__month"])
+        query = ev.metric_dry_run_queries[0]
+        assert query["time_granularity"] == "month"
+        assert query["time_granularity_explicit"] is False
+
+    def test_record_metric_dry_run_multi_metric_combined_sql_key(self):
+        ev = GenerationEvidence()
+        result = {"success": 1, "result": {"metadata": {"sql": "SELECT 1"}}}
+        ev.record_metric_dry_run(["m1", "m2"], result)
+        # more than one metric -> stored under combined key
+        assert "__query_metrics_dry_run__" in ev.metric_sqls
+
+    def test_record_metric_dry_run_single_metric_uses_name_as_key(self):
+        ev = GenerationEvidence()
+        result = {"success": 1, "result": {"metadata": {"sql": "SELECT 1"}}}
+        ev.record_metric_dry_run(["revenue_total"], result)
+        assert "revenue_total" in ev.metric_sqls

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -793,3 +793,425 @@ class TestGenerateSqlSummaryId:
             result = generation_tools.generate_sql_summary_id("SELECT 1")
         assert result.success == 0
         assert "hash error" in result.error
+
+
+class TestRowsToDicts:
+    """Tests for generation_tools._rows_to_dicts helper."""
+
+    def test_none_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        assert _rows_to_dicts(None) == []
+
+    def test_list_of_dicts_returned_as_is(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        rows = [{"a": 1}, {"b": 2}]
+        assert _rows_to_dicts(rows) == rows
+
+    def test_single_dict_wrapped_in_list(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        assert _rows_to_dicts({"a": 1}) == [{"a": 1}]
+
+    def test_tuple_of_dicts_returned(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        rows = ({"a": 1}, {"b": 2})
+        result = _rows_to_dicts(rows)
+        assert result == [{"a": 1}, {"b": 2}]
+
+    def test_non_dict_items_in_list_filtered_out(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        rows = [{"a": 1}, "not_a_dict", 42, {"b": 2}]
+        assert _rows_to_dicts(rows) == [{"a": 1}, {"b": 2}]
+
+    def test_object_with_to_pylist_called(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        mock_table = Mock()
+        mock_table.to_pylist.return_value = [{"x": 1}]
+        assert _rows_to_dicts(mock_table) == [{"x": 1}]
+
+    def test_string_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        assert _rows_to_dicts("some_string") == []
+
+    def test_bytes_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        assert _rows_to_dicts(b"bytes") == []
+
+    def test_generator_of_dicts_consumed(self):
+        from datus.tools.func_tool.generation_tools import _rows_to_dicts
+
+        def gen():
+            yield {"a": 1}
+            yield {"b": 2}
+
+        assert _rows_to_dicts(gen()) == [{"a": 1}, {"b": 2}]
+
+
+class TestIsSupportedRowContainer:
+    """Tests for generation_tools._is_supported_row_container helper."""
+
+    def test_none_is_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        assert _is_supported_row_container(None) is True
+
+    def test_list_is_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        assert _is_supported_row_container([]) is True
+
+    def test_dict_is_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        assert _is_supported_row_container({}) is True
+
+    def test_tuple_is_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        assert _is_supported_row_container(()) is True
+
+    def test_object_with_to_pylist_is_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        mock_table = Mock()
+        mock_table.to_pylist = lambda: []
+        assert _is_supported_row_container(mock_table) is True
+
+    def test_string_not_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        assert _is_supported_row_container("str") is False
+
+    def test_bytes_not_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        assert _is_supported_row_container(b"bytes") is False
+
+    def test_integer_not_supported(self):
+        from datus.tools.func_tool.generation_tools import _is_supported_row_container
+
+        assert _is_supported_row_container(42) is False
+
+
+class TestRagScopeConditions:
+    """Tests for generation_tools._rag_scope_conditions helper."""
+
+    def test_no_method_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import _rag_scope_conditions
+
+        class NoMethod:
+            pass
+
+        assert _rag_scope_conditions(NoMethod()) == []
+
+    def test_non_callable_attribute_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import _rag_scope_conditions
+
+        class WithAttr:
+            _sub_agent_conditions = "not callable"
+
+        assert _rag_scope_conditions(WithAttr()) == []
+
+    def test_method_returning_list_returned(self):
+        from datus.tools.func_tool.generation_tools import _rag_scope_conditions
+
+        sentinel = object()
+        rag = Mock()
+        rag._sub_agent_conditions.return_value = [sentinel]
+        result = _rag_scope_conditions(rag)
+        assert result == [sentinel]
+
+    def test_method_returning_non_list_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import _rag_scope_conditions
+
+        rag = Mock()
+        rag._sub_agent_conditions.return_value = "not a list"
+        assert _rag_scope_conditions(rag) == []
+
+    def test_method_raising_exception_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import _rag_scope_conditions
+
+        rag = Mock()
+        rag._sub_agent_conditions.side_effect = RuntimeError("boom")
+        assert _rag_scope_conditions(rag) == []
+
+
+class TestCheckSemanticObjectExistsCacheHit:
+    """Test that the cache hit path (lines 129-130) is exercised."""
+
+    def test_cache_hit_returns_copy(self, generation_tools):
+        mock_storage = Mock()
+        generation_tools.semantic_rag.storage = mock_storage
+        mock_storage.search_all.return_value = [{"id": "t1", "name": "orders", "kind": "table"}]
+
+        with patch("datus.tools.func_tool.generation_tools.And"), patch("datus.tools.func_tool.generation_tools.eq"):
+            # First call populates the cache
+            result1 = generation_tools.check_semantic_object_exists("orders", kind="table")
+            # Second call should hit the cache
+            result2 = generation_tools.check_semantic_object_exists("orders", kind="table")
+
+        assert result1.success == result2.success
+        assert result1.result == result2.result
+        # Cache should have been populated
+        assert len(generation_tools._semantic_object_exists_cache) >= 1
+
+
+class TestEndSemanticModelGenerationCacheReset:
+    """Test that end_semantic_model_generation resets caches (lines 272-273)."""
+
+    def test_clears_caches_on_success(self, generation_tools):
+        generation_tools.generation_evidence.validation_passed = True
+        # Pre-populate caches
+        generation_tools._semantic_object_exists_cache[("table", "orders", "")] = Mock()
+        generation_tools._semantic_table_object_index = {"orders": {}}
+
+        result = generation_tools.end_semantic_model_generation(["/path/model.yaml"])
+
+        assert result.success == 1
+        assert generation_tools._semantic_object_exists_cache == {}
+        assert generation_tools._semantic_table_object_index is None
+
+
+class TestEndMetricGenerationLegacyParam:
+    """Test end_metric_generation with the legacy semantic_model_file param (line 319)."""
+
+    def test_legacy_semantic_model_file_param(self, generation_tools, tmp_path):
+        generation_tools.generation_evidence.validation_passed = True
+        generation_tools.generation_evidence.metric_dry_run_passed = True
+        generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue")
+
+        good = tmp_path / "semantic_models" / "good_metric.yml"
+        good.parent.mkdir(parents=True, exist_ok=True)
+        good.write_text("metric:\n  name: revenue\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
+        mock_pm = Mock()
+        mock_pm.subject_dir = str(tmp_path)
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_metric_to_db", return_value={"success": True, "message": "ok"}),
+        ):
+            result = generation_tools.end_metric_generation(
+                metric_file=str(good),
+                semantic_model_file="/some/model.yaml",  # legacy param
+            )
+        # The legacy param should be converted to semantic_model_files
+        assert result.success == 0  # will fail because /some/model.yaml is outside sandbox
+
+
+class TestEndMetricGenerationMetricSqlsFromEvidence:
+    """Test that metric_sqls from generation_evidence take precedence (line 362-363)."""
+
+    def test_uses_evidence_metric_sqls_when_present(self, generation_tools, tmp_path):
+        generation_tools.generation_evidence.validation_passed = True
+        generation_tools.generation_evidence.metric_dry_run_passed = True
+        generation_tools.generation_evidence.metric_dry_run_metrics.add("revenue")
+        generation_tools.generation_evidence.metric_sqls = {"revenue": "SELECT SUM(revenue)"}
+
+        good = tmp_path / "semantic_models" / "good_metric.yml"
+        good.parent.mkdir(parents=True, exist_ok=True)
+        good.write_text("metric:\n  name: revenue\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
+        mock_pm = Mock()
+        mock_pm.subject_dir = str(tmp_path)
+        captured = {}
+
+        def fake_sync(metric_file, *args, **kwargs):
+            captured["metric_sqls"] = kwargs.get("metric_sqls")
+            return {"success": True, "message": "ok"}
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_metric_to_db", side_effect=fake_sync),
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(good))
+
+        assert result.success == 1
+        # Evidence SQLs should be visible in the returned result
+        assert result.result["metric_sqls"] == {"revenue": "SELECT SUM(revenue)"}
+
+
+class TestEndMetricGenerationSemanticFileSandbox:
+    """Test that semantic_model_files outside sandbox is rejected (line 398)."""
+
+    def test_rejects_semantic_file_outside_sandbox(self, generation_tools, tmp_path):
+        generation_tools.generation_evidence.validation_passed = True
+        generation_tools.generation_evidence.metric_dry_run_passed = True
+
+        good = tmp_path / "semantic_models" / "good_metric.yml"
+        good.parent.mkdir(parents=True, exist_ok=True)
+        good.write_text("metric:\n  name: revenue\n  type: measure_proxy\n  type_params:\n    measure: revenue\n")
+        mock_pm = Mock()
+        mock_pm.subject_dir = str(tmp_path)
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(
+                metric_file=str(good),
+                semantic_model_files=["/outside/model.yaml"],
+            )
+
+        assert result.success == 0
+        assert "Knowledge Base sandbox" in result.error
+        sync_mock.assert_not_called()
+
+
+class TestFilterMetricSqls:
+    """Tests for GenerationTools._filter_metric_sqls static method."""
+
+    def test_none_returns_none(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        assert GenerationTools._filter_metric_sqls(None, {"revenue"}) is None
+
+    def test_filters_to_matching_names(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        sqls = {"revenue_total": "SELECT 1", "cost": "SELECT 2", "__combined__": "SELECT 3"}
+        result = GenerationTools._filter_metric_sqls(sqls, {"revenue_total"})
+        assert result == {"revenue_total": "SELECT 1"}
+
+    def test_empty_sync_set_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        sqls = {"revenue": "SELECT 1"}
+        result = GenerationTools._filter_metric_sqls(sqls, set())
+        assert result == {}
+
+
+class TestWriteFilteredMetricFile:
+    """Tests for GenerationTools._write_filtered_metric_file static method."""
+
+    def test_writes_only_matching_docs(self, tmp_path):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        metric_file = tmp_path / "metrics.yml"
+        metric_file.write_text(
+            "metric:\n  name: revenue\n  type: measure_proxy\n---\nmetric:\n  name: cost\n  type: measure_proxy\n"
+        )
+        temp_path = GenerationTools._write_filtered_metric_file(str(metric_file), {"revenue"})
+        try:
+            import yaml
+
+            with open(temp_path, encoding="utf-8") as f:
+                docs = list(yaml.safe_load_all(f))
+            names = [d["metric"]["name"] for d in docs if isinstance(d, dict) and "metric" in d]
+            assert names == ["revenue"]
+        finally:
+            import os
+
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+    def test_raises_when_no_matching_docs(self, tmp_path):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        metric_file = tmp_path / "metrics.yml"
+        metric_file.write_text("metric:\n  name: revenue\n  type: measure_proxy\n")
+
+        with pytest.raises(ValueError, match="No matching metric definitions"):
+            GenerationTools._write_filtered_metric_file(str(metric_file), {"nonexistent"})
+
+
+class TestValidateMetricNameConflicts:
+    """Tests for GenerationTools._validate_metric_name_conflicts."""
+
+    def test_empty_definitions_returns_none(self, generation_tools):
+        assert generation_tools._validate_metric_name_conflicts([]) is None
+
+    def test_no_existing_metrics_returns_none(self, generation_tools):
+        generation_tools.metric_rag.search_all_metrics.return_value = []
+        result = generation_tools._validate_metric_name_conflicts([{"name": "revenue", "metric_type": "measure_proxy"}])
+        assert result is None
+
+    def test_non_conflicting_same_definition_returns_none(self, generation_tools):
+        from unittest.mock import patch
+
+        generation_tools.metric_rag.search_all_metrics.return_value = [
+            {
+                "id": "m1",
+                "name": "revenue",
+                "semantic_model_name": "orders",
+                "metric_type": "measure_proxy",
+                "measure_expr": "revenue",
+                "base_measures": ["revenue"],
+            }
+        ]
+        with patch("datus.tools.func_tool.generation_tools.metric_definition_conflict", return_value=None):
+            result = generation_tools._validate_metric_name_conflicts(
+                [
+                    {
+                        "name": "revenue",
+                        "metric_type": "measure_proxy",
+                        "measure_expr": "revenue",
+                        "base_measures": ["revenue"],
+                    }
+                ]
+            )
+        assert result is None
+
+    def test_conflicting_definition_returns_error_string(self, generation_tools):
+        from unittest.mock import patch
+
+        generation_tools.metric_rag.search_all_metrics.return_value = [
+            {
+                "id": "m1",
+                "name": "revenue",
+                "semantic_model_name": "orders",
+                "metric_type": "measure_proxy",
+                "measure_expr": "revenue",
+                "base_measures": ["revenue"],
+            }
+        ]
+        with patch("datus.tools.func_tool.generation_tools.metric_definition_conflict", return_value="metric_type"):
+            result = generation_tools._validate_metric_name_conflicts([{"name": "revenue", "metric_type": "ratio"}])
+        assert result is not None
+        assert "conflict" in result.lower()
+
+    def test_exception_during_search_returns_none(self, generation_tools):
+        generation_tools.metric_rag.search_all_metrics.side_effect = RuntimeError("storage error")
+        result = generation_tools._validate_metric_name_conflicts([{"name": "revenue"}])
+        assert result is None
+
+
+class TestFilterMetricNames:
+    """Tests for GenerationTools._filter_metric_names static method."""
+
+    def test_none_scope_returns_all(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        assert GenerationTools._filter_metric_names(["a", "b"], None) == ["a", "b"]
+
+    def test_filters_to_scope(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        result = GenerationTools._filter_metric_names(["revenue_total", "cost"], {"revenue_total"})
+        assert result == ["revenue_total"]
+
+
+class TestPublicMetricSqlNames:
+    """Tests for GenerationTools._public_metric_sql_names static method."""
+
+    def test_filters_out_dunder_names(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        sqls = {"revenue": "SELECT 1", "__query_metrics_dry_run__": "SELECT 2", "__combined__": "SELECT 3"}
+        result = GenerationTools._public_metric_sql_names(sqls)
+        assert result == {"revenue"}
+
+    def test_none_returns_empty(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        assert GenerationTools._public_metric_sql_names(None) == set()
+
+    def test_empty_name_skipped(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        assert GenerationTools._public_metric_sql_names({"": "SELECT 1"}) == set()

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -227,20 +227,20 @@ class TestEndMetricGeneration:
             result = generation_tools.end_metric_generation(metric_file="/path/semantic_models/metric.yaml")
         assert result.success == 1
         assert result.result["metric_file"] == "/path/semantic_models/metric.yaml"
-        assert result.result["semantic_model_file"] == ""
+        assert result.result["semantic_model_files"] == []
         assert result.result["metric_sqls"] == {}
         assert result.result["sync"]["success"] is True
 
-    def test_success_with_semantic_model(self, generation_tools):
+    def test_success_with_semantic_models(self, generation_tools):
         self._mark_ready_to_publish(generation_tools)
         p1, p2, p3 = self._patch_sync(generation_tools)
         with p1, p2, p3:
             result = generation_tools.end_metric_generation(
                 metric_file="/path/semantic_models/metric.yaml",
-                semantic_model_file="/path/semantic_models/model.yaml",
+                semantic_model_files=["/path/semantic_models/model.yaml"],
             )
         assert result.success == 1
-        assert result.result["semantic_model_file"] == "/path/semantic_models/model.yaml"
+        assert result.result["semantic_model_files"] == ["/path/semantic_models/model.yaml"]
 
     def test_success_with_metric_sqls_json(self, generation_tools):
         self._mark_ready_to_publish(generation_tools)
@@ -352,6 +352,124 @@ class TestEndMetricGenerationPreflight:
         ):
             result = generation_tools.end_metric_generation(metric_file=str(good))
         assert result.success == 1
+
+    def test_metric_sqls_scope_excludes_existing_file_metrics(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        generation_tools.generation_evidence.metric_dry_run_metrics.add("new_metric")
+        generation_tools.generation_evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["existing_metric"],
+                    "dimension_hints": ["start_month"],
+                    "time_group_hints": [
+                        {
+                            "alias": "start_month",
+                            "base_expr": "created_at",
+                            "grain": "month",
+                        }
+                    ],
+                }
+            ]
+        )
+        metric_file = tmp_path / "semantic_models" / "mixed_metrics.yml"
+        metric_file.parent.mkdir(parents=True, exist_ok=True)
+        metric_file.write_text(
+            "metric:\n"
+            "  name: existing_metric\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: existing_metric\n"
+            "---\n"
+            "metric:\n"
+            "  name: new_metric\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: new_metric\n"
+        )
+        metric_sqls_json = json.dumps(
+            {
+                "existing_metric": "SELECT old_metric",
+                "new_metric": "SELECT new_metric",
+                "__query_metrics_dry_run__": "SELECT grouped_validation",
+            }
+        )
+
+        with (
+            self._patch_path_resolution(generation_tools, tmp_path),
+            patch.object(generation_tools, "_existing_metric_names", return_value={"existing_metric"}),
+            patch.object(generation_tools, "_validate_metric_name_conflicts", return_value=None),
+            patch.object(
+                generation_tools, "_sync_metric_to_db", return_value={"success": True, "message": "ok"}
+            ) as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(
+                metric_file=str(metric_file),
+                metric_sqls_json=metric_sqls_json,
+            )
+
+        assert result.success == 1
+        sync_mock.assert_called_once()
+        assert sync_mock.call_args.kwargs["metric_names_to_sync"] == {"new_metric"}
+
+    def test_combined_dry_run_scope_syncs_all_new_metrics(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        generation_tools.generation_evidence.metric_dry_run_metrics.update(
+            {"existing_metric", "new_metric", "other_new_metric"}
+        )
+        generation_tools.generation_evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["existing_metric"],
+                    "dimension_hints": ["start_month"],
+                }
+            ]
+        )
+        metric_file = tmp_path / "semantic_models" / "combined_metrics.yml"
+        metric_file.parent.mkdir(parents=True, exist_ok=True)
+        metric_file.write_text(
+            "metric:\n"
+            "  name: existing_metric\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: existing_metric\n"
+            "---\n"
+            "metric:\n"
+            "  name: new_metric\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: new_metric\n"
+            "---\n"
+            "metric:\n"
+            "  name: other_new_metric\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: other_new_metric\n"
+        )
+        metric_sqls_json = json.dumps(
+            {
+                "existing_metric": "SELECT old_metric",
+                "__query_metrics_dry_run__": "SELECT grouped_validation",
+            }
+        )
+
+        with (
+            self._patch_path_resolution(generation_tools, tmp_path),
+            patch.object(generation_tools, "_existing_metric_names", return_value={"existing_metric"}),
+            patch.object(generation_tools, "_validate_metric_name_conflicts", return_value=None),
+            patch.object(
+                generation_tools, "_sync_metric_to_db", return_value={"success": True, "message": "ok"}
+            ) as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(
+                metric_file=str(metric_file),
+                metric_sqls_json=metric_sqls_json,
+            )
+
+        assert result.success == 1
+        sync_mock.assert_called_once()
+        assert sync_mock.call_args.kwargs["metric_names_to_sync"] == {"new_metric", "other_new_metric"}
 
     def test_rejects_missing_grouped_queryability_dry_run(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
@@ -519,8 +637,8 @@ class TestSyncMetricToDb:
             original_yaml_path=str(metric_file),
         )
 
-    def test_metric_with_semantic_model_combines_files(self, generation_tools, tmp_path):
-        """When both metric and semantic model files exist, combine into temp file."""
+    def test_metric_with_semantic_models_syncs_semantic_then_metric(self, generation_tools, tmp_path):
+        """When semantic model files are provided, sync semantic objects before metrics."""
         metric_file = tmp_path / "metric.yaml"
         metric_file.write_text("metric:\n  name: revenue\n  type: simple\n")
         semantic_file = tmp_path / "model.yaml"
@@ -528,23 +646,69 @@ class TestSyncMetricToDb:
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.return_value = {"success": True, "message": "synced"}
-            result = generation_tools._sync_metric_to_db(str(metric_file), str(semantic_file), {"rev": "SELECT 1"})
+            result = generation_tools._sync_metric_to_db(str(metric_file), [str(semantic_file)], {"rev": "SELECT 1"})
 
         assert result["success"] is True
         assert result["semantic_synced"] is True
+        assert result["semantic_model_files_synced"] == [str(semantic_file)]
         # Should have been called twice: first for semantic objects, then for metrics
         assert mock_sync.call_count == 2
         # First call: sync semantic objects
         sem_call = mock_sync.call_args_list[0]
         assert sem_call.kwargs.get("include_semantic_objects") is True
         assert sem_call.kwargs.get("include_metrics") is False
-        # Second call: sync metrics from combined temp file
+        # Second call: sync metrics from the metric file itself
         metric_call = mock_sync.call_args_list[1]
-        actual_temp_path = metric_call[0][0]
-        assert not os.path.exists(actual_temp_path), f"Temp file should be cleaned up: {actual_temp_path}"
+        assert metric_call[0][0] == str(metric_file)
         assert metric_call.kwargs.get("include_semantic_objects") is False
         assert metric_call.kwargs.get("include_metrics") is True
         assert metric_call.kwargs.get("metric_sqls") == {"rev": "SELECT 1"}
+        assert metric_call.kwargs.get("original_yaml_path") == str(metric_file)
+
+    def test_metric_sync_filters_to_publish_scope(self, generation_tools, tmp_path):
+        """When a publish scope is supplied, sync only those metric YAML docs."""
+        metric_file = tmp_path / "metric.yaml"
+        metric_file.write_text(
+            "metric:\n"
+            "  name: existing_metric\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: existing_metric\n"
+            "---\n"
+            "metric:\n"
+            "  name: new_metric\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: new_metric\n"
+        )
+        captured = {}
+
+        def fake_sync(file_path, *args, **kwargs):
+            captured["file_path"] = file_path
+            with open(file_path, encoding="utf-8") as f:
+                captured["content"] = f.read()
+            captured["kwargs"] = kwargs
+            return {"success": True, "message": "synced"}
+
+        with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db", side_effect=fake_sync):
+            result = generation_tools._sync_metric_to_db(
+                str(metric_file),
+                metric_sqls={
+                    "existing_metric": "SELECT old_metric",
+                    "new_metric": "SELECT new_metric",
+                    "__query_metrics_dry_run__": "SELECT grouped_validation",
+                },
+                metric_names_to_sync={"new_metric"},
+            )
+
+        assert result["success"] is True
+        assert result["metric_names_synced"] == ["new_metric"]
+        assert captured["file_path"] != str(metric_file)
+        assert not os.path.exists(captured["file_path"])
+        assert "name: new_metric" in captured["content"]
+        assert "name: existing_metric" not in captured["content"]
+        assert captured["kwargs"]["metric_sqls"] == {"new_metric": "SELECT new_metric"}
+        assert captured["kwargs"]["original_yaml_path"] == str(metric_file)
 
     def test_semantic_sync_failure_aborts_metric_sync(self, generation_tools, tmp_path):
         """When semantic object sync fails, metric sync is skipped and failure propagated."""
@@ -555,33 +719,25 @@ class TestSyncMetricToDb:
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.return_value = {"success": False, "error": "semantic sync failed"}
-            result = generation_tools._sync_metric_to_db(str(metric_file), str(semantic_file))
+            result = generation_tools._sync_metric_to_db(str(metric_file), [str(semantic_file)])
 
         assert result["success"] is False
         assert result["error"] == "semantic sync failed"
         # Only called once (semantic sync), metric sync was skipped
         assert mock_sync.call_count == 1
 
-    def test_semantic_model_not_exists_falls_through(self, generation_tools, tmp_path):
-        """When semantic_model_file path provided but file doesn't exist, sync metric alone."""
+    def test_missing_semantic_model_file_returns_failure(self, generation_tools, tmp_path):
+        """When semantic_model_files contains a missing file, return failure before syncing metrics."""
         metric_file = tmp_path / "metric.yaml"
         metric_file.write_text("metric:\n  name: revenue\n")
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.return_value = {"success": True, "message": "ok"}
-            result = generation_tools._sync_metric_to_db(str(metric_file), "/nonexistent/model.yaml")
+            result = generation_tools._sync_metric_to_db(str(metric_file), ["/nonexistent/model.yaml"])
 
-        assert result["success"] is True
-        assert result["semantic_synced"] is False
-        # Should call with metric file directly (not combined)
-        mock_sync.assert_called_once_with(
-            str(metric_file),
-            generation_tools.agent_config,
-            include_semantic_objects=False,
-            include_metrics=True,
-            metric_sqls=None,
-            original_yaml_path=str(metric_file),
-        )
+        assert result["success"] is False
+        assert "Semantic model file not found" in result["error"]
+        mock_sync.assert_not_called()
 
     def test_sync_failure_propagated(self, generation_tools, tmp_path):
         """Sync failure result is returned as-is."""
@@ -607,8 +763,8 @@ class TestSyncMetricToDb:
         assert result["success"] is False
         assert "connection lost" in result["error"]
 
-    def test_temp_file_cleaned_on_sync_exception(self, generation_tools, tmp_path):
-        """Temp combined file is cleaned up even when sync raises."""
+    def test_exception_during_semantic_sync_returns_failure(self, generation_tools, tmp_path):
+        """Exception during semantic sync is caught and returned as failure dict."""
         metric_file = tmp_path / "metric.yaml"
         metric_file.write_text("metric:\n  name: revenue\n")
         semantic_file = tmp_path / "model.yaml"
@@ -616,11 +772,10 @@ class TestSyncMetricToDb:
 
         with patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db") as mock_sync:
             mock_sync.side_effect = RuntimeError("boom")
-            result = generation_tools._sync_metric_to_db(str(metric_file), str(semantic_file))
+            result = generation_tools._sync_metric_to_db(str(metric_file), [str(semantic_file)])
 
         assert result["success"] is False
-        # Temp file should still be cleaned up
-        assert not (tmp_path / "model.yaml.combined.tmp").exists()
+        assert "boom" in result["error"]
 
 
 class TestGenerateSqlSummaryId:

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -200,3 +200,273 @@ data_source:
         data_source = docs[0]["data_source"]
         assert data_source["measures"][0]["expr"] == "CASE WHEN status = 'paid' THEN 1 END"
         assert "SELECT '\\'' AS literal_value" in data_source["sql_query"]
+
+
+class TestEditFile:
+    """Tests for MetricFilesystemFuncTool.edit_file — covers lines 65-97."""
+
+    def test_edit_file_in_semantic_yaml(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("data_source:\n  name: orders\n  description: old\n", encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+        result = tool.edit_file(
+            "subject/semantic_models/orders.yml",
+            "description: old",
+            "description: new",
+        )
+        assert result.success == 1
+        assert "description: new" in target.read_text(encoding="utf-8")
+
+    def test_edit_file_old_string_not_found(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("data_source:\n  name: orders\n", encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+        result = tool.edit_file(
+            "subject/semantic_models/orders.yml",
+            "nonexistent string",
+            "replacement",
+        )
+        assert result.success == 0
+
+    def test_edit_file_outside_semantic_yaml_no_postprocess(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir(parents=True)
+        target = project / "notes.txt"
+        target.write_text("hello world\n", encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+        result = tool.edit_file("notes.txt", "hello", "goodbye")
+        assert result.success == 1
+
+    def test_edit_file_postprocess_restores_on_invalid_yaml(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        original = "data_source:\n  name: orders\n"
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+        # Replace valid YAML with something that becomes invalid after edit
+        result = tool.edit_file(
+            "subject/semantic_models/orders.yml",
+            "name: orders",
+            "name: orders\n  bad: : :",
+        )
+        # Should fail due to invalid YAML and restore original
+        assert result.success == 0
+        # Original content should be restored
+        assert target.read_text(encoding="utf-8") == original
+
+
+class TestMergeSemanticModelContentErrors:
+    """Tests for _merge_semantic_model_content error paths — lines 213-216, 220-228."""
+
+    def test_rejects_missing_existing_data_source(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("semantic_model:\n  name: orders\n", encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/orders.yml",
+            "data_source:\n  name: orders\n  measures:\n    - name: revenue\n      agg: SUM\n      expr: revenue\n",
+        )
+        assert result.success == 0
+        assert "data_source" in result.error.lower()
+
+    def test_rejects_missing_incoming_data_source(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "data_source:\n  name: orders\n  measures:\n    - name: revenue\n      agg: SUM\n      expr: revenue\n",
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/orders.yml",
+            "semantic_model:\n  name: orders\n",
+        )
+        assert result.success == 0
+        assert "data_source" in result.error.lower()
+
+
+class TestMergeMetricContentErrors:
+    """Tests for _merge_metric_content error paths — lines 245-248, 256-257, 290-291."""
+
+    def test_rejects_when_existing_has_no_metrics(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ds" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("some_key:\n  name: something\n", encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ds/metrics/orders_metrics.yml",
+            "metric:\n  name: new_metric\n  type: measure_proxy\n",
+        )
+        assert result.success == 0
+        assert "metric" in result.error.lower()
+
+    def test_rejects_when_incoming_has_no_metrics(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ds" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("metric:\n  name: order_count\n  type: measure_proxy\n", encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ds/metrics/orders_metrics.yml",
+            "some_key:\n  name: something\n",
+        )
+        assert result.success == 0
+        assert "metric" in result.error.lower()
+
+
+class TestNormalizeMetricSubjectTreeTags:
+    """Tests for _normalize_metric_subject_tree_tags — lines 296-327."""
+
+    def test_normalizes_subject_tree_tag_in_metric(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "myds" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        # Write a metric with a subject_tree tag that will be normalized
+        target.write_text(
+            "metric:\n"
+            "  name: order_count\n"
+            "  type: measure_proxy\n"
+            "  type_params:\n"
+            "    measure: order_count\n"
+            "  locked_metadata:\n"
+            "    tags:\n"
+            "      - 'subject_tree: metrics/OrderCount'\n",
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+        result = tool.write_file(
+            "subject/semantic_models/myds/metrics/orders_metrics.yml",
+            "metric:\n  name: new_metric\n  type: measure_proxy\n  type_params:\n    measure: new_metric\n",
+        )
+        assert result.success == 1
+
+
+class TestStaticHelpers:
+    """Tests for static methods: _metric_scope_from_path, _merge_metric_fields, etc."""
+
+    def test_metric_scope_from_path_with_metrics_suffix(self, tmp_path):
+        path = tmp_path / "subject" / "semantic_models" / "myds" / "metrics" / "orders_metrics.yml"
+        datasource, table_name = MetricFilesystemFuncTool._metric_scope_from_path(path)
+        assert datasource == "myds"
+        assert table_name == "orders"
+
+    def test_metric_scope_from_path_without_suffix(self, tmp_path):
+        path = tmp_path / "subject" / "semantic_models" / "myds" / "metrics" / "revenue.yml"
+        _, table_name = MetricFilesystemFuncTool._metric_scope_from_path(path)
+        assert table_name == "revenue"
+
+    def test_metric_from_doc_non_dict_returns_none(self):
+        assert MetricFilesystemFuncTool._metric_from_doc("not_a_dict") is None
+        assert MetricFilesystemFuncTool._metric_from_doc(None) is None
+
+    def test_metric_from_doc_no_metric_key_returns_none(self):
+        assert MetricFilesystemFuncTool._metric_from_doc({"other": "value"}) is None
+
+    def test_metric_from_doc_valid_returns_dict(self):
+        result = MetricFilesystemFuncTool._metric_from_doc({"metric": {"name": "m1"}})
+        assert result == {"name": "m1"}
+
+    def test_merge_metric_fields_fills_empty(self):
+        existing = {"name": "m1", "type": "measure_proxy", "description": ""}
+        incoming = {"name": "m1", "description": "new description", "extra": "value"}
+        merged = MetricFilesystemFuncTool._merge_metric_fields(existing, incoming)
+        assert merged["description"] == "new description"
+        assert merged["extra"] == "value"
+        assert merged["type"] == "measure_proxy"
+
+    def test_merge_metric_fields_preserves_existing_non_empty(self):
+        existing = {"name": "m1", "description": "existing"}
+        incoming = {"name": "m1", "description": "new"}
+        merged = MetricFilesystemFuncTool._merge_metric_fields(existing, incoming)
+        assert merged["description"] == "existing"
+
+    def test_metric_definition_conflict_detects_type_change(self):
+        existing = {"name": "m1", "type": "measure_proxy"}
+        incoming = {"name": "m1", "type": "ratio"}
+        assert MetricFilesystemFuncTool._metric_definition_conflict(existing, incoming) == "type"
+
+    def test_metric_definition_conflict_no_conflict(self):
+        existing = {"name": "m1", "type": "measure_proxy"}
+        incoming = {"name": "m1", "type": "measure_proxy"}
+        assert MetricFilesystemFuncTool._metric_definition_conflict(existing, incoming) == ""
+
+    def test_metric_definition_conflict_missing_value_skipped(self):
+        existing = {"name": "m1", "type": None}
+        incoming = {"name": "m1", "type": "measure_proxy"}
+        assert MetricFilesystemFuncTool._metric_definition_conflict(existing, incoming) == ""
+
+    def test_find_data_source_doc_found(self):
+        docs = [{"other": "value"}, {"data_source": {"name": "orders"}}]
+        idx, doc, ds = MetricFilesystemFuncTool._find_data_source_doc(docs)
+        assert idx == 1
+        assert ds == {"name": "orders"}
+
+    def test_find_data_source_doc_not_found(self):
+        docs = [{"other": "value"}]
+        idx, doc, ds = MetricFilesystemFuncTool._find_data_source_doc(docs)
+        assert idx == -1
+        assert ds is None
+
+    def test_named_item_conflict_detects_field_diff(self):
+        existing = {"name": "m1", "agg": "SUM"}
+        incoming = {"name": "m1", "agg": "COUNT"}
+        assert MetricFilesystemFuncTool._named_item_conflict(existing, incoming, ("agg",)) == "agg"
+
+    def test_named_item_conflict_no_conflict(self):
+        existing = {"name": "m1", "agg": "SUM"}
+        incoming = {"name": "m1", "agg": "SUM"}
+        assert MetricFilesystemFuncTool._named_item_conflict(existing, incoming, ("agg",)) == ""
+
+    def test_named_item_conflict_empty_values_skipped(self):
+        existing = {"name": "m1", "agg": None}
+        incoming = {"name": "m1", "agg": "SUM"}
+        assert MetricFilesystemFuncTool._named_item_conflict(existing, incoming, ("agg",)) == ""
+
+    def test_stable_yaml_value_is_deterministic(self):
+        val = {"b": 2, "a": 1}
+        s1 = MetricFilesystemFuncTool._stable_yaml_value(val)
+        s2 = MetricFilesystemFuncTool._stable_yaml_value(val)
+        assert s1 == s2
+
+    def test_merge_stable_scalar_fills_empty(self):
+        merged = {"name": "orders"}
+        incoming = {"sql_table": "orders_table"}
+        err = MetricFilesystemFuncTool._merge_stable_scalar(merged, incoming, "sql_table", "orders")
+        assert err == ""
+        assert merged["sql_table"] == "orders_table"
+
+    def test_merge_stable_scalar_conflict_returns_error(self):
+        merged = {"sql_table": "original_table"}
+        incoming = {"sql_table": "different_table"}
+        err = MetricFilesystemFuncTool._merge_stable_scalar(merged, incoming, "sql_table", "orders")
+        assert err != ""
+        assert "original_table" in err or "different_table" in err
+
+    def test_merge_data_sources_name_conflict_returns_error(self):
+        tool = MetricFilesystemFuncTool.__new__(MetricFilesystemFuncTool)
+        existing_ds = {"name": "orders"}
+        incoming_ds = {"name": "customers"}
+        _, error = tool._merge_data_sources(existing_ds, incoming_ds)
+        assert error != ""
+        assert "orders" in error
+
+    def test_merge_named_items_conflict_returns_error(self):
+        tool = MetricFilesystemFuncTool.__new__(MetricFilesystemFuncTool)
+        existing = [{"name": "order_count", "agg": "COUNT", "expr": "1"}]
+        incoming = [{"name": "order_count", "agg": "SUM", "expr": "amount"}]
+        _, error = tool._merge_named_items("measures", existing, incoming, ("agg", "expr"), "orders")
+        assert error != ""
+        assert "order_count" in error

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -1,0 +1,202 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import pytest
+import yaml
+
+from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
+
+
+class TestMetricFilesystemFuncTool:
+    def test_write_file_merges_existing_semantic_model(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: order_count
+      agg: COUNT
+      expr: "1"
+  dimensions:
+    - name: ds
+      type: TIME
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/orders.yml",
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: paid_order_count
+      agg: SUM
+      expr: "CASE WHEN status = 'paid' THEN 1 ELSE 0 END"
+""".lstrip(),
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        data_source = docs[0]["data_source"]
+        assert [measure["name"] for measure in data_source["measures"]] == [
+            "order_count",
+            "paid_order_count",
+        ]
+        assert data_source["dimensions"][0]["name"] == "ds"
+
+    def test_write_file_rejects_conflicting_measure_overwrite(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        original = """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: order_count
+      agg: COUNT
+      expr: "1"
+""".lstrip()
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/orders.yml",
+            """
+data_source:
+  name: orders
+  sql_table: ac_manage.orders
+  measures:
+    - name: order_count
+      agg: SUM
+      expr: amount
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "Refusing to overwrite measure 'order_count'" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_write_file_merges_existing_metric_file(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            """
+metric:
+  name: paid_order_count
+  type: measure_proxy
+  type_params:
+    measure: paid_order_count
+""".lstrip(),
+        )
+
+        assert result.success == 1
+        docs = list(yaml.safe_load_all(target.read_text(encoding="utf-8")))
+        assert [doc["metric"]["name"] for doc in docs] == ["order_count", "paid_order_count"]
+
+    def test_write_file_rejects_conflicting_metric_overwrite(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders_metrics.yml"
+        target.parent.mkdir(parents=True)
+        original = """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip()
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics")
+
+        result = tool.write_file(
+            "subject/semantic_models/ac_manage/metrics/orders_metrics.yml",
+            """
+metric:
+  name: order_count
+  type: ratio
+  type_params:
+    numerator: paid_order_count
+    denominator: order_count
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "Refusing to overwrite metric 'order_count'" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_write_file_strict_external_path_is_rejected_before_merge(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        target = tmp_path / "outside" / "subject" / "semantic_models" / "ac_manage" / "metrics" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(root_path=str(project), current_node="gen_metrics", strict=True)
+
+        def fail_if_called(*_args, **_kwargs):
+            pytest.fail("external file was read before strict path rejection")
+
+        monkeypatch.setattr(tool, "_merge_metric_content", fail_if_called)
+
+        result = tool.write_file(
+            str(target),
+            """
+metric:
+  name: paid_order_count
+  type: measure_proxy
+  type_params:
+    measure: paid_order_count
+""".lstrip(),
+        )
+
+        assert result.success == 0
+        assert "outside workspace" in result.error
+
+    def test_quote_escape_repair_only_touches_yaml_error_location(self):
+        content = """
+data_source:
+  name: orders
+  sql_query: |
+    SELECT '\\'' AS literal_value
+  measures:
+    - name: paid_order_count
+      agg: SUM
+      expr: "CASE WHEN status = \\'paid\\' THEN 1 END"
+""".lstrip()
+
+        repaired = MetricFilesystemFuncTool._repair_invalid_yaml_single_quote_escapes(content)
+
+        docs = list(yaml.safe_load_all(repaired))
+        data_source = docs[0]["data_source"]
+        assert data_source["measures"][0]["expr"] == "CASE WHEN status = 'paid' THEN 1 END"
+        assert "SELECT '\\'' AS literal_value" in data_source["sql_query"]

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -586,6 +586,39 @@ class TestAnalyzeMetricCandidatesFromHistory:
         assert evidence["tables"] == ["users"]
         assert evidence["filters"] == ["is_test = 0 AND country = 'US'"]
 
+    def test_count_star_with_distinct_business_count_is_support_measure(self):
+        tools = _make_tools()
+        result = tools.analyze_metric_candidates_from_history(
+            sql_queries=[
+                """
+                SELECT COUNT(*) AS product_row_count,
+                       COUNT(DISTINCT ac_code) AS activity_count
+                FROM v_udata_ac_info
+                WHERE request_name LIKE '%小罗%' AND FIND_IN_SET('1', ac_tags)
+                """
+            ]
+        )
+
+        assert result.success == 1
+        assert [candidate["name"] for candidate in result.result["direct_metric_candidates"]] == ["activity_count"]
+        assert [candidate["name"] for candidate in result.result["metric_candidates"]] == ["activity_count"]
+        assert result.result["support_measure_candidates"][0]["name"] == "product_row_count"
+        assert result.result["support_measure_candidates"][0]["evidence_kind"] == "support_measure"
+        assert result.result["support_measure_candidates"][0]["base_measures"][0]["agg"] == "COUNT"
+
+    def test_count_star_without_distinct_business_count_stays_direct_metric(self):
+        tools = _make_tools()
+        result = tools.analyze_metric_candidates_from_history(
+            sql_queries=["SELECT COUNT(*) AS order_count, SUM(amount) AS revenue FROM orders"]
+        )
+
+        assert result.success == 1
+        assert [candidate["name"] for candidate in result.result["direct_metric_candidates"]] == [
+            "order_count",
+            "revenue",
+        ]
+        assert result.result["support_measure_candidates"] == []
+
     def test_repeated_aliases_are_merged(self):
         tools = _make_tools()
         result = tools.analyze_metric_candidates_from_history(

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -83,6 +83,27 @@ class TestGenerationEvidence:
 
         assert evidence.has_required_queryability_dry_runs(["revenue_total"]) is True
 
+    def test_queryability_contract_skips_unrelated_metric_scope(self):
+        evidence = GenerationEvidence()
+        evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "metric_hints": ["activity_count"],
+                    "dimension_hints": ["start_month"],
+                    "time_group_hints": [
+                        {
+                            "alias": "start_month",
+                            "base_expr": "start_date",
+                            "grain": "month",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        assert evidence.has_required_queryability_dry_runs(["avg_sr_value"]) is True
+
     def test_queryability_contract_accepts_split_grouped_dry_runs_for_source_metrics(self):
         contract = {
             "source": "sql_1",

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -1058,14 +1058,13 @@ class TestQueryMetricsCompression:
 
         assert result.success == 1
         assert evidence.metric_dry_run_passed is True
-        assert evidence.metric_dry_run_queries == [
-            {
-                "metrics": ["revenue"],
-                "dimensions": ["customer_segment"],
-                "time_granularity": "month",
-                "sql": "SELECT SUM(revenue) AS revenue FROM orders",
-            }
-        ]
+        assert len(evidence.metric_dry_run_queries) == 1
+        dry_run = evidence.metric_dry_run_queries[0]
+        assert dry_run["metrics"] == ["revenue"]
+        assert dry_run["dimensions"] == ["customer_segment"]
+        assert dry_run["time_granularity"] == "month"
+        assert dry_run["time_granularity_explicit"] is True
+        assert dry_run["sql"] == "SELECT SUM(revenue) AS revenue FROM orders"
         assert evidence.metric_sqls == {"revenue": "SELECT SUM(revenue) AS revenue FROM orders"}
 
     def test_query_metrics_non_dry_run_does_not_record_publish_evidence(self, semantic_tools):

--- a/tests/unit_tests/tools/semantic_tools/test_storage_sync.py
+++ b/tests/unit_tests/tools/semantic_tools/test_storage_sync.py
@@ -379,7 +379,7 @@ class TestStoreMetric:
             manager.store_metric({"name": "revenue"}, subject_path=["Finance", "Revenue"])
 
         stored = mock_store.batch_store_metrics.call_args[0][0]
-        assert "Finance/Revenue.revenue" in stored[0]["id"]
+        assert stored[0]["id"] == "metric:revenue"
 
     def test_metric_type_defaults_to_simple(self):
         manager = _make_manager()


### PR DESCRIPTION
## Why

`bootstrap-kb --components metrics --kb_update_strategy overwrite` in a multi-datasource project drops the **entire project table** and rebuilds it, silently deleting metrics belonging to other datasources. Additionally, metrics bootstrap has several reliability and efficiency issues:

- Batches with only non-metric SQL (detail/ranking queries) still trigger full LLM calls
- Skill content (~1000 lines) is printed verbatim to CLI output on every batch, flooding the terminal
- MetricFlow YAML merge logic can lose earlier batch results when later batches overwrite files
- `metrics_count` double-counts when multiple batches sync the same metric file

This is a re-implementation of the reverted #969, with a cleaner row-level isolation approach.

## Solution

### 1. Row-level datasource isolation (core fix)
- New `datasource_scope.py` module: `datasource_id` + `storage_key` columns for row-level scoping
- `BaseEmbeddingStore.delete_datasource_rows(datasource_id)` deletes only the target datasource's rows instead of dropping the table
- All stores (metric, semantic_model, reference_sql, reference_template, schema_metadata, subject_tree) add `datasource_condition()` to queries, updates, and deletes
- Registry cache key extended to `(factory, project, datasource_id)`
- Legacy data compatibility: old rows get `datasource_id=""`, `storage_key="legacy:{id}"`

### 2. Metrics bootstrap hardening
- Batch context refresh: after each successful batch, rebuild `existing_metric_catalog` and `candidate_plan` so later batches don't regenerate existing metrics
- `_final_metric_count()` queries storage for the deduplicated final count
- MetricFlow YAML merge: `write_file` merges measures/dimensions/metrics into existing files instead of overwriting
- `support_measure_candidates`: `COUNT(*)` alongside `COUNT(DISTINCT ...)` is demoted to support measure, not published as a metric
- `end_metric_generation` accepts `semantic_model_files: List[str]` for multi-file sync
- `check_semantic_object_exists` caching and identifier-variant matching

### 3. Optimizations (new in this PR)
- **No-candidate batch early skip**: `_batch_has_no_metric_candidates()` skips LLM calls when the scoped candidate plan has zero direct/derived candidates but has non-metric evidence (e.g. detail queries, identity references, derived datasource recommendations)
- **CLI output truncation**: `_emit_metrics_event` truncates `raw_output` > 500 chars before printing, preventing `load_skill` content from flooding the terminal

### 4. API graceful degradation
- Explorer and database services handle missing datasource context without 500 errors

## Test Cases

- `tests/unit_tests/storage/metric/test_metric_init.py` — 46 tests including 7 new tests for `_batch_has_no_metric_candidates` covering: unavailable plan, direct candidates exist, derived candidates exist, only non-metric evidence, only identity references, only derived datasource recommendations, no evidence at all
- `tests/unit_tests/storage/test_rag_datasource_isolation.py` — datasource row isolation tests
- `tests/unit_tests/storage/test_base_extensions.py` — scope column migration, delete_datasource_rows
- `tests/unit_tests/storage/test_registry_cache.py` — cache key includes datasource_id
- `tests/unit_tests/tools/func_tool/test_generation_tools.py` — end_metric_generation multi-file, object exists caching
- `tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py` — support_measure_candidates extraction
- `tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py` — YAML merge logic
- Full QA test plan: `docs/qa/metric-bootstrap-generation-qa.zh.md`

No nightly/regression tests added — changes are internal to storage and bootstrap workflow, covered by CI unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-datasource row isolation across shared projects
  * Publish multiple semantic model files when generating metrics
  * Metric-aware filesystem editor with safe merges and semantic YAML validation

* **Improvements**
  * Stronger metric preflight: candidate planning, dry-run and queryability checks, conflict detection
  * Refined metric classification to avoid promoting support-only measures
  * More reliable path-like globbing for filesystem searches

* **Bug Fixes**
  * Long streaming agent outputs are truncated for cleaner display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
