### PR TITLE
[BugFix] Backport storage adapters 0.1.5 to release/0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "datus-db-core>=0.1.4",
-    "datus-storage-base>=0.1.4,<0.2.0",
+    "datus-storage-base>=0.1.5,<0.2.0",
     "python-dotenv==1.0.0",
     "pandas==2.1.4",
     "sqlalchemy==2.0.23",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,4 +6,4 @@ pytest-timeout>=2.3.1
 chardet>=3.0.2,<6
 diff-cover>=9.0
 defusedxml>=0.7.1
-datus-storage-postgresql>=0.1.4
+datus-storage-postgresql>=0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ beautifulsoup4>=4.12.0
 lxml>=5.0.0
 markdown-it-py>=3.0.0
 tabulate>=0.9.0
-datus-storage-base==0.1.4
+datus-storage-base==0.1.5
 datus-db-core>=0.1.4
 datus-semantic-core>=0.2.0
 datus-bi-core>=0.1.2


### PR DESCRIPTION
Summary
- Backport #1004 to release/0.3.4.
- Bump datus-storage-base dependency to 0.1.5.
- Bump datus-storage-postgresql test dependency to 0.1.5.

Validation
- uv run python ci/audit_tests.py --paths pyproject.toml requirements.txt requirements-test.txt
- uv run ruff format --check pyproject.toml
- git diff --check upstream/release/0.3.4...HEAD

Backport
- Original PR: #1004
- Cherry-picked from: 132623edc0a6e97dafd04124702695aacf4fcef5