### PR TITLE
[Feature] Metric preview: compile saved metric to SQL + dimensions endpoint

### DIFF
--- a/datus/api/models/explorer_models.py
+++ b/datus/api/models/explorer_models.py
@@ -126,12 +126,44 @@ class MetricPreviewInput(BaseModel):
     order_by: Optional[List[str]] = Field(None, description="Optional order-by columns; prefix '-' for descending")
 
 
-class MetricPreviewData(BaseModel):
-    """Compiled SQL for previewing a metric's data."""
+class MetricDimensionItem(BaseModel):
+    """A queryable dimension of a metric."""
+
+    name: str = Field(..., description="Dimension name")
+    type: Optional[str] = Field(None, description="Dimension type, e.g. 'time', 'string', 'number'")
+    description: Optional[str] = Field(None, description="Dimension description")
+    is_primary_key: Optional[bool] = Field(None, description="Whether the dimension is a primary key")
+
+
+class MetricDimensionsData(BaseModel):
+    """Available dimensions for a saved metric."""
 
     metric: str = Field(..., description="Metric name")
-    sql: str = Field(..., description="Runnable SQL compiled from the metric definition")
+    dimensions: List[MetricDimensionItem] = Field(default_factory=list, description="Queryable dimensions")
+
+
+class MetricDimensionPreflight(BaseModel):
+    """Why the requested dimensions are not all supported by the metric."""
+
+    message: str = Field(..., description="Human-readable explanation")
+    invalid_dimensions: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Requested dimensions the metric does not support"
+    )
+    common_dimensions: List[str] = Field(default_factory=list, description="Dimensions the metric does support")
+    suggested_metric_groups: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Compatible metric/dimension groupings"
+    )
+
+
+class MetricPreviewData(BaseModel):
+    """Compiled SQL for previewing a metric's data, or a dimension preflight error."""
+
+    metric: str = Field(..., description="Metric name")
+    sql: Optional[str] = Field(None, description="Runnable SQL compiled from the metric definition")
     datasource: Optional[str] = Field(None, description="Datasource the SQL should run against")
+    preflight_error: Optional[MetricDimensionPreflight] = Field(
+        None, description="Set instead of sql when the requested dimensions are invalid"
+    )
 
 
 class EditSemanticModelInput(BaseModel):

--- a/datus/api/models/explorer_models.py
+++ b/datus/api/models/explorer_models.py
@@ -113,6 +113,27 @@ class EditMetricInput(BaseModel):
     yaml: str = Field(..., description="Updated YAML content")
 
 
+class MetricPreviewInput(BaseModel):
+    """Preview a saved metric by compiling it to SQL (dry-run)."""
+
+    subject_path: List[str] = Field(..., description="Path to the saved metric; the leaf is the metric name")
+    dimensions: Optional[List[str]] = Field(None, description="Optional dimensions to group by")
+    time_start: Optional[str] = Field(None, description="Optional start time (ISO or relative, e.g. '-7d')")
+    time_end: Optional[str] = Field(None, description="Optional end time (ISO or relative, e.g. 'now')")
+    time_granularity: Optional[str] = Field(None, description="Optional grain: day/week/month/quarter/year")
+    where: Optional[str] = Field(None, description="Optional SQL WHERE clause (without the WHERE keyword)")
+    limit: Optional[int] = Field(None, description="Optional row limit")
+    order_by: Optional[List[str]] = Field(None, description="Optional order-by columns; prefix '-' for descending")
+
+
+class MetricPreviewData(BaseModel):
+    """Compiled SQL for previewing a metric's data."""
+
+    metric: str = Field(..., description="Metric name")
+    sql: str = Field(..., description="Runnable SQL compiled from the metric definition")
+    datasource: Optional[str] = Field(None, description="Datasource the SQL should run against")
+
+
 class EditSemanticModelInput(BaseModel):
     """Edit semantic model entry (table or column)."""
 

--- a/datus/api/routes/explorer_routes.py
+++ b/datus/api/routes/explorer_routes.py
@@ -11,6 +11,7 @@ from datus.api.models.explorer_models import (
     DeleteSubjectInput,
     EditMetricInput,
     EditSemanticModelInput,
+    MetricDimensionsData,
     MetricInfo,
     MetricPreviewData,
     MetricPreviewInput,
@@ -94,6 +95,20 @@ async def get_metric(
 ) -> Result[MetricInfo]:
     """Get metric info."""
     return await svc.explorer.get_metric(request.subject_path)
+
+
+@router.post(
+    "/subject/metric/dimensions",
+    response_model=Result[MetricDimensionsData],
+    summary="Get Metric Dimensions",
+    description="List the queryable dimensions of a saved metric for the preview panel",
+)
+async def get_metric_dimensions(
+    request: SubjectPathInput,
+    svc: ServiceDep,
+) -> Result[MetricDimensionsData]:
+    """List a metric's queryable dimensions."""
+    return await svc.explorer.get_metric_dimensions(request.subject_path)
 
 
 @router.post(

--- a/datus/api/routes/explorer_routes.py
+++ b/datus/api/routes/explorer_routes.py
@@ -12,6 +12,8 @@ from datus.api.models.explorer_models import (
     EditMetricInput,
     EditSemanticModelInput,
     MetricInfo,
+    MetricPreviewData,
+    MetricPreviewInput,
     ReferenceSQLInfo,
     ReferenceSQLInput,
     RenameSubjectInput,
@@ -92,6 +94,20 @@ async def get_metric(
 ) -> Result[MetricInfo]:
     """Get metric info."""
     return await svc.explorer.get_metric(request.subject_path)
+
+
+@router.post(
+    "/subject/metric/preview",
+    response_model=Result[MetricPreviewData],
+    summary="Preview Metric",
+    description="Compile a saved metric into runnable SQL (dry-run) for previewing its data",
+)
+async def preview_metric(
+    request: MetricPreviewInput,
+    svc: ServiceDep,
+) -> Result[MetricPreviewData]:
+    """Compile a saved metric to SQL for preview."""
+    return await svc.explorer.preview_metric(request)
 
 
 @router.post(

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -12,6 +12,8 @@ from datus.api.models.explorer_models import (
     EditMetricInput,
     EditSemanticModelInput,
     MetricInfo,
+    MetricPreviewData,
+    MetricPreviewInput,
     ReferenceSQLInfo,
     ReferenceSQLInput,
     RenameSubjectInput,
@@ -597,6 +599,77 @@ class ExplorerService:
             from datus.api.models.config_models import ErrorCode
 
             return Result[MetricInfo](
+                success=False,
+                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorMessage=str(e),
+            )
+
+    async def preview_metric(self, request: MetricPreviewInput) -> Result[MetricPreviewData]:
+        """Compile a saved metric into runnable SQL via the semantic adapter.
+
+        Uses dry-run so nothing executes here: the frontend hands the returned
+        SQL to the existing SQL-result panel, which runs it and renders the
+        table / chart. Only already-saved (registered) metrics are supported.
+        """
+        from datus.api.models.config_models import ErrorCode
+
+        try:
+            self._require_datasource()
+
+            if not request.subject_path:
+                return Result[MetricPreviewData](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage="Subject path cannot be empty",
+                )
+
+            metric_name = request.subject_path[-1]
+
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            tools = SemanticTools(self.agent_config)
+            adapter = tools.adapter
+            if adapter is None:
+                return Result[MetricPreviewData](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage="Semantic adapter is not available; cannot preview this metric.",
+                )
+
+            # dry_run asks the adapter to render SQL without executing it.
+            query_result = await adapter.query_metrics(
+                metrics=[metric_name],
+                dimensions=request.dimensions or [],
+                time_start=request.time_start,
+                time_end=request.time_end,
+                time_granularity=request.time_granularity,
+                where=request.where,
+                limit=request.limit,
+                order_by=request.order_by or None,
+                dry_run=True,
+            )
+
+            metadata = query_result.metadata or {}
+            sql = metadata.get("sql")
+            if not sql and query_result.data:
+                # MetricFlow also echoes the rendered SQL in the single data row.
+                sql = (query_result.data[0] or {}).get("sql")
+
+            if not sql:
+                return Result[MetricPreviewData](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage=f"Failed to compile SQL for metric '{metric_name}'.",
+                )
+
+            return Result[MetricPreviewData](
+                success=True,
+                data=MetricPreviewData(metric=metric_name, sql=sql, datasource=self.datasource_id or None),
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to preview metric: {e}")
+            return Result[MetricPreviewData](
                 success=False,
                 errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
                 errorMessage=str(e),

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -2,6 +2,7 @@
 Explorer service for catalog and subject tree management.
 """
 
+import asyncio
 import os
 from typing import List, Optional, Tuple
 
@@ -11,6 +12,9 @@ from datus.api.models.explorer_models import (
     DeleteSubjectInput,
     EditMetricInput,
     EditSemanticModelInput,
+    MetricDimensionItem,
+    MetricDimensionPreflight,
+    MetricDimensionsData,
     MetricInfo,
     MetricPreviewData,
     MetricPreviewInput,
@@ -604,12 +608,68 @@ class ExplorerService:
                 errorMessage=str(e),
             )
 
+    async def get_metric_dimensions(self, subject_path: List[str]) -> Result[MetricDimensionsData]:
+        """List the queryable dimensions of a saved metric.
+
+        Powers the preview panel's dimension picker, so the user only chooses
+        dimensions the metric actually supports.
+        """
+        from datus.api.models.config_models import ErrorCode
+
+        try:
+            self._require_datasource()
+
+            if not subject_path:
+                return Result[MetricDimensionsData](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage="Subject path cannot be empty",
+                )
+
+            metric_name = subject_path[-1]
+
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            tools = SemanticTools(self.agent_config)
+            adapter = tools.adapter
+            if adapter is None:
+                return Result[MetricDimensionsData](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage="Semantic adapter is not available; cannot load dimensions.",
+                )
+
+            dimensions = await adapter.get_dimensions(metric_name=metric_name)
+            items = [
+                MetricDimensionItem(
+                    name=d.name,
+                    type=getattr(d, "type", None),
+                    description=getattr(d, "description", None),
+                    is_primary_key=getattr(d, "is_primary_key", None),
+                )
+                for d in (dimensions or [])
+            ]
+            return Result[MetricDimensionsData](
+                success=True,
+                data=MetricDimensionsData(metric=metric_name, dimensions=items),
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to get metric dimensions: {e}")
+            return Result[MetricDimensionsData](
+                success=False,
+                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorMessage=str(e),
+            )
+
     async def preview_metric(self, request: MetricPreviewInput) -> Result[MetricPreviewData]:
         """Compile a saved metric into runnable SQL via the semantic adapter.
 
         Uses dry-run so nothing executes here: the frontend hands the returned
         SQL to the existing SQL-result panel, which runs it and renders the
         table / chart. Only already-saved (registered) metrics are supported.
+        When requested dimensions aren't supported, returns a structured
+        ``preflight_error`` (with the metric's valid dimensions) instead of SQL.
         """
         from datus.api.models.config_models import ErrorCode
 
@@ -628,16 +688,18 @@ class ExplorerService:
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
             tools = SemanticTools(self.agent_config)
-            adapter = tools.adapter
-            if adapter is None:
+            if tools.adapter is None:
                 return Result[MetricPreviewData](
                     success=False,
                     errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
                     errorMessage="Semantic adapter is not available; cannot preview this metric.",
                 )
 
-            # dry_run asks the adapter to render SQL without executing it.
-            query_result = await adapter.query_metrics(
+            # query_metrics is sync (it wraps an async adapter call); run it off
+            # the event loop. dry_run renders SQL and runs the dimension preflight
+            # without executing anything.
+            func_result = await asyncio.to_thread(
+                tools.query_metrics,
                 metrics=[metric_name],
                 dimensions=request.dimensions or [],
                 time_start=request.time_start,
@@ -649,22 +711,45 @@ class ExplorerService:
                 dry_run=True,
             )
 
-            metadata = query_result.metadata or {}
-            sql = metadata.get("sql")
-            if not sql and query_result.data:
-                # MetricFlow also echoes the rendered SQL in the single data row.
-                sql = (query_result.data[0] or {}).get("sql")
-
-            if not sql:
+            if func_result.success == 1:
+                payload = func_result.result or {}
+                sql = (payload.get("metadata") or {}).get("sql")
+                if not sql:
+                    data = payload.get("data")
+                    if isinstance(data, list) and data:
+                        sql = (data[0] or {}).get("sql")
+                if not sql:
+                    return Result[MetricPreviewData](
+                        success=False,
+                        errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                        errorMessage=f"Failed to compile SQL for metric '{metric_name}'.",
+                    )
                 return Result[MetricPreviewData](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=f"Failed to compile SQL for metric '{metric_name}'.",
+                    success=True,
+                    data=MetricPreviewData(metric=metric_name, sql=sql, datasource=self.datasource_id or None),
+                )
+
+            # A dimension preflight failure carries structured detail; surface it
+            # so the UI can guide the user instead of showing a raw error.
+            detail = func_result.result
+            if isinstance(detail, dict) and detail.get("invalid_dimensions") is not None:
+                return Result[MetricPreviewData](
+                    success=True,
+                    data=MetricPreviewData(
+                        metric=metric_name,
+                        preflight_error=MetricDimensionPreflight(
+                            message=func_result.error or "Some dimensions are not supported by this metric.",
+                            invalid_dimensions=detail.get("invalid_dimensions") or [],
+                            common_dimensions=detail.get("common_dimensions") or [],
+                            suggested_metric_groups=detail.get("suggested_metric_groups") or [],
+                        ),
+                    ),
                 )
 
             return Result[MetricPreviewData](
-                success=True,
-                data=MetricPreviewData(metric=metric_name, sql=sql, datasource=self.datasource_id or None),
+                success=False,
+                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorMessage=func_result.error or "Failed to preview metric.",
             )
 
         except Exception as e:

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -885,12 +885,11 @@ class TestExplorerServiceHelpers:
 
 
 @pytest.mark.asyncio
-class TestExplorerServicePreviewMetric:
-    """Tests for preview_metric — compile a saved metric to SQL via dry-run."""
+class TestExplorerServiceMetricDimensions:
+    """Tests for get_metric_dimensions — power the preview panel's dim picker."""
 
     @staticmethod
     def _patch_adapter(monkeypatch, *, adapter):
-        """Make SemanticTools(...) yield a stub exposing ``adapter``."""
         from types import SimpleNamespace
 
         tools_stub = SimpleNamespace(adapter=adapter)
@@ -899,11 +898,67 @@ class TestExplorerServicePreviewMetric:
             lambda *a, **k: tools_stub,
         )
 
+    async def test_empty_subject_path_fails(self, real_agent_config):
+        """Empty subject path is rejected before touching the adapter."""
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.get_metric_dimensions([])
+        assert result.success is False
+        assert "Subject path cannot be empty" in result.errorMessage
+
+    async def test_adapter_unavailable_fails(self, real_agent_config, monkeypatch):
+        """A missing semantic adapter surfaces a clear error."""
+        self._patch_adapter(monkeypatch, adapter=None)
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.get_metric_dimensions(["Finance", "revenue"])
+        assert result.success is False
+        assert "adapter is not available" in result.errorMessage
+
+    async def test_maps_dimension_fields(self, real_agent_config, monkeypatch):
+        """Adapter DimensionInfo objects are mapped onto the response model."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        adapter = MagicMock()
+        adapter.get_dimensions = AsyncMock(
+            return_value=[
+                SimpleNamespace(name="region", type="string", description="Sales region", is_primary_key=False),
+                SimpleNamespace(name="metric_time", type="time", description=None, is_primary_key=None),
+            ]
+        )
+        self._patch_adapter(monkeypatch, adapter=adapter)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.get_metric_dimensions(["Finance", "revenue"])
+
+        assert result.success is True
+        assert result.data.metric == "revenue"
+        assert [d.name for d in result.data.dimensions] == ["region", "metric_time"]
+        assert result.data.dimensions[0].type == "string"
+        assert result.data.dimensions[1].type == "time"
+        assert adapter.get_dimensions.await_args.kwargs["metric_name"] == "revenue"
+
+
+@pytest.mark.asyncio
+class TestExplorerServicePreviewMetric:
+    """Tests for preview_metric — compile a saved metric to SQL via dry-run."""
+
     @staticmethod
-    def _query_result(*, metadata=None, data=None):
+    def _patch_tools(monkeypatch, *, adapter, query_metrics=None):
+        """Stub SemanticTools(...) with an ``adapter`` and sync ``query_metrics``."""
         from types import SimpleNamespace
 
-        return SimpleNamespace(metadata=metadata or {}, data=data or [])
+        tools_stub = SimpleNamespace(adapter=adapter, query_metrics=query_metrics)
+        monkeypatch.setattr(
+            "datus.tools.func_tool.semantic_tools.SemanticTools",
+            lambda *a, **k: tools_stub,
+        )
+        return tools_stub
+
+    @staticmethod
+    def _func_result(*, success=1, error=None, result=None):
+        from datus.tools.func_tool.base import FuncToolResult
+
+        return FuncToolResult(success=success, error=error, result=result)
 
     async def test_empty_subject_path_fails(self, real_agent_config):
         """Empty subject path is rejected before touching the adapter."""
@@ -918,7 +973,7 @@ class TestExplorerServicePreviewMetric:
         """A missing semantic adapter surfaces a clear error, not a crash."""
         from datus.api.models.explorer_models import MetricPreviewInput
 
-        self._patch_adapter(monkeypatch, adapter=None)
+        self._patch_tools(monkeypatch, adapter=None)
         svc = ExplorerService(agent_config=real_agent_config)
         result = await svc.preview_metric(MetricPreviewInput(subject_path=["Finance", "revenue"]))
         assert result.success is False
@@ -926,68 +981,105 @@ class TestExplorerServicePreviewMetric:
 
     async def test_returns_compiled_sql_from_metadata(self, real_agent_config, monkeypatch):
         """Happy path: leaf is the metric, SQL comes from dry-run metadata."""
-        from unittest.mock import AsyncMock
-
         from datus.api.models.explorer_models import MetricPreviewInput
 
-        adapter = MagicMock()
-        adapter.query_metrics = AsyncMock(
-            return_value=self._query_result(metadata={"explain": True, "sql": "SELECT 1 AS revenue"})
+        query_metrics = MagicMock(
+            return_value=self._func_result(
+                result={"metadata": {"explain": True, "sql": "SELECT 1 AS revenue"}, "data": []}
+            )
         )
-        self._patch_adapter(monkeypatch, adapter=adapter)
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
 
         svc = ExplorerService(agent_config=real_agent_config)
-        result = await svc.preview_metric(MetricPreviewInput(subject_path=["Finance", "revenue"]))
+        result = await svc.preview_metric(
+            MetricPreviewInput(subject_path=["Finance", "revenue"], dimensions=["region"], limit=100)
+        )
 
         assert result.success is True
         assert result.data.metric == "revenue"
         assert result.data.sql == "SELECT 1 AS revenue"
         assert result.data.datasource == svc.datasource_id
+        assert result.data.preflight_error is None
         # dry_run must be requested so nothing actually executes.
-        assert adapter.query_metrics.await_args.kwargs["dry_run"] is True
-        assert adapter.query_metrics.await_args.kwargs["metrics"] == ["revenue"]
+        assert query_metrics.call_args.kwargs["dry_run"] is True
+        assert query_metrics.call_args.kwargs["metrics"] == ["revenue"]
+        assert query_metrics.call_args.kwargs["dimensions"] == ["region"]
 
     async def test_falls_back_to_data_row_sql(self, real_agent_config, monkeypatch):
         """SQL is recovered from the single data row when metadata omits it."""
-        from unittest.mock import AsyncMock
-
         from datus.api.models.explorer_models import MetricPreviewInput
 
-        adapter = MagicMock()
-        adapter.query_metrics = AsyncMock(return_value=self._query_result(metadata={}, data=[{"sql": "SELECT 2"}]))
-        self._patch_adapter(monkeypatch, adapter=adapter)
+        query_metrics = MagicMock(
+            return_value=self._func_result(result={"metadata": {}, "data": [{"sql": "SELECT 2"}]})
+        )
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
 
         svc = ExplorerService(agent_config=real_agent_config)
         result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
         assert result.success is True
         assert result.data.sql == "SELECT 2"
 
-    async def test_no_sql_compiled_fails(self, real_agent_config, monkeypatch):
-        """When neither metadata nor data carry SQL, report a clean failure."""
-        from unittest.mock import AsyncMock
-
+    async def test_dimension_preflight_failure_is_structured(self, real_agent_config, monkeypatch):
+        """A dimension preflight failure becomes a structured preflight_error, not a raw error."""
         from datus.api.models.explorer_models import MetricPreviewInput
 
-        adapter = MagicMock()
-        adapter.query_metrics = AsyncMock(return_value=self._query_result(metadata={}, data=[]))
-        self._patch_adapter(monkeypatch, adapter=adapter)
+        preflight = {
+            "metrics": ["revenue"],
+            "requested_dimensions": ["country"],
+            "invalid_dimensions": [{"name": "country", "unsupported_metrics": ["revenue"], "supported_metrics": []}],
+            "common_dimensions": ["metric_time", "region"],
+            "suggested_metric_groups": [{"metrics": ["revenue"], "dimensions": ["region"]}],
+        }
+        query_metrics = MagicMock(
+            return_value=self._func_result(success=0, error="dimension preflight failed", result=preflight)
+        )
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"], dimensions=["country"]))
+
+        assert result.success is True
+        assert result.data.sql is None
+        pf = result.data.preflight_error
+        assert pf is not None
+        assert pf.common_dimensions == ["metric_time", "region"]
+        assert pf.invalid_dimensions[0]["name"] == "country"
+        assert pf.suggested_metric_groups[0]["dimensions"] == ["region"]
+
+    async def test_no_sql_compiled_fails(self, real_agent_config, monkeypatch):
+        """When neither metadata nor data carry SQL, report a clean failure."""
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        query_metrics = MagicMock(return_value=self._func_result(result={"metadata": {}, "data": []}))
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
 
         svc = ExplorerService(agent_config=real_agent_config)
         result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
         assert result.success is False
         assert "Failed to compile SQL" in result.errorMessage
 
-    async def test_adapter_exception_is_caught(self, real_agent_config, monkeypatch):
-        """Adapter errors become a failed Result rather than propagating."""
-        from unittest.mock import AsyncMock
-
+    async def test_hard_failure_surfaces_error(self, real_agent_config, monkeypatch):
+        """A non-preflight tool failure becomes a failed Result with its message."""
         from datus.api.models.explorer_models import MetricPreviewInput
 
-        adapter = MagicMock()
-        adapter.query_metrics = AsyncMock(side_effect=RuntimeError("unknown metric 'revenue'"))
-        self._patch_adapter(monkeypatch, adapter=adapter)
+        query_metrics = MagicMock(
+            return_value=self._func_result(success=0, error="unknown metric 'revenue'", result=None)
+        )
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
 
         svc = ExplorerService(agent_config=real_agent_config)
         result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
         assert result.success is False
         assert "unknown metric" in result.errorMessage
+
+    async def test_exception_is_caught(self, real_agent_config, monkeypatch):
+        """Unexpected errors become a failed Result rather than propagating."""
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        query_metrics = MagicMock(side_effect=RuntimeError("boom"))
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
+        assert result.success is False
+        assert "boom" in result.errorMessage

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -882,3 +882,112 @@ class TestExplorerServiceHelpers:
         id1 = svc._gen_reference_sql_id("SELECT 1")
         id2 = svc._gen_reference_sql_id("SELECT 2")
         assert id1 != id2
+
+
+@pytest.mark.asyncio
+class TestExplorerServicePreviewMetric:
+    """Tests for preview_metric — compile a saved metric to SQL via dry-run."""
+
+    @staticmethod
+    def _patch_adapter(monkeypatch, *, adapter):
+        """Make SemanticTools(...) yield a stub exposing ``adapter``."""
+        from types import SimpleNamespace
+
+        tools_stub = SimpleNamespace(adapter=adapter)
+        monkeypatch.setattr(
+            "datus.tools.func_tool.semantic_tools.SemanticTools",
+            lambda *a, **k: tools_stub,
+        )
+
+    @staticmethod
+    def _query_result(*, metadata=None, data=None):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(metadata=metadata or {}, data=data or [])
+
+    async def test_empty_subject_path_fails(self, real_agent_config):
+        """Empty subject path is rejected before touching the adapter."""
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=[]))
+        assert result.success is False
+        assert "Subject path cannot be empty" in result.errorMessage
+
+    async def test_adapter_unavailable_fails(self, real_agent_config, monkeypatch):
+        """A missing semantic adapter surfaces a clear error, not a crash."""
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        self._patch_adapter(monkeypatch, adapter=None)
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["Finance", "revenue"]))
+        assert result.success is False
+        assert "adapter is not available" in result.errorMessage
+
+    async def test_returns_compiled_sql_from_metadata(self, real_agent_config, monkeypatch):
+        """Happy path: leaf is the metric, SQL comes from dry-run metadata."""
+        from unittest.mock import AsyncMock
+
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        adapter = MagicMock()
+        adapter.query_metrics = AsyncMock(
+            return_value=self._query_result(metadata={"explain": True, "sql": "SELECT 1 AS revenue"})
+        )
+        self._patch_adapter(monkeypatch, adapter=adapter)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["Finance", "revenue"]))
+
+        assert result.success is True
+        assert result.data.metric == "revenue"
+        assert result.data.sql == "SELECT 1 AS revenue"
+        assert result.data.datasource == svc.datasource_id
+        # dry_run must be requested so nothing actually executes.
+        assert adapter.query_metrics.await_args.kwargs["dry_run"] is True
+        assert adapter.query_metrics.await_args.kwargs["metrics"] == ["revenue"]
+
+    async def test_falls_back_to_data_row_sql(self, real_agent_config, monkeypatch):
+        """SQL is recovered from the single data row when metadata omits it."""
+        from unittest.mock import AsyncMock
+
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        adapter = MagicMock()
+        adapter.query_metrics = AsyncMock(return_value=self._query_result(metadata={}, data=[{"sql": "SELECT 2"}]))
+        self._patch_adapter(monkeypatch, adapter=adapter)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
+        assert result.success is True
+        assert result.data.sql == "SELECT 2"
+
+    async def test_no_sql_compiled_fails(self, real_agent_config, monkeypatch):
+        """When neither metadata nor data carry SQL, report a clean failure."""
+        from unittest.mock import AsyncMock
+
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        adapter = MagicMock()
+        adapter.query_metrics = AsyncMock(return_value=self._query_result(metadata={}, data=[]))
+        self._patch_adapter(monkeypatch, adapter=adapter)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
+        assert result.success is False
+        assert "Failed to compile SQL" in result.errorMessage
+
+    async def test_adapter_exception_is_caught(self, real_agent_config, monkeypatch):
+        """Adapter errors become a failed Result rather than propagating."""
+        from unittest.mock import AsyncMock
+
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        adapter = MagicMock()
+        adapter.query_metrics = AsyncMock(side_effect=RuntimeError("unknown metric 'revenue'"))
+        self._patch_adapter(monkeypatch, adapter=adapter)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
+        assert result.success is False
+        assert "unknown metric" in result.errorMessage


### PR DESCRIPTION
## Why

The metric editor (Datus-saas `EditMetric`) lets users author a metric's YAML but gives no way to *see* the data it produces — you'd drop into chat and ask the agent to run `query_metrics`. There's no REST surface to turn a saved metric into runnable SQL, nor to list the dimensions it can be sliced by.

## Solution

Two endpoints powering a preview panel over **already-saved** metrics:

**`POST /api/v1/subject/metric/dimensions`** — lists a metric's queryable dimensions (`name` / `type` / `description` / `is_primary_key`) via `adapter.get_dimensions`, so the UI's dimension picker only offers valid choices.

**`POST /api/v1/subject/metric/preview`** — compiles the metric to SQL and returns it; the frontend hands that SQL to its SQL-result panel to run + chart, so the backend stays a pure compile step and reuses all existing execution + visualization UI.
- Accepts `dimensions` / `time_start` / `time_end` / `time_granularity` / `where` / `limit` / `order_by`.
- Routes through `SemanticTools.query_metrics(..., dry_run=True)` off the event loop (`asyncio.to_thread`; `run_async` is loop-safe in a worker thread) so the **dimension preflight** runs. `dry_run` renders SQL without executing.
- On success: reads the rendered SQL from `QueryResult.metadata["sql"]` (data-row fallback).
- On dimension preflight failure: returns a structured `preflight_error` (invalid dims, the metric's supported dims, suggested groups) so the UI guides the user instead of showing a raw error.

Models: `MetricDimensionItem`, `MetricDimensionsData`, `MetricDimensionPreflight`; `MetricPreviewData.sql` is optional alongside `preflight_error`. Previewing unsaved YAML is intentionally out of scope (the metric must be saved/registered first).

## Test Cases

`tests/unit_tests/api/services/test_explorer_service.py` (adapter mocked, deterministic, no warehouse):
- `TestExplorerServiceMetricDimensions`: empty path, missing adapter, field mapping of adapter `DimensionInfo` → response.
- `TestExplorerServicePreviewMetric`: empty path, missing adapter, SQL from metadata (asserts `dry_run=True`, metric leaf, dimensions passed), data-row SQL fallback, **structured dimension preflight**, no-SQL-compiled failure, hard-failure passthrough, exception caught.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metric preview: preview generated SQL for saved metrics (dry-run) via a new preview endpoint.
  * Added metric dimensions endpoint: fetch available/queryable dimensions for a saved metric to drive previews and UI controls.
* **Bug Fixes**
  * Improved handling of invalid dimension selections with structured preflight feedback and suggested compatible groupings.
* **Tests**
  * Added unit tests covering preview, dimensions, preflight failures, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->