### PR TITLE
[UT] Pass is_subagent=True in nightly memory inheritance test

### DIFF
--- a/tests/integration/agent/test_auto_memory_agentic.py
+++ b/tests/integration/agent/test_auto_memory_agentic.py
@@ -99,6 +99,8 @@ class TestAutoMemoryLoadAndInherit:
         config = _isolated_config(nightly_agent_config, tmp_path)
         _write_memory(str(tmp_path), "chat", f"# Memory\n\n## Domain\n- {CUSTOM_MEMORY_MARKER}\n")
 
+        # ``is_subagent=True`` so the node follows the sub-agent path; without it
+        # the node counts as a main agent and resolves the shared 'chat' memory.
         node = GenSQLAgenticNode(
             node_id="nightly_mem_inherit",
             description="gen_sql inherits chat memory",
@@ -106,6 +108,7 @@ class TestAutoMemoryLoadAndInherit:
             agent_config=config,
             node_name="gen_sql",
             execution_mode="workflow",
+            is_subagent=True,
         )
         assert has_memory("gen_sql") is False, "built-in gen_sql must not own a memory file"
 


### PR DESCRIPTION
## Why

Nightly run [27237883727](https://github.com/Datus-ai/Datus-agent/actions/runs/27237883727) failed on `tests/integration/agent/test_auto_memory_agentic.py::TestAutoMemoryLoadAndInherit::test_builtin_subagent_inherits_parent_memory_readonly` (1 failed, 49 passed).

The test (added in #975) constructs `GenSQLAgenticNode` without `is_subagent=True`. `AgenticNode._inject_memory_context` therefore treats the node as a **main agent**: `resolve_memory_node("gen_sql")` maps the built-in node to the shared `chat` memory, and the chat MEMORY.md the test seeds is injected writable (with `**Save**` instructions) — breaking the assertion that no memory is loaded without an active inheritance override. The failure is deterministic; it only surfaced now because the test is `@pytest.mark.nightly` and the previous nightly (on the #975 merge commit) died earlier at the knowledge-base build step, so this was the first nightly that actually executed it.

## Solution

Construct the node with `is_subagent=True` so it follows the sub-agent path, matching the equivalent unit test in `tests/unit_tests/agent/node/test_agentic_node_inherited_memory.py` which documents the same requirement. Production code is unchanged — the main-agent behavior (built-in node run as top-level agent shares `chat` memory writable) is by design and covered by other tests.

## Test Cases

- Fixed nightly test verified locally: `uv run pytest tests/integration/agent/test_auto_memory_agentic.py::TestAutoMemoryLoadAndInherit -m nightly` → 3 passed.
- PR harness: `uv run python ci/run-pr-tests.py upstream/main` → 173 passed, 0 failed.
- Test audit: `ci/audit_tests.py --diff-only upstream/main` → P0=0, P1=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [x] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for sub-agent memory inheritance to verify read-only access to inherited parent memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->