### PR TITLE
[Enhancement] Improve ask_metrics metric query flow

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1746,6 +1746,7 @@ class AgenticNode(Node):
             "adapter_type",
             "semantic_adapter",
             "subject_tree_prompt_limit",
+            "require_final_result_selection",
             "sql_file_threshold",
             "sql_preview_lines",
             "bi_platform",

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -51,7 +51,6 @@ class AskMetricsAgenticNode(AgenticNode):
         "semantic_tools.attribution_analyze",
         "context_search_tools.list_subject_tree",
     )
-
     _TOOL_NAMES_BY_CATEGORY = {
         "db_tools": set(DBFuncTool.all_tools_name()),
         "context_search_tools": set(ContextSearchTools.all_tools_name()),
@@ -95,6 +94,8 @@ class AskMetricsAgenticNode(AgenticNode):
         self.subject_tree_metric_entries: List[Dict[str, Any]] = []
         self.subject_tree_mode: str = "none"
         self.subject_tree_prompt: str = ""
+        self._metric_catalog_cache: Optional[Dict[str, Dict[str, Any]]] = None
+        self._selected_final_metric_result_id: Optional[str] = None
         self.startup_error: Optional[str] = None
 
         super().__init__(
@@ -116,6 +117,7 @@ class AskMetricsAgenticNode(AgenticNode):
         self.skill_func_tool = None
         self.ask_user_tool = None
         self.sub_agent_task_tool = None
+        self.require_final_result_selection = self._resolve_bool_config("require_final_result_selection", False)
         self.subject_tree_prompt_limit = self._resolve_subject_tree_prompt_limit()
         self.setup_tools()
         self._populate_tool_registry()
@@ -153,6 +155,21 @@ class AskMetricsAgenticNode(AgenticNode):
             return self.SUBJECT_TREE_PROMPT_LIMIT
         return limit
 
+    def _resolve_bool_config(self, key: str, default: bool = False) -> bool:
+        raw_value = self.node_config.get(key, default)
+        if isinstance(raw_value, bool):
+            return raw_value
+        if isinstance(raw_value, str):
+            normalized = raw_value.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "off", ""}:
+                return False
+        if raw_value in (0, 1):
+            return bool(raw_value)
+        logger.warning("Invalid ask_metrics %s=%r; using default %s", key, raw_value, default)
+        return default
+
     def setup_tools(self) -> None:
         if not self.agent_config:
             return
@@ -187,6 +204,8 @@ class AskMetricsAgenticNode(AgenticNode):
 
         for pattern in tool_patterns:
             self._setup_tool_pattern(pattern)
+        if self.require_final_result_selection:
+            self._append_tool(trans_to_function_tool(self.select_final_metric_result))
 
     def _configured_tool_patterns(self) -> List[str]:
         config_value = self.node_config.get("tools")
@@ -240,7 +259,11 @@ class AskMetricsAgenticNode(AgenticNode):
             logger.warning("Ignoring unsupported ask_metrics tool: %s.%s", category, method_name)
             return
 
-        method = getattr(tool_instance, method_name)
+        method = (
+            self.query_metrics
+            if category == "semantic_tools" and method_name == "query_metrics"
+            else getattr(tool_instance, method_name)
+        )
         if category == "db_tools" and callable(getattr(tool_instance, "to_function_tool", None)):
             tool = tool_instance.to_function_tool(method)
         else:
@@ -291,6 +314,8 @@ class AskMetricsAgenticNode(AgenticNode):
         if not callable(available_tools):
             return
         for tool in available_tools():
+            if tool_instance is self.semantic_tools and getattr(tool, "name", "") == "query_metrics":
+                tool = trans_to_function_tool(self.query_metrics)
             self._append_tool(tool)
 
     def _add_available_context_tools(self) -> None:
@@ -385,6 +410,222 @@ class AskMetricsAgenticNode(AgenticNode):
             }
         )
 
+    def query_metrics(
+        self,
+        metrics: Optional[List[str]] = None,
+        dimensions: Optional[List[str]] = None,
+        path: Optional[List[str]] = None,
+        time_start: Optional[str] = None,
+        time_end: Optional[str] = None,
+        time_granularity: Optional[str] = None,
+        where: Optional[str] = None,
+        limit: Optional[int] = None,
+        order_by: Optional[List[str]] = None,
+        dry_run: bool = False,
+    ) -> FuncToolResult:
+        """
+        Query metric values.
+
+        For period-over-period derived metrics, AskMetrics expands the request
+        to include the base and previous-period metrics when those metrics are
+        already present in the executable catalog.
+        """
+        if not self.semantic_tools:
+            return FuncToolResult(success=0, error="semantic tools unavailable")
+
+        expanded_metrics = self._expand_period_over_period_metrics(metrics)
+        if not expanded_metrics:
+            return FuncToolResult(
+                success=0,
+                error=(
+                    "query_metrics requires at least one metric name. "
+                    "Call list_metrics first and pass one or more metric names exactly as returned."
+                ),
+            )
+        return self.semantic_tools.query_metrics(
+            metrics=expanded_metrics,
+            dimensions=dimensions,
+            path=path,
+            time_start=time_start,
+            time_end=time_end,
+            time_granularity=time_granularity,
+            where=where,
+            limit=limit,
+            order_by=order_by,
+            dry_run=dry_run,
+        )
+
+    def select_final_metric_result(self, result_id: str) -> FuncToolResult:
+        """
+        Select the query_metrics result that should be stored as the final structured result.
+
+        This tool is only exposed when require_final_result_selection is enabled.
+        The result_id must be returned by a successful query_metrics call.
+        """
+        result_id = str(result_id or "").strip()
+        if not result_id:
+            return FuncToolResult(success=0, error="result_id is required")
+        if (
+            self.semantic_tools
+            and hasattr(self.semantic_tools, "get_cached_query_metrics_result")
+            and self.semantic_tools.get_cached_query_metrics_result(result_id) is None
+        ):
+            return FuncToolResult(success=0, error=f"Unknown query_metrics result_id: {result_id}")
+
+        self._selected_final_metric_result_id = result_id
+        return FuncToolResult(result={"result_id": result_id})
+
+    def _expand_period_over_period_metrics(self, metrics: Optional[List[str]]) -> List[str]:
+        requested_metrics = self._normalize_string_list(metrics)
+        if not requested_metrics:
+            return []
+
+        catalog = self._metric_catalog()
+        if not catalog:
+            return requested_metrics
+
+        expanded: List[str] = []
+        for metric_name in requested_metrics:
+            metric = catalog.get(metric_name)
+            if not metric:
+                self._append_unique(expanded, metric_name)
+                continue
+
+            for bundled_metric in self._period_over_period_metric_bundle(metric_name, metric, catalog):
+                self._append_unique(expanded, bundled_metric)
+
+        return expanded
+
+    def _metric_catalog(self) -> Dict[str, Dict[str, Any]]:
+        if self._metric_catalog_cache is not None:
+            return self._metric_catalog_cache
+        if not self.semantic_tools:
+            return {}
+
+        catalog: Dict[str, Dict[str, Any]] = {}
+        offset = 0
+        limit = 500
+        for _ in range(10):
+            try:
+                result = self.semantic_tools.list_metrics(limit=limit, offset=offset)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Unable to load ask_metrics metric catalog: %s", exc)
+                break
+
+            if not isinstance(result, FuncToolResult) or result.success == 0:
+                logger.debug("Unable to load ask_metrics metric catalog: %s", getattr(result, "error", None))
+                break
+
+            payload = result.result if isinstance(result.result, dict) else {}
+            items = payload.get("items", []) if isinstance(payload, dict) else []
+            for item in items:
+                if isinstance(item, dict) and item.get("name"):
+                    catalog[str(item["name"])] = item
+
+            if not isinstance(payload, dict) or not payload.get("has_more"):
+                break
+            extra = payload.get("extra") if isinstance(payload.get("extra"), dict) else {}
+            next_offset = extra.get("next_offset")
+            if not isinstance(next_offset, int) or next_offset <= offset:
+                break
+            offset = next_offset
+
+        self._metric_catalog_cache = catalog
+        return catalog
+
+    @classmethod
+    def _period_over_period_metric_bundle(
+        cls,
+        metric_name: str,
+        metric: Dict[str, Any],
+        catalog: Dict[str, Dict[str, Any]],
+    ) -> List[str]:
+        metadata = metric.get("metadata") if isinstance(metric, dict) else {}
+        if not isinstance(metadata, dict):
+            return [metric_name]
+
+        inputs = metadata.get("inputs")
+        if not isinstance(inputs, list):
+            return [metric_name]
+
+        base_metrics: List[str] = []
+        previous_metrics: List[str] = []
+        has_current_input = False
+        has_offset_input = False
+        for item in inputs:
+            if not isinstance(item, dict):
+                continue
+
+            base_name = item.get("name")
+            if not isinstance(base_name, str) or base_name not in catalog:
+                continue
+
+            if item.get("offset_window"):
+                has_offset_input = True
+                alias = item.get("alias")
+                if isinstance(alias, str) and alias in catalog:
+                    cls._append_unique(previous_metrics, alias)
+                for equivalent_metric in cls._equivalent_offset_identity_metrics(base_name, item, catalog):
+                    cls._append_unique(previous_metrics, equivalent_metric)
+            else:
+                has_current_input = True
+                cls._append_unique(base_metrics, base_name)
+
+        if not has_current_input or not has_offset_input:
+            return [metric_name]
+
+        return [*base_metrics, *previous_metrics, metric_name]
+
+    @classmethod
+    def _equivalent_offset_identity_metrics(
+        cls,
+        base_name: str,
+        offset_input: Dict[str, Any],
+        catalog: Dict[str, Dict[str, Any]],
+    ) -> List[str]:
+        offset_window = str(offset_input.get("offset_window") or "").strip()
+        offset_to_grain = str(offset_input.get("offset_to_grain") or "").strip()
+        if not offset_window:
+            return []
+
+        equivalent_metrics: List[str] = []
+        for candidate_name, candidate in catalog.items():
+            metadata = candidate.get("metadata") if isinstance(candidate, dict) else {}
+            inputs = metadata.get("inputs") if isinstance(metadata, dict) else None
+            if not isinstance(inputs, list) or len(inputs) != 1:
+                continue
+            candidate_input = inputs[0]
+            if not isinstance(candidate_input, dict):
+                continue
+            if candidate_input.get("name") != base_name:
+                continue
+            if str(candidate_input.get("offset_window") or "").strip() != offset_window:
+                continue
+            if str(candidate_input.get("offset_to_grain") or "").strip() != offset_to_grain:
+                continue
+            alias = candidate_input.get("alias")
+            expr = metadata.get("expr")
+            if isinstance(alias, str) and isinstance(expr, str) and expr.strip() == alias and candidate_name == alias:
+                cls._append_unique(equivalent_metrics, candidate_name)
+        return equivalent_metrics
+
+    @staticmethod
+    def _normalize_string_list(value: Optional[List[str]]) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            values = [value]
+        elif isinstance(value, (list, tuple)):
+            values = list(value)
+        else:
+            return []
+        return [str(item).strip() for item in values if str(item).strip()]
+
+    @staticmethod
+    def _append_unique(values: List[str], value: str) -> None:
+        if value not in values:
+            values.append(value)
+
     async def _before_stream(self, ctx: StreamRunContext) -> None:
         if self.startup_error:
             raise DatusException(
@@ -409,6 +650,7 @@ class AskMetricsAgenticNode(AgenticNode):
             "subject_tree_count": len(self.subject_tree_metric_entries),
             "subject_tree_prompt": self.subject_tree_prompt,
             "subject_tree_prompt_limit": self.subject_tree_prompt_limit,
+            "require_final_result_selection": self.require_final_result_selection,
         }
 
         if self.agent_config:
@@ -470,35 +712,159 @@ class AskMetricsAgenticNode(AgenticNode):
             },
         )
 
-    def update_context(self, workflow: "Workflow") -> Dict:
-        """Extract last query_metrics result into sql_context for OutputNode."""
-        actions = getattr(self.result, "action_history", None) or []
-        for action in reversed(actions):
+    @staticmethod
+    def _query_action_arguments(action: Dict[str, Any]) -> Dict[str, Any]:
+        raw_arguments = (action.get("input") or {}).get("arguments")
+        if isinstance(raw_arguments, dict):
+            return raw_arguments
+        if isinstance(raw_arguments, str) and raw_arguments.strip():
+            try:
+                parsed = json.loads(raw_arguments)
+            except json.JSONDecodeError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
+
+    @staticmethod
+    def _query_result_payload(action: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        output = action.get("output", {})
+        if not isinstance(output, dict):
+            return None
+        raw_output = output.get("raw_output", output)
+        if not isinstance(raw_output, dict) or not raw_output.get("success"):
+            return None
+        result = raw_output.get("result", {})
+        return result if isinstance(result, dict) else None
+
+    @staticmethod
+    def _query_result_columns(result: Dict[str, Any]) -> List[str]:
+        columns = result.get("columns", [])
+        if not isinstance(columns, list):
+            return []
+        return [str(column) for column in columns if str(column)]
+
+    @staticmethod
+    def _query_result_row_count(result: Dict[str, Any]) -> int:
+        data = result.get("data")
+        if isinstance(data, dict):
+            raw_count = data.get("original_rows", 0)
+            try:
+                return int(raw_count)
+            except (TypeError, ValueError):
+                return 0
+        if isinstance(data, list):
+            return len(data)
+        return 0
+
+    @staticmethod
+    def _query_result_id(result: Dict[str, Any]) -> Optional[str]:
+        result_id = result.get("result_id")
+        if isinstance(result_id, str) and result_id.strip():
+            return result_id.strip()
+        metadata = result.get("metadata")
+        if isinstance(metadata, dict):
+            cache_key = metadata.get("_full_result_cache_key")
+            if isinstance(cache_key, str) and cache_key.strip():
+                return cache_key.strip()
+        return None
+
+    @classmethod
+    def _select_last_query_metrics_action(cls, actions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        selected: Optional[Dict[str, Any]] = None
+
+        for action in actions:
             if not isinstance(action, dict):
                 continue
             if action.get("action_type") != "query_metrics":
                 continue
             if action.get("status") != "success":
                 continue
+            result = cls._query_result_payload(action)
+            if not result:
+                continue
+            columns = cls._query_result_columns(result)
+            data = result.get("data")
+            if not columns or not data:
+                continue
+            selected = action
 
-            output = action.get("output", {})
-            if not isinstance(output, dict):
+        return selected
+
+    @classmethod
+    def _selected_final_result_id_from_actions(cls, actions: List[Dict[str, Any]]) -> Optional[str]:
+        selected_result_id: Optional[str] = None
+        for action in actions:
+            if not isinstance(action, dict):
                 continue
-            raw_output = output.get("raw_output", output)
-            if not isinstance(raw_output, dict) or not raw_output.get("success"):
+            if action.get("action_type") != "select_final_metric_result":
                 continue
-            result = raw_output.get("result", {})
-            if not isinstance(result, dict):
+            if action.get("status") != "success":
                 continue
+            result = cls._query_result_payload(action)
+            if not result:
+                continue
+            result_id = result.get("result_id")
+            if isinstance(result_id, str) and result_id.strip():
+                selected_result_id = result_id.strip()
+        return selected_result_id
+
+    @classmethod
+    def _select_query_metrics_action_by_result_id(
+        cls,
+        actions: List[Dict[str, Any]],
+        result_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            if action.get("action_type") != "query_metrics" or action.get("status") != "success":
+                continue
+            result = cls._query_result_payload(action)
+            if result and cls._query_result_id(result) == result_id:
+                return action
+        return None
+
+    def update_context(self, workflow: "Workflow") -> Dict:
+        """Extract the selected query_metrics result into sql_context for OutputNode."""
+        actions = getattr(self.result, "action_history", None) or []
+        require_selection = getattr(self, "require_final_result_selection", False)
+        require_selection = require_selection if isinstance(require_selection, bool) else False
+
+        if require_selection:
+            selected_result_id = self._selected_final_result_id_from_actions(actions)
+            if not selected_result_id:
+                selected_result_id = getattr(self, "_selected_final_metric_result_id", None)
+            if not selected_result_id:
+                logger.warning("ask_metrics requires select_final_metric_result, but no final result was selected")
+                return {"success": False, "message": "final query_metrics result was not selected"}
+            action = self._select_query_metrics_action_by_result_id(actions, selected_result_id)
+            if not action:
+                logger.warning("Selected query_metrics result_id was not found: %s", selected_result_id)
+                return {"success": False, "message": f"selected query_metrics result not found: {selected_result_id}"}
+        else:
+            action = self._select_last_query_metrics_action(actions)
+
+        if action:
+            result = self._query_result_payload(action) or {}
 
             columns = result.get("columns", [])
             data = result.get("data")
             if not columns or not data:
-                continue
+                return super().update_context(workflow)
+
+            metadata = result.get("metadata", {}) or {}
+            cached_result = None
+            cache_key = metadata.get("_full_result_cache_key")
+            if cache_key and self.semantic_tools and hasattr(self.semantic_tools, "get_cached_query_metrics_result"):
+                cached_result = self.semantic_tools.get_cached_query_metrics_result(cache_key)
 
             if isinstance(data, dict) and data.get("compressed_data"):
-                sql_return = data["compressed_data"]
                 row_count = data.get("original_rows", 0)
+                if isinstance(cached_result, dict) and cached_result.get("csv"):
+                    sql_return = cached_result["csv"]
+                    row_count = cached_result.get("row_count", row_count)
+                else:
+                    sql_return = data["compressed_data"]
             elif isinstance(data, list):
                 import csv
                 import io
@@ -510,9 +876,8 @@ class AskMetricsAgenticNode(AgenticNode):
                 sql_return = buf.getvalue()
                 row_count = len(data)
             else:
-                continue
+                return super().update_context(workflow)
 
-            metadata = result.get("metadata", {}) or {}
             sql_query = ""
             for key in ("sql", "compiled_sql", "generated_sql"):
                 if metadata.get(key):

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -784,7 +784,7 @@ class AskMetricsAgenticNode(AgenticNode):
                 continue
             columns = cls._query_result_columns(result)
             data = result.get("data")
-            if not columns or not data:
+            if not columns or data is None:
                 continue
             selected = action
 
@@ -849,7 +849,7 @@ class AskMetricsAgenticNode(AgenticNode):
 
             columns = result.get("columns", [])
             data = result.get("data")
-            if not columns or not data:
+            if not columns or data is None:
                 return super().update_context(workflow)
 
             metadata = result.get("metadata", {}) or {}

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -27,6 +27,14 @@ Use the narrow metric workflow below:
 - Prefer `get_dimensions` and `query_metrics` after a direct subject-tree match; only retrieve metric details when the answer depends on the definition text.
 - Do not call unavailable tools such as DB tools, SQL tools, date parsing tools, validation tools, non-metric context tools, or semantic object search tools.
 - Infer concrete time ranges yourself from the current date. Do not ask for a date parser tool.
+- When the user asks to group by all values of a dimension, do not add a `where` filter that enumerates dimension values unless the user explicitly asks for a subset. The grouped metric query already returns all dimension values.
+- Prefer the most specific metric whose name or description directly matches the requested business concept. Do not rebuild a specific metric by querying a generic base metric plus filters when a matching specific metric is available.
+- For ratio, rate, conditional count, and compound-condition metrics, use the dedicated metric directly when available. Do not approximate it with numerator/base metrics or ad hoc `where` filters unless no dedicated metric exists.
+- If `query_metrics` succeeds and metadata says the full result is cached, treat the query as complete. Do not run follow-up queries only because the visible tool output is a compressed preview.
+{% if require_final_result_selection %}
+- When you have the query result that should be used as the final structured answer, call `select_final_metric_result` with the `result_id` from that successful `query_metrics` result. This selection is required; do not select diagnostic or exploratory queries as final.
+- Before selecting the final result, verify that its columns include every grouping dimension explicitly requested by the user and every requested metric value that is exposed as a metric. If another successful `query_metrics` result better matches those requested dimensions and metrics, select that result instead.
+{% endif %}
 
 ## Period-Over-Period Metric Queries
 
@@ -36,7 +44,9 @@ Use the narrow metric workflow below:
   - `1 month`: use `dimensions=["metric_time__month"]` and `time_granularity="month"`.
   - `1 quarter`: use `dimensions=["metric_time__quarter"]` and `time_granularity="quarter"`.
   - `1 year`: use `dimensions=["metric_time__year"]` and `time_granularity="year"`.
-- For period-over-period trend tables, query the base metric together with the derived metric and order by the metric-time dimension. Querying only the derived metric can omit the first period because no prior-period value exists.
+- For period-over-period trend tables, query the complete metric bundle: the base metric, any separate previous-period metric exposed in the metric catalog, and the derived delta/rate metric. Order by the metric-time dimension.
+- Previous-period aliases inside a derived metric are calculation inputs, not output columns. If the user asks for the previous-period value itself, include the separate previous-period metric in `query_metrics`; do not rely on an internal alias to appear in the result.
+- Querying only the derived metric can omit the first period because no prior-period value exists.
 - If the user asks for the previous-period value itself, only return it when a separate metric exposes that value; otherwise report the delta/rate metric and state that the intermediate prior-period value is not exposed as a metric.
 
 ## Subject Tree

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 import pandas as pd
+import yaml
 
 from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 from datus.configuration.agent_config import AgentConfig
@@ -527,6 +528,283 @@ def _all_candidate_metrics_satisfied(
     return True
 
 
+def _offset_grain(offset_window: Any) -> Optional[str]:
+    parts = str(offset_window or "").strip().lower().split()
+    if len(parts) < 2:
+        return None
+    unit = parts[1].rstrip("s")
+    return unit if unit in {"day", "week", "month", "quarter", "year"} else None
+
+
+def _is_offset_derived_candidate(candidate: dict[str, Any]) -> bool:
+    if _normalized_metric_type(candidate.get("metric_type") or candidate.get("type")) != "derived":
+        return False
+    inputs = candidate.get("inputs")
+    return isinstance(inputs, list) and any(isinstance(item, dict) and item.get("offset_window") for item in inputs)
+
+
+def _candidate_input_metric_names(candidate: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for item in candidate.get("inputs") or []:
+        if isinstance(item, dict):
+            normalized = _normalize_metric_name(item.get("name"))
+            if normalized:
+                names.add(normalized)
+    return names
+
+
+def _candidate_subject_tags(candidate: dict[str, Any], existing_by_name: dict[str, dict[str, Any]]) -> list[str]:
+    tags: list[str] = []
+    for input_name in _candidate_input_metric_names(candidate):
+        subject_path = existing_by_name.get(input_name, {}).get("subject_path")
+        if isinstance(subject_path, list) and subject_path:
+            joined = "/".join(str(part) for part in subject_path if str(part).strip())
+            if joined:
+                tags.extend([joined, f"subject_tree: {joined}"])
+                break
+    return tags
+
+
+def _derived_metric_doc(candidate: dict[str, Any], existing_by_name: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    metric_inputs: list[dict[str, Any]] = []
+    for item in candidate.get("inputs") or []:
+        if not isinstance(item, dict) or not item.get("name"):
+            continue
+        metric_input = {"name": str(item["name"]).strip()}
+        alias = str(item.get("alias") or "").strip()
+        offset_window = str(item.get("offset_window") or "").strip()
+        offset_to_grain = str(item.get("offset_to_grain") or "").strip()
+        if alias:
+            metric_input["alias"] = alias
+        if offset_window:
+            metric_input["offset_window"] = offset_window
+        if offset_to_grain:
+            metric_input["offset_to_grain"] = offset_to_grain
+        metric_inputs.append(metric_input)
+
+    metric: dict[str, Any] = {
+        "name": str(candidate["name"]).strip(),
+        "description": str(candidate.get("description") or candidate.get("source_alias") or candidate["name"]).strip(),
+        "type": "derived",
+        "type_params": {
+            "metrics": metric_inputs,
+            "expr": str(candidate.get("expression") or candidate["name"]).strip(),
+        },
+    }
+    tags = _candidate_subject_tags(candidate, existing_by_name)
+    if tags:
+        metric["locked_metadata"] = {"tags": tags}
+    return {"metric": metric}
+
+
+def _offset_identity_alias_candidates(candidate: dict[str, Any]) -> list[dict[str, Any]]:
+    inputs = [item for item in candidate.get("inputs") or [] if isinstance(item, dict) and item.get("offset_window")]
+    if len(inputs) != 1:
+        return []
+
+    offset_input = inputs[0]
+    base_name = _normalize_metric_name(offset_input.get("name"))
+    alias = _normalize_metric_name(offset_input.get("alias"))
+    offset_window = str(offset_input.get("offset_window") or "").strip()
+    grain = _offset_grain(offset_window)
+    if not base_name or not alias or not grain:
+        return []
+
+    expression = _normalize_metric_name(candidate.get("expression"))
+    candidate_name = _normalize_metric_name(candidate.get("name"))
+    if expression != alias or candidate_name != alias:
+        return []
+
+    equivalent_name = f"{base_name}_previous_{grain}"
+    if equivalent_name == candidate_name:
+        return []
+
+    equivalent = dict(candidate)
+    equivalent["name"] = equivalent_name
+    equivalent["expression"] = equivalent_name
+    equivalent["source_alias"] = equivalent_name
+    equivalent["description"] = str(candidate.get("description") or equivalent_name).replace(
+        candidate_name, equivalent_name
+    )
+    equivalent_inputs: list[dict[str, Any]] = []
+    for item in candidate.get("inputs") or []:
+        if not isinstance(item, dict):
+            continue
+        copied = dict(item)
+        if copied.get("offset_window"):
+            copied["alias"] = equivalent_name
+        equivalent_inputs.append(copied)
+    equivalent["inputs"] = equivalent_inputs
+    return [equivalent]
+
+
+def _load_metric_doc_names(metric_file: Path) -> set[str]:
+    if not metric_file.exists():
+        return set()
+    try:
+        docs = list(yaml.safe_load_all(metric_file.read_text(encoding="utf-8")))
+    except Exception:
+        return set()
+    names: set[str] = set()
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        metric = doc.get("metric")
+        if isinstance(metric, dict):
+            normalized = _normalize_metric_name(metric.get("name"))
+            if normalized:
+                names.add(normalized)
+    return names
+
+
+def _append_metric_docs(metric_file: Path, docs: list[dict[str, Any]]) -> None:
+    metric_file.parent.mkdir(parents=True, exist_ok=True)
+    rendered = "\n---\n".join(
+        yaml.safe_dump(doc, allow_unicode=True, sort_keys=False).strip() for doc in docs if isinstance(doc, dict)
+    )
+    if not rendered:
+        return
+    if metric_file.exists() and metric_file.read_text(encoding="utf-8").strip():
+        with metric_file.open("a", encoding="utf-8") as handle:
+            handle.write("\n\n---\n")
+            handle.write(rendered)
+            handle.write("\n")
+    else:
+        metric_file.write_text(f"{rendered}\n", encoding="utf-8")
+
+
+def _auto_generate_offset_derived_metrics(
+    candidate_plan: dict[str, Any],
+    existing_metric_catalog: list[dict[str, Any]],
+    agent_config: AgentConfig,
+) -> dict[str, Any]:
+    """Deterministically materialize MetricFlow offset-window derived metrics from mined SQL evidence."""
+    if not candidate_plan or not candidate_plan.get("available"):
+        return {"generated_metric_names": [], "metric_artifact_ids": []}
+    derived_candidates = candidate_plan.get("derived_metric_candidates")
+    if not isinstance(derived_candidates, list):
+        return {"generated_metric_names": [], "metric_artifact_ids": []}
+    offset_candidates = [
+        candidate
+        for candidate in derived_candidates
+        if isinstance(candidate, dict) and candidate.get("name") and _is_offset_derived_candidate(candidate)
+    ]
+    if not offset_candidates:
+        return {"generated_metric_names": [], "metric_artifact_ids": []}
+    expanded_offset_candidates: list[dict[str, Any]] = []
+    seen_candidate_names: set[str] = set()
+    for candidate in offset_candidates:
+        for expanded_candidate in [candidate, *_offset_identity_alias_candidates(candidate)]:
+            normalized = _normalize_metric_name(expanded_candidate.get("name"))
+            if not normalized or normalized in seen_candidate_names:
+                continue
+            expanded_offset_candidates.append(expanded_candidate)
+            seen_candidate_names.add(normalized)
+
+    existing_by_name = {
+        _normalize_metric_name(item.get("name")): item for item in existing_metric_catalog if item.get("name")
+    }
+    metric_file = (
+        agent_config.path_manager.semantic_model_path(agent_config.current_datasource)
+        / "metrics"
+        / "auto_offset_derived_metrics.yml"
+    )
+    file_metric_names = _load_metric_doc_names(metric_file)
+
+    docs: list[dict[str, Any]] = []
+    generated_names: list[str] = []
+    for candidate in expanded_offset_candidates:
+        normalized_name = _normalize_metric_name(candidate.get("name"))
+        if normalized_name in existing_by_name or normalized_name in file_metric_names:
+            continue
+        input_names = _candidate_input_metric_names(candidate)
+        if not input_names or not input_names <= set(existing_by_name):
+            continue
+        docs.append(_derived_metric_doc(candidate, existing_by_name))
+        generated_names.append(str(candidate["name"]).strip())
+        file_metric_names.add(normalized_name)
+
+    if not docs:
+        return {"generated_metric_names": [], "metric_artifact_ids": []}
+
+    _append_metric_docs(metric_file, docs)
+
+    from datus.tools.func_tool.generation_tools import GenerationTools
+    from datus.tools.func_tool.semantic_tools import SemanticTools
+
+    semantic_tools = SemanticTools(agent_config=agent_config, sub_agent_name=METRICS_NODE_NAME)
+    validation = semantic_tools.validate_semantic(scope="all")
+    if not validation.success:
+        logger.warning(
+            "Auto-generated offset derived metrics failed validation: %s",
+            validation.error,
+        )
+        return {"generated_metric_names": [], "metric_artifact_ids": [], "error": validation.error}
+
+    metric_sqls: dict[str, str] = {}
+    for name in generated_names:
+        candidate = next(
+            (item for item in expanded_offset_candidates if item.get("name") == name),
+            {},
+        )
+        grain = _offset_grain(candidate.get("offset_window"))
+        dimensions = [f"metric_time__{grain}"] if grain else []
+        dry_run = semantic_tools.query_metrics(
+            metrics=[name],
+            dimensions=dimensions,
+            time_granularity=grain,
+            dry_run=True,
+        )
+        if dry_run.success and isinstance(dry_run.result, dict):
+            metadata = dry_run.result.get("metadata") if isinstance(dry_run.result.get("metadata"), dict) else {}
+            sql = metadata.get("sql")
+            if isinstance(sql, str) and sql.strip():
+                metric_sqls[name] = sql
+
+    sync = GenerationTools(agent_config=agent_config)._sync_metric_to_db(
+        str(metric_file),
+        metric_sqls=metric_sqls,
+        metric_names_to_sync=set(generated_names),
+    )
+    if not sync.get("success"):
+        logger.warning("Auto-generated offset derived metrics failed to sync: %s", sync.get("error"))
+        return {"generated_metric_names": [], "metric_artifact_ids": [], "error": sync.get("error")}
+
+    artifact_ids = [f"metric:{name}" for name in generated_names]
+    logger.info("Auto-generated %d offset derived metric(s): %s", len(generated_names), generated_names)
+    return {
+        "generated_metric_names": generated_names,
+        "metric_artifact_ids": artifact_ids,
+        "metric_file": str(metric_file),
+        "metric_sqls": metric_sqls,
+        "sync": sync,
+    }
+
+
+def _append_auto_offset_result(
+    batch_result: dict[str, Any],
+    auto_derived_result: dict[str, Any],
+    provenance_entries: int = 0,
+) -> None:
+    """Attach deterministic offset-derived metric artifacts to a batch result."""
+    generated_names = list(auto_derived_result.get("generated_metric_names") or [])
+    artifact_ids = list(auto_derived_result.get("metric_artifact_ids") or [])
+    if generated_names:
+        existing_names = batch_result.setdefault("auto_generated_offset_derived_metrics", [])
+        if isinstance(existing_names, list):
+            for name in generated_names:
+                if name not in existing_names:
+                    existing_names.append(name)
+    if artifact_ids:
+        existing_ids = batch_result.setdefault("_synced_metric_artifact_ids", [])
+        if isinstance(existing_ids, list):
+            for artifact_id in artifact_ids:
+                if artifact_id not in existing_ids:
+                    existing_ids.append(artifact_id)
+    if provenance_entries:
+        batch_result["provenance_entries"] = batch_result.get("provenance_entries", 0) + provenance_entries
+
+
 async def _generate_metrics_batch(
     batch_queries: list[str],
     batch_idx: int,
@@ -772,7 +1050,24 @@ async def init_success_story_metrics_async(
 
         logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
 
-        if build_mode == "incremental" and _all_candidate_metrics_satisfied(
+        auto_derived_result = _auto_generate_offset_derived_metrics(
+            batch_candidate_plan,
+            existing_metric_catalog,
+            agent_config,
+        )
+        auto_metric_artifact_ids = list(auto_derived_result.get("metric_artifact_ids") or [])
+        if auto_metric_artifact_ids:
+            batch_provenance_entries = _sync_metric_provenance(agent_config, auto_metric_artifact_ids, source_entries)
+            provenance_entries += batch_provenance_entries
+            auto_derived_result["provenance_entries"] = batch_provenance_entries
+            existing_metric_catalog = _build_existing_metric_catalog(agent_config)
+            existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
+
+        auto_satisfied = bool(auto_metric_artifact_ids) and _all_candidate_metrics_satisfied(
+            batch_candidate_plan,
+            existing_metric_catalog,
+        )
+        if (build_mode == "incremental" or auto_satisfied) and _all_candidate_metrics_satisfied(
             batch_candidate_plan,
             existing_metric_catalog,
         ):
@@ -806,6 +1101,12 @@ async def init_success_story_metrics_async(
                 "skipped_queries": len(batch_records),
                 "skipped_metric_candidates": skipped_names,
             }
+            if auto_metric_artifact_ids:
+                batch_result["auto_generated_offset_derived_metrics"] = auto_derived_result.get(
+                    "generated_metric_names", []
+                )
+                batch_result["_synced_metric_artifact_ids"] = auto_metric_artifact_ids
+                batch_result["provenance_entries"] = auto_derived_result.get("provenance_entries", 0)
             if merged_result is None:
                 merged_result = batch_result
             elif isinstance(merged_result, dict):
@@ -886,6 +1187,29 @@ async def init_success_story_metrics_async(
                 batch_result["provenance_entries"] = (
                     batch_result.get("provenance_entries", 0) + batch_provenance_entries
                 )
+
+            if isinstance(batch_result, dict):
+                refreshed_catalog = _build_existing_metric_catalog(agent_config)
+                post_auto_derived_result = _auto_generate_offset_derived_metrics(
+                    batch_candidate_plan,
+                    refreshed_catalog,
+                    agent_config,
+                )
+                post_auto_metric_artifact_ids = list(post_auto_derived_result.get("metric_artifact_ids") or [])
+                if post_auto_metric_artifact_ids:
+                    post_auto_provenance_entries = _sync_metric_provenance(
+                        agent_config,
+                        post_auto_metric_artifact_ids,
+                        source_entries,
+                    )
+                    provenance_entries += post_auto_provenance_entries
+                    _append_auto_offset_result(
+                        batch_result,
+                        post_auto_derived_result,
+                        provenance_entries=post_auto_provenance_entries,
+                    )
+                    existing_metric_catalog = _build_existing_metric_catalog(agent_config)
+                    existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
 
             if merged_result is None:
                 merged_result = batch_result

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -673,6 +673,31 @@ def _append_metric_docs(metric_file: Path, docs: list[dict[str, Any]]) -> None:
         metric_file.write_text(f"{rendered}\n", encoding="utf-8")
 
 
+def _restore_metric_file(metric_file: Path, previous_content: Optional[str]) -> None:
+    if previous_content is None:
+        if metric_file.exists():
+            metric_file.unlink()
+        return
+    metric_file.parent.mkdir(parents=True, exist_ok=True)
+    metric_file.write_text(previous_content, encoding="utf-8")
+
+
+def _unique_metric_catalog_by_name(
+    existing_metric_catalog: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], set[str]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for item in existing_metric_catalog:
+        if not isinstance(item, dict):
+            continue
+        normalized = _normalize_metric_name(item.get("name"))
+        if normalized:
+            grouped.setdefault(normalized, []).append(item)
+
+    unique = {name: items[0] for name, items in grouped.items() if len(items) == 1}
+    ambiguous = {name for name, items in grouped.items() if len(items) > 1}
+    return unique, ambiguous
+
+
 def _auto_generate_offset_derived_metrics(
     candidate_plan: dict[str, Any],
     existing_metric_catalog: list[dict[str, Any]],
@@ -701,9 +726,7 @@ def _auto_generate_offset_derived_metrics(
             expanded_offset_candidates.append(expanded_candidate)
             seen_candidate_names.add(normalized)
 
-    existing_by_name = {
-        _normalize_metric_name(item.get("name")): item for item in existing_metric_catalog if item.get("name")
-    }
+    existing_by_name, ambiguous_existing_names = _unique_metric_catalog_by_name(existing_metric_catalog)
     metric_file = (
         agent_config.path_manager.semantic_model_path(agent_config.current_datasource)
         / "metrics"
@@ -713,21 +736,41 @@ def _auto_generate_offset_derived_metrics(
 
     docs: list[dict[str, Any]] = []
     generated_names: list[str] = []
+    resync_names: set[str] = set()
     for candidate in expanded_offset_candidates:
         normalized_name = _normalize_metric_name(candidate.get("name"))
-        if normalized_name in existing_by_name or normalized_name in file_metric_names:
+        if not normalized_name:
+            continue
+        if normalized_name in ambiguous_existing_names:
+            logger.warning("Skipping auto offset metric %s because existing metric name is ambiguous", normalized_name)
+            continue
+        if normalized_name in existing_by_name:
             continue
         input_names = _candidate_input_metric_names(candidate)
-        if not input_names or not input_names <= set(existing_by_name):
+        if not input_names:
+            continue
+        if input_names & ambiguous_existing_names:
+            logger.warning(
+                "Skipping auto offset metric %s because input metric names are ambiguous: %s",
+                normalized_name,
+                sorted(input_names & ambiguous_existing_names),
+            )
+            continue
+        if not input_names <= set(existing_by_name):
+            continue
+        if normalized_name in file_metric_names:
+            resync_names.add(normalized_name)
             continue
         docs.append(_derived_metric_doc(candidate, existing_by_name))
         generated_names.append(str(candidate["name"]).strip())
         file_metric_names.add(normalized_name)
 
-    if not docs:
+    if not docs and not resync_names:
         return {"generated_metric_names": [], "metric_artifact_ids": []}
 
-    _append_metric_docs(metric_file, docs)
+    previous_metric_file_content = metric_file.read_text(encoding="utf-8") if metric_file.exists() else None
+    if docs:
+        _append_metric_docs(metric_file, docs)
 
     from datus.tools.func_tool.generation_tools import GenerationTools
     from datus.tools.func_tool.semantic_tools import SemanticTools
@@ -739,6 +782,8 @@ def _auto_generate_offset_derived_metrics(
             "Auto-generated offset derived metrics failed validation: %s",
             validation.error,
         )
+        if docs:
+            _restore_metric_file(metric_file, previous_metric_file_content)
         return {"generated_metric_names": [], "metric_artifact_ids": [], "error": validation.error}
 
     metric_sqls: dict[str, str] = {}
@@ -761,19 +806,23 @@ def _auto_generate_offset_derived_metrics(
             if isinstance(sql, str) and sql.strip():
                 metric_sqls[name] = sql
 
+    metric_names_to_sync = set(generated_names) | resync_names
     sync = GenerationTools(agent_config=agent_config)._sync_metric_to_db(
         str(metric_file),
         metric_sqls=metric_sqls,
-        metric_names_to_sync=set(generated_names),
+        metric_names_to_sync=metric_names_to_sync,
     )
     if not sync.get("success"):
         logger.warning("Auto-generated offset derived metrics failed to sync: %s", sync.get("error"))
+        if docs:
+            _restore_metric_file(metric_file, previous_metric_file_content)
         return {"generated_metric_names": [], "metric_artifact_ids": [], "error": sync.get("error")}
 
-    artifact_ids = [f"metric:{name}" for name in generated_names]
-    logger.info("Auto-generated %d offset derived metric(s): %s", len(generated_names), generated_names)
+    synced_names = [*generated_names, *sorted(resync_names)]
+    artifact_ids = [f"metric:{name}" for name in synced_names]
+    logger.info("Auto-generated/resynced %d offset derived metric(s): %s", len(synced_names), synced_names)
     return {
-        "generated_metric_names": generated_names,
+        "generated_metric_names": synced_names,
         "metric_artifact_ids": artifact_ids,
         "metric_file": str(metric_file),
         "metric_sqls": metric_sqls,
@@ -1046,7 +1095,6 @@ async def init_success_story_metrics_async(
         batch_candidate_plan = _candidate_plan_for_sources(candidate_plan, batch_sources)
         batch_candidate_plan_json = _json_dump_compact(batch_candidate_plan) if batch_candidate_plan else ""
         source_entries = [record["source"] for record in batch_records if record.get("source")]
-        metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
 
         logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
 
@@ -1062,6 +1110,8 @@ async def init_success_story_metrics_async(
             auto_derived_result["provenance_entries"] = batch_provenance_entries
             existing_metric_catalog = _build_existing_metric_catalog(agent_config)
             existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
+
+        metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
 
         auto_satisfied = bool(auto_metric_artifact_ids) and _all_candidate_metrics_satisfied(
             batch_candidate_plan,

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -100,9 +100,10 @@ class GenerationTools:
 
     def check_semantic_object_exists(
         self,
-        object_name: str,
+        name: str = "",
         kind: str = "table",  # table, column, metric
         table_context: str = "",
+        object_name: str = "",
     ) -> FuncToolResult:
         """
         Check if a semantic object (table, column, metric) already exists in vector store.
@@ -110,18 +111,23 @@ class GenerationTools:
         Use this tool to avoid duplicating work.
 
         Args:
-            object_name: Name of the object (e.g. "orders", "orders.amount")
+            name: Name of the object (e.g. "orders", "orders.amount")
             kind: Type of object ("table", "column", "metric")
             table_context: If checking a column/metric, providing the table name helps narrow search.
+            object_name: Backward-compatible alias for name.
 
         Returns:
             dict: Check results containing existence status and details.
         """
         try:
+            object_name = str(name or object_name or "").strip()
+            if not object_name:
+                return FuncToolResult(success=0, error="name is required")
+
             normalized_kind = str(kind or "").strip().lower()
             cache_key = (
                 normalized_kind,
-                str(object_name or "").strip().lower(),
+                object_name.lower(),
                 str(table_context or "").strip().lower(),
             )
             cached = self._semantic_object_exists_cache.get(cache_key)

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -9,9 +9,11 @@ Provides unified interface to semantic layer services through adapters.
 All public semantic tools require a successfully initialized semantic adapter.
 """
 
+import csv
 import inspect
+import io
 import json
-from typing import Dict, List, Literal, Optional, Set
+from typing import Any, Dict, List, Literal, Optional, Set
 
 from agents import Tool
 
@@ -92,6 +94,12 @@ def _normalize_name_list(value) -> List[str]:
         if text:
             names.append(text)
     return names
+
+
+def _normalize_optional_path(value) -> Optional[List[str]]:
+    """Normalize optional subject paths and drop null placeholders."""
+    names = _normalize_name_list(value)
+    return names or None
 
 
 _TIME_GRANULARITIES = {"day", "week", "month", "quarter", "year"}
@@ -252,11 +260,74 @@ class SemanticTools:
         self.semantic_model_rag = SemanticModelRAG(agent_config, sub_agent_name)
         self.metric_rag = MetricRAG(agent_config, sub_agent_name)
         self.compressor = DataCompressor(model_name=agent_config.active_model().model)
+        self._query_metrics_result_cache: Dict[str, dict] = {}
+        self._query_metrics_result_cache_counter = 0
 
         # Lazy load adapter and attribution tool
         self._adapter: Optional[BaseSemanticAdapter] = None
         self._attribution_tool: Optional[DimensionAttributionUtil] = None
         self._adapter_load_error: Optional[str] = None
+
+    @staticmethod
+    def _query_data_row_count(data: Any) -> int:
+        if data is None:
+            return 0
+        if hasattr(data, "num_rows"):
+            try:
+                return int(data.num_rows)
+            except (TypeError, ValueError):
+                return 0
+        if hasattr(data, "shape"):
+            try:
+                return int(data.shape[0])
+            except (TypeError, ValueError, IndexError):
+                return 0
+        try:
+            return len(data)
+        except TypeError:
+            return 0
+
+    @staticmethod
+    def _query_data_to_csv(columns: List[str], data: Any) -> str:
+        if data is None:
+            return ""
+
+        if hasattr(data, "to_pandas"):
+            data = data.to_pandas()
+
+        if hasattr(data, "to_csv"):
+            return data.to_csv(index=False)
+
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(columns)
+        for row in data or []:
+            if isinstance(row, dict):
+                writer.writerow([row.get(column, "") for column in columns])
+            elif isinstance(row, (list, tuple)):
+                writer.writerow(row)
+            else:
+                writer.writerow([row])
+        return buf.getvalue()
+
+    def _cache_query_metrics_result(self, columns: List[str], data: Any) -> Optional[str]:
+        if data is None:
+            return None
+        full_csv = self._query_data_to_csv(columns, data)
+        if not full_csv:
+            return None
+
+        self._query_metrics_result_cache_counter += 1
+        cache_key = f"query_metrics:{self._query_metrics_result_cache_counter}"
+        self._query_metrics_result_cache[cache_key] = {
+            "columns": list(columns),
+            "csv": full_csv,
+            "row_count": self._query_data_row_count(data),
+        }
+        return cache_key
+
+    def get_cached_query_metrics_result(self, cache_key: str) -> Optional[dict]:
+        return self._query_metrics_result_cache.get(cache_key)
 
     def _configured_adapter_type(self) -> Optional[str]:
         """Return the configured adapter type without instantiating the adapter."""
@@ -456,7 +527,7 @@ class SemanticTools:
             response size.
         """
         # Normalize null values from LLM
-        path = normalize_null(path)
+        path = _normalize_optional_path(path)
         logger.info(f"list_metrics called: path={path}, limit={limit}, offset={offset}")
         adapter, error = self._require_adapter("list_metrics")
         if error:
@@ -539,7 +610,7 @@ class SemanticTools:
                 equals len(items) and has_more is False.
         """
         # Normalize null values from LLM
-        path = normalize_null(path)
+        path = _normalize_optional_path(path)
         logger.info(f"get_dimensions called: metric={metric_name}, path={path}")
         adapter, error = self._require_adapter("get_dimensions")
         if error:
@@ -701,6 +772,7 @@ class SemanticTools:
             )
 
         # Sanitize time parameters: LLM may pass string "null"/"None" instead of omitting
+        path = _normalize_optional_path(path)
         time_start = normalize_null(time_start)
         time_end = normalize_null(time_end)
         time_granularity = normalize_null(time_granularity)
@@ -743,8 +815,20 @@ class SemanticTools:
                     safe_metadata[k] = v
                 except (TypeError, ValueError):
                     continue
+            cache_key = None
+            if not dry_run:
+                cache_key = self._cache_query_metrics_result(result.columns, result.data)
+                if cache_key:
+                    safe_metadata["_full_result_cache_key"] = cache_key
+                    safe_metadata["_full_result_cached"] = True
+                    safe_metadata["_full_result_row_count"] = self._query_data_row_count(result.data)
+                    safe_metadata["_full_result_note"] = (
+                        "The complete uncompressed query result is cached and will be used for final output; "
+                        "do not re-query only because the returned data is a compressed preview."
+                    )
 
             result_dict = {
+                "result_id": cache_key,
                 "columns": result.columns,
                 "data": self.compressor.compress(result.data),
                 "metadata": safe_metadata,

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -13,6 +13,7 @@ import csv
 import inspect
 import io
 import json
+from collections import OrderedDict
 from typing import Any, Dict, List, Literal, Optional, Set
 
 from agents import Tool
@@ -221,6 +222,8 @@ def _run_async(coro):
 class SemanticTools:
     """Function tool wrapper for semantic layer operations."""
 
+    MAX_QUERY_METRICS_RESULT_CACHE_SIZE = 100
+
     @classmethod
     def all_tools_name(cls) -> List[str]:
         """Return list of all tool method names for wizard display."""
@@ -260,7 +263,7 @@ class SemanticTools:
         self.semantic_model_rag = SemanticModelRAG(agent_config, sub_agent_name)
         self.metric_rag = MetricRAG(agent_config, sub_agent_name)
         self.compressor = DataCompressor(model_name=agent_config.active_model().model)
-        self._query_metrics_result_cache: Dict[str, dict] = {}
+        self._query_metrics_result_cache: OrderedDict[str, dict] = OrderedDict()
         self._query_metrics_result_cache_counter = 0
 
         # Lazy load adapter and attribution tool
@@ -324,6 +327,8 @@ class SemanticTools:
             "csv": full_csv,
             "row_count": self._query_data_row_count(data),
         }
+        while len(self._query_metrics_result_cache) > self.MAX_QUERY_METRICS_RESULT_CACHE_SIZE:
+            self._query_metrics_result_cache.popitem(last=False)
         return cache_key
 
     def get_cached_query_metrics_result(self, cache_key: str) -> Optional[dict]:

--- a/datus/utils/compress_utils.py
+++ b/datus/utils/compress_utils.py
@@ -110,34 +110,17 @@ def _format_as_csv(df: pd.DataFrame, compressed_indices: Optional[Tuple[List[int
 
         # Split the dataframe
         head_df = df.iloc[: len(head_indices)].copy()
+        ellipsis_df = df.iloc[len(head_indices) : len(head_indices) + 1].copy()
         tail_df = df.iloc[len(head_indices) + 1 :].copy()
 
         # Set proper indices
         head_df.index = head_indices
+        ellipsis_df.index = ["..."]
         tail_df.index = tail_indices
 
-        # Format each part
-        result_parts = []
-
-        # Header
-        header = "index," + ",".join(df.columns)
-        result_parts.append(header)
-
-        # Head rows
-        for idx, row in head_df.iterrows():
-            row_str = str(idx) + "," + ",".join(str(val) for val in row.values)
-            result_parts.append(row_str)
-
-        # Ellipsis row
-        ellipsis_str = "...," + ",".join("..." for _ in df.columns)
-        result_parts.append(ellipsis_str)
-
-        # Tail rows
-        for idx, row in tail_df.iterrows():
-            row_str = str(idx) + "," + ",".join(str(val) for val in row.values)
-            result_parts.append(row_str)
-
-        return "\n".join(result_parts)
+        output = StringIO()
+        pd.concat([head_df, ellipsis_df, tail_df]).to_csv(output, index=True, index_label="index")
+        return output.getvalue().strip()
     else:
         # Normal formatting with index
         output = StringIO()

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -1017,6 +1017,34 @@ class TestUpdateContext:
         assert ctx.row_count == 0
         assert ctx.sql_query == "SELECT month, count FROM t WHERE 1 = 0"
 
+    def test_query_result_helpers_handle_defensive_branches(self):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+
+        assert AskMetricsAgenticNode._query_action_arguments({"input": {"arguments": {"a": 1}}}) == {"a": 1}
+        assert AskMetricsAgenticNode._query_action_arguments({"input": {"arguments": '{"a": 1}'}}) == {"a": 1}
+        assert AskMetricsAgenticNode._query_action_arguments({"input": {"arguments": "not-json"}}) == {}
+        assert AskMetricsAgenticNode._query_action_arguments({"input": {"arguments": "[1]"}}) == {}
+        assert AskMetricsAgenticNode._query_action_arguments({}) == {}
+
+        assert AskMetricsAgenticNode._query_result_payload({"output": "not-dict"}) is None
+        assert AskMetricsAgenticNode._query_result_payload({"output": {"raw_output": {"success": 0}}}) is None
+        assert (
+            AskMetricsAgenticNode._query_result_payload({"output": {"raw_output": {"success": 1, "result": []}}})
+            is None
+        )
+        assert AskMetricsAgenticNode._query_result_columns({"columns": "x"}) == []
+        assert AskMetricsAgenticNode._query_result_columns({"columns": ["x", None, ""]}) == ["x", "None"]
+        assert AskMetricsAgenticNode._query_result_row_count({"data": {"original_rows": "bad"}}) == 0
+        assert AskMetricsAgenticNode._query_result_row_count({"data": [["a"], ["b"]]}) == 2
+        assert AskMetricsAgenticNode._query_result_row_count({"data": "not-list"}) == 0
+        assert AskMetricsAgenticNode._query_result_id({"result_id": " rid "}) == "rid"
+        assert AskMetricsAgenticNode._query_result_id({"metadata": {"_full_result_cache_key": " cache "}}) == "cache"
+        assert AskMetricsAgenticNode._query_result_id({"metadata": {}}) is None
+
+        assert AskMetricsAgenticNode._select_last_query_metrics_action(["bad"]) is None
+        assert AskMetricsAgenticNode._selected_final_result_id_from_actions(["bad"]) is None
+        assert AskMetricsAgenticNode._select_query_metrics_action_by_result_id(["bad"], "missing") is None
+
     def test_skips_failed_actions(self):
         actions = [
             {

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -987,6 +987,36 @@ class TestUpdateContext:
         assert ctx.row_count == 2
         assert ctx.sql_query == ""
 
+    def test_captures_zero_row_result(self):
+        actions = [
+            {
+                "action_type": "query_metrics",
+                "status": "success",
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "columns": ["metric_time__month", "activity_count"],
+                            "data": [],
+                            "metadata": {"sql": "SELECT month, count FROM t WHERE 1 = 0"},
+                        },
+                    }
+                },
+            }
+        ]
+        node = self._make_node_with_result(actions)
+        workflow = MagicMock()
+        workflow.context.sql_contexts = []
+
+        result = node.update_context(workflow)
+
+        assert result["success"] is True
+        assert len(workflow.context.sql_contexts) == 1
+        ctx = workflow.context.sql_contexts[0]
+        assert ctx.sql_return == "metric_time__month,activity_count\r\n"
+        assert ctx.row_count == 0
+        assert ctx.sql_query == "SELECT month, count FROM t WHERE 1 = 0"
+
     def test_skips_failed_actions(self):
         actions = [
             {

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -101,8 +101,11 @@ class TestAskMetricsAgenticNode:
         assert "When the subject tree gives a direct metric/path match" in prompt
         assert "`offset_window` metadata" in prompt
         assert 'dimensions=["metric_time__month"]' in prompt
-        assert "query the base metric together with the derived metric" in prompt
+        assert "query the complete metric bundle" in prompt
+        assert "Previous-period aliases inside a derived metric are calculation inputs" in prompt
         assert "first period" in prompt
+        assert "do not add a `where` filter that enumerates dimension values" in prompt
+        assert "full result is cached" in prompt
         assert node.subject_tree_prompt_limit == 100
 
     def test_large_subject_tree_exposes_list_subject_tree_tool(self, real_agent_config, mock_llm_create):
@@ -174,6 +177,26 @@ class TestAskMetricsAgenticNode:
         assert "metric_1" in prompt
         assert "metric_2" not in prompt
 
+    def test_final_result_selection_tool_is_opt_in(self, real_agent_config, mock_llm_create):
+        tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+
+        default_node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_name="default_final_selection_agent",
+        )
+        strict_node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={"require_final_result_selection": True},
+            node_name="strict_final_selection_agent",
+        )
+
+        assert "select_final_metric_result" not in [tool.name for tool in default_node.tools]
+        assert "select_final_metric_result" not in default_node._get_system_prompt()
+        assert "select_final_metric_result" in [tool.name for tool in strict_node.tools]
+        assert "select_final_metric_result" in strict_node._get_system_prompt()
+
     def test_invalid_subject_tree_prompt_limit_uses_default(self, real_agent_config, mock_llm_create):
         tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
 
@@ -233,6 +256,388 @@ class TestAskMetricsAgenticNode:
             "query_metrics",
             "attribution_analyze",
         ]
+
+    def test_query_metrics_expands_period_over_period_bundle(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Marketing": {"Activity": {"metrics": ["activity_count_mom_delta"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={
+                "items": [
+                    {"name": "activity_count", "metadata": {"metric_kind": "measure_proxy"}},
+                    {
+                        "name": "previous_month_activity_count",
+                        "metadata": {
+                            "expr": "previous_month_activity_count",
+                            "inputs": [
+                                {
+                                    "name": "activity_count",
+                                    "alias": "previous_month_activity_count",
+                                    "offset_window": "1 month",
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "name": "activity_count_previous_month",
+                        "metadata": {
+                            "expr": "activity_count_previous_month",
+                            "inputs": [
+                                {
+                                    "name": "activity_count",
+                                    "alias": "activity_count_previous_month",
+                                    "offset_window": "1 month",
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "name": "activity_count_mom_delta",
+                        "metadata": {
+                            "inputs": [
+                                {"name": "activity_count"},
+                                {
+                                    "name": "activity_count",
+                                    "alias": "previous_month_activity_count",
+                                    "offset_window": "1 month",
+                                },
+                            ]
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+        )
+        semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
+
+        result = node.query_metrics(
+            metrics=["activity_count", "activity_count_mom_delta"],
+            dimensions=["product_type", "metric_time__month"],
+            time_start="2025-04-01",
+            time_end="2025-10-31",
+            time_granularity="month",
+            order_by=["metric_time__month", "product_type"],
+        )
+
+        assert result.success == 1
+        semantic_tools.query_metrics.assert_called_once_with(
+            metrics=[
+                "activity_count",
+                "previous_month_activity_count",
+                "activity_count_previous_month",
+                "activity_count_mom_delta",
+            ],
+            dimensions=["product_type", "metric_time__month"],
+            path=None,
+            time_start="2025-04-01",
+            time_end="2025-10-31",
+            time_granularity="month",
+            where=None,
+            limit=None,
+            order_by=["metric_time__month", "product_type"],
+            dry_run=False,
+        )
+
+    def test_query_metrics_does_not_invent_missing_previous_period_metric(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Marketing": {"Activity": {"metrics": ["activity_count_mom_delta"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={
+                "items": [
+                    {"name": "activity_count", "metadata": {}},
+                    {
+                        "name": "activity_count_mom_delta",
+                        "metadata": {
+                            "inputs": [
+                                {"name": "activity_count"},
+                                {
+                                    "name": "activity_count",
+                                    "alias": "previous_month_activity_count",
+                                    "offset_window": "1 month",
+                                },
+                            ]
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+        )
+        semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
+
+        node.query_metrics(metrics=["activity_count_mom_delta"])
+
+        semantic_tools.query_metrics.assert_called_once_with(
+            metrics=["activity_count", "activity_count_mom_delta"],
+            dimensions=None,
+            path=None,
+            time_start=None,
+            time_end=None,
+            time_granularity=None,
+            where=None,
+            limit=None,
+            order_by=None,
+            dry_run=False,
+        )
+
+    def test_query_metrics_rejects_missing_metrics_without_raising(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Marketing": {"Activity": {"metrics": ["activity_count"]}}},
+        )
+
+        result = node.query_metrics()
+
+        assert result.success == 0
+        assert "at least one metric name" in result.error
+        semantic_tools.query_metrics.assert_not_called()
+
+    def test_query_metrics_does_not_expand_previous_period_metric_alone(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Marketing": {"Activity": {"metrics": ["previous_month_activity_count"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={
+                "items": [
+                    {"name": "activity_count", "metadata": {}},
+                    {
+                        "name": "previous_month_activity_count",
+                        "metadata": {
+                            "inputs": [
+                                {
+                                    "name": "activity_count",
+                                    "alias": "previous_month_activity_count",
+                                    "offset_window": "1 month",
+                                }
+                            ]
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+        )
+        semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
+
+        node.query_metrics(metrics=["previous_month_activity_count"])
+
+        semantic_tools.query_metrics.assert_called_once_with(
+            metrics=["previous_month_activity_count"],
+            dimensions=None,
+            path=None,
+            time_start=None,
+            time_end=None,
+            time_granularity=None,
+            where=None,
+            limit=None,
+            order_by=None,
+            dry_run=False,
+        )
+
+    def test_query_metrics_does_not_expand_plain_derived_metric(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Marketing": {"Activity": {"metrics": ["delivery_activity_ratio"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={
+                "items": [
+                    {"name": "activity_count", "metadata": {}},
+                    {"name": "delivery_activity_count", "metadata": {}},
+                    {
+                        "name": "delivery_activity_ratio",
+                        "metadata": {
+                            "inputs": [
+                                {"name": "delivery_activity_count"},
+                                {"name": "activity_count"},
+                            ]
+                        },
+                    },
+                ],
+                "has_more": False,
+            }
+        )
+        semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
+
+        node.query_metrics(metrics=["delivery_activity_ratio"])
+
+        semantic_tools.query_metrics.assert_called_once_with(
+            metrics=["delivery_activity_ratio"],
+            dimensions=None,
+            path=None,
+            time_start=None,
+            time_end=None,
+            time_granularity=None,
+            where=None,
+            limit=None,
+            order_by=None,
+            dry_run=False,
+        )
+
+    def test_query_metrics_passes_limit_through(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Marketing": {"Activity": {"metrics": ["activity_count"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={"items": [{"name": "activity_count", "metadata": {}}], "has_more": False}
+        )
+        semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
+
+        node.query_metrics(
+            metrics=["activity_count"],
+            dimensions=["ac_channel"],
+            limit=10,
+        )
+
+        semantic_tools.query_metrics.assert_called_once()
+        assert semantic_tools.query_metrics.call_args.kwargs["limit"] == 10
+
+    def test_update_context_defaults_to_last_query_metrics_result(
+        self,
+        real_agent_config,
+        mock_llm_create,
+    ):
+        node, _, _ = _make_node(real_agent_config, tree={})
+
+        def query_action(rows, *, limit):
+            return {
+                "action_type": "query_metrics",
+                "status": "success",
+                "input": {"arguments": f'{{"limit": {limit}}}'},
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "columns": [
+                                "metric_time__month",
+                                "product_type",
+                                "activity_count",
+                                "previous_month_activity_count",
+                                "activity_count_mom_delta",
+                            ],
+                            "data": {
+                                "original_rows": rows,
+                                "compressed_data": f"rows={rows}",
+                            },
+                            "metadata": {},
+                        },
+                    }
+                },
+            }
+
+        node.result = Mock(
+            action_history=[
+                query_action(21, limit=100),
+                query_action(3, limit=5),
+            ]
+        )
+        workflow = Mock()
+        workflow.context.sql_contexts = []
+
+        result = node.update_context(workflow)
+
+        assert result == {"success": True, "message": "query_metrics result captured"}
+        assert len(workflow.context.sql_contexts) == 1
+        assert workflow.context.sql_contexts[0].sql_return == "rows=3"
+        assert workflow.context.sql_contexts[0].row_count == 3
+
+    def test_update_context_required_selection_uses_selected_result_id(
+        self,
+        real_agent_config,
+        mock_llm_create,
+    ):
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree={},
+            node_config={"require_final_result_selection": True},
+            node_name="strict_ask_metrics",
+        )
+
+        def query_action(result_id, rows):
+            return {
+                "action_type": "query_metrics",
+                "status": "success",
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "result_id": result_id,
+                            "columns": ["metric_time__month", "activity_count"],
+                            "data": {
+                                "original_rows": rows,
+                                "compressed_data": f"rows={rows}",
+                            },
+                            "metadata": {},
+                        },
+                    }
+                },
+            }
+
+        node.result = Mock(
+            action_history=[
+                query_action("query_metrics:1", 21),
+                query_action("query_metrics:2", 3),
+                {
+                    "action_type": "select_final_metric_result",
+                    "status": "success",
+                    "output": {
+                        "raw_output": {
+                            "success": 1,
+                            "result": {"result_id": "query_metrics:1"},
+                        }
+                    },
+                },
+            ]
+        )
+        workflow = Mock()
+        workflow.context.sql_contexts = []
+
+        result = node.update_context(workflow)
+
+        assert result == {"success": True, "message": "query_metrics result captured"}
+        assert workflow.context.sql_contexts[0].sql_return == "rows=21"
+        assert workflow.context.sql_contexts[0].row_count == 21
+
+    def test_update_context_required_selection_fails_without_selection(
+        self,
+        real_agent_config,
+        mock_llm_create,
+    ):
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree={},
+            node_config={"require_final_result_selection": True},
+            node_name="strict_ask_metrics_missing_selection",
+        )
+        node.result = Mock(
+            action_history=[
+                {
+                    "action_type": "query_metrics",
+                    "status": "success",
+                    "output": {
+                        "raw_output": {
+                            "success": 1,
+                            "result": {
+                                "result_id": "query_metrics:1",
+                                "columns": ["activity_count"],
+                                "data": {"original_rows": 1, "compressed_data": "activity_count\n1"},
+                                "metadata": {},
+                            },
+                        }
+                    },
+                }
+            ]
+        )
+        workflow = Mock()
+        workflow.context.sql_contexts = []
+
+        result = node.update_context(workflow)
+
+        assert result == {"success": False, "message": "final query_metrics result was not selected"}
+        assert workflow.context.sql_contexts == []
 
     def test_unsupported_tool_patterns_are_ignored(self, real_agent_config, mock_llm_create):
         node, _, _ = _make_node(
@@ -470,6 +875,11 @@ class TestUpdateContext:
         node = MagicMock(spec=AskMetricsAgenticNode)
         node.result = MagicMock()
         node.result.action_history = action_history
+        node.require_final_result_selection = False
+        node._select_last_query_metrics_action = AskMetricsAgenticNode._select_last_query_metrics_action
+        node._selected_final_result_id_from_actions = AskMetricsAgenticNode._selected_final_result_id_from_actions
+        node._select_query_metrics_action_by_result_id = AskMetricsAgenticNode._select_query_metrics_action_by_result_id
+        node._query_result_payload = AskMetricsAgenticNode._query_result_payload
         node.update_context = AskMetricsAgenticNode.update_context.__get__(node)
         return node
 
@@ -506,6 +916,47 @@ class TestUpdateContext:
         assert "activity_count" in ctx.sql_return
         assert ctx.sql_query == "SELECT COUNT(*) FROM t"
         assert ctx.row_count == 1
+
+    def test_captures_full_cached_data_before_compressed_preview(self):
+        actions = [
+            {
+                "action_type": "query_metrics",
+                "status": "success",
+                "output": {
+                    "raw_output": {
+                        "success": 1,
+                        "result": {
+                            "columns": ["metric_time__month", "activity_count"],
+                            "data": {
+                                "compressed_data": (
+                                    "metric_time__month,activity_count\n2025-01-01,1\n...,...\n2025-12-01,12"
+                                ),
+                                "original_rows": 21,
+                                "is_compressed": True,
+                                "compression_type": "rows",
+                            },
+                            "metadata": {"_full_result_cache_key": "query_metrics:1"},
+                        },
+                    }
+                },
+            }
+        ]
+        node = self._make_node_with_result(actions)
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.get_cached_query_metrics_result.return_value = {
+            "csv": "metric_time__month,activity_count\n2025-01-01,1\n2025-02-01,2\n",
+            "row_count": 21,
+        }
+        workflow = MagicMock()
+        workflow.context.sql_contexts = []
+
+        result = node.update_context(workflow)
+
+        assert result["success"] is True
+        ctx = workflow.context.sql_contexts[0]
+        assert "2025-02-01,2" in ctx.sql_return
+        assert "..." not in ctx.sql_return
+        assert ctx.row_count == 21
 
     def test_captures_list_data(self):
         actions = [

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -15,11 +15,18 @@ from datus.storage.metric.metric_init import (
     DEFAULT_METRICS_BATCH_SIZE,
     _action_status_value,
     _append_auto_offset_result,
+    _append_metric_docs,
     _auto_generate_offset_derived_metrics,
+    _derived_metric_doc,
     _extract_metric_artifact_ids,
     _generate_metrics_batch,
+    _is_offset_derived_candidate,
+    _load_metric_doc_names,
+    _offset_grain,
+    _offset_identity_alias_candidates,
     _source_provenance_from_row,
     _sync_metric_provenance,
+    _unique_metric_catalog_by_name,
     init_semantic_yaml_metrics,
 )
 from datus.tools.func_tool.base import FuncToolResult
@@ -1227,6 +1234,81 @@ class TestAutoGenerateOffsetDerivedMetrics:
 
     def _metric_file(self, tmp_path):
         return tmp_path / "subject" / "semantic_models" / "starrocks" / "metrics" / "auto_offset_derived_metrics.yml"
+
+    def test_offset_helper_defensive_branches(self, tmp_path):
+        assert _offset_grain(None) is None
+        assert _offset_grain("1 centuries") is None
+        assert _offset_grain("1 months") == "month"
+        assert (
+            _is_offset_derived_candidate({"metric_type": "simple", "inputs": [{"offset_window": "1 month"}]}) is False
+        )
+        assert _is_offset_derived_candidate({"metric_type": "derived", "inputs": []}) is False
+        assert _offset_identity_alias_candidates({"inputs": []}) == []
+        assert (
+            _offset_identity_alias_candidates(
+                {
+                    "name": "previous_month_activity_count",
+                    "expression": "previous_month_activity_count",
+                    "inputs": [{"name": "activity_count", "alias": "", "offset_window": "1 month"}],
+                }
+            )
+            == []
+        )
+        assert (
+            _offset_identity_alias_candidates(
+                {
+                    "name": "activity_count_previous_month",
+                    "expression": "activity_count_previous_month",
+                    "inputs": [
+                        {"name": "activity_count", "alias": "activity_count_previous_month", "offset_window": "1 month"}
+                    ],
+                }
+            )
+            == []
+        )
+
+        metric_doc = _derived_metric_doc(
+            {
+                "name": "activity_count_previous_month",
+                "expression": "activity_count_previous_month",
+                "inputs": [
+                    "not-dict",
+                    {},
+                    {
+                        "name": "activity_count",
+                        "alias": "activity_count_previous_month",
+                        "offset_window": "1 month",
+                        "offset_to_grain": "month",
+                    },
+                ],
+            },
+            {"activity_count": {"subject_path": ["ac_manage", "campaign"]}},
+        )
+        metric_input = metric_doc["metric"]["type_params"]["metrics"][0]
+        assert metric_input["offset_to_grain"] == "month"
+        assert metric_doc["metric"]["locked_metadata"]["tags"] == [
+            "ac_manage/campaign",
+            "subject_tree: ac_manage/campaign",
+        ]
+
+        malformed_metric_file = tmp_path / "bad.yml"
+        malformed_metric_file.write_text("metric: [", encoding="utf-8")
+        assert _load_metric_doc_names(malformed_metric_file) == set()
+
+        empty_metric_file = tmp_path / "empty.yml"
+        _append_metric_docs(empty_metric_file, [])
+        assert not empty_metric_file.exists()
+
+        unique, ambiguous = _unique_metric_catalog_by_name(
+            [
+                "not-dict",
+                {"name": "activity_count"},
+                {"name": "activity_count"},
+                {"name": "order_count"},
+            ]
+        )
+        assert unique == {"order_count": {"name": "order_count"}}
+        assert ambiguous == {"activity_count"}
 
     def test_generates_and_syncs_offset_derived_metrics(self, tmp_path, monkeypatch):
         synced = {}

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -1225,6 +1225,9 @@ class TestAutoGenerateOffsetDerivedMetrics:
             ],
         }
 
+    def _metric_file(self, tmp_path):
+        return tmp_path / "subject" / "semantic_models" / "starrocks" / "metrics" / "auto_offset_derived_metrics.yml"
+
     def test_generates_and_syncs_offset_derived_metrics(self, tmp_path, monkeypatch):
         synced = {}
 
@@ -1279,6 +1282,150 @@ class TestAutoGenerateOffsetDerivedMetrics:
         assert "name: activity_count_previous_month" in text
         assert "offset_window: 1 month" in text
         assert "expr: activity_count - previous_month_activity_count" in text
+
+    def test_skips_ambiguous_existing_input_metric_names(self, tmp_path, monkeypatch):
+        class UnexpectedSemanticTools:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("semantic tools should not be constructed")
+
+        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", UnexpectedSemanticTools)
+
+        result = _auto_generate_offset_derived_metrics(
+            self._candidate_plan(),
+            [
+                {"name": "activity_count", "type": "measure_proxy", "subject_path": ["a"]},
+                {"name": "activity_count", "type": "measure_proxy", "subject_path": ["b"]},
+            ],
+            self._config(tmp_path),
+        )
+
+        assert result == {"generated_metric_names": [], "metric_artifact_ids": []}
+
+    def test_rolls_back_metric_file_when_validation_fails(self, tmp_path, monkeypatch):
+        metric_file = self._metric_file(tmp_path)
+        metric_file.parent.mkdir(parents=True)
+        original_content = "metric:\n  name: existing_metric\n"
+        metric_file.write_text(original_content, encoding="utf-8")
+
+        class FakeSemanticTools:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validate_semantic(self, scope="all"):
+                return FuncToolResult(success=0, error="bad model")
+
+        class UnexpectedGenerationTools:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("generation tools should not be constructed")
+
+        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
+        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", UnexpectedGenerationTools)
+
+        result = _auto_generate_offset_derived_metrics(
+            self._candidate_plan(),
+            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
+            self._config(tmp_path),
+        )
+
+        assert result["error"] == "bad model"
+        assert metric_file.read_text(encoding="utf-8") == original_content
+
+    def test_rolls_back_metric_file_when_sync_fails(self, tmp_path, monkeypatch):
+        metric_file = self._metric_file(tmp_path)
+
+        class FakeSemanticTools:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validate_semantic(self, scope="all"):
+                return FuncToolResult(result={"valid": True, "scope": scope})
+
+            def query_metrics(self, metrics, dimensions=None, time_granularity=None, dry_run=False, **kwargs):
+                return FuncToolResult(result={"metadata": {"sql": f"SELECT {metrics[0]}"}})
+
+        class FakeGenerationTools:
+            def __init__(self, agent_config):
+                self.agent_config = agent_config
+
+            def _sync_metric_to_db(self, metric_file, metric_sqls=None, metric_names_to_sync=None):
+                return {"success": False, "error": "sync failed"}
+
+        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
+        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", FakeGenerationTools)
+
+        result = _auto_generate_offset_derived_metrics(
+            self._candidate_plan(),
+            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
+            self._config(tmp_path),
+        )
+
+        assert result["error"] == "sync failed"
+        assert not metric_file.exists()
+
+    def test_resyncs_file_backed_metric_missing_from_catalog(self, tmp_path, monkeypatch):
+        synced = {}
+        metric_file = self._metric_file(tmp_path)
+        metric_file.parent.mkdir(parents=True)
+        metric_file.write_text(
+            "metric:\n"
+            "  name: activity_count_previous_month\n"
+            "  type: derived\n"
+            "  type_params:\n"
+            "    expr: activity_count_previous_month\n"
+            "    metrics:\n"
+            "      - name: activity_count\n"
+            "        alias: activity_count_previous_month\n"
+            "        offset_window: 1 month\n",
+            encoding="utf-8",
+        )
+
+        class FakeSemanticTools:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validate_semantic(self, scope="all"):
+                return FuncToolResult(result={"valid": True, "scope": scope})
+
+        class FakeGenerationTools:
+            def __init__(self, agent_config):
+                self.agent_config = agent_config
+
+            def _sync_metric_to_db(self, metric_file, metric_sqls=None, metric_names_to_sync=None):
+                synced["metric_file"] = metric_file
+                synced["metric_sqls"] = metric_sqls
+                synced["metric_names_to_sync"] = metric_names_to_sync
+                return {"success": True}
+
+        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
+        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", FakeGenerationTools)
+
+        result = _auto_generate_offset_derived_metrics(
+            {
+                "available": True,
+                "derived_metric_candidates": [
+                    {
+                        "name": "activity_count_previous_month",
+                        "metric_type": "derived",
+                        "expression": "activity_count_previous_month",
+                        "inputs": [
+                            {
+                                "name": "activity_count",
+                                "alias": "activity_count_previous_month",
+                                "offset_window": "1 month",
+                            }
+                        ],
+                    }
+                ],
+            },
+            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
+            self._config(tmp_path),
+        )
+
+        assert result["generated_metric_names"] == ["activity_count_previous_month"]
+        assert result["metric_artifact_ids"] == ["metric:activity_count_previous_month"]
+        assert synced["metric_sqls"] == {}
+        assert synced["metric_names_to_sync"] == {"activity_count_previous_month"}
+        assert metric_file.read_text(encoding="utf-8").count("name: activity_count_previous_month") == 1
 
     def test_skips_when_input_metric_missing(self, tmp_path, monkeypatch):
         class UnexpectedSemanticTools:

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -5,6 +5,7 @@
 """Unit tests for datus.storage.metric.metric_init."""
 
 from enum import Enum
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,12 +14,15 @@ from datus.storage.metric.metric_init import (
     BIZ_NAME,
     DEFAULT_METRICS_BATCH_SIZE,
     _action_status_value,
+    _append_auto_offset_result,
+    _auto_generate_offset_derived_metrics,
     _extract_metric_artifact_ids,
     _generate_metrics_batch,
     _source_provenance_from_row,
     _sync_metric_provenance,
     init_semantic_yaml_metrics,
 )
+from datus.tools.func_tool.base import FuncToolResult
 
 # ---------------------------------------------------------------------------
 # _action_status_value
@@ -1179,6 +1183,142 @@ class TestBatchHasNoMetricCandidates:
 
         plan = {"available": True}
         assert _batch_has_no_metric_candidates(plan) is False
+
+
+class TestAutoGenerateOffsetDerivedMetrics:
+    def _config(self, tmp_path):
+        semantic_root = tmp_path / "subject" / "semantic_models" / "starrocks"
+        path_manager = SimpleNamespace(semantic_model_path=lambda datasource: semantic_root)
+        return SimpleNamespace(current_datasource="starrocks", path_manager=path_manager)
+
+    def _candidate_plan(self):
+        return {
+            "available": True,
+            "derived_metric_candidates": [
+                {
+                    "name": "previous_month_activity_count",
+                    "metric_type": "derived",
+                    "expression": "previous_month_activity_count",
+                    "inputs": [
+                        {
+                            "name": "activity_count",
+                            "alias": "previous_month_activity_count",
+                            "offset_window": "1 month",
+                        }
+                    ],
+                    "offset_window": "1 month",
+                },
+                {
+                    "name": "activity_count_mom_delta",
+                    "metric_type": "derived",
+                    "expression": "activity_count - previous_month_activity_count",
+                    "inputs": [
+                        {"name": "activity_count"},
+                        {
+                            "name": "activity_count",
+                            "alias": "previous_month_activity_count",
+                            "offset_window": "1 month",
+                        },
+                    ],
+                    "offset_window": "1 month",
+                },
+            ],
+        }
+
+    def test_generates_and_syncs_offset_derived_metrics(self, tmp_path, monkeypatch):
+        synced = {}
+
+        class FakeSemanticTools:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def validate_semantic(self, scope="all"):
+                return FuncToolResult(result={"valid": True, "scope": scope})
+
+            def query_metrics(self, metrics, dimensions=None, time_granularity=None, dry_run=False, **kwargs):
+                return FuncToolResult(result={"metadata": {"sql": f"SELECT {metrics[0]}"}})
+
+        class FakeGenerationTools:
+            def __init__(self, agent_config):
+                self.agent_config = agent_config
+
+            def _sync_metric_to_db(self, metric_file, metric_sqls=None, metric_names_to_sync=None):
+                synced["metric_file"] = metric_file
+                synced["metric_sqls"] = metric_sqls
+                synced["metric_names_to_sync"] = metric_names_to_sync
+                return {"success": True}
+
+        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
+        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", FakeGenerationTools)
+
+        result = _auto_generate_offset_derived_metrics(
+            self._candidate_plan(),
+            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
+            self._config(tmp_path),
+        )
+
+        assert result["generated_metric_names"] == [
+            "previous_month_activity_count",
+            "activity_count_previous_month",
+            "activity_count_mom_delta",
+        ]
+        assert result["metric_artifact_ids"] == [
+            "metric:previous_month_activity_count",
+            "metric:activity_count_previous_month",
+            "metric:activity_count_mom_delta",
+        ]
+        assert synced["metric_names_to_sync"] == {
+            "previous_month_activity_count",
+            "activity_count_previous_month",
+            "activity_count_mom_delta",
+        }
+        metric_file = (
+            tmp_path / "subject" / "semantic_models" / "starrocks" / "metrics" / "auto_offset_derived_metrics.yml"
+        )
+        text = metric_file.read_text()
+        assert "name: activity_count_previous_month" in text
+        assert "offset_window: 1 month" in text
+        assert "expr: activity_count - previous_month_activity_count" in text
+
+    def test_skips_when_input_metric_missing(self, tmp_path, monkeypatch):
+        class UnexpectedSemanticTools:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("semantic tools should not be constructed")
+
+        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", UnexpectedSemanticTools)
+
+        result = _auto_generate_offset_derived_metrics(self._candidate_plan(), [], self._config(tmp_path))
+
+        assert result == {"generated_metric_names": [], "metric_artifact_ids": []}
+
+    def test_append_auto_offset_result_merges_without_duplicates(self):
+        batch_result = {
+            "auto_generated_offset_derived_metrics": ["previous_month_activity_count"],
+            "_synced_metric_artifact_ids": ["metric:previous_month_activity_count"],
+            "provenance_entries": 1,
+        }
+
+        _append_auto_offset_result(
+            batch_result,
+            {
+                "generated_metric_names": ["previous_month_activity_count", "activity_count_mom_delta"],
+                "metric_artifact_ids": [
+                    "metric:previous_month_activity_count",
+                    "metric:activity_count_mom_delta",
+                ],
+            },
+            provenance_entries=2,
+        )
+
+        assert batch_result["auto_generated_offset_derived_metrics"] == [
+            "previous_month_activity_count",
+            "activity_count_mom_delta",
+        ]
+        assert batch_result["_synced_metric_artifact_ids"] == [
+            "metric:previous_month_activity_count",
+            "metric:activity_count_mom_delta",
+        ]
+        assert batch_result["provenance_entries"] == 3
 
 
 @pytest.mark.ci

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -56,6 +56,34 @@ class TestCheckSemanticObjectExists:
         assert result.result["exists"] is True
         assert result.result["name"] == "orders"
 
+    def test_accepts_prompt_documented_name_argument(self, generation_tools):
+        mock_storage = Mock()
+        generation_tools.semantic_rag.storage = mock_storage
+        mock_storage.search_all.return_value = [{"id": "t1", "name": "orders", "kind": "table"}]
+
+        with patch("datus.tools.func_tool.generation_tools.And"), patch("datus.tools.func_tool.generation_tools.eq"):
+            result = generation_tools.check_semantic_object_exists(name="orders", kind="table")
+
+        assert result.success == 1
+        assert result.result["exists"] is True
+
+    def test_accepts_legacy_object_name_argument(self, generation_tools):
+        mock_storage = Mock()
+        generation_tools.semantic_rag.storage = mock_storage
+        mock_storage.search_all.return_value = [{"id": "t1", "name": "orders", "kind": "table"}]
+
+        with patch("datus.tools.func_tool.generation_tools.And"), patch("datus.tools.func_tool.generation_tools.eq"):
+            result = generation_tools.check_semantic_object_exists(object_name="orders", kind="table")
+
+        assert result.success == 1
+        assert result.result["exists"] is True
+
+    def test_requires_name(self, generation_tools):
+        result = generation_tools.check_semantic_object_exists(kind="table")
+
+        assert result.success == 0
+        assert "name is required" in result.error
+
     def test_table_not_found(self, generation_tools):
         mock_storage = Mock()
         generation_tools.semantic_rag.storage = mock_storage

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -893,6 +893,42 @@ class TestQueryMetricsCompression:
         assert semantic_tools.get_cached_query_metrics_result(second)["row_count"] == 1
         assert semantic_tools.get_cached_query_metrics_result(third)["row_count"] == 1
 
+    def test_query_metrics_result_cache_helpers_handle_supported_data_shapes(self, semantic_tools):
+        class NumRows:
+            num_rows = "7"
+
+        class BadNumRows:
+            num_rows = "bad"
+
+        class ShapeRows:
+            shape = (3, 2)
+
+        class BadShapeRows:
+            shape = ()
+
+        class CsvLike:
+            def to_csv(self, index=False):
+                assert index is False
+                return "x\n1\n"
+
+        class ToPandasLike:
+            def to_pandas(self):
+                return CsvLike()
+
+        assert semantic_tools._query_data_row_count(None) == 0
+        assert semantic_tools._query_data_row_count(NumRows()) == 7
+        assert semantic_tools._query_data_row_count(BadNumRows()) == 0
+        assert semantic_tools._query_data_row_count(ShapeRows()) == 3
+        assert semantic_tools._query_data_row_count(BadShapeRows()) == 0
+        assert semantic_tools._query_data_row_count(1) == 0
+
+        assert semantic_tools._query_data_to_csv(["x"], None) == ""
+        assert semantic_tools._query_data_to_csv(["x"], ToPandasLike()) == "x\n1\n"
+        assert semantic_tools._query_data_to_csv(["x"], [{"x": 1}, (2,), 3]) == "x\r\n1\r\n2\r\n3\r\n"
+        assert semantic_tools._cache_query_metrics_result(["x"], None) is None
+        with patch.object(semantic_tools, "_query_data_to_csv", return_value=""):
+            assert semantic_tools._cache_query_metrics_result(["x"], [{"x": 1}]) is None
+
     def test_query_metrics_empty_data(self, semantic_tools):
         """Test query_metrics with empty result set."""
         query_result = QueryResult(

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -882,6 +882,17 @@ class TestQueryMetricsCompression:
         assert "49,4900" in cached_result["csv"]
         assert "..." not in cached_result["csv"]
 
+    def test_query_metrics_full_result_cache_is_bounded(self, semantic_tools):
+        semantic_tools.MAX_QUERY_METRICS_RESULT_CACHE_SIZE = 2
+
+        first = semantic_tools._cache_query_metrics_result(["id"], [{"id": 1}])
+        second = semantic_tools._cache_query_metrics_result(["id"], [{"id": 2}])
+        third = semantic_tools._cache_query_metrics_result(["id"], [{"id": 3}])
+
+        assert semantic_tools.get_cached_query_metrics_result(first) is None
+        assert semantic_tools.get_cached_query_metrics_result(second)["row_count"] == 1
+        assert semantic_tools.get_cached_query_metrics_result(third)["row_count"] == 1
+
     def test_query_metrics_empty_data(self, semantic_tools):
         """Test query_metrics with empty result set."""
         query_result = QueryResult(

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -817,6 +817,7 @@ class TestQueryMetricsCompression:
         assert "columns" in result_dict
         assert "data" in result_dict
         assert "metadata" in result_dict
+        assert result_dict["result_id"] == result_dict["metadata"]["_full_result_cache_key"]
 
         # Verify data is now a compressed dict (not raw list)
         compressed_data = result_dict["data"]
@@ -830,7 +831,11 @@ class TestQueryMetricsCompression:
 
         # Verify metadata is preserved
         assert result_dict["columns"] == ["date", "revenue", "orders"]
-        assert result_dict["metadata"] == {"execution_time": 0.5}
+        assert result_dict["metadata"]["execution_time"] == 0.5
+        assert result_dict["metadata"]["_full_result_cache_key"]
+        assert result_dict["metadata"]["_full_result_cached"] is True
+        assert result_dict["metadata"]["_full_result_row_count"] == 2
+        assert "complete uncompressed query result is cached" in result_dict["metadata"]["_full_result_note"]
 
     def test_query_metrics_small_data_not_compressed(self, semantic_tools):
         """Test that small data within token threshold is not compressed."""
@@ -867,6 +872,15 @@ class TestQueryMetricsCompression:
         assert compressed_data["original_rows"] == 50
         assert compressed_data["is_compressed"] is True
         assert compressed_data["compression_type"] in ("rows", "rows_and_columns")
+
+        cache_key = result.result["metadata"]["_full_result_cache_key"]
+        assert result.result["result_id"] == cache_key
+        cached_result = semantic_tools.get_cached_query_metrics_result(cache_key)
+        assert cached_result["row_count"] == 50
+        assert result.result["metadata"]["_full_result_row_count"] == 50
+        assert "10,1000" in cached_result["csv"]
+        assert "49,4900" in cached_result["csv"]
+        assert "..." not in cached_result["csv"]
 
     def test_query_metrics_empty_data(self, semantic_tools):
         """Test query_metrics with empty result set."""
@@ -1030,7 +1044,9 @@ class TestQueryMetricsCompression:
             )
 
         assert result.result["columns"] == ["metric_time__day", "revenue", "cost"]
-        assert result.result["metadata"] == {"sql": "SELECT ...", "row_count": 1}
+        assert result.result["metadata"]["sql"] == "SELECT ..."
+        assert result.result["metadata"]["row_count"] == 1
+        assert result.result["metadata"]["_full_result_cache_key"]
 
     def test_query_metrics_dry_run_records_generation_evidence(self, semantic_tools):
         """Successful dry-run evidence gates metric publishing."""
@@ -1393,6 +1409,15 @@ class TestListMetrics:
         assert envelope["has_more"] is True
         assert envelope["extra"] == {"next_offset": 5}
         mock_adapter.list_metrics.assert_called_once_with(path=["Finance"], limit=3, offset=2)
+
+    def test_drops_null_path_placeholders(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=[]):
+            result = tool.list_metrics(path=[None, "", "null"], limit=50, offset=0)
+
+        assert result.success == 1
+        mock_adapter.list_metrics.assert_called_once_with(path=None, limit=50, offset=0)
 
     def test_ignores_non_dict_metric_metadata(self, semantic_tools_with_adapter):
         tool, _ = semantic_tools_with_adapter

--- a/tests/unit_tests/utils/test_compress_utils.py
+++ b/tests/unit_tests/utils/test_compress_utils.py
@@ -1,5 +1,7 @@
+import csv
 from datetime import date
 from decimal import Decimal
+from io import StringIO
 from typing import Dict, List
 from unittest.mock import patch
 
@@ -90,6 +92,19 @@ def test_compress_mock():
     assert result_large["compression_type"] in {"rows", "rows_and_columns"}
     assert result_large["compressed_data"]
     assert "user_id" in result_large["compressed_data"]
+
+
+def test_compressed_csv_quotes_values_with_commas():
+    data = [{"month": "2025-04-01", "ac_channel": f"1,{i}", "activity_count": i} for i in range(25)]
+
+    result = DataCompressor(model_name="gpt-3.5-turbo", token_threshold=1024, output_format="csv").compress(data)
+
+    assert result["is_compressed"] is True
+    rows = list(csv.DictReader(StringIO(result["compressed_data"])))
+    assert rows[0]["ac_channel"] == "1,0"
+    assert rows[9]["ac_channel"] == "1,9"
+    assert rows[10]["month"] == "..."
+    assert rows[-1]["ac_channel"] == "1,24"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add opt-in final metric result selection for ask_metrics so benchmark-style runs can require the LLM to explicitly choose the query_metrics result used for structured output
- expand period-over-period derived metric queries to include current, previous-period, and delta metrics already present in the executable catalog
- preserve complete cached query_metrics results while showing compressed previews to the model
- improve metric bootstrap provenance and generated metric sync behavior for ask_metrics flows

## Validation
- uv run --project /Users/kangxue/work/datus/Datus-agent-ask-metrics-pop pytest tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py tests/unit_tests/tools/func_tool/test_semantic_tools.py tests/unit_tests/storage/metric/test_metric_init.py tests/unit_tests/tools/func_tool/test_generation_tools.py tests/unit_tests/utils/test_compress_utils.py -q
- Baisheng ask_metrics benchmark 31-36 from clean generated semantic YAML: query phase 5/6 passed; task 32 fails because the LLM explicitly selected the wrong cached result_id, while query_metrics had already produced the correct 130-row result

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

* **New Features**
  * Added optional final metric result selection for metric queries.
  * Implemented result caching and identification for improved query performance and reference tracking.
  * Enhanced period-over-period metric handling with automatic expansion of derived metrics.

* **Documentation**
  * Updated metric query guidance with improved instructions for metric selection, dimension grouping, and result caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in final metric-result selection workflow.
  * Full-result caching for metric queries with stable result identifiers.
  * Automatic expansion/handling of period-over-period metric bundles.
  * Deterministic auto-generation of offset-derived metrics during bootstrap.

* **Documentation**
  * Updated metric-query guidance: metric choice, grouping, caching, and trend-query rules.

* **Tests**
  * Expanded unit tests for selection flow, caching/eviction, bundle expansion, bootstrap generation, and CSV compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->