### PR TITLE
[Doc] Gate GA4 docs analytics to docs.datus.ai only

### DIFF
--- a/docs/javascripts/analytics.js
+++ b/docs/javascripts/analytics.js
@@ -1,0 +1,41 @@
+(function () {
+  var GA_ID = "G-8HMXHZDV7F";
+  var allowedHost = "docs.datus.ai";
+
+  // Only load GA4 on the production docs host. This keeps localhost,
+  // 127.0.0.1, and *.github.io preview/developer traffic out of GA4.
+  if (window.location.hostname !== allowedHost) {
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    window.dataLayer.push(arguments);
+  }
+  window.gtag = gtag;
+
+  var script = document.createElement("script");
+  script.async = true;
+  script.src = "https://www.googletagmanager.com/gtag/js?id=" + GA_ID;
+  document.head.appendChild(script);
+
+  gtag("js", new Date());
+  gtag("config", GA_ID, {
+    page_title: document.title,
+    page_location: window.location.href,
+    page_path: window.location.pathname + window.location.search
+  });
+
+  // Material for MkDocs uses instant navigation; re-send a page_view on each
+  // client-side navigation so page_location / page_path stay accurate and the
+  // "(not set)" landing-page rate stays low.
+  if (window.document$ && window.location$) {
+    window.location$.subscribe(function (url) {
+      gtag("config", GA_ID, {
+        page_title: document.title,
+        page_location: window.location.href,
+        page_path: url.pathname + url.search
+      });
+    });
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,9 +218,12 @@ edit_uri: !ENV [DOCS_EDIT_URI, "edit/main/docs/"]
 extra:
   version:
     provider: mike
-  analytics:
-    provider: google
-    property: G-8HMXHZDV7F
+  # GA4 is loaded via docs/javascripts/analytics.js instead of the built-in
+  # Material analytics, so it only fires on docs.datus.ai (excludes localhost /
+  # 127.0.0.1 / *.github.io developer & preview traffic).
+  # analytics:
+  #   provider: google
+  #   property: G-8HMXHZDV7F
 
   alternate:
     - name: English
@@ -288,3 +291,6 @@ markdown_extensions:
 
 extra_css:
   - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/analytics.js


### PR DESCRIPTION
## Why

GA4 for the docs site is currently configured through MkDocs Material's built-in analytics:

```yaml
extra:
  analytics:
    provider: google
    property: G-8HMXHZDV7F
```

This injects the gtag snippet **unconditionally on every host**. As a result, GA4 receives traffic from local previews (`localhost`, `127.0.0.1`) and GitHub Pages preview builds (`*.github.io`), polluting the reports with internal/developer traffic. We want only real production traffic on `docs.datus.ai` to be counted.

## Solution

Replace the built-in analytics with a custom, host-gated loader:

1. **`mkdocs.yml`** — comment out the built-in `extra.analytics` block (kept as documentation of where GA lives now). `version`, `alternate`, and `social` are untouched.
2. **`docs/javascripts/analytics.js`** (new) — loads GA4 only when `window.location.hostname === "docs.datus.ai"`; otherwise returns early. On the production host it injects gtag and sends `config` with explicit `page_title` / `page_location` / `page_path`, and re-sends a page_view on Material's instant navigation via the `location$` observable (reduces the GA4 "(not set)" landing-page rate).
3. **`mkdocs.yml`** — register the script via `extra_javascript`.

Net effect after publish: `localhost`, `127.0.0.1`, and `*.github.io` no longer send GA4 hits; only `docs.datus.ai` does, with controlled page params.

Recommended complement (out of scope for this PR, GA4 Admin side): also define **internal/developer traffic** + a Data Filter in GA4 so future stray non-prod sources are excluded server-side.

## Test Cases

No automated tests — this is a docs-build/static-asset change. Verified locally:

- `mkdocs build` succeeds with no errors.
- Generated HTML contains **no** built-in Material GA injection (`gtag/js?id=...`, `__md_analytics`, unconditional `"config", "G-..."` all absent).
- `javascripts/analytics.js` is referenced in all 168 generated HTML pages and copied to `site/javascripts/analytics.js`.
- (Pre-existing `--strict` warnings about `skills.md` missing image assets are unrelated to this change.)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [x] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured Google Analytics 4 tracking for the documentation site, restricted to the production environment only to exclude local development traffic from analytics data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->