### PR TITLE
[Doc] Document datus upgrade command and drop the update alias

### DIFF
--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -22,7 +22,13 @@ logger = get_logger(__name__)
 class ArgumentParser:
     def __init__(self):
         self.parser = argparse.ArgumentParser(
-            description="Datus: Data engineering agent builds evolvable context for your data system"
+            description="Datus: Data engineering agent builds evolvable context for your data system",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=(
+                "subcommands:\n"
+                "  upgrade            Upgrade datus-agent and installed datus-* packages to the latest release\n"
+                "  upgrade --check    Report the latest version without installing"
+            ),
         )
         self._setup_arguments()
 
@@ -243,8 +249,8 @@ class Application:
         elif args.web:
             self._run_web_interface(args)
         else:
-            # Import lazily so the 'upgrade'/'update' interceptor in main() can run
-            # even when datus.cli.repl is broken (the whole point of self-upgrade).
+            # Import lazily so the 'upgrade' interceptor in main() can run even
+            # when datus.cli.repl is broken (the whole point of self-upgrade).
             from datus.cli.repl import DatusCLI
 
             cli = DatusCLI(args)
@@ -509,10 +515,10 @@ def main():
     import signal
     import sys
 
-    # Intercept 'upgrade'/'update' subcommand: self-upgrade datus-agent and the
-    # installed datus-* adapter packages. Handled before the REPL is built so it
-    # works even when the installed CLI is otherwise broken.
-    if len(sys.argv) > 1 and sys.argv[1] in ("upgrade", "update"):
+    # Intercept 'upgrade' subcommand: self-upgrade datus-agent and the installed
+    # datus-* adapter packages. Handled before the REPL is built so it works even
+    # when the installed CLI is otherwise broken.
+    if len(sys.argv) > 1 and sys.argv[1] == "upgrade":
         from datus.cli.upgrade_cli import run_upgrade_command
 
         configure_logging(False, console_output=False)

--- a/datus/cli/upgrade_cli.py
+++ b/datus/cli/upgrade_cli.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Non-REPL handler for the ``datus upgrade`` / ``datus update`` subcommand.
+"""Non-REPL handler for the ``datus upgrade`` subcommand.
 
 Lists the ``datus-*`` packages installed in the active interpreter and
 upgrades them to the latest release in a single ``uv``/``pip`` run. Lives

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -84,3 +84,22 @@ datus-agent bootstrap-kb --datasource my_duckdb --components metadata
 The old database-selection flag is no longer accepted by the current CLI; use `--datasource`.
 
 ---
+
+## Self-Upgrade
+
+### `datus upgrade`
+
+Upgrade `datus-agent` and every installed `datus-*` adapter package to the
+latest release in one `uv` / `pip` run. Third-party dependencies are bumped only
+when a new datus release requires it; editable / source (`git`) checkouts are
+skipped. Add `--check` to report the latest version without installing.
+
+```bash
+datus upgrade
+datus upgrade --check
+```
+
+On an interactive launch, `datus` also prints a one-line hint when a newer
+release is available. Set `DATUS_DISABLE_VERSION_CHECK=1` to silence it.
+
+---


### PR DESCRIPTION
Remove the undocumented `update` alias for the self-upgrade subcommand so `datus upgrade` is the single entry point, and add a short reference for #949.

- main.py: intercept only `upgrade` (was `upgrade`/`update`); refresh comments
- upgrade_cli.py: drop `datus update` from the module docstring
- docs/cli-commands.md: add a Self-Upgrade section covering upgrade scope, --check, and the startup version notice

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [x] release/0.3.4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for `update` subcommand; standardized on `upgrade` command only.

* **Documentation**
  * Added Self-Upgrade section documenting the `upgrade` command, including upgrade behavior for core and adapter packages, handling of editable/source installations, and the `--check` option to view available versions without installing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->