### PR TITLE
[BugFix] Track and drain fire-and-forget create_task calls on shutdown (#1002)

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -44,6 +44,7 @@ from datus.api.models.cli_models import (
     StreamChatInput,
     UserInteractionInput,
 )
+from datus.api.services.background_drain import track_background_task
 from datus.tools.data_access_policy import DataAccessConfig
 from datus.utils.feedback_prompt import build_reaction_feedback_prompt
 from datus.utils.loggings import get_logger
@@ -56,7 +57,6 @@ if TYPE_CHECKING:
     from datus.api.services.datus_service import DatusService
 
 router = APIRouter(prefix="/api/v1/chat", tags=["chat"])
-
 
 # Additional builtin subagents accepted by ``stream_chat`` beyond the canonical
 # ``BUILTIN_SUBAGENTS`` set — these are wired directly in
@@ -651,10 +651,11 @@ async def _stream_with_post_hook(
             )
 
             try:
-                asyncio.create_task(
+                _task = asyncio.create_task(
                     _safe_post_chat(hooks, http_request, request, ctx),
                     name=f"chat-post-hook:{session_id_value or '-'}",
                 )
+                track_background_task(_task)
             except Exception:  # pragma: no cover — defensive
                 logger.error("Failed to schedule post_chat hook", exc_info=True)
 

--- a/datus/api/service.py
+++ b/datus/api/service.py
@@ -18,6 +18,7 @@ from fastapi.responses import StreamingResponse
 from datus.agent.agent import Agent
 from datus.api.auth import load_auth_provider
 from datus.api.deps import init_deps
+from datus.api.services.background_drain import drain_background_tasks
 from datus.api.services.datus_service_cache import DatusServiceCache
 from datus.configuration.agent_config_loader import load_agent_config, parse_config_path
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
@@ -452,9 +453,14 @@ async def lifespan(app: FastAPI):
     )
 
     logger.info("Datus API Service started")
-    yield
-    # Shutdown
-    logger.info("Datus API Service shutting down")
+    try:
+        yield
+    finally:
+        logger.info("Datus API Service shutting down")
+        try:
+            await drain_background_tasks()
+        finally:
+            await service_cache.shutdown()
 
 
 def create_app(agent_args: argparse.Namespace) -> FastAPI:

--- a/datus/api/services/background_drain.py
+++ b/datus/api/services/background_drain.py
@@ -1,0 +1,28 @@
+"""Shared registry for fire-and-forget background tasks spawned during request handling.
+
+Tasks are tracked here so the FastAPI lifespan shutdown handler can await them
+before the event loop closes, without depending on any optional route module.
+"""
+
+import asyncio
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+_background_tasks: set[asyncio.Task] = set()
+
+
+def track_background_task(task: asyncio.Task) -> None:
+    """Register a background task for graceful drain on shutdown."""
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def drain_background_tasks() -> None:
+    """Await all tracked background tasks (call from lifespan shutdown)."""
+    if _background_tasks:
+        results = await asyncio.gather(*list(_background_tasks), return_exceptions=True)
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.warning("Background task failed during drain", exc_info=result)

--- a/datus/api/services/datus_service_cache.py
+++ b/datus/api/services/datus_service_cache.py
@@ -22,6 +22,13 @@ class DatusServiceCache:
         self._cache: collections.OrderedDict[str, DatusService] = collections.OrderedDict()
         self._futures: dict[str, asyncio.Future[DatusService]] = {}
         self._lock = asyncio.Lock()
+        self._pending_tasks: set[asyncio.Task] = set()
+
+    def _track(self, task: asyncio.Task) -> asyncio.Task:
+        """Register a background task so drain()/shutdown() can await it."""
+        self._pending_tasks.add(task)
+        task.add_done_callback(self._pending_tasks.discard)
+        return task
 
     async def get_or_create(
         self,
@@ -103,7 +110,7 @@ class DatusServiceCache:
         # Shutdown evicted services outside the lock
         for old_pid, old_svc in evicted:
             logger.info(f"LRU evicting DatusService for project {old_pid}")
-            asyncio.create_task(old_svc.shutdown())
+            self._track(asyncio.create_task(old_svc.shutdown()))
 
         return svc
 
@@ -123,7 +130,7 @@ class DatusServiceCache:
         """Shutdown a service, deferring if it still has active tasks."""
         if svc.has_active_tasks():
             logger.info(f"Evicting DatusService for project {project_id} (deferring shutdown — active tasks)")
-            asyncio.create_task(self._deferred_shutdown(project_id, svc))
+            self._track(asyncio.create_task(self._deferred_shutdown(project_id, svc)))
         else:
             logger.info(f"Evicting DatusService for project {project_id}")
             await svc.shutdown()
@@ -138,8 +145,17 @@ class DatusServiceCache:
         except Exception:
             logger.exception(f"Error in deferred shutdown for project {project_id}")
 
+    async def drain(self) -> None:
+        """Await all pending background shutdown tasks before the loop closes."""
+        if self._pending_tasks:
+            results = await asyncio.gather(*list(self._pending_tasks), return_exceptions=True)
+            for result in results:
+                if isinstance(result, BaseException):
+                    logger.warning("Background shutdown task failed", exc_info=result)
+
     async def shutdown(self) -> None:
         """Shutdown all cached DatusService instances (application exit)."""
+        await self.drain()
         async with self._lock:
             items = list(self._cache.items())
             self._cache.clear()

--- a/tests/unit_tests/api/services/test_background_drain.py
+++ b/tests/unit_tests/api/services/test_background_drain.py
@@ -1,0 +1,81 @@
+"""Tests for datus.api.services.background_drain — shared background task registry."""
+
+import asyncio
+
+import pytest
+
+import datus.api.services.background_drain as mod
+from datus.api.services.background_drain import drain_background_tasks, track_background_task
+
+
+@pytest.mark.asyncio
+class TestDrainBackgroundTasks:
+    """Tests for drain_background_tasks / track_background_task lifecycle."""
+
+    async def test_drain_awaits_registered_tasks(self):
+        """drain_background_tasks() awaits all tasks added to _background_tasks."""
+        completed = []
+
+        async def _work():
+            await asyncio.sleep(0.01)
+            completed.append(1)
+
+        original = mod._background_tasks
+        task = asyncio.create_task(_work())
+        mod._background_tasks = {task}
+        task.add_done_callback(mod._background_tasks.discard)
+
+        try:
+            await drain_background_tasks()
+            assert completed == [1]
+            assert len(mod._background_tasks) == 0
+        finally:
+            mod._background_tasks = original
+
+    async def test_drain_is_noop_when_empty(self):
+        """drain_background_tasks() leaves the set empty and does not raise."""
+        original = mod._background_tasks
+        mod._background_tasks = set()
+        try:
+            await drain_background_tasks()
+            assert len(mod._background_tasks) == 0
+        finally:
+            mod._background_tasks = original
+
+    async def test_drain_tolerates_task_exception(self):
+        """drain_background_tasks() swallows task exceptions and empties the set."""
+        original = mod._background_tasks
+        mod._background_tasks = set()
+
+        async def _boom():
+            raise RuntimeError("hook failure")
+
+        task = asyncio.create_task(_boom())
+        mod._background_tasks.add(task)
+        task.add_done_callback(mod._background_tasks.discard)
+
+        try:
+            await drain_background_tasks()
+            assert len(mod._background_tasks) == 0
+        finally:
+            mod._background_tasks = original
+
+    async def test_track_registers_and_auto_removes_on_completion(self):
+        """track_background_task() adds the task and removes it via done-callback."""
+        pause = asyncio.Event()
+
+        async def _work():
+            await pause.wait()
+
+        original = mod._background_tasks
+        mod._background_tasks = set()
+        try:
+            task = asyncio.create_task(_work())
+            track_background_task(task)
+            assert len(mod._background_tasks) == 1
+
+            pause.set()
+            await task  # wait for completion; done-callback runs before await returns
+            assert len(mod._background_tasks) == 0
+        finally:
+            mod._background_tasks = original

--- a/tests/unit_tests/api/services/test_datus_service_cache.py
+++ b/tests/unit_tests/api/services/test_datus_service_cache.py
@@ -238,6 +238,106 @@ class TestEvict:
 
 
 @pytest.mark.asyncio
+class TestPendingTaskTracking:
+    """Tests for _track() / drain() — background task lifecycle management."""
+
+    async def test_lru_eviction_task_is_tracked(self):
+        """LRU eviction create_task is registered in _pending_tasks."""
+        cache = DatusServiceCache(max_size=1)
+        svc_a = _mock_service("a", has_active=False)
+        svc_b = _mock_service("b", has_active=False)
+
+        # Pause the shutdown task so it stays in _pending_tasks when we check.
+        pause = asyncio.Event()
+
+        async def _paused_shutdown():
+            await pause.wait()
+
+        svc_a.shutdown = AsyncMock(side_effect=_paused_shutdown)
+
+        await cache.get_or_create("a", AsyncMock(return_value=svc_a))
+        await cache.get_or_create("b", AsyncMock(return_value=svc_b))
+
+        assert len(cache._pending_tasks) == 1
+
+        pause.set()
+        await cache.drain()
+
+    async def test_deferred_shutdown_task_is_tracked(self):
+        """_dispose with active tasks registers the deferred-shutdown Task."""
+        cache = DatusServiceCache()
+        pause = asyncio.Event()
+
+        async def _paused_wait():
+            await pause.wait()
+
+        svc = _mock_service("p", has_active=True)
+        svc.task_manager.wait_all_tasks = AsyncMock(side_effect=_paused_wait)
+        await cache.get_or_create("p", AsyncMock(return_value=svc))
+
+        await cache._dispose("p", svc)
+
+        assert len(cache._pending_tasks) == 1
+
+        pause.set()
+        await cache.drain()
+
+    async def test_pending_task_removed_on_completion(self):
+        """Completed task is discarded from _pending_tasks via done callback."""
+        cache = DatusServiceCache()
+        svc = _mock_service("p")
+        await cache.get_or_create("p", AsyncMock(return_value=svc))
+        await cache._dispose("p", svc)  # has_active=False → direct await, no task
+
+        assert len(cache._pending_tasks) == 0
+
+    async def test_drain_awaits_pending_tasks(self):
+        """drain() awaits all registered background tasks."""
+        cache = DatusServiceCache()
+        completed = []
+
+        async def _slow_work():
+            await asyncio.sleep(0.01)
+            completed.append(1)
+
+        task = asyncio.create_task(_slow_work())
+        cache._track(task)
+        assert len(cache._pending_tasks) == 1
+
+        await cache.drain()
+        assert completed == [1]
+        assert len(cache._pending_tasks) == 0
+
+    async def test_drain_tolerates_task_exception(self):
+        """drain() swallows task exceptions and clears the pending set."""
+        cache = DatusServiceCache()
+
+        async def _boom():
+            raise RuntimeError("background failure")
+
+        cache._track(asyncio.create_task(_boom()))
+        await cache.drain()
+        assert len(cache._pending_tasks) == 0
+
+    async def test_shutdown_drains_before_clearing_cache(self):
+        """shutdown() calls drain() before shutting down cached services."""
+        cache = DatusServiceCache()
+        order = []
+
+        async def _background():
+            await asyncio.sleep(0.01)
+            order.append("drained")
+
+        svc = _mock_service("p")
+        svc.shutdown = AsyncMock(side_effect=lambda: order.append("service-shutdown"))
+        await cache.get_or_create("p", AsyncMock(return_value=svc))
+        cache._track(asyncio.create_task(_background()))
+
+        await cache.shutdown()
+        assert order == ["drained", "service-shutdown"]
+
+
+@pytest.mark.asyncio
 class TestShutdown:
     """Tests for shutdown — clean teardown of all services."""
 


### PR DESCRIPTION
## Why

While investigating PR #952 (asyncio teardown race in `run_in_terminal_sync`), we identified a shared failure class across the API layer: three `asyncio.create_task()` call-sites discard the returned `Task` reference immediately. When the FastAPI event loop shuts down before these tasks complete, `loop.close()` calls `_ready.clear()` and silently drops the pending work — no error, no warning.

Additionally, `DatusServiceCache.shutdown()` was never called from the FastAPI lifespan handler, meaning the entire cache teardown was being skipped on application exit.

Closes #1002.

## Solution

**`datus/api/services/background_drain.py`** (new) — stable module that owns the shared background task registry (`_background_tasks`, `track_background_task()`, `drain_background_tasks()`). Extracted into its own module so `service.py` can import `drain_background_tasks` at module load time rather than inside the shutdown block. A deferred import there could abort teardown before `service_cache.shutdown()` runs if the route module is ever unavailable — `chat_routes` is loaded conditionally at startup alongside all other route modules.

**`datus/api/services/datus_service_cache.py`** — add `_pending_tasks: set[Task]` and a `_track(task)` helper; wrap both `create_task` call-sites (LRU eviction and deferred dispose) with `_track()`; `drain()` gathers the set with `return_exceptions=True` and logs each exception via `logger.warning` so failures are visible rather than silently discarded; `shutdown()` calls `drain()` first so in-flight tasks complete before the cache is cleared.

**`datus/api/routes/chat_routes.py`** — post-chat hook scheduling uses `track_background_task()` from `background_drain` instead of a local set.

**`datus/api/service.py`** — lifespan shutdown now imports `drain_background_tasks` at module level and calls it followed by `service_cache.shutdown()`, wiring both drains into the application exit path.

## Test Cases

Added 6 tests in `tests/unit_tests/api/services/test_datus_service_cache.py` (`TestPendingTaskTracking`):
- LRU eviction task is registered in `_pending_tasks`
- Deferred shutdown task is registered in `_pending_tasks`
- Completed task is auto-discarded via done callback
- `drain()` awaits registered tasks and empties the set
- `drain()` tolerates and logs task exceptions without raising
- `shutdown()` drains before shutting down cached services (ordering guarantee)

Added 4 tests in `tests/unit_tests/api/services/test_background_drain.py` (`TestDrainBackgroundTasks`):
- `drain_background_tasks()` awaits registered tasks and empties the set
- `drain_background_tasks()` is a no-op when the set is empty
- `drain_background_tasks()` tolerates task exceptions without raising
- `track_background_task()` registers the task and auto-removes it on completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background “fire-and-forget” task tracking so work started during requests is reliably accounted for.
  * Enhanced graceful shutdown: tracked background work is drained before the app and service cache fully stop.

* **Bug Fixes**
  * Prevented background post-chat hooks and service shutdown operations from being left untracked or cut off during shutdown; task errors are logged without crashing shutdown.

* **Tests**
  * Added unit tests covering task tracking, draining behavior, eviction/deferred shutdown ordering, and exception-tolerant draining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
