### PR TITLE
[Enhancement] Add strict OSI semantic authoring path

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -184,9 +184,14 @@ class GenMetricsAgenticNode(AgenticNode):
     def _setup_generation_tools(self):
         """Setup generation tools."""
         try:
+            from datus.agent.node.semantic_authoring import resolve_authoring_format
             from datus.tools.func_tool import trans_to_function_tool
 
-            self.generation_tools = GenerationTools(self.agent_config, generation_evidence=self.generation_evidence)
+            self.generation_tools = GenerationTools(
+                self.agent_config,
+                generation_evidence=self.generation_evidence,
+                authoring_format=resolve_authoring_format(self.agent_config, self.node_config),
+            )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
             self.tools.append(trans_to_function_tool(self.generation_tools.end_metric_generation))
@@ -197,6 +202,16 @@ class GenMetricsAgenticNode(AgenticNode):
 
         except Exception as e:
             logger.error(f"Failed to setup generation tools: {e}")
+
+    def _setup_skill_func_tools(self) -> None:
+        """Avoid injecting MetricFlow authoring skills into OSI workflows."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        node_config = getattr(self, "node_config", None) or {}
+        if is_osi_authoring(self.agent_config, node_config) and "skills" not in node_config:
+            logger.info("Skipping default MetricFlow skills for OSI metrics authoring")
+            return
+        super()._setup_skill_func_tools()
 
     def _setup_semantic_tools(self):
         """Setup semantic tools for metrics querying and exploration."""
@@ -368,12 +383,28 @@ class GenMetricsAgenticNode(AgenticNode):
         Returns:
             System prompt string loaded from the template
         """
-        version = (
-            prompt_version or getattr(self.input, "prompt_version", None) or self.node_config.get("prompt_version")
+        from datus.agent.node.semantic_authoring import (
+            AUTHORING_FORMAT_OSI,
+            osi_prompt_version,
+            osi_template_name,
+            resolve_authoring_format,
         )
 
-        # Hardcoded system_prompt template name
-        template_name = f"{self.NODE_NAME}_system"
+        # Select the authoring format (metricflow YAML vs OSI + Datus hints).
+        # OSI mode uses a separate template name so the default metricflow
+        # template and its latest-version scan are left untouched.
+        authoring_format = resolve_authoring_format(self.agent_config, self.node_config)
+        if authoring_format == AUTHORING_FORMAT_OSI:
+            template_name = osi_template_name(self.NODE_NAME)
+            requested = (
+                prompt_version or getattr(self.input, "prompt_version", None) or self.node_config.get("prompt_version")
+            )
+            version = osi_prompt_version(self.agent_config, self.NODE_NAME, requested)
+        else:
+            template_name = f"{self.NODE_NAME}_system"
+            version = (
+                prompt_version or getattr(self.input, "prompt_version", None) or self.node_config.get("prompt_version")
+            )
 
         try:
             # Prepare template variables
@@ -590,6 +621,16 @@ class GenMetricsAgenticNode(AgenticNode):
         status: Optional[str],
     ) -> None:
         """Ensure generated metric artifacts are published without relying on one LLM tool call."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        if is_osi_authoring(self.agent_config, self.node_config):
+            self._finalize_osi_metric_generation(
+                semantic_model_files=semantic_model_files,
+                metric_file=metric_file,
+                status=status,
+            )
+            return
+
         normalized_status = status.strip().lower() if isinstance(status, str) else status
 
         if normalized_status == "skipped":
@@ -675,6 +716,88 @@ class GenMetricsAgenticNode(AgenticNode):
         )
         if not self._tool_succeeded(publish_result):
             raise RuntimeError(f"Metric KB sync failed: {self._tool_error(publish_result)}")
+        self.generation_evidence.mark_kb_sync("metric")
+
+    def _finalize_osi_metric_generation(
+        self,
+        semantic_model_files: Optional[List[str] | str],
+        metric_file: Optional[str],
+        status: Optional[str],
+    ) -> None:
+        """Finalize OSI-authored metrics without using MetricFlow YAML preflight."""
+        normalized_status = status.strip().lower() if isinstance(status, str) else status
+
+        if normalized_status == "skipped":
+            if metric_file:
+                raise RuntimeError(
+                    "Metric generation returned status='skipped' with a non-null metric_file. "
+                    "Skipped responses must set metric_file to null; generated metric files must be published."
+                )
+            return
+
+        if self.generation_evidence.metric_kb_sync_passed:
+            return
+
+        if normalized_status and not metric_file:
+            raise RuntimeError(
+                f"Metric generation returned status='{normalized_status}' without a metric_file. "
+                "Non-skipped OSI metric responses must include metric_file or call end_metric_generation."
+            )
+
+        if not metric_file:
+            return
+
+        if not self.generation_tools:
+            raise RuntimeError("Metric generation produced a metric_file, but generation tools are unavailable.")
+        self._set_metric_queryability_contracts_from_input(getattr(self, "input", None))
+
+        if not self.generation_evidence.validation_passed:
+            if not getattr(self, "semantic_tools", None):
+                raise RuntimeError("Metric generation produced a metric_file, but validate_semantic is unavailable.")
+            validation_result = self.semantic_tools.validate_semantic()
+            self.generation_evidence.record_validation_result(validation_result)
+            if not self._tool_succeeded(validation_result):
+                raise RuntimeError(
+                    f"validate_semantic failed before publishing OSI metrics: {self._tool_error(validation_result)}"
+                )
+
+        abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
+        if isinstance(semantic_model_files, str):
+            semantic_model_file_candidates = [semantic_model_files]
+        else:
+            semantic_model_file_candidates = semantic_model_files or []
+        abs_semantic_model_files = [
+            self._resolve_metric_artifact_path(semantic_model_file, "semantic")
+            for semantic_model_file in semantic_model_file_candidates
+            if semantic_model_file
+        ]
+        metric_names = self.generation_tools.extract_osi_metric_names(abs_metric_file)
+        if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
+            if not getattr(self, "semantic_tools", None):
+                raise RuntimeError("Metric generation produced a metric_file, but query_metrics is unavailable.")
+            dry_run_result = self.semantic_tools.query_metrics(metrics=metric_names, dry_run=True)
+            self.generation_evidence.record_metric_dry_run(metric_names, dry_run_result)
+            if not self._tool_succeeded(dry_run_result):
+                raise RuntimeError(
+                    "query_metrics(dry_run=True) failed for generated OSI metric(s) "
+                    f"{', '.join(metric_names)}: {self._tool_error(dry_run_result)}"
+                )
+        if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
+            missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
+            raise DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions before "
+                "publishing metrics. Run a dry-run query for the generated metric names with the matching "
+                "dimensions/time grain, fix semantic model join or dimension issues, and retry. "
+                f"Missing: {summarize_queryability_contracts(missing_contracts)}",
+            )
+
+        publish_result = self.generation_tools.end_metric_generation(
+            metric_file=abs_metric_file,
+            semantic_model_files=abs_semantic_model_files,
+        )
+        if not self._tool_succeeded(publish_result):
+            raise RuntimeError(f"OSI metric KB sync failed: {self._tool_error(publish_result)}")
         self.generation_evidence.mark_kb_sync("metric")
 
     def _extract_metric_and_output_from_response(

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -205,9 +205,14 @@ class GenSemanticModelAgenticNode(AgenticNode):
     def _setup_generation_tools(self):
         """Setup generation tools."""
         try:
+            from datus.agent.node.semantic_authoring import resolve_authoring_format
             from datus.tools.func_tool import trans_to_function_tool
 
-            self.generation_tools = GenerationTools(self.agent_config, generation_evidence=self.generation_evidence)
+            self.generation_tools = GenerationTools(
+                self.agent_config,
+                generation_evidence=self.generation_evidence,
+                authoring_format=resolve_authoring_format(self.agent_config, self.node_config),
+            )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
             self.tools.append(trans_to_function_tool(self.generation_tools.end_semantic_model_generation))
@@ -215,6 +220,16 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
         except Exception as e:
             logger.error(f"Failed to setup generation tools: {e}")
+
+    def _setup_skill_func_tools(self) -> None:
+        """Avoid injecting MetricFlow authoring skills into OSI workflows."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        node_config = getattr(self, "node_config", None) or {}
+        if is_osi_authoring(self.agent_config, node_config) and "skills" not in node_config:
+            logger.info("Skipping default MetricFlow skills for OSI semantic-model authoring")
+            return
+        super()._setup_skill_func_tools()
 
     def _setup_hooks(self):
         """Setup hooks for interactive mode."""
@@ -318,12 +333,25 @@ class GenSemanticModelAgenticNode(AgenticNode):
         Returns:
             System prompt string loaded from the template
         """
+        from datus.agent.node.semantic_authoring import (
+            AUTHORING_FORMAT_OSI,
+            osi_prompt_version,
+            osi_template_name,
+            resolve_authoring_format,
+        )
+
         # ``prompt_version`` kwarg wins over the config default; preserves the
         # template's signature parity with the other nodes.
-        version = prompt_version or self.node_config.get("prompt_version")
-
-        # Hardcoded system_prompt template name
-        template_name = f"{self.NODE_NAME}_system"
+        # OSI mode uses a separate template name so the default metricflow
+        # template and its latest-version scan are left untouched.
+        authoring_format = resolve_authoring_format(self.agent_config, self.node_config)
+        if authoring_format == AUTHORING_FORMAT_OSI:
+            template_name = osi_template_name(self.NODE_NAME)
+            requested = prompt_version or self.node_config.get("prompt_version")
+            version = osi_prompt_version(self.agent_config, self.NODE_NAME, requested)
+        else:
+            template_name = f"{self.NODE_NAME}_system"
+            version = prompt_version or self.node_config.get("prompt_version")
 
         try:
             # Prepare template variables
@@ -539,6 +567,20 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
             if not os.path.exists(full_path):
                 logger.warning(f"Semantic model file not found: {full_path}")
+                return False
+
+            from datus.agent.node.semantic_authoring import is_osi_authoring
+
+            if is_osi_authoring(self.agent_config, self.node_config):
+                if not self.generation_tools:
+                    logger.error("Generation tools unavailable for OSI semantic sync")
+                    return False
+                result = self.generation_tools.sync_osi_semantic_to_db(full_path)
+                if result.get("success"):
+                    self.generation_evidence.mark_kb_sync("semantic")
+                    logger.info(f"Successfully saved OSI semantic model to database: {result.get('message')}")
+                    return True
+                logger.error(f"Failed to save OSI semantic model to database: {result.get('error', 'unknown error')}")
                 return False
 
             # Call static method to save to database

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -1,0 +1,88 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Semantic authoring format resolution for generation nodes.
+
+Datus can author semantic assets in two formats:
+
+- ``metricflow`` (default): the LLM writes MetricFlow YAML directly. This is the
+  original behavior and is left untouched.
+- ``osi``: the LLM writes OSI semantic models + Datus business hints, which the
+  Datus OSI compiler later lowers to a backend (e.g. MetricFlow). The LLM never
+  writes backend YAML.
+
+The format is resolved (in priority order) from:
+
+1. an explicit per-node/workflow ``authoring_format`` in ``node_config``;
+2. the active semantic adapter (the consumer of the generated assets) -- when it
+   is ``osi``, author OSI;
+3. the ``metricflow`` default.
+
+OSI mode uses a *separate* prompt template name (``{node}_osi_system``) so the
+default ``{node}_system`` latest-version scan is never affected.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+AUTHORING_FORMAT_METRICFLOW = "metricflow"
+AUTHORING_FORMAT_OSI = "osi"
+
+
+def resolve_authoring_format(
+    agent_config: Any = None,
+    node_config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Resolve the semantic authoring format. Defaults to ``metricflow``."""
+    if node_config:
+        explicit = node_config.get("authoring_format")
+        if explicit:
+            normalized = str(explicit).strip().lower()
+            if normalized in (AUTHORING_FORMAT_METRICFLOW, AUTHORING_FORMAT_OSI):
+                return normalized
+
+    adapter: Optional[str] = None
+    adapter_type: Optional[str] = None
+    if node_config:
+        adapter_type = node_config.get("semantic_adapter") or node_config.get("adapter_type")
+    if agent_config is not None and hasattr(agent_config, "resolve_semantic_adapter"):
+        try:
+            adapter = agent_config.resolve_semantic_adapter(adapter_type)
+        except Exception:
+            adapter = None
+
+    if adapter and str(adapter).strip().lower() == AUTHORING_FORMAT_OSI:
+        return AUTHORING_FORMAT_OSI
+    return AUTHORING_FORMAT_METRICFLOW
+
+
+def is_osi_authoring(agent_config: Any = None, node_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Return ``True`` when this node should author OSI instead of MetricFlow."""
+    return resolve_authoring_format(agent_config, node_config) == AUTHORING_FORMAT_OSI
+
+
+def osi_template_name(node_name: str) -> str:
+    """Return the OSI-mode system prompt template name for a generation node."""
+    return f"{node_name}_osi_system"
+
+
+def osi_prompt_version(agent_config: Any, node_name: str, requested: Optional[str]) -> Optional[str]:
+    """Resolve the OSI template version, ignoring versions meant for other templates.
+
+    Callers (e.g. success-story bootstrap) often pin the latest version of the
+    *metricflow* template ``{node}_system`` and inject it as ``prompt_version``.
+    The OSI template ``{node}_osi_system`` versions independently, so an injected
+    metricflow version would not exist here. Honor ``requested`` only when it is a
+    real version of the OSI template; otherwise fall back to its latest (``None``).
+    """
+    if not requested:
+        return None
+    try:
+        from datus.prompts.prompt_manager import get_prompt_manager
+
+        available = get_prompt_manager(agent_config=agent_config).list_template_versions(osi_template_name(node_name))
+    except Exception:
+        available = []
+    return requested if requested in available else None

--- a/datus/prompts/prompt_templates/gen_metrics_osi_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_osi_system_1.0.j2
@@ -1,0 +1,128 @@
+You are a metric **semantics** expert. Your task is to ADD metrics to an existing strict OSI (Open Semantic Interchange) core semantic model, capturing each metric's business meaning from SQL queries or natural language.
+
+CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow YAML, `measure_proxy`, `type_params`, `measures:`, `ratio`, `cumulative`, or any execution-engine syntax. The Datus OSI compiler infers backing measures, picks the backend metric kind, and lowers to the execution engine.
+Do NOT write legacy MetricFlow `metric:` blocks.
+
+CRITICAL MODEL RULE - **build the model once, then only add metrics**:
+- The datasets and relationships are owned by the semantic-model step and are ALREADY built.
+- A given physical table has one canonical dataset shared by all metrics. Never create a second dataset for the same table.
+- In OSI core, metrics live under `semantic_model[0].metrics`. Prefer editing the existing OSI core semantic-model file and appending metrics there.
+- If you create a separate metric YAML file, it must still be a complete valid OSI core document with `version` and `semantic_model`; copy the existing dataset definitions exactly so the file passes core schema. Do not invent or alter datasets in that file.
+- This is the OSI authoring path. Do NOT load or follow generic MetricFlow `gen-metrics` / `gen-semantic-model` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
+
+{% if native_tools %}- Native tools: {{ native_tools }}{% endif %}
+{% if mcp_tools %}- MCP servers: {{ mcp_tools }}{% endif %}
+
+## What you produce
+
+Metric definitions inside a valid OSI core document:
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: <existing_model_name>
+    datasets:
+      - name: <existing_dataset_name>
+        source: <existing_source>
+        primary_key: [<existing_primary_key>]
+        fields: [...]                         # copy exactly if this is a separate metric file
+    relationships: [...]                       # copy existing relationships exactly when needed
+    metrics:
+      - name: <metric_name>                    # globally unique snake_case
+        description: "<business meaning / koujing>"
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: "COUNT(DISTINCT id)" # aggregate business expression; no OVER/LAG/RANK
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"dataset":"<existing_dataset_name>","time_dimension":"<date_column>","format":"0.00%","unit":"<unit>"}'
+```
+
+Datus execution hints such as `dataset`, `time_dimension`, `filters`, `metric_kind`, `inputs`, `numerator`, `denominator`, `window`, `grain_to_date`, `offset_window`, `subject_path`, `format`, and `unit` MUST be encoded in the metric's DATUS `custom_extensions[].data` JSON string. They are not OSI core top-level metric fields.
+
+## Authoring rules
+
+1. **Reference, don't rebuild.** Every metric's DATUS `dataset` hint must reference an existing dataset of the semantic model. If a needed dataset, field, time field, or relationship is missing, do not invent a conflicting one; note it and minimally update the semantic model only if truly absent.
+2. **Aggregates**: write the natural business expression in OSI core `expression.dialects[0].expression`, e.g. `COUNT(DISTINCT order_id)`, `SUM(amount)`, `AVG(score)`.
+3. **Conditional aggregates**: keep the CASE inside the expression, e.g. `COUNT(DISTINCT CASE WHEN <condition> THEN id END)`. Preserve literal values exactly.
+4. **Business filters**: put metric filters in DATUS extension JSON, e.g. `{"filters":[{"expression":"status = 'paid'","scope":"metric"}]}`. Do NOT create a filtered dataset for a metric-only business filter. Do NOT bury query-time date ranges into the metric; time ranges are query parameters.
+5. **Ratios**: if the expression is unambiguous, write the division expression. If numerator/denominator cannot be parsed unambiguously, use DATUS hints `{"metric_kind":"ratio","numerator":"...","denominator":"..."}`.
+6. **Time-window metrics - do NOT simplify away.**
+   - Rolling / cumulative: the OSI core metric expression is the base aggregate itself plus DATUS hints `window` or `grain_to_date`.
+     ```yaml
+     metrics:
+       - name: revenue_l7d
+         expression:
+           dialects:
+             - dialect: ANSI_SQL
+               expression: "SUM(amount)"
+         custom_extensions:
+           - vendor_name: DATUS
+             data: '{"dataset":"orders","time_dimension":"order_date","window":"7 days"}'
+     ```
+   - Period-over-period (`LAG() OVER`, MoM/YoY): write a derived metric over a base metric with an input `offset_window`. Do NOT write `LAG`/`OVER` in the OSI expression. If `analyze_metric_candidates_from_history` returns a `derived_metric_candidates` item with `metric_kind: derived`, `inputs`, and `offset_window`, encode that shape in DATUS extension JSON.
+     ```yaml
+     metrics:
+       - name: revenue_mom
+         expression:
+           dialects:
+             - dialect: ANSI_SQL
+               expression: "(revenue - revenue_prev) / NULLIF(revenue_prev, 0)"
+         custom_extensions:
+           - vendor_name: DATUS
+             data: '{"metric_kind":"derived","inputs":[{"name":"revenue"},{"name":"revenue","alias":"revenue_prev","offset_window":"1 month"}]}'
+     ```
+7. **Joins**: to group/filter by another table, use the existing semantic-model relationships. If the link is truly absent, add one OSI core relationship under the semantic model object:
+   ```yaml
+   relationships:
+     - name: <fact_dataset>_to_<dimension_dataset>
+       from: <fact_or_many_side_dataset>
+       to: <dimension_or_one_side_dataset>
+       from_columns: [<foreign_key_column>]
+       to_columns: [<primary_or_unique_key_column>]
+   ```
+   Never put `relationships` inside a dataset. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
+8. **Not metrics**: detail/list queries (`SELECT DISTINCT ...`) and window/ranking (`ROW_NUMBER()`, `RANK() OVER`, TopN per group) are NOT metrics. In `gen_metrics`, SKIP them. Do NOT create a dataset/view here and never force them into a metric. If the discovery tool returns `metric_generation_skips` or rank-like `derived_datasource_recommendations`, treat that SQL as skipped.
+9. Use clear English `snake_case` metric names; metric names must be globally unique; put the business koujing in `description`.
+
+## Hard skip gate
+
+Before writing any YAML, classify the source SQL:
+
+- If the SQL has no aggregate output (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, ratio, rolling/cumulative aggregate, etc.) and primarily returns row-level fields (`SELECT DISTINCT ac_name, ac_code, ...`, list/detail/ranking), then it is not a metric request.
+- For non-metric SQL, do not invent convenience metrics such as `*_count`, `*_avg_duration`, `*_max_sr`, or `*_min_sr` just because the table contains those columns.
+- For non-metric SQL, do not call `write_file`, `validate_semantic`, `query_metrics`, or `end_metric_generation`.
+- For TopN per group / ranking-window SQL (`ROW_NUMBER`, `RANK`, `DENSE_RANK`) do the same: skip metric generation. A derived dataset/view may be a future modeling task, but it is outside this `gen_metrics` run.
+- Finish with:
+  ```json
+  {
+    "semantic_model_file": "{{ kind_subdir }}/<existing_model>.yml",
+    "metric_file": null,
+    "status": "skipped",
+    "output": "No metric generated: the SQL is a detail/list query, not an aggregate metric definition."
+  }
+  ```
+
+## Workflow
+
+{% if current_datasource %}- Active datasource: `{{ current_datasource }}`{% endif %}
+{% if kind_subdir %}- Write OSI core YAML under `{{ kind_subdir }}/...` only. Prefer appending metrics to the existing semantic-model file; a separate metric file is allowed only if it is a complete OSI core document.{% endif %}
+- FIRST, load the existing model. Read the existing OSI core YAML in the datasource directory to learn dataset names, fields, time fields, and relationships. Call `list_metrics()` to see metrics that already exist.
+- For provided SQL/history, call `analyze_metric_candidates_from_history` before writing files. Use `direct_metric_candidates` for base metrics and `derived_metric_candidates` for second-stage OSI metrics. If it returns `metric_generation_skips`, skip those SQLs instead of writing metric YAML.
+- Reference, reconcile, reuse: point each metric's DATUS `dataset` hint at an existing dataset. If a metric with the same meaning already exists (`check_semantic_object_exists(name, kind='metric')`), reuse/skip it. For a derived metric, make sure its input metrics already exist.
+- From SQL: find the table (FROM), aggregate expression(s), and business filters vs query-time ranges. Anchor the metric on the aggregated table's existing dataset; express filters as metric DATUS hints or CASE.
+- When a required business input is missing or ambiguous, ASK for the business semantics; do not guess.
+- Produce valid OSI core YAML; the Datus OSI compiler validates it against OSI core schema, compiles Datus extensions into IR, and lowers it to the configured backend.
+- Call `validate_semantic(scope="all")` after writing OSI metrics and fix errors until it passes.
+- Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric name before publishing.
+- After validation and dry-run pass, call `end_metric_generation(metric_file="<osi core file containing the new metrics>", semantic_model_file="<existing semantic model file>", metric_sqls_json="<dry-run SQL JSON>")`.
+- Finish with JSON:
+  ```json
+  {
+    "semantic_model_file": "{{ kind_subdir }}/<existing_model>.yml",
+    "metric_file": "{{ kind_subdir }}/<file_containing_generated_metrics>.yml",
+    "status": "generated",
+    "output": "<brief summary>"
+  }
+  ```

--- a/datus/prompts/prompt_templates/gen_semantic_model_osi_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_osi_system_1.0.j2
@@ -1,0 +1,79 @@
+You are a semantic modeling expert. Your task is to describe tables as strict **OSI (Open Semantic Interchange) core schema** documents plus Datus business hints.
+
+CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow `data_source:`, `measures:`, `identifiers:`, `agg_time_dimension`, `create_metric`, or any execution-engine YAML. The Datus OSI compiler lowers OSI core documents to the configured backend.
+This is the OSI authoring path. Do NOT load or follow generic MetricFlow `gen-semantic-model` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
+
+{% if native_tools %}- Native tools: {{ native_tools }}{% endif %}
+{% if mcp_tools %}- MCP servers: {{ mcp_tools }}{% endif %}
+
+## What you produce
+
+Every YAML file MUST be a valid OSI core document:
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: <model_name>
+    datasets:
+      - name: <dataset_name>
+        source: <physical_table_or_view_name>
+        primary_key: [<primary_key_column>]
+        fields:
+          - name: <date_or_timestamp_column>
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: <date_or_timestamp_column>
+            dimension:
+              is_time: true
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"type":"time","time_granularity":"day"}'
+          - name: <business_column>
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: <business_column>
+            dimension:
+              is_time: false
+            description: "<business meaning of the column>"
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"type":"categorical"}'
+    relationships:
+      - name: <fact_dataset>_to_<dimension_dataset>
+        from: <fact_or_many_side_dataset>
+        to: <dimension_or_one_side_dataset>
+        from_columns: [<foreign_key_column>]
+        to_columns: [<primary_or_unique_key_column>]
+```
+
+## Authoring rules
+
+1. **Root schema is fixed.** Root keys are only `version` and `semantic_model`. `semantic_model` is a list. Do NOT write top-level `datasets:`, `relationships:`, or `metrics:`.
+2. **Use OSI core dataset shape.** Dataset `source` is a string, not `{table: ...}`. Dataset columns are `fields`, not `dimensions`. Field expressions are `expression.dialects[]`, not `expr`.
+3. **Datus-only hints go into `custom_extensions`.** OSI core does not have top-level dataset `time_dimension`, field `type`, field `granularity`, metric `dataset`, metric `window`, etc. Put those Datus execution hints in `custom_extensions: [{vendor_name: DATUS, data: '<JSON object string>'}]`.
+4. **One canonical dataset per physical table.** Name the dataset predictably after the table (e.g. table `orders` -> dataset `orders`) so metrics can reference it by name. Include the FULL table: primary key, primary time field, and all business-meaningful fields. Do NOT create per-query or filtered variants of the same table here.
+5. **Primary / unique keys** -> OSI core `primary_key: [<column>]`. Use real columns only.
+6. **Time dimension**: mark the primary date/time field with `dimension.is_time: true` and Datus extension `{"type":"time","time_granularity":"day|week|month|quarter|year"}`. Point it at a real date/time column, never a numeric surrogate key.
+7. **Fields**: include every business-meaningful column the user may group or filter by. Populate `description` for ALL non-obvious fields by combining the column comment, sample values, and external knowledge. Wrap descriptions in double quotes.
+8. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
+9. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
+10. Preserve literal values and column names exactly; do not invent columns.
+
+## Workflow
+
+{% if current_datasource %}- Active datasource: `{{ current_datasource }}`{% endif %}
+{% if semantic_model_dir %}- Write OSI core YAML files under `{{ semantic_model_dir }}` only.{% endif %}
+- Inspect the table schema and comments; map columns to keys, the time field, business fields, and relationships.
+- When a critical modeling choice is ambiguous (which column is the grain, which is the primary time dimension), ASK before generating.
+- Produce valid OSI core YAML; the Datus OSI compiler validates it against OSI core schema, then lowers it to the configured execution backend.
+- Call `validate_semantic(scope="semantic_model")` after writing the OSI semantic model and fix errors until it passes.
+- After validation passes, call `end_semantic_model_generation(semantic_model_files=[...])`. In OSI mode this syncs OSI datasets to Knowledge Base without using MetricFlow YAML.
+- Finish with JSON:
+  ```json
+  {
+    "semantic_model_files": ["{{ kind_subdir }}/<table_name>.yml"],
+    "output": "<brief summary>"
+  }
+  ```

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -6,6 +6,8 @@
 import os
 import tempfile
 from collections.abc import Iterable
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
@@ -13,7 +15,7 @@ from agents import Tool
 from datus_storage_base.conditions import And, eq
 
 from datus.configuration.agent_config import AgentConfig
-from datus.storage.metric.store import MetricRAG, metric_definition_conflict, normalize_metric_name
+from datus.storage.metric.store import MetricRAG, build_metric_id, metric_definition_conflict, normalize_metric_name
 from datus.storage.semantic_model.store import SemanticModelRAG, _identifier_variants, _normalized_identifier
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
@@ -73,13 +75,22 @@ class GenerationTools:
     completing the generation process.
     """
 
-    def __init__(self, agent_config: AgentConfig, generation_evidence: Optional[GenerationEvidence] = None):
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        generation_evidence: Optional[GenerationEvidence] = None,
+        authoring_format: str = "metricflow",
+    ):
         self.agent_config = agent_config
         self.generation_evidence = generation_evidence or GenerationEvidence()
+        self.authoring_format = (authoring_format or "metricflow").strip().lower()
         self.metric_rag = MetricRAG(agent_config)
         self.semantic_rag = SemanticModelRAG(agent_config)
         self._semantic_object_exists_cache: Dict[tuple[str, str, str], FuncToolResult] = {}
         self._semantic_table_object_index: Optional[Dict[str, Dict[str, object]]] = None
+
+    def _is_osi_authoring(self) -> bool:
+        return self.authoring_format == "osi"
 
     def available_tools(self) -> List[Tool]:
         """
@@ -272,6 +283,33 @@ class GenerationTools:
             self._semantic_object_exists_cache.clear()
             self._semantic_table_object_index = None
 
+            if self._is_osi_authoring():
+                sync_results = []
+                for semantic_model_file in semantic_model_files:
+                    resolved = self._resolve_generation_path(semantic_model_file, "semantic")
+                    if not resolved:
+                        return FuncToolResult(
+                            success=0,
+                            error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}",
+                            result={"semantic_model_files": semantic_model_files},
+                        )
+                    sync_result = self.sync_osi_semantic_to_db(resolved)
+                    sync_results.append(sync_result)
+                    if not sync_result.get("success"):
+                        return FuncToolResult(
+                            success=0,
+                            error=f"OSI semantic model KB sync failed: {sync_result.get('error', 'unknown')}",
+                            result={"semantic_model_files": semantic_model_files, "sync": sync_results},
+                        )
+                self.generation_evidence.mark_kb_sync("semantic")
+                return FuncToolResult(
+                    result={
+                        "message": f"Semantic model generation completed and synced {len(sync_results)} OSI file(s)",
+                        "semantic_model_files": semantic_model_files,
+                        "sync": sync_results,
+                    }
+                )
+
             return FuncToolResult(
                 result={
                     "message": f"Semantic model generation completed for {len(semantic_model_files)} file(s)",
@@ -417,6 +455,33 @@ class GenerationTools:
                         "semantic_model_files": semantic_model_files,
                         "metric_sqls": metric_sqls,
                     },
+                )
+
+            if self._is_osi_authoring():
+                primary_semantic_file = abs_semantic_files[0] if abs_semantic_files else ""
+                sync_result = self._sync_osi_metric_to_db(abs_metric, primary_semantic_file, metric_sqls)
+                if not sync_result.get("success"):
+                    return FuncToolResult(
+                        success=0,
+                        error=f"OSI metric file written but KB sync failed: {sync_result.get('error', 'unknown')}",
+                        result={
+                            "metric_file": metric_file,
+                            "semantic_model_files": semantic_model_files,
+                            "metric_sqls": metric_sqls,
+                            "sync": sync_result,
+                        },
+                    )
+                self.generation_evidence.mark_kb_sync("metric")
+                if sync_result.get("semantic_synced"):
+                    self.generation_evidence.mark_kb_sync("semantic")
+                return FuncToolResult(
+                    result={
+                        "message": "OSI metric generation completed and synced to Knowledge Base",
+                        "metric_file": metric_file,
+                        "semantic_model_files": semantic_model_files,
+                        "metric_sqls": metric_sqls,
+                        "sync": sync_result,
+                    }
                 )
 
             # Pre-flight: refuse to sync a metric file that has no `metric:`
@@ -848,6 +913,406 @@ class GenerationTools:
                         "or update the existing metric explicitly."
                     )
         return None
+
+    def _resolve_generation_path(self, path: str, kind: str) -> str:
+        if not path:
+            return ""
+        from datus.cli.generation_hooks import resolve_kb_sandbox_path
+
+        subject_root = str(get_path_manager(agent_config=self.agent_config).subject_dir)
+        return resolve_kb_sandbox_path(path, kind, subject_root) or ""
+
+    @staticmethod
+    def _iter_yaml_docs(path: str) -> List[dict]:
+        p = Path(path)
+        files = sorted(p.rglob("*.yml")) + sorted(p.rglob("*.yaml")) if p.is_dir() else [p]
+        docs: List[dict] = []
+        for file_path in files:
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    loaded = list(yaml.safe_load_all(f))
+            except (OSError, yaml.YAMLError):
+                continue
+            docs.extend(doc for doc in loaded if isinstance(doc, dict))
+        return docs
+
+    def extract_osi_metric_names(self, metric_path: str) -> List[str]:
+        """Return metric names from OSI core documents or compatibility metric docs."""
+        names: List[str] = []
+        for doc in self._iter_yaml_docs(metric_path):
+            semantic_models = doc.get("semantic_model")
+            if isinstance(semantic_models, list):
+                for model in semantic_models:
+                    if not isinstance(model, dict):
+                        continue
+                    for item in model.get("metrics") or []:
+                        if isinstance(item, dict) and isinstance(item.get("name"), str):
+                            names.append(item["name"])
+            metric = doc.get("metric")
+            if isinstance(metric, dict) and isinstance(metric.get("name"), str):
+                names.append(metric["name"])
+            metrics = doc.get("metrics")
+            if isinstance(metrics, list):
+                for item in metrics:
+                    if isinstance(item, dict) and isinstance(item.get("name"), str):
+                        names.append(item["name"])
+        return names
+
+    def extract_osi_dataset_names(self, semantic_model_path: str) -> List[str]:
+        """Return dataset names declared in OSI core semantic-model documents."""
+        names: List[str] = []
+        for doc in self._iter_yaml_docs(semantic_model_path):
+            semantic_models = doc.get("semantic_model")
+            if isinstance(semantic_models, list):
+                for model in semantic_models:
+                    if not isinstance(model, dict):
+                        continue
+                    for item in model.get("datasets") or []:
+                        if isinstance(item, dict) and isinstance(item.get("name"), str):
+                            names.append(item["name"])
+            datasets = doc.get("datasets")
+            if not isinstance(datasets, list):
+                continue
+            for item in datasets:
+                if isinstance(item, dict) and isinstance(item.get("name"), str):
+                    names.append(item["name"])
+        return names
+
+    def _osi_document_root(self, metric_file: Optional[str] = None, semantic_model_file: Optional[str] = None) -> str:
+        """Resolve the datasource-scoped OSI directory used by the adapter."""
+        candidates: List[Path] = []
+        try:
+            datasource = getattr(self.agent_config, "current_datasource", "")
+            path_manager = getattr(self.agent_config, "path_manager", None)
+            if datasource and path_manager and hasattr(path_manager, "semantic_model_path"):
+                candidates.append(Path(path_manager.semantic_model_path(datasource)))
+        except Exception:
+            pass
+
+        for raw in (semantic_model_file, metric_file):
+            if not raw:
+                continue
+            path = Path(raw)
+            if path.is_file():
+                parent = path.parent
+                candidates.append(parent.parent if parent.name == "metrics" else parent)
+            elif path.is_dir():
+                candidates.append(path)
+
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate)
+        return str(candidates[0]) if candidates else str(Path(metric_file or semantic_model_file or ".").parent)
+
+    def _load_osi_document(self, metric_file: Optional[str] = None, semantic_model_file: Optional[str] = None):
+        from datus_semantic_osi.profile import load_osi_path
+
+        return load_osi_path(self._osi_document_root(metric_file, semantic_model_file), normalize=True)
+
+    @staticmethod
+    def _current_db_parts(agent_config: AgentConfig) -> dict[str, str]:
+        try:
+            current_db_config = agent_config.current_db_config()
+        except Exception:
+            current_db_config = object()
+        return {
+            "catalog_name": getattr(current_db_config, "catalog", "") or "",
+            "database_name": getattr(current_db_config, "database", "") or "",
+            "schema_name": getattr(current_db_config, "schema", "") or "",
+        }
+
+    @staticmethod
+    def _dataset_table_name(dataset: Any) -> str:
+        source = getattr(dataset, "source", None)
+        table = getattr(source, "table", None) or getattr(dataset, "name", "")
+        return str(table).split(".")[-1]
+
+    @staticmethod
+    def _dataset_lookup(doc: Any) -> dict[str, Any]:
+        return {getattr(dataset, "name", ""): dataset for dataset in getattr(doc, "datasets", [])}
+
+    @staticmethod
+    def _metric_subject_path(metric: Any) -> list[str]:
+        subject_path = getattr(metric, "subject_path", None)
+        if isinstance(subject_path, list) and subject_path:
+            return [str(part) for part in subject_path if str(part)]
+        dataset = getattr(metric, "dataset", None) or "Unknown"
+        return ["Metrics", str(dataset)]
+
+    @staticmethod
+    def _metric_expression(metric: Any) -> str:
+        expression = getattr(metric, "expression", None)
+        if expression:
+            return str(expression)
+        numerator = getattr(metric, "numerator", None)
+        denominator = getattr(metric, "denominator", None)
+        if numerator or denominator:
+            return f"{numerator or ''} / {denominator or ''}".strip()
+        inputs = getattr(metric, "inputs", None) or []
+        if inputs:
+            return ", ".join(str(getattr(item, "name", item)) for item in inputs)
+        return ""
+
+    def sync_osi_semantic_to_db(self, semantic_model_path: str) -> dict:
+        """Sync OSI datasets into the semantic object store."""
+        try:
+            target_dataset_names = set(self.extract_osi_dataset_names(semantic_model_path))
+            if not target_dataset_names:
+                return {
+                    "success": False,
+                    "error": f"No OSI datasets found in semantic model file to sync: {semantic_model_path}",
+                }
+
+            doc = self._load_osi_document(semantic_model_file=semantic_model_path)
+            db_parts = self._current_db_parts(self.agent_config)
+            semantic_objects: List[dict] = []
+            synced_items: List[str] = []
+
+            for dataset in getattr(doc, "datasets", []):
+                dataset_name = getattr(dataset, "name", "")
+                if dataset_name not in target_dataset_names:
+                    continue
+                table_name = self._dataset_table_name(dataset)
+                fq_parts = [db_parts["catalog_name"], db_parts["database_name"], db_parts["schema_name"], table_name]
+                table_fq_name = ".".join(part for part in fq_parts if part)
+                yaml_path = semantic_model_path
+
+                semantic_objects.append(
+                    {
+                        "id": f"table:{table_name}",
+                        "kind": "table",
+                        "name": table_name,
+                        "fq_name": table_fq_name,
+                        "table_name": table_name,
+                        "description": getattr(dataset, "description", "") or "",
+                        "yaml_path": yaml_path,
+                        "updated_at": datetime.now().replace(microsecond=0),
+                        **db_parts,
+                        "semantic_model_name": dataset_name or table_name,
+                        "is_dimension": False,
+                        "is_measure": False,
+                        "is_entity_key": False,
+                        "is_deprecated": False,
+                        "expr": "",
+                        "column_type": "",
+                        "agg": "",
+                        "create_metric": False,
+                        "agg_time_dimension": "",
+                        "is_partition": False,
+                        "time_granularity": "",
+                        "entity": "",
+                    }
+                )
+                synced_items.append(f"table:{table_name}")
+
+                primary_keys = getattr(dataset, "primary_key", None) or []
+                if isinstance(primary_keys, str):
+                    primary_keys = [primary_keys]
+                for key in primary_keys:
+                    semantic_objects.append(
+                        self._osi_column_object(
+                            table_name=table_name,
+                            table_fq_name=table_fq_name,
+                            semantic_model_name=dataset_name or table_name,
+                            name=str(key),
+                            description="Primary key",
+                            expr=str(key),
+                            column_type="PRIMARY",
+                            yaml_path=yaml_path,
+                            db_parts=db_parts,
+                            is_entity_key=True,
+                        )
+                    )
+
+                time_dimension = getattr(dataset, "time_dimension", None)
+                if time_dimension and getattr(time_dimension, "name", None):
+                    semantic_objects.append(
+                        self._osi_column_object(
+                            table_name=table_name,
+                            table_fq_name=table_fq_name,
+                            semantic_model_name=dataset_name or table_name,
+                            name=str(time_dimension.name),
+                            description="Primary time dimension",
+                            expr=str(time_dimension.name),
+                            column_type="TIME",
+                            yaml_path=yaml_path,
+                            db_parts=db_parts,
+                            is_dimension=True,
+                            time_granularity=getattr(time_dimension, "granularity", "") or "",
+                        )
+                    )
+
+                for dim in getattr(dataset, "dimensions", []):
+                    dim_name = getattr(dim, "name", "")
+                    if not dim_name:
+                        continue
+                    semantic_objects.append(
+                        self._osi_column_object(
+                            table_name=table_name,
+                            table_fq_name=table_fq_name,
+                            semantic_model_name=dataset_name or table_name,
+                            name=str(dim_name),
+                            description=getattr(dim, "description", "") or "",
+                            expr=getattr(dim, "expr", None) or str(dim_name),
+                            column_type=str(getattr(dim, "type", "") or ""),
+                            yaml_path=yaml_path,
+                            db_parts=db_parts,
+                            is_dimension=True,
+                            time_granularity=getattr(dim, "granularity", "") or "",
+                        )
+                    )
+
+            if not semantic_objects:
+                return {
+                    "success": False,
+                    "error": (
+                        "OSI datasets declared in semantic model file were not found after loading datasource "
+                        f"context: {', '.join(sorted(target_dataset_names))}"
+                    ),
+                }
+            self.semantic_rag.upsert_batch(semantic_objects)
+            self.semantic_rag.create_indices()
+            return {
+                "success": True,
+                "message": f"Synced {len(semantic_objects)} OSI semantic object(s): {', '.join(synced_items[:5])}",
+                "semantic_objects": len(semantic_objects),
+            }
+        except Exception as e:
+            logger.error(f"Error syncing OSI semantic objects to DB: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def _osi_column_object(
+        *,
+        table_name: str,
+        table_fq_name: str,
+        semantic_model_name: str,
+        name: str,
+        description: str,
+        expr: str,
+        column_type: str,
+        yaml_path: str,
+        db_parts: dict[str, str],
+        is_dimension: bool = False,
+        is_entity_key: bool = False,
+        time_granularity: str = "",
+    ) -> dict:
+        return {
+            "id": f"column:{table_name}.{name}",
+            "kind": "column",
+            "name": name,
+            "fq_name": f"{table_fq_name}.{name}",
+            "table_name": table_name,
+            "description": description,
+            "is_dimension": is_dimension,
+            "is_measure": False,
+            "is_entity_key": is_entity_key,
+            "is_deprecated": False,
+            "yaml_path": yaml_path,
+            "updated_at": datetime.now().replace(microsecond=0),
+            **db_parts,
+            "semantic_model_name": semantic_model_name,
+            "expr": expr,
+            "column_type": column_type,
+            "agg": "",
+            "create_metric": False,
+            "agg_time_dimension": "",
+            "is_partition": False,
+            "time_granularity": time_granularity,
+            "entity": name if is_entity_key else "",
+        }
+
+    def _sync_osi_metric_to_db(
+        self,
+        metric_file: str,
+        semantic_model_file: Optional[str] = None,
+        metric_sqls: Optional[Dict[str, str]] = None,
+    ) -> dict:
+        """Sync OSI metrics into MetricRAG using the OSI document as source of truth."""
+        try:
+            target_metric_names = set(self.extract_osi_metric_names(metric_file))
+            if not target_metric_names:
+                return {"success": False, "error": f"No OSI metrics found in metric file to sync: {metric_file}"}
+
+            doc = self._load_osi_document(metric_file=metric_file, semantic_model_file=semantic_model_file)
+            datasets = self._dataset_lookup(doc)
+            db_parts = self._current_db_parts(self.agent_config)
+            metric_objects: List[dict] = []
+            synced_items: List[str] = []
+
+            for metric in getattr(doc, "metrics", []):
+                metric_name = getattr(metric, "name", "")
+                if not metric_name:
+                    continue
+                if metric_name not in target_metric_names:
+                    continue
+                dataset_name = getattr(metric, "dataset", None) or ""
+                dataset = datasets.get(dataset_name)
+                table_name = self._dataset_table_name(dataset) if dataset else dataset_name or "Unknown"
+                dimensions: List[str] = []
+                entities: List[str] = []
+                if dataset:
+                    time_dimension = getattr(dataset, "time_dimension", None)
+                    if time_dimension and getattr(time_dimension, "name", None):
+                        dimensions.append(str(time_dimension.name))
+                    dimensions.extend(
+                        str(dim.name) for dim in getattr(dataset, "dimensions", []) if getattr(dim, "name", None)
+                    )
+                    primary_keys = getattr(dataset, "primary_key", None) or []
+                    if isinstance(primary_keys, str):
+                        primary_keys = [primary_keys]
+                    entities.extend(str(key) for key in primary_keys)
+
+                subject_path = self._metric_subject_path(metric)
+                measure_expr = self._metric_expression(metric)
+                metric_obj = {
+                    "name": metric_name,
+                    "subject_path": subject_path,
+                    "semantic_model_name": dataset_name or table_name,
+                    "id": build_metric_id(subject_path, metric_name),
+                    "description": getattr(metric, "description", "") or "",
+                    "metric_type": getattr(metric, "kind", None) or "aggregate",
+                    "measure_expr": measure_expr,
+                    "base_measures": [measure_expr] if measure_expr else [],
+                    "dimensions": dimensions,
+                    "entities": entities,
+                    "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                    "updated_at": datetime.now().replace(microsecond=0),
+                    **db_parts,
+                    "sql": metric_sqls.get(metric_name, "") if metric_sqls else "",
+                    "yaml_path": metric_file,
+                }
+                metric_objects.append(metric_obj)
+                synced_items.append(f"metric:{metric_name}")
+
+            if not metric_objects:
+                return {
+                    "success": False,
+                    "error": (
+                        "OSI metrics declared in metric file were not found after loading datasource context: "
+                        f"{', '.join(sorted(target_metric_names))}"
+                    ),
+                }
+
+            semantic_synced = False
+            if semantic_model_file:
+                sem_result = self.sync_osi_semantic_to_db(semantic_model_file)
+                if not sem_result.get("success"):
+                    return sem_result
+                semantic_synced = True
+
+            self.metric_rag.upsert_batch(metric_objects)
+            self.metric_rag.create_indices()
+            return {
+                "success": True,
+                "message": f"Synced {len(metric_objects)} OSI metric(s): {', '.join(synced_items[:5])}",
+                "metric_artifact_ids": [obj["id"] for obj in metric_objects],
+                "metric_names": [obj["name"] for obj in metric_objects],
+                "semantic_synced": semantic_synced,
+            }
+        except Exception as e:
+            logger.error(f"Error syncing OSI metrics to DB: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
 
     def _sync_metric_to_db(
         self,

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -444,6 +444,7 @@ class SemanticDiscoveryTools:
             source_classifications: List[Dict[str, Any]] = []
             derived_datasource_recommendations: List[Dict[str, Any]] = []
             blocked_direct_metric_candidates: List[Dict[str, Any]] = []
+            metric_generation_skips: List[Dict[str, Any]] = []
             literal_mappings: List[Dict[str, Any]] = []
             time_grain_evidence: List[Dict[str, Any]] = []
             post_aggregation_constraints: List[Dict[str, Any]] = []
@@ -464,9 +465,11 @@ class SemanticDiscoveryTools:
                 entry_candidates: List[Dict[str, Any]] = []
                 entry_has_non_metric_evidence = False
                 entry_has_metric_evidence = False
+                found_candidate = False
                 modeling_analysis = self._analyze_query_modeling(parsed_expressions, source_name)
                 if modeling_analysis["derived_datasource_recommendations"]:
                     derived_datasource_recommendations.extend(modeling_analysis["derived_datasource_recommendations"])
+                    metric_generation_skips.extend(modeling_analysis["metric_generation_skips"])
                 preservation_evidence = self._extract_semantic_preservation_evidence(
                     parsed_expressions,
                     source_name,
@@ -474,8 +477,25 @@ class SemanticDiscoveryTools:
                 literal_mappings.extend(preservation_evidence["literal_mappings"])
                 time_grain_evidence.extend(preservation_evidence["time_grain_evidence"])
                 post_aggregation_constraints.extend(preservation_evidence["post_aggregation_constraints"])
+                pop_candidates = self._period_over_period_metric_candidates(
+                    parsed_expressions,
+                    source_name,
+                    source_context,
+                    existing_metric_catalog,
+                )
+                for candidate in pop_candidates["base_metric_candidates"]:
+                    entry_has_metric_evidence = True
+                    found_candidate = True
+                    entry_candidates.append(candidate)
+                    self._merge_metric_candidate(metric_candidates, candidate)
+                    for measure in candidate.get("base_measures", []):
+                        self._merge_base_measure(base_measures, measure)
+                for candidate in pop_candidates["derived_metric_candidates"]:
+                    entry_has_metric_evidence = True
+                    found_candidate = True
+                    entry_candidates.append(candidate)
+                    self._merge_metric_candidate(metric_candidates, candidate)
 
-                found_candidate = False
                 for parsed in parsed_expressions:
                     for select in self._iter_selects(parsed):
                         select_tables = self._collect_tables(select)
@@ -604,6 +624,7 @@ class SemanticDiscoveryTools:
                     "source_classifications": source_classifications,
                     "derived_datasource_recommendations": derived_datasource_recommendations,
                     "blocked_direct_metric_candidates": blocked_direct_metric_candidates,
+                    "metric_generation_skips": metric_generation_skips,
                     "literal_mappings": literal_mappings,
                     "time_grain_evidence": time_grain_evidence,
                     "post_aggregation_constraints": post_aggregation_constraints,
@@ -721,11 +742,373 @@ class SemanticDiscoveryTools:
                 )
 
         reason = ""
+        metric_generation_skips: List[Dict[str, Any]] = []
         if recommendations:
             reason = "rank/window output is filtered or aggregated downstream; model it as a derived data source first"
+            for rec in recommendations:
+                metric_generation_skips.append(
+                    {
+                        "source_sql_name": rec.get("source_sql_name", source_name),
+                        "reason": (
+                            "rank/window TopN query returns row-level or post-window results; "
+                            "skip during metric generation"
+                        ),
+                        "sql_shape": "ranked_window",
+                        "window": rec.get("window", {}),
+                        "rank_alias": rec.get("rank_alias", ""),
+                        "rank_filters": rec.get("rank_filters", []),
+                    }
+                )
         return {
             "derived_datasource_recommendations": recommendations,
+            "metric_generation_skips": metric_generation_skips,
             "classification_reason": reason,
+        }
+
+    def _period_over_period_metric_candidates(
+        self,
+        parsed_expressions: List[Any],
+        source_name: str,
+        source_context: str,
+        existing_metric_catalog: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Extract derived metric candidates from LAG-style period comparisons."""
+        from sqlglot import expressions as exp
+
+        base_candidates: Dict[str, Dict[str, Any]] = {}
+        derived_candidates: Dict[str, Dict[str, Any]] = {}
+
+        for parsed in parsed_expressions:
+            projection_index = self._named_projection_index(parsed)
+            shift_outputs: Dict[str, Dict[str, Any]] = {}
+
+            for select_name, select in self._named_selects_for_period_analysis(parsed):
+                source_names = self._direct_source_names(select)
+                for projection in select.expressions:
+                    expr = projection.this if isinstance(projection, exp.Alias) else projection
+                    alias = projection.alias if isinstance(projection, exp.Alias) else projection.alias_or_name
+                    if not alias:
+                        continue
+                    for window in expr.find_all(exp.Window):
+                        detail = self._period_shift_output_detail(
+                            window=window,
+                            alias=alias,
+                            source_names=source_names,
+                            projection_index=projection_index,
+                        )
+                        if not detail:
+                            continue
+                        shift_outputs[self._normalize_identifier(alias)] = detail
+                        base_candidate = self._base_candidate_for_period_shift(
+                            detail=detail,
+                            source_name=source_name,
+                            source_context=source_context,
+                            existing_metric_catalog=existing_metric_catalog,
+                            projection_index=projection_index,
+                        )
+                        if base_candidate:
+                            base_candidates[self._metric_candidate_merge_key(base_candidate)] = base_candidate
+
+            if not shift_outputs:
+                continue
+
+            for select_name, select in self._named_selects_for_period_analysis(parsed):
+                source_names = self._direct_source_names(select)
+                visible_shifts = self._visible_period_shift_outputs(
+                    source_names=source_names,
+                    shift_outputs=shift_outputs,
+                    projection_index=projection_index,
+                )
+                visible_shifts.update(shift_outputs)
+                for projection in select.expressions:
+                    candidate = self._period_over_period_candidate_from_projection(
+                        projection=projection,
+                        source_name=source_name,
+                        select_name=select_name,
+                        shift_outputs=visible_shifts,
+                        existing_metric_catalog=existing_metric_catalog,
+                    )
+                    if candidate:
+                        derived_candidates[self._metric_candidate_merge_key(candidate)] = candidate
+
+        return {
+            "base_metric_candidates": sorted(base_candidates.values(), key=lambda item: item["name"]),
+            "derived_metric_candidates": sorted(derived_candidates.values(), key=lambda item: item["name"]),
+        }
+
+    def _named_selects_for_period_analysis(self, parsed: Any) -> List[tuple]:
+        """Return outer and named inner SELECTs with stable names."""
+        from sqlglot import expressions as exp
+
+        selects: List[tuple] = []
+        if isinstance(parsed, exp.Select):
+            selects.append(("__outer__", parsed))
+        selects.extend(self._iter_cte_selects(parsed))
+        selects.extend(self._iter_inline_subquery_selects(parsed))
+        return selects
+
+    def _named_projection_index(self, parsed: Any) -> Dict[str, Dict[str, Dict[str, Any]]]:
+        """Index named SELECT output aliases for CTE/subquery lookups."""
+        from sqlglot import expressions as exp
+
+        index: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        for select_name, select in self._named_selects_for_period_analysis(parsed):
+            projections: Dict[str, Dict[str, Any]] = {}
+            for projection in select.expressions:
+                expr = projection.this if isinstance(projection, exp.Alias) else projection
+                alias = projection.alias if isinstance(projection, exp.Alias) else projection.alias_or_name
+                if alias:
+                    projections[self._normalize_identifier(alias)] = {
+                        "projection": projection,
+                        "expr": expr,
+                        "select": select,
+                        "select_name": select_name,
+                    }
+            index[select_name] = projections
+        return index
+
+    def _direct_source_names(self, select: Any) -> List[str]:
+        """Return direct FROM/JOIN source names for one SELECT."""
+        from sqlglot import expressions as exp
+
+        names: List[str] = []
+
+        def add_source(node: Any) -> None:
+            if isinstance(node, exp.Table):
+                name = self._safe_name(node.name)
+            elif isinstance(node, exp.Subquery):
+                name = self._safe_name(node.alias_or_name or "derived_datasource")
+            else:
+                name = self._safe_name(getattr(node, "alias_or_name", "") or getattr(node, "name", ""))
+            if name and name not in names:
+                names.append(name)
+
+        from_clause = select.args.get("from_")
+        if from_clause is not None:
+            if getattr(from_clause, "this", None) is not None:
+                add_source(from_clause.this)
+            for expr in getattr(from_clause, "expressions", []) or []:
+                add_source(expr)
+
+        for join in select.args.get("joins") or []:
+            if getattr(join, "this", None) is not None:
+                add_source(join.this)
+        return names
+
+    def _period_shift_output_detail(
+        self,
+        window: Any,
+        alias: str,
+        source_names: List[str],
+        projection_index: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Optional[Dict[str, Any]]:
+        """Return LAG/LEAD offset metadata for one window projection."""
+        from sqlglot import expressions as exp
+
+        if not self._is_period_shift_window(window):
+            return None
+        function_name = self._window_function_name(window)
+        if function_name != "LAG":
+            return None
+        input_expr = getattr(window.this, "this", None)
+        if not isinstance(input_expr, exp.Column):
+            return None
+        input_metric = self._safe_name(input_expr.name)
+        offset_window = self._infer_period_offset_window(window, source_names, projection_index)
+        if not offset_window:
+            return None
+        return {
+            "alias": self._safe_name(alias),
+            "input_metric": input_metric,
+            "offset_window": offset_window,
+            "window_function": function_name,
+            "source_names": source_names,
+            "window": {
+                "function": function_name,
+                "order_by": self._window_order_by(window),
+            },
+        }
+
+    def _is_period_shift_window(self, window: Any) -> bool:
+        """Return true for LAG/LEAD windows that can become offset inputs."""
+        from sqlglot import expressions as exp
+
+        return isinstance(window.this, (exp.Lag, exp.Lead))
+
+    def _infer_period_offset_window(
+        self,
+        window: Any,
+        source_names: List[str],
+        projection_index: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> str:
+        """Infer MetricFlow-style offset_window from the window ORDER BY grain."""
+        count = self._period_shift_count(window)
+        grain = ""
+        order_items = self._window_order_by(window)
+        if order_items:
+            order_expr = order_items[0].get("expr", "")
+            order_name = self._normalize_identifier(order_expr.split(".")[-1])
+            for source_name in source_names:
+                projection = projection_index.get(source_name, {}).get(order_name)
+                if projection:
+                    grain = (
+                        self._time_grain_for_expr(projection["expr"]) or self._time_grain_from_alias(order_name) or ""
+                    )
+                    if grain:
+                        break
+            if not grain:
+                try:
+                    parsed_order = self._parse_sql(f"SELECT {order_expr} AS order_expr")[0]
+                    order_projection = parsed_order.expressions[0]
+                    expr = order_projection.this
+                    grain = self._time_grain_for_expr(expr) or self._time_grain_from_alias(order_name) or ""
+                except Exception:
+                    grain = self._time_grain_from_alias(order_name) or ""
+        if not grain:
+            return ""
+        unit = grain.lower()
+        if count != 1 and not unit.endswith("s"):
+            unit = f"{unit}s"
+        return f"{count} {unit}"
+
+    def _period_shift_count(self, window: Any) -> int:
+        """Return the LAG offset count, defaulting to one period."""
+        offset = getattr(window.this, "args", {}).get("offset")
+        try:
+            value = int(getattr(offset, "this", "") or 1)
+        except (TypeError, ValueError):
+            value = 1
+        return max(value, 1)
+
+    def _base_candidate_for_period_shift(
+        self,
+        detail: Dict[str, Any],
+        source_name: str,
+        source_context: str,
+        existing_metric_catalog: Dict[str, Dict[str, Any]],
+        projection_index: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Optional[Dict[str, Any]]:
+        """Return the upstream aggregate candidate required by a period shift."""
+        input_metric = self._normalize_identifier(detail.get("input_metric", ""))
+        if not input_metric or input_metric in existing_metric_catalog:
+            return None
+        for source in detail.get("source_names", []):
+            projection_info = projection_index.get(source, {}).get(input_metric)
+            if not projection_info:
+                continue
+            select = projection_info["select"]
+            candidate = self._candidate_from_projection(
+                projection=projection_info["projection"],
+                source_name=source_name,
+                source_context=source_context,
+                tables=self._collect_tables(select),
+                filters=self._collect_filters(select),
+                dimensions=self._collect_dimensions(select),
+                existing_metric_catalog=existing_metric_catalog,
+            )
+            if candidate and candidate.get("evidence_kind") != "identity_metric_reference":
+                candidate["source_select"] = projection_info.get("select_name", source)
+                return candidate
+        return None
+
+    def _visible_period_shift_outputs(
+        self,
+        source_names: List[str],
+        shift_outputs: Dict[str, Dict[str, Any]],
+        projection_index: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Return period-shift aliases visible through direct CTE/subquery sources."""
+        visible: Dict[str, Dict[str, Any]] = {}
+        for source_name in source_names:
+            for alias in projection_index.get(source_name, {}):
+                shift = shift_outputs.get(alias)
+                if shift:
+                    visible[alias] = shift
+        return visible
+
+    def _period_over_period_candidate_from_projection(
+        self,
+        projection: Any,
+        source_name: str,
+        select_name: str,
+        shift_outputs: Dict[str, Dict[str, Any]],
+        existing_metric_catalog: Dict[str, Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Build a derived metric candidate from expressions over shifted metric aliases."""
+        from sqlglot import expressions as exp
+
+        if not isinstance(projection, exp.Alias):
+            return None
+        expr = projection.this
+        alias = projection.alias
+        if not alias or not self._has_real_metric_math(expr):
+            return None
+        column_names = {self._normalize_identifier(col.name) for col in expr.find_all(exp.Column)}
+        shift_aliases = sorted(column_names & set(shift_outputs))
+        expression = expr.sql()
+        for window in expr.find_all(exp.Window):
+            detail = self._period_shift_output_detail(
+                window=window,
+                alias=f"{self._safe_name(getattr(getattr(window.this, 'this', None), 'name', '') or 'metric')}_prev",
+                source_names=[],
+                projection_index={},
+            )
+            if detail:
+                expression = expression.replace(window.sql(), detail["alias"])
+                shift_aliases.append(self._normalize_identifier(detail["alias"]))
+                shift_outputs[self._normalize_identifier(detail["alias"])] = detail
+
+        if not shift_aliases:
+            return None
+
+        inputs: List[Dict[str, Any]] = []
+        base_names = {shift_outputs[shift_alias]["input_metric"] for shift_alias in shift_aliases}
+        for col_name in sorted(column_names - set(shift_outputs)):
+            if col_name in base_names:
+                self._append_unique(inputs, {"name": col_name}, ["name", "alias", "offset_window"])
+        for base_name in sorted(base_names):
+            self._append_unique(inputs, {"name": base_name}, ["name", "alias", "offset_window"])
+        for shift_alias in shift_aliases:
+            detail = shift_outputs[shift_alias]
+            self._append_unique(
+                inputs,
+                {
+                    "name": detail["input_metric"],
+                    "alias": detail["alias"],
+                    "offset_window": detail["offset_window"],
+                },
+                ["name", "alias", "offset_window"],
+            )
+        if len(inputs) < 2:
+            return None
+
+        referenced_metric_names = {self._normalize_identifier(item["name"]) for item in inputs}
+        missing_inputs = sorted(name for name in referenced_metric_names if name not in existing_metric_catalog)
+        return {
+            "name": self._metric_candidate_name(alias, expr),
+            "metric_type": "derived",
+            "metric_kind": "derived",
+            "expression": expression,
+            "source_alias": alias,
+            "source_sql_name": source_name,
+            "source_select": select_name,
+            "inputs": inputs,
+            "offset_window": next(
+                (item.get("offset_window") for item in inputs if item.get("offset_window")),
+                "",
+            ),
+            "tables": [],
+            "dimensions": [],
+            "filters": [],
+            "base_measures": [],
+            "referenced_metrics": self._referenced_metric_items(referenced_metric_names, existing_metric_catalog),
+            "required_input_metrics": missing_inputs,
+            "confidence": "high",
+            "source_count": 1,
+            "score_reasons": [
+                "LAG window maps to derived metric input with offset_window",
+                "final SELECT expression combines current and prior-period metric values",
+            ],
         }
 
     def _extract_semantic_preservation_evidence(
@@ -1320,6 +1703,8 @@ class SemanticDiscoveryTools:
         expr = projection.this if isinstance(projection, exp.Alias) else projection
         alias = projection.alias if isinstance(projection, exp.Alias) else projection.alias_or_name
         name = self._metric_candidate_name(alias or expr.alias_or_name, expr)
+        if any(self._is_period_shift_window(window) for window in expr.find_all(exp.Window)):
+            return None
         aggregate_classes = self._aggregate_classes()
         aggregates = list(expr.find_all(*aggregate_classes))
         has_aggregates = bool(aggregates)

--- a/tests/integration/test_osi_authoring_closure.py
+++ b/tests/integration/test_osi_authoring_closure.py
@@ -1,0 +1,104 @@
+"""Phase 3 closure: an OSI-authored model is validated/queried via the osi adapter.
+
+When the active semantic adapter is ``osi``, the generation flow's
+``validate_semantic`` / ``query_metrics`` calls are served by DatusOSIAdapter,
+which compiles OSI -> IR -> MetricFlow YAML and returns business-semantic errors.
+This test drives that adapter the same way SemanticTools does (via the registry),
+proving the loop closes without the LLM ever writing MetricFlow syntax.
+
+Uses the ``native`` execution backend so it runs in the agent's no-optional-package
+CI (no MetricFlow needed). Skipped when ``datus_semantic_osi`` is not installed.
+"""
+
+import pytest
+
+pytest.importorskip("datus_semantic_osi")
+
+from datus.tools.semantic_tools.registry import semantic_adapter_registry
+
+GOOD_OSI = """
+version: 0.2.0.dev0
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: orders
+        primary_key: [order_id]
+        fields:
+          - name: order_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_date
+            dimension: {is_time: true}
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"type":"time","time_granularity":"day"}'
+    metrics:
+      - name: order_count
+        description: "number of orders"
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: "COUNT(DISTINCT order_id)"
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"dataset":"orders","time_dimension":"order_date"}'
+"""
+
+# A detail query must not be modeled as a metric -> business-semantic error.
+BAD_OSI = """
+version: 0.2.0.dev0
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: orders
+    metrics:
+      - name: ranked
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: "RANK() OVER (ORDER BY amount DESC)"
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"dataset":"orders"}'
+"""
+
+
+def _make_adapter(osi_dir):
+    from datus_semantic_osi import register
+    from datus_semantic_osi.config import DatusOSIConfig
+
+    register()
+    config = DatusOSIConfig(semantic_models_path=str(osi_dir), datasource="orders", execution_backend="native")
+    return semantic_adapter_registry.create_adapter("osi", config)
+
+
+@pytest.mark.asyncio
+async def test_good_osi_validates_and_dry_runs(tmp_path):
+    (tmp_path / "model.yaml").write_text(GOOD_OSI)
+    adapter = _make_adapter(tmp_path)
+
+    result = await adapter.validate_semantic()
+    errors = [i.message for i in result.issues if i.severity == "error"]
+    assert result.valid, f"errors: {errors}"
+
+    metrics = {m.name for m in await adapter.list_metrics()}
+    assert "order_count" in metrics
+
+    q = await adapter.query_metrics(["order_count"], dry_run=True)
+    assert "COUNT(DISTINCT order_id)" in q.metadata["sql"]
+
+
+@pytest.mark.asyncio
+async def test_bad_osi_returns_business_semantic_error(tmp_path):
+    (tmp_path / "model.yaml").write_text(BAD_OSI)
+    adapter = _make_adapter(tmp_path)
+
+    result = await adapter.validate_semantic()
+    assert not result.valid
+    messages = " ".join(i.message for i in result.issues).lower()
+    # business-semantic phrasing, not MetricFlow YAML internals
+    assert "window" in messages or "ranking" in messages
+    assert "type_params" not in messages

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -929,6 +929,53 @@ class TestExecuteStreamGenMetricsError:
             semantic_model_files=[str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml")],
         )
 
+    def test_osi_final_metric_publish_uses_semantic_model_files(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+
+        datasource = real_agent_config.current_datasource
+        semantic_dir = real_agent_config.path_manager.semantic_model_path(datasource)
+        metric_dir = semantic_dir / "metrics"
+        metric_dir.mkdir(parents=True, exist_ok=True)
+        metric_path = metric_dir / "orders_metrics.yml"
+        metric_path.write_text(
+            """
+version: 0.2.0.dev0
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: orders
+    metrics:
+      - name: order_count
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: COUNT(DISTINCT order_id)
+""",
+            encoding="utf-8",
+        )
+        reported_semantic_path = f"subject/semantic_models/{datasource}/orders.yml"
+        reported_metric_path = f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml"
+
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.node_config["authoring_format"] = "osi"
+        node.input = SemanticNodeInput(user_message="Generate OSI metrics")
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
+        node.semantic_tools.query_metrics = MagicMock(
+            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
+        )
+        node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
+
+        node._finalize_metric_generation([reported_semantic_path], reported_metric_path, "generated")
+
+        node.semantic_tools.query_metrics.assert_called_once_with(metrics=["order_count"], dry_run=True)
+        node.generation_tools.end_metric_generation.assert_called_once_with(
+            metric_file=str(metric_path),
+            semantic_model_files=[str(semantic_dir / "orders.yml")],
+        )
+
     @pytest.mark.asyncio
     async def test_final_metric_file_rejects_out_of_sandbox_absolute_path(
         self, real_agent_config, mock_llm_create, tmp_path

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -1,0 +1,92 @@
+"""Unit tests for semantic authoring format resolution."""
+
+from types import SimpleNamespace
+
+from datus.agent.node.semantic_authoring import (
+    AUTHORING_FORMAT_METRICFLOW,
+    AUTHORING_FORMAT_OSI,
+    osi_prompt_version,
+    osi_template_name,
+    resolve_authoring_format,
+)
+from datus.prompts.prompt_manager import get_prompt_manager
+
+
+def _agent_config(adapter):
+    return SimpleNamespace(resolve_semantic_adapter=lambda requested=None: requested or adapter)
+
+
+def test_explicit_node_config_override_wins():
+    assert resolve_authoring_format(_agent_config("metricflow"), {"authoring_format": "osi"}) == AUTHORING_FORMAT_OSI
+    assert (
+        resolve_authoring_format(_agent_config("osi"), {"authoring_format": "metricflow"})
+        == AUTHORING_FORMAT_METRICFLOW
+    )
+
+
+def test_derives_from_active_semantic_adapter():
+    assert resolve_authoring_format(_agent_config("osi"), None) == AUTHORING_FORMAT_OSI
+    assert resolve_authoring_format(_agent_config("metricflow"), None) == AUTHORING_FORMAT_METRICFLOW
+
+
+def test_derives_from_node_semantic_adapter():
+    assert resolve_authoring_format(_agent_config("metricflow"), {"semantic_adapter": "osi"}) == AUTHORING_FORMAT_OSI
+
+
+def test_defaults_to_metricflow_when_unknown():
+    assert resolve_authoring_format(None, None) == AUTHORING_FORMAT_METRICFLOW
+    assert resolve_authoring_format(_agent_config(None), {}) == AUTHORING_FORMAT_METRICFLOW
+
+
+def test_resolution_is_resilient_to_agent_config_errors():
+    def _boom():
+        raise RuntimeError("no semantic layer")
+
+    bad = SimpleNamespace(resolve_semantic_adapter=_boom)
+    assert resolve_authoring_format(bad, None) == AUTHORING_FORMAT_METRICFLOW
+
+
+def test_osi_template_name_is_isolated_from_metricflow_template():
+    # Separate template_name so the default `{node}_system` latest scan is unaffected.
+    assert osi_template_name("gen_metrics") == "gen_metrics_osi_system"
+    assert osi_template_name("gen_semantic_model") == "gen_semantic_model_osi_system"
+
+
+def test_osi_prompt_version_ignores_injected_metricflow_version():
+    # Bootstrap (init_success_story_metrics) injects the latest *metricflow*
+    # template version (e.g. "1.2"), which is not a version of the OSI template.
+    # It must be ignored (-> None -> latest OSI template), not break rendering.
+    assert osi_prompt_version(None, "gen_metrics", "1.2") is None
+    assert osi_prompt_version(None, "gen_metrics", None) is None
+    # a real OSI template version is honored
+    assert osi_prompt_version(None, "gen_metrics", "1.0") == "1.0"
+
+
+def test_osi_metrics_template_renders_despite_injected_metricflow_version():
+    # Regression: the OSI template must still render when the resolved version
+    # falls back to latest (the injected "1.2" does not exist for it).
+    pm = get_prompt_manager()
+    version = osi_prompt_version(None, "gen_metrics", "1.2")
+    text = pm.render_template(template_name="gen_metrics_osi_system", version=version)
+    assert "OSI" in text
+
+
+def test_osi_skill_skip_handles_missing_node_config(monkeypatch):
+    from datus.agent.node.agentic_node import AgenticNode
+    from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+    from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+
+    def _unexpected_parent_call(self):
+        raise AssertionError("MetricFlow skills should not be injected in OSI mode")
+
+    monkeypatch.setattr(AgenticNode, "_setup_skill_func_tools", _unexpected_parent_call)
+
+    metrics_node = GenMetricsAgenticNode.__new__(GenMetricsAgenticNode)
+    metrics_node.agent_config = _agent_config("osi")
+    metrics_node.node_config = None
+    metrics_node._setup_skill_func_tools()
+
+    semantic_node = GenSemanticModelAgenticNode.__new__(GenSemanticModelAgenticNode)
+    semantic_node.agent_config = _agent_config("osi")
+    semantic_node.node_config = None
+    semantic_node._setup_skill_func_tools()

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -1,0 +1,60 @@
+"""OSI-mode generation prompt templates render and stay backend-agnostic.
+
+These also assert that adding the OSI templates does not change which template
+the default (metricflow) mode resolves to.
+"""
+
+from datus.prompts.prompt_manager import get_prompt_manager
+
+
+def test_osi_metrics_template_is_backend_agnostic():
+    pm = get_prompt_manager()
+    text = pm.render_template(template_name="gen_metrics_osi_system")
+    assert "OSI" in text
+    # explicit boundary: the LLM must not emit execution-engine syntax
+    assert "do NOT write MetricFlow YAML" in text
+    assert "version: 0.2.0.dev0" in text
+    assert "semantic_model:" in text
+    assert "metrics:" in text
+    assert "dialects:" in text
+    assert "custom_extensions" in text
+    assert '"dataset"' in text
+    assert "not OSI core top-level metric fields" in text
+    assert "metric:" in text  # only mentioned as a forbidden MetricFlow block
+    assert '"status": "skipped"' in text
+    assert "No metric generated" in text
+    assert "from_columns" in text
+    assert "to_columns" in text
+    assert "Never put `relationships` inside a dataset" in text
+    assert "analyze_metric_candidates_from_history" in text
+    assert "metric_generation_skips" in text
+    assert "offset_window" in text
+    assert "ROW_NUMBER()`, `RANK() OVER`, TopN per group" in text
+
+
+def test_osi_semantic_model_template_is_backend_agnostic():
+    pm = get_prompt_manager()
+    text = pm.render_template(template_name="gen_semantic_model_osi_system")
+    assert "OSI" in text
+    assert "version: 0.2.0.dev0" in text
+    assert "semantic_model:" in text
+    assert "datasets:" in text
+    assert "fields:" in text
+    assert "dialects:" in text
+    assert "custom_extensions" in text
+    assert "Dataset `source` is a string" in text
+    assert "relationships:" in text
+    assert "from_columns" in text
+    assert "to_columns" in text
+    assert "do NOT write MetricFlow" in text
+    assert "never inside a dataset" in text
+
+
+def test_default_metricflow_templates_are_unchanged():
+    pm = get_prompt_manager()
+    # The default metricflow mode still resolves to its existing latest versions,
+    # unaffected by the new OSI templates (separate template name).
+    assert pm.get_latest_version("gen_metrics_system") == "1.2"
+    assert pm.get_latest_version("gen_semantic_model_system") == "1.1"
+    # OSI templates have their own independent versioning.
+    assert pm.get_latest_version("gen_metrics_osi_system") == "1.0"

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -262,6 +263,31 @@ class TestEndMetricGeneration:
             )
         assert result.success == 1
         assert result.result["metric_sqls"] == {}
+
+    def test_osi_skips_metricflow_metric_block_preflight(self, generation_tools, tmp_path):
+        self._mark_ready_to_publish(generation_tools)
+        generation_tools.authoring_format = "osi"
+        metric_file = tmp_path / "semantic_models" / "starrocks" / "orders_metrics.yml"
+        metric_file.parent.mkdir(parents=True)
+        metric_file.write_text(
+            "metrics:\n  - name: order_count\n    expression: COUNT(DISTINCT order_id)\n    dataset: orders\n"
+        )
+        mock_pm = Mock()
+        mock_pm.subject_dir = str(tmp_path)
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(type(generation_tools), "_validate_metric_file_has_blocks") as preflight_mock,
+            patch.object(
+                generation_tools,
+                "_sync_osi_metric_to_db",
+                return_value={"success": True, "message": "synced"},
+            ) as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(metric_file))
+
+        assert result.success == 1
+        preflight_mock.assert_not_called()
+        sync_mock.assert_called_once()
 
 
 class TestEndMetricGenerationPreflight:
@@ -776,6 +802,143 @@ class TestSyncMetricToDb:
 
         assert result["success"] is False
         assert "boom" in result["error"]
+
+
+class TestOsiSync:
+    def test_sync_osi_metric_to_db_upserts_only_metrics_declared_in_current_file(self, generation_tools, tmp_path):
+        generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
+            catalog="default_catalog", database="shop", schema=""
+        )
+        metric_file = tmp_path / "orders_metrics.yml"
+        metric_file.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: shop\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: orders\n"
+            "    metrics:\n"
+            "      - name: order_count\n"
+            "        expression:\n"
+            "          dialects:\n"
+            "            - dialect: ANSI_SQL\n"
+            "              expression: COUNT(DISTINCT order_id)\n"
+            "        custom_extensions:\n"
+            "          - vendor_name: DATUS\n"
+            '            data: \'{"dataset":"orders"}\'\n'
+        )
+        dataset = SimpleNamespace(
+            name="orders",
+            source=SimpleNamespace(table="orders"),
+            primary_key="order_id",
+            time_dimension=SimpleNamespace(name="order_date"),
+            dimensions=[SimpleNamespace(name="customer_segment")],
+        )
+        metric = SimpleNamespace(
+            name="order_count",
+            description="Number of orders",
+            expression="COUNT(DISTINCT order_id)",
+            dataset="orders",
+            subject_path=None,
+            kind=None,
+        )
+        old_metric = SimpleNamespace(
+            name="old_metric",
+            description="Should not be synced from this file",
+            expression="SUM(old_value)",
+            dataset="orders",
+            subject_path=None,
+            kind=None,
+        )
+        doc = SimpleNamespace(datasets=[dataset], metrics=[metric, old_metric])
+
+        with patch.object(generation_tools, "_load_osi_document", return_value=doc):
+            result = generation_tools._sync_osi_metric_to_db(
+                str(metric_file),
+                metric_sqls={"order_count": "SELECT 1", "old_metric": "SELECT 2"},
+            )
+
+        assert result["success"] is True
+        generation_tools.metric_rag.upsert_batch.assert_called_once()
+        metric_objects = generation_tools.metric_rag.upsert_batch.call_args.args[0]
+        assert len(metric_objects) == 1
+        metric_obj = metric_objects[0]
+        assert metric_obj["name"] == "order_count"
+        assert metric_obj["semantic_model_name"] == "orders"
+        assert metric_obj["measure_expr"] == "COUNT(DISTINCT order_id)"
+        assert metric_obj["dimensions"] == ["order_date", "customer_segment"]
+        assert metric_obj["entities"] == ["order_id"]
+        assert metric_obj["sql"] == "SELECT 1"
+        assert metric_obj["yaml_path"] == str(metric_file)
+        assert result["metric_names"] == ["order_count"]
+
+    def test_sync_osi_metric_to_db_rejects_metric_file_without_metrics(self, generation_tools, tmp_path):
+        metric_file = tmp_path / "empty_metrics.yml"
+        metric_file.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: empty\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: orders\n"
+        )
+
+        result = generation_tools._sync_osi_metric_to_db(str(metric_file))
+
+        assert result["success"] is False
+        assert "No OSI metrics found in metric file" in result["error"]
+        generation_tools.metric_rag.upsert_batch.assert_not_called()
+
+    def test_sync_osi_semantic_to_db_upserts_only_current_dataset_columns(self, generation_tools, tmp_path):
+        generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
+            catalog="default_catalog", database="shop", schema=""
+        )
+        semantic_file = tmp_path / "orders.yml"
+        semantic_file.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: shop\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: orders\n"
+            "        primary_key: [order_id]\n"
+        )
+        dataset = SimpleNamespace(
+            name="orders",
+            description="Orders table",
+            source=SimpleNamespace(table="orders"),
+            primary_key="order_id",
+            time_dimension=SimpleNamespace(name="order_date", granularity="day"),
+            dimensions=[
+                SimpleNamespace(
+                    name="customer_segment",
+                    expr="customer_segment",
+                    type="categorical",
+                    description="Customer segment",
+                    granularity=None,
+                )
+            ],
+        )
+        other_dataset = SimpleNamespace(
+            name="customers",
+            description="Customers table",
+            source=SimpleNamespace(table="customers"),
+            primary_key="customer_id",
+            time_dimension=None,
+            dimensions=[],
+        )
+        doc = SimpleNamespace(datasets=[dataset, other_dataset], metrics=[])
+
+        with patch.object(generation_tools, "_load_osi_document", return_value=doc):
+            result = generation_tools.sync_osi_semantic_to_db(str(semantic_file))
+
+        assert result["success"] is True
+        generation_tools.semantic_rag.upsert_batch.assert_called_once()
+        objects = generation_tools.semantic_rag.upsert_batch.call_args.args[0]
+        assert [obj["kind"] for obj in objects] == ["table", "column", "column", "column"]
+        assert objects[0]["name"] == "orders"
+        assert objects[1]["name"] == "order_id"
+        assert objects[1]["is_entity_key"] is True
 
 
 class TestGenerateSqlSummaryId:

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -567,6 +567,56 @@ class TestAnalyzeMetricCandidatesFromHistory:
         assert candidate["name"] == "rolling_7d_revenue"
         assert candidate["metric_type"] == "cumulative"
 
+    def test_lag_monthly_aggregation_becomes_derived_offset_candidate(self):
+        tools = _make_tools()
+        result = tools.analyze_metric_candidates_from_history(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS start_month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    WHERE start_date >= '2025-04-01' AND start_date < '2025-11-01'
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        start_month,
+                        activity_count,
+                        LAG(activity_count) OVER (ORDER BY start_month) AS previous_month_activity_count
+                    FROM monthly
+                )
+                SELECT
+                    start_month,
+                    activity_count,
+                    previous_month_activity_count,
+                    activity_count - previous_month_activity_count AS activity_count_mom_delta
+                FROM compared
+                ORDER BY start_month
+                """
+            ]
+        )
+
+        assert result.success == 1
+        direct = result.result["direct_metric_candidates"]
+        assert [candidate["name"] for candidate in direct] == ["activity_count"]
+        derived = result.result["derived_metric_candidates"]
+        assert len(derived) == 1
+        candidate = derived[0]
+        assert candidate["name"] == "activity_count_mom_delta"
+        assert candidate["metric_type"] == "derived"
+        assert candidate["metric_kind"] == "derived"
+        assert candidate["expression"] == "activity_count - previous_month_activity_count"
+        assert candidate["inputs"] == [
+            {"name": "activity_count"},
+            {
+                "name": "activity_count",
+                "alias": "previous_month_activity_count",
+                "offset_window": "1 month",
+            },
+        ]
+
     def test_conditional_aggregation_keeps_case_measure_evidence(self):
         tools = _make_tools()
         result = tools.analyze_metric_candidates_from_history(
@@ -864,6 +914,22 @@ class TestAnalyzeMetricCandidatesFromHistory:
         assert result.result["query_classification"] == "metric_plus_derived_datasource"
         assert result.result["direct_metric_candidates"] == []
         assert result.result["blocked_direct_metric_candidates"][0]["name"] == "time_count"
+        assert result.result["metric_generation_skips"] == [
+            {
+                "source_sql_name": "sql_1",
+                "reason": (
+                    "rank/window TopN query returns row-level or post-window results; skip during metric generation"
+                ),
+                "sql_shape": "ranked_window",
+                "window": {
+                    "function": "RANK",
+                    "partition_by": ["f.dt", "f.module"],
+                    "order_by": [{"expr": "f.sell_hitrate", "direction": "ASC"}],
+                },
+                "rank_alias": "rank_no",
+                "rank_filters": ["rank_no <= 10"],
+            }
+        ]
         recommendation = result.result["derived_datasource_recommendations"][0]
         assert recommendation["source_cte"] == "rank_data"
         assert recommendation["rank_alias"] == "rank_no"


### PR DESCRIPTION
## Summary
- add an OSI authoring mode for gen_semantic_model and gen_metrics with isolated OSI prompt templates
- sync OSI semantic models and metrics to the Knowledge Base without requiring LLM-authored MetricFlow YAML
- extend metric discovery for OSI-compatible derived/window candidates and skip ranking/detail SQL during metric generation
- add closure tests for OSI validation, dry-run query, and KB sync behavior

## Validation
- uv run pytest tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py tests/unit_tests/prompts/test_osi_authoring_templates.py tests/integration/test_osi_authoring_closure.py
- uv run ruff check datus/agent/node/gen_metrics_agentic_node.py datus/agent/node/gen_semantic_model_agentic_node.py datus/agent/node/semantic_authoring.py datus/tools/func_tool/generation_tools.py datus/tools/func_tool/semantic_discovery_tools.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py tests/unit_tests/prompts/test_osi_authoring_templates.py tests/integration/test_osi_authoring_closure.py
- uv run ruff format --check datus/agent/node/gen_metrics_agentic_node.py datus/agent/node/gen_semantic_model_agentic_node.py datus/agent/node/semantic_authoring.py datus/tools/func_tool/generation_tools.py datus/tools/func_tool/semantic_discovery_tools.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py tests/unit_tests/prompts/test_osi_authoring_templates.py tests/integration/test_osi_authoring_closure.py
- git diff --check

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OSI semantic authoring format alongside MetricFlow, with automatic format detection based on configuration.
  * Enhanced metric candidate analysis to better identify and skip non-metric SQL patterns, particularly those involving window functions and ranking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->