### PR TITLE
[BugFix] Make offset derived metric bootstrap authoring-format agnostic

### DIFF
--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -114,6 +114,7 @@ Before generating metrics, verify that semantic models exist for all involved ta
 - Preserve `post_aggregation_constraints` such as HAVING clauses as query constraints, metric usage notes, or later derived data sources. Do not silently drop them or push them into base measures.
 - Treat `derived_metric_candidates` as second-stage metrics over existing or newly generated metrics. Generate non-derived metrics first, validate, refresh `list_metrics`, then generate derived metrics only when every referenced metric exists.
 - For period-over-period SQL that projects both a prior-period value and a delta/rate, generate both derived metrics. The prior-period value metric should use the shifted input alias as its `expr` (for example `{metric_name}_previous_period`), and the delta/rate metric should reference both the current metric and shifted input alias (for example `{metric_name}_period_delta`).
+- Materialize EVERY `derived_metric_candidates` entry whose inputs carry `offset_window`, including previous-period identity candidates whose `expr` is just the shifted input alias (for example `activity_count_previous_month`). A delta metric that references the same shifted alias does NOT replace the identity metric — publish both. The bootstrap host verifies offset candidate completeness after all batches and re-runs generation for anything missing.
 - Treat `identity_metric_references` as evidence that the SQL selected an existing metric without a new formula. Do not generate a new metric for those references.
 - Natural-language fields in the candidate plan (`question`, `name`, `summary`, or `source_context`) are naming and business-meaning evidence only. They should never override the SQL expression structure or turn a detail query into a metric by themselves.
 
@@ -345,6 +346,32 @@ metric:
   locked_metadata:
     tags:
       - "subject_tree: {domain}/{layer1}/{layer2}"
+```
+
+Period-over-period example — a MoM SQL like `LAG(activity_count) OVER (ORDER BY month)` yields TWO derived metrics, an identity metric for the prior-period value and a delta metric:
+```yaml
+metric:
+  name: activity_count_previous_month
+  description: "Activity count of the previous month"
+  type: derived
+  type_params:
+    metrics:
+      - name: activity_count
+        alias: activity_count_previous_month
+        offset_window: 1 month
+    expr: "activity_count_previous_month"
+---
+metric:
+  name: activity_count_mom_delta
+  description: "Month-over-month activity count delta"
+  type: derived
+  type_params:
+    metrics:
+      - name: activity_count
+      - name: activity_count
+        alias: activity_count_previous_month
+        offset_window: 1 month
+    expr: "activity_count - activity_count_previous_month"
 ```
 
 **cumulative** (running total over time):

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -114,7 +114,7 @@ Before generating metrics, verify that semantic models exist for all involved ta
 - Preserve `post_aggregation_constraints` such as HAVING clauses as query constraints, metric usage notes, or later derived data sources. Do not silently drop them or push them into base measures.
 - Treat `derived_metric_candidates` as second-stage metrics over existing or newly generated metrics. Generate non-derived metrics first, validate, refresh `list_metrics`, then generate derived metrics only when every referenced metric exists.
 - For period-over-period SQL that projects both a prior-period value and a delta/rate, generate both derived metrics. The prior-period value metric should use the shifted input alias as its `expr` (for example `{metric_name}_previous_period`), and the delta/rate metric should reference both the current metric and shifted input alias (for example `{metric_name}_period_delta`).
-- Materialize EVERY `derived_metric_candidates` entry whose inputs carry `offset_window`, including previous-period identity candidates whose `expr` is just the shifted input alias (for example `previous_month_activity_count`). A delta metric that references the same shifted alias does NOT replace the identity metric — publish both. The bootstrap host verifies offset candidate completeness after all batches and re-runs generation for anything missing.
+- Materialize EVERY `derived_metric_candidates` entry whose inputs carry `offset_window`, including previous-period identity candidates whose `expr` is just the shifted input alias (for example `previous_month_{metric_name}`). A delta metric that references the same shifted alias does NOT replace the identity metric — publish both. The bootstrap host verifies offset candidate completeness after all batches and re-runs generation for anything missing.
 - Use the candidate's `name` exactly as the published metric name. When a candidate lists `equivalent_names`, those are acceptable aliases for the same metric — publish ONE metric (prefer the candidate `name`), never one per alias.
 - Treat `identity_metric_references` as evidence that the SQL selected an existing metric without a new formula. Do not generate a new metric for those references.
 - Natural-language fields in the candidate plan (`question`, `name`, `summary`, or `source_context`) are naming and business-meaning evidence only. They should never override the SQL expression structure or turn a detail query into a metric by themselves.
@@ -349,30 +349,30 @@ metric:
       - "subject_tree: {domain}/{layer1}/{layer2}"
 ```
 
-Period-over-period example — a MoM SQL like `LAG(activity_count) OVER (ORDER BY month) AS previous_month_activity_count` yields TWO derived metrics, an identity metric for the prior-period value (named after the SQL alias) and a delta metric:
+Period-over-period example — a MoM SQL like `LAG(metric_a) OVER (ORDER BY month) AS previous_month_metric_a` yields TWO derived metrics, an identity metric for the prior-period value (named after the SQL alias) and a delta metric:
 ```yaml
 metric:
-  name: previous_month_activity_count
-  description: "Activity count of the previous month"
+  name: previous_month_metric_a
+  description: "{metric_a description} of the previous month"
   type: derived
   type_params:
     metrics:
-      - name: activity_count
-        alias: previous_month_activity_count
+      - name: metric_a
+        alias: previous_month_metric_a
         offset_window: 1 month
-    expr: "previous_month_activity_count"
+    expr: "previous_month_metric_a"
 ---
 metric:
-  name: activity_count_mom_delta
-  description: "Month-over-month activity count delta"
+  name: metric_a_mom_delta
+  description: "Month-over-month {metric_a description} delta"
   type: derived
   type_params:
     metrics:
-      - name: activity_count
-      - name: activity_count
-        alias: previous_month_activity_count
+      - name: metric_a
+      - name: metric_a
+        alias: previous_month_metric_a
         offset_window: 1 month
-    expr: "activity_count - previous_month_activity_count"
+    expr: "metric_a - previous_month_metric_a"
 ```
 
 **cumulative** (running total over time):

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -114,7 +114,8 @@ Before generating metrics, verify that semantic models exist for all involved ta
 - Preserve `post_aggregation_constraints` such as HAVING clauses as query constraints, metric usage notes, or later derived data sources. Do not silently drop them or push them into base measures.
 - Treat `derived_metric_candidates` as second-stage metrics over existing or newly generated metrics. Generate non-derived metrics first, validate, refresh `list_metrics`, then generate derived metrics only when every referenced metric exists.
 - For period-over-period SQL that projects both a prior-period value and a delta/rate, generate both derived metrics. The prior-period value metric should use the shifted input alias as its `expr` (for example `{metric_name}_previous_period`), and the delta/rate metric should reference both the current metric and shifted input alias (for example `{metric_name}_period_delta`).
-- Materialize EVERY `derived_metric_candidates` entry whose inputs carry `offset_window`, including previous-period identity candidates whose `expr` is just the shifted input alias (for example `activity_count_previous_month`). A delta metric that references the same shifted alias does NOT replace the identity metric — publish both. The bootstrap host verifies offset candidate completeness after all batches and re-runs generation for anything missing.
+- Materialize EVERY `derived_metric_candidates` entry whose inputs carry `offset_window`, including previous-period identity candidates whose `expr` is just the shifted input alias (for example `previous_month_activity_count`). A delta metric that references the same shifted alias does NOT replace the identity metric — publish both. The bootstrap host verifies offset candidate completeness after all batches and re-runs generation for anything missing.
+- Use the candidate's `name` exactly as the published metric name. When a candidate lists `equivalent_names`, those are acceptable aliases for the same metric — publish ONE metric (prefer the candidate `name`), never one per alias.
 - Treat `identity_metric_references` as evidence that the SQL selected an existing metric without a new formula. Do not generate a new metric for those references.
 - Natural-language fields in the candidate plan (`question`, `name`, `summary`, or `source_context`) are naming and business-meaning evidence only. They should never override the SQL expression structure or turn a detail query into a metric by themselves.
 
@@ -348,18 +349,18 @@ metric:
       - "subject_tree: {domain}/{layer1}/{layer2}"
 ```
 
-Period-over-period example — a MoM SQL like `LAG(activity_count) OVER (ORDER BY month)` yields TWO derived metrics, an identity metric for the prior-period value and a delta metric:
+Period-over-period example — a MoM SQL like `LAG(activity_count) OVER (ORDER BY month) AS previous_month_activity_count` yields TWO derived metrics, an identity metric for the prior-period value (named after the SQL alias) and a delta metric:
 ```yaml
 metric:
-  name: activity_count_previous_month
+  name: previous_month_activity_count
   description: "Activity count of the previous month"
   type: derived
   type_params:
     metrics:
       - name: activity_count
-        alias: activity_count_previous_month
+        alias: previous_month_activity_count
         offset_window: 1 month
-    expr: "activity_count_previous_month"
+    expr: "previous_month_activity_count"
 ---
 metric:
   name: activity_count_mom_delta
@@ -369,9 +370,9 @@ metric:
     metrics:
       - name: activity_count
       - name: activity_count
-        alias: activity_count_previous_month
+        alias: previous_month_activity_count
         offset_window: 1 month
-    expr: "activity_count - activity_count_previous_month"
+    expr: "activity_count - previous_month_activity_count"
 ```
 
 **cumulative** (running total over time):

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -569,7 +569,16 @@ def _expand_offset_identity_candidates(derived_candidates: Any) -> list[Any]:
             continue
         variants = [candidate]
         if candidate.get("name") and _is_offset_derived_candidate(candidate):
-            variants.extend(_offset_identity_alias_candidates(candidate))
+            alias_variants = _offset_identity_alias_candidates(candidate)
+            if alias_variants:
+                # Mark equivalent names as one group: the generation agent may
+                # publish the metric under any of them, and the completeness
+                # check treats the group as satisfied once one name exists.
+                group_name = _normalize_metric_name(alias_variants[0].get("name"))
+                candidate = {**candidate, "offset_identity_group": group_name}
+                for alias_variant in alias_variants:
+                    alias_variant["offset_identity_group"] = group_name
+                variants = [candidate, *alias_variants]
         for variant in variants:
             normalized = _normalize_metric_name(variant.get("name"))
             if normalized:
@@ -654,23 +663,45 @@ def _missing_offset_derived_candidates(
         return []
 
     existing_by_name, ambiguous_existing_names = _unique_metric_catalog_by_name(existing_metric_catalog)
+
+    identity_group_names: dict[str, set[str]] = {}
+    for candidate in derived_candidates:
+        if not isinstance(candidate, dict):
+            continue
+        group = _normalize_metric_name(candidate.get("offset_identity_group"))
+        normalized_name = _normalize_metric_name(candidate.get("name"))
+        if group and normalized_name:
+            identity_group_names.setdefault(group, set()).add(normalized_name)
+
     missing: list[dict[str, Any]] = []
     seen: set[str] = set()
+    satisfied_or_reported_groups: set[str] = set()
     for candidate in derived_candidates:
         if not (isinstance(candidate, dict) and candidate.get("name") and _is_offset_derived_candidate(candidate)):
             continue
         normalized_name = _normalize_metric_name(candidate.get("name"))
         if not normalized_name or normalized_name in seen:
             continue
+        seen.add(normalized_name)
         if normalized_name in ambiguous_existing_names or normalized_name in existing_by_name:
             continue
+        group = _normalize_metric_name(candidate.get("offset_identity_group"))
+        if group:
+            if group in satisfied_or_reported_groups:
+                continue
+            # Equivalent names (mined alias vs canonical {base}_previous_{grain})
+            # describe one metric; any of them existing satisfies the group.
+            if identity_group_names.get(group, set()) & set(existing_by_name):
+                satisfied_or_reported_groups.add(group)
+                continue
         input_names = _candidate_input_metric_names(candidate)
         if not input_names or input_names & ambiguous_existing_names:
             continue
         if not input_names <= set(existing_by_name):
             continue
         missing.append(candidate)
-        seen.add(normalized_name)
+        if group:
+            satisfied_or_reported_groups.add(group)
     return missing
 
 

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -345,7 +345,7 @@ def _build_candidate_plan(
         plan = dict(result.result or {})
         plan["available"] = True
         plan["sql_to_table_lineage"] = _build_sql_to_table_lineage(sql_entries, agent_config)
-        plan["derived_metric_candidates"] = _expand_offset_identity_candidates(plan.get("derived_metric_candidates"))
+        plan["derived_metric_candidates"] = _annotate_offset_identity_candidates(plan.get("derived_metric_candidates"))
         return plan
     except Exception as exc:  # pragma: no cover - defensive; agent can still infer from SQL prompt
         logger.warning("Metric candidate extraction raised; continuing without a candidate plan: %s", exc)
@@ -553,40 +553,28 @@ def _candidate_input_metric_names(candidate: dict[str, Any]) -> set[str]:
     return names
 
 
-def _expand_offset_identity_candidates(derived_candidates: Any) -> list[Any]:
-    """Expand offset derived candidates with previous-period identity alias variants.
+def _annotate_offset_identity_candidates(derived_candidates: Any) -> list[Any]:
+    """Annotate offset identity candidates with their canonical equivalent names.
 
     Identity candidates mined from SQL keep their historical alias (e.g.
-    ``previous_month_activity_count``); the canonical ``{base}_previous_{grain}``
-    variant is added alongside so the generation agent sees both names. Operates
-    purely on structured candidates, independent of any authoring format.
+    ``previous_month_activity_count``) as the metric name the agent should
+    publish; the canonical ``{base}_previous_{grain}`` variant is recorded in
+    ``equivalent_names`` so the completeness check accepts either name without
+    tempting the agent to rename the metric. Operates purely on structured
+    candidates, independent of any authoring format.
     """
-    expanded: list[Any] = []
-    seen: set[str] = set()
+    annotated: list[Any] = []
     for candidate in derived_candidates or []:
         if not isinstance(candidate, dict):
-            expanded.append(candidate)
+            annotated.append(candidate)
             continue
-        variants = [candidate]
         if candidate.get("name") and _is_offset_derived_candidate(candidate):
             alias_variants = _offset_identity_alias_candidates(candidate)
-            if alias_variants:
-                # Mark equivalent names as one group: the generation agent may
-                # publish the metric under any of them, and the completeness
-                # check treats the group as satisfied once one name exists.
-                group_name = _normalize_metric_name(alias_variants[0].get("name"))
-                candidate = {**candidate, "offset_identity_group": group_name}
-                for alias_variant in alias_variants:
-                    alias_variant["offset_identity_group"] = group_name
-                variants = [candidate, *alias_variants]
-        for variant in variants:
-            normalized = _normalize_metric_name(variant.get("name"))
-            if normalized:
-                if normalized in seen:
-                    continue
-                seen.add(normalized)
-            expanded.append(variant)
-    return expanded
+            equivalent_names = [str(variant.get("name")).strip() for variant in alias_variants if variant.get("name")]
+            if equivalent_names:
+                candidate = {**candidate, "equivalent_names": equivalent_names}
+        annotated.append(candidate)
+    return annotated
 
 
 def _offset_identity_alias_candidates(candidate: dict[str, Any]) -> list[dict[str, Any]]:
@@ -663,19 +651,8 @@ def _missing_offset_derived_candidates(
         return []
 
     existing_by_name, ambiguous_existing_names = _unique_metric_catalog_by_name(existing_metric_catalog)
-
-    identity_group_names: dict[str, set[str]] = {}
-    for candidate in derived_candidates:
-        if not isinstance(candidate, dict):
-            continue
-        group = _normalize_metric_name(candidate.get("offset_identity_group"))
-        normalized_name = _normalize_metric_name(candidate.get("name"))
-        if group and normalized_name:
-            identity_group_names.setdefault(group, set()).add(normalized_name)
-
     missing: list[dict[str, Any]] = []
     seen: set[str] = set()
-    satisfied_or_reported_groups: set[str] = set()
     for candidate in derived_candidates:
         if not (isinstance(candidate, dict) and candidate.get("name") and _is_offset_derived_candidate(candidate)):
             continue
@@ -683,25 +660,19 @@ def _missing_offset_derived_candidates(
         if not normalized_name or normalized_name in seen:
             continue
         seen.add(normalized_name)
-        if normalized_name in ambiguous_existing_names or normalized_name in existing_by_name:
+        # Equivalent names (mined alias vs canonical {base}_previous_{grain})
+        # describe one metric; any of them existing satisfies the candidate.
+        candidate_names = {normalized_name} | {
+            _normalize_metric_name(name) for name in candidate.get("equivalent_names") or [] if name
+        }
+        if candidate_names & ambiguous_existing_names or candidate_names & set(existing_by_name):
             continue
-        group = _normalize_metric_name(candidate.get("offset_identity_group"))
-        if group:
-            if group in satisfied_or_reported_groups:
-                continue
-            # Equivalent names (mined alias vs canonical {base}_previous_{grain})
-            # describe one metric; any of them existing satisfies the group.
-            if identity_group_names.get(group, set()) & set(existing_by_name):
-                satisfied_or_reported_groups.add(group)
-                continue
         input_names = _candidate_input_metric_names(candidate)
         if not input_names or input_names & ambiguous_existing_names:
             continue
         if not input_names <= set(existing_by_name):
             continue
         missing.append(candidate)
-        if group:
-            satisfied_or_reported_groups.add(group)
     return missing
 
 

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 import pandas as pd
-import yaml
 
 from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 from datus.configuration.agent_config import AgentConfig
@@ -346,6 +345,7 @@ def _build_candidate_plan(
         plan = dict(result.result or {})
         plan["available"] = True
         plan["sql_to_table_lineage"] = _build_sql_to_table_lineage(sql_entries, agent_config)
+        plan["derived_metric_candidates"] = _expand_offset_identity_candidates(plan.get("derived_metric_candidates"))
         return plan
     except Exception as exc:  # pragma: no cover - defensive; agent can still infer from SQL prompt
         logger.warning("Metric candidate extraction raised; continuing without a candidate plan: %s", exc)
@@ -553,48 +553,31 @@ def _candidate_input_metric_names(candidate: dict[str, Any]) -> set[str]:
     return names
 
 
-def _candidate_subject_tags(candidate: dict[str, Any], existing_by_name: dict[str, dict[str, Any]]) -> list[str]:
-    tags: list[str] = []
-    for input_name in _candidate_input_metric_names(candidate):
-        subject_path = existing_by_name.get(input_name, {}).get("subject_path")
-        if isinstance(subject_path, list) and subject_path:
-            joined = "/".join(str(part) for part in subject_path if str(part).strip())
-            if joined:
-                tags.extend([joined, f"subject_tree: {joined}"])
-                break
-    return tags
+def _expand_offset_identity_candidates(derived_candidates: Any) -> list[Any]:
+    """Expand offset derived candidates with previous-period identity alias variants.
 
-
-def _derived_metric_doc(candidate: dict[str, Any], existing_by_name: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    metric_inputs: list[dict[str, Any]] = []
-    for item in candidate.get("inputs") or []:
-        if not isinstance(item, dict) or not item.get("name"):
+    Identity candidates mined from SQL keep their historical alias (e.g.
+    ``previous_month_activity_count``); the canonical ``{base}_previous_{grain}``
+    variant is added alongside so the generation agent sees both names. Operates
+    purely on structured candidates, independent of any authoring format.
+    """
+    expanded: list[Any] = []
+    seen: set[str] = set()
+    for candidate in derived_candidates or []:
+        if not isinstance(candidate, dict):
+            expanded.append(candidate)
             continue
-        metric_input = {"name": str(item["name"]).strip()}
-        alias = str(item.get("alias") or "").strip()
-        offset_window = str(item.get("offset_window") or "").strip()
-        offset_to_grain = str(item.get("offset_to_grain") or "").strip()
-        if alias:
-            metric_input["alias"] = alias
-        if offset_window:
-            metric_input["offset_window"] = offset_window
-        if offset_to_grain:
-            metric_input["offset_to_grain"] = offset_to_grain
-        metric_inputs.append(metric_input)
-
-    metric: dict[str, Any] = {
-        "name": str(candidate["name"]).strip(),
-        "description": str(candidate.get("description") or candidate.get("source_alias") or candidate["name"]).strip(),
-        "type": "derived",
-        "type_params": {
-            "metrics": metric_inputs,
-            "expr": str(candidate.get("expression") or candidate["name"]).strip(),
-        },
-    }
-    tags = _candidate_subject_tags(candidate, existing_by_name)
-    if tags:
-        metric["locked_metadata"] = {"tags": tags}
-    return {"metric": metric}
+        variants = [candidate]
+        if candidate.get("name") and _is_offset_derived_candidate(candidate):
+            variants.extend(_offset_identity_alias_candidates(candidate))
+        for variant in variants:
+            normalized = _normalize_metric_name(variant.get("name"))
+            if normalized:
+                if normalized in seen:
+                    continue
+                seen.add(normalized)
+            expanded.append(variant)
+    return expanded
 
 
 def _offset_identity_alias_candidates(candidate: dict[str, Any]) -> list[dict[str, Any]]:
@@ -638,50 +621,6 @@ def _offset_identity_alias_candidates(candidate: dict[str, Any]) -> list[dict[st
     return [equivalent]
 
 
-def _load_metric_doc_names(metric_file: Path) -> set[str]:
-    if not metric_file.exists():
-        return set()
-    try:
-        docs = list(yaml.safe_load_all(metric_file.read_text(encoding="utf-8")))
-    except Exception:
-        return set()
-    names: set[str] = set()
-    for doc in docs:
-        if not isinstance(doc, dict):
-            continue
-        metric = doc.get("metric")
-        if isinstance(metric, dict):
-            normalized = _normalize_metric_name(metric.get("name"))
-            if normalized:
-                names.add(normalized)
-    return names
-
-
-def _append_metric_docs(metric_file: Path, docs: list[dict[str, Any]]) -> None:
-    metric_file.parent.mkdir(parents=True, exist_ok=True)
-    rendered = "\n---\n".join(
-        yaml.safe_dump(doc, allow_unicode=True, sort_keys=False).strip() for doc in docs if isinstance(doc, dict)
-    )
-    if not rendered:
-        return
-    if metric_file.exists() and metric_file.read_text(encoding="utf-8").strip():
-        with metric_file.open("a", encoding="utf-8") as handle:
-            handle.write("\n\n---\n")
-            handle.write(rendered)
-            handle.write("\n")
-    else:
-        metric_file.write_text(f"{rendered}\n", encoding="utf-8")
-
-
-def _restore_metric_file(metric_file: Path, previous_content: Optional[str]) -> None:
-    if previous_content is None:
-        if metric_file.exists():
-            metric_file.unlink()
-        return
-    metric_file.parent.mkdir(parents=True, exist_ok=True)
-    metric_file.write_text(previous_content, encoding="utf-8")
-
-
 def _unique_metric_catalog_by_name(
     existing_metric_catalog: list[dict[str, Any]],
 ) -> tuple[dict[str, dict[str, Any]], set[str]]:
@@ -698,160 +637,127 @@ def _unique_metric_catalog_by_name(
     return unique, ambiguous
 
 
-def _auto_generate_offset_derived_metrics(
+def _missing_offset_derived_candidates(
     candidate_plan: dict[str, Any],
     existing_metric_catalog: list[dict[str, Any]],
-    agent_config: AgentConfig,
-) -> dict[str, Any]:
-    """Deterministically materialize MetricFlow offset-window derived metrics from mined SQL evidence."""
+) -> list[dict[str, Any]]:
+    """Return offset derived candidates whose inputs exist but which are absent from the catalog.
+
+    Pure completeness check over structured candidates and the metric catalog;
+    it never inspects or renders authoring YAML, so it is independent of the
+    authoring format (MetricFlow, OSI, ...).
+    """
     if not candidate_plan or not candidate_plan.get("available"):
-        return {"generated_metric_names": [], "metric_artifact_ids": []}
+        return []
     derived_candidates = candidate_plan.get("derived_metric_candidates")
     if not isinstance(derived_candidates, list):
-        return {"generated_metric_names": [], "metric_artifact_ids": []}
-    offset_candidates = [
-        candidate
-        for candidate in derived_candidates
-        if isinstance(candidate, dict) and candidate.get("name") and _is_offset_derived_candidate(candidate)
-    ]
-    if not offset_candidates:
-        return {"generated_metric_names": [], "metric_artifact_ids": []}
-    expanded_offset_candidates: list[dict[str, Any]] = []
-    seen_candidate_names: set[str] = set()
-    for candidate in offset_candidates:
-        for expanded_candidate in [candidate, *_offset_identity_alias_candidates(candidate)]:
-            normalized = _normalize_metric_name(expanded_candidate.get("name"))
-            if not normalized or normalized in seen_candidate_names:
-                continue
-            expanded_offset_candidates.append(expanded_candidate)
-            seen_candidate_names.add(normalized)
+        return []
 
     existing_by_name, ambiguous_existing_names = _unique_metric_catalog_by_name(existing_metric_catalog)
-    metric_file = (
-        agent_config.path_manager.semantic_model_path(agent_config.current_datasource)
-        / "metrics"
-        / "auto_offset_derived_metrics.yml"
-    )
-    file_metric_names = _load_metric_doc_names(metric_file)
-
-    docs: list[dict[str, Any]] = []
-    generated_names: list[str] = []
-    resync_names: set[str] = set()
-    for candidate in expanded_offset_candidates:
+    missing: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in derived_candidates:
+        if not (isinstance(candidate, dict) and candidate.get("name") and _is_offset_derived_candidate(candidate)):
+            continue
         normalized_name = _normalize_metric_name(candidate.get("name"))
-        if not normalized_name:
+        if not normalized_name or normalized_name in seen:
             continue
-        if normalized_name in ambiguous_existing_names:
-            logger.warning("Skipping auto offset metric %s because existing metric name is ambiguous", normalized_name)
-            continue
-        if normalized_name in existing_by_name:
+        if normalized_name in ambiguous_existing_names or normalized_name in existing_by_name:
             continue
         input_names = _candidate_input_metric_names(candidate)
-        if not input_names:
-            continue
-        if input_names & ambiguous_existing_names:
-            logger.warning(
-                "Skipping auto offset metric %s because input metric names are ambiguous: %s",
-                normalized_name,
-                sorted(input_names & ambiguous_existing_names),
-            )
+        if not input_names or input_names & ambiguous_existing_names:
             continue
         if not input_names <= set(existing_by_name):
             continue
-        if normalized_name in file_metric_names:
-            resync_names.add(normalized_name)
-            continue
-        docs.append(_derived_metric_doc(candidate, existing_by_name))
-        generated_names.append(str(candidate["name"]).strip())
-        file_metric_names.add(normalized_name)
+        missing.append(candidate)
+        seen.add(normalized_name)
+    return missing
 
-    if not docs and not resync_names:
-        return {"generated_metric_names": [], "metric_artifact_ids": []}
 
-    previous_metric_file_content = metric_file.read_text(encoding="utf-8") if metric_file.exists() else None
-    if docs:
-        _append_metric_docs(metric_file, docs)
+async def _ensure_offset_derived_metrics(
+    candidate_plan: dict[str, Any],
+    agent_config: AgentConfig,
+    subject_tree: Optional[list],
+    extra_instructions: Optional[str],
+    event_helper: Optional[BatchEventHelper],
+    action_callback: Optional[Callable[["ActionHistory"], None]],
+    all_query_records: list[dict[str, Any]],
+    total_batches: int,
+) -> dict[str, Any]:
+    """Verify offset derived candidates landed in the metric store; retry the missing ones once.
 
-    from datus.tools.func_tool.generation_tools import GenerationTools
-    from datus.tools.func_tool.semantic_tools import SemanticTools
+    The retry re-runs the regular gen_metrics agent with a focused instruction,
+    so the metric YAML is always authored by the LLM in whatever format the
+    node is configured for. Candidates still missing afterwards are reported,
+    never silently dropped.
+    """
+    catalog = _build_existing_metric_catalog(agent_config)
+    missing = _missing_offset_derived_candidates(candidate_plan, catalog)
+    if not missing:
+        return {"generated": [], "missing": [], "retried": False}
 
-    semantic_tools = SemanticTools(agent_config=agent_config, sub_agent_name=METRICS_NODE_NAME)
-    validation = semantic_tools.validate_semantic(scope="all")
-    if not validation.success:
-        logger.warning(
-            "Auto-generated offset derived metrics failed validation: %s",
-            validation.error,
+    missing_names = [str(candidate.get("name")).strip() for candidate in missing]
+    missing_sources: set[str] = set()
+    for candidate in missing:
+        missing_sources |= _source_names(
+            candidate.get("source_sql_name") or candidate.get("source") or candidate.get("sql_name")
         )
-        if docs:
-            _restore_metric_file(metric_file, previous_metric_file_content)
-        return {"generated_metric_names": [], "metric_artifact_ids": [], "error": validation.error}
+    retry_records = [record for record in all_query_records if record.get("source_sql_name") in missing_sources]
+    retry_queries = [record["query"] for record in retry_records] or [
+        "Materialize the missing offset derived metric candidates listed in the candidate plan."
+    ]
 
-    metric_sqls: dict[str, str] = {}
-    for name in generated_names:
-        candidate = next(
-            (item for item in expanded_offset_candidates if item.get("name") == name),
-            {},
-        )
-        grain = _offset_grain(candidate.get("offset_window"))
-        dimensions = [f"metric_time__{grain}"] if grain else []
-        dry_run = semantic_tools.query_metrics(
-            metrics=[name],
-            dimensions=dimensions,
-            time_granularity=grain,
-            dry_run=True,
-        )
-        if dry_run.success and isinstance(dry_run.result, dict):
-            metadata = dry_run.result.get("metadata") if isinstance(dry_run.result.get("metadata"), dict) else {}
-            sql = metadata.get("sql")
-            if isinstance(sql, str) and sql.strip():
-                metric_sqls[name] = sql
-
-    metric_names_to_sync = set(generated_names) | resync_names
-    sync = GenerationTools(agent_config=agent_config)._sync_metric_to_db(
-        str(metric_file),
-        metric_sqls=metric_sqls,
-        metric_names_to_sync=metric_names_to_sync,
+    retry_plan = dict(candidate_plan)
+    retry_plan["derived_metric_candidates"] = missing
+    retry_plan["summary"] = f"Offset completeness retry for {len(missing)} derived metric candidate(s)."
+    retry_instructions = (
+        "Offset completeness retry: the following offset derived metric candidates were mined from the "
+        f"success-story SQL but are still missing from the metric store: {', '.join(missing_names)}. "
+        "Materialize EVERY one of them as a derived metric over its existing input metrics, including "
+        "previous-period identity metrics whose expression is just the offset input alias."
     )
-    if not sync.get("success"):
-        logger.warning("Auto-generated offset derived metrics failed to sync: %s", sync.get("error"))
-        if docs:
-            _restore_metric_file(metric_file, previous_metric_file_content)
-        return {"generated_metric_names": [], "metric_artifact_ids": [], "error": sync.get("error")}
+    if extra_instructions:
+        retry_instructions = f"{extra_instructions}\n\n{retry_instructions}"
 
-    synced_names = [*generated_names, *sorted(resync_names)]
-    artifact_ids = [f"metric:{name}" for name in synced_names]
-    logger.info("Auto-generated/resynced %d offset derived metric(s): %s", len(synced_names), synced_names)
-    return {
-        "generated_metric_names": synced_names,
-        "metric_artifact_ids": artifact_ids,
-        "metric_file": str(metric_file),
-        "metric_sqls": metric_sqls,
-        "sync": sync,
+    logger.info("Retrying %d missing offset derived metric(s): %s", len(missing_names), missing_names)
+    source_entries = [record["source"] for record in retry_records if record.get("source")]
+    metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
+    success, error, batch_result = await _generate_metrics_batch(
+        retry_queries,
+        total_batches,
+        agent_config,
+        subject_tree,
+        retry_instructions,
+        event_helper,
+        action_callback,
+        candidate_plan_json=_json_dump_compact(retry_plan),
+        existing_metric_catalog_json=_json_dump_compact(catalog),
+    )
+    if not success:
+        logger.warning("Offset completeness retry batch failed: %s", error)
+
+    provenance_entries = 0
+    if source_entries:
+        new_artifact_ids = sorted(_metric_ids_in_storage(agent_config) - metric_ids_before)
+        if new_artifact_ids:
+            provenance_entries = _sync_metric_provenance(agent_config, new_artifact_ids, source_entries)
+
+    refreshed_catalog = _build_existing_metric_catalog(agent_config)
+    still_missing_names = {
+        _normalize_metric_name(candidate.get("name"))
+        for candidate in _missing_offset_derived_candidates(candidate_plan, refreshed_catalog)
     }
-
-
-def _append_auto_offset_result(
-    batch_result: dict[str, Any],
-    auto_derived_result: dict[str, Any],
-    provenance_entries: int = 0,
-) -> None:
-    """Attach deterministic offset-derived metric artifacts to a batch result."""
-    generated_names = list(auto_derived_result.get("generated_metric_names") or [])
-    artifact_ids = list(auto_derived_result.get("metric_artifact_ids") or [])
-    if generated_names:
-        existing_names = batch_result.setdefault("auto_generated_offset_derived_metrics", [])
-        if isinstance(existing_names, list):
-            for name in generated_names:
-                if name not in existing_names:
-                    existing_names.append(name)
-    if artifact_ids:
-        existing_ids = batch_result.setdefault("_synced_metric_artifact_ids", [])
-        if isinstance(existing_ids, list):
-            for artifact_id in artifact_ids:
-                if artifact_id not in existing_ids:
-                    existing_ids.append(artifact_id)
-    if provenance_entries:
-        batch_result["provenance_entries"] = batch_result.get("provenance_entries", 0) + provenance_entries
+    generated = [name for name in missing_names if _normalize_metric_name(name) not in still_missing_names]
+    unresolved = [name for name in missing_names if _normalize_metric_name(name) in still_missing_names]
+    if unresolved:
+        logger.warning("Offset derived metric(s) still missing after completeness retry: %s", unresolved)
+    return {
+        "generated": generated,
+        "missing": unresolved,
+        "retried": True,
+        "provenance_entries": provenance_entries,
+        "batch_result": batch_result if isinstance(batch_result, dict) else None,
+    }
 
 
 async def _generate_metrics_batch(
@@ -1098,26 +1004,9 @@ async def init_success_story_metrics_async(
 
         logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
 
-        auto_derived_result = _auto_generate_offset_derived_metrics(
-            batch_candidate_plan,
-            existing_metric_catalog,
-            agent_config,
-        )
-        auto_metric_artifact_ids = list(auto_derived_result.get("metric_artifact_ids") or [])
-        if auto_metric_artifact_ids:
-            batch_provenance_entries = _sync_metric_provenance(agent_config, auto_metric_artifact_ids, source_entries)
-            provenance_entries += batch_provenance_entries
-            auto_derived_result["provenance_entries"] = batch_provenance_entries
-            existing_metric_catalog = _build_existing_metric_catalog(agent_config)
-            existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
-
         metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
 
-        auto_satisfied = bool(auto_metric_artifact_ids) and _all_candidate_metrics_satisfied(
-            batch_candidate_plan,
-            existing_metric_catalog,
-        )
-        if (build_mode == "incremental" or auto_satisfied) and _all_candidate_metrics_satisfied(
+        if build_mode == "incremental" and _all_candidate_metrics_satisfied(
             batch_candidate_plan,
             existing_metric_catalog,
         ):
@@ -1151,12 +1040,6 @@ async def init_success_story_metrics_async(
                 "skipped_queries": len(batch_records),
                 "skipped_metric_candidates": skipped_names,
             }
-            if auto_metric_artifact_ids:
-                batch_result["auto_generated_offset_derived_metrics"] = auto_derived_result.get(
-                    "generated_metric_names", []
-                )
-                batch_result["_synced_metric_artifact_ids"] = auto_metric_artifact_ids
-                batch_result["provenance_entries"] = auto_derived_result.get("provenance_entries", 0)
             if merged_result is None:
                 merged_result = batch_result
             elif isinstance(merged_result, dict):
@@ -1238,29 +1121,6 @@ async def init_success_story_metrics_async(
                     batch_result.get("provenance_entries", 0) + batch_provenance_entries
                 )
 
-            if isinstance(batch_result, dict):
-                refreshed_catalog = _build_existing_metric_catalog(agent_config)
-                post_auto_derived_result = _auto_generate_offset_derived_metrics(
-                    batch_candidate_plan,
-                    refreshed_catalog,
-                    agent_config,
-                )
-                post_auto_metric_artifact_ids = list(post_auto_derived_result.get("metric_artifact_ids") or [])
-                if post_auto_metric_artifact_ids:
-                    post_auto_provenance_entries = _sync_metric_provenance(
-                        agent_config,
-                        post_auto_metric_artifact_ids,
-                        source_entries,
-                    )
-                    provenance_entries += post_auto_provenance_entries
-                    _append_auto_offset_result(
-                        batch_result,
-                        post_auto_derived_result,
-                        provenance_entries=post_auto_provenance_entries,
-                    )
-                    existing_metric_catalog = _build_existing_metric_catalog(agent_config)
-                    existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
-
             if merged_result is None:
                 merged_result = batch_result
             elif isinstance(merged_result, dict) and isinstance(batch_result, dict):
@@ -1301,6 +1161,21 @@ async def init_success_story_metrics_async(
         logger.warning(f"Metrics extraction partially succeeded: {partial_error}")
 
     if isinstance(merged_result, dict):
+        offset_completeness = await _ensure_offset_derived_metrics(
+            candidate_plan=candidate_plan,
+            agent_config=agent_config,
+            subject_tree=subject_tree,
+            extra_instructions=extra_instructions,
+            event_helper=event_helper,
+            action_callback=action_callback,
+            all_query_records=all_query_records,
+            total_batches=total_batches,
+        )
+        if offset_completeness.get("retried"):
+            provenance_entries += offset_completeness.get("provenance_entries", 0)
+            merged_result["offset_retry_generated_metrics"] = offset_completeness.get("generated", [])
+        if offset_completeness.get("missing"):
+            merged_result["missing_offset_derived_metrics"] = offset_completeness["missing"]
         if provenance_entries:
             merged_result["provenance_entries"] = provenance_entries
         final_metrics_count = _final_metric_count(agent_config)

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -1562,6 +1562,8 @@ class TestExpandOffsetIdentityCandidates:
         assert alias_variant["source_sql_name"] == "sql_25"
         assert alias_variant["inputs"][0]["offset_window"] == "1 month"
         assert alias_variant["inputs"][0]["alias"] == "activity_count_previous_month"
+        assert expanded[0]["offset_identity_group"] == "activity_count_previous_month"
+        assert alias_variant["offset_identity_group"] == "activity_count_previous_month"
 
     def test_preserves_non_offset_items_and_dedupes(self):
         simple = {"name": "activity_count", "metric_type": "simple", "inputs": []}
@@ -1686,6 +1688,32 @@ class TestMissingOffsetDerivedCandidates:
         assert _missing_offset_derived_candidates(_offset_plan(), ambiguous_catalog) == []
         assert _missing_offset_derived_candidates(_offset_plan(), []) == []
         assert _missing_offset_derived_candidates({"available": False}, []) == []
+
+    def test_identity_group_satisfied_by_any_equivalent_name(self):
+        plan = _offset_plan()
+        plan["derived_metric_candidates"] = _expand_offset_identity_candidates(plan["derived_metric_candidates"])
+
+        catalog_canonical_name = [
+            {"name": "activity_count", "type": "measure_proxy"},
+            {"name": "activity_count_previous_month", "type": "derived"},
+            {"name": "activity_count_mom_delta", "type": "derived"},
+        ]
+        assert _missing_offset_derived_candidates(plan, catalog_canonical_name) == []
+
+        catalog_original_alias = [
+            {"name": "activity_count", "type": "measure_proxy"},
+            {"name": "previous_month_activity_count", "type": "derived"},
+            {"name": "activity_count_mom_delta", "type": "derived"},
+        ]
+        assert _missing_offset_derived_candidates(plan, catalog_original_alias) == []
+
+    def test_identity_group_reported_once_when_fully_missing(self):
+        plan = _offset_plan()
+        plan["derived_metric_candidates"] = _expand_offset_identity_candidates(plan["derived_metric_candidates"])
+
+        catalog = [{"name": "activity_count", "type": "measure_proxy"}]
+        missing_names = [candidate["name"] for candidate in _missing_offset_derived_candidates(plan, catalog)]
+        assert missing_names == ["previous_month_activity_count", "activity_count_mom_delta"]
 
 
 @pytest.mark.ci

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -14,14 +14,13 @@ from datus.storage.metric.metric_init import (
     BIZ_NAME,
     DEFAULT_METRICS_BATCH_SIZE,
     _action_status_value,
-    _append_auto_offset_result,
-    _append_metric_docs,
-    _auto_generate_offset_derived_metrics,
-    _derived_metric_doc,
+    _build_candidate_plan,
+    _ensure_offset_derived_metrics,
+    _expand_offset_identity_candidates,
     _extract_metric_artifact_ids,
     _generate_metrics_batch,
     _is_offset_derived_candidate,
-    _load_metric_doc_names,
+    _missing_offset_derived_candidates,
     _offset_grain,
     _offset_identity_alias_candidates,
     _source_provenance_from_row,
@@ -1192,50 +1191,9 @@ class TestBatchHasNoMetricCandidates:
         assert _batch_has_no_metric_candidates(plan) is False
 
 
-class TestAutoGenerateOffsetDerivedMetrics:
-    def _config(self, tmp_path):
-        semantic_root = tmp_path / "subject" / "semantic_models" / "starrocks"
-        path_manager = SimpleNamespace(semantic_model_path=lambda datasource: semantic_root)
-        return SimpleNamespace(current_datasource="starrocks", path_manager=path_manager)
-
-    def _candidate_plan(self):
-        return {
-            "available": True,
-            "derived_metric_candidates": [
-                {
-                    "name": "previous_month_activity_count",
-                    "metric_type": "derived",
-                    "expression": "previous_month_activity_count",
-                    "inputs": [
-                        {
-                            "name": "activity_count",
-                            "alias": "previous_month_activity_count",
-                            "offset_window": "1 month",
-                        }
-                    ],
-                    "offset_window": "1 month",
-                },
-                {
-                    "name": "activity_count_mom_delta",
-                    "metric_type": "derived",
-                    "expression": "activity_count - previous_month_activity_count",
-                    "inputs": [
-                        {"name": "activity_count"},
-                        {
-                            "name": "activity_count",
-                            "alias": "previous_month_activity_count",
-                            "offset_window": "1 month",
-                        },
-                    ],
-                    "offset_window": "1 month",
-                },
-            ],
-        }
-
-    def _metric_file(self, tmp_path):
-        return tmp_path / "subject" / "semantic_models" / "starrocks" / "metrics" / "auto_offset_derived_metrics.yml"
-
-    def test_offset_helper_defensive_branches(self, tmp_path):
+@pytest.mark.ci
+class TestOffsetCandidateHelpers:
+    def test_offset_grain_and_candidate_shape_guards(self):
         assert _offset_grain(None) is None
         assert _offset_grain("1 centuries") is None
         assert _offset_grain("1 months") == "month"
@@ -1243,6 +1201,8 @@ class TestAutoGenerateOffsetDerivedMetrics:
             _is_offset_derived_candidate({"metric_type": "simple", "inputs": [{"offset_window": "1 month"}]}) is False
         )
         assert _is_offset_derived_candidate({"metric_type": "derived", "inputs": []}) is False
+
+    def test_identity_alias_guards(self):
         assert _offset_identity_alias_candidates({"inputs": []}) == []
         assert (
             _offset_identity_alias_candidates(
@@ -1267,38 +1227,7 @@ class TestAutoGenerateOffsetDerivedMetrics:
             == []
         )
 
-        metric_doc = _derived_metric_doc(
-            {
-                "name": "activity_count_previous_month",
-                "expression": "activity_count_previous_month",
-                "inputs": [
-                    "not-dict",
-                    {},
-                    {
-                        "name": "activity_count",
-                        "alias": "activity_count_previous_month",
-                        "offset_window": "1 month",
-                        "offset_to_grain": "month",
-                    },
-                ],
-            },
-            {"activity_count": {"subject_path": ["ac_manage", "campaign"]}},
-        )
-        metric_input = metric_doc["metric"]["type_params"]["metrics"][0]
-        assert metric_input["offset_to_grain"] == "month"
-        assert metric_doc["metric"]["locked_metadata"]["tags"] == [
-            "ac_manage/campaign",
-            "subject_tree: ac_manage/campaign",
-        ]
-
-        malformed_metric_file = tmp_path / "bad.yml"
-        malformed_metric_file.write_text("metric: [", encoding="utf-8")
-        assert _load_metric_doc_names(malformed_metric_file) == set()
-
-        empty_metric_file = tmp_path / "empty.yml"
-        _append_metric_docs(empty_metric_file, [])
-        assert not empty_metric_file.exists()
-
+    def test_unique_metric_catalog_by_name(self):
         unique, ambiguous = _unique_metric_catalog_by_name(
             [
                 "not-dict",
@@ -1309,245 +1238,6 @@ class TestAutoGenerateOffsetDerivedMetrics:
         )
         assert unique == {"order_count": {"name": "order_count"}}
         assert ambiguous == {"activity_count"}
-
-    def test_generates_and_syncs_offset_derived_metrics(self, tmp_path, monkeypatch):
-        synced = {}
-
-        class FakeSemanticTools:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def validate_semantic(self, scope="all"):
-                return FuncToolResult(result={"valid": True, "scope": scope})
-
-            def query_metrics(self, metrics, dimensions=None, time_granularity=None, dry_run=False, **kwargs):
-                return FuncToolResult(result={"metadata": {"sql": f"SELECT {metrics[0]}"}})
-
-        class FakeGenerationTools:
-            def __init__(self, agent_config):
-                self.agent_config = agent_config
-
-            def _sync_metric_to_db(self, metric_file, metric_sqls=None, metric_names_to_sync=None):
-                synced["metric_file"] = metric_file
-                synced["metric_sqls"] = metric_sqls
-                synced["metric_names_to_sync"] = metric_names_to_sync
-                return {"success": True}
-
-        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
-        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", FakeGenerationTools)
-
-        result = _auto_generate_offset_derived_metrics(
-            self._candidate_plan(),
-            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
-            self._config(tmp_path),
-        )
-
-        assert result["generated_metric_names"] == [
-            "previous_month_activity_count",
-            "activity_count_previous_month",
-            "activity_count_mom_delta",
-        ]
-        assert result["metric_artifact_ids"] == [
-            "metric:previous_month_activity_count",
-            "metric:activity_count_previous_month",
-            "metric:activity_count_mom_delta",
-        ]
-        assert synced["metric_names_to_sync"] == {
-            "previous_month_activity_count",
-            "activity_count_previous_month",
-            "activity_count_mom_delta",
-        }
-        metric_file = (
-            tmp_path / "subject" / "semantic_models" / "starrocks" / "metrics" / "auto_offset_derived_metrics.yml"
-        )
-        text = metric_file.read_text()
-        assert "name: activity_count_previous_month" in text
-        assert "offset_window: 1 month" in text
-        assert "expr: activity_count - previous_month_activity_count" in text
-
-    def test_skips_ambiguous_existing_input_metric_names(self, tmp_path, monkeypatch):
-        class UnexpectedSemanticTools:
-            def __init__(self, *args, **kwargs):
-                raise AssertionError("semantic tools should not be constructed")
-
-        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", UnexpectedSemanticTools)
-
-        result = _auto_generate_offset_derived_metrics(
-            self._candidate_plan(),
-            [
-                {"name": "activity_count", "type": "measure_proxy", "subject_path": ["a"]},
-                {"name": "activity_count", "type": "measure_proxy", "subject_path": ["b"]},
-            ],
-            self._config(tmp_path),
-        )
-
-        assert result == {"generated_metric_names": [], "metric_artifact_ids": []}
-
-    def test_rolls_back_metric_file_when_validation_fails(self, tmp_path, monkeypatch):
-        metric_file = self._metric_file(tmp_path)
-        metric_file.parent.mkdir(parents=True)
-        original_content = "metric:\n  name: existing_metric\n"
-        metric_file.write_text(original_content, encoding="utf-8")
-
-        class FakeSemanticTools:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def validate_semantic(self, scope="all"):
-                return FuncToolResult(success=0, error="bad model")
-
-        class UnexpectedGenerationTools:
-            def __init__(self, *args, **kwargs):
-                raise AssertionError("generation tools should not be constructed")
-
-        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
-        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", UnexpectedGenerationTools)
-
-        result = _auto_generate_offset_derived_metrics(
-            self._candidate_plan(),
-            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
-            self._config(tmp_path),
-        )
-
-        assert result["error"] == "bad model"
-        assert metric_file.read_text(encoding="utf-8") == original_content
-
-    def test_rolls_back_metric_file_when_sync_fails(self, tmp_path, monkeypatch):
-        metric_file = self._metric_file(tmp_path)
-
-        class FakeSemanticTools:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def validate_semantic(self, scope="all"):
-                return FuncToolResult(result={"valid": True, "scope": scope})
-
-            def query_metrics(self, metrics, dimensions=None, time_granularity=None, dry_run=False, **kwargs):
-                return FuncToolResult(result={"metadata": {"sql": f"SELECT {metrics[0]}"}})
-
-        class FakeGenerationTools:
-            def __init__(self, agent_config):
-                self.agent_config = agent_config
-
-            def _sync_metric_to_db(self, metric_file, metric_sqls=None, metric_names_to_sync=None):
-                return {"success": False, "error": "sync failed"}
-
-        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
-        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", FakeGenerationTools)
-
-        result = _auto_generate_offset_derived_metrics(
-            self._candidate_plan(),
-            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
-            self._config(tmp_path),
-        )
-
-        assert result["error"] == "sync failed"
-        assert not metric_file.exists()
-
-    def test_resyncs_file_backed_metric_missing_from_catalog(self, tmp_path, monkeypatch):
-        synced = {}
-        metric_file = self._metric_file(tmp_path)
-        metric_file.parent.mkdir(parents=True)
-        metric_file.write_text(
-            "metric:\n"
-            "  name: activity_count_previous_month\n"
-            "  type: derived\n"
-            "  type_params:\n"
-            "    expr: activity_count_previous_month\n"
-            "    metrics:\n"
-            "      - name: activity_count\n"
-            "        alias: activity_count_previous_month\n"
-            "        offset_window: 1 month\n",
-            encoding="utf-8",
-        )
-
-        class FakeSemanticTools:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def validate_semantic(self, scope="all"):
-                return FuncToolResult(result={"valid": True, "scope": scope})
-
-        class FakeGenerationTools:
-            def __init__(self, agent_config):
-                self.agent_config = agent_config
-
-            def _sync_metric_to_db(self, metric_file, metric_sqls=None, metric_names_to_sync=None):
-                synced["metric_file"] = metric_file
-                synced["metric_sqls"] = metric_sqls
-                synced["metric_names_to_sync"] = metric_names_to_sync
-                return {"success": True}
-
-        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", FakeSemanticTools)
-        monkeypatch.setattr("datus.tools.func_tool.generation_tools.GenerationTools", FakeGenerationTools)
-
-        result = _auto_generate_offset_derived_metrics(
-            {
-                "available": True,
-                "derived_metric_candidates": [
-                    {
-                        "name": "activity_count_previous_month",
-                        "metric_type": "derived",
-                        "expression": "activity_count_previous_month",
-                        "inputs": [
-                            {
-                                "name": "activity_count",
-                                "alias": "activity_count_previous_month",
-                                "offset_window": "1 month",
-                            }
-                        ],
-                    }
-                ],
-            },
-            [{"name": "activity_count", "type": "measure_proxy", "subject_path": ["ac_manage", "campaign"]}],
-            self._config(tmp_path),
-        )
-
-        assert result["generated_metric_names"] == ["activity_count_previous_month"]
-        assert result["metric_artifact_ids"] == ["metric:activity_count_previous_month"]
-        assert synced["metric_sqls"] == {}
-        assert synced["metric_names_to_sync"] == {"activity_count_previous_month"}
-        assert metric_file.read_text(encoding="utf-8").count("name: activity_count_previous_month") == 1
-
-    def test_skips_when_input_metric_missing(self, tmp_path, monkeypatch):
-        class UnexpectedSemanticTools:
-            def __init__(self, *args, **kwargs):
-                raise AssertionError("semantic tools should not be constructed")
-
-        monkeypatch.setattr("datus.tools.func_tool.semantic_tools.SemanticTools", UnexpectedSemanticTools)
-
-        result = _auto_generate_offset_derived_metrics(self._candidate_plan(), [], self._config(tmp_path))
-
-        assert result == {"generated_metric_names": [], "metric_artifact_ids": []}
-
-    def test_append_auto_offset_result_merges_without_duplicates(self):
-        batch_result = {
-            "auto_generated_offset_derived_metrics": ["previous_month_activity_count"],
-            "_synced_metric_artifact_ids": ["metric:previous_month_activity_count"],
-            "provenance_entries": 1,
-        }
-
-        _append_auto_offset_result(
-            batch_result,
-            {
-                "generated_metric_names": ["previous_month_activity_count", "activity_count_mom_delta"],
-                "metric_artifact_ids": [
-                    "metric:previous_month_activity_count",
-                    "metric:activity_count_mom_delta",
-                ],
-            },
-            provenance_entries=2,
-        )
-
-        assert batch_result["auto_generated_offset_derived_metrics"] == [
-            "previous_month_activity_count",
-            "activity_count_mom_delta",
-        ]
-        assert batch_result["_synced_metric_artifact_ids"] == [
-            "metric:previous_month_activity_count",
-            "metric:activity_count_mom_delta",
-        ]
-        assert batch_result["provenance_entries"] == 3
 
 
 @pytest.mark.ci
@@ -1818,3 +1508,320 @@ class TestAllCandidateMetricsSatisfied:
         }
         existing = [{"name": "revenue_total", "type": "measure_proxy", "base_measures": ["revenue"]}]
         assert _all_candidate_metrics_satisfied(plan, existing) is False
+
+
+# ---------------------------------------------------------------------------
+# Offset derived candidate expansion (format-agnostic LLM path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestExpandOffsetIdentityCandidates:
+    def _identity_candidate(self):
+        return {
+            "name": "previous_month_activity_count",
+            "metric_type": "derived",
+            "expression": "previous_month_activity_count",
+            "source_sql_name": "sql_25",
+            "inputs": [
+                {
+                    "name": "activity_count",
+                    "alias": "previous_month_activity_count",
+                    "offset_window": "1 month",
+                }
+            ],
+        }
+
+    def _delta_candidate(self):
+        return {
+            "name": "activity_count_mom_delta",
+            "metric_type": "derived",
+            "expression": "activity_count - previous_month_activity_count",
+            "source_sql_name": "sql_25",
+            "inputs": [
+                {"name": "activity_count"},
+                {
+                    "name": "activity_count",
+                    "alias": "previous_month_activity_count",
+                    "offset_window": "1 month",
+                },
+            ],
+        }
+
+    def test_appends_alias_variant_for_identity_candidate(self):
+        expanded = _expand_offset_identity_candidates([self._identity_candidate(), self._delta_candidate()])
+
+        names = [candidate["name"] for candidate in expanded]
+        assert names == [
+            "previous_month_activity_count",
+            "activity_count_previous_month",
+            "activity_count_mom_delta",
+        ]
+        alias_variant = expanded[1]
+        assert alias_variant["expression"] == "activity_count_previous_month"
+        assert alias_variant["source_sql_name"] == "sql_25"
+        assert alias_variant["inputs"][0]["offset_window"] == "1 month"
+        assert alias_variant["inputs"][0]["alias"] == "activity_count_previous_month"
+
+    def test_preserves_non_offset_items_and_dedupes(self):
+        simple = {"name": "activity_count", "metric_type": "simple", "inputs": []}
+        duplicate = dict(self._identity_candidate())
+        expanded = _expand_offset_identity_candidates(["not-a-dict", simple, self._identity_candidate(), duplicate])
+
+        names = [candidate["name"] for candidate in expanded if isinstance(candidate, dict)]
+        assert names == [
+            "activity_count",
+            "previous_month_activity_count",
+            "activity_count_previous_month",
+        ]
+        assert "not-a-dict" in expanded
+
+    def test_build_candidate_plan_applies_expansion(self, monkeypatch):
+        class FakeDiscovery:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def analyze_metric_candidates_from_history(self, **kwargs):
+                return FuncToolResult(
+                    result={
+                        "derived_metric_candidates": [
+                            {
+                                "name": "previous_month_activity_count",
+                                "metric_type": "derived",
+                                "expression": "previous_month_activity_count",
+                                "inputs": [
+                                    {
+                                        "name": "activity_count",
+                                        "alias": "previous_month_activity_count",
+                                        "offset_window": "1 month",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                )
+
+        monkeypatch.setattr(
+            "datus.tools.func_tool.semantic_discovery_tools.SemanticDiscoveryTools",
+            FakeDiscovery,
+        )
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._build_sql_to_table_lineage",
+            lambda sql_entries, agent_config: [],
+        )
+
+        plan = _build_candidate_plan(
+            [{"name": "sql_25", "sql": "SELECT 1", "question": "q"}],
+            "[]",
+            SimpleNamespace(),
+        )
+
+        names = [candidate["name"] for candidate in plan["derived_metric_candidates"]]
+        assert names == ["previous_month_activity_count", "activity_count_previous_month"]
+
+
+# ---------------------------------------------------------------------------
+# Offset derived completeness check + retry
+# ---------------------------------------------------------------------------
+
+
+def _offset_plan():
+    return {
+        "available": True,
+        "derived_metric_candidates": [
+            {
+                "name": "previous_month_activity_count",
+                "metric_type": "derived",
+                "expression": "previous_month_activity_count",
+                "source_sql_name": "sql_25",
+                "inputs": [
+                    {
+                        "name": "activity_count",
+                        "alias": "previous_month_activity_count",
+                        "offset_window": "1 month",
+                    }
+                ],
+            },
+            {
+                "name": "activity_count_mom_delta",
+                "metric_type": "derived",
+                "expression": "activity_count - previous_month_activity_count",
+                "source_sql_name": "sql_25",
+                "inputs": [
+                    {"name": "activity_count"},
+                    {
+                        "name": "activity_count",
+                        "alias": "previous_month_activity_count",
+                        "offset_window": "1 month",
+                    },
+                ],
+            },
+        ],
+    }
+
+
+@pytest.mark.ci
+class TestMissingOffsetDerivedCandidates:
+    def test_detects_missing_when_inputs_exist(self):
+        catalog = [{"name": "activity_count", "type": "measure_proxy"}]
+        missing = _missing_offset_derived_candidates(_offset_plan(), catalog)
+        assert [candidate["name"] for candidate in missing] == [
+            "previous_month_activity_count",
+            "activity_count_mom_delta",
+        ]
+
+    def test_empty_when_all_candidates_exist(self):
+        catalog = [
+            {"name": "activity_count", "type": "measure_proxy"},
+            {"name": "previous_month_activity_count", "type": "derived"},
+            {"name": "activity_count_mom_delta", "type": "derived"},
+        ]
+        assert _missing_offset_derived_candidates(_offset_plan(), catalog) == []
+
+    def test_skips_ambiguous_and_unresolved_inputs(self):
+        ambiguous_catalog = [
+            {"name": "activity_count", "type": "measure_proxy", "subject_path": ["a"]},
+            {"name": "activity_count", "type": "measure_proxy", "subject_path": ["b"]},
+        ]
+        assert _missing_offset_derived_candidates(_offset_plan(), ambiguous_catalog) == []
+        assert _missing_offset_derived_candidates(_offset_plan(), []) == []
+        assert _missing_offset_derived_candidates({"available": False}, []) == []
+
+
+@pytest.mark.ci
+class TestEnsureOffsetDerivedMetrics:
+    def _records(self):
+        return [
+            {
+                "source_sql_name": "sql_25",
+                "query": "Query 25:\nQuestion: q\nSQL:\nSELECT 1",
+                "source": {"source_id": "seed:24"},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_retries_missing_candidates_once(self, monkeypatch):
+        catalogs = iter(
+            [
+                [{"name": "activity_count", "type": "measure_proxy"}],
+                [
+                    {"name": "activity_count", "type": "measure_proxy"},
+                    {"name": "previous_month_activity_count", "type": "derived"},
+                    {"name": "activity_count_previous_month", "type": "derived"},
+                    {"name": "activity_count_mom_delta", "type": "derived"},
+                ],
+            ]
+        )
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._build_existing_metric_catalog",
+            lambda agent_config: next(catalogs),
+        )
+        batch_calls = {}
+
+        async def fake_generate(batch_queries, batch_idx, *args, **kwargs):
+            batch_calls["queries"] = batch_queries
+            batch_calls["batch_idx"] = batch_idx
+            batch_calls["extra_instructions"] = args[2] if len(args) > 2 else kwargs.get("extra_instructions")
+            return True, "", {"processed_queries": len(batch_queries)}
+
+        monkeypatch.setattr("datus.storage.metric.metric_init._generate_metrics_batch", fake_generate)
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._sync_metric_provenance",
+            lambda agent_config, artifact_ids, source_entries: 0,
+        )
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._metric_ids_in_storage",
+            lambda agent_config: set(),
+        )
+
+        result = await _ensure_offset_derived_metrics(
+            candidate_plan=_offset_plan(),
+            agent_config=SimpleNamespace(),
+            subject_tree=None,
+            extra_instructions=None,
+            event_helper=None,
+            action_callback=None,
+            all_query_records=self._records(),
+            total_batches=3,
+        )
+
+        assert result["retried"] is True
+        assert result["missing"] == []
+        assert sorted(result["generated"]) == [
+            "activity_count_mom_delta",
+            "previous_month_activity_count",
+        ]
+        assert batch_calls["batch_idx"] == 3
+        assert batch_calls["queries"] == ["Query 25:\nQuestion: q\nSQL:\nSELECT 1"]
+        instructions = batch_calls["extra_instructions"] or ""
+        assert "previous_month_activity_count" in instructions
+        assert "activity_count_mom_delta" in instructions
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_complete(self, monkeypatch):
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._build_existing_metric_catalog",
+            lambda agent_config: [
+                {"name": "activity_count", "type": "measure_proxy"},
+                {"name": "previous_month_activity_count", "type": "derived"},
+                {"name": "activity_count_previous_month", "type": "derived"},
+                {"name": "activity_count_mom_delta", "type": "derived"},
+            ],
+        )
+
+        async def unexpected_generate(*args, **kwargs):
+            raise AssertionError("retry batch must not run when candidates are satisfied")
+
+        monkeypatch.setattr("datus.storage.metric.metric_init._generate_metrics_batch", unexpected_generate)
+
+        result = await _ensure_offset_derived_metrics(
+            candidate_plan=_offset_plan(),
+            agent_config=SimpleNamespace(),
+            subject_tree=None,
+            extra_instructions=None,
+            event_helper=None,
+            action_callback=None,
+            all_query_records=self._records(),
+            total_batches=3,
+        )
+
+        assert result == {"generated": [], "missing": [], "retried": False}
+
+    @pytest.mark.asyncio
+    async def test_reports_unresolved_after_retry(self, monkeypatch):
+        catalog = [{"name": "activity_count", "type": "measure_proxy"}]
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._build_existing_metric_catalog",
+            lambda agent_config: list(catalog),
+        )
+
+        async def fake_generate(*args, **kwargs):
+            return False, "llm failed", None
+
+        monkeypatch.setattr("datus.storage.metric.metric_init._generate_metrics_batch", fake_generate)
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._sync_metric_provenance",
+            lambda agent_config, artifact_ids, source_entries: 0,
+        )
+        monkeypatch.setattr(
+            "datus.storage.metric.metric_init._metric_ids_in_storage",
+            lambda agent_config: set(),
+        )
+
+        result = await _ensure_offset_derived_metrics(
+            candidate_plan=_offset_plan(),
+            agent_config=SimpleNamespace(),
+            subject_tree=None,
+            extra_instructions=None,
+            event_helper=None,
+            action_callback=None,
+            all_query_records=self._records(),
+            total_batches=3,
+        )
+
+        assert result["retried"] is True
+        assert result["generated"] == []
+        assert sorted(result["missing"]) == [
+            "activity_count_mom_delta",
+            "previous_month_activity_count",
+        ]

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -14,9 +14,9 @@ from datus.storage.metric.metric_init import (
     BIZ_NAME,
     DEFAULT_METRICS_BATCH_SIZE,
     _action_status_value,
+    _annotate_offset_identity_candidates,
     _build_candidate_plan,
     _ensure_offset_derived_metrics,
-    _expand_offset_identity_candidates,
     _extract_metric_artifact_ids,
     _generate_metrics_batch,
     _is_offset_derived_candidate,
@@ -1548,35 +1548,31 @@ class TestExpandOffsetIdentityCandidates:
             ],
         }
 
-    def test_appends_alias_variant_for_identity_candidate(self):
-        expanded = _expand_offset_identity_candidates([self._identity_candidate(), self._delta_candidate()])
+    def test_annotates_identity_candidate_with_equivalent_names(self):
+        annotated = _annotate_offset_identity_candidates([self._identity_candidate(), self._delta_candidate()])
 
-        names = [candidate["name"] for candidate in expanded]
+        names = [candidate["name"] for candidate in annotated]
         assert names == [
             "previous_month_activity_count",
-            "activity_count_previous_month",
             "activity_count_mom_delta",
         ]
-        alias_variant = expanded[1]
-        assert alias_variant["expression"] == "activity_count_previous_month"
-        assert alias_variant["source_sql_name"] == "sql_25"
-        assert alias_variant["inputs"][0]["offset_window"] == "1 month"
-        assert alias_variant["inputs"][0]["alias"] == "activity_count_previous_month"
-        assert expanded[0]["offset_identity_group"] == "activity_count_previous_month"
-        assert alias_variant["offset_identity_group"] == "activity_count_previous_month"
+        identity = annotated[0]
+        assert identity["equivalent_names"] == ["activity_count_previous_month"]
+        assert identity["expression"] == "previous_month_activity_count"
+        assert identity["source_sql_name"] == "sql_25"
+        assert "equivalent_names" not in annotated[1]
 
-    def test_preserves_non_offset_items_and_dedupes(self):
+    def test_preserves_non_offset_items(self):
         simple = {"name": "activity_count", "metric_type": "simple", "inputs": []}
-        duplicate = dict(self._identity_candidate())
-        expanded = _expand_offset_identity_candidates(["not-a-dict", simple, self._identity_candidate(), duplicate])
+        annotated = _annotate_offset_identity_candidates(["not-a-dict", simple, self._identity_candidate()])
 
-        names = [candidate["name"] for candidate in expanded if isinstance(candidate, dict)]
+        names = [candidate["name"] for candidate in annotated if isinstance(candidate, dict)]
         assert names == [
             "activity_count",
             "previous_month_activity_count",
-            "activity_count_previous_month",
         ]
-        assert "not-a-dict" in expanded
+        assert "equivalent_names" not in annotated[1]
+        assert "not-a-dict" in annotated
 
     def test_build_candidate_plan_applies_expansion(self, monkeypatch):
         class FakeDiscovery:
@@ -1618,8 +1614,9 @@ class TestExpandOffsetIdentityCandidates:
             SimpleNamespace(),
         )
 
-        names = [candidate["name"] for candidate in plan["derived_metric_candidates"]]
-        assert names == ["previous_month_activity_count", "activity_count_previous_month"]
+        candidates = plan["derived_metric_candidates"]
+        assert [candidate["name"] for candidate in candidates] == ["previous_month_activity_count"]
+        assert candidates[0]["equivalent_names"] == ["activity_count_previous_month"]
 
 
 # ---------------------------------------------------------------------------
@@ -1689,9 +1686,9 @@ class TestMissingOffsetDerivedCandidates:
         assert _missing_offset_derived_candidates(_offset_plan(), []) == []
         assert _missing_offset_derived_candidates({"available": False}, []) == []
 
-    def test_identity_group_satisfied_by_any_equivalent_name(self):
+    def test_identity_candidate_satisfied_by_any_equivalent_name(self):
         plan = _offset_plan()
-        plan["derived_metric_candidates"] = _expand_offset_identity_candidates(plan["derived_metric_candidates"])
+        plan["derived_metric_candidates"] = _annotate_offset_identity_candidates(plan["derived_metric_candidates"])
 
         catalog_canonical_name = [
             {"name": "activity_count", "type": "measure_proxy"},
@@ -1707,9 +1704,9 @@ class TestMissingOffsetDerivedCandidates:
         ]
         assert _missing_offset_derived_candidates(plan, catalog_original_alias) == []
 
-    def test_identity_group_reported_once_when_fully_missing(self):
+    def test_identity_candidate_reported_once_when_fully_missing(self):
         plan = _offset_plan()
-        plan["derived_metric_candidates"] = _expand_offset_identity_candidates(plan["derived_metric_candidates"])
+        plan["derived_metric_candidates"] = _annotate_offset_identity_candidates(plan["derived_metric_candidates"])
 
         catalog = [{"name": "activity_count", "type": "measure_proxy"}]
         missing_names = [candidate["name"] for candidate in _missing_offset_derived_candidates(plan, catalog)]


### PR DESCRIPTION
## Why

The metrics bootstrap had a deterministic fallback (`_auto_generate_offset_derived_metrics`) that rendered MetricFlow-only YAML in `datus/storage/metric/metric_init.py` to materialize offset-window derived metrics (previous-period value, MoM delta) mined from success-story SQL. Under the OSI authoring path (#1007), strict OSI core validation rejects that legacy YAML, the auto file is rolled back, and previous-period metrics are silently lost — `baisheng_ask_metrics` tasks 35/36 fail with a missing column. The root problem is structural: a shared bootstrap layer was hard-coding one authoring dialect.

## Solution

Replace code-side YAML rendering with an LLM-first flow plus a format-agnostic completeness check; `metric_init.py` no longer renders any authoring YAML dialect:

- **Candidate annotation** (`_annotate_offset_identity_candidates`): offset identity candidates keep the mined SQL alias as the metric name (the user's business naming is ground truth) and carry the canonical `{base}_previous_{grain}` variant in `equivalent_names`. The agent sees one candidate and is told to publish exactly one metric under the candidate name; renaming is no longer encouraged by injecting variants as separate candidates.
- **Prompt strengthening** (`gen_metrics_system_1.2`, in-place per the #989 convention): materialize EVERY offset derived candidate including previous-period identity metrics (a delta metric does not replace the identity metric), with a complete MoM identity + delta YAML example.
- **Completeness check + retry** (`_missing_offset_derived_candidates`, `_ensure_offset_derived_metrics`): after all batches, verify each eligible offset candidate (or any equivalent name) landed in the metric store; re-run the regular gen_metrics agent once with a focused instruction for anything missing, and report unresolved names in the result instead of dropping them silently.

The same flow now works for MetricFlow, OSI, and future authoring formats, since the YAML is always authored by the LLM in whatever format the node is configured for.

## Test Cases

- `tests/unit_tests/storage/metric/test_metric_init.py`: 11 new/updated tests covering candidate annotation (equivalent-name marking, non-offset passthrough), missing-candidate detection (existing/ambiguous/unresolved-input filtering, equivalent-name satisfaction), and the retry flow (retry-once with focused instructions, no-retry when complete, unresolved reporting). Legacy fallback tests for the removed YAML-rendering helpers were replaced accordingly.
- PR harness: 417 passed / 0 failed, diff coverage 91%; `ci/audit_tests.py --diff-only`: P0=0, P1=0.
- End-to-end (MetricFlow): `baisheng_ask_metrics` bootstrap from success stories produces `activity_count` / `previous_month_activity_count` / `activity_count_mom_delta`; `query_metrics` results match the gold `LAG()` SQL row-for-row on StarRocks. Benchmark tasks 31-36 score 5/6 (the one miss is the agent answering the literal question wording, not a generation defect — the previous-period metric exists and is queryable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

* **Improvements**
  * Enhanced period-over-period metric generation (e.g., month-over-month calculations) with clearer handling of identity and delta metrics.
  * Improved reliability of offset-derived metrics by implementing a more robust completeness-checking and retry mechanism.

* **Refactor**
  * Modernized the approach to generating missing offset-derived metrics for better consistency and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clearer period-over-period metric generation (e.g., month-over-month) producing distinct identity and delta metrics and requiring published metric names come from the candidate’s primary name.
  * More reliable offset-derived metric completeness checks with a focused retry for missing metrics.

* **Refactor**
  * Simplified offset-derived workflow to a post-extraction completeness-and-retry flow (aliases treated as allowable equivalents).

* **Tests**
  * Expanded unit tests covering offset candidate annotation, alias handling, detection, and retry semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->