### PR TITLE
[BugFix] Stop Anthropic SDK env credential fallback from sending dualauth headers

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -209,6 +209,11 @@ class ClaudeModel(OpenAICompatibleModel):
                 http_client=self.async_proxy_client,
                 default_headers=extra_headers or None,
             )
+            # The SDK falls back to the ANTHROPIC_API_KEY env var when api_key=None,
+            # and auth_headers merges both credentials — a stale env key would make
+            # requests carry X-Api-Key alongside the Bearer token and get rejected.
+            self.anthropic_client.api_key = None
+            self.async_anthropic_client.api_key = None
         else:
             self.anthropic_client = anthropic.Anthropic(
                 api_key=self.api_key,
@@ -222,6 +227,11 @@ class ClaudeModel(OpenAICompatibleModel):
                 http_client=self.async_proxy_client,
                 default_headers=extra_headers or None,
             )
+            # Symmetric guard: the SDK falls back to the ANTHROPIC_AUTH_TOKEN env
+            # var when auth_token is not given, which would add a spurious
+            # Authorization: Bearer header next to X-Api-Key.
+            self.anthropic_client.auth_token = None
+            self.async_anthropic_client.auth_token = None
 
         # Wrap with LangSmith if available. Wrap sync and async clients
         # independently so a failure on the async wrap (e.g. older langsmith

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -2499,6 +2499,60 @@ class TestProxyClientInit:
 
 
 # ---------------------------------------------------------------------------
+# Env credential fallback guard
+# ---------------------------------------------------------------------------
+
+
+class TestEnvCredentialFallbackGuard:
+    """The Anthropic SDK silently falls back to ANTHROPIC_API_KEY /
+    ANTHROPIC_AUTH_TOKEN env vars when the corresponding constructor arg is
+    None, and ``auth_headers`` merges both credentials. A stale env var would
+    make every request carry two auth headers and get rejected (401). These
+    tests construct REAL SDK clients (no network) to pin the guard behaviour.
+    """
+
+    def _build_model(self, cfg, env):
+        with (
+            patch("datus.models.openai_compatible.LiteLLMAdapter") as mock_adapter_cls,
+            patch("langsmith.wrappers.wrap_anthropic", side_effect=lambda c: c),
+            patch(
+                "datus.auth.claude_credential.get_claude_subscription_token",
+                return_value=(cfg.api_key, "config (agent.yml)"),
+            ),
+            patch.dict("os.environ", env, clear=True),
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.litellm_model_name = "anthropic/claude-sonnet-4-5"
+            mock_adapter.provider = "anthropic"
+            mock_adapter.is_thinking_model = False
+            mock_adapter.get_agents_sdk_model.return_value = MagicMock()
+            mock_adapter_cls.return_value = mock_adapter
+            return ClaudeModel(cfg)
+
+    def test_subscription_mode_ignores_env_api_key(self):
+        """OAuth requests must carry ONLY the Bearer header even when the
+        user's environment exports a (possibly stale) ANTHROPIC_API_KEY."""
+        cfg = _make_model_config(api_key="sk-ant-oat01-sub-token", auth_type="subscription")
+        model = self._build_model(cfg, {"ANTHROPIC_API_KEY": "sk-ant-stale-env-key"})
+
+        for client in (model.anthropic_client, model.async_anthropic_client):
+            assert client.api_key is None
+            assert client.auth_token == "sk-ant-oat01-sub-token"
+            assert client.auth_headers == {"Authorization": "Bearer sk-ant-oat01-sub-token"}
+
+    def test_api_key_mode_ignores_env_auth_token(self):
+        """API-key requests must carry ONLY X-Api-Key even when the user's
+        environment exports a leftover ANTHROPIC_AUTH_TOKEN."""
+        cfg = _make_model_config(api_key="sk-ant-real-key", auth_type="api_key")
+        model = self._build_model(cfg, {"ANTHROPIC_AUTH_TOKEN": "leaked-bearer-token"})
+
+        for client in (model.anthropic_client, model.async_anthropic_client):
+            assert client.auth_token is None
+            assert client.api_key == "sk-ant-real-key"
+            assert client.auth_headers == {"X-Api-Key": "sk-ant-real-key"}
+
+
+# ---------------------------------------------------------------------------
 # _anthropic_messages_stream routing
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION

The SDK falls back to ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN env vars when the corresponding constructor arg is None, and auth_headers merges both credentials. In subscription mode a stale env API key made requests carry X-Api-Key alongside Authorization: Bearer and get rejected (401). Clear the unused credential on both sync/async clients after construction.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed authentication credential handling to prevent invalid mixed-authentication requests that could cause authentication failures.

* **Tests**
  * Added comprehensive test coverage for authentication credential isolation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->