### PR TITLE
[Enhancement] Cache AgenticNode system prompt per session to preserve prefix cache

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -912,13 +912,21 @@ class AgenticNode(Node):
         version = prompt_version
         if version is None and agent_config is not None and hasattr(agent_config, "prompt_version"):
             version = agent_config.prompt_version
-        model_id = ""
-        try:
-            mc = agent_config.active_model() if agent_config is not None else None
-            if mc is not None:
-                model_id = f"{getattr(mc, 'type', '') or ''}:{getattr(mc, 'model', '') or ''}"
-        except Exception:
+        # A node-level model override (``node_config.model``) pins the
+        # effective model regardless of the agent-level target, so it must be
+        # the identity when set — otherwise a /model switch that doesn't
+        # affect this node would spuriously rebuild (and vice versa).
+        node_model = getattr(self, "_node_model_name", None)
+        if node_model:
+            model_id = f"node:{node_model}"
+        else:
             model_id = ""
+            try:
+                mc = agent_config.active_model() if agent_config is not None else None
+                if mc is not None:
+                    model_id = f"{getattr(mc, 'type', '') or ''}:{getattr(mc, 'model', '') or ''}"
+            except Exception:
+                model_id = ""
         return {
             "node_name": self.get_node_name(),
             "prompt_version": str(version or ""),
@@ -955,6 +963,9 @@ class AgenticNode(Node):
         if sm is not None:
             snapshot = sm.load_system_prompt_snapshot(session_id)
             if snapshot is not None and all(snapshot.get(k) == v for k, v in meta.items()):
+                # The replayed prompt advertises skill/bash/memory tools whose
+                # mounting is normally a side effect of the (skipped) build.
+                self._ensure_lazy_tools_mounted()
                 return snapshot["prompt"]
 
         # Cache miss / stale meta: rebuild. Preserve the call shape — several
@@ -1057,14 +1068,8 @@ class AgenticNode(Node):
         if agents_md:
             base_prompt = base_prompt + "\n\n" + agents_md
 
-        # Ensure skill tools are in self.tools (lazy injection after subclass setup_tools()).
-        self._ensure_skill_tools_in_tools()
-
-        # Same lazy-injection trick for the general-purpose BashTool.
-        self._ensure_bash_tool_in_tools()
-
-        # And for the dedicated memory tools (main agents only; sub-agents skip).
-        self._ensure_memory_tool_in_tools()
+        # Mount the lazily injected skill/bash/memory tools.
+        self._ensure_lazy_tools_mounted()
 
         # Inject available skills XML into system prompt when skill_func_tool is active.
         if self.skill_func_tool:
@@ -1080,6 +1085,21 @@ class AgenticNode(Node):
         base_prompt = self._inject_response_language(base_prompt)
 
         return base_prompt
+
+    def _ensure_lazy_tools_mounted(self) -> None:
+        """Mount the lazily injected skill/bash/memory tools into ``self.tools``.
+
+        Normally a side effect of :meth:`_finalize_system_prompt` during the
+        prompt build. A snapshot cache hit skips that build entirely, so the
+        hit path calls this directly — the replayed prompt advertises these
+        capabilities and a fresh node instance (API per-request, ``/resume``)
+        must actually have them mounted. All three are idempotent; subclass
+        gating overrides (e.g. artifact-ask nodes) are honored via virtual
+        dispatch.
+        """
+        self._ensure_skill_tools_in_tools()
+        self._ensure_bash_tool_in_tools()
+        self._ensure_memory_tool_in_tools()
 
     def _runtime_context_current_date(self) -> str:
         """Session-start date rendered into the shared runtime-context block.
@@ -2846,6 +2866,12 @@ class AgenticNode(Node):
         (which various subclasses already define with ``(user_input, …)``
         signatures); subclasses that need template context override this hook
         and typically delegate: ``return self._prepare_template_context(ctx.user_input)``.
+
+        Contract: the returned values are rendered into the system prompt,
+        which is frozen into the per-session snapshot and replayed on later
+        turns — so they must be **session-stable** (tool wiring, execution
+        mode), never per-turn (current datasource, user input). Per-turn
+        values belong in :meth:`_build_enhanced_message`.
         """
         return None
 

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -682,6 +682,49 @@ class AgenticNode(Node):
         elif self.is_in_plan_mode():
             self.deactivate_plan_mode()
 
+    def _build_datasource_reminder(self, user_input: Any = None) -> str:
+        """Live per-turn datasource line for the user-message envelope.
+
+        The frozen system-prompt snapshot must never pin the *current*
+        datasource: a mid-session ``/datasource`` switch would silently leave a
+        stale dialect in every later turn. Instead this line rides in the
+        ``<system_reminder>`` envelope of each user message. It merges what
+        used to be a separate "Database Context" block — dialect, catalog,
+        database (resolved via the connector default), and schema — into one
+        line so the dialect is stated exactly once per turn. Gated on
+        ``db_func_tool`` so non-DB nodes add no noise; returns an empty string
+        when no datasource is selected.
+        """
+        agent_config = getattr(self, "agent_config", None)
+        if not agent_config or getattr(self, "db_func_tool", None) is None:
+            return ""
+        from datus.utils.node_utils import build_datasource_prompt_context, resolve_database_name_for_prompt
+
+        ds_ctx = build_datasource_prompt_context(agent_config)
+        datasource = ds_ctx.get("datasource")
+        if not datasource:
+            return ""
+
+        details: List[str] = []
+        dialect = ds_ctx.get("current_datasource_dialect")
+        if dialect:
+            details.append(f"dialect: {dialect}")
+        catalog = getattr(user_input, "catalog", "") or ""
+        if catalog:
+            details.append(f"catalog: {catalog}")
+        connector = getattr(self.db_func_tool, "connector", None)
+        database = resolve_database_name_for_prompt(connector, getattr(user_input, "database", "") or "")
+        if database:
+            details.append(f"database: {database}")
+        schema = getattr(user_input, "db_schema", "") or ""
+        if schema:
+            details.append(f"schema: {schema}")
+        suffix = f" ({', '.join(details)})" if details else ""
+        return (
+            f"Current datasource: {datasource}{suffix}. This is the authoritative "
+            "target for this turn; generate SQL for THIS dialect."
+        )
+
     def _build_enhanced_message(
         self,
         user_input: Any,
@@ -720,12 +763,22 @@ class AgenticNode(Node):
 
         enhanced_parts: List[str] = []
 
+        # Live per-turn datasource line (dialect + catalog/database/schema in
+        # one place). Deliberately NOT in the frozen system-prompt snapshot —
+        # injecting it here keeps the system-prompt prefix byte-stable across
+        # a mid-session datasource switch while the model still targets the
+        # right dialect THIS turn. It supersedes the legacy "Database Context"
+        # block, which only renders below when this line is absent.
+        datasource_reminder = self._build_datasource_reminder(user_input)
+        if datasource_reminder:
+            enhanced_parts.append(datasource_reminder)
+
         ext_know = getattr(user_input, "external_knowledge", "") or ""
         if ext_know:
             enhanced_parts.append(f"MUST use these business logic:\n{ext_know}")
 
         db_type = getattr(self.agent_config, "db_type", "") if self.agent_config else ""
-        if db_type:
+        if db_type and not datasource_reminder:
             # Always resolve empty database via the connector default — the
             # helper is a no-op when no connector is wired or value is set.
             from datus.utils.node_utils import resolve_database_name_for_prompt
@@ -844,6 +897,77 @@ class AgenticNode(Node):
             return node_class
         return AgenticNode.get_node_name(self)
 
+    def _system_prompt_snapshot_meta(self, prompt_version: Optional[str]) -> Dict[str, str]:
+        """Identity keys that invalidate the cached system-prompt snapshot.
+
+        The snapshot is replayed verbatim while these stay equal. They cover
+        the inputs that change the prompt's identity within a session: the
+        node template, its version, and the active model (a model switch also
+        resets the provider-side prefix cache, so rebuilding is free). The
+        live per-turn datasource/dialect is injected in the user message
+        instead, so it deliberately does **not** appear here; date, language,
+        memory, and skills are frozen until the snapshot is rebuilt.
+        """
+        agent_config = getattr(self, "agent_config", None)
+        version = prompt_version
+        if version is None and agent_config is not None and hasattr(agent_config, "prompt_version"):
+            version = agent_config.prompt_version
+        model_id = ""
+        try:
+            mc = agent_config.active_model() if agent_config is not None else None
+            if mc is not None:
+                model_id = f"{getattr(mc, 'type', '') or ''}:{getattr(mc, 'model', '') or ''}"
+        except Exception:
+            model_id = ""
+        return {
+            "node_name": self.get_node_name(),
+            "prompt_version": str(version or ""),
+            "model_name": model_id,
+        }
+
+    def _get_session_system_prompt(
+        self,
+        prompt_version: Optional[str] = None,
+        template_context: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Return the system prompt for this turn, served from a session snapshot.
+
+        On the first LLM call of a session the finalized prompt is built via
+        :meth:`_get_system_prompt` (subclass overrides honored) and persisted
+        under ``{session_dir}/{session_id}.sysprompt.json``. Later turns —
+        including new node instances, API per-request nodes, ``/resume``, and
+        subagent sessions — replay the exact bytes, keeping the provider
+        prefix cache warm and skipping the per-turn template render and
+        AGENTS.md/MEMORY.md file reads. A major compact or ``/clear`` drops
+        the snapshot so it rebuilds (session-rebuild semantics); a model
+        switch invalidates it via the meta comparison.
+        """
+        session_id = getattr(self, "session_id", "") or ""
+        meta = self._system_prompt_snapshot_meta(prompt_version)
+        sm = None
+        if session_id:
+            try:
+                sm = self.session_manager
+            except Exception as exc:  # session manager wiring is optional in some unit paths
+                logger.debug("System-prompt snapshot disabled (no session manager): %s", exc)
+                sm = None
+
+        if sm is not None:
+            snapshot = sm.load_system_prompt_snapshot(session_id)
+            if snapshot is not None and all(snapshot.get(k) == v for k, v in meta.items()):
+                return snapshot["prompt"]
+
+        # Cache miss / stale meta: rebuild. Preserve the call shape — several
+        # subclass overrides accept only ``prompt_version``.
+        if template_context:
+            prompt = self._get_system_prompt(prompt_version=prompt_version, template_context=template_context)
+        else:
+            prompt = self._get_system_prompt(prompt_version=prompt_version)
+
+        if sm is not None:
+            sm.save_system_prompt_snapshot(session_id, prompt, meta)
+        return prompt
+
     def _get_system_prompt(
         self,
         prompt_version: Optional[str] = None,
@@ -922,6 +1046,12 @@ class AgenticNode(Node):
         Returns:
             Prompt with skills XML and memory context appended
         """
+        # Inject the shared runtime-context block (session-start date,
+        # datasource catalog, sql files root) for DB-capable nodes. Replaces
+        # the per-template "Current context" stanzas; the *current* datasource
+        # selection lives in the per-turn user message instead.
+        base_prompt = self._inject_runtime_context(base_prompt)
+
         # Inject AGENTS.md project context if present in cwd
         agents_md = self._load_agents_md()
         if agents_md:
@@ -949,6 +1079,51 @@ class AgenticNode(Node):
         # sub-agents invoked via ``task`` — honors the configured output language.
         base_prompt = self._inject_response_language(base_prompt)
 
+        return base_prompt
+
+    def _runtime_context_current_date(self) -> str:
+        """Session-start date rendered into the shared runtime-context block.
+
+        Defaults to today. Subclasses with a reference-date concept (e.g.
+        GenSQL/AskMetrics, which honor a benchmark/replay ``reference_date``)
+        override this so the frozen prompt reflects the intended evaluation
+        date.
+        """
+        from datus.utils.time_utils import get_default_current_date
+
+        return get_default_current_date(None)
+
+    def _inject_runtime_context(self, base_prompt: str) -> str:
+        """Append the shared runtime-context block for DB-capable nodes.
+
+        Renders ``runtime_context_1.0.j2`` with the session-stable values that
+        used to be duplicated inline across the node templates: the
+        session-start date, the configured datasource catalog, and the sql
+        files root. Gated on ``db_func_tool`` so non-DB nodes (e.g.
+        report/dashboard writers without a connector) are unaffected. The
+        *current* datasource selection and its dialect are NOT here — they are
+        injected per turn into the user message (see
+        :meth:`_build_datasource_reminder`).
+        """
+        if getattr(self, "db_func_tool", None) is None:
+            return base_prompt
+        agent_config = getattr(self, "agent_config", None)
+        try:
+            from datus.utils.node_utils import build_datasource_prompt_context
+
+            ds_ctx = build_datasource_prompt_context(agent_config) if agent_config else {}
+            section = get_prompt_manager(agent_config=agent_config).render_template(
+                template_name="runtime_context",
+                version=None,
+                current_date=self._runtime_context_current_date(),
+                available_datasources=ds_ctx.get("available_datasources") or {},
+                workspace_root=self._resolve_workspace_root(),
+            )
+        except Exception as e:
+            logger.warning(f"Failed to inject runtime context: {e}")
+            return base_prompt
+        if section and section.strip():
+            base_prompt = base_prompt + "\n\n" + section.strip()
         return base_prompt
 
     def _inject_response_language(self, base_prompt: str) -> str:
@@ -1185,6 +1360,14 @@ class AgenticNode(Node):
                 compact_action_id = f"compact_{uuid.uuid4().hex[:8]}"
                 self._emit_compact_display_action(compact_action_id, "progress")
                 result = await self._major_compact(reason=reason)
+                # A major compact is a session rebuild: drop the frozen system
+                # prompt so the next turn re-bakes it (fresh date, AGENTS.md,
+                # memory, skills) instead of replaying the pre-compact snapshot.
+                if result.get("success") and self.session_id:
+                    try:
+                        self.session_manager.delete_system_prompt_snapshot(self.session_id)
+                    except Exception as exc:
+                        logger.debug("Failed to drop system-prompt snapshot after compact: %s", exc)
                 # Always emit the terminal action — even on failure — so the
                 # pinned hint is cleared; the renderer only draws the panel when
                 # a summary is actually present.
@@ -2426,13 +2609,12 @@ class AgenticNode(Node):
 
             template_context = self._build_template_context(ctx)
             prompt_version = getattr(self.input, "prompt_version", None)
-            if template_context:
-                ctx.system_instruction = self._get_system_prompt(
-                    prompt_version=prompt_version,
-                    template_context=template_context,
-                )
-            else:
-                ctx.system_instruction = self._get_system_prompt(prompt_version=prompt_version)
+            # Served from a per-session snapshot when available; rebuilt and
+            # re-persisted on a cache miss or when the snapshot meta is stale.
+            ctx.system_instruction = self._get_session_system_prompt(
+                prompt_version=prompt_version,
+                template_context=template_context,
+            )
 
             # Compose the user prompt, optionally with a per-run override of
             # ``user_input.user_message`` set during ``_before_stream`` (used

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -400,6 +400,13 @@ class AskMetricsAgenticNode(AgenticNode):
                 mapping[category] = category_tools
         return mapping
 
+    def _runtime_context_current_date(self) -> str:
+        """Honor the per-input ``reference_date`` in the frozen runtime context."""
+        from datus.utils.time_utils import get_default_current_date
+
+        input_ref_date = getattr(self.input, "reference_date", None) if self.input else None
+        return get_default_current_date(input_ref_date)
+
     def _get_system_prompt(self, prompt_version: Optional[str] = None) -> str:
         context: Dict[str, Any] = {
             "agent_config": self.agent_config,
@@ -416,11 +423,6 @@ class AskMetricsAgenticNode(AgenticNode):
 
             context.update(build_datasource_prompt_context(self.agent_config))
             context["db_name"] = context.get("datasource")
-
-        from datus.utils.time_utils import get_default_current_date
-
-        input_ref_date = getattr(self.input, "reference_date", None) if self.input else None
-        context["current_date"] = get_default_current_date(input_ref_date)
 
         version_value = prompt_version if prompt_version not in (None, "") else self.node_config.get("prompt_version")
         version = None if version_value in (None, "") else str(version_value)

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -471,10 +471,10 @@ class ChatAgenticNode(AgenticNode):
         )
         context["has_task_tool"] = bool(self.sub_agent_task_tool)
         context["has_ask_user_tool"] = "ask_user" in exposed
-        context["active_profile"] = getattr(self.agent_config, "active_profile_name", None) or "normal"
-        from datus.utils.time_utils import get_default_current_date
-
-        context["current_date"] = get_default_current_date(None)
+        # No per-turn values here: the current date lives in the shared
+        # runtime-context block, the current datasource/dialect in the user
+        # turn's <system_reminder>, and the permission profile is enforced by
+        # the permission hooks at tool-call time rather than prompted.
         prompt_version = prompt_version or self.node_config.get("prompt_version")
 
         system_prompt_name = self.node_config.get("system_prompt") or self.get_node_name()

--- a/datus/agent/node/deliverable_node.py
+++ b/datus/agent/node/deliverable_node.py
@@ -256,14 +256,15 @@ class DeliverableAgenticNode(AgenticNode):
             self._validation_hook = None
 
     def _prepare_template_context(self, user_input: Any) -> dict:
-        from datus.utils.node_utils import build_datasource_prompt_context
-
+        # Session-stable values only — this render is frozen into the
+        # per-session system-prompt snapshot. The current datasource and its
+        # dialect are deliberately absent: they arrive per turn in the user
+        # message (see ``_build_enhanced_message``).
         context = {
             "native_tools": ", ".join([tool.name for tool in self.tools]) if self.tools else "None",
             "mcp_tools": ", ".join(list(self.mcp_servers.keys())) if self.mcp_servers else "None",
             "has_ask_user_tool": self.ask_user_tool is not None,
         }
-        context.update(build_datasource_prompt_context(self.agent_config))
         logger.debug("Prepared template context: %s", context)
         return context
 
@@ -418,22 +419,31 @@ class DeliverableAgenticNode(AgenticNode):
         from datus.utils.node_utils import resolve_database_name_for_prompt
 
         enhanced_parts = []
-        catalog = getattr(user_input, "catalog", None)
-        db_schema = getattr(user_input, "db_schema", None)
-        database_raw = getattr(user_input, "database", None) or ""
-        effective_db = resolve_database_name_for_prompt(
-            self.db_func_tool.connector if self.db_func_tool else None,
-            database_raw,
-        )
-        if catalog or effective_db or db_schema:
-            context_parts = []
-            if catalog:
-                context_parts.append(f"catalog: {catalog}")
-            if effective_db:
-                context_parts.append(f"database: {effective_db}")
-            if db_schema:
-                context_parts.append(f"schema: {db_schema}")
-            enhanced_parts.append(f"Context: {', '.join(context_parts)}")
+        # Per-turn datasource/dialect line — the frozen system prompt never
+        # carries the current selection. The reminder already merges
+        # catalog/database/schema, superseding the legacy Context line; nodes
+        # without a DB tool (gen_dashboard, scheduler) get an empty reminder
+        # and keep the legacy fallback below.
+        datasource_reminder = self._build_datasource_reminder(user_input)
+        if datasource_reminder:
+            enhanced_parts.append(datasource_reminder)
+        else:
+            catalog = getattr(user_input, "catalog", None)
+            db_schema = getattr(user_input, "db_schema", None)
+            database_raw = getattr(user_input, "database", None) or ""
+            effective_db = resolve_database_name_for_prompt(
+                self.db_func_tool.connector if self.db_func_tool else None,
+                database_raw,
+            )
+            if catalog or effective_db or db_schema:
+                context_parts = []
+                if catalog:
+                    context_parts.append(f"catalog: {catalog}")
+                if effective_db:
+                    context_parts.append(f"database: {effective_db}")
+                if db_schema:
+                    context_parts.append(f"schema: {db_schema}")
+                enhanced_parts.append(f"Context: {', '.join(context_parts)}")
 
         if enhanced_parts:
             enhanced_context = "\n\n".join(enhanced_parts)

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -204,7 +204,6 @@ class ExploreAgenticNode(AgenticNode):
     def _get_system_prompt(self, prompt_version: Optional[str] = None) -> str:
         """Get the system prompt for the explore node."""
         from datus.prompts.prompt_manager import get_prompt_manager
-        from datus.utils.time_utils import get_default_current_date
 
         version = prompt_version or self.node_config.get("prompt_version")
         template_name = "explore_system"
@@ -223,7 +222,6 @@ class ExploreAgenticNode(AgenticNode):
             "has_date_parsing_tools": bool(self.date_parsing_tools),
             **build_datasource_prompt_context(self.agent_config),
             "workspace_root": self._resolve_workspace_root(),
-            "current_date": get_default_current_date(None),
             "scoped_tables": (
                 self.input.scoped_tables
                 if isinstance(self.input, ExploreNodeInput) and self.input.scoped_tables

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -347,10 +347,6 @@ class GenReportAgenticNode(AgenticNode):
             context.update(build_datasource_prompt_context(self.agent_config))
             context["db_name"] = context.get("datasource")
 
-        from datus.utils.time_utils import get_default_current_date
-
-        context["current_date"] = get_default_current_date(None)
-
         version = None if prompt_version in (None, "") else str(prompt_version)
 
         # Construct template name: {system_prompt}_system or fallback to {node_name}_system

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -599,6 +599,13 @@ class GenSQLAgenticNode(AgenticNode):
 
         return {getattr(tool, "name", "") for tool in cached_tools if getattr(tool, "name", "")}
 
+    def _runtime_context_current_date(self) -> str:
+        """Honor the benchmark/replay ``reference_date`` in the frozen runtime context."""
+        from datus.utils.time_utils import get_default_current_date
+
+        ref = self.date_parsing_tools.reference_date if self.date_parsing_tools else None
+        return get_default_current_date(ref)
+
     def _get_system_prompt(
         self,
         prompt_version: Optional[str] = None,
@@ -643,10 +650,9 @@ class GenSQLAgenticNode(AgenticNode):
                 "execute_reference_template",
             )
         )
-        from datus.utils.time_utils import get_default_current_date
-
-        ref = self.date_parsing_tools.reference_date if self.date_parsing_tools else None
-        context["current_date"] = get_default_current_date(ref)
+        # The current date is rendered by the shared runtime-context block via
+        # _runtime_context_current_date() (reference_date aware); the current
+        # datasource/dialect arrives per turn in the user message.
         prompt_version = prompt_version or self.node_config.get("prompt_version")
         system_prompt_name = self.node_config.get("system_prompt") or self.get_node_name()
         template_name = f"{system_prompt_name}_system"

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -172,6 +172,87 @@ class SessionManager:
             logger.debug(f"Cleared session: {session_id}")
         else:
             logger.warning(f"Attempted to clear non-existent session: {session_id}")
+        # Clearing history is a session rebuild: drop the frozen system prompt
+        # so the next turn re-bakes it instead of replaying pre-clear context.
+        self.delete_system_prompt_snapshot(session_id)
+
+    # ------------------------------------------------------------------
+    # System-prompt snapshot persistence
+    # ------------------------------------------------------------------
+    # The finalized system prompt of a session is frozen on the first LLM
+    # call and replayed verbatim on every later turn so the provider-side
+    # prefix cache (Anthropic ephemeral / OpenAI prompt_cache_key) stays
+    # warm. The snapshot lives next to the session db. Multi-process note:
+    # when a CLI and an API server share a session dir the last writer wins
+    # on disk; rebuilt prompts for the same meta are semantically equivalent
+    # and the live datasource/dialect is injected per turn in the user
+    # message, so a stale snapshot can never emit a wrong dialect.
+
+    _SNAPSHOT_SCHEMA_VERSION = 1
+
+    def _snapshot_path(self, session_id: str) -> str:
+        self._validate_session_id(session_id)
+        return os.path.join(self.session_dir, f"{session_id}.sysprompt.json")
+
+    def save_system_prompt_snapshot(self, session_id: str, prompt: str, meta: Dict[str, Any]) -> None:
+        """Persist the finalized system prompt plus its invalidation metadata.
+
+        ``meta`` carries the identity keys (node_name, prompt_version,
+        model_name) the consumer compares before replaying; a mismatch on any
+        key triggers a rebuild that overwrites this file. Written atomically
+        (``.tmp`` then ``os.replace``) so a crash mid-write never leaves a
+        truncated snapshot. A disk failure only logs a warning — the caller
+        already holds the freshly built prompt for this turn.
+        """
+        path = self._snapshot_path(session_id)
+        payload: Dict[str, Any] = {"schema_version": self._SNAPSHOT_SCHEMA_VERSION, "prompt": prompt, **meta}
+        tmp_path = f"{path}.tmp"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False)
+            os.replace(tmp_path, path)
+            logger.debug(f"Saved system-prompt snapshot: {path}")
+        except OSError as exc:
+            logger.warning("Failed to save system-prompt snapshot %s: %s", path, exc)
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+
+    def load_system_prompt_snapshot(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return the stored snapshot payload, or ``None`` when unusable.
+
+        Missing file, corrupt JSON, a non-dict payload, a schema-version
+        mismatch, or a non-string prompt all yield ``None`` so the caller
+        transparently rebuilds and overwrites. Meta comparison is the
+        caller's job — the full payload is returned for that purpose.
+        """
+        path = self._snapshot_path(session_id)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+        except FileNotFoundError:
+            return None
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to load system-prompt snapshot %s: %s", path, exc)
+            return None
+        if not isinstance(payload, dict) or payload.get("schema_version") != self._SNAPSHOT_SCHEMA_VERSION:
+            return None
+        if not isinstance(payload.get("prompt"), str):
+            return None
+        return payload
+
+    def delete_system_prompt_snapshot(self, session_id: str) -> None:
+        """Delete the snapshot file (best-effort, idempotent)."""
+        path = self._snapshot_path(session_id)
+        try:
+            os.remove(path)
+            logger.debug(f"Deleted system-prompt snapshot: {path}")
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Failed to delete system-prompt snapshot %s: %s", path, exc)
 
     def delete_session(self, session_id: str) -> None:
         """
@@ -211,6 +292,9 @@ class SessionManager:
                 logger.debug(f"Deleted session archive dir: {archive_root}")
             except OSError as exc:
                 logger.warning("Failed to remove session archive dir %s: %s", archive_root, exc)
+
+        # The frozen system prompt belongs to the deleted conversation.
+        self.delete_system_prompt_snapshot(session_id)
 
     def copy_session(self, source_session_id: str, target_node_name: str) -> str:
         """Copy a session to a new one with a different node-name prefix.

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -70,17 +70,7 @@ Include:
 
 ## Context
 
-{% if current_date -%}
-- Current date: {{ current_date }}
-{% endif -%}
-{% if datasource -%}
-{% if current_datasource_dialect -%}
-- Current datasource: {{ datasource }} ({{ current_datasource_dialect }})
-{% else -%}
-- Current datasource: {{ datasource }}
-{% endif -%}
-- Use only the current datasource. If the user asks for another datasource, say AskMetrics is scoped to the current datasource.
-{% endif -%}
+- The current datasource and its SQL dialect for THIS turn are given in the `<system_reminder>` block of the user message. Use only that datasource. If the user asks for another datasource, say AskMetrics is scoped to the current datasource.
 
 {% if rules %}
 ## Rules

--- a/datus/prompts/prompt_templates/chat_system_1.2.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.2.j2
@@ -132,28 +132,7 @@ Guidelines:
 - Always check reference SQL files(*.sql) in allowed directory for similar patterns before writing new queries
 - Provide context about database schema and available data when relevant
 
-Current context:
-{% if current_date -%}
-- Current date: {{ current_date }}
-{% endif -%}
-{% if datasource -%}
-{% if current_datasource_dialect -%}
-- Current datasource: {{ datasource }} ({{ current_datasource_dialect }})
-{% else -%}
-- Current datasource: {{ datasource }}
-{% endif -%}
-{% if available_datasources and available_datasources|length > 1 -%}
-- Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
-
-- Unless the user explicitly requests a different datasource, use ONLY the current datasource for all operations.
-{% endif -%}
-{% endif -%}
-{% if workspace_root -%}
-- Current sql files root directory: {{ workspace_root }}
-{% endif -%}
-{% if active_profile -%}
-- Current permission profile: {{ active_profile }} (authoritative for this turn; previous messages may mention an older profile)
-{% endif -%}
+- The current datasource and its SQL dialect for THIS turn are given in the `<system_reminder>` block of the user message. Unless the user explicitly requests a different datasource, use ONLY that datasource for all operations and generate SQL for that dialect.
 - If a `<project_context>` block follows, it contains the project's AGENTS.md — an overview of the project architecture, directory layout, configured services, and data assets. Use it to understand the project context, but always verify with tools (list_tables, describe_table, etc.) for current data details.
 
 Output format: Respond directly in markdown format. Do not wrap your response in JSON.

--- a/datus/prompts/prompt_templates/explore_system_1.0.j2
+++ b/datus/prompts/prompt_templates/explore_system_1.0.j2
@@ -84,27 +84,10 @@ table_name | key_columns (name:type) | partition/date_column | notes
 **Recommendation**: 2-3 sentences on which tables to use, how to join, and key filters/caveats.
 
 Current context:
-{% if current_date -%}
-- Current date: {{ current_date }}
-{% endif -%}
-{% if datasource -%}
-{% if current_datasource_dialect -%}
-- Current datasource: {{ datasource }} ({{ current_datasource_dialect }})
-{% else -%}
-- Current datasource: {{ datasource }}
-{% endif -%}
-{% if available_datasources and available_datasources|length > 1 -%}
-- Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
-
-- Unless the user explicitly requests a different datasource, use ONLY the current datasource for all operations.
-{% endif -%}
-{% endif -%}
+- The current datasource and its SQL dialect for THIS turn are given in the `<system_reminder>` block of the user message. Unless the user explicitly requests a different datasource, use ONLY that datasource for all operations.
 {% if scoped_tables -%}
 - Scoped tables: {{ scoped_tables | join(", ") }}
 - IMPORTANT: Only use database tools against the scoped tables above. Do NOT rename, broaden, or explore outside this allowlist.
 - IMPORTANT: In scoped-table mode, do NOT call `list_tables`, `list_schemas`, `list_databases`, or `search_table`. Use `describe_table` on the scoped table first, then `read_query` only for the minimum sampling/probe queries needed to answer the task.
 - IMPORTANT: Once you have completed the requested profiling for the scoped table(s), stop immediately and return the findings. Do NOT continue exploratory probing.
-{% endif -%}
-{% if workspace_root -%}
-- Workspace root: {{ workspace_root }}
 {% endif -%}

--- a/datus/prompts/prompt_templates/gen_job_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_job_system_1.0.j2
@@ -80,10 +80,6 @@ Return a concise result that states:
 - What validation / reconciliation checks were run, and pass / fail.
 - Any remaining issues or assumptions.
 
-{% if current_date -%}
-Current date: {{ current_date }}
-{% endif -%}
-
 Output format: Return a single valid JSON object (no prose, no Markdown fences, no comments). Fields:
 
 - `mode`: exactly one of the strings `"intra-db"` or `"cross-db"`.

--- a/datus/prompts/prompt_templates/gen_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_report_system_1.0.j2
@@ -66,21 +66,7 @@ Your final response MUST be a valid JSON object:
 {% endif %}
 
 ## Context
-{% if current_date -%}
-- Current date: {{ current_date }}
-{% endif -%}
-{% if datasource -%}
-{% if current_datasource_dialect -%}
-- Current datasource: {{ datasource }} ({{ current_datasource_dialect }})
-{% else -%}
-- Current datasource: {{ datasource }}
-{% endif -%}
-{% if available_datasources and available_datasources|length > 1 -%}
-- Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
-
-- Unless the user explicitly requests a different datasource, use ONLY the current datasource for all operations.
-{% endif -%}
-{% endif -%}
+- The current datasource and its SQL dialect for THIS turn are given in the `<system_reminder>` block of the user message. Unless the user explicitly requests a different datasource, use ONLY that datasource for all operations.
 
 ## Important Notes
 - **CRITICAL**: Your final response MUST be valid JSON with `report` field containing Markdown content.

--- a/datus/prompts/prompt_templates/gen_sql_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_sql_system_1.2.j2
@@ -140,21 +140,7 @@ When generated SQL is 50 lines or more:
 For shorter SQL, return the SQL text inline.
 {% endif %}
 
-{% if datasource -%}
-{% if current_datasource_dialect -%}
-Current datasource: {{ datasource }} ({{ current_datasource_dialect }})
-{% else -%}
-Current datasource: {{ datasource }}
-{% endif -%}
-{% if available_datasources and available_datasources|length > 1 -%}
-Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
-
-Unless the user explicitly requests a different datasource, use ONLY the current datasource for all operations.
-{% endif -%}
-{% endif -%}
-{% if current_date -%}
-Current date: {{ current_date }}
-{% endif -%}
+The current datasource and its SQL dialect for THIS turn are given in the `<system_reminder>` block of the user message. Unless the user explicitly requests a different datasource, use ONLY that datasource for all operations and generate SQL for that dialect.
 
 ## Final Output Format
 Your final assistant response MUST be one valid JSON object, with no markdown fence and no extra text:

--- a/datus/prompts/prompt_templates/runtime_context_1.0.j2
+++ b/datus/prompts/prompt_templates/runtime_context_1.0.j2
@@ -1,0 +1,19 @@
+{# Shared runtime-context block appended uniformly by ``_finalize_system_prompt``
+   for DB-capable nodes. Holds the session-stable context that used to be
+   duplicated inline across the ``*_system_*.j2`` templates: the session-start
+   date, the configured datasource catalog, and the sql files root. These
+   values are frozen into the per-session system-prompt snapshot. The *current*
+   datasource selection and its dialect are NOT here — they are live per-turn
+   values injected into the user message's ``<system_reminder>`` envelope so a
+   mid-session switch stays correct without invalidating the cached prefix. #}
+Current context:
+{% if current_date -%}
+- Current date: {{ current_date }}
+{% endif -%}
+{% if available_datasources and available_datasources|length > 0 -%}
+- Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
+
+{% endif -%}
+{% if workspace_root -%}
+- Current sql files root directory: {{ workspace_root }}
+{% endif -%}

--- a/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
@@ -43,6 +43,14 @@ ACTIVE_TEMPLATES = [
     "gen_report_system_1.0.j2",
     "ask_metrics_system_1.0.j2",
 ]
+# Deliverable templates never inlined the datasource selection; they are held
+# to the same no-volatile-variables bar but don't point to <system_reminder>.
+DELIVERABLE_TEMPLATES = [
+    "gen_table_system_1.0.j2",
+    "gen_dashboard_system_1.0.j2",
+    "gen_job_system_1.0.j2",
+    "scheduler_system_1.0.j2",
+]
 
 
 def _agent_config(*, current_datasource=None, services=None, model="gpt-4.1"):
@@ -63,6 +71,18 @@ class _SnapshotNode(AgenticNode):
         self.agent_config = agent_config
         self.db_func_tool = db_func_tool
         self.build_count = 0
+        self.lazy_mount_count = 0
+        # Lazy-tool wiring runs on the cache-hit path too; give the ensure
+        # methods the attributes they gate on (all "nothing to mount" here).
+        self.skill_func_tool = None
+        self.bash_tool = None
+        self.memory_func_tool = None
+        self._is_subagent = True
+        self._node_model_name = None
+
+    def _ensure_lazy_tools_mounted(self) -> None:
+        self.lazy_mount_count += 1
+        super()._ensure_lazy_tools_mounted()
 
     def get_node_name(self) -> str:
         return "chat"
@@ -155,6 +175,28 @@ class TestGetSessionSystemPrompt:
         node._get_session_system_prompt(prompt_version="1.2")
         assert node.build_count == 1
 
+    def test_cache_hit_mounts_lazy_tools(self, session_manager):
+        """A replayed prompt advertises skill/bash/memory tools — the hit path
+        must run the (skipped) build's tool-mounting side effect."""
+        node1 = _SnapshotNode(session_manager, _agent_config())
+        node1._get_session_system_prompt(prompt_version="1.2")
+
+        # Fresh instance resuming the session: pure cache hit, no build.
+        node2 = _SnapshotNode(session_manager, _agent_config())
+        node2.session_id = node1.session_id
+        node2._get_session_system_prompt(prompt_version="1.2")
+        assert node2.build_count == 0
+        assert node2.lazy_mount_count == 1
+
+    def test_node_model_override_switch_rebuilds(self, session_manager):
+        """A node-level model override change must invalidate the snapshot."""
+        node = _SnapshotNode(session_manager, _agent_config())
+        node._node_model_name = "gpt-5-mini"
+        assert node._get_session_system_prompt(prompt_version="1.2") == "SYS#1"
+        node._node_model_name = "gpt-5"
+        assert node._get_session_system_prompt(prompt_version="1.2") == "SYS#2"
+        assert node.build_count == 2
+
 
 class TestSnapshotMeta:
     def test_meta_is_exactly_the_identity_keys(self, session_manager):
@@ -176,6 +218,14 @@ class TestSnapshotMeta:
         node = _SnapshotNode(session_manager, cfg)
         meta = node._system_prompt_snapshot_meta("1.2")
         assert meta["model_name"] == ""
+
+    def test_meta_prefers_node_model_override(self, session_manager):
+        """``node_config.model`` pins the effective model — it is the identity,
+        not the agent-level target."""
+        node = _SnapshotNode(session_manager, _agent_config(model="gpt-4.1"))
+        node._node_model_name = "gpt-5-mini"
+        meta = node._system_prompt_snapshot_meta("1.2")
+        assert meta["model_name"] == "node:gpt-5-mini"
 
 
 class TestDatasourceReminder:
@@ -334,7 +384,7 @@ class TestReferenceDateOverrides:
 class TestTemplateHygiene:
     """The active templates must not inline per-turn volatile variables."""
 
-    @pytest.mark.parametrize("template", ACTIVE_TEMPLATES)
+    @pytest.mark.parametrize("template", ACTIVE_TEMPLATES + DELIVERABLE_TEMPLATES)
     def test_no_inline_volatile_variables(self, template):
         source = (TEMPLATE_DIR / template).read_text(encoding="utf-8")
         assert "{{ current_date }}" not in source

--- a/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
@@ -1,0 +1,353 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the per-session system-prompt snapshot cache.
+
+Covers:
+- ``_get_session_system_prompt``: build-once / replay-verbatim across turns and
+  node instances, rebuild on a meta change (model switch), no caching without a
+  session id.
+- ``_system_prompt_snapshot_meta``: identity keys exclude per-turn live values
+  (datasource, profile, date, language).
+- ``_build_datasource_reminder``: live per-turn datasource + dialect line for
+  the user-message ``<system_reminder>`` envelope; never mentions the
+  permission profile.
+- ``_inject_runtime_context``: gated on ``db_func_tool``; renders the shared
+  ``runtime_context`` partial (session-start date + datasource catalog +
+  workspace root) WITHOUT the current datasource selection.
+- Template hygiene: the active node templates no longer inline the per-turn
+  volatile variables.
+
+A lightweight fake node bypasses the heavy ``AgenticNode.__init__`` and wires a
+real :class:`SessionManager` over ``tmp_path`` — no LLM, no network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+from datus.agent.node.agentic_node import AgenticNode
+from datus.models.session_manager import SessionManager
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[4] / "datus" / "prompts" / "prompt_templates"
+ACTIVE_TEMPLATES = [
+    "chat_system_1.2.j2",
+    "gen_sql_system_1.2.j2",
+    "explore_system_1.0.j2",
+    "gen_report_system_1.0.j2",
+    "ask_metrics_system_1.0.j2",
+]
+
+
+def _agent_config(*, current_datasource=None, services=None, model="gpt-4.1"):
+    return SimpleNamespace(
+        prompt_version="1.2",
+        current_datasource=current_datasource,
+        services=services,
+        active_model=lambda: SimpleNamespace(type="openai", model=model),
+    )
+
+
+class _SnapshotNode(AgenticNode):
+    """Minimal node exposing the real snapshot/reminder/runtime-context methods."""
+
+    def __init__(self, session_manager: SessionManager, agent_config, *, db_func_tool=None):
+        self.session_id = "chat_session_x"
+        self._session_manager = session_manager
+        self.agent_config = agent_config
+        self.db_func_tool = db_func_tool
+        self.build_count = 0
+
+    def get_node_name(self) -> str:
+        return "chat"
+
+    def _resolve_workspace_root(self) -> str:
+        return "/tmp/ws"
+
+    def _get_system_prompt(
+        self,
+        prompt_version: Optional[str] = None,
+        template_context: Optional[dict] = None,
+    ) -> str:
+        # Each rebuild is observable and uniquely tagged so replay vs rebuild
+        # is unambiguous in assertions.
+        self.build_count += 1
+        return f"SYS#{self.build_count}"
+
+
+@pytest.fixture
+def session_manager(tmp_path):
+    manager = SessionManager(session_dir=str(tmp_path))
+    yield manager
+    manager.close_all_sessions()
+
+
+class TestGetSessionSystemPrompt:
+    def test_first_turn_builds_and_persists(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config())
+        prompt = node._get_session_system_prompt(prompt_version="1.2")
+        assert prompt == "SYS#1"
+        assert node.build_count == 1
+        # Snapshot file now persists the exact prompt for replay.
+        snapshot = session_manager.load_system_prompt_snapshot(node.session_id)
+        assert snapshot["prompt"] == "SYS#1"
+        assert snapshot["model_name"] == "openai:gpt-4.1"
+
+    def test_second_turn_replays_verbatim(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config())
+        first = node._get_session_system_prompt(prompt_version="1.2")
+        second = node._get_session_system_prompt(prompt_version="1.2")
+        assert first == second == "SYS#1"
+        # The expensive builder ran exactly once across both turns.
+        assert node.build_count == 1
+
+    def test_new_node_instance_replays_snapshot(self, session_manager):
+        """API per-request nodes and /resume reuse the snapshot of the session."""
+        node1 = _SnapshotNode(session_manager, _agent_config())
+        first = node1._get_session_system_prompt(prompt_version="1.2")
+
+        node2 = _SnapshotNode(session_manager, _agent_config())
+        node2.session_id = node1.session_id
+        second = node2._get_session_system_prompt(prompt_version="1.2")
+
+        assert second == first == "SYS#1"
+        assert node2.build_count == 0
+
+    def test_model_switch_rebuilds(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config(model="gpt-4.1"))
+        first = node._get_session_system_prompt(prompt_version="1.2")
+        assert first == "SYS#1"
+        # Switch model → meta mismatch → rebuild and overwrite.
+        node.agent_config = _agent_config(model="gpt-5")
+        second = node._get_session_system_prompt(prompt_version="1.2")
+        assert second == "SYS#2"
+        assert node.build_count == 2
+        # The overwritten snapshot now replays for the new model.
+        assert node._get_session_system_prompt(prompt_version="1.2") == "SYS#2"
+        assert node.build_count == 2
+
+    def test_prompt_version_change_rebuilds(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config())
+        assert node._get_session_system_prompt(prompt_version="1.2") == "SYS#1"
+        assert node._get_session_system_prompt(prompt_version="1.3") == "SYS#2"
+
+    def test_no_session_id_skips_cache(self, session_manager, tmp_path):
+        node = _SnapshotNode(session_manager, _agent_config())
+        node.session_id = ""
+        node._get_session_system_prompt(prompt_version="1.2")
+        node._get_session_system_prompt(prompt_version="1.2")
+        # Without a session id there is no snapshot to replay → always rebuilds,
+        # and nothing is written to disk.
+        assert node.build_count == 2
+        assert list(tmp_path.glob("*.sysprompt.json")) == []
+
+    def test_datasource_switch_does_not_rebuild(self, session_manager):
+        """The live datasource is a user-message concern, never a cache key."""
+        node = _SnapshotNode(session_manager, _agent_config(current_datasource="main"))
+        node._get_session_system_prompt(prompt_version="1.2")
+        node.agent_config = _agent_config(current_datasource="dev")
+        node._get_session_system_prompt(prompt_version="1.2")
+        assert node.build_count == 1
+
+
+class TestSnapshotMeta:
+    def test_meta_is_exactly_the_identity_keys(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config(current_datasource="main"))
+        meta = node._system_prompt_snapshot_meta("1.2")
+        assert meta == {"node_name": "chat", "prompt_version": "1.2", "model_name": "openai:gpt-4.1"}
+
+    def test_meta_falls_back_to_agent_config_version(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config())
+        meta = node._system_prompt_snapshot_meta(None)
+        assert meta["prompt_version"] == "1.2"
+
+    def test_meta_survives_broken_model_resolution(self, session_manager):
+        def boom():
+            raise RuntimeError("no model configured")
+
+        cfg = _agent_config()
+        cfg.active_model = boom
+        node = _SnapshotNode(session_manager, cfg)
+        meta = node._system_prompt_snapshot_meta("1.2")
+        assert meta["model_name"] == ""
+
+
+class TestDatasourceReminder:
+    def test_requires_db_tool(self, session_manager):
+        cfg = _agent_config(current_datasource="main")
+        without = _SnapshotNode(session_manager, cfg, db_func_tool=None)
+        assert without._build_datasource_reminder() == ""
+
+        with_db = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        line = with_db._build_datasource_reminder()
+        assert "Current datasource: main" in line
+        assert "authoritative" in line
+
+    def test_dialect_included_when_available(self, session_manager):
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="snowflake")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        line = node._build_datasource_reminder()
+        assert "Current datasource: main (dialect: snowflake)" in line
+        assert "generate SQL for THIS dialect" in line
+
+    def test_empty_without_current_datasource(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config(current_datasource=None), db_func_tool=object())
+        assert node._build_datasource_reminder() == ""
+
+    def test_never_mentions_permission_profile(self, session_manager):
+        """The profile is enforced by permission hooks, never prompted."""
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="duckdb")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        cfg.active_profile_name = "dangerous"
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        line = node._build_datasource_reminder()
+        assert "profile" not in line.lower()
+        assert "dangerous" not in line
+
+    def test_merges_catalog_database_schema_details(self, session_manager):
+        """The reminder absorbs the legacy Database Context fields in one line."""
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="snowflake")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        db_tool = SimpleNamespace(connector=SimpleNamespace(database_name="proddb"))
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=db_tool)
+
+        user_input = SimpleNamespace(catalog="c1", database="", db_schema="s1")
+        line = node._build_datasource_reminder(user_input)
+
+        assert "Current datasource: main (dialect: snowflake, catalog: c1, database: proddb, schema: s1)" in line
+
+    def test_explicit_database_overrides_connector_default(self, session_manager):
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="duckdb")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        db_tool = SimpleNamespace(connector=SimpleNamespace(database_name="default_db"))
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=db_tool)
+
+        user_input = SimpleNamespace(database="explicit_db")
+        line = node._build_datasource_reminder(user_input)
+
+        assert "database: explicit_db" in line
+        assert "default_db" not in line
+
+    def test_enhanced_message_carries_reminder_in_envelope(self, session_manager):
+        """The reminder rides inside the existing <system_reminder> envelope."""
+        from datus.utils.message_utils import extract_enhanced_context, extract_user_input
+
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="snowflake")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        node.plan_mode_active = False
+        node._plan_just_confirmed = False
+        node.plan_file_path = None
+
+        user_input = SimpleNamespace(user_message="show me revenue", plan_mode=False)
+        message = node._build_enhanced_message(user_input)
+
+        enhanced = extract_enhanced_context(message)
+        assert "Current datasource: main (dialect: snowflake)" in enhanced
+        assert extract_user_input(message) == "show me revenue"
+        # Merged design: the dialect value is stated exactly once — no
+        # separate legacy "Database Context" block when the reminder is present.
+        assert "Database Context" not in enhanced
+        assert enhanced.lower().count("dialect:") == 1
+
+    def test_legacy_database_context_when_reminder_absent(self, session_manager):
+        """Nodes without a DB tool keep the legacy Database Context block."""
+        from datus.utils.message_utils import extract_enhanced_context
+
+        cfg = _agent_config(current_datasource="main")
+        cfg.db_type = "sqlite"
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=None)
+        node.plan_mode_active = False
+        node._plan_just_confirmed = False
+        node.plan_file_path = None
+
+        user_input = SimpleNamespace(user_message="hello", plan_mode=False, database="db1")
+        message = node._build_enhanced_message(user_input)
+
+        enhanced = extract_enhanced_context(message)
+        assert "Database Context" in enhanced
+        assert "**Dialect**: sqlite" in enhanced
+        assert "Current datasource:" not in enhanced
+
+
+class TestInjectRuntimeContext:
+    def test_skipped_without_db_tool(self, session_manager):
+        node = _SnapshotNode(session_manager, _agent_config(), db_func_tool=None)
+        assert node._inject_runtime_context("BASE") == "BASE"
+
+    def test_appends_date_catalog_and_workspace_for_db_node(self, session_manager):
+        services = SimpleNamespace(
+            datasources={"main": SimpleNamespace(type="snowflake"), "dev": SimpleNamespace(type="duckdb")}
+        )
+        cfg = _agent_config(current_datasource="main", services=services)
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        out = node._inject_runtime_context("BASE")
+        assert out.startswith("BASE")
+        assert "Current context:" in out
+        assert re.search(r"Current date: \d{4}-\d{2}-\d{2}", out)
+        assert "Available datasources:" in out
+        assert "main (snowflake)" in out
+        assert "dev (duckdb)" in out
+        assert "/tmp/ws" in out
+
+    def test_does_not_pin_current_datasource_selection(self, session_manager):
+        """The frozen prompt lists the catalog but never the live selection."""
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="snowflake")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        out = node._inject_runtime_context("BASE")
+        assert "Current datasource:" not in out
+
+    def test_runtime_context_date_hook_is_overridable(self, session_manager):
+        """Subclasses (GenSQL/AskMetrics) pin a reference date into the snapshot."""
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="duckdb")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        node._runtime_context_current_date = lambda: "1999-12-31"
+        out = node._inject_runtime_context("BASE")
+        assert "Current date: 1999-12-31" in out
+
+
+class TestReferenceDateOverrides:
+    def test_gen_sql_uses_date_parsing_reference_date(self):
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        node = GenSQLAgenticNode.__new__(GenSQLAgenticNode)
+        node.date_parsing_tools = SimpleNamespace(reference_date="2024-06-15")
+        assert node._runtime_context_current_date() == "2024-06-15"
+
+    def test_ask_metrics_uses_input_reference_date(self):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+        node = AskMetricsAgenticNode.__new__(AskMetricsAgenticNode)
+        node.input = SimpleNamespace(reference_date="2024-06-15")
+        assert node._runtime_context_current_date() == "2024-06-15"
+
+
+class TestTemplateHygiene:
+    """The active templates must not inline per-turn volatile variables."""
+
+    @pytest.mark.parametrize("template", ACTIVE_TEMPLATES)
+    def test_no_inline_volatile_variables(self, template):
+        source = (TEMPLATE_DIR / template).read_text(encoding="utf-8")
+        assert "{{ current_date }}" not in source
+        assert "{{ active_profile }}" not in source
+        assert "Current datasource: {{ datasource }}" not in source
+
+    @pytest.mark.parametrize("template", ACTIVE_TEMPLATES)
+    def test_points_to_system_reminder(self, template):
+        source = (TEMPLATE_DIR / template).read_text(encoding="utf-8")
+        assert "<system_reminder>" in source
+
+    def test_runtime_context_partial_has_no_current_selection(self):
+        source = (TEMPLATE_DIR / "runtime_context_1.0.j2").read_text(encoding="utf-8")
+        assert "{{ current_date }}" in source
+        assert "available_datasources" in source
+        assert "Current datasource: {{ datasource }}" not in source

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -698,22 +698,26 @@ class TestChatAgenticNodeSystemPrompt:
         assert isinstance(prompt, str)
         assert len(prompt) >= 100
 
-    def test_get_system_prompt_contains_active_permission_profile(self, real_agent_config, mock_llm_create):
-        """Runtime /profile changes must be visible to the next LLM turn."""
+    def test_get_system_prompt_excludes_permission_profile(self, real_agent_config, mock_llm_create):
+        """The permission profile is enforced by hooks at tool-call time, never prompted.
+
+        Keeping it out of the system prompt also keeps the frozen per-session
+        snapshot byte-stable across a runtime /profile switch.
+        """
         from datus.agent.node.chat_agentic_node import ChatAgenticNode
 
         real_agent_config.active_profile_name = "dangerous"
         node = ChatAgenticNode(
             node_id="test_prompt_profile",
-            description="Test active permission profile in prompt",
+            description="Test permission profile absent from prompt",
             node_type=NodeType.TYPE_CHAT,
             agent_config=real_agent_config,
         )
 
         prompt = node._get_system_prompt()
 
-        assert "Current permission profile: dangerous" in prompt
-        assert "authoritative for this turn" in prompt
+        assert "Current permission profile" not in prompt
+        assert "dangerous" not in prompt
 
     def test_workflow_prompt_does_not_advertise_ask_user(self, real_agent_config, mock_llm_create):
         """Workflow chat has no ask_user tool, so the prompt must not route to it."""

--- a/tests/unit_tests/agent/node/test_deliverable_node.py
+++ b/tests/unit_tests/agent/node/test_deliverable_node.py
@@ -154,3 +154,60 @@ class TestRetryLoopDrivenByOnEnd:
         output = last.output or {}
         assert output.get("success") is False
         assert output["validation_report"]["checks"][0]["error"] == "synthetic blocking failure for retry-loop test"
+
+
+class TestDeliverableDatasourceContext:
+    """The frozen system prompt is datasource-free; the live selection rides per turn.
+
+    Mirrors the chat-node design: ``_prepare_template_context`` (rendered into
+    the per-session snapshot) carries only session-stable values, while the
+    current datasource/dialect arrives in each user message via
+    ``_build_datasource_reminder``.
+    """
+
+    def _make_node(self, *, db_func_tool=None, current_datasource=None, services=None):
+        from types import SimpleNamespace
+
+        from datus.agent.node.deliverable_node import DeliverableAgenticNode
+
+        node = DeliverableAgenticNode.__new__(DeliverableAgenticNode)
+        node.agent_config = SimpleNamespace(current_datasource=current_datasource, services=services)
+        node.tools = []
+        node.mcp_servers = {}
+        node.ask_user_tool = None
+        node.db_func_tool = db_func_tool
+        return node
+
+    def test_template_context_has_no_datasource_keys(self):
+        from types import SimpleNamespace
+
+        node = self._make_node(current_datasource="main")
+        ctx = node._prepare_template_context(SimpleNamespace(user_message="create table t"))
+
+        assert set(ctx) == {"native_tools", "mcp_tools", "has_ask_user_tool"}
+
+    def test_enhanced_message_uses_datasource_reminder_with_db_tool(self):
+        from types import SimpleNamespace
+
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="duckdb")})
+        db_tool = SimpleNamespace(connector=SimpleNamespace(database_name="proddb"))
+        node = self._make_node(db_func_tool=db_tool, current_datasource="main", services=services)
+
+        user_input = SimpleNamespace(user_message="create table t", catalog="", database="", db_schema="")
+        message = node._build_enhanced_message(user_input)
+
+        # The merged reminder supersedes the legacy Context line entirely.
+        assert "Current datasource: main (dialect: duckdb, database: proddb)" in message
+        assert "Context:" not in message
+        assert "create table t" in message
+
+    def test_enhanced_message_falls_back_to_legacy_context_without_db_tool(self):
+        from types import SimpleNamespace
+
+        node = self._make_node(db_func_tool=None, current_datasource="main")
+
+        user_input = SimpleNamespace(user_message="make dashboard", catalog="c1", database="db1", db_schema="s1")
+        message = node._build_enhanced_message(user_input)
+
+        assert "Context: catalog: c1, database: db1, schema: s1" in message
+        assert "Current datasource:" not in message

--- a/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
@@ -561,13 +561,14 @@ class TestExtractReportFromResponse:
 
 class TestBuildEnhancedMessage:
     def test_includes_dialect_block_from_agent_config(self, real_agent_config, mock_llm_create):
-        """``db_type`` from agent_config drives the dialect block even without input-side ctx."""
+        """The dialect surfaces even without input-side ctx (merged datasource reminder)."""
         node = _make_node(real_agent_config, mock_llm_create)
         user_input = GenReportNodeInput(user_message="Analyze revenue")
         result = node._build_enhanced_message(user_input)
         assert "Analyze revenue" in result
-        # Dialect comes from agent_config.db_type
-        assert "Dialect" in result
+        # Dialect rides in the per-turn datasource reminder line
+        assert "dialect:" in result
+        assert "Current datasource:" in result
 
     def test_with_database_context_builds_structured_message(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -1500,7 +1500,9 @@ class TestEdgeCases:
 
         message = node._build_enhanced_message(ChatNodeInput(user_message="有哪些表"))
 
-        assert "**Database**: connector_db" in message
+        # Connector-default database resolution surfaces in the merged
+        # per-turn datasource reminder line.
+        assert "database: connector_db" in message
 
     def test_display_markdown_response_simple_text(self, real_agent_config, mock_llm_create):
         """Simple text with no markdown formatting is still displayed."""

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1898,3 +1898,116 @@ class TestSessionMatchesAgent:
         assert session_matches_agent("legacy-id", None) is True
         assert session_matches_agent("legacy-id", "chat") is True
         assert session_matches_agent("legacy-id", "gen_metrics") is False
+
+
+# ===========================================================================
+# TestSystemPromptSnapshot
+# ===========================================================================
+
+
+class TestSystemPromptSnapshot:
+    """save/load/delete_system_prompt_snapshot: the frozen per-session prompt."""
+
+    META = {"node_name": "chat", "prompt_version": "1.2", "model_name": "openai:gpt-4.1"}
+
+    def _path(self, sm_custom, session_id):
+        return os.path.join(sm_custom.session_dir, f"{session_id}.sysprompt.json")
+
+    def test_round_trip_returns_prompt_and_meta(self, sm_custom):
+        """A saved snapshot loads back with the exact prompt bytes and meta keys."""
+        prompt = "SYSTEM PROMPT\nwith unicode — 中文 ✓"
+        sm_custom.save_system_prompt_snapshot("chat_session_rt", prompt, dict(self.META))
+
+        payload = sm_custom.load_system_prompt_snapshot("chat_session_rt")
+
+        assert payload["prompt"] == prompt
+        assert payload["schema_version"] == 1
+        for key, value in self.META.items():
+            assert payload[key] == value
+
+    def test_load_missing_returns_none(self, sm_custom):
+        """No snapshot file -> None (caller rebuilds)."""
+        assert sm_custom.load_system_prompt_snapshot("chat_session_missing") is None
+
+    def test_load_corrupt_json_returns_none(self, sm_custom):
+        """A truncated/corrupt file -> None, never an exception."""
+        path = self._path(sm_custom, "chat_session_corrupt")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write('{"schema_version": 1, "prompt": "trunc')
+
+        assert sm_custom.load_system_prompt_snapshot("chat_session_corrupt") is None
+
+    def test_load_schema_mismatch_returns_none(self, sm_custom):
+        """A future schema version is not replayed by this build."""
+        path = self._path(sm_custom, "chat_session_schema")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"schema_version": 99, "prompt": "p", **self.META}, f)
+
+        assert sm_custom.load_system_prompt_snapshot("chat_session_schema") is None
+
+    def test_load_non_string_prompt_returns_none(self, sm_custom):
+        """A payload whose prompt is not a string is unusable -> None."""
+        path = self._path(sm_custom, "chat_session_badprompt")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"schema_version": 1, "prompt": ["not", "a", "string"], **self.META}, f)
+
+        assert sm_custom.load_system_prompt_snapshot("chat_session_badprompt") is None
+
+    def test_save_overwrites_previous_snapshot(self, sm_custom):
+        """A rebuild (stale meta) replaces the old snapshot in full."""
+        sm_custom.save_system_prompt_snapshot("chat_session_ow", "OLD", dict(self.META))
+        new_meta = {**self.META, "model_name": "anthropic:claude"}
+        sm_custom.save_system_prompt_snapshot("chat_session_ow", "NEW", new_meta)
+
+        payload = sm_custom.load_system_prompt_snapshot("chat_session_ow")
+        assert payload["prompt"] == "NEW"
+        assert payload["model_name"] == "anthropic:claude"
+
+    def test_delete_removes_file_and_is_idempotent(self, sm_custom):
+        """delete removes the file; deleting again is a silent no-op."""
+        sm_custom.save_system_prompt_snapshot("chat_session_del", "P", dict(self.META))
+        path = self._path(sm_custom, "chat_session_del")
+        assert os.path.exists(path)
+
+        sm_custom.delete_system_prompt_snapshot("chat_session_del")
+        assert not os.path.exists(path)
+        assert sm_custom.load_system_prompt_snapshot("chat_session_del") is None
+
+        sm_custom.delete_system_prompt_snapshot("chat_session_del")
+        assert not os.path.exists(path)
+
+    def test_delete_session_drops_snapshot(self, sm_custom):
+        """Deleting a session (CLI /clear, API delete) drops its frozen prompt too."""
+        session_id = "chat_session_dropall"
+        sm_custom.get_session(session_id)
+        sm_custom.save_system_prompt_snapshot(session_id, "P", dict(self.META))
+
+        sm_custom.delete_session(session_id)
+
+        assert not os.path.exists(self._path(sm_custom, session_id))
+        assert sm_custom.load_system_prompt_snapshot(session_id) is None
+
+    def test_clear_session_drops_snapshot(self, sm_custom):
+        """Clearing history is a session rebuild: the frozen prompt must go."""
+        session_id = "chat_session_clear"
+        sm_custom.get_session(session_id)
+        sm_custom.save_system_prompt_snapshot(session_id, "P", dict(self.META))
+
+        sm_custom.clear_session(session_id)
+
+        assert sm_custom.load_system_prompt_snapshot(session_id) is None
+
+    def test_invalid_session_id_raises(self, sm_custom):
+        """Path-unsafe session ids are rejected before touching the filesystem."""
+        with pytest.raises(ValueError):
+            sm_custom.save_system_prompt_snapshot("../escape", "P", dict(self.META))
+        with pytest.raises(ValueError):
+            sm_custom.load_system_prompt_snapshot("../escape")
+        with pytest.raises(ValueError):
+            sm_custom.delete_system_prompt_snapshot("../escape")
+
+    def test_save_leaves_no_tmp_file(self, sm_custom):
+        """The atomic write must not leave a .tmp behind on success."""
+        sm_custom.save_system_prompt_snapshot("chat_session_tmp", "P", dict(self.META))
+        leftovers = [f for f in os.listdir(sm_custom.session_dir) if f.endswith(".tmp")]
+        assert leftovers == []


### PR DESCRIPTION


## Why

Every conversation turn rebuilt the full system prompt in execute_stream() (Jinja render + AGENTS.md/MEMORY.md file I/O + skills XML). Any byte change (date rollover, inline current-datasource, active profile) invalidated the provider-side prefix cache (Anthropic ephemeral / OpenAI prompt_cache_key), recharging the entire input on every turn.

## Solution

Snapshot the finalized system prompt on the first LLM call of a session and replay it verbatim on every later turn (new node instances, API per-request nodes, /resume, subagent sessions), keeping the provider prefix cache warm.

- SessionManager: add save/load/delete_system_prompt_snapshot, persisted as {session_dir}/{session_id}.sysprompt.json (atomic write, schema-versioned, corrupt/mismatch -> None -> rebuild). delete_session and clear_session drop the snapshot too. Disk-only, no in-process layer.
- AgenticNode._get_session_system_prompt: build-once / replay; meta key is {node_name, prompt_version, model_name} so a /model switch rebuilds. A major compact drops the snapshot (session-rebuild semantics).
- Correctness: the live current datasource rides in the user turn's existing <system_reminder> envelope as one merged line — datasource, dialect, catalog, database (connector-default resolved), schema — superseding the legacy "Database Context" block (kept only as fallback for nodes without a DB tool). A frozen snapshot can never emit a stale dialect.
- The permission profile is no longer prompted at all; permission hooks enforce it at tool-call time.
- Dedup: new runtime_context_1.0.j2 partial appended once by _finalize_system_prompt for db-tool nodes (session-start date + available-datasources catalog + workspace root), replacing the scattered inline "Current context" stanzas in 5 active templates. gen_sql/ask_metrics keep their reference_date via the overridable _runtime_context_current_date hook.

Verified end-to-end with mitmproxy over two datus -p runs (separate processes, same session): all 8 OpenAI requests carried byte-identical instructions (sha-equal, == snapshot file), and the resumed turn hit 10752 of 11035 input tokens cached (~97%).

## Test Cases

- tests/unit_tests/models/test_session_manager.py: 11 snapshot tests (round-trip, missing/corrupt/schema-mismatch -> None, overwrite, delete idempotent, delete_session/clear_session drop snapshot, invalid id raises, atomic write leaves no tmp file).
- tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py: 36 tests (build-once/replay, cross-instance replay, model/prompt-version switch rebuild, datasource switch does NOT rebuild, no-session skip, meta excludes live values, merged datasource reminder incl. catalog/database/schema and connector-default override, envelope integration with single dialect mention, legacy Database Context fallback, runtime_context gating and reference-date overrides, template hygiene for 5 active templates).
- test_chat_agentic_node.py / test_gen_report_agentic_node.py / test_chat_commands.py: assertions updated for profile removal and the merged reminder format.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

* **New Features**
  * System prompts are now cached per session, reducing rendering overhead and improving response times.
  * Datasource and SQL dialect information is now explicitly provided per conversation turn, allowing mid-session datasource switches to affect only the current turn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-session system-prompt snapshotting to speed prompt reuse and reduce render work.
  * Per-turn "Current datasource" reminder injected into user messages so mid-session datasource/dialect switches apply only to that turn.
  * Shared runtime-context block added to system prompts (session-stable date, available datasources, workspace root).

* **Bug Fixes**
  * Snapshot invalidation on major compaction and session clears to avoid stale prompts.

* **Tests**
  * New unit tests covering snapshot cache, datasource reminder, and runtime-context behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->