### PR TITLE
[Doc] Document orchestrator tools

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -167,29 +167,38 @@ flow_groups:
           - docs/cli/model_command.md
           - docs/cli/language_command.md
           - docs/cli/effort_command.md
+          - docs/cli/orchestrator_tools.md
           - docs/cli/plan_mode.md
           - docs/configuration/compact.md
         entrypoints:
           - "CLI: datus"
+          - "CLI print mode: --orchestrator-tools with --proxy_tools orchestrator_tools.*"
           - "CLI slash commands: /model, /language, /effort"
         contracts:
           - Documented CLI command routing remains stable.
           - Model, language, and effort overrides are accepted and persisted through the CLI layer.
+          - Print mode can expose orchestrator lifecycle tools and proxy them externally without tracker credentials in Datus-agent.
         coverage:
           pr_acceptance:
             status: covered
             nodeids:
               - tests/unit_tests/cli/test_core_entrypoint_acceptance.py
+              - tests/unit_tests/cli/test_main.py
+              - tests/unit_tests/cli/test_print_mode.py
               - tests/unit_tests/cli/test_model_commands.py
               - tests/unit_tests/cli/test_language_commands.py
               - tests/unit_tests/cli/test_effort_commands.py
+              - tests/unit_tests/tools/func_tool/test_orchestrator_tools.py
           merge_queue:
             status: covered
             nodeids:
               - tests/unit_tests/cli/test_core_entrypoint_acceptance.py
+              - tests/unit_tests/cli/test_main.py
+              - tests/unit_tests/cli/test_print_mode.py
               - tests/unit_tests/cli/test_model_commands.py
               - tests/unit_tests/cli/test_language_commands.py
               - tests/unit_tests/cli/test_effort_commands.py
+              - tests/unit_tests/tools/func_tool/test_orchestrator_tools.py
           nightly:
             status: covered
             nodeids:

--- a/docs/cli/orchestrator_tools.md
+++ b/docs/cli/orchestrator_tools.md
@@ -1,0 +1,114 @@
+# Orchestrator Tools
+
+`--orchestrator-tools` exposes issue lifecycle tools in CLI print mode. It is intended for an external orchestrator that runs Datus as a worker while the orchestrator owns tracker credentials, issue status changes, operator questions, and final task reporting.
+
+The flag does not make Datus call GitHub, Jira, Linear, or any other tracker directly. It registers a small `orchestrator_tools` tool category on the agent. In production, those tools should be proxied back to the orchestrator with `--proxy_tools orchestrator_tools.*`.
+
+## When To Use
+
+Use orchestrator tools when:
+
+- An external runtime invokes Datus with `--print` for one issue or task.
+- The model should be able to request issue comments, status moves, human input, or final mission reporting.
+- Tracker credentials should stay outside Datus-agent.
+- The orchestrator already consumes print-mode JSON lines and can answer proxied tool calls through stdin.
+
+Do not use this flag for normal interactive CLI sessions. `--orchestrator-tools` requires `--print`; using it without print mode is a CLI error.
+
+## Basic Usage
+
+```bash
+datus --datasource analytics \
+  --print "Investigate issue DAT-123 and report the fix status." \
+  --orchestrator-tools \
+  --proxy_tools orchestrator_tools.*
+```
+
+The proxy flag is spelled `--proxy_tools` with an underscore. `--orchestrator-tools` is attached before proxying, so `orchestrator_tools.*` can match the newly registered tools.
+
+For local debugging, you can omit `--proxy_tools`:
+
+```bash
+datus --datasource analytics \
+  --print "Summarize what you would report to the issue." \
+  --orchestrator-tools
+```
+
+In that mode the tools are visible to the model, but each call returns `success: 0` with an error saying the call must be proxied. This verifies prompt and tool selection behavior without touching a tracker.
+
+## Available Tools
+
+| Tool | Purpose | Key arguments |
+|------|---------|---------------|
+| `create_issue_comment` | Ask the orchestrator to append a Markdown comment to the current issue | `body`, optional `issue_id` |
+| `update_issue_status` | Ask the orchestrator to move an issue to a tracker status | `status`, optional `issue_id` |
+| `request_human_input` | Ask the operator for a decision or missing input | `question`, optional `issue_id`, optional `next_status` |
+| `mark_blocked` | Report a concrete blocker that prevents completion | `reason`, optional `issue_id`, optional `next_status`, optional `artifacts`, optional `validation` |
+| `finish_mission` | Report the final task outcome to the orchestrator | `outcome`, `summary`, optional `issue_id`, optional `next_status`, optional `artifacts`, optional `validation` |
+
+`finish_mission.outcome` should be one of:
+
+- `completed`
+- `needs_review`
+- `blocked`
+- `failed`
+
+`artifacts` and `validation` are lists of structured objects. Their exact shape belongs to the orchestrator contract; Datus passes them through.
+
+## Proxy Protocol
+
+Print mode writes one `MessagePayload` JSON object per stdout line. When a proxied orchestrator tool is called, the orchestrator sees a `call-tool` content item:
+
+```json
+{
+  "message_id": "tool_123",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "call-tool",
+      "payload": {
+        "callToolId": "tool_123",
+        "toolName": "finish_mission",
+        "toolParams": {
+          "outcome": "completed",
+          "summary": "Docs updated and validation passed.",
+          "next_status": "In Review"
+        }
+      }
+    }
+  ]
+}
+```
+
+The orchestrator executes the tracker-side operation, then writes a `call-tool-result` JSON line to stdin with the same `callToolId`:
+
+```json
+{
+  "message_id": "tool_123_result",
+  "role": "user",
+  "content": [
+    {
+      "type": "call-tool-result",
+      "payload": {
+        "callToolId": "tool_123",
+        "result": {
+          "success": 1,
+          "result": {
+            "tracker_id": "DAT-123",
+            "status": "In Review"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Datus resumes the model run with that proxied result. If stdin closes before the orchestrator answers, pending proxied tool calls are cancelled.
+
+## Operational Notes
+
+- Keep tracker credentials in the orchestrator, not in Datus configuration.
+- Proxy only `orchestrator_tools.*` unless the orchestrator also owns other tool categories.
+- Treat `request_human_input` as a pause point: the orchestrator should surface the question to an operator and return the answer as a print-mode `user-interaction` payload when available.
+- Use `finish_mission` for normal completion and `mark_blocked` when work cannot continue without external input or state changes.

--- a/docs/cli/orchestrator_tools.zh.md
+++ b/docs/cli/orchestrator_tools.zh.md
@@ -1,0 +1,114 @@
+# Orchestrator Tools
+
+`--orchestrator-tools` 会在 CLI print mode 中暴露 issue 生命周期工具。它面向外部 orchestrator：orchestrator 把 Datus 当作 worker 运行，同时由 orchestrator 持有 tracker 凭证、issue 状态流转、人工输入和最终任务上报逻辑。
+
+这个参数不会让 Datus 直接调用 GitHub、Jira、Linear 或其他 tracker。它只是在 agent 上注册一个 `orchestrator_tools` 工具类别。生产环境中应同时使用 `--proxy_tools orchestrator_tools.*`，把这些工具调用代理回外部 orchestrator。
+
+## 适用场景
+
+适合使用 orchestrator tools 的情况：
+
+- 外部 runtime 用 `--print` 为单个 issue 或任务启动 Datus。
+- 模型需要请求追加 issue comment、移动 issue 状态、询问人工输入或上报最终任务结果。
+- tracker 凭证必须保留在 Datus-agent 之外。
+- orchestrator 已经消费 print-mode JSON lines，并能通过 stdin 返回代理工具结果。
+
+不要在普通交互式 CLI 会话里使用这个参数。`--orchestrator-tools` 必须配合 `--print`；没有 print mode 时会直接报 CLI 参数错误。
+
+## 基本用法
+
+```bash
+datus --datasource analytics \
+  --print "Investigate issue DAT-123 and report the fix status." \
+  --orchestrator-tools \
+  --proxy_tools orchestrator_tools.*
+```
+
+代理参数的实际拼写是带下划线的 `--proxy_tools`。`--orchestrator-tools` 会先注册工具，再执行 proxy 包装，因此 `orchestrator_tools.*` 能匹配到这些新注册的工具。
+
+本地调试时也可以不加 `--proxy_tools`：
+
+```bash
+datus --datasource analytics \
+  --print "Summarize what you would report to the issue." \
+  --orchestrator-tools
+```
+
+这种模式下工具会暴露给模型，但每次调用都会返回 `success: 0`，错误信息会说明该调用必须由 orchestrator 代理。这样可以只验证 prompt 和工具选择行为，不会真的操作 tracker。
+
+## 可用工具
+
+| 工具 | 用途 | 主要参数 |
+|------|------|----------|
+| `create_issue_comment` | 请求 orchestrator 给当前 issue 追加 Markdown 评论 | `body`，可选 `issue_id` |
+| `update_issue_status` | 请求 orchestrator 把 issue 移动到某个 tracker 状态 | `status`，可选 `issue_id` |
+| `request_human_input` | 请求操作员提供决策或缺失输入 | `question`，可选 `issue_id`，可选 `next_status` |
+| `mark_blocked` | 上报阻塞当前任务的具体原因 | `reason`，可选 `issue_id`，可选 `next_status`，可选 `artifacts`，可选 `validation` |
+| `finish_mission` | 向 orchestrator 上报最终任务结果 | `outcome`，`summary`，可选 `issue_id`，可选 `next_status`，可选 `artifacts`，可选 `validation` |
+
+`finish_mission.outcome` 应使用以下值之一：
+
+- `completed`
+- `needs_review`
+- `blocked`
+- `failed`
+
+`artifacts` 和 `validation` 是结构化对象列表，具体字段形状属于 orchestrator 自己的契约；Datus 只负责透传。
+
+## 代理协议
+
+Print mode 会向 stdout 输出一行一个 `MessagePayload` JSON 对象。当模型调用被代理的 orchestrator 工具时，orchestrator 会看到一个 `call-tool` content item：
+
+```json
+{
+  "message_id": "tool_123",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "call-tool",
+      "payload": {
+        "callToolId": "tool_123",
+        "toolName": "finish_mission",
+        "toolParams": {
+          "outcome": "completed",
+          "summary": "Docs updated and validation passed.",
+          "next_status": "In Review"
+        }
+      }
+    }
+  ]
+}
+```
+
+orchestrator 执行 tracker 侧操作后，需要向 stdin 写入一行 `call-tool-result` JSON，并带上相同的 `callToolId`：
+
+```json
+{
+  "message_id": "tool_123_result",
+  "role": "user",
+  "content": [
+    {
+      "type": "call-tool-result",
+      "payload": {
+        "callToolId": "tool_123",
+        "result": {
+          "success": 1,
+          "result": {
+            "tracker_id": "DAT-123",
+            "status": "In Review"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Datus 会用这个代理结果继续模型执行。如果 stdin 在 orchestrator 返回前关闭，未完成的代理工具调用会被取消。
+
+## 运行注意事项
+
+- tracker 凭证应保留在 orchestrator 中，不要写入 Datus 配置。
+- 除非 orchestrator 也负责其他工具类别，否则只代理 `orchestrator_tools.*`。
+- 把 `request_human_input` 视为暂停点：orchestrator 应把问题展示给操作员，并在拿到答案后通过 print-mode `user-interaction` payload 返回。
+- 正常完成时使用 `finish_mission`，遇到必须依赖外部输入或外部状态变化的阻塞时使用 `mark_blocked`。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Context Command: cli/context_command.md
       - Execution Command: cli/execution_command.md
       - MCP Extensions: cli/mcp_extensions.md
+      - Orchestrator Tools: cli/orchestrator_tools.md
       - SQL Execution: cli/sql_execution.md
       - Skill Command: cli/skill_command.md
       - Reference: cli/reference.md
@@ -118,6 +119,7 @@ plugins:
             Context Command: 上下文命令
             Execution Command: 执行命令
             MCP Extensions: MCP 扩展
+            Orchestrator Tools: Orchestrator 工具
             SQL Execution: SQL 执行
             Skill Command: 技能命令
             Reference: 参考


### PR DESCRIPTION
## Summary
- Add English and Chinese CLI documentation for --orchestrator-tools.
- Document print-mode-only usage, proxy expectations, available lifecycle tools, and the JSONL proxy protocol.
- Register the page in MkDocs navigation and docs coverage map.

## Validation
- uv run python ci/harness/validate_coverage_map.py --strict --report-json ci/harness/coverage-map-report.json --report-md ci/harness/coverage-map-report.md
- uv run mkdocs build --strict
- uv run pytest tests/unit_tests/cli/test_main.py::TestArgumentParser::test_parse_args_orchestrator_tools tests/unit_tests/cli/test_main.py::TestApplicationRun::test_orchestrator_tools_without_print_mode_errors tests/unit_tests/cli/test_print_mode.py::TestRunProxyTools::test_run_attaches_orchestrator_tools_before_proxying tests/unit_tests/tools/func_tool/test_orchestrator_tools.py
- git diff --check

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `--orchestrator-tools` CLI flag, detailing available tools, usage patterns, and integration guidance
  * Documentation provided in both English and Chinese
  * Updated site navigation to include new CLI reference guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->