### PR TITLE
[BugFix] DBManager: tolerate nulled _conn_dict entries; log list_databases traceback

### DIFF
--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -307,7 +307,7 @@ class DatasourceService:
             return Result(success=True, data=data)
 
         except Exception as e:
-            logger.error(f"Failed to list databases: {e}")
+            logger.error(f"Failed to list databases: {e}", exc_info=True)
             return Result(
                 success=False,
                 errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -257,7 +257,13 @@ class DBManager:
 
     def _init_connection(self, datasource: str, database: str) -> BaseSqlConnector:
         db_name, db_config = self._resolve_db_config(datasource, database)
-        group = self._conn_dict.setdefault(datasource, {})
+        # Self-heal: a caller may have nulled this datasource's entry to mark its
+        # connectors closed (e.g. an external pool on eviction). setdefault keeps
+        # an existing None, so rebuild a fresh group rather than calling .get on it.
+        group = self._conn_dict.get(datasource)
+        if not isinstance(group, dict):
+            group = {}
+            self._conn_dict[datasource] = group
         cached = group.get(db_name)
         if cached is not None:
             return cached
@@ -355,6 +361,8 @@ class DBManager:
     def close(self):
         """Close all database connections."""
         for datasource, group in list(self._conn_dict.items()):
+            if not isinstance(group, dict):
+                continue
             for db_name, conn in list(group.items()):
                 if conn is None:
                     continue

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -385,6 +385,33 @@ class TestDBManager:
         assert "raw" not in mgr._conn_dict["analytics"]
         assert "main" not in mgr._conn_dict["mart"]
 
+    def test_get_conn_self_heals_when_entry_nulled(self):
+        # An external pool may null a datasource entry to mark its connectors
+        # closed on eviction. setdefault keeps the None, so the manager must
+        # rebuild rather than raise 'NoneType' object has no attribute 'get'.
+        configs = {"ns": _cfg(type="sqlite", uri="sqlite:///test.db")}
+        mgr = DBManager(configs)
+        with patch.object(mgr, "_build_conn", side_effect=lambda cfg: MagicMock()):
+            first = mgr.get_conn("ns")
+            mgr._conn_dict["ns"] = None  # external eviction landmine
+            rebuilt = mgr.get_conn("ns")
+        assert rebuilt is not first
+        assert isinstance(mgr._conn_dict["ns"], dict)
+
+    def test_close_skips_nulled_entry(self):
+        # A nulled datasource entry must not break close() with
+        # 'NoneType' object has no attribute 'items'.
+        mgr = DBManager({})
+        conn = MagicMock()
+        mgr._conn_dict["analytics"] = {"raw": conn}
+        mgr._conn_dict["mart"] = None
+
+        mgr.close()
+
+        conn.close.assert_called_once()
+        assert "raw" not in mgr._conn_dict["analytics"]  # live group still drained
+        assert mgr._conn_dict["mart"] is None  # nulled entry skipped, not crashed
+
 
 # ---------------------------------------------------------------------------
 # DBManager._db_config_to_connection_config — adapter branch (lines 269-309)


### PR DESCRIPTION
## Why

`GET /api/v1/catalog/list` (SaaS backend) fails persistently with
`PROVIDER_CONFIG_ERROR: 'NoneType' object has no attribute 'get'`.

Root cause (reproduced live): the backend's connection pool marks a datasource's
connectors closed on a metadata/config-change eviction by setting
`DBManager._conn_dict[datasource] = None`. The cached `DatusService` (and its
`DBManager`) is then **reused**, and:

- `_init_connection` does `group = self._conn_dict.setdefault(datasource, {})`.
  `setdefault` keeps the existing `None`, so `group.get(db_name)` raises
  `'NoneType' object has no attribute 'get'` — wrapped by `list_databases` into
  `PROVIDER_CONFIG_ERROR`, and every subsequent `catalog/list`/`get_conn` for
  that datasource fails until the service is rebuilt.
- `close()` iterates `group.items()` and hits the sibling
  `'NoneType' object has no attribute 'items'` on the same nulled entry.

The failure was also hard to diagnose because `list_databases` logged only
`str(e)` (no traceback).

The owning fix lives in the backend pool (it now drops the entry instead of
nulling it). This PR hardens `DBManager` so a nulled entry can never crash it,
and makes the swallowed error diagnosable.

## Solution

- `DBManager._init_connection`: take the cached group via `.get` and rebuild a
  fresh dict when it is not a dict (e.g. `None`), instead of `setdefault` +
  `.get` on a possibly-`None` value. The manager self-heals after an external
  eviction nulled the entry.
- `DBManager.close()`: skip non-dict (nulled) datasource entries.
- `DatasourceService.list_databases`: log the swallowed exception with
  `exc_info=True` so the root cause is visible in logs.

Behaviour is unchanged on the happy path; these only add resilience to an
externally-mutated `_conn_dict` and improve logging.

## Test Cases

`tests/unit_tests/tools/db_tools/test_db_manager.py` (unit, fully mocked — no
real DB/network):

- `test_get_conn_self_heals_when_entry_nulled` — null `_conn_dict[ds]`, then
  `get_conn` rebuilds instead of raising `AttributeError`.
- `test_close_skips_nulled_entry` — a `None` datasource entry does not break
  `close()`; live groups are still drained.

`uv run pytest tests/unit_tests/tools/db_tools/test_db_manager.py` → 65 passed;
`test_database_service.py` → 22 passed. ruff format + check clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [x] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database connection reliability with better error recovery.
  * Enhanced error logging with detailed diagnostic information for troubleshooting.

* **Tests**
  * Added tests for database connection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->