### PR TITLE
[Feature] Capture query_metrics result in AskMetricsAgenticNode for benchmark

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -4,8 +4,13 @@
 
 """AskMetricsAgenticNode for fast metric-based question answering."""
 
+from __future__ import annotations
+
 import json
-from typing import Any, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+
+if TYPE_CHECKING:
+    from datus.agent.workflow import Workflow
 
 from agents import Tool
 
@@ -463,3 +468,49 @@ class AskMetricsAgenticNode(AgenticNode):
                 "total_tokens": int(tokens_used),
             },
         )
+
+    def update_context(self, workflow: "Workflow") -> Dict:
+        """Extract last query_metrics result into sql_context for OutputNode."""
+        actions = getattr(self.result, "action_history", None) or []
+        for action in reversed(actions):
+            if not isinstance(action, dict):
+                continue
+            if action.get("action_type") != "query_metrics":
+                continue
+            if action.get("status") != "success":
+                continue
+            output = action.get("output", {})
+            if not isinstance(output, dict) or not output.get("success"):
+                continue
+            result = output.get("result", {})
+            if not isinstance(result, dict):
+                continue
+
+            columns = result.get("columns", [])
+            data = result.get("data", [])
+            if not columns or not data:
+                continue
+
+            import csv
+            import io
+
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(columns)
+            writer.writerows(data)
+            sql_return = buf.getvalue()
+
+            metadata = result.get("metadata", {}) or {}
+            sql_query = ""
+            for key in ("sql", "compiled_sql", "generated_sql"):
+                if metadata.get(key):
+                    sql_query = metadata[key]
+                    break
+
+            from datus.schemas.node_models import SQLContext
+
+            workflow.context.sql_contexts.append(SQLContext(sql_query=sql_query, sql_return=sql_return))
+            logger.info("Captured query_metrics result: %d columns, %d rows", len(columns), len(data))
+            return {"success": True, "message": "query_metrics result captured"}
+
+        return super().update_context(workflow)

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -479,26 +479,37 @@ class AskMetricsAgenticNode(AgenticNode):
                 continue
             if action.get("status") != "success":
                 continue
+
             output = action.get("output", {})
-            if not isinstance(output, dict) or not output.get("success"):
+            if not isinstance(output, dict):
                 continue
-            result = output.get("result", {})
+            raw_output = output.get("raw_output", output)
+            if not isinstance(raw_output, dict) or not raw_output.get("success"):
+                continue
+            result = raw_output.get("result", {})
             if not isinstance(result, dict):
                 continue
 
             columns = result.get("columns", [])
-            data = result.get("data", [])
+            data = result.get("data")
             if not columns or not data:
                 continue
 
-            import csv
-            import io
+            if isinstance(data, dict) and data.get("compressed_data"):
+                sql_return = data["compressed_data"]
+                row_count = data.get("original_rows", 0)
+            elif isinstance(data, list):
+                import csv
+                import io
 
-            buf = io.StringIO()
-            writer = csv.writer(buf)
-            writer.writerow(columns)
-            writer.writerows(data)
-            sql_return = buf.getvalue()
+                buf = io.StringIO()
+                writer = csv.writer(buf)
+                writer.writerow(columns)
+                writer.writerows(data)
+                sql_return = buf.getvalue()
+                row_count = len(data)
+            else:
+                continue
 
             metadata = result.get("metadata", {}) or {}
             sql_query = ""
@@ -510,7 +521,7 @@ class AskMetricsAgenticNode(AgenticNode):
             from datus.schemas.node_models import SQLContext
 
             workflow.context.sql_contexts.append(SQLContext(sql_query=sql_query, sql_return=sql_return))
-            logger.info("Captured query_metrics result: %d columns, %d rows", len(columns), len(data))
+            logger.info("Captured query_metrics result: %d columns, %d rows", len(columns), row_count)
             return {"success": True, "message": "query_metrics result captured"}
 
         return super().update_context(workflow)

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -520,7 +520,9 @@ class AskMetricsAgenticNode(AgenticNode):
 
             from datus.schemas.node_models import SQLContext
 
-            workflow.context.sql_contexts.append(SQLContext(sql_query=sql_query, sql_return=sql_return))
+            workflow.context.sql_contexts.append(
+                SQLContext(sql_query=sql_query, sql_return=sql_return, row_count=row_count)
+            )
             logger.info("Captured query_metrics result: %d columns, %d rows", len(columns), row_count)
             return {"success": True, "message": "query_metrics result captured"}
 

--- a/datus/agent/plan.py
+++ b/datus/agent/plan.py
@@ -170,9 +170,11 @@ def _create_single_node(
         normalized_type = NodeType.TYPE_EXECUTE_SQL
     elif node_type == "chat":
         normalized_type = NodeType.TYPE_CHAT
-    # Check if node_type is defined in agentic_nodes config - if so, map to gen_sql
+    # Check if node_type is defined in agentic_nodes config
     elif agent_config and hasattr(agent_config, "agentic_nodes") and node_type in agent_config.agentic_nodes:
-        normalized_type = NodeType.TYPE_GEN_SQL
+        agentic_config = agent_config.agentic_nodes[node_type]
+        configured_type = agentic_config.get("node_type") if isinstance(agentic_config, dict) else None
+        normalized_type = configured_type if configured_type in NodeType.ACTION_TYPES else NodeType.TYPE_GEN_SQL
 
     description = NodeType.get_description(normalized_type)
 
@@ -182,6 +184,15 @@ def _create_single_node(
             sql_task=sql_task,
             matching_rate=agent_config.schema_linking_rate if agent_config else "fast",
         )
+    elif normalized_type == NodeType.TYPE_ASK_METRICS:
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        input_data = AskMetricsNodeInput(
+            user_message=sql_task.task or "",
+            catalog=sql_task.catalog_name or None,
+            database=sql_task.database_name or None,
+            db_schema=sql_task.schema_name or None,
+        )
 
     node = Node.new_instance(
         node_id=node_id,
@@ -189,9 +200,7 @@ def _create_single_node(
         node_type=normalized_type,
         input_data=input_data,
         agent_config=agent_config,
-        node_name=node_type
-        if normalized_type == NodeType.TYPE_GEN_SQL
-        else None,  # Pass original name for gen_sql nodes
+        node_name=node_type if normalized_type in (NodeType.TYPE_GEN_SQL, NodeType.TYPE_ASK_METRICS) else None,
     )
 
     return node

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -455,3 +455,155 @@ class TestAskMetricsAgenticNode:
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
 
         assert AskMetricsAgenticNode._extract_subject_tree_metric_entries(["not", "a", "tree"]) == []
+
+
+class TestUpdateContext:
+    """Tests for AskMetricsAgenticNode.update_context."""
+
+    def _make_node_with_result(self, action_history):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+        node = MagicMock(spec=AskMetricsAgenticNode)
+        node.result = MagicMock()
+        node.result.action_history = action_history
+        node.update_context = AskMetricsAgenticNode.update_context.__get__(node)
+        return node
+
+    def test_captures_compressed_data(self):
+        actions = [
+            {
+                "action_type": "query_metrics",
+                "status": "success",
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "columns": ["metric_time__month", "activity_count"],
+                            "data": {
+                                "compressed_data": "index,metric_time__month,activity_count\n0,2025-06,100",
+                                "original_rows": 1,
+                                "is_compressed": False,
+                            },
+                            "metadata": {"sql": "SELECT COUNT(*) FROM t"},
+                        },
+                    }
+                },
+            }
+        ]
+        node = self._make_node_with_result(actions)
+        workflow = MagicMock()
+        workflow.context.sql_contexts = []
+
+        result = node.update_context(workflow)
+
+        assert result["success"] is True
+        assert len(workflow.context.sql_contexts) == 1
+        ctx = workflow.context.sql_contexts[0]
+        assert "activity_count" in ctx.sql_return
+        assert ctx.sql_query == "SELECT COUNT(*) FROM t"
+        assert ctx.row_count == 1
+
+    def test_captures_list_data(self):
+        actions = [
+            {
+                "action_type": "query_metrics",
+                "status": "success",
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "columns": ["ac_channel", "count"],
+                            "data": [["ch1", 10], ["ch2", 20]],
+                            "metadata": {},
+                        },
+                    }
+                },
+            }
+        ]
+        node = self._make_node_with_result(actions)
+        workflow = MagicMock()
+        workflow.context.sql_contexts = []
+
+        result = node.update_context(workflow)
+
+        assert result["success"] is True
+        ctx = workflow.context.sql_contexts[0]
+        assert "ch1" in ctx.sql_return
+        assert ctx.row_count == 2
+        assert ctx.sql_query == ""
+
+    def test_skips_failed_actions(self):
+        actions = [
+            {
+                "action_type": "query_metrics",
+                "status": "failed",
+                "output": {"error": "some error"},
+            }
+        ]
+        node = self._make_node_with_result(actions)
+        workflow = MagicMock()
+        workflow.context.sql_contexts = []
+
+        with patch(
+            "datus.agent.node.agentic_node.AgenticNode.update_context",
+            return_value={"success": True},
+        ):
+            node.update_context(workflow)
+
+        assert len(workflow.context.sql_contexts) == 0
+
+    def test_picks_last_successful_call(self):
+        actions = [
+            {
+                "action_type": "query_metrics",
+                "status": "success",
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "columns": ["x"],
+                            "data": {"compressed_data": "index,x\n0,first", "original_rows": 1},
+                            "metadata": {},
+                        },
+                    }
+                },
+            },
+            {
+                "action_type": "query_metrics",
+                "status": "success",
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "columns": ["x"],
+                            "data": {"compressed_data": "index,x\n0,last", "original_rows": 1},
+                            "metadata": {},
+                        },
+                    }
+                },
+            },
+        ]
+        node = self._make_node_with_result(actions)
+        workflow = MagicMock()
+        workflow.context.sql_contexts = []
+
+        node.update_context(workflow)
+
+        assert "last" in workflow.context.sql_contexts[0].sql_return
+
+    def test_no_query_metrics_falls_back_to_super(self):
+        actions = [
+            {"action_type": "list_metrics", "status": "success", "output": {}},
+        ]
+        node = self._make_node_with_result(actions)
+        workflow = MagicMock()
+        workflow.context.sql_contexts = []
+
+        with patch(
+            "datus.agent.node.agentic_node.AgenticNode.update_context",
+            return_value={"success": True, "message": "parent called"},
+        ) as parent_update:
+            result = node.update_context(workflow)
+
+        parent_update.assert_called_once()
+        assert result["message"] == "parent called"

--- a/tests/unit_tests/agent/test_plan.py
+++ b/tests/unit_tests/agent/test_plan.py
@@ -137,6 +137,37 @@ class TestCreateSingleNode:
         assert call_kwargs["node_type"] == NodeType.TYPE_GEN_SQL
         assert call_kwargs["node_name"] == "myagent"
 
+    def test_agentic_node_with_node_type_ask_metrics(self):
+        """When agentic_nodes has node_type=ask_metrics, it creates an ask_metrics node."""
+        cfg = _mock_config(agentic_nodes={"my_ask_metrics": {"node_type": "ask_metrics"}})
+        task = _sql_task(task="how many activities?")
+        fake_node = MagicMock()
+        fake_node.type = NodeType.TYPE_ASK_METRICS
+        with patch("datus.agent.plan.Node.new_instance", return_value=fake_node) as new_instance:
+            node = _create_single_node("my_ask_metrics", "node_am", task, cfg)
+        assert node.type == NodeType.TYPE_ASK_METRICS
+        new_instance.assert_called_once()
+        call_kwargs = new_instance.call_args.kwargs
+        assert call_kwargs["node_type"] == NodeType.TYPE_ASK_METRICS
+        assert call_kwargs["node_name"] == "my_ask_metrics"
+        input_data = call_kwargs["input_data"]
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        assert isinstance(input_data, AskMetricsNodeInput)
+        assert input_data.user_message == "how many activities?"
+
+    def test_agentic_node_with_invalid_node_type_falls_back_to_gen_sql(self):
+        """When agentic_nodes has an invalid node_type, it falls back to gen_sql."""
+        cfg = _mock_config(agentic_nodes={"my_node": {"node_type": "nonexistent_type"}})
+        task = _sql_task()
+        fake_node = MagicMock()
+        fake_node.type = NodeType.TYPE_GEN_SQL
+        with patch("datus.agent.plan.Node.new_instance", return_value=fake_node) as new_instance:
+            node = _create_single_node("my_node", "node_x", task, cfg)
+        assert node.type == NodeType.TYPE_GEN_SQL
+        call_kwargs = new_instance.call_args.kwargs
+        assert call_kwargs["node_type"] == NodeType.TYPE_GEN_SQL
+
     def test_schema_linking_creates_schema_linking_input(self):
         task = _sql_task()
         cfg = _mock_config()


### PR DESCRIPTION
## Why

When `AskMetricsAgenticNode` is used in a benchmark workflow without `execute_sql`, `OutputNode` has no `sql_context` data to save as CSV. This blocks benchmark evaluation for the new `baisheng_ask_metrics` scenario which uses `[ask_metrics, output]` workflow (no execute_sql).

## Solution

Override `update_context` in `AskMetricsAgenticNode` to extract the last successful `query_metrics` call from `action_history`:
- `result.data` (columns + rows) → formatted as CSV string → `sql_context.sql_return`
- `result.metadata` (compiled SQL from MetricFlow) → `sql_context.sql_query`

This allows `OutputNode` to save query_metrics results as `task_{id}.csv` for benchmark evaluation.

**No impact on interactive mode** — `update_context` is only called during workflow execution. Falls back to parent behavior when no query_metrics result is found.

## Test Cases

- Interactive ask_metrics usage unchanged (no `update_context` dependency)
- Benchmark workflow `[ask_metrics, output]` can now capture and save query results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **Refactor**
  * Enhanced SQL context management to improve query result handling and integration within the agent workflow. Query metrics are now automatically processed and serialized for better downstream analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "ask metrics" node type so plans can include metric-query steps with preserved node types and names.

* **Refactor**
  * Workflow now captures the most recent successful metric query, extracts query text, returned payload (including compressed or tabular forms), and row count, and appends a structured SQL context for downstream use.

* **Tests**
  * Added unit tests covering compressed/list results, skipping failed actions, last-success selection, fallback behavior, and node-creation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->