### PR TITLE
[Doc] Add AskMetrics documentation

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -491,28 +491,33 @@ flow_groups:
           - docs/knowledge_base/metrics.md
           - docs/subagent/gen_semantic_model.md
           - docs/subagent/gen_metrics.md
+          - docs/subagent/ask_metrics.md
           - docs/configuration/semantic_layer.md
         entrypoints:
           - CLI bootstrap
           - Gen semantic model subagent
           - Gen metrics subagent
+          - Ask metrics subagent
           - Extract-knowledge skill
           - Context search tools
         contracts:
           - Bootstrap and agentic generation persist semantic objects that are available to query-time retrieval.
           - Metrics and semantic models remain separable by kind and datasource scope, and extracted knowledge is captured as markdown via the extract-knowledge skill.
+          - Existing metrics can be queried through the metric-first AskMetrics subagent without falling back to raw SQL generation.
         coverage:
           pr_acceptance:
             status: covered
             nodeids:
               - tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
               - tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+              - tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
               - tests/unit_tests/tools/func_tool/test_context_search.py
           merge_queue:
             status: covered
             nodeids:
               - tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
               - tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+              - tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
               - tests/unit_tests/tools/func_tool/test_context_search.py
           nightly:
             status: covered

--- a/docs/subagent/ask_metrics.md
+++ b/docs/subagent/ask_metrics.md
@@ -1,0 +1,150 @@
+# AskMetrics Guide
+
+## Overview
+
+`ask_metrics` is a built-in metric question-answering subagent. It answers questions from existing semantic metrics instead of exploring raw tables or generating SQL.
+
+Use AskMetrics when the user asks for:
+
+- KPI values, such as "What was revenue last month?"
+- Metric trends, such as "How did shipped quantity change by month?"
+- Grouped metric results, such as "Revenue by region for Q1"
+- Metric attribution, such as "Which customer segment drove the revenue drop?"
+
+AskMetrics is intentionally narrow. If no existing metric can answer the question, it says so directly and does not fall back to raw SQL.
+
+## Prerequisites
+
+AskMetrics needs a configured semantic layer and published metrics.
+
+For MetricFlow, configure the semantic adapter in `agent.yml`:
+
+```yaml
+agent:
+  services:
+    semantic_layer:
+      metricflow: {}
+```
+
+See [Semantic Layer Configuration](../configuration/semantic_layer.md) for full semantic adapter options.
+
+Metrics can come from existing MetricFlow YAML or from the [Generate Metrics](gen_metrics.md) subagent. A metric subject tree is optional, but recommended because AskMetrics uses it as a routing catalog before searching.
+
+## Quick Start
+
+Start Datus with the datasource that owns the metrics:
+
+```bash
+datus --datasource production
+```
+
+Ask a metric question through the built-in subagent:
+
+```bash
+/ask_metrics What was total revenue last month by customer segment?
+```
+
+The main chat agent can also delegate to AskMetrics automatically through `task(type="ask_metrics")` when the question is metric-first. Web/API callers can route directly by using `subagent_id: "ask_metrics"`.
+
+AskMetrics is scoped to the current datasource. If the user asks for another datasource, switch datasource first and ask again.
+
+## How It Works
+
+AskMetrics follows a metric-first workflow:
+
+```mermaid
+graph LR
+    A[User metric question] --> B[Match subject tree]
+    B --> C{Direct metric match?}
+    C -->|Yes| D[Use metric name and path]
+    C -->|No| E[Search metrics]
+    D --> F[Get dimensions when needed]
+    E --> F
+    F --> G[Query metrics]
+    G --> H{Attribution question?}
+    H -->|Yes| I[Run attribution analysis]
+    H -->|No| J[Return Markdown answer]
+    I --> J
+```
+
+Key behavior:
+
+- Direct subject-tree matches are preferred over search.
+- `search_metrics` is used only when the subject tree is missing, partial, or ambiguous.
+- `get_dimensions` is called before grouping, filtering, or attribution.
+- `query_metrics` is the primary tool for metric values.
+- `attribution_analyze` is used for change explanation and contribution questions.
+- Raw SQL tools are not part of the default AskMetrics surface.
+
+## Default Tools
+
+| Tool | Purpose |
+|------|---------|
+| `context_search_tools.search_metrics` | Find candidate metrics when direct subject-tree matching is not enough |
+| `context_search_tools.get_metrics` | Retrieve details for a known metric and subject path |
+| `context_search_tools.list_subject_tree` | List metric subject paths when the startup subject tree is too large to inline |
+| `semantic_tools.list_metrics` | Enumerate executable metrics from the semantic adapter |
+| `semantic_tools.get_dimensions` | Discover valid dimensions for grouping, filtering, and attribution |
+| `semantic_tools.query_metrics` | Query metric values |
+| `semantic_tools.attribution_analyze` | Explain metric movement across candidate dimensions |
+
+If the semantic adapter is unavailable, AskMetrics is unavailable because it cannot safely answer metric questions. If context search is unavailable, AskMetrics can still use semantic adapter tools, but it will not have subject-tree routing context.
+
+## Output
+
+AskMetrics returns a concise Markdown report with:
+
+- the interpreted question and time range
+- the metric names used
+- the result values from metric tools
+- attribution findings when attribution was run
+- limitations when the question cannot be answered with existing metrics
+
+It does not return raw SQL and does not invent metric values.
+
+## Configuration
+
+The built-in `ask_metrics` subagent works out of the box once the semantic adapter is configured. You can override model and turn budget:
+
+```yaml
+agent:
+  agentic_nodes:
+    ask_metrics:
+      model: claude
+      max_turns: 12
+      semantic_adapter: metricflow
+      subject_tree_prompt_limit: 100
+```
+
+### Custom AskMetrics Agents
+
+Use `type: ask_metrics` to create a custom metric QA agent with its own name, prompt template, or tool allowlist:
+
+```yaml
+agent:
+  agentic_nodes:
+    sales_metric_qa:
+      type: ask_metrics
+      model: claude
+      max_turns: 12
+      prompt_version: "1.0"
+      tools: "context_search_tools.search_metrics,context_search_tools.get_metrics,semantic_tools.get_dimensions,semantic_tools.query_metrics"
+      subject_tree_prompt_limit: 50
+      agent_description: "Answer sales metric questions using the sales semantic layer."
+```
+
+When `system_prompt` is omitted, Datus first looks for a prompt template matching the custom agent name, such as `sales_metric_qa_system_1.0.j2`, then falls back to the built-in `ask_metrics_system` template.
+
+`tools` can be a comma-separated string or a list. The default surface is metric-focused. Custom agents can opt into other user-facing tool categories when needed, but keeping AskMetrics metric-only produces more deterministic answers.
+
+## When Not To Use AskMetrics
+
+Use another subagent when the task is not answerable through existing semantic metrics:
+
+| Need | Use |
+|------|-----|
+| Generate new metric definitions from SQL | [gen_metrics](gen_metrics.md) |
+| Generate or fix SQL over raw tables | [gen_sql](builtin_subagents.md#gen_sql) |
+| Explore schemas, samples, or reference context | [explore](builtin_subagents.md#explore) |
+| Build a visual report artifact | [gen_visual_report](gen_visual_report.md) |
+| Create a dashboard in BI tools | [gen_dashboard](gen_dashboard.md) |

--- a/docs/subagent/ask_metrics.zh.md
+++ b/docs/subagent/ask_metrics.zh.md
@@ -1,0 +1,150 @@
+# AskMetrics 指南
+
+## 概览
+
+`ask_metrics` 是内置的指标问答 subagent。它基于已有语义指标回答问题，不探索原始表，也不生成 SQL。
+
+适合使用 AskMetrics 的问题包括：
+
+- KPI 数值，例如“上个月收入是多少？”
+- 指标趋势，例如“发货数量按月如何变化？”
+- 按维度分组的指标结果，例如“Q1 各地区收入”
+- 指标归因，例如“哪个客户分群导致收入下降？”
+
+AskMetrics 的能力边界刻意保持较窄。如果没有现有指标能够回答问题，它会直接说明原因，不会退回到原始 SQL 查询。
+
+## 前置条件
+
+AskMetrics 需要已配置的语义层和已发布的指标。
+
+以 MetricFlow 为例，在 `agent.yml` 中配置语义层：
+
+```yaml
+agent:
+  services:
+    semantic_layer:
+      metricflow: {}
+```
+
+完整配置见 [语义层配置](../configuration/semantic_layer.zh.md)。
+
+指标可以来自已有 MetricFlow YAML，也可以由 [Generate Metrics](gen_metrics.zh.md) subagent 生成。主题树不是必需的，但建议使用，因为 AskMetrics 会先把主题树作为指标路由目录，再决定是否搜索指标。
+
+## 快速开始
+
+使用包含指标的 datasource 启动 Datus：
+
+```bash
+datus --datasource production
+```
+
+通过内置 subagent 提问：
+
+```bash
+/ask_metrics What was total revenue last month by customer segment?
+```
+
+主 chat agent 也可以在识别到 metric-first 问题时，通过 `task(type="ask_metrics")` 自动委派给 AskMetrics。Web/API 调用方可以使用 `subagent_id: "ask_metrics"` 直接路由。
+
+AskMetrics 只作用于当前 datasource。如果用户询问其他 datasource，请先切换 datasource 再提问。
+
+## 工作方式
+
+AskMetrics 遵循 metric-first 工作流：
+
+```mermaid
+graph LR
+    A[用户指标问题] --> B[匹配主题树]
+    B --> C{直接命中指标?}
+    C -->|是| D[使用指标名和路径]
+    C -->|否| E[搜索指标]
+    D --> F[必要时获取维度]
+    E --> F
+    F --> G[查询指标]
+    G --> H{是否为归因问题?}
+    H -->|是| I[运行归因分析]
+    H -->|否| J[返回 Markdown 答案]
+    I --> J
+```
+
+关键行为：
+
+- 优先使用主题树中的直接指标匹配，而不是搜索。
+- 只有在主题树缺失、不完整或存在歧义时才使用 `search_metrics`。
+- 分组、过滤或归因前会先调用 `get_dimensions`。
+- `query_metrics` 是查询指标值的主要工具。
+- 变化解释和贡献分析问题使用 `attribution_analyze`。
+- 默认工具面不包含原始 SQL 工具。
+
+## 默认工具
+
+| 工具 | 用途 |
+|------|------|
+| `context_search_tools.search_metrics` | 当主题树无法直接匹配时搜索候选指标 |
+| `context_search_tools.get_metrics` | 获取已知主题路径和指标名的指标详情 |
+| `context_search_tools.list_subject_tree` | 当启动时主题树过大、只能内联部分内容时列出指标主题路径 |
+| `semantic_tools.list_metrics` | 从语义适配器列出可执行指标 |
+| `semantic_tools.get_dimensions` | 发现可用于分组、过滤和归因的维度 |
+| `semantic_tools.query_metrics` | 查询指标值 |
+| `semantic_tools.attribution_analyze` | 按候选维度解释指标变化 |
+
+如果语义适配器不可用，AskMetrics 会不可用，因为它无法安全回答指标问题。如果上下文搜索不可用，AskMetrics 仍可使用语义适配器工具，但不会有主题树路由上下文。
+
+## 输出
+
+AskMetrics 返回简洁的 Markdown 报告，包含：
+
+- 解释后的问题和时间范围
+- 使用的指标名
+- 指标工具返回的结果值
+- 执行归因时的归因结论
+- 无法通过现有指标回答时的限制说明
+
+它不会返回原始 SQL，也不会编造指标值。
+
+## 配置
+
+配置语义适配器后，内置 `ask_metrics` subagent 即可使用。你可以覆盖模型和轮数：
+
+```yaml
+agent:
+  agentic_nodes:
+    ask_metrics:
+      model: claude
+      max_turns: 12
+      semantic_adapter: metricflow
+      subject_tree_prompt_limit: 100
+```
+
+### 自定义 AskMetrics Agent
+
+使用 `type: ask_metrics` 可以创建具有独立名称、提示词模板或工具 allowlist 的自定义指标问答 agent：
+
+```yaml
+agent:
+  agentic_nodes:
+    sales_metric_qa:
+      type: ask_metrics
+      model: claude
+      max_turns: 12
+      prompt_version: "1.0"
+      tools: "context_search_tools.search_metrics,context_search_tools.get_metrics,semantic_tools.get_dimensions,semantic_tools.query_metrics"
+      subject_tree_prompt_limit: 50
+      agent_description: "Answer sales metric questions using the sales semantic layer."
+```
+
+如果省略 `system_prompt`，Datus 会先查找与自定义 agent 名称匹配的模板，例如 `sales_metric_qa_system_1.0.j2`，找不到时再回退到内置 `ask_metrics_system` 模板。
+
+`tools` 可以是逗号分隔字符串，也可以是列表。默认工具面聚焦指标。自定义 agent 可以按需选择其他用户可见工具类别，但保持 AskMetrics 仅使用指标工具通常能得到更稳定的回答。
+
+## 不适合使用 AskMetrics 的场景
+
+当任务无法通过现有语义指标回答时，请使用其他 subagent：
+
+| 需求 | 使用 |
+|------|------|
+| 从 SQL 生成新的指标定义 | [gen_metrics](gen_metrics.zh.md) |
+| 生成或修复原始表 SQL | [gen_sql](builtin_subagents.zh.md#gen_sql) |
+| 探索 schema、样本或参考上下文 | [explore](builtin_subagents.zh.md#explore) |
+| 构建可视化报告 artifact | [gen_visual_report](gen_visual_report.zh.md) |
+| 在 BI 工具中创建 dashboard | [gen_dashboard](gen_dashboard.zh.md) |

--- a/docs/subagent/builtin_subagents.md
+++ b/docs/subagent/builtin_subagents.md
@@ -4,20 +4,21 @@
 
 The **Builtin Subagent** are specialized AI assistants integrated within the Datus Agent system. Each subagent focuses on a specific aspect of data engineering automation — analyzing SQL, generating semantic models, and converting queries into reusable metrics — together forming a closed-loop workflow from raw SQL to knowledge-aware data products.
 
-This document covers twelve core subagents:
+This document covers thirteen core subagents:
 
 1. **[gen_sql_summary](#gen_sql_summary)** — Summarizes and classifies SQL queries
 2. **[gen_semantic_model](#gen_semantic_model)** — Generates MetricFlow semantic models
 3. **[gen_metrics](#gen_metrics)** — Generates MetricFlow metric definitions
-4. **[explore](#explore)** — Read-only data exploration and context gathering
-5. **[gen_sql](#gen_sql)** — Specialized SQL generation with deep expertise
-6. **[gen_report](#gen_report)** — Flexible report generation with configurable tools
-7. **[gen_table](gen_table.md)** — Database table creation via CTAS or natural language
-8. **[gen_job](gen_job.md)** — Data pipeline execution (single-database ETL AND cross-database migration with reconciliation)
-9. **[gen_skill](#gen_skill)** — Skill creation and optimization
-10. **[gen_dashboard](#gen_dashboard)** — BI dashboard CRUD for Superset and Grafana
-11. **[gen_visual_report](gen_visual_report.md)** — Self-contained visual report under `reports/<slug>/`
-12. **[scheduler](#scheduler)** — Airflow job lifecycle management
+4. **[ask_metrics](ask_metrics.md)** — Answers KPI, trend, grouped metric, and attribution questions from existing semantic metrics
+5. **[explore](#explore)** — Read-only data exploration and context gathering
+6. **[gen_sql](#gen_sql)** — Specialized SQL generation with deep expertise
+7. **[gen_report](#gen_report)** — Flexible report generation with configurable tools
+8. **[gen_table](gen_table.md)** — Database table creation via CTAS or natural language
+9. **[gen_job](gen_job.md)** — Data pipeline execution (single-database ETL AND cross-database migration with reconciliation)
+10. **[gen_skill](#gen_skill)** — Skill creation and optimization
+11. **[gen_dashboard](#gen_dashboard)** — BI dashboard CRUD for Superset and Grafana
+12. **[gen_visual_report](gen_visual_report.md)** — Self-contained visual report under `reports/<slug>/`
+13. **[scheduler](#scheduler)** — Airflow job lifecycle management
 
 ## Configuration
 
@@ -33,6 +34,10 @@ agent:
     gen_metrics:
       model: claude     # Optional: defaults to configured model
       max_turns: 30     # Optional: defaults to 30
+
+    ask_metrics:
+      model: claude     # Optional: defaults to configured model
+      max_turns: 12     # Optional: defaults to 12
 
     gen_sql_summary:
       model: deepseek   # Optional: defaults to configured model
@@ -1027,6 +1032,7 @@ agent:
 | `gen_sql_summary` | Summarize and classify SQL queries | YAML (SQL summary) | `/data/reference_sql` | Subject tree categorization, auto context retrieval |
 | `gen_semantic_model` | Generate semantic model from tables | YAML (semantic model) | `/data/semantic_models` | DDL to MetricFlow model, built-in validation |
 | `gen_metrics` | Generate metrics from SQL | YAML (metric) | `/data/semantic_models` | SQL to MetricFlow metric, subject tree support |
+| `ask_metrics` | Answer existing metric questions | Markdown report | N/A | KPI values, trends, grouped results, attribution, no raw SQL fallback |
 | `explore` | Read-only data exploration | Structured context | N/A | Strictly read-only, fast turn budget, three exploration directions |
 | `gen_sql` | Generate optimized SQL | SQL query / SQL file | N/A | Deep SQL expertise, auto-validation, file-based output |
 | `gen_report` | Flexible report generation | Structured report | N/A | Configurable tools, extensible, custom report subagents |

--- a/docs/subagent/builtin_subagents.zh.md
+++ b/docs/subagent/builtin_subagents.zh.md
@@ -1031,7 +1031,7 @@ agent:
 | `gen_sql_summary` | 总结和分类 SQL 查询 | YAML（SQL 摘要） | `/data/reference_sql` | 主题树分类、自动上下文检索 |
 | `gen_semantic_model` | 从表生成语义模型 | YAML（语义模型） | `/data/semantic_models` | DDL 到 MetricFlow 模型、内置验证 |
 | `gen_metrics` | 从 SQL 生成指标 | YAML（指标） | `/data/semantic_models` | SQL 到 MetricFlow 指标、主题树支持 |
-| `ask_metrics` | 回答已有指标问题 | Markdown 报告 | N/A | KPI 数值、趋势、分组结果、归因分析，不退回原始 SQL |
+| `ask_metrics` | 回答已有指标问题 | Markdown 报告 | N/A | KPI 数值、趋势、分组结果、归因分析、不退回原始 SQL |
 | `explore` | 只读数据探索 | 结构化上下文 | N/A | 严格只读、低轮数、三方向探索 |
 | `gen_sql` | 生成优化 SQL | SQL 查询 / SQL 文件 | N/A | 深度 SQL 专长、自动验证、支持文件输出 |
 | `gen_report` | 灵活报告生成 | 结构化报告 | N/A | 工具可配置、可扩展、自定义报告 subagent |

--- a/docs/subagent/builtin_subagents.zh.md
+++ b/docs/subagent/builtin_subagents.zh.md
@@ -4,20 +4,21 @@
 
 **内置 Subagent**  是集成在 Datus Agent 系统中的专用 AI 助手。每个subagent专注于数据工程自动化的特定方面——分析 SQL、生成语义模型、将查询转换为可复用指标——共同构成从原始 SQL 到具备知识感知的数据产品的闭环工作流。
 
-本文档涵盖十二个核心 subagent：
+本文档涵盖十三个核心 subagent：
 
 1. **[gen_sql_summary](#gen_sql_summary)** — 总结和分类 SQL 查询
 2. **[gen_semantic_model](#gen_semantic_model)** — 生成 MetricFlow 语义模型
 3. **[gen_metrics](#gen_metrics)** — 生成 MetricFlow 指标定义
-4. **[explore](#explore)** — 只读数据探索和上下文收集
-5. **[gen_sql](#gen_sql)** — 具备深度专业知识的专用 SQL 生成
-6. **[gen_report](#gen_report)** — 灵活的报告生成，支持可配置工具
-7. **[gen_table](gen_table.zh.md)** — 数据库建表（CTAS 或自然语言描述）
-8. **[gen_job](gen_job.zh.md)** — 数据管道执行（单库 ETL 和跨库迁移，含对数校验）
-9. **[gen_skill](#gen_skill)** — skill 创建与优化
-10. **[gen_dashboard](#gen_dashboard)** — Superset 和 Grafana 的 BI 仪表盘 CRUD
-11. **[gen_visual_report](gen_visual_report.zh.md)** — 在 `reports/<slug>/` 下产出自包含的可视化报告
-12. **[scheduler](#scheduler)** — Airflow 作业生命周期管理
+4. **[ask_metrics](ask_metrics.zh.md)** — 基于已有语义指标回答 KPI、趋势、分组指标和归因问题
+5. **[explore](#explore)** — 只读数据探索和上下文收集
+6. **[gen_sql](#gen_sql)** — 具备深度专业知识的专用 SQL 生成
+7. **[gen_report](#gen_report)** — 灵活的报告生成，支持可配置工具
+8. **[gen_table](gen_table.zh.md)** — 数据库建表（CTAS 或自然语言描述）
+9. **[gen_job](gen_job.zh.md)** — 数据管道执行（单库 ETL 和跨库迁移，含对数校验）
+10. **[gen_skill](#gen_skill)** — skill 创建与优化
+11. **[gen_dashboard](#gen_dashboard)** — Superset 和 Grafana 的 BI 仪表盘 CRUD
+12. **[gen_visual_report](gen_visual_report.zh.md)** — 在 `reports/<slug>/` 下产出自包含的可视化报告
+13. **[scheduler](#scheduler)** — Airflow 作业生命周期管理
 
 ## 配置
 
@@ -33,6 +34,10 @@ agent:
     gen_metrics:
       model: claude     # 可选：默认使用已配置的模型
       max_turns: 30     # 可选：默认为 30
+
+    ask_metrics:
+      model: claude     # 可选：默认使用已配置的模型
+      max_turns: 12     # 可选：默认为 12
 
     gen_sql_summary:
       model: deepseek   # 可选：默认使用已配置的模型
@@ -1026,6 +1031,7 @@ agent:
 | `gen_sql_summary` | 总结和分类 SQL 查询 | YAML（SQL 摘要） | `/data/reference_sql` | 主题树分类、自动上下文检索 |
 | `gen_semantic_model` | 从表生成语义模型 | YAML（语义模型） | `/data/semantic_models` | DDL 到 MetricFlow 模型、内置验证 |
 | `gen_metrics` | 从 SQL 生成指标 | YAML（指标） | `/data/semantic_models` | SQL 到 MetricFlow 指标、主题树支持 |
+| `ask_metrics` | 回答已有指标问题 | Markdown 报告 | N/A | KPI 数值、趋势、分组结果、归因分析，不退回原始 SQL |
 | `explore` | 只读数据探索 | 结构化上下文 | N/A | 严格只读、低轮数、三方向探索 |
 | `gen_sql` | 生成优化 SQL | SQL 查询 / SQL 文件 | N/A | 深度 SQL 专长、自动验证、支持文件输出 |
 | `gen_report` | 灵活报告生成 | 结构化报告 | N/A | 工具可配置、可扩展、自定义报告 subagent |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Customized subagents: subagent/customized_subagent.md
       - Generate Dashboard: subagent/gen_dashboard.md
       - Generate Metrics: subagent/gen_metrics.md
+      - Ask Metrics: subagent/ask_metrics.md
       - Generate Semantic Model: subagent/gen_semantic_model.md
       - Scheduler: subagent/scheduler.md
       - Generate SQL Summary: subagent/gen_sql_summary.md
@@ -126,6 +127,7 @@ plugins:
             Customized subagents: 自定义 subagent
             Generate Dashboard: 生成 Dashboard
             Generate Metrics: 生成指标
+            Ask Metrics: 指标问答
             Generate Semantic Model: 生成语义模型
             Scheduler: 调度器
             Chatbot: chatbot


### PR DESCRIPTION
## Summary
- Add English and Chinese AskMetrics subagent documentation.
- Link AskMetrics from the Subagent navigation and built-in subagent summary pages.

## Validation
- git diff --check
- uv run mkdocs build --strict

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
## Summary by CodeRabbit

* **Documentation**
  * Added new documentation for the `ask_metrics` subagent, including quick start guides, configuration options, feature descriptions, and usage recommendations
  * Updated subagent overview documentation and site navigation to include the new subagent
  * Documentation and navigation provided in both English and Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added user-facing documentation for the new Ask Metrics subagent: quick start, metric-first workflow, default toolset, configuration overrides, output characteristics, and guidance on when to use other subagents
  * Updated subagent overview pages and site navigation to include Ask Metrics
  * Documentation provided in both English and Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->