### PR TITLE
[Doc] Add 0.3.4 release notes

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,31 @@
 
 ## 0.3
 
+### 0.3.4
+
+**New Features**
+
+- **AskMetrics Subagent** - A dedicated metric QA agent for KPI, trend, group-by, and attribution questions that reaches for metric-specific tools and prompts instead of raw SQL, with customizable routing, templates, and tools. [#954](https://github.com/Datus-ai/Datus-agent/pull/954) [docs](subagent/ask_metrics.md)
+- **OpenRouter Provider** - Point a single `OPENROUTER_API_KEY` at the full vendor/model catalog; the `/model` picker now has search filtering and hides the non-canonical `-fast` Claude aliases. [#973](https://github.com/Datus-ai/Datus-agent/pull/973) [#936](https://github.com/Datus-ai/Datus-agent/pull/936) [docs](cli/model_command.md)
+- **Self-Update Commands** - `datus upgrade` / `datus update` check for and install new versions of your `datus-*` packages from the CLI; interactive sessions flag new versions on startup, and `--check` looks without installing. [#949](https://github.com/Datus-ai/Datus-agent/pull/949)
+- **Orchestrator Tools in Print Mode** - `--orchestrator-tools` lets an external orchestrator request issue comments, status updates, human input, blocked flags, and mission completion through proxy tools, with each tool's strict JSON schema preserved. [#950](https://github.com/Datus-ai/Datus-agent/pull/950)
+
+**Enhancements**
+
+- **Queryable Metrics by Default** - Metric generation now extracts a queryability contract and validates it with `query_metrics(dry_run=True)`, so you no longer get metrics that are structurally valid but cannot actually be queried at the original grain. [#943](https://github.com/Datus-ai/Datus-agent/pull/943) [#962](https://github.com/Datus-ai/Datus-agent/pull/962)
+- **Scoped Agent Memory** - Each agent gets a per-agent 2000-byte `MEMORY.md` that is write-only through `add_memory` / `edit_memory`; sub-agents inherit it read-only. [#975](https://github.com/Datus-ai/Datus-agent/pull/975) [docs](integration/memory.md)
+- **Built-in Knowledge Extraction** - External knowledge generation moved off the old `ext_knowledge` vector subsystem to the built-in `extract-knowledge` skill, trimming legacy storage and tooling while keeping the knowledge-base API. [#932](https://github.com/Datus-ai/Datus-agent/pull/932)
+- **Stronger Snowflake Support** - Snowflake setups now accept inline PEM private keys, reject unsupported catalog params, and normalize time-grain queries across the DB and MetricFlow adapters; docs clarify that password and private key are mutually exclusive, warehouse is required, and catalog usually should not be set. [#937](https://github.com/Datus-ai/Datus-agent/pull/937) [datus-db-adapters#70](https://github.com/Datus-ai/datus-db-adapters/pull/70) [datus-db-adapters#72](https://github.com/Datus-ai/datus-db-adapters/pull/72) [datus-semantic-adapter#27](https://github.com/Datus-ai/datus-semantic-adapter/pull/27) [datus-semantic-adapter#28](https://github.com/Datus-ai/datus-semantic-adapter/pull/28) [datus-semantic-adapter#29](https://github.com/Datus-ai/datus-semantic-adapter/pull/29) [docs](configuration/datasources.md)
+- **Unified `gen_sql` Naming** - The SQL-generation node, workflow, config, CLI command (`/gen_sql`), prompt templates, and sub-agent name now share one consistent `gen_sql` naming; projects on the old `generate_sql` / `sql_system` config should migrate. [#935](https://github.com/Datus-ai/Datus-agent/pull/935) [docs](configuration/nodes.md)
+- **Configurable Metrics Batch Size** - `bootstrap-kb --components metrics` adds `--metrics-batch-size`; set it to `1` when you need per-success-story provenance, or keep the default of `5` for the original throughput. [#976](https://github.com/Datus-ai/Datus-agent/pull/976)
+
+**Bug Fixes**
+
+- **Datasource-Isolated Metrics Bootstrap** - Metrics bootstrap now isolates rows per datasource in multi-datasource projects, so `overwrite` no longer deletes another datasource's KB data, with hardened MetricFlow YAML merge, batch refresh, final metric de-duplication, and CLI long-output truncation. [#974](https://github.com/Datus-ai/Datus-agent/pull/974)
+- **Robust Semantic Metric Query & Validation** - Snowflake table coordinates now reach semantic-model generation prompts, multi-metric dimension compatibility gets a preflight with split suggestions, temporary YAML validation no longer scans unrelated parent directories, and non-string / nullable PyArrow results display safely. [#941](https://github.com/Datus-ai/Datus-agent/pull/941) [#946](https://github.com/Datus-ai/Datus-agent/pull/946)
+- **Cross-Datasource Subject Node Migration** - Upgrading older SQLite storage migrates the stale `subject_nodes` UNIQUE constraint so same-named subject nodes can coexist across datasources while staying de-duplicated within one. [#964](https://github.com/Datus-ai/Datus-agent/pull/964)
+- **One Datasource, Multiple Databases** - A single datasource can now route to multiple databases — file-glob datasources, benchmark tasks, `/database` switching, DB tools, and node execution all select the connection by `(datasource, database)`, and benchmark SQL tasks can name their datasource explicitly. [#961](https://github.com/Datus-ai/Datus-agent/pull/961) [#934](https://github.com/Datus-ai/Datus-agent/pull/934) [datus-db-adapters#71](https://github.com/Datus-ai/datus-db-adapters/pull/71)
+
 ### 0.3.3
 
 **New Features**

--- a/docs/release_notes.zh.md
+++ b/docs/release_notes.zh.md
@@ -2,6 +2,31 @@
 
 ## 0.3
 
+### 0.3.4
+
+**新功能**
+
+- **AskMetrics 子代理** - 面向 KPI、趋势、group-by 和 attribution 问题的专属 metric QA agent，会优先使用 metric 专用工具与提示词而非裸 SQL，并支持自定义路由、模板和工具。[#954](https://github.com/Datus-ai/Datus-agent/pull/954) [文档](subagent/ask_metrics.zh.md)
+- **OpenRouter Provider** - 用一个 `OPENROUTER_API_KEY` 即可访问完整的 vendor/model 目录；`/model` 选择器新增搜索过滤，并隐藏 Anthropic Claude 的非 canonical `-fast` 别名。[#973](https://github.com/Datus-ai/Datus-agent/pull/973) [#936](https://github.com/Datus-ai/Datus-agent/pull/936) [文档](cli/model_command.zh.md)
+- **自更新命令** - `datus upgrade` / `datus update` 可在 CLI 中检查并安装 `datus-*` 包的新版本；交互式会话启动时会提示可用新版本，`--check` 则只查看不安装。[#949](https://github.com/Datus-ai/Datus-agent/pull/949)
+- **Print 模式 Orchestrator 工具** - `--orchestrator-tools` 让外部 orchestrator 通过代理工具请求 issue 评论、状态更新、人工输入、blocked 标记和 mission 完成，且每个工具的 strict JSON schema 都被完整保留。[#950](https://github.com/Datus-ai/Datus-agent/pull/950)
+
+**增强**
+
+- **默认可查询的指标** - 指标生成现在会提取一份 queryability contract，并用 `query_metrics(dry_run=True)` 校验，因此不再产出结构合法、却无法按原始粒度查询的指标。[#943](https://github.com/Datus-ai/Datus-agent/pull/943) [#962](https://github.com/Datus-ai/Datus-agent/pull/962)
+- **隔离的 Agent Memory** - 每个 agent 拥有一份独立的 2000 字节 `MEMORY.md`，仅能通过 `add_memory` / `edit_memory` 写入；sub-agent 只以只读方式继承。[#975](https://github.com/Datus-ai/Datus-agent/pull/975) [文档](integration/memory.zh.md)
+- **内置知识抽取** - 外部知识生成从旧的 `ext_knowledge` 向量子系统切换为内置的 `extract-knowledge` skill，精简了遗留存储与工具面，同时保留 knowledge-base API。[#932](https://github.com/Datus-ai/Datus-agent/pull/932)
+- **更强的 Snowflake 支持** - Snowflake 现支持 inline PEM 私钥、拒绝不支持的 catalog 参数，并在 DB 与 MetricFlow adapter 中规范化 time-grain 查询；文档也明确 password 与私钥二选一、warehouse 必填，且通常不应设置 catalog。[#937](https://github.com/Datus-ai/Datus-agent/pull/937) [datus-db-adapters#70](https://github.com/Datus-ai/datus-db-adapters/pull/70) [datus-db-adapters#72](https://github.com/Datus-ai/datus-db-adapters/pull/72) [datus-semantic-adapter#27](https://github.com/Datus-ai/datus-semantic-adapter/pull/27) [datus-semantic-adapter#28](https://github.com/Datus-ai/datus-semantic-adapter/pull/28) [datus-semantic-adapter#29](https://github.com/Datus-ai/datus-semantic-adapter/pull/29) [文档](configuration/datasources.zh.md)
+- **统一的 `gen_sql` 命名** - SQL 生成节点、工作流、配置、CLI 命令（`/gen_sql`）、prompt 模板和 sub-agent 名称统一为同一套 `gen_sql` 命名；使用旧 `generate_sql` / `sql_system` 配置的项目需要迁移。[#935](https://github.com/Datus-ai/Datus-agent/pull/935) [文档](configuration/nodes.zh.md)
+- **可配置的指标批量大小** - `bootstrap-kb --components metrics` 新增 `--metrics-batch-size`；需要逐条 success-story provenance 时设为 `1`，否则保留默认值 `5` 以维持原有吞吐。[#976](https://github.com/Datus-ai/Datus-agent/pull/976)
+
+**Bug 修复**
+
+- **按 Datasource 隔离的指标 Bootstrap** - 多 datasource 项目中指标 bootstrap 现按 datasource 做行级隔离，`overwrite` 不再删除其他 datasource 的 KB 数据，同时加固了 MetricFlow YAML merge、批次刷新、最终指标去重和 CLI 长输出截断。[#974](https://github.com/Datus-ai/Datus-agent/pull/974) [文档](qa/metric-bootstrap-generation-qa.zh.md)
+- **更稳健的语义指标查询与校验** - Snowflake 表坐标现能正确进入 semantic model 生成提示，多指标维度兼容性有 preflight 与拆分建议，临时 YAML 校验不再扫描无关父目录，非字符串/可空 PyArrow 结果也能安全展示。[#941](https://github.com/Datus-ai/Datus-agent/pull/941) [#946](https://github.com/Datus-ai/Datus-agent/pull/946)
+- **跨 Datasource 的 Subject 节点迁移** - 升级旧版 SQLite 存储时会迁移陈旧的 `subject_nodes` UNIQUE 约束，使同名 subject 节点可在不同 datasource 间共存，同时保持同一 datasource 内的去重。[#964](https://github.com/Datus-ai/Datus-agent/pull/964)
+- **一个 Datasource 路由到多个 Database** - 单个 datasource 现可路由到多个 database——文件 glob datasource、benchmark 任务、`/database` 切换、DB 工具和节点执行都按 `(datasource, database)` 选择连接，benchmark SQL 任务也可显式指定 datasource。[#961](https://github.com/Datus-ai/Datus-agent/pull/961) [#934](https://github.com/Datus-ai/Datus-agent/pull/934) [datus-db-adapters#71](https://github.com/Datus-ai/datus-db-adapters/pull/71)
+
 ### 0.3.3
 
 **新功能**


### PR DESCRIPTION
## Why

The 0.3.4 release ships a batch of metric-focused features, provider/CLI additions, and multi-datasource fixes that are not yet documented in the user-facing release notes.

## Solution

Add a new `### 0.3.4` section at the top of the 0.3 version list in both `docs/release_notes.md` (EN) and `docs/release_notes.zh.md` (ZH), following the established three-section format (New Features / Enhancements / Bug Fixes) with one user-facing sentence per bullet and PR/doc links.

- **New Features**: AskMetrics subagent (#954), OpenRouter provider (#973, #936), self-update commands (#949), orchestrator tools in print mode (#950)
- **Enhancements**: queryable-by-default metrics (#943, #962), scoped agent memory (#975), built-in knowledge extraction (#932), stronger Snowflake support (#937 + adapter PRs), unified `gen_sql` naming (#935), configurable metrics batch size (#976)
- **Bug Fixes**: datasource-isolated metrics bootstrap (#974), robust semantic metric query/validation (#941, #946), cross-datasource subject node migration (#964), one-datasource-to-multiple-databases (#961, #934)

The ZH file is a 1:1 structural mirror with `.zh.md` doc-link targets. All PR/issue links and doc paths were batch-verified (all 200). The English metric-bootstrap QA doc has no `.md` variant yet, so that `[docs]` link is included only in the ZH file to avoid shipping a 404.

## Test Cases

None — documentation-only change. No code paths are affected.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [x] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes documentation with version 0.3.4 release information covering new features, enhancements, and bug fixes across both English and Chinese language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->