### PR TITLE
[Enhancement] Support non-interactive plan mode with auto-confirm in print mode and benchmark

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -489,12 +489,14 @@ class AgenticNode(Node):
         if not self.plan_mode_active or not self.plan_file_path:
             return ""
 
+        auto_execute_plan = bool(getattr(self.input, "auto_execute_plan", False))
         try:
             rendered = get_prompt_manager(agent_config=self.agent_config).render_template(
                 template_name="plan_mode_system",
                 version=None,
                 plan_file_path=self.plan_file_path,
                 workflow_prompt_sent=self.workflow_prompt_sent,
+                auto_execute_plan=auto_execute_plan,
             )
         except FileNotFoundError:
             logger.warning("plan_mode_system template not found, using inline fallback")

--- a/datus/agent/workflow_runner.py
+++ b/datus/agent/workflow_runner.py
@@ -48,8 +48,11 @@ class WorkflowRunner:
         )
 
         if hasattr(self.args, "plan_mode"):
-            self.workflow.metadata["plan_mode"] = self.args.plan_mode
-            self.workflow.metadata["auto_execute_plan"] = True
+            plan_mode = bool(self.args.plan_mode)
+            self.workflow.metadata["plan_mode"] = plan_mode
+            # Workflow runs are headless: a generated plan must be auto-approved
+            # (consumed by ConfirmPlanTool) instead of waiting for user input.
+            self.workflow.metadata["auto_execute_plan"] = plan_mode
 
         self.workflow.display()
         logger.info("Initial workflow generated")

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -210,6 +210,17 @@ class ArgumentParser:
             help="Expose orchestrator issue lifecycle tools in print mode",
         )
 
+        self.parser.add_argument(
+            "--plan-mode",
+            dest="plan_mode",
+            action="store_true",
+            default=False,
+            help=(
+                "Enable plan mode in print mode: the agent writes a plan first, the plan is "
+                "auto-confirmed (no interactive approval), then executed in the same run"
+            ),
+        )
+
     def parse_args(self):
         return self.parser.parse_args()
 
@@ -241,6 +252,9 @@ class Application:
 
         if getattr(args, "orchestrator_tools", False) and args.print_mode is None:
             self.arg_parser.parser.error("--orchestrator-tools requires --print mode")
+
+        if getattr(args, "plan_mode", False) and args.print_mode is None:
+            self.arg_parser.parser.error("--plan-mode requires --print mode (use Shift+Tab in the REPL)")
 
         if args.print_mode is not None:
             from datus.cli.print_mode import PrintModeRunner

--- a/datus/cli/print_mode.py
+++ b/datus/cli/print_mode.py
@@ -52,6 +52,7 @@ class PrintModeRunner:
         self.orchestrator_tools = getattr(args, "orchestrator_tools", False)
         self.scope = getattr(args, "session_scope", None)
         self.stream_thinking = getattr(args, "stream_thinking", False)
+        self.plan_mode = getattr(args, "plan_mode", False)
 
         self.catalog, self.database, self.db_schema = self._resolve_database_context(args)
 
@@ -107,7 +108,12 @@ class PrintModeRunner:
             at_tables=at_tables,
             at_metrics=at_metrics,
             at_sqls=at_sqls,
+            plan_mode=self.plan_mode,
         )
+        if self.plan_mode and hasattr(node_input, "auto_execute_plan"):
+            # Print mode is headless: the plan must be auto-approved so the
+            # run does not block waiting for an interactive confirmation.
+            node_input.auto_execute_plan = True
         node.input = node_input
         run_async(self._stream_chat(node))
 

--- a/datus/multi_round_benchmark.py
+++ b/datus/multi_round_benchmark.py
@@ -90,6 +90,13 @@ def setup_base_parser_args(parser: argparse.ArgumentParser):
         action="store_true",
         help="Delete existing round output directory before each round starts",
     )
+    parser.add_argument(
+        "--plan-mode",
+        "--plan_mode",
+        dest="plan_mode",
+        action="store_true",
+        help="Enable plan mode for benchmark execution (generates plan then auto-executes without confirmation)",
+    )
 
 
 def sanitize_group_name(workflow: str) -> str:
@@ -161,6 +168,7 @@ def build_agent_args(
         "output_file": str(evaluation_file),
         "max_workers": cli_args.workers,
         "summary_report_file": cli_args.summary_report_file,
+        "plan_mode": getattr(cli_args, "plan_mode", False),
     }
     return argparse.Namespace(**common_kwargs)
 

--- a/datus/prompts/prompt_templates/plan_mode_system_2.0.j2
+++ b/datus/prompts/prompt_templates/plan_mode_system_2.0.j2
@@ -5,6 +5,9 @@
    - workflow_prompt_sent: When False, render the full workflow description.
                            When True, render a short reminder so we do not
                            re-send the full workflow on every turn.
+   - auto_execute_plan: When True the run is non-interactive (benchmark /
+                        print mode): no user is available to answer
+                        questions, and confirm_plan is auto-approved.
 #}
 {% if not workflow_prompt_sent -%}
 ## Plan File Info
@@ -38,7 +41,11 @@ Goal: Design the implementation approach.
    - Anticipate potential challenges.
 
 ### Phase 3: Review
+{% if auto_execute_plan -%}
+Goal: Review the plan from Phase 2 and ensure alignment with the user's intent. This run is non-interactive — do NOT call `ask_user`; resolve any remaining ambiguities by making reasonable assumptions and recording them in the plan file.
+{%- else -%}
 Goal: Review the plan from Phase 2 and ensure alignment with the user's intent. Use AskUser-style clarifying questions to resolve any remaining ambiguities.
+{%- endif %}
 
 ### Phase 4: Final Plan
 Goal: Write the final plan to the plan file ({{ plan_file_path }}) — the only file you are allowed to edit.
@@ -50,6 +57,11 @@ Goal: Write the final plan to the plan file ({{ plan_file_path }}) — the only 
 - Include a **Verification** section describing how to test the changes end-to-end.
 
 ### Phase 5: Call confirm_plan
+{% if auto_execute_plan -%}
+After finalising the plan file, call the `confirm_plan` tool. It will be auto-approved (no user is available in this non-interactive run); immediately afterwards, execute the plan steps following the instructions returned by the tool.
+
+**Hard rule — end every plan-mode turn with a `confirm_plan` call.** Do NOT call `ask_user` (nobody will answer) and do NOT end a plan-mode turn with only a natural-language response.
+{%- else -%}
 After clarifying open questions and finalising the plan file, call the `confirm_plan` tool to request the user's approval.
 
 **Hard rule — end every plan-mode turn with a tool call.** A plan-mode turn must terminate with EITHER:
@@ -57,10 +69,15 @@ After clarifying open questions and finalising the plan file, call the `confirm_
 - a call to the `confirm_plan` tool (when the plan is ready for the user to approve).
 
 Do NOT end a plan-mode turn with only a natural-language response that poses questions in plain text — wrap any question in `ask_user`. Do NOT use clarifying tools to ask "Is this plan okay?" or "Should I proceed?" — that is exactly what `confirm_plan` is for.
+{%- endif %}
 {%- else -%}
 Plan mode is still active. Plan file: {{ plan_file_path }}.
 
 **If the plan file already contains a draft**, prefer calling `confirm_plan` (when the plan looks complete) or using `edit_file` for incremental refinements — do NOT regenerate the whole file with `write_file`.
 
+{% if auto_execute_plan -%}
+**End-of-turn rule still applies**: every turn must terminate with `confirm_plan` once the plan is ready — it will be auto-approved. Do NOT call `ask_user` (this run is non-interactive); make reasonable assumptions and record them in the plan file.
+{%- else -%}
 **End-of-turn rule still applies**: every turn must terminate with `ask_user` (if you still need information) or `confirm_plan` (if the plan is ready). No bare-text questions.
+{%- endif %}
 {%- endif %}

--- a/datus/tools/func_tool/plan_tools.py
+++ b/datus/tools/func_tool/plan_tools.py
@@ -518,6 +518,10 @@ class ConfirmPlanTool:
         - Ask the user to either ``confirm`` or type free-text feedback.
         - On ``confirm``: deactivate plan mode and return success.
         - On feedback: return the text so the LLM can revise the plan.
+
+        When the node input carries ``auto_execute_plan=True`` (benchmark /
+        print mode), the user-facing prompt is skipped entirely: the plan is
+        treated as approved and the confirmed result is returned immediately.
         """
         # Local imports to avoid cycles with execution_state / schemas.
         from datus.cli.execution_state import InteractionCancelled
@@ -542,8 +546,10 @@ class ConfirmPlanTool:
                 ),
             )
 
+        auto_execute = bool(getattr(getattr(self.node, "input", None), "auto_execute_plan", False))
+
         broker = getattr(self.node, "interaction_broker", None)
-        if broker is None:
+        if broker is None and not auto_execute:
             return FuncToolResult(success=0, error="interaction broker unavailable on node")
 
         try:
@@ -552,7 +558,11 @@ class ConfirmPlanTool:
             return FuncToolResult(success=0, error=f"failed to read plan file: {exc}")
 
         preview = f"\n---\n\n{plan_md}"
-        await broker.send(content=preview, content_type="markdown", action_type="plan_preview")
+        if broker is not None:
+            await broker.send(content=preview, content_type="markdown", action_type="plan_preview")
+
+        if auto_execute:
+            return self._confirmed_result(auto_confirmed=True)
 
         event = InteractionEvent(
             title="Plan",
@@ -574,36 +584,7 @@ class ConfirmPlanTool:
             user_choice = answers[0][0] or ""
 
         if user_choice == "confirm":
-            plan_path = self.node.plan_file_path
-            self.node.deactivate_plan_mode()
-            # Set a one-shot flag so the next user prompt carries an "execute
-            # the confirmed plan" reminder in the enhanced section.
-            self.node._plan_just_confirmed = True
-            return FuncToolResult(
-                result={
-                    "status": "confirmed",
-                    "plan_file": plan_path,
-                    "next_action": (
-                        f"The plan at {plan_path} has been approved. Plan mode is now exited.\n"
-                        "**Do NOT end this turn with a natural-language message yet.** "
-                        "Your immediate next steps MUST be:\n"
-                        f"  1. Read {plan_path} via read_file to recall the plan content.\n"
-                        "  2. Call todo_write with [{title, content}] for each concrete actionable "
-                        "step (title ≤ 8 words; content is the detailed instruction).\n"
-                        "  3. Before starting work on a step, call todo_update(id, 'in_progress') "
-                        "so the sidebar reflects what you are doing.\n"
-                        "  4. Execute the step by calling the relevant tools "
-                        "(grep / read_file / list_tables / read_query / write_file — whatever "
-                        "the step requires).\n"
-                        "  5. After completing the step, call todo_update(id, 'completed'); "
-                        "use 'failed' instead if it could not be finished. Then move to the "
-                        "next step.\n"
-                        "  6. Continue executing steps without asking the user for permission, "
-                        "until either all todos are done or you hit a blocker that genuinely "
-                        "requires user input (in which case use ask_user)."
-                    ),
-                }
-            )
+            return self._confirmed_result(auto_confirmed=False)
 
         return FuncToolResult(
             result={
@@ -616,3 +597,42 @@ class ConfirmPlanTool:
                 ),
             }
         )
+
+    def _confirmed_result(self, auto_confirmed: bool) -> FuncToolResult:
+        """Exit plan mode and build the shared "plan approved" result.
+
+        Used by both the interactive path (user clicked ``confirm``) and the
+        auto-execute path (``auto_execute_plan=True`` on the node input).
+        """
+        plan_path = self.node.plan_file_path
+        self.node.deactivate_plan_mode()
+        # Set a one-shot flag so the next user prompt carries an "execute
+        # the confirmed plan" reminder in the enhanced section.
+        self.node._plan_just_confirmed = True
+        result = {
+            "status": "confirmed",
+            "plan_file": plan_path,
+            "next_action": (
+                f"The plan at {plan_path} has been approved. Plan mode is now exited.\n"
+                "**Do NOT end this turn with a natural-language message yet.** "
+                "Your immediate next steps MUST be:\n"
+                f"  1. Read {plan_path} via read_file to recall the plan content.\n"
+                "  2. Call todo_write with [{title, content}] for each concrete actionable "
+                "step (title ≤ 8 words; content is the detailed instruction).\n"
+                "  3. Before starting work on a step, call todo_update(id, 'in_progress') "
+                "so the sidebar reflects what you are doing.\n"
+                "  4. Execute the step by calling the relevant tools "
+                "(grep / read_file / list_tables / read_query / write_file — whatever "
+                "the step requires).\n"
+                "  5. After completing the step, call todo_update(id, 'completed'); "
+                "use 'failed' instead if it could not be finished. Then move to the "
+                "next step.\n"
+                "  6. Continue executing steps without asking the user for permission, "
+                "until either all todos are done or you hit a blocker that genuinely "
+                "requires user input (in which case use ask_user)."
+            ),
+        }
+        if auto_confirmed:
+            result["auto_confirmed"] = True
+            logger.info("Plan auto-confirmed (auto_execute_plan=True): %s", plan_path)
+        return FuncToolResult(result=result)

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -1633,6 +1633,41 @@ class TestChatAgenticNodePlanMode:
         finally:
             os.chdir(cwd)
 
+    def test_build_plan_mode_prompt_passes_auto_execute_flag(self, real_agent_config, mock_llm_create, tmp_path):
+        """build_plan_mode_enhanced_prompt forwards input.auto_execute_plan to the template."""
+        import os
+
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            node = ChatAgenticNode(
+                node_id="test_auto_exec_prompt",
+                description="Plan prompt auto-execute flag",
+                node_type=NodeType.TYPE_CHAT,
+                agent_config=real_agent_config,
+            )
+            node.activate_plan_mode()
+            node.input = ChatNodeInput(user_message="hi", plan_mode=True, auto_execute_plan=True)
+
+            with patch("datus.agent.node.agentic_node.get_prompt_manager") as mock_pm:
+                mock_pm.return_value.render_template.return_value = "RENDERED"
+                rendered = node.build_plan_mode_enhanced_prompt()
+
+            assert rendered == "RENDERED"
+            assert mock_pm.return_value.render_template.call_args.kwargs["auto_execute_plan"] is True
+
+            # Interactive default: the flag resolves False.
+            node.workflow_prompt_sent = False
+            node.input = ChatNodeInput(user_message="hi", plan_mode=True)
+            with patch("datus.agent.node.agentic_node.get_prompt_manager") as mock_pm:
+                mock_pm.return_value.render_template.return_value = "RENDERED"
+                node.build_plan_mode_enhanced_prompt()
+            assert mock_pm.return_value.render_template.call_args.kwargs["auto_execute_plan"] is False
+        finally:
+            os.chdir(cwd)
+
 
 # ===========================================================================
 # _rebuild_tools Tests

--- a/tests/unit_tests/agent/test_workflow_runner.py
+++ b/tests/unit_tests/agent/test_workflow_runner.py
@@ -175,7 +175,7 @@ class TestInitializeWorkflow:
         mock_wf.display.assert_called_once()
 
     def test_plan_mode_stored_in_metadata(self):
-        args = _make_args(plan_mode="auto")
+        args = _make_args(plan_mode=True)
         runner = _make_runner(args=args)
         mock_wf = _make_mock_workflow()
         mock_wf.display = MagicMock()
@@ -184,8 +184,21 @@ class TestInitializeWorkflow:
         with patch("datus.agent.workflow_runner.generate_workflow", return_value=mock_wf):
             runner.initialize_workflow(_make_sql_task())
 
-        assert mock_wf.metadata.get("plan_mode") == "auto"
+        assert mock_wf.metadata.get("plan_mode") is True
         assert mock_wf.metadata.get("auto_execute_plan") is True
+
+    def test_plan_mode_disabled_keeps_auto_execute_off(self):
+        args = _make_args(plan_mode=False)
+        runner = _make_runner(args=args)
+        mock_wf = _make_mock_workflow()
+        mock_wf.display = MagicMock()
+        mock_wf.metadata = {}
+
+        with patch("datus.agent.workflow_runner.generate_workflow", return_value=mock_wf):
+            runner.initialize_workflow(_make_sql_task())
+
+        assert mock_wf.metadata.get("plan_mode") is False
+        assert mock_wf.metadata.get("auto_execute_plan") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -70,6 +70,18 @@ class TestArgumentParser:
             args = ap.parse_args()
         assert args.orchestrator_tools is True
 
+    def test_parse_args_plan_mode(self):
+        ap = ArgumentParser()
+        with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--print", "hello", "--plan-mode"]):
+            args = ap.parse_args()
+        assert args.plan_mode is True
+
+    def test_parse_args_plan_mode_default_off(self):
+        ap = ArgumentParser()
+        with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--print", "hello"]):
+            args = ap.parse_args()
+        assert args.plan_mode is False
+
     def test_parse_args_web(self):
         ap = ArgumentParser()
         with patch.object(sys, "argv", ["datus", "--datasource", "ns1", "--web"]):
@@ -164,6 +176,28 @@ class TestApplicationRun:
             resume=None,
             proxy_tools=None,
             orchestrator_tools=True,
+            config=None,
+        )
+        with (
+            patch.object(app.arg_parser, "parse_args", return_value=mock_args),
+            patch("datus.cli.main.configure_logging"),
+            patch.object(app, "_ensure_project_config"),
+        ):
+            with pytest.raises(SystemExit):
+                app.run()
+
+    def test_plan_mode_without_print_mode_errors(self):
+        """Verify that --plan-mode without --print raises SystemExit."""
+        app = Application()
+        mock_args = SimpleNamespace(
+            debug=False,
+            datasource="ns1",
+            print_mode=None,
+            web=False,
+            resume=None,
+            proxy_tools=None,
+            orchestrator_tools=False,
+            plan_mode=True,
             config=None,
         )
         with (

--- a/tests/unit_tests/cli/test_print_mode.py
+++ b/tests/unit_tests/cli/test_print_mode.py
@@ -522,6 +522,55 @@ class TestRunUsesFactory:
 
 
 # ---------------------------------------------------------------------------
+# Tests: run() with --plan-mode
+# ---------------------------------------------------------------------------
+
+
+class TestRunPlanMode:
+    def _run_with_plan_mode(self, plan_mode_override):
+        overrides = {} if plan_mode_override is None else {"plan_mode": plan_mode_override}
+        runner = _make_runner(**overrides)
+
+        mock_node = MagicMock()
+        mock_node.session_id = None
+
+        async def fake_stream(actions):
+            return
+            yield
+
+        mock_node.execute_stream_with_interactions = fake_stream
+        # Real-shaped input: plan fields behave like ChatNodeInput defaults.
+        node_input = SimpleNamespace(plan_mode=False, auto_execute_plan=False)
+
+        with (
+            patch("datus.cli.print_mode.create_interactive_node", return_value=mock_node),
+            patch("datus.cli.print_mode.create_node_input", return_value=node_input) as mock_create_input,
+        ):
+            runner.run()
+        return mock_create_input, mock_node
+
+    def test_plan_mode_flag_enables_auto_execute(self):
+        mock_create_input, mock_node = self._run_with_plan_mode(True)
+
+        assert mock_create_input.call_args.kwargs["plan_mode"] is True
+        # Print mode is headless, so the generated plan must auto-confirm.
+        assert mock_node.input.auto_execute_plan is True
+
+    def test_plan_mode_default_off(self):
+        mock_create_input, mock_node = self._run_with_plan_mode(False)
+
+        assert mock_create_input.call_args.kwargs["plan_mode"] is False
+        assert mock_node.input.auto_execute_plan is False
+
+    def test_plan_mode_missing_arg_defaults_off(self):
+        # Older callers build args without the plan_mode attribute at all.
+        mock_create_input, mock_node = self._run_with_plan_mode(None)
+
+        assert mock_create_input.call_args.kwargs["plan_mode"] is False
+        assert mock_node.input.auto_execute_plan is False
+
+
+# ---------------------------------------------------------------------------
 # Tests: run() with proxy_tool_patterns
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_tests/prompts/test_prompt_manager.py
+++ b/tests/unit_tests/prompts/test_prompt_manager.py
@@ -339,3 +339,35 @@ class TestEnvCacheBehavior:
         env_after = manager._get_env()
 
         assert env_before is not env_after
+
+
+class TestPlanModeSystemTemplate:
+    """Render the real packaged plan_mode_system template (interactive vs auto-execute)."""
+
+    def _render(self, tmp_path, **kwargs):
+        # Keep the packaged default_templates_dir so the real template resolves.
+        manager = PromptManager(path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        return manager.render_template("plan_mode_system", None, plan_file_path="./.datus/plans/x.md", **kwargs)
+
+    def test_full_workflow_interactive_requires_user_approval(self, tmp_path):
+        rendered = self._render(tmp_path, workflow_prompt_sent=False, auto_execute_plan=False)
+        assert "request the user's approval" in rendered
+        assert "`ask_user`" in rendered
+        assert "auto-approved" not in rendered
+
+    def test_full_workflow_auto_execute_forbids_ask_user(self, tmp_path):
+        rendered = self._render(tmp_path, workflow_prompt_sent=False, auto_execute_plan=True)
+        assert "auto-approved" in rendered
+        assert "Do NOT call `ask_user`" in rendered
+        assert "request the user's approval" not in rendered
+
+    def test_reminder_interactive_keeps_ask_user_rule(self, tmp_path):
+        rendered = self._render(tmp_path, workflow_prompt_sent=True, auto_execute_plan=False)
+        assert "Plan mode is still active" in rendered
+        assert "`ask_user` (if you still need information)" in rendered
+
+    def test_reminder_auto_execute_auto_approves(self, tmp_path):
+        rendered = self._render(tmp_path, workflow_prompt_sent=True, auto_execute_plan=True)
+        assert "Plan mode is still active" in rendered
+        assert "auto-approved" in rendered
+        assert "Do NOT call `ask_user`" in rendered

--- a/tests/unit_tests/test_multi_round_benchmark.py
+++ b/tests/unit_tests/test_multi_round_benchmark.py
@@ -471,6 +471,17 @@ class TestBuildAgentArgs:
         assert "runABC" in result.output_file
         assert "2" in result.output_file
 
+    def test_plan_mode_passthrough(self, tmp_path):
+        cli_args = self._make_cli_args(plan_mode=True)
+        result = build_agent_args(cli_args, ["t1"], tmp_path, 0, "run1")
+        assert result.plan_mode is True
+
+    def test_plan_mode_defaults_off_when_missing(self, tmp_path):
+        # _make_cli_args has no plan_mode attribute → getattr fallback.
+        cli_args = self._make_cli_args()
+        result = build_agent_args(cli_args, ["t1"], tmp_path, 0, "run1")
+        assert result.plan_mode is False
+
 
 # ---------------------------------------------------------------------------
 # resolve_task_ids - explicit ids
@@ -537,3 +548,13 @@ class TestSetupBaseParserArgs:
         setup_base_parser_args(parser)
         args = parser.parse_args(["--datasource", "ns", "--benchmark", "bm"])
         assert args.workflow == "reflection"
+
+    def test_plan_mode_flag(self):
+        parser = argparse.ArgumentParser()
+        setup_base_parser_args(parser)
+        args = parser.parse_args(["--datasource", "ns", "--benchmark", "bm"])
+        assert args.plan_mode is False
+        args = parser.parse_args(["--datasource", "ns", "--benchmark", "bm", "--plan-mode"])
+        assert args.plan_mode is True
+        args = parser.parse_args(["--datasource", "ns", "--benchmark", "bm", "--plan_mode"])
+        assert args.plan_mode is True

--- a/tests/unit_tests/tools/func_tool/test_plan_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_plan_tools.py
@@ -3,13 +3,15 @@
 """Unit tests for plan_tools module - CI level, zero external dependencies."""
 
 import json
-from unittest.mock import Mock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from pydantic import ValidationError
 
 from datus.tools.func_tool.plan_tools import (
     TITLE_WORD_LIMIT,
+    ConfirmPlanTool,
     PlanTool,
     SessionTodoStorage,
     TodoItem,
@@ -511,3 +513,108 @@ class TestPlanToolTodoUpdate:
         result = plan_tool.todo_update(999, "completed")
         assert result.success == 0
         assert "not found" in result.error
+
+
+def _make_plan_node(tmp_path, *, plan_active=True, auto_execute=False, broker="default", plan_file_exists=True):
+    """Build a mocked AgenticNode shaped for ConfirmPlanTool."""
+    node = MagicMock()
+    node.is_in_plan_mode.return_value = plan_active
+    plan_file = tmp_path / "plan.md"
+    if plan_file_exists:
+        plan_file.write_text("# My Plan\n\n1. step one", encoding="utf-8")
+    node.plan_file_path = str(plan_file)
+    node.input = SimpleNamespace(auto_execute_plan=auto_execute)
+    if broker == "default":
+        broker_mock = MagicMock()
+        broker_mock.send = AsyncMock()
+        broker_mock.request = AsyncMock(return_value=[["confirm"]])
+        node.interaction_broker = broker_mock
+    else:
+        node.interaction_broker = broker
+    return node
+
+
+class TestConfirmPlanTool:
+    @pytest.mark.asyncio
+    async def test_auto_execute_skips_user_interaction(self, tmp_path):
+        node = _make_plan_node(tmp_path, auto_execute=True)
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        assert result.success == 1
+        assert result.result["status"] == "confirmed"
+        assert result.result["auto_confirmed"] is True
+        assert result.result["plan_file"] == str(tmp_path / "plan.md")
+        assert "todo_write" in result.result["next_action"]
+        node.deactivate_plan_mode.assert_called_once()
+        assert node._plan_just_confirmed is True
+        # The plan preview is still streamed, but no approval prompt is issued.
+        node.interaction_broker.send.assert_awaited_once()
+        node.interaction_broker.request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_execute_works_without_broker(self, tmp_path):
+        node = _make_plan_node(tmp_path, auto_execute=True, broker=None)
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        assert result.success == 1
+        assert result.result["status"] == "confirmed"
+        assert result.result["auto_confirmed"] is True
+        node.deactivate_plan_mode.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_execute_handles_node_without_input(self, tmp_path):
+        node = _make_plan_node(tmp_path)
+        node.input = None
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        # No input → auto_execute_plan resolves False → interactive path runs.
+        assert result.success == 1
+        assert result.result["status"] == "confirmed"
+        node.interaction_broker.request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_interactive_confirm_choice(self, tmp_path):
+        node = _make_plan_node(tmp_path, auto_execute=False)
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        assert result.success == 1
+        assert result.result["status"] == "confirmed"
+        assert "auto_confirmed" not in result.result
+        node.interaction_broker.request.assert_awaited_once()
+        node.deactivate_plan_mode.assert_called_once()
+        assert node._plan_just_confirmed is True
+
+    @pytest.mark.asyncio
+    async def test_interactive_feedback_keeps_plan_mode(self, tmp_path):
+        node = _make_plan_node(tmp_path, auto_execute=False)
+        node.interaction_broker.request = AsyncMock(return_value=[["please add an index step"]])
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        assert result.success == 1
+        assert result.result["status"] == "feedback"
+        assert result.result["feedback"] == "please add an index step"
+        node.deactivate_plan_mode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plan_mode_inactive_errors(self, tmp_path):
+        node = _make_plan_node(tmp_path, plan_active=False, auto_execute=True)
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        assert result.success == 0
+        assert "plan mode is not active" in result.error
+
+    @pytest.mark.asyncio
+    async def test_missing_plan_file_errors(self, tmp_path):
+        node = _make_plan_node(tmp_path, auto_execute=True, plan_file_exists=False)
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        assert result.success == 0
+        assert "plan file not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_interactive_without_broker_errors(self, tmp_path):
+        node = _make_plan_node(tmp_path, auto_execute=False, broker=None)
+        result = await ConfirmPlanTool(node).confirm_plan()
+
+        assert result.success == 0
+        assert "interaction broker unavailable" in result.error


### PR DESCRIPTION


ConfirmPlanTool now consumes input.auto_execute_plan: when set, the plan preview is still streamed but the interactive approval prompt is skipped and the plan is treated as confirmed (result carries auto_confirmed=true). This unblocks the previously dead-ended benchmark --plan-mode path, whose auto_execute_plan metadata had no consumer and hung on broker.request().

- datus -p gains --plan-mode: plan_mode=True + auto_execute_plan=True on the node input; flag is rejected outside print mode
- multi-round-benchmark passes --plan-mode through build_agent_args
- workflow metadata auto_execute_plan now follows the plan_mode boolean instead of being unconditionally true
- plan_mode_system template renders non-interactive guidance (no ask_user, confirm_plan is auto-approved) when auto_execute_plan is set

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--plan-mode` CLI flag for headless plan generation and auto-execution in print mode
  * Agent now creates a plan and immediately executes it without requiring manual confirmation
  
* **Tests**
  * Comprehensive test coverage added for plan-mode CLI behavior and non-interactive execution workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->