### PR TITLE
[BugFix] Pass reference date to AskMetricsAgenticNode system prompt

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -419,7 +419,8 @@ class AskMetricsAgenticNode(AgenticNode):
 
         from datus.utils.time_utils import get_default_current_date
 
-        context["current_date"] = get_default_current_date(None)
+        input_ref_date = getattr(self.input, "reference_date", None) if self.input else None
+        context["current_date"] = get_default_current_date(input_ref_date)
 
         version_value = prompt_version if prompt_version not in (None, "") else self.node_config.get("prompt_version")
         version = None if version_value in (None, "") else str(version_value)

--- a/datus/agent/plan.py
+++ b/datus/agent/plan.py
@@ -192,6 +192,7 @@ def _create_single_node(
             catalog=sql_task.catalog_name or None,
             database=sql_task.database_name or None,
             db_schema=sql_task.schema_name or None,
+            reference_date=sql_task.current_date or None,
         )
 
     node = Node.new_instance(

--- a/datus/schemas/ask_metrics_agentic_node_models.py
+++ b/datus/schemas/ask_metrics_agentic_node_models.py
@@ -20,6 +20,7 @@ class AskMetricsNodeInput(BaseInput):
     db_schema: Optional[str] = Field(None, description="Database schema")
     max_turns: int = Field(default=12, description="Maximum turns for quick metric answering")
     prompt_version: Optional[str] = Field(None, description="Prompt template version override")
+    reference_date: Optional[str] = Field(None, description="Reference date for relative time expressions (YYYY-MM-DD)")
 
 
 class AskMetricsNodeResult(BaseResult):

--- a/tests/unit_tests/agent/test_plan.py
+++ b/tests/unit_tests/agent/test_plan.py
@@ -156,6 +156,18 @@ class TestCreateSingleNode:
         assert isinstance(input_data, AskMetricsNodeInput)
         assert input_data.user_message == "how many activities?"
 
+    def test_agentic_node_ask_metrics_passes_reference_date(self):
+        """When sql_task has current_date, it is passed as reference_date to AskMetricsNodeInput."""
+        cfg = _mock_config(agentic_nodes={"my_am": {"node_type": "ask_metrics"}})
+        task = _sql_task(task="activity count in June")
+        task.current_date = "2025-06-01"
+        fake_node = MagicMock()
+        fake_node.type = NodeType.TYPE_ASK_METRICS
+        with patch("datus.agent.plan.Node.new_instance", return_value=fake_node) as new_instance:
+            _create_single_node("my_am", "node_am", task, cfg)
+        input_data = new_instance.call_args.kwargs["input_data"]
+        assert input_data.reference_date == "2025-06-01"
+
     def test_agentic_node_with_invalid_node_type_falls_back_to_gen_sql(self):
         """When agentic_nodes has an invalid node_type, it falls back to gen_sql."""
         cfg = _mock_config(agentic_nodes={"my_node": {"node_type": "nonexistent_type"}})


### PR DESCRIPTION
## Why

`AskMetricsAgenticNode` always calls `get_default_current_date(None)` for its system prompt context, which returns the system date. When benchmark or scenario configuration specifies `current_date` (e.g. `2025-06-01`), the agent ignores it and uses the real system date instead. This causes the agent to interpret relative month references like "6月" as the current year (2026) rather than the intended year (2025), returning 0 results because no data exists for 2026.

## Solution

- Add `reference_date` field to `AskMetricsNodeInput` (optional, defaults to None)
- In `plan.py`, pass `sql_task.current_date` as `reference_date` when building `AskMetricsNodeInput`
- In `ask_metrics_agentic_node.py`, use `input.reference_date` instead of `None` when calling `get_default_current_date`

No impact on interactive mode — `reference_date` defaults to None, falling back to system date as before.

## Test Cases

- Added `test_agentic_node_ask_metrics_passes_reference_date` verifying the date flows from SqlTask to AskMetricsNodeInput
- All 57 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **New Features**
  * Metrics agent now accepts an optional reference date to provide accurate context for relative time expressions in metric prompts (format: YYYY-MM-DD).

* **Tests**
  * Added unit test to verify reference date propagation from SQL tasks through the metrics workflow pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics agent now accepts an optional reference date (YYYY-MM-DD) so relative-time metric prompts use the provided date when available, improving accuracy of time-based queries and results.

* **Tests**
  * Added a unit test to verify that a task-provided reference date is propagated through the metrics workflow and used when constructing metric prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->