### PR TITLE
[Feature] Add --metrics-batch-size CLI argument to bootstrap-kb

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -574,6 +574,7 @@ class Agent:
                         self.args.success_story,
                         subject_tree,
                         emit=self._emit_metrics_event,
+                        batch_size=getattr(self.args, "metrics_batch_size", 5),
                     )
 
                 if successful:

--- a/datus/main.py
+++ b/datus/main.py
@@ -265,6 +265,13 @@ def create_parser() -> argparse.ArgumentParser:
         "If not provided, existing categories will be reused or new ones created.",
     )
     bootstrap_parser.add_argument(
+        "--metrics-batch-size",
+        type=int,
+        default=5,
+        help="Number of SQL queries per batch for metrics extraction (default: 5). "
+        "Set to 1 to enable per-query provenance tracking.",
+    )
+    bootstrap_parser.add_argument(
         "-y",
         "--yes",
         action="store_true",


### PR DESCRIPTION
## Why

When `bootstrap-kb --components metrics` runs with the default `batch_size=5`, `_sync_metric_provenance` skips provenance writes because it cannot determine which source row produced which metric. This causes `source_context_id` to be missing from all metric search results, breaking benchmark retrieval evaluation for `metrics_context_ranking` (0/29 tasks matched).

## Solution

Add `--metrics-batch-size` CLI argument to `bootstrap-kb` so callers (e.g. benchmark harness) can set `batch_size=1` to enable unambiguous per-query provenance tracking. The default remains 5 to preserve existing behavior.

Changes:
- `datus/main.py`: Add `--metrics-batch-size` argument to bootstrap-kb parser
- `datus/agent/agent.py`: Pass the value through to `init_success_story_metrics`

## Test Cases

- Existing metrics bootstrap tests are unaffected (default behavior unchanged)
- Benchmark harness will pass `--metrics-batch-size 1` to enable provenance tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--metrics-batch-size` option (default: 5) to control SQL query batch processing during metrics extraction. Set to 1 for per-query provenance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->