### PR TITLE
[Enhancement] Support all hooks in Claude native Anthropic SDK loop

### DIFF
--- a/datus/cli/action_display/display.py
+++ b/datus/cli/action_display/display.py
@@ -234,6 +234,17 @@ class ActionHistoryDisplay:
             # INTERACTION actions: only shown during live interaction, skip in history replay
             if action.role == ActionRole.INTERACTION:
                 continue
+            # token_usage actions drive the status bar / pinned-header token
+            # counters only — they carry no transcript content. The live
+            # streaming path folds them into subagent totals via
+            # ``StreamingActionContext._apply_subagent_usage``; this replay path
+            # (Ctrl+O toggle, .resume, end-of-turn reprint) has no counter
+            # display, so skip them outright. Otherwise a subagent's depth>0
+            # ``token_usage`` would buffer into the group and render as a bogus
+            # ``💬 Token usage update`` row (and a main-agent depth=0 one would
+            # render as a standalone line on .resume).
+            if action.action_type == "token_usage":
+                continue
             # Skip PROCESSING TOOL entries (only render SUCCESS/FAILED)
             if action.role == ActionRole.TOOL and action.status == ActionStatus.PROCESSING:
                 continue

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -19,6 +19,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 import anthropic
@@ -26,7 +27,7 @@ import httpx
 from agents import Agent, RunContextWrapper, Usage
 from agents.mcp import MCPServerStdio
 from agents.tool_context import ToolContext
-from agents.usage import InputTokensDetails, OutputTokensDetails
+from agents.usage import InputTokensDetails, OutputTokensDetails, RequestUsage
 
 from datus.configuration.agent_config import ModelConfig
 from datus.models.mcp_utils import multiple_mcp_servers
@@ -448,6 +449,7 @@ class ClaudeModel(OpenAICompatibleModel):
             async with multiple_mcp_servers(mcp_servers) as connected_servers:
                 # Get all tools and build tool-name-to-server mapping once
                 tool_server_map = {}  # tool_name -> connected_server
+                mcp_tool_objs = {}  # tool_name -> SDK tool object (carries .name for hooks)
                 for server_name, connected_server in connected_servers.items():
                     try:
                         agent = Agent(name="mcp-tools-agent")
@@ -460,12 +462,20 @@ class ClaudeModel(OpenAICompatibleModel):
                                     f"overwriting previous mapping"
                                 )
                             tool_server_map[tool.name] = connected_server
+                            mcp_tool_objs[tool.name] = tool
                         all_tools.extend(mcp_tools)
                         logger.info(f"Retrieved {len(mcp_tools)} tools from {server_name}")
 
                     except Exception as e:
                         logger.error(f"Error getting tools from {server_name}: {str(e)}")
                         continue
+
+                # Shared placeholder agent for hook lifecycle calls. The native
+                # loop is not driven by the openai-agents Runner, so we fire the
+                # composed ``hooks`` (permission / compact / KB-sync / token-usage)
+                # ourselves; the hooks barely read ``agent`` so one placeholder is
+                # sufficient for every callback.
+                hook_agent = Agent(name="claude-native-agent")
 
                 logger.info(f"Retrieved {len(all_tools)} total tools from MCP servers")
 
@@ -522,11 +532,15 @@ class ClaudeModel(OpenAICompatibleModel):
                 cache_read_tokens = 0
                 last_call_input_tokens = 0
 
-                # Reset the per-LLM-call usage baseline so the first response
-                # of this user turn reports its full usage as a delta (the
-                # native loop never triggers the SDK ``on_start`` that the
-                # streaming Runner path relies on for the same reset).
-                await self._reset_token_usage_hook(hooks)
+                # Drive the composed run hooks through their standard lifecycle
+                # so the native loop behaves exactly like the SDK Runner path.
+                # ``run_ctx`` carries a real SDK ``Usage`` accumulator that
+                # ``TokenUsageHook.on_llm_end`` reads via ``_extract_usage_info``
+                # (inherited from OpenAICompatibleModel) — no bespoke per-hook
+                # plumbing. ``on_start`` resets each hook's per-turn baseline so
+                # the first response reports its full usage as a delta.
+                run_ctx = RunContextWrapper(context=None, usage=Usage())
+                await self._invoke_hook(hooks, "on_start", run_ctx, hook_agent)
 
                 # Execute conversation loop
                 turn = -1
@@ -643,21 +657,20 @@ class ClaudeModel(OpenAICompatibleModel):
                         cache_read_tokens += call_cache_read
                         last_call_input_tokens = call_total_input
 
-                        # Drive the per-LLM-call usage update so the CLI status
-                        # bar / API ``usage`` events refresh mid-turn. The
-                        # native loop bypasses the SDK Runner, so this is the
-                        # only place the hook can observe each response.
-                        await self._emit_native_token_usage(
-                            hooks,
-                            self._build_native_usage_info(
-                                requests=turn + 1,
-                                cumulative_input_tokens=cumulative_input_tokens,
-                                cumulative_output_tokens=cumulative_output_tokens,
-                                cache_read_tokens=cache_read_tokens,
-                                cache_creation_tokens=cache_creation_tokens,
-                                last_call_input_tokens=last_call_input_tokens,
-                            ),
+                        # Drive the per-LLM-call usage update through the standard
+                        # ``on_llm_end`` hook so the CLI status bar / API ``usage``
+                        # events refresh mid-turn. The native loop bypasses the SDK
+                        # Runner, so we mutate the shared ``run_ctx.usage`` with an
+                        # SDK ``Usage`` snapshot and fire the hook exactly as the
+                        # Runner would after each model response.
+                        run_ctx.usage = self._build_sdk_usage(
+                            requests=turn + 1,
+                            cumulative_input_tokens=cumulative_input_tokens,
+                            cumulative_output_tokens=cumulative_output_tokens,
+                            cache_read_tokens=cache_read_tokens,
+                            last_call_input_tokens=last_call_input_tokens,
                         )
+                        await self._invoke_hook(hooks, "on_llm_end", run_ctx, hook_agent, response)
 
                     message = response.content
 
@@ -691,28 +704,50 @@ class ClaudeModel(OpenAICompatibleModel):
                                 action_history_manager.add_action(start_action)
                             yield start_action
 
+                            # Build the per-tool context and resolve a tool object
+                            # exposing ``.name`` BEFORE running the tool, then fire
+                            # ``on_tool_start`` so the composed permission hook can
+                            # gate execution exactly like the SDK Runner path. This
+                            # MUST sit before the execution try/except blocks below:
+                            # a ``PermissionDeniedException`` has to propagate out of
+                            # the generator (mirroring the SDK, where on_tool_start
+                            # raising aborts the run) instead of being swallowed and
+                            # downgraded into a tool_result error by them.
+                            tool_args = json.dumps(block.input, ensure_ascii=False)
+                            tool_ctx = ToolContext(
+                                context=None,
+                                usage=Usage(),
+                                tool_name=block.name,
+                                tool_call_id=block.id,
+                                tool_arguments=tool_args,
+                            )
+                            tool_obj = (
+                                func_tool_map.get(block.name)
+                                or mcp_tool_objs.get(block.name)
+                                or SimpleNamespace(name=block.name)
+                            )
+                            await self._invoke_hook(hooks, "on_tool_start", tool_ctx, hook_agent, tool_obj)
+
                             tool_executed = False
+                            # Raw structured result handed to ``on_tool_end``; GenerationHooks
+                            # inspects the FuncToolResult dict / result text to sync the KB.
+                            hook_result: Any = None
 
                             # Try function tools first
                             if block.name in func_tool_map:
                                 try:
                                     ft = func_tool_map[block.name]
-                                    # Pass a ToolContext (not a bare RunContextWrapper) so the
-                                    # tool's ``tool_call_id`` matches this block's ``action_id``
-                                    # (``block.id``). The ``task`` tool reads ``tool_call_id`` to
-                                    # link every sub-agent action's ``parent_action_id`` to the
-                                    # wrapping task action; without it the CLI renderer cannot
-                                    # anchor the sub-agent group and mis-renders it as separate
-                                    # ``<node>_request`` / ``<node>_response`` blocks.
-                                    tool_args = json.dumps(block.input)
-                                    run_context = ToolContext(
-                                        context=None,
-                                        usage=Usage(),
-                                        tool_name=block.name,
-                                        tool_call_id=block.id,
-                                        tool_arguments=tool_args,
-                                    )
-                                    result_val = await ft.on_invoke_tool(run_context, tool_args)
+                                    # Reuse ``tool_ctx`` (a ToolContext, not a bare
+                                    # RunContextWrapper) so the tool's ``tool_call_id``
+                                    # matches this block's ``action_id`` (``block.id``).
+                                    # The ``task`` tool reads ``tool_call_id`` to link
+                                    # every sub-agent action's ``parent_action_id`` to the
+                                    # wrapping task action; without it the CLI renderer
+                                    # cannot anchor the sub-agent group and mis-renders it
+                                    # as separate ``<node>_request`` / ``<node>_response``
+                                    # blocks.
+                                    result_val = await ft.on_invoke_tool(tool_ctx, tool_args)
+                                    hook_result = result_val
                                     # Ensure result is a string (Anthropic API requires string content)
                                     result_str = result_val if isinstance(result_val, str) else json.dumps(result_val)
                                     # Wrap in object matching MCP tool result format
@@ -734,6 +769,7 @@ class ClaudeModel(OpenAICompatibleModel):
                                             else block.input,
                                         )
                                         tool_call_cache[block.id] = tool_result
+                                        hook_result = tool_result.content[0].text if tool_result.content else ""
                                         tool_executed = True
                                     except Exception as e:
                                         logger.error(f"Error executing tool {block.name}: {str(e)}")
@@ -766,6 +802,19 @@ class ClaudeModel(OpenAICompatibleModel):
                             if action_history_manager is not None:
                                 action_history_manager.add_action(complete_action)
                             yield complete_action
+
+                            # Fire ``on_tool_end`` so the compact / KB-sync hooks run
+                            # per tool completion, mirroring the SDK Runner loop. On
+                            # failure pass a ``{"success": 0}`` marker so consumers that
+                            # inspect the result treat it as a failed call.
+                            await self._invoke_hook(
+                                hooks,
+                                "on_tool_end",
+                                tool_ctx,
+                                hook_agent,
+                                tool_obj,
+                                hook_result if tool_executed else {"success": 0, "error": result_summary},
+                            )
 
                     # Build assistant message content from all blocks
                     content = []
@@ -888,6 +937,11 @@ class ClaudeModel(OpenAICompatibleModel):
                         max_turns,
                     )
 
+                # Close out the composed hooks' lifecycle, completing parity with
+                # the SDK Runner path (current ``on_end`` implementations are
+                # no-ops, but the native loop now drives the full interface).
+                await self._invoke_hook(hooks, "on_end", run_ctx, hook_agent, final_content)
+
                 yield final_action
 
         except anthropic.AuthenticationError as e:
@@ -938,39 +992,76 @@ class ClaudeModel(OpenAICompatibleModel):
             "last_call_input_tokens": last_call_input_tokens,
         }
 
-    @staticmethod
-    def _iter_token_usage_hooks(hooks):
-        """Yield every ``TokenUsageHook`` reachable from a composed hook.
+    def _build_sdk_usage(
+        self,
+        *,
+        requests: int,
+        cumulative_input_tokens: int,
+        cumulative_output_tokens: int,
+        cache_read_tokens: int,
+        last_call_input_tokens: int,
+    ) -> Usage:
+        """Build an SDK ``Usage`` snapshot from the native loop's counters.
 
-        ``hooks`` may be a bare hook or a ``CompositeHooks`` wrapping several;
-        we duck-type on ``emit_manual`` so the native loop stays decoupled
-        from the concrete hook classes.
+        The native Anthropic loop bypasses the openai-agents Runner, so it must
+        feed :class:`TokenUsageHook` (via ``on_llm_end``) the same shape the
+        Runner would. ``TokenUsageHook._emit`` reads ``context.usage`` and calls
+        :meth:`OpenAICompatibleModel._extract_usage_info` (inherited here), which
+        consumes ``input_tokens`` / ``output_tokens`` / ``total_tokens``,
+        ``input_tokens_details.cached_tokens`` and ``request_usage_entries[-1]``
+        for the last-call input. ``cumulative_input_tokens`` already folds in the
+        cache_read / cache_creation components (done by the caller) so the OpenAI
+        "input includes cached" semantics carry through cache-hit-rate and
+        context-usage-ratio derivation.
+        """
+        total_tokens = cumulative_input_tokens + cumulative_output_tokens
+        return Usage(
+            requests=requests,
+            input_tokens=cumulative_input_tokens,
+            input_tokens_details=InputTokensDetails(cached_tokens=cache_read_tokens),
+            output_tokens=cumulative_output_tokens,
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+            total_tokens=total_tokens,
+            # ``_extract_usage_info`` derives ``last_call_input_tokens`` from the
+            # final request entry's ``input_tokens`` — the real context-window
+            # occupancy of the most recent LLM call.
+            request_usage_entries=[
+                RequestUsage(
+                    input_tokens=last_call_input_tokens,
+                    output_tokens=0,
+                    total_tokens=last_call_input_tokens,
+                    input_tokens_details=InputTokensDetails(cached_tokens=cache_read_tokens),
+                    output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+                )
+            ],
+        )
+
+    async def _invoke_hook(self, hooks, method_name: str, *args) -> None:
+        """Drive one composed-hook lifecycle method from the native loop.
+
+        ``hooks`` may be a bare ``AgentHooks`` or a ``CompositeHooks`` wrapping
+        several; either way we call ``getattr(hooks, method_name)`` once and let
+        ``CompositeHooks`` fan out to its children. ``PermissionDeniedException``
+        MUST propagate so a denied tool aborts the run, mirroring the SDK path
+        (where ``on_tool_start`` raising surfaces as a ``UserError``). Every
+        other exception is logged and swallowed so a best-effort hook (compact,
+        KB sync, token usage) can never crash the agent loop.
         """
         if hooks is None:
             return
-        if hasattr(hooks, "emit_manual"):
-            yield hooks
-        inner = getattr(hooks, "hooks_list", None)
-        if inner:
-            for h in inner:
-                if hasattr(h, "emit_manual"):
-                    yield h
+        method = getattr(hooks, method_name, None)
+        if method is None:
+            return
+        # Local import keeps the module import graph light and matches the
+        # file's convention of importing permission types lazily.
+        from datus.tools.permission.permission_hooks import PermissionDeniedException
 
-    async def _reset_token_usage_hook(self, hooks) -> None:
-        """Reset each token-usage hook's per-turn delta baseline."""
-        for hook in self._iter_token_usage_hooks(hooks):
-            try:
-                await hook.on_start(None, None)
-            except Exception:  # noqa: BLE001 — never break the native loop
-                logger.debug("Failed to reset token usage hook baseline", exc_info=True)
-
-    async def _emit_native_token_usage(self, hooks, usage_info: dict) -> None:
-        """Push one per-LLM-call usage snapshot through the token-usage hook(s)."""
-        for hook in self._iter_token_usage_hooks(hooks):
-            try:
-                await hook.emit_manual(usage_info)
-            except Exception:  # noqa: BLE001 — never break the native loop
-                logger.debug("Failed to emit native token usage", exc_info=True)
+        try:
+            await method(*args)
+        except PermissionDeniedException:
+            raise
+        except Exception:  # noqa: BLE001 — best-effort hooks never break the loop
+            logger.debug("Hook '%s' raised; ignoring", method_name, exc_info=True)
 
     async def _store_native_turn_usage(self, session, usage_info: dict) -> None:
         """Persist the native turn's cumulative usage into ``turn_usage``.

--- a/tests/unit_tests/cli/test_action_history_display.py
+++ b/tests/unit_tests/cli/test_action_history_display.py
@@ -1069,6 +1069,73 @@ class TestRenderActionHistory:
         assert "Done" in combined
         assert "1 tool uses" in combined
 
+    def test_subagent_token_usage_not_rendered(self):
+        """A subagent depth>0 ``token_usage`` action is dropped, not rendered as a row."""
+        display = ActionHistoryDisplay()
+        actions = [
+            _make_action(
+                ActionRole.USER,
+                ActionStatus.PROCESSING,
+                depth=1,
+                action_type="gen_sql",
+                messages="User: What is total revenue?",
+            ),
+            # TokenUsageHook emits this as an ASSISTANT action with the bare
+            # "Token usage update" message and a usage-only output payload.
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                depth=1,
+                action_type="token_usage",
+                messages="Token usage update",
+                output_data={"cumulative": {"input_tokens": 100, "output_tokens": 20}},
+            ),
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                depth=1,
+                messages="describe_table(orders)",
+                input_data={"function_name": "describe_table"},
+            ),
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                depth=0,
+                action_type="task",
+                input_data={"function_name": "task"},
+                end_time=datetime(2025, 1, 1, 12, 0, 5),
+            ),
+        ]
+        actions[0].start_time = datetime(2025, 1, 1, 12, 0, 0)
+
+        printed = self._collect_prints(display, actions, verbose=True)
+        combined = "\n".join(printed)
+
+        # The usage event must never surface as a transcript line.
+        assert "Token usage update" not in combined
+        # The real subagent work is still rendered.
+        assert "describe_table" in combined
+        assert "Done" in combined
+        # token_usage is not a tool — the Done count stays at the single tool.
+        assert "1 tool uses" in combined
+
+    def test_main_agent_token_usage_not_rendered(self):
+        """A depth=0 ``token_usage`` action (e.g. from .resume replay) is skipped."""
+        display = ActionHistoryDisplay()
+        actions = [
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                depth=0,
+                action_type="token_usage",
+                messages="Token usage update",
+                output_data={"cumulative": {"input_tokens": 100, "output_tokens": 20}},
+            ),
+        ]
+        printed = self._collect_prints(display, actions)
+        combined = "\n".join(printed)
+        assert "Token usage update" not in combined
+
     def test_subagent_verbose_shows_args_and_output(self):
         """In verbose mode, subagent tool actions show full arguments and output."""
         display = ActionHistoryDisplay()

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -1445,9 +1445,16 @@ class TestNativeLoopHooks:
     @pytest.mark.asyncio
     async def test_invoke_hook_noop_when_method_absent(self):
         model = _make_claude_model(_make_model_config(use_native_api=True))
-        # Bare object without the method, and None hooks: both no-op silently.
-        await model._invoke_hook(SimpleNamespace(), "on_tool_end", None)
-        await model._invoke_hook(None, "on_tool_end", None)
+        # Bare object without the method, and None hooks: both no-op silently
+        # (return None) rather than raising AttributeError / calling None(...).
+        assert await model._invoke_hook(SimpleNamespace(), "on_tool_end", None) is None
+        assert await model._invoke_hook(None, "on_tool_end", None) is None
+
+        # A hooks object whose lifecycle attribute is explicitly None must hit
+        # the ``method is None`` guard and never be awaited.
+        hooks = MagicMock()
+        hooks.on_tool_end = None
+        assert await model._invoke_hook(hooks, "on_tool_end", None) is None
 
     @pytest.mark.asyncio
     async def test_tool_lifecycle_hooks_fired_for_func_tool(self):

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -1263,6 +1263,10 @@ class TestNativeTokenUsageStreaming:
         func_tool.on_invoke_tool = AsyncMock(return_value="ok")
 
         hook, node, emitted = self._usage_hook()
+        # The native loop now feeds usage through the standard ``on_llm_end``
+        # hook, which reads ``node.model._extract_usage_info`` — point it at the
+        # real model so the SDK ``Usage`` snapshot is parsed for real.
+        node.model = model
 
         ahm = ActionHistoryManager()
         node._current_action_history = ahm
@@ -1396,45 +1400,307 @@ class TestNativeTokenUsageStreaming:
         session.add_items.assert_not_awaited()
 
 
-class TestNativeTokenUsageHooks:
-    """The native loop drives token-usage hooks manually (no SDK Runner)."""
+def _make_recorder_hooks():
+    """A duck-typed AgentHooks recorder: every lifecycle method is an AsyncMock.
 
-    def test_iter_yields_bare_hook_and_composite_inner_hooks(self):
-        model = _make_claude_model(_make_model_config(use_native_api=True))
-        bare = MagicMock(spec=["emit_manual"])
-        assert list(model._iter_token_usage_hooks(bare)) == [bare]
-        assert list(model._iter_token_usage_hooks(None)) == []
+    The native loop calls ``getattr(hooks, name)`` and awaits it, so a plain
+    MagicMock with AsyncMock attributes stands in for a composed hook without
+    importing the real classes. ``emit_manual`` is set so tests can prove the
+    native loop no longer uses the legacy manual-fan-in path.
+    """
+    rec = MagicMock()
+    rec.on_start = AsyncMock()
+    rec.on_tool_start = AsyncMock()
+    rec.on_tool_end = AsyncMock()
+    rec.on_llm_end = AsyncMock()
+    rec.on_end = AsyncMock()
+    rec.emit_manual = AsyncMock()
+    return rec
 
-        # Composite: hooks_list with a mix of usage and non-usage hooks.
-        usage_hook = MagicMock(spec=["emit_manual", "on_start"])
-        other_hook = MagicMock(spec=["on_start"])  # no emit_manual → skipped
-        composite = SimpleNamespace(hooks_list=[usage_hook, other_hook])
-        assert list(model._iter_token_usage_hooks(composite)) == [usage_hook]
 
-    @pytest.mark.asyncio
-    async def test_reset_and_emit_drive_composite_inner_hooks(self):
-        model = _make_claude_model(_make_model_config(use_native_api=True))
-        usage_hook = MagicMock()
-        usage_hook.on_start = AsyncMock()
-        usage_hook.emit_manual = AsyncMock()
-        composite = SimpleNamespace(hooks_list=[usage_hook])
-
-        await model._reset_token_usage_hook(composite)
-        usage_hook.on_start.assert_awaited_once()
-
-        await model._emit_native_token_usage(composite, {"total_tokens": 42})
-        usage_hook.emit_manual.assert_awaited_once_with({"total_tokens": 42})
+class TestNativeLoopHooks:
+    """The native Anthropic loop drives the full AgentHooks lifecycle itself
+    (no SDK Runner), so permission / compact / KB-sync / token-usage hooks all
+    fire exactly as they would on the SDK path."""
 
     @pytest.mark.asyncio
-    async def test_emit_swallows_hook_failure(self):
+    async def test_invoke_hook_swallows_non_permission_errors(self):
         model = _make_claude_model(_make_model_config(use_native_api=True))
-        bad = MagicMock()
-        bad.emit_manual = AsyncMock(side_effect=RuntimeError("boom"))
-        # Must not propagate — the native loop keeps running.
-        await model._emit_native_token_usage(bad, {"total_tokens": 1})
-        # The hook WAS invoked (so the raise happened inside and was swallowed),
-        # proving the suppression path — not a silent skip — was exercised.
-        bad.emit_manual.assert_awaited_once_with({"total_tokens": 1})
+        hooks = MagicMock()
+        hooks.on_tool_end = AsyncMock(side_effect=RuntimeError("boom"))
+        # A best-effort hook raising must NOT propagate out of the loop driver.
+        await model._invoke_hook(hooks, "on_tool_end", None, None, None)
+        hooks.on_tool_end.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_invoke_hook_reraises_permission_denied(self):
+        from datus.tools.permission.permission_hooks import PermissionDeniedException
+
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        hooks = MagicMock()
+        hooks.on_tool_start = AsyncMock(side_effect=PermissionDeniedException("no"))
+        with pytest.raises(PermissionDeniedException):
+            await model._invoke_hook(hooks, "on_tool_start", None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_invoke_hook_noop_when_method_absent(self):
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        # Bare object without the method, and None hooks: both no-op silently.
+        await model._invoke_hook(SimpleNamespace(), "on_tool_end", None)
+        await model._invoke_hook(None, "on_tool_end", None)
+
+    @pytest.mark.asyncio
+    async def test_tool_lifecycle_hooks_fired_for_func_tool(self):
+        import json as _json
+
+        from datus.schemas.action_history import ActionHistoryManager
+
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        tool_block = _make_tool_use_block(name="list_tables", block_id="call_1", input_data={"db": "main"})
+        resp_tool = _make_response([tool_block])
+        resp_final = _make_response([_make_text_block("done")])
+        model.anthropic_client.messages.create.side_effect = [resp_tool, resp_final]
+
+        func_tool = MagicMock()
+        func_tool.name = "list_tables"
+        func_tool.description = "List tables"
+        func_tool.params_json_schema = {"type": "object"}
+        func_tool.on_invoke_tool = AsyncMock(return_value='["t1", "t2"]')
+
+        hooks = _make_recorder_hooks()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt="q",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                func_tools=[func_tool],
+                action_history_manager=ActionHistoryManager(),
+                hooks=hooks,
+            ):
+                pass
+
+        # on_tool_start: context carries the real arguments; tool exposes .name.
+        hooks.on_tool_start.assert_awaited_once()
+        ts_ctx, _agent, ts_tool = hooks.on_tool_start.await_args.args
+        assert _json.loads(ts_ctx.tool_arguments) == {"db": "main"}
+        assert ts_tool.name == "list_tables"
+        # on_tool_end: receives the func tool's raw structured return value.
+        hooks.on_tool_end.assert_awaited_once()
+        te_args = hooks.on_tool_end.await_args.args
+        assert te_args[3] == '["t1", "t2"]'
+        # on_tool_start fires BEFORE the tool actually runs.
+        assert hooks.on_tool_start.await_args_list  # sanity
+        func_tool.on_invoke_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_tool_lifecycle_hooks_fired_for_mcp_tool(self):
+        from datus.schemas.action_history import ActionHistoryManager
+
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        tool_block = _make_tool_use_block(name="read_data", block_id="call_m", input_data={"k": "v"})
+        resp_tool = _make_response([tool_block])
+        resp_final = _make_response([_make_text_block("done")])
+        model.anthropic_client.messages.create.side_effect = [resp_tool, resp_final]
+
+        mcp_tool = SimpleNamespace(
+            name="read_data",
+            description="d",
+            inputSchema={"type": "object", "properties": {}},
+            annotations=None,
+        )
+        tool_result = SimpleNamespace(content=[SimpleNamespace(text="rows")])
+        connected_server = MagicMock()
+        connected_server.list_tools = AsyncMock(return_value=[mcp_tool])
+        connected_server.call_tool = AsyncMock(return_value=tool_result)
+
+        hooks = _make_recorder_hooks()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={"srv": connected_server})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt="q",
+                mcp_servers={"srv": MagicMock()},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ActionHistoryManager(),
+                hooks=hooks,
+            ):
+                pass
+
+        hooks.on_tool_start.assert_awaited_once()
+        _ctx, _agent, ts_tool = hooks.on_tool_start.await_args.args
+        assert ts_tool.name == "read_data"  # the real MCP tool object, not a stub
+        hooks.on_tool_end.assert_awaited_once()
+        assert hooks.on_tool_end.await_args.args[3] == "rows"
+        connected_server.call_tool.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_denied_tool_aborts_native_loop(self):
+        """on_tool_start raising PermissionDeniedException must propagate out of
+        the generator and prevent the tool from running — mirroring the SDK
+        path, where a denied tool aborts the run instead of feeding the model a
+        tool_result."""
+        from datus.schemas.action_history import ActionHistoryManager, ActionStatus
+        from datus.tools.permission.permission_hooks import PermissionDeniedException
+
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        tool_block = _make_tool_use_block(name="list_tables", block_id="call_1")
+        resp_tool = _make_response([tool_block])
+        # Second response would only be reached if the loop kept going.
+        model.anthropic_client.messages.create.side_effect = [resp_tool, _make_response([_make_text_block("x")])]
+
+        func_tool = MagicMock()
+        func_tool.name = "list_tables"
+        func_tool.description = ""
+        func_tool.params_json_schema = {"type": "object"}
+        func_tool.on_invoke_tool = AsyncMock(return_value="result")
+
+        hooks = _make_recorder_hooks()
+        hooks.on_tool_start = AsyncMock(side_effect=PermissionDeniedException("denied"))
+
+        seen = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(PermissionDeniedException):
+                async for action in model._generate_with_mcp_stream(
+                    prompt="q",
+                    mcp_servers={},
+                    instruction="sys",
+                    output_type={},
+                    func_tools=[func_tool],
+                    action_history_manager=ActionHistoryManager(),
+                    hooks=hooks,
+                ):
+                    seen.append(action)
+
+        # Tool never executed; no SUCCESS completion emitted for the block.
+        func_tool.on_invoke_tool.assert_not_awaited()
+        assert not any(getattr(a, "status", None) == ActionStatus.SUCCESS and a.role.name == "TOOL" for a in seen)
+
+    @pytest.mark.asyncio
+    async def test_token_usage_via_standard_on_llm_end(self):
+        """Token usage flows through the standard on_llm_end hook: the loop hands
+        each response an SDK ``Usage`` snapshot via ``context.usage`` and never
+        falls back to the legacy ``emit_manual`` path."""
+        from datus.schemas.action_history import ActionHistoryManager
+
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        resp = _make_response([_make_text_block("hi")], input_tokens=120, output_tokens=30)
+        resp.usage.cache_read_input_tokens = 20
+        model.anthropic_client.messages.create.return_value = resp
+
+        captured = {}
+
+        async def _capture(ctx, agent, response):
+            captured["info"] = model._extract_usage_info(ctx.usage)
+
+        hooks = _make_recorder_hooks()
+        hooks.on_llm_end = AsyncMock(side_effect=_capture)
+
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt="q",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ActionHistoryManager(),
+                hooks=hooks,
+            ):
+                pass
+
+        hooks.on_llm_end.assert_awaited_once()
+        hooks.emit_manual.assert_not_called()
+        info = captured["info"]
+        # input_tokens folds the cache_read component back in (120 + 20).
+        assert info["input_tokens"] == 140
+        assert info["output_tokens"] == 30
+        assert info["cached_tokens"] == 20
+        assert info["last_call_input_tokens"] == 140
+        assert info["requests"] == 1
+
+    @pytest.mark.asyncio
+    async def test_on_start_and_on_end_fired_once(self):
+        from datus.schemas.action_history import ActionHistoryManager
+
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        model.anthropic_client.messages.create.return_value = _make_response([_make_text_block("hi")])
+
+        hooks = _make_recorder_hooks()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt="q",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                action_history_manager=ActionHistoryManager(),
+                hooks=hooks,
+            ):
+                pass
+
+        hooks.on_start.assert_awaited_once()
+        hooks.on_end.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_composite_permission_hook_denies_and_aborts(self):
+        """End-to-end: a real CompositeHooks wrapping a real PermissionHooks with
+        a DENY rule blocks the tool and propagates, while the token-usage hook
+        in the same composite still saw the LLM response."""
+        from datus.schemas.action_history import ActionHistoryManager
+        from datus.tools.permission.permission_config import PermissionConfig, PermissionLevel, PermissionRule
+        from datus.tools.permission.permission_hooks import CompositeHooks, PermissionDeniedException, PermissionHooks
+        from datus.tools.permission.permission_manager import PermissionManager
+        from datus.tools.registry.tool_registry import ToolRegistry
+
+        model = _make_claude_model(_make_model_config(use_native_api=True))
+        tool_block = _make_tool_use_block(name="list_tables", block_id="call_1")
+        model.anthropic_client.messages.create.side_effect = [
+            _make_response([tool_block]),
+            _make_response([_make_text_block("x")]),
+        ]
+
+        func_tool = MagicMock()
+        func_tool.name = "list_tables"
+        func_tool.description = ""
+        func_tool.params_json_schema = {"type": "object"}
+        func_tool.on_invoke_tool = AsyncMock(return_value="result")
+
+        registry = ToolRegistry({"list_tables": "db_tools"})
+        manager = PermissionManager(
+            global_config=PermissionConfig(
+                default_permission=PermissionLevel.ALLOW,
+                rules=[PermissionRule(tool="db_tools", pattern="list_tables", permission=PermissionLevel.DENY)],
+            )
+        )
+        perm = PermissionHooks(broker=MagicMock(), permission_manager=manager, node_name="chat", tool_registry=registry)
+        recorder = _make_recorder_hooks()
+        composite = CompositeHooks([perm, recorder])
+
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(PermissionDeniedException):
+                async for _ in model._generate_with_mcp_stream(
+                    prompt="q",
+                    mcp_servers={},
+                    instruction="sys",
+                    output_type={},
+                    func_tools=[func_tool],
+                    action_history_manager=ActionHistoryManager(),
+                    hooks=composite,
+                ):
+                    pass
+
+        func_tool.on_invoke_tool.assert_not_awaited()
+        # The composite still fanned the first LLM response out to the recorder.
+        recorder.on_llm_end.assert_awaited()
 
 
 class TestStoreNativeTurnUsage:


### PR DESCRIPTION
## Why

When using a Claude subscription OAuth token, the model is forced down the
native Anthropic SDK path (`_generate_with_mcp_stream`), which is not driven
by the openai-agents Runner. That loop only drove `TokenUsageHook` through a
bespoke `emit_manual` duck-typing path and skipped every other hook. As a
result, subscription users silently bypassed `PermissionHooks.on_tool_start`
(profile rules, filesystem-zone policy, user confirmation all inert — a
security gap), plus `CompactHook`/`GenerationHooks` `on_tool_end`.

## Solution

Drive the full `AgentHooks` lifecycle from the native loop so it matches the
SDK Runner path:

- Add `_invoke_hook(hooks, method, *args)` that calls the composed hook
  directly (`CompositeHooks` fans out). It re-raises `PermissionDeniedException`
  so a denied tool aborts the run (mirroring the SDK, where on_tool_start
  raising surfaces as a UserError), and swallows every other exception so a
  best-effort hook never crashes the loop.
- Fire `on_start` (baseline reset), `on_tool_start` (before each tool, ahead of
  the execution try/except so denials propagate), `on_tool_end`, `on_llm_end`,
  and `on_end`.
- Make token usage a standard hook: drop `_iter_token_usage_hooks` /
  `_reset_token_usage_hook` / `_emit_native_token_usage` / `emit_manual` usage;
  add `_build_sdk_usage` to fold Anthropic's separate cache counters into a real
  SDK `Usage`, driven through `on_llm_end`. `ClaudeModel` already inherits
  `_extract_usage_info`, so the standard pipeline parses it unchanged.

`_build_native_usage_info` is kept for the final action's usage field and
durable turn-usage persistence (non-hook concerns). `emit_manual` stays on
`TokenUsageHook` for other callers.

## Test Cases

`tests/unit_tests/models/test_claude_model.py`: new `TestNativeLoopHooks`
covering func/MCP `on_tool_start`/`on_tool_end`, denied-tool abort parity,
token usage via standard `on_llm_end` (no `emit_manual`), `on_start`/`on_end`,
and an end-to-end real `CompositeHooks` + `PermissionHooks` DENY case. Removed
the obsolete `TestNativeTokenUsageHooks` tests and repointed
`TestNativeTokenUsageStreaming` at the real model. All 95 module tests pass,
plus permission/token-usage suites (94).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Token-usage-only entries are now excluded from action history and replay output, ensuring cleaner transcript views.

* **Tests**
  * Added comprehensive test coverage for action history filtering and hook lifecycle execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token-usage-only entries are excluded from action history/replay, keeping transcripts focused on meaningful actions.

* **Refactor**
  * Improved streaming and usage reporting lifecycle for more consistent per-call usage aggregation and hook handling.

* **Tests**
  * Added tests verifying action history filtering, tool lifecycle hook behavior, and native-loop usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->