### PR TITLE
[Refactor] Declare permission categories at tool definition sites

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2386,43 +2386,6 @@ class AgenticNode(Node):
             node_class=self.get_node_class_name(),
         )
 
-    def _get_tool_category(self, tool_name: str) -> str:
-        """
-        Determine tool category from tool name for permission checking.
-
-        Args:
-            tool_name: Name of the tool
-
-        Returns:
-            Tool category string: "db_tools", "mcp", "skills", or "tools"
-        """
-        # Check for skill-related tools
-        if tool_name == "load_skill" or tool_name.startswith("skill_"):
-            return "skills"
-
-        # Check for database tools
-        if tool_name.startswith("db_") or tool_name in [
-            "list_tables",
-            "describe_table",
-            "execute_ddl",
-            "execute_write",
-            "transfer_query_result",
-            "execute_sql",
-            "get_sample_data",
-        ]:
-            return "db_tools"
-
-        # Check for MCP tools (usually have mcp_ prefix or are in mcp_servers)
-        mcp_tool_names = set()
-        for server_name in self.mcp_servers.keys():
-            mcp_tool_names.add(f"{server_name}_")
-        for mcp_prefix in mcp_tool_names:
-            if tool_name.startswith(mcp_prefix):
-                return "mcp"
-
-        # Default to generic tools category
-        return "tools"
-
     def setup_input(self, workflow: "Workflow") -> Dict:
         """
         Setup input for agentic node from workflow context.
@@ -3315,44 +3278,66 @@ class AgenticNode(Node):
     # never fired for anything other than ``chat``. These helpers let
     # every subclass participate in the permission system with one call.
 
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Return ``{category: tools}`` for permission registration.
+    def _iter_tool_groups(self) -> List[Any]:
+        """Collect tool-group instances mounted as attributes on this node.
 
-        Subclasses override this to declare which of ``self.tools`` belong
-        to which permission category (``bi_tools``, ``scheduler_tools``,
-        ``db_tools``, etc.). Categories not declared here fall back to the
-        ``tools`` catch-all, which only matches explicit ``tools.*`` rules.
-
-        The base implementation registers ``skill_func_tool`` under
-        ``skills`` and ``bash_tool`` under ``bash_tools`` so the
-        ``skills.*`` and ``bash_tools.*`` profile rules apply to every
-        subagent that exposes them — overrides should ``super()`` +
-        extend.
+        A tool group is any object that declares both ``permission_category``
+        (the class-level category from ``BaseTool`` or a plain class attribute)
+        and ``available_tools()``. Category declaration lives at the tool's
+        definition site, so nodes no longer maintain hand-written
+        category maps that silently drift when a tool is added or renamed.
         """
-        mapping: Dict[str, List[Any]] = {}
-        if self.skill_func_tool:
-            mapping["skills"] = list(self.skill_func_tool.available_tools())
-        bash_tool = getattr(self, "bash_tool", None)
-        if bash_tool:
-            bash_tools = list(bash_tool.available_tools())
-            if bash_tools:
-                mapping["bash_tools"] = bash_tools
-        # Dedicated memory tools are mounted on every main agent (and the
-        # feedback node), so classify them here in the base map — otherwise
-        # nodes without a ``_tool_category_map`` override (e.g. feedback) would
-        # fall back to the ``tools`` catch-all and the ``memory_tools.*`` profile
-        # rules would never govern ``add_memory`` / ``edit_memory``.
-        memory_func_tool = getattr(self, "memory_func_tool", None)
-        if memory_func_tool:
-            mapping["memory_tools"] = list(memory_func_tool.available_tools())
-        return mapping
+        groups: List[Any] = []
+        seen: set = set()
+        for attr_name in sorted(vars(self)):
+            value = getattr(self, attr_name, None)
+            if value is None or id(value) in seen:
+                continue
+            if isinstance(value, type):
+                continue
+            # ``permission_category`` must be a plain string — this also keeps
+            # ``Mock()`` stand-ins in tests out of the registry unless they
+            # explicitly declare a category.
+            category = getattr(value, "permission_category", None)
+            if isinstance(category, str) and callable(getattr(value, "available_tools", None)):
+                seen.add(id(value))
+                groups.append(value)
+        return groups
+
+    @staticmethod
+    def _tool_group_names(group: Any) -> List[str]:
+        """Return every permission-relevant tool name a group can expose.
+
+        Prefers ``all_tools_name()`` (the full surface, independent of
+        runtime availability) over ``available_tools()`` so the registry
+        also covers method-level wrappers some nodes mount directly (e.g.
+        ``DBFuncTool.execute_ddl`` on gen_job) and conditional tools that
+        appear only with certain configs. Registering a superset is safe:
+        the registry is a name → category lookup consulted per call, so
+        names that are never mounted are never queried.
+        """
+        all_names = getattr(group, "all_tools_name", None)
+        if callable(all_names):
+            try:
+                return [str(name) for name in all_names()]
+            except Exception:
+                logger.debug("all_tools_name() failed for %s", type(group).__name__, exc_info=True)
+        try:
+            return [getattr(tool, "name", str(tool)) for tool in group.available_tools()]
+        except Exception:
+            logger.debug("available_tools() failed for %s", type(group).__name__, exc_info=True)
+            return []
 
     def _populate_tool_registry(self) -> None:
-        """Register every tool in :meth:`_tool_category_map` into
-        :attr:`tool_registry`.
+        """Register every mounted tool group's names into :attr:`tool_registry`.
+
+        Categories come from each tool class's ``permission_category``
+        declaration (see :meth:`_iter_tool_groups`), so the mapping is
+        deterministic across nodes — the same tool name always lands in the
+        same category no matter which node mounts it.
 
         Decoupled from :meth:`_ensure_permission_hooks` so callers that
-        need the category map filled *before* the first LLM turn — most
+        need the registry filled *before* the first LLM turn — most
         importantly :func:`apply_proxy_tools`, which inspects the
         registry to honour the ``_FS_DEPENDENT_NODES`` exclusion — can
         trigger it eagerly. Safe to call multiple times because
@@ -3363,9 +3348,10 @@ class AgenticNode(Node):
         a ``permission_manager`` and never builds ``PermissionHooks``.
         """
         try:
-            for category, tools in self._tool_category_map().items():
-                if tools:
-                    self.tool_registry.register_tools(category, tools)
+            for group in self._iter_tool_groups():
+                names = self._tool_group_names(group)
+                if names:
+                    self.tool_registry.register_tools(group.permission_category, names)
         except Exception:
             logger.debug(
                 "Failed to populate tool_registry for %s; falling back to lazy registration.",

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -647,8 +647,13 @@ class AgenticNode(Node):
         # Lambda resolves session_id lazily — at setup time it's still None,
         # ``_get_or_create_session`` allocates it on the first turn. Snapshot
         # would leave the storage permanently unbound and never persist.
-        tools: List[Tool] = list(PlanTool(self._session, session_id=lambda: self.session_id).available_tools())
-        tools.extend(ConfirmPlanTool(self).available_tools())
+        # Keep both instances on the node so ``_iter_tool_groups`` registers
+        # their ``permission_category`` — locals would silently fall back to
+        # the ``tools`` catch-all at hook time.
+        self.plan_tool = PlanTool(self._session, session_id=lambda: self.session_id)
+        self.confirm_plan_tool = ConfirmPlanTool(self)
+        tools: List[Tool] = list(self.plan_tool.available_tools())
+        tools.extend(self.confirm_plan_tool.available_tools())
         return tools
 
     def _register_plan_mode_tools(self) -> None:

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -51,15 +51,6 @@ class AskMetricsAgenticNode(AgenticNode):
         "semantic_tools.attribution_analyze",
         "context_search_tools.list_subject_tree",
     )
-    _TOOL_NAMES_BY_CATEGORY = {
-        "db_tools": set(DBFuncTool.all_tools_name()),
-        "context_search_tools": set(ContextSearchTools.all_tools_name()),
-        "semantic_tools": set(SemanticTools.all_tools_name()),
-        "reference_template_tools": set(ReferenceTemplateTools.all_tools_name()),
-        "date_parsing_tools": {"parse_temporal_expressions"},
-        "filesystem_tools": set(FilesystemFuncTool.all_tools_name()),
-        "platform_doc_tools": set(PlatformDocSearchTool.all_tools_name()),
-    }
 
     def __init__(
         self,
@@ -632,14 +623,6 @@ class AskMetricsAgenticNode(AgenticNode):
                 code=ErrorCode.COMMON_CONFIG_ERROR,
                 message_args={"config_error": f"ask_metrics is unavailable: {self.startup_error}"},
             )
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        mapping = super()._tool_category_map()
-        for category, names in self._TOOL_NAMES_BY_CATEGORY.items():
-            category_tools = [tool for tool in self.tools if getattr(tool, "name", "") in names]
-            if category_tools:
-                mapping[category] = category_tools
-        return mapping
 
     def _runtime_context_current_date(self) -> str:
         """Honor the per-input ``reference_date`` in the frozen runtime context."""

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -204,7 +204,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # whitelist may request them (metric/dimension/attribution analysis).
         # Declare the slot before super().__init__() (which triggers
         # ``setup_tools``) so the whitelist pass can build it on demand and
-        # ``_tool_category_map`` can reference it safely.
+        # ``_populate_tool_registry`` can pick it up safely.
         self.semantic_tools = None
 
         # Resolve the artifact binding BEFORE super().__init__() because
@@ -292,18 +292,6 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         """
         super()._rebuild_tools()
         self._apply_tools_whitelist()
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register semantic tools under their canonical permission category.
-
-        The chat base has no semantic tools so its map omits them; when the
-        whitelist makes us build them, surface them here so PermissionHooks
-        matches ``semantic_tools.*`` rules instead of the ``tools.*`` catch-all.
-        """
-        mapping = super()._tool_category_map()
-        if getattr(self, "semantic_tools", None):
-            mapping["semantic_tools"] = list(self.semantic_tools.available_tools())
-        return mapping
 
     def _apply_tools_whitelist(self) -> None:
         """Replace ``self.tools`` with exactly the tools the whitelist grants.

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -291,52 +291,6 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         except Exception as exc:
             logger.error("Failed to setup filesystem tools: %s", exc)
 
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register tool buckets so category-scoped rules and the
-        ``_FS_DEPENDENT_NODES`` exclusion in ``apply_proxy_tools`` apply.
-
-        Without this mapping, every tool falls back to the catch-all
-        ``tools`` category. That breaks two things for the visual artifact
-        nodes:
-
-        * ``filesystem_tools.*`` rules (and the zone-based fs policy in
-          ``PermissionHooks._handle_filesystem_zone``) never match, so the
-          INTERNAL / EXTERNAL gating that every other fs-using node gets
-          would silently skip visual reports/dashboards.
-        * ``apply_proxy_tools`` cannot recognise their filesystem tools as
-          excluded — it looks up the tool's category in the registry — so
-          a parent agent's ``write_file`` / ``edit_file`` proxy patterns
-          end up wrapping the sub-agent's filesystem tools, round-tripping
-          every chunk to the browser instead of writing ``render/*.jsx``
-          server-side.
-        """
-        mapping = super()._tool_category_map()
-        if self.db_func_tool:
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        semantic_bucket: List[Any] = []
-        if self.semantic_tools:
-            semantic_bucket.extend(self.semantic_tools.available_tools())
-        # Artifact-specific helpers (``start_new_*`` / ``bind_existing_*`` /
-        # ``save_query*`` / ``validate_render``) are subagent-internal state
-        # mutations; lump them into the ``semantic_tools`` bucket so the
-        # ``semantic_tools.*`` ALLOW rule (normal profile) covers them.
-        # Without this they fall through to ``tools.<name>`` and the default
-        # ASK gate would block at the broker.
-        if self.artifact_tools and hasattr(self.artifact_tools, "available_tools"):
-            try:
-                semantic_bucket.extend(self.artifact_tools.available_tools())
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.debug("artifact_tools.available_tools() failed: %s", exc)
-        if semantic_bucket:
-            mapping["semantic_tools"] = semantic_bucket
-        if self.context_search_tools:
-            mapping["context_search_tools"] = list(self.context_search_tools.available_tools())
-        if self.filesystem_func_tool:
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if self.ask_user_tool:
-            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
-        return mapping
-
     def _setup_specific_tool_method(self, tool_type: str, method_name: str) -> None:
         try:
             if tool_type == "semantic_tools":

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -10,7 +10,7 @@ chat interactions with markdown output, database/filesystem tool support,
 skills, and permissions. This node is fully independent from GenSQLAgenticNode.
 """
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.gen_sql_agentic_node import prepare_template_context
@@ -251,40 +251,6 @@ class ChatAgenticNode(AgenticNode):
             logger.debug(f"Setup skill tools: {self.skill_manager.get_skill_count()} skills discovered")
         except Exception as e:
             logger.error(f"Failed to setup skill tools: {e}")
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Declare chat-specific tool categories for permission registration.
-
-        Picked up by ``AgenticNode._populate_tool_registry`` so the base
-        ``_ensure_permission_hooks`` can build ``PermissionHooks`` with the
-        full registry. The base implementation already covers ``skills`` and
-        ``bash_tools``; this override extends with chat's own tool surface.
-        Tools that aren't tied to a profile category (``ask_user_tool``,
-        ``_platform_doc_tool``) land in the ``tools`` catch-all so explicit
-        ``tools.*`` rules can still match them.
-        """
-        mapping = super()._tool_category_map()
-        if self.db_func_tool:
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        if self.context_search_tools:
-            mapping["context_search_tools"] = list(self.context_search_tools.available_tools())
-        if self.reference_template_tools:
-            mapping["reference_template_tools"] = list(self.reference_template_tools.available_tools())
-        if self.date_parsing_tools:
-            mapping["date_parsing_tools"] = list(self.date_parsing_tools.available_tools())
-        if self.filesystem_func_tool:
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        # ``memory_tools`` is registered by the base ``_tool_category_map``.
-        if self.sub_agent_task_tool:
-            mapping["sub_agent_tools"] = list(self.sub_agent_task_tool.available_tools())
-        catch_all: List[Any] = []
-        if self.ask_user_tool:
-            catch_all.extend(self.ask_user_tool.available_tools())
-        if self._platform_doc_tool:
-            catch_all.extend(self._platform_doc_tool.available_tools())
-        if catch_all:
-            mapping["tools"] = catch_all
-        return mapping
 
     def _rebuild_tools(self):
         """Rebuild the tools list with current tool instances including skills."""

--- a/datus/agent/node/compare_agentic_node.py
+++ b/datus/agent/node/compare_agentic_node.py
@@ -109,19 +109,6 @@ class CompareAgenticNode(AgenticNode):
             logger.error(f"Failed to initialize tools for CompareAgenticNode: {exc}")
             self.tools = self.tools or []
 
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register the db tools under ``db_tools`` so permission rules fire.
-
-        Without this override the bound ``read_query`` lookup falls through to
-        the ``tools.*`` catch-all (default ASK on normal/auto profiles), which
-        would block at ``InteractionBroker.request`` whenever a caller wires
-        permission hooks but does not also run an interactive broker listener.
-        """
-        mapping = super()._tool_category_map()
-        if getattr(self, "db_func_tool", None):
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        return mapping
-
     @staticmethod
     def _prepare_prompt_components(
         input_data: CompareInput, agent_config: Optional[Any] = None

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -11,7 +11,7 @@ SQL generation. It exposes only read-only tools and runs with a low max_turns
 budget for fast, focused exploration.
 """
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Dict, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
@@ -173,33 +173,6 @@ class ExploreAgenticNode(AgenticNode):
             self.tools.extend(self.date_parsing_tools.available_tools())
         except Exception as e:
             logger.warning(f"Failed to setup date parsing tools, continuing without: {e}")
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register read-only tool surface so ``db_tools.read_*`` ALLOW rules fire."""
-        mapping = super()._tool_category_map()
-        if getattr(self, "db_func_tool", None):
-            # Mirror the subset actually exposed by this node — describe/read
-            # always, the rest only when scoped_tables isn't set.
-            db_bucket = [
-                self.db_func_tool.to_function_tool(self.db_func_tool.describe_table),
-                self.db_func_tool.to_function_tool(self.db_func_tool.read_query),
-            ]
-            scoped = isinstance(self.input, ExploreNodeInput) and self.input.scoped_tables
-            if not scoped:
-                db_bucket = list(self.db_func_tool.available_tools())
-            mapping["db_tools"] = db_bucket
-        if getattr(self, "context_search_tools", None):
-            mapping["context_search_tools"] = list(self.context_search_tools.available_tools())
-        if getattr(self, "filesystem_func_tool", None):
-            fs_bucket: List[Any] = []
-            for method_name in READONLY_FILESYSTEM_METHODS:
-                if hasattr(self.filesystem_func_tool, method_name):
-                    fs_bucket.append(trans_to_function_tool(getattr(self.filesystem_func_tool, method_name)))
-            if fs_bucket:
-                mapping["filesystem_tools"] = fs_bucket
-        if getattr(self, "date_parsing_tools", None):
-            mapping["date_parsing_tools"] = list(self.date_parsing_tools.available_tools())
-        return mapping
 
     def _get_system_prompt(self, prompt_version: Optional[str] = None) -> str:
         """Get the system prompt for the explore node."""

--- a/datus/agent/node/gen_dashboard_agentic_node.py
+++ b/datus/agent/node/gen_dashboard_agentic_node.py
@@ -12,7 +12,7 @@ workflow skill injection, and the domain result shape.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List, Literal, Optional
+from typing import Any, ClassVar, Literal, Optional
 
 from datus.agent.node.deliverable_node import DeliverableAgenticNode
 from datus.configuration.agent_config import AgentConfig
@@ -209,21 +209,6 @@ class GenDashboardAgenticNode(DeliverableAgenticNode):
         if len(msg) > 300:
             msg = msg[:300] + "..."
         return f"{type(exc).__name__}: {msg}" if msg else type(exc).__name__
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Declare categories so ``bi_tools.delete_*`` DENY rules fire.
-
-        Without this mapping ``PermissionHooks`` falls back to the catch-all
-        ``tools`` category for every BI tool, so no ``bi_tools.*`` rule can
-        ever match — every profile (even ``normal``) silently lets
-        ``delete_chart`` / ``delete_dataset`` through.
-        """
-        mapping = super()._tool_category_map()
-        if self.bi_func_tool:
-            mapping["bi_tools"] = list(self.bi_func_tool.available_tools())
-        if self.ask_user_tool:
-            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
-        return mapping
 
     # ── template context ──────────────────────────────────────────────
 

--- a/datus/agent/node/gen_job_agentic_node.py
+++ b/datus/agent/node/gen_job_agentic_node.py
@@ -17,7 +17,7 @@ Post-transfer reconciliation is driven by the ``transfer-reconciliation``
 validator skill via :class:`ValidationHook`, not by this node directly.
 """
 
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import ClassVar, Optional
 
 from datus.agent.node.deliverable_node import DeliverableAgenticNode
 from datus.configuration.node_type import NodeType
@@ -76,33 +76,3 @@ class GenJobAgenticNode(DeliverableAgenticNode):
                 code=ErrorCode.COMMON_CONFIG_ERROR,
                 message_args={"config_error": f"Failed to setup database tools for {self.NODE_NAME}: {e}"},
             ) from e
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register db / filesystem tools for permission profile rule matching.
-
-        DB writes (``execute_ddl`` / ``execute_write`` / ``transfer_query_result``)
-        should ASK in ``normal`` and ``auto`` profiles — without this
-        mapping they'd fall into the ``tools`` catch-all and bypass
-        ``db_tools.*`` rules entirely.
-        """
-        mapping = super()._tool_category_map()
-        db_bucket: List[Any] = []
-        if getattr(self, "db_func_tool", None):
-            db_bucket.extend(self.db_func_tool.available_tools())
-            for attr in (
-                "execute_ddl",
-                "execute_write",
-                "transfer_query_result",
-                "get_migration_capabilities",
-                "suggest_table_layout",
-                "validate_ddl",
-            ):
-                if hasattr(self.db_func_tool, attr):
-                    db_bucket.append(trans_to_function_tool(getattr(self.db_func_tool, attr)))
-        if db_bucket:
-            mapping["db_tools"] = db_bucket
-        if getattr(self, "filesystem_func_tool", None):
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if self.ask_user_tool:
-            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
-        return mapping

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -260,39 +260,6 @@ class GenMetricsAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup semantic discovery tools: {e}")
 
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Map tools to permission categories so profile rules apply.
-
-        ``generation_tools`` / ``semantic_discovery_tools`` expose semantic
-        layer operations (``end_metric_generation`` etc.) so they ride the
-        ``semantic_tools`` category for the sake of profile rules.
-        """
-        mapping = super()._tool_category_map()
-        if self.db_func_tool:
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        semantic_bucket: List[Any] = []
-        if getattr(self, "semantic_tools", None):
-            semantic_bucket.extend(self.semantic_tools.available_tools())
-        if self.generation_tools:
-            from datus.tools.func_tool import trans_to_function_tool
-
-            semantic_bucket.extend(
-                [
-                    trans_to_function_tool(self.generation_tools.check_semantic_object_exists),
-                    trans_to_function_tool(self.generation_tools.end_metric_generation),
-                    trans_to_function_tool(self.generation_tools.end_semantic_model_generation),
-                ]
-            )
-        if self.semantic_discovery_tools:
-            semantic_bucket.extend(self.semantic_discovery_tools.available_tools())
-        if semantic_bucket:
-            mapping["semantic_tools"] = semantic_bucket
-        if self.filesystem_func_tool:
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if self.ask_user_tool:
-            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
-        return mapping
-
     def _get_existing_subject_trees(self) -> list:
         """
         Query existing subject_tree values from metrics storage.

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -203,25 +203,6 @@ class GenReportAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup tool pattern '{pattern}': {e}")
 
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register tools under their canonical categories so permission rules fire.
-
-        Without this override the bound tools fall through to the ``tools.*``
-        catch-all (default ASK on normal/auto profiles), which would block at
-        ``InteractionBroker.request`` whenever a caller wires permission hooks
-        but does not also run an interactive broker listener.
-        """
-        mapping = super()._tool_category_map()
-        if getattr(self, "db_func_tool", None):
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        if getattr(self, "semantic_tools", None):
-            mapping["semantic_tools"] = list(self.semantic_tools.available_tools())
-        if getattr(self, "context_search_tools", None):
-            mapping["context_search_tools"] = list(self.context_search_tools.available_tools())
-        if getattr(self, "filesystem_func_tool", None):
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        return mapping
-
     def _setup_db_tools(self):
         """Setup database tools."""
         try:

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -10,7 +10,7 @@ semantic model generation with support for filesystem tools, generation tools,
 database tools, hooks, and metricflow MCP server integration.
 """
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
@@ -228,33 +228,6 @@ class GenSemanticModelAgenticNode(AgenticNode):
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Route tools to permission categories so profile rules apply."""
-        from datus.tools.func_tool import trans_to_function_tool
-
-        mapping = super()._tool_category_map()
-        if self.db_func_tool:
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        semantic_bucket: List[Any] = []
-        if getattr(self, "semantic_func_tool", None):
-            semantic_bucket.extend(self.semantic_func_tool.available_tools())
-        if self.generation_tools:
-            semantic_bucket.extend(
-                [
-                    trans_to_function_tool(self.generation_tools.check_semantic_object_exists),
-                    trans_to_function_tool(self.generation_tools.end_semantic_model_generation),
-                ]
-            )
-        if self.semantic_discovery_tools:
-            semantic_bucket.extend(self.semantic_discovery_tools.available_tools())
-        if semantic_bucket:
-            mapping["semantic_tools"] = semantic_bucket
-        if self.filesystem_func_tool:
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if self.ask_user_tool:
-            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
-        return mapping
 
     def _get_existing_subject_trees(self) -> list:
         """

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -12,7 +12,7 @@ higher max_turns budget for extended multi-step interactions.
 """
 
 import re
-from typing import Any, Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
@@ -208,29 +208,6 @@ class SkillCreatorAgenticNode(AgenticNode):
             logger.debug(f"Setup session search tool with sessions_dir: {sessions_dir}")
         except Exception as e:
             logger.warning(f"Failed to setup session search tool, continuing without: {e}")
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register filesystem / db / skill-loading tools for permission rules."""
-        mapping = super()._tool_category_map()
-        if getattr(self, "filesystem_func_tool", None):
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if getattr(self, "db_func_tool", None):
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        # Skill loader is a second ``SkillFuncTool`` instance distinct from
-        # the base ``skill_func_tool`` (authoring flow). Register it under
-        # ``skills`` so ``skills.*`` rules still apply.
-        if getattr(self, "skill_func_tool_instance", None):
-            mapping.setdefault("skills", []).extend(self.skill_func_tool_instance.available_tools())
-        catchall: List[Any] = []
-        if self.ask_user_tool:
-            catchall.extend(self.ask_user_tool.available_tools())
-        if getattr(self, "skill_validate_tool", None):
-            catchall.extend(self.skill_validate_tool.available_tools())
-        if getattr(self, "_session_search_tool", None):
-            catchall.extend(self._session_search_tool.available_tools())
-        if catchall:
-            mapping.setdefault("tools", []).extend(catchall)
-        return mapping
 
     # Companion skills loaded into system prompt
     COMPANION_SKILLS = ("create-skill", "optimize-skill")

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -10,7 +10,7 @@ SQL generation with support for limited context, enhanced template variables,
 and flexible configuration through agent.yml.
 """
 
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
@@ -783,31 +783,6 @@ class GenSQLAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to update SQL generation context: {e}")
             return {"success": False, "message": str(e)}
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register tools under their canonical categories so permission rules fire.
-
-        Without this override the bound tools fall through to the ``tools.*``
-        catch-all (default ASK on normal/auto profiles), which would block at
-        ``InteractionBroker.request`` whenever a caller wires permission hooks
-        but does not also run an interactive broker listener.
-        """
-        mapping = super()._tool_category_map()
-        if getattr(self, "db_func_tool", None):
-            mapping["db_tools"] = list(self.db_func_tool.available_tools())
-        if getattr(self, "context_search_tools", None):
-            mapping["context_search_tools"] = list(self.context_search_tools.available_tools())
-        if getattr(self, "semantic_tools", None):
-            mapping["semantic_tools"] = list(self.semantic_tools.available_tools())
-        if getattr(self, "reference_template_tools", None):
-            mapping["semantic_tools"] = mapping.get("semantic_tools", []) + list(
-                self.reference_template_tools.available_tools()
-            )
-        if getattr(self, "date_parsing_tools", None):
-            mapping["date_parsing_tools"] = list(self.date_parsing_tools.available_tools())
-        if getattr(self, "filesystem_func_tool", None):
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        return mapping
 
     def _extract_sql_and_output_from_response(self, output: dict) -> tuple[Optional[str], Optional[str]]:
         """

--- a/datus/agent/node/gen_table_agentic_node.py
+++ b/datus/agent/node/gen_table_agentic_node.py
@@ -12,7 +12,7 @@ tool set (``execute_ddl`` on top of the read-only DB tools) and the permission
 profile category map.
 """
 
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import ClassVar, Optional
 
 from datus.agent.node.deliverable_node import DeliverableAgenticNode
 from datus.configuration.node_type import NodeType
@@ -56,19 +56,3 @@ class GenTableAgenticNode(DeliverableAgenticNode):
                 code=ErrorCode.COMMON_CONFIG_ERROR,
                 message_args={"config_error": f"Failed to setup database tools for {self.NODE_NAME}: {e}"},
             ) from e
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register db / filesystem tools so write/destructive rules fire."""
-        mapping = super()._tool_category_map()
-        db_bucket: List[Any] = []
-        if getattr(self, "db_func_tool", None):
-            db_bucket.extend(self.db_func_tool.available_tools())
-            if hasattr(self.db_func_tool, "execute_ddl"):
-                db_bucket.append(trans_to_function_tool(self.db_func_tool.execute_ddl))
-        if db_bucket:
-            mapping["db_tools"] = db_bucket
-        if getattr(self, "filesystem_func_tool", None):
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if self.ask_user_tool:
-            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
-        return mapping

--- a/datus/agent/node/scheduler_agentic_node.py
+++ b/datus/agent/node/scheduler_agentic_node.py
@@ -12,7 +12,7 @@ skill injection, and the domain result shape.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List, Literal, Optional
+from typing import Any, ClassVar, Literal, Optional
 
 from datus.agent.node.deliverable_node import DeliverableAgenticNode
 from datus.configuration.agent_config import AgentConfig
@@ -134,17 +134,6 @@ class SchedulerAgenticNode(DeliverableAgenticNode):
             skills_to_inject,
         )
         self._setup_skill_func_tools()
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Register scheduler tools so ``scheduler_tools.delete_job`` DENY fires."""
-        mapping = super()._tool_category_map()
-        if self.scheduler_tools:
-            mapping["scheduler_tools"] = list(self.scheduler_tools.available_tools())
-        if getattr(self, "filesystem_func_tool", None):
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if self.ask_user_tool:
-            mapping.setdefault("tools", []).extend(self.ask_user_tool.available_tools())
-        return mapping
 
     # ── template context ──────────────────────────────────────────────
 

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -11,7 +11,7 @@ generation tools, and hooks.
 """
 
 import re
-from typing import Any, Dict, List, Literal, Optional
+from typing import List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
@@ -170,19 +170,6 @@ class SqlSummaryAgenticNode(AgenticNode):
             logger.info("Setup hooks: generation_hooks")
         except Exception as e:
             logger.error(f"Failed to setup generation_hooks: {e}")
-
-    def _tool_category_map(self) -> Dict[str, List[Any]]:
-        """Route filesystem/generation helpers to permission categories."""
-        from datus.tools.func_tool import trans_to_function_tool
-
-        mapping = super()._tool_category_map()
-        if self.filesystem_func_tool:
-            mapping["filesystem_tools"] = list(self.filesystem_func_tool.available_tools())
-        if self.generation_tools:
-            mapping.setdefault("semantic_tools", []).append(
-                trans_to_function_tool(self.generation_tools.generate_sql_summary_id)
-            )
-        return mapping
 
     def _get_existing_subject_trees(self) -> list:
         """

--- a/datus/tools/base.py
+++ b/datus/tools/base.py
@@ -60,7 +60,7 @@ class BaseTool(ABC):
     # tool-group instance mounted on a node. Subclasses whose tools are governed
     # by a dedicated rule set (``db_tools``, ``filesystem_tools``, ...) must
     # override it; the default lands in the ``tools`` catch-all bucket.
-    permission_category = "tools"
+    permission_category: str = "tools"
 
     def __init__(self, **kwargs):
         """Initialize the tool with common parameters.

--- a/datus/tools/base.py
+++ b/datus/tools/base.py
@@ -54,6 +54,13 @@ class BaseTool(ABC):
 
     tool_name = "base_tool"
     tool_description = "Base tool class"
+    # Permission category for the unified permission system. Profile rules in
+    # ``datus.tools.permission.profiles`` match on ``(category, tool_name)``;
+    # ``AgenticNode._populate_tool_registry`` reads this attribute from every
+    # tool-group instance mounted on a node. Subclasses whose tools are governed
+    # by a dedicated rule set (``db_tools``, ``filesystem_tools``, ...) must
+    # override it; the default lands in the ``tools`` catch-all bucket.
+    permission_category = "tools"
 
     def __init__(self, **kwargs):
         """Initialize the tool with common parameters.

--- a/datus/tools/func_tool/ask_user_tools.py
+++ b/datus/tools/func_tool/ask_user_tools.py
@@ -59,7 +59,7 @@ class AskUserTool:
         broker: InteractionBroker instance (shared with permission hooks).
     """
 
-    permission_category = "tools"
+    permission_category: str = "tools"
 
     MAX_QUESTIONS = 10
     MAX_OPTIONS_PER_QUESTION = 10

--- a/datus/tools/func_tool/ask_user_tools.py
+++ b/datus/tools/func_tool/ask_user_tools.py
@@ -59,6 +59,8 @@ class AskUserTool:
         broker: InteractionBroker instance (shared with permission hooks).
     """
 
+    permission_category = "tools"
+
     MAX_QUESTIONS = 10
     MAX_OPTIONS_PER_QUESTION = 10
     MIN_OPTIONS_PER_QUESTION = 2

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -58,6 +58,8 @@ class BashTool:
     - ``shell=False`` subprocess invocation (argv via ``shlex.split``)
     """
 
+    permission_category = "bash_tools"
+
     def __init__(
         self,
         workspace_root: str,

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -58,7 +58,7 @@ class BashTool:
     - ``shell=False`` subprocess invocation (argv via ``shlex.split``)
     """
 
-    permission_category = "bash_tools"
+    permission_category: str = "bash_tools"
 
     def __init__(
         self,

--- a/datus/tools/func_tool/bi_tools.py
+++ b/datus/tools/func_tool/bi_tools.py
@@ -38,7 +38,7 @@ class BIFuncTool:
     - dataset_db set on the service config: get_bi_serving_target
     """
 
-    permission_category = "bi_tools"
+    permission_category: str = "bi_tools"
 
     def __init__(
         self,

--- a/datus/tools/func_tool/bi_tools.py
+++ b/datus/tools/func_tool/bi_tools.py
@@ -38,6 +38,8 @@ class BIFuncTool:
     - dataset_db set on the service config: get_bi_serving_target
     """
 
+    permission_category = "bi_tools"
+
     def __init__(
         self,
         agent_config: Optional["AgentConfig"] = None,

--- a/datus/tools/func_tool/context_search.py
+++ b/datus/tools/func_tool/context_search.py
@@ -38,7 +38,7 @@ _NAME_TEMPLATE_RENDER = "reference_template_tools.render_reference_template"
     availability_property="has_context_tools",
 )
 class ContextSearchTools:
-    permission_category = "context_search_tools"
+    permission_category: str = "context_search_tools"
 
     @classmethod
     def create_dynamic(cls, agent_config: AgentConfig, sub_agent_name: Optional[str] = None) -> "ContextSearchTools":

--- a/datus/tools/func_tool/context_search.py
+++ b/datus/tools/func_tool/context_search.py
@@ -38,6 +38,8 @@ _NAME_TEMPLATE_RENDER = "reference_template_tools.render_reference_template"
     availability_property="has_context_tools",
 )
 class ContextSearchTools:
+    permission_category = "context_search_tools"
+
     @classmethod
     def create_dynamic(cls, agent_config: AgentConfig, sub_agent_name: Optional[str] = None) -> "ContextSearchTools":
         """

--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -436,7 +436,7 @@ class DashboardArtifactTools:
        every ``params`` literal's keys match the template's declaration.
     """
 
-    permission_category = "artifact_tools"
+    permission_category: str = "artifact_tools"
 
     def __init__(
         self,

--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -436,6 +436,8 @@ class DashboardArtifactTools:
        every ``params`` literal's keys match the template's declaration.
     """
 
+    permission_category = "artifact_tools"
+
     def __init__(
         self,
         *,

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -81,7 +81,7 @@ class DBFuncTool:
     repeated lookups while limiting memory usage.
     """
 
-    permission_category = "db_tools"
+    permission_category: str = "db_tools"
 
     DEFAULT_CONNECTOR_CACHE_SIZE = 8
 

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -81,6 +81,8 @@ class DBFuncTool:
     repeated lookups while limiting memory usage.
     """
 
+    permission_category = "db_tools"
+
     DEFAULT_CONNECTOR_CACHE_SIZE = 8
 
     @classmethod

--- a/datus/tools/func_tool/date_parsing_tools.py
+++ b/datus/tools/func_tool/date_parsing_tools.py
@@ -19,7 +19,7 @@ logger = get_logger(__name__)
 class DateParsingTools:
     """Function tool wrapper for date parsing operations."""
 
-    permission_category = "date_parsing_tools"
+    permission_category: str = "date_parsing_tools"
 
     def __init__(self, agent_config: AgentConfig, model: LLMBaseModel):
         self.agent_config = agent_config

--- a/datus/tools/func_tool/date_parsing_tools.py
+++ b/datus/tools/func_tool/date_parsing_tools.py
@@ -19,6 +19,8 @@ logger = get_logger(__name__)
 class DateParsingTools:
     """Function tool wrapper for date parsing operations."""
 
+    permission_category = "date_parsing_tools"
+
     def __init__(self, agent_config: AgentConfig, model: LLMBaseModel):
         self.agent_config = agent_config
         self.model = model

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -69,6 +69,8 @@ class FilesystemFuncTool(BaseTool):
       is responsible for asking the user first.
     """
 
+    permission_category = "filesystem_tools"
+
     def __init__(
         self,
         root_path: str = None,

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -69,7 +69,7 @@ class FilesystemFuncTool(BaseTool):
       is responsible for asking the user first.
     """
 
-    permission_category = "filesystem_tools"
+    permission_category: str = "filesystem_tools"
 
     def __init__(
         self,

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -73,6 +73,8 @@ class GenerationTools:
     completing the generation process.
     """
 
+    permission_category = "semantic_tools"
+
     def __init__(self, agent_config: AgentConfig, generation_evidence: Optional[GenerationEvidence] = None):
         self.agent_config = agent_config
         self.generation_evidence = generation_evidence or GenerationEvidence()

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -73,7 +73,7 @@ class GenerationTools:
     completing the generation process.
     """
 
-    permission_category = "semantic_tools"
+    permission_category: str = "semantic_tools"
 
     def __init__(self, agent_config: AgentConfig, generation_evidence: Optional[GenerationEvidence] = None):
         self.agent_config = agent_config

--- a/datus/tools/func_tool/memory_filesystem_tools.py
+++ b/datus/tools/func_tool/memory_filesystem_tools.py
@@ -46,6 +46,8 @@ class MemoryFilesystemFuncTool(BaseTool):
     ``"/"`` is stripped, and ``"."`` is treated as the bundle root.
     """
 
+    permission_category = "filesystem_tools"
+
     tool_name = "memory_filesystem"
     tool_description = "Read-only filesystem operations over an in-memory bundle."
 

--- a/datus/tools/func_tool/memory_filesystem_tools.py
+++ b/datus/tools/func_tool/memory_filesystem_tools.py
@@ -46,7 +46,7 @@ class MemoryFilesystemFuncTool(BaseTool):
     ``"/"`` is stripped, and ``"."`` is treated as the bundle root.
     """
 
-    permission_category = "filesystem_tools"
+    permission_category: str = "filesystem_tools"
 
     tool_name = "memory_filesystem"
     tool_description = "Read-only filesystem operations over an in-memory bundle."

--- a/datus/tools/func_tool/memory_tools.py
+++ b/datus/tools/func_tool/memory_tools.py
@@ -42,6 +42,8 @@ class MemoryFuncTool(BaseTool):
     system prompt; children that may not write simply do not mount this tool.
     """
 
+    permission_category = "memory_tools"
+
     tool_name = "memory"
     tool_description = "Append to or edit the agent's persistent memory (single MEMORY.md, hard byte cap)."
 

--- a/datus/tools/func_tool/memory_tools.py
+++ b/datus/tools/func_tool/memory_tools.py
@@ -42,7 +42,7 @@ class MemoryFuncTool(BaseTool):
     system prompt; children that may not write simply do not mount this tool.
     """
 
-    permission_category = "memory_tools"
+    permission_category: str = "memory_tools"
 
     tool_name = "memory"
     tool_description = "Append to or edit the agent's persistent memory (single MEMORY.md, hard byte cap)."

--- a/datus/tools/func_tool/orchestrator_tools.py
+++ b/datus/tools/func_tool/orchestrator_tools.py
@@ -23,6 +23,8 @@ from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 class OrchestratorIssueTools:
     """Issue lifecycle tools owned by an external orchestrator runtime."""
 
+    permission_category = "tools"
+
     def available_tools(self) -> List[FunctionTool]:
         return [
             trans_to_function_tool(self.create_issue_comment, strict_mode=False),

--- a/datus/tools/func_tool/orchestrator_tools.py
+++ b/datus/tools/func_tool/orchestrator_tools.py
@@ -23,7 +23,7 @@ from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 class OrchestratorIssueTools:
     """Issue lifecycle tools owned by an external orchestrator runtime."""
 
-    permission_category = "tools"
+    permission_category: str = "tools"
 
     def available_tools(self) -> List[FunctionTool]:
         return [

--- a/datus/tools/func_tool/plan_tools.py
+++ b/datus/tools/func_tool/plan_tools.py
@@ -266,7 +266,7 @@ class SessionTodoStorage:
 class PlanTool:
     """Main tool for todo list management with read, write, and update capabilities"""
 
-    permission_category = "tools"
+    permission_category: str = "tools"
 
     def __init__(
         self,
@@ -499,7 +499,7 @@ class ConfirmPlanTool:
     feedback so it can iterate.
     """
 
-    permission_category = "tools"
+    permission_category: str = "tools"
 
     def __init__(self, node: "AgenticNode"):
         self.node = node

--- a/datus/tools/func_tool/plan_tools.py
+++ b/datus/tools/func_tool/plan_tools.py
@@ -266,6 +266,8 @@ class SessionTodoStorage:
 class PlanTool:
     """Main tool for todo list management with read, write, and update capabilities"""
 
+    permission_category = "tools"
+
     def __init__(
         self,
         session: SQLiteSession,
@@ -496,6 +498,8 @@ class ConfirmPlanTool:
     exits plan mode; any free-text response is returned to the LLM as
     feedback so it can iterate.
     """
+
+    permission_category = "tools"
 
     def __init__(self, node: "AgenticNode"):
         self.node = node

--- a/datus/tools/func_tool/platform_doc_search.py
+++ b/datus/tools/func_tool/platform_doc_search.py
@@ -29,6 +29,8 @@ class PlatformDocSearchTool:
     - web_search_document: Web search via Tavily
     """
 
+    permission_category = "platform_doc_tools"
+
     def __init__(self, agent_config: AgentConfig):
         self.agent_config = agent_config
 

--- a/datus/tools/func_tool/platform_doc_search.py
+++ b/datus/tools/func_tool/platform_doc_search.py
@@ -29,7 +29,7 @@ class PlatformDocSearchTool:
     - web_search_document: Web search via Tavily
     """
 
-    permission_category = "platform_doc_tools"
+    permission_category: str = "platform_doc_tools"
 
     def __init__(self, agent_config: AgentConfig):
         self.agent_config = agent_config

--- a/datus/tools/func_tool/reference_template_tools.py
+++ b/datus/tools/func_tool/reference_template_tools.py
@@ -23,6 +23,8 @@ logger = get_logger(__name__)
     availability_property="has_reference_template_tools",
 )
 class ReferenceTemplateTools:
+    permission_category = "reference_template_tools"
+
     @classmethod
     def create_dynamic(
         cls, agent_config: AgentConfig, sub_agent_name: Optional[str] = None

--- a/datus/tools/func_tool/reference_template_tools.py
+++ b/datus/tools/func_tool/reference_template_tools.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
     availability_property="has_reference_template_tools",
 )
 class ReferenceTemplateTools:
-    permission_category = "reference_template_tools"
+    permission_category: str = "reference_template_tools"
 
     @classmethod
     def create_dynamic(

--- a/datus/tools/func_tool/report_artifact_tools.py
+++ b/datus/tools/func_tool/report_artifact_tools.py
@@ -294,6 +294,8 @@ class ReportArtifactTools:
        subagent stops on its first success.
     """
 
+    permission_category = "artifact_tools"
+
     def __init__(
         self,
         *,

--- a/datus/tools/func_tool/report_artifact_tools.py
+++ b/datus/tools/func_tool/report_artifact_tools.py
@@ -294,7 +294,7 @@ class ReportArtifactTools:
        subagent stops on its first success.
     """
 
-    permission_category = "artifact_tools"
+    permission_category: str = "artifact_tools"
 
     def __init__(
         self,

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -24,6 +24,8 @@ logger = get_logger(__name__)
 class SchedulerTools(BaseTool):
     """Function tools for interacting with the configured scheduler platform (e.g. Airflow)."""
 
+    permission_category = "scheduler_tools"
+
     tool_name = "scheduler_tools"
     tool_description = "Tools for submitting and managing scheduled jobs via Airflow"
 

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 class SchedulerTools(BaseTool):
     """Function tools for interacting with the configured scheduler platform (e.g. Airflow)."""
 
-    permission_category = "scheduler_tools"
+    permission_category: str = "scheduler_tools"
 
     tool_name = "scheduler_tools"
     tool_description = "Tools for submitting and managing scheduled jobs via Airflow"

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -29,6 +29,8 @@ class SemanticDiscoveryTools:
     to help generate semantic models and MetricFlow metrics.
     """
 
+    permission_category = "semantic_tools"
+
     _AGGREGATE_CLASSES = ()
 
     def __init__(self, db_tool: DBFuncTool):

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -29,7 +29,7 @@ class SemanticDiscoveryTools:
     to help generate semantic models and MetricFlow metrics.
     """
 
-    permission_category = "semantic_tools"
+    permission_category: str = "semantic_tools"
 
     _AGGREGATE_CLASSES = ()
 

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -222,6 +222,8 @@ def _run_async(coro):
 class SemanticTools:
     """Function tool wrapper for semantic layer operations."""
 
+    permission_category = "semantic_tools"
+
     MAX_QUERY_METRICS_RESULT_CACHE_SIZE = 100
 
     @classmethod

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -222,7 +222,7 @@ def _run_async(coro):
 class SemanticTools:
     """Function tool wrapper for semantic layer operations."""
 
-    permission_category = "semantic_tools"
+    permission_category: str = "semantic_tools"
 
     MAX_QUERY_METRICS_RESULT_CACHE_SIZE = 100
 

--- a/datus/tools/func_tool/session_search_tool.py
+++ b/datus/tools/func_tool/session_search_tool.py
@@ -29,7 +29,7 @@ class SessionSearchTool:
     records for analysis.
     """
 
-    permission_category = "tools"
+    permission_category: str = "tools"
 
     def __init__(self, sessions_dir: Optional[str] = None):
         self.sessions_dir = sessions_dir

--- a/datus/tools/func_tool/session_search_tool.py
+++ b/datus/tools/func_tool/session_search_tool.py
@@ -29,6 +29,8 @@ class SessionSearchTool:
     records for analysis.
     """
 
+    permission_category = "tools"
+
     def __init__(self, sessions_dir: Optional[str] = None):
         self.sessions_dir = sessions_dir
 

--- a/datus/tools/func_tool/skill_validate_tool.py
+++ b/datus/tools/func_tool/skill_validate_tool.py
@@ -36,7 +36,7 @@ class SkillValidateTool:
     - Directory structure is correct
     """
 
-    permission_category = "tools"
+    permission_category: str = "tools"
 
     def validate_skill(self, skill_path: str) -> FuncToolResult:
         """Validate a SKILL.md file and report any issues.

--- a/datus/tools/func_tool/skill_validate_tool.py
+++ b/datus/tools/func_tool/skill_validate_tool.py
@@ -36,6 +36,8 @@ class SkillValidateTool:
     - Directory structure is correct
     """
 
+    permission_category = "tools"
+
     def validate_skill(self, skill_path: str) -> FuncToolResult:
         """Validate a SKILL.md file and report any issues.
 

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -220,6 +220,8 @@ class SubAgentTaskTool:
     for every task invocation to ensure fully independent context.
     """
 
+    permission_category = "sub_agent_tools"
+
     def __init__(
         self,
         agent_config: AgentConfig,

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -220,7 +220,7 @@ class SubAgentTaskTool:
     for every task invocation to ensure fully independent context.
     """
 
-    permission_category = "sub_agent_tools"
+    permission_category: str = "sub_agent_tools"
 
     def __init__(
         self,

--- a/datus/tools/permission/permission_manager.py
+++ b/datus/tools/permission/permission_manager.py
@@ -218,15 +218,17 @@ class PermissionManager:
         Args:
             tools: List of available tools
             node_name: Name of the current agentic node
-            tool_category: Optional explicit tool category (auto-detected if not provided)
+            tool_category: Optional explicit tool category. Callers that know
+                the category (e.g. from ``ToolRegistry``) should pass it;
+                otherwise the ``tools`` catch-all applies, matching the
+                fallback in ``PermissionHooks._get_category_and_pattern``.
 
         Returns:
             Filtered list of tools (DENY removed)
         """
         filtered = []
         for tool in tools:
-            # Use provided category or determine from tool name
-            category = tool_category if tool_category else self._get_tool_category(tool.name)
+            category = tool_category or "tools"
 
             permission = self.check_permission(category, tool.name, node_name)
 
@@ -379,46 +381,6 @@ class PermissionManager:
             f"{len(self.global_config.rules)} effective rules, "
             f"session approvals cleared"
         )
-
-    def _get_tool_category(self, tool_name: str) -> str:
-        """Determine tool category from tool name.
-
-        Args:
-            tool_name: Name of the tool
-
-        Returns:
-            Tool category string
-        """
-        # Common tool name prefixes to categories
-        if tool_name.startswith("db_") or tool_name in (
-            "execute_sql",
-            "list_tables",
-            "describe_table",
-            "get_table_schema",
-            "get_sample_data",
-        ):
-            return "db_tools"
-        elif tool_name == "load_skill" or tool_name.startswith("skill_"):
-            return "skills"
-        elif tool_name.startswith("search_") or tool_name in ("search_metrics", "search_tables", "search_documents"):
-            return "context_search_tools"
-        elif tool_name.startswith("fs_") or tool_name in (
-            "read_file",
-            "write_file",
-            "edit_file",
-            "glob",
-            "grep",
-        ):
-            return "filesystem_tools"
-        elif tool_name.startswith("date_") or tool_name in ("parse_date", "parse_temporal_expressions"):
-            return "date_parsing_tools"
-        elif tool_name in ("add_memory", "edit_memory"):
-            return "memory_tools"
-        else:
-            # For MCP tools, the category might be in the format "server.tool"
-            if "." in tool_name:
-                return "mcp"
-            return "tools"
 
     def get_permission_summary(self, node_name: str) -> Dict[str, Any]:
         """Get a summary of permissions for debugging.

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -121,6 +121,24 @@ _NORMAL_RULES = [
     # subagent's own PermissionHooks instance. Double-prompting here would
     # fire on nearly every chat interaction for zero safety benefit.
     _rule("sub_agent_tools", "*", PermissionLevel.ALLOW),
+    # reference templates: read-only end to end — search/get/render are pure
+    # lookups and ``execute_reference_template`` renders Jinja then runs
+    # ``db_tools.read_query`` (never a write). Historically gen_sql lumped
+    # these into ``semantic_tools`` (ALLOW) while chat left them in the
+    # catch-all (ASK); the dedicated category unifies on ALLOW.
+    _rule("reference_template_tools", "*", PermissionLevel.ALLOW),
+    # artifact authoring helpers (``start_new_*`` / ``bind_existing_*`` /
+    # ``save_query*`` / ``validate_render``) are subagent-internal state
+    # mutations confined to the artifact tree; users review the artifact as
+    # a whole via the rendered preview, not per-call prompts. Mirrors the
+    # historical lumping into ``semantic_tools``.
+    _rule("artifact_tools", "*", PermissionLevel.ALLOW),
+    # platform doc lookups are read-only; ``web_search_document`` reaches
+    # the network (Tavily) and stays at the profile default (ASK in
+    # normal/auto).
+    _rule("platform_doc_tools", "list_*", PermissionLevel.ALLOW),
+    _rule("platform_doc_tools", "get_*", PermissionLevel.ALLOW),
+    _rule("platform_doc_tools", "search_*", PermissionLevel.ALLOW),
     # mcp: ASK; skill loading ALLOW, but skill script execution still ASK.
     _rule("mcp.*", "*", PermissionLevel.ASK),
     _rule("skills", "*", PermissionLevel.ALLOW),

--- a/datus/tools/skill_tools/skill_func_tool.py
+++ b/datus/tools/skill_tools/skill_func_tool.py
@@ -43,7 +43,7 @@ class SkillFuncTool:
         # LLM calls load_skill(skill_name="sql-optimization")
     """
 
-    permission_category = "skills"
+    permission_category: str = "skills"
 
     def __init__(
         self,

--- a/datus/tools/skill_tools/skill_func_tool.py
+++ b/datus/tools/skill_tools/skill_func_tool.py
@@ -43,6 +43,8 @@ class SkillFuncTool:
         # LLM calls load_skill(skill_name="sql-optimization")
     """
 
+    permission_category = "skills"
+
     def __init__(
         self,
         manager: SkillManager,

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -286,33 +286,6 @@ class TestGetSystemPromptWorkspaceRoot:
 
 
 # ---------------------------------------------------------------------------
-# TestGetToolCategory
-# ---------------------------------------------------------------------------
-
-
-class TestGetToolCategory:
-    def test_skill_tool(self):
-        node = _make_node()
-        assert node._get_tool_category("load_skill") == "skills"
-        assert node._get_tool_category("skill_something") == "skills"
-
-    def test_db_tool(self):
-        node = _make_node()
-        assert node._get_tool_category("list_tables") == "db_tools"
-        assert node._get_tool_category("execute_sql") == "db_tools"
-        assert node._get_tool_category("db_custom_tool") == "db_tools"
-
-    def test_generic_tool(self):
-        node = _make_node()
-        assert node._get_tool_category("some_random_tool") == "tools"
-
-    def test_mcp_tool(self):
-        node = _make_node()
-        node.mcp_servers = {"myserver": MagicMock()}
-        assert node._get_tool_category("myserver_do_something") == "mcp"
-
-
-# ---------------------------------------------------------------------------
 # TestSetupInput (default implementation)
 # ---------------------------------------------------------------------------
 
@@ -1056,35 +1029,6 @@ class TestParseNodeConfigExtended:
 
 # ---------------------------------------------------------------------------
 # _get_tool_category
-# ---------------------------------------------------------------------------
-
-
-class TestGetToolCategoryExtended:
-    def test_load_skill_is_skills(self):
-        node = _make_simple_node()
-        assert node._get_tool_category("load_skill") == "skills"
-
-    def test_skill_prefix_is_skills(self):
-        node = _make_simple_node()
-        assert node._get_tool_category("skill_run_query") == "skills"
-
-    def test_db_prefix_is_db_tools(self):
-        node = _make_simple_node()
-        assert node._get_tool_category("db_execute") == "db_tools"
-
-    def test_list_tables_is_db_tools(self):
-        node = _make_simple_node()
-        assert node._get_tool_category("list_tables") == "db_tools"
-
-    def test_execute_sql_is_db_tools(self):
-        node = _make_simple_node()
-        assert node._get_tool_category("execute_sql") == "db_tools"
-
-    def test_unknown_tool_is_tools(self):
-        node = _make_simple_node()
-        assert node._get_tool_category("my_custom_tool") == "tools"
-
-
 # ---------------------------------------------------------------------------
 # _resolve_workspace_root
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -1035,9 +1035,10 @@ class TestBashToolToggle:
         node.tools = []
         node._ensure_bash_tool_in_tools()
         assert node.tools == []
-        # Category map must drop the ``bash_tools`` bucket so profile
-        # rules don't inherit a phantom entry.
-        assert "bash_tools" not in node._tool_category_map()
+        # The registry must not carry a phantom ``bash_tools`` entry when
+        # the bash tool is disabled.
+        node._populate_tool_registry()
+        assert "bash_tools" not in node.tool_registry.to_dict().values()
 
     def test_bash_tool_skipped_without_permission_manager(self, mock_agent_config):
         """Without permission enforcement, BashTool must NOT be created.

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -666,10 +666,17 @@ class TestAskMetricsAgenticNode:
         # guard in ``AgenticNode._iter_tool_groups``).
         db_tools.permission_category = "db_tools"
         db_tools.all_tools_name = lambda: ["read_query"]
+        # Model available_tools() explicitly instead of relying on Mock
+        # auto-creation, so the double mirrors the full production contract
+        # (permission_category + available_tools() + all_tools_name()).
+        db_tools.available_tools.return_value = [_fake_function_tool(db_tools.read_query)]
         date_parsing_tools = Mock()
         date_parsing_tools.parse_temporal_expressions = Mock(name="parse_temporal_expressions")
         date_parsing_tools.permission_category = "date_parsing_tools"
         date_parsing_tools.all_tools_name = lambda: ["parse_temporal_expressions"]
+        date_parsing_tools.available_tools.return_value = [
+            _fake_function_tool(date_parsing_tools.parse_temporal_expressions)
+        ]
 
         with (
             patch("datus.agent.node.ask_metrics_agentic_node.DBFuncTool", return_value=db_tools),

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -661,8 +661,15 @@ class TestAskMetricsAgenticNode:
         db_tools = Mock()
         db_tools.read_query = Mock(name="read_query")
         db_tools.to_function_tool.side_effect = _fake_function_tool
+        # Plain-string category + name list so the registry scanner picks the
+        # mock up (Mock auto-attributes are excluded by the isinstance(str)
+        # guard in ``AgenticNode._iter_tool_groups``).
+        db_tools.permission_category = "db_tools"
+        db_tools.all_tools_name = lambda: ["read_query"]
         date_parsing_tools = Mock()
         date_parsing_tools.parse_temporal_expressions = Mock(name="parse_temporal_expressions")
+        date_parsing_tools.permission_category = "date_parsing_tools"
+        date_parsing_tools.all_tools_name = lambda: ["parse_temporal_expressions"]
 
         with (
             patch("datus.agent.node.ask_metrics_agentic_node.DBFuncTool", return_value=db_tools),
@@ -679,9 +686,10 @@ class TestAskMetricsAgenticNode:
             )
 
         assert [tool.name for tool in node.tools] == ["read_query", "parse_temporal_expressions"]
-        mapping = node._tool_category_map()
-        assert [tool.name for tool in mapping["db_tools"]] == ["read_query"]
-        assert [tool.name for tool in mapping["date_parsing_tools"]] == ["parse_temporal_expressions"]
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry.get("read_query") == "db_tools"
+        assert registry.get("parse_temporal_expressions") == "date_parsing_tools"
 
     def test_setup_tools_handles_context_search_failure(self, real_agent_config, mock_llm_create):
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
@@ -844,18 +852,21 @@ class TestAskMetricsAgenticNode:
         assert result.response == "{'value': 10}"
         assert result.markdown_report == "{'value': 10}"
 
-    def test_tool_category_map_is_narrow(self, real_agent_config, mock_llm_create):
+    def test_mounted_tool_surface_is_narrow(self, real_agent_config, mock_llm_create):
+        """The mounted tool surface stays the DEFAULT_TOOLS whitelist.
+
+        The registry intentionally registers each class's full name surface
+        (superset, name -> category lookup only); narrowness is enforced by
+        ``node.tools``, so assert on the mounted names instead.
+        """
         tree = {"Sales": {"metrics": ["revenue"]}}
         node, _, _ = _make_node(real_agent_config, tree=tree)
 
-        mapping = node._tool_category_map()
-        assert {tool.name for tool in mapping["semantic_tools"]} == {
+        assert {tool.name for tool in node.tools} == {
             "list_metrics",
             "get_dimensions",
             "query_metrics",
             "attribution_analyze",
-        }
-        assert {tool.name for tool in mapping["context_search_tools"]} == {
             "search_metrics",
             "get_metrics",
         }

--- a/tests/unit_tests/agent/node/test_explore_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_explore_agentic_node.py
@@ -172,8 +172,8 @@ class TestExploreAgenticNodeTools:
         )
         assert node.mcp_servers == {}
 
-    def test_tool_category_map_registers_categories(self, real_agent_config, mock_llm_create):
-        """``_tool_category_map`` must split read-only tools into the right
+    def test_tool_registry_registers_categories(self, real_agent_config, mock_llm_create):
+        """The tool registry must classify read-only tools into the right
         categories so ``db_tools.read_*`` ALLOW rules match under normal profile."""
         from datus.agent.node.explore_agentic_node import ExploreAgenticNode
 
@@ -184,10 +184,11 @@ class TestExploreAgenticNodeTools:
             agent_config=real_agent_config,
             node_name="explore",
         )
-        mapping = node._tool_category_map()
-        assert "db_tools" in mapping
-        assert "filesystem_tools" in mapping
-        assert "date_parsing_tools" in mapping
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry.get("read_query") == "db_tools"
+        assert registry.get("read_file") == "filesystem_tools"
+        assert registry.get("parse_temporal_expressions") == "date_parsing_tools"
 
     def test_context_search_prompt_only_lists_available_tools(self, real_agent_config, mock_llm_create):
         """Explore prompt should not advertise context tools that are not exposed."""

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -420,7 +420,7 @@ class TestGenDashboardToolSetup:
 class TestGenDashboardPermissionWiring:
     """Without proper wiring ``bi_tools.delete_*`` DENY rules silently leak."""
 
-    def test_tool_category_map_registers_bi_tools(self, real_agent_config, mock_llm_create):
+    def test_tool_registry_registers_bi_tools(self, real_agent_config, mock_llm_create):
         """Every BI tool must land in the ``bi_tools`` category.
 
         Falling back to the ``tools`` catch-all would prevent
@@ -434,10 +434,10 @@ class TestGenDashboardPermissionWiring:
             from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
 
             node = GenDashboardAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-            mapping = node._tool_category_map()
-            assert "bi_tools" in mapping
-            bi_names = {t.name for t in mapping["bi_tools"]}
-            assert {"delete_chart", "delete_dataset", "delete_dashboard"}.issubset(bi_names)
+            node._populate_tool_registry()
+            registry = node.tool_registry.to_dict()
+            for name in ("delete_chart", "delete_dataset", "delete_dashboard"):
+                assert registry.get(name) == "bi_tools"
 
     def test_compose_hooks_yields_permission_hooks(self, real_agent_config, mock_llm_create):
         """``generate_with_tools_stream`` must receive a real hook, not None.

--- a/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
@@ -120,17 +120,19 @@ class TestGenJobAgenticNodeInit:
 
         check_dynamic_db_func_tool(GenJobAgenticNode, real_agent_config)
 
-    def test_tool_category_map_lumps_db_write_helpers_under_db_tools(self, real_agent_config, mock_llm_create):
-        """``_tool_category_map`` must keep ``execute_write`` / ``execute_ddl`` /
-        ``transfer_query_result`` in ``db_tools`` so profile ASK rules fire."""
+    def test_tool_registry_keeps_db_write_helpers_under_db_tools(self, real_agent_config, mock_llm_create):
+        """``execute_write`` / ``execute_ddl`` / ``transfer_query_result`` must
+        stay in ``db_tools`` so profile ASK rules fire. They are mounted as
+        method-level wrappers, so the registry must cover the full
+        ``DBFuncTool.all_tools_name()`` surface, not just ``available_tools()``."""
         from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
 
         node = GenJobAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        mapping = node._tool_category_map()
-        db_names = {t.name for t in mapping.get("db_tools", [])}
-        assert "execute_ddl" in db_names
-        assert "execute_write" in db_names
-        assert "transfer_query_result" in db_names
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry.get("execute_ddl") == "db_tools"
+        assert registry.get("execute_write") == "db_tools"
+        assert registry.get("transfer_query_result") == "db_tools"
 
     def test_system_prompt_requires_explicit_authorization_for_replacement(self, real_agent_config, mock_llm_create):
         """gen_job inherits gen-table behavior and must not overwrite in workflow mode by default."""

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -108,8 +108,8 @@ class TestGenMetricsAgenticNodeInit:
             if original is not None:
                 real_agent_config.agentic_nodes["gen_metrics"] = original
 
-    def test_tool_category_map_splits_semantic_and_db(self, real_agent_config, mock_llm_create):
-        """``_tool_category_map`` buckets semantic helpers into ``semantic_tools`` and
+    def test_tool_registry_splits_semantic_and_db(self, real_agent_config, mock_llm_create):
+        """The registry buckets semantic helpers into ``semantic_tools`` and
         DB helpers into ``db_tools`` so profile rules for each match correctly."""
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
@@ -117,12 +117,12 @@ class TestGenMetricsAgenticNodeInit:
             agent_config=real_agent_config,
             execution_mode="workflow",
         )
-        mapping = node._tool_category_map()
-        semantic_names = {t.name for t in mapping.get("semantic_tools", [])}
-        assert "end_metric_generation" in semantic_names
-        assert "check_semantic_object_exists" in semantic_names
-        assert "db_tools" in mapping
-        assert "filesystem_tools" in mapping
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry.get("end_metric_generation") == "semantic_tools"
+        assert registry.get("check_semantic_object_exists") == "semantic_tools"
+        assert registry.get("read_query") == "db_tools"
+        assert registry.get("write_file") == "filesystem_tools"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
@@ -107,17 +107,17 @@ class TestGenTableAgenticNodeInit:
         node = GenTableAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         assert node.execution_mode == "workflow"
 
-    def test_tool_category_map_buckets_db_and_filesystem(self, real_agent_config, mock_llm_create):
+    def test_tool_registry_buckets_db_and_filesystem(self, real_agent_config, mock_llm_create):
         """DB helpers (incl. ``execute_ddl``) land in ``db_tools`` and FS tools
         in ``filesystem_tools`` so profile rules gate them correctly."""
         from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
 
         node = GenTableAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        mapping = node._tool_category_map()
-        db_names = {t.name for t in mapping.get("db_tools", [])}
-        assert "execute_ddl" in db_names
-        assert "read_query" in db_names
-        assert "filesystem_tools" in mapping
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry.get("execute_ddl") == "db_tools"
+        assert registry.get("read_query") == "db_tools"
+        assert registry.get("write_file") == "filesystem_tools"
 
     def test_interactive_mode(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -105,18 +105,18 @@ class TestGenVisualDashboardInit:
         assert "validate_render" not in tool_names
         assert "start_new_dashboard" not in tool_names
 
-    def test_tool_category_map_registers_filesystem_tools(self, real_agent_config, mock_llm_create):
+    def test_tool_registry_registers_filesystem_tools(self, real_agent_config, mock_llm_create):
         """Same contract as the visual report node: filesystem tools must
         be declared under ``filesystem_tools`` so permission gating and
         ``_FS_DEPENDENT_NODES`` exclusion in ``apply_proxy_tools`` apply.
         """
         node = _make_node(real_agent_config)
-        mapping = node._tool_category_map()
-        assert "filesystem_tools" in mapping
-        fs_tool_names = {t.name for t in mapping["filesystem_tools"]}
-        assert {"read_file", "write_file", "edit_file", "delete_file"}.issubset(fs_tool_names)
-        assert "db_tools" in mapping
-        assert "semantic_tools" in mapping
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        for name in ("read_file", "write_file", "edit_file", "delete_file"):
+            assert registry.get(name) == "filesystem_tools"
+        assert registry.get("read_query") == "db_tools"
+        assert "semantic_tools" in registry.values()
 
     def test_metric_discovery_tools_exposed_when_metrics_present(self, real_agent_config, mock_llm_create, monkeypatch):
         """Mirrors the report-node contract: with metrics indexed, the

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -121,20 +121,20 @@ class TestGenVisualReportInit:
         assert "save_query" not in tool_names
         assert "validate_render" not in tool_names
 
-    def test_tool_category_map_registers_filesystem_tools(self, real_agent_config, mock_llm_create):
+    def test_tool_registry_registers_filesystem_tools(self, real_agent_config, mock_llm_create):
         """Filesystem tools must be declared in the ``filesystem_tools``
         category so ``PermissionHooks._handle_filesystem_zone`` engages and
         ``apply_proxy_tools`` recognises them as excluded via
         ``_FS_DEPENDENT_NODES``.
         """
         node = _make_node(real_agent_config)
-        mapping = node._tool_category_map()
-        assert "filesystem_tools" in mapping
-        fs_tool_names = {t.name for t in mapping["filesystem_tools"]}
-        assert {"read_file", "write_file", "edit_file", "delete_file"}.issubset(fs_tool_names)
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        for name in ("read_file", "write_file", "edit_file", "delete_file"):
+            assert registry.get(name) == "filesystem_tools"
         # db_tools and semantic_tools also surface under their own categories.
-        assert "db_tools" in mapping
-        assert "semantic_tools" in mapping
+        assert registry.get("read_query") == "db_tools"
+        assert "semantic_tools" in registry.values()
 
     def test_metric_discovery_tools_exposed_when_metrics_present(self, real_agent_config, mock_llm_create, monkeypatch):
         """When the project has indexed metrics, the visual report node must

--- a/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
@@ -57,6 +57,10 @@ def _make_mock_scheduler_tools():
         tool.name = name
         fake_tools.append(tool)
     mock_tools.available_tools.return_value = fake_tools
+    # Plain-string category so AgenticNode._iter_tool_groups picks the mock
+    # up (Mock auto-attributes are excluded by the isinstance(str) guard).
+    mock_tools.permission_category = "scheduler_tools"
+    mock_tools.all_tools_name = lambda: fake_tool_names
     return mock_tools
 
 
@@ -298,20 +302,20 @@ class TestSchedulerToolSetup:
             assert "submit_sql_job" not in tool_names
             assert "write_file" in tool_names
 
-    def test_tool_category_map_registers_scheduler_tools(self, real_agent_config, mock_llm_create):
-        """``_tool_category_map`` must place scheduler tools under ``scheduler_tools``
-        so ``scheduler_tools.delete_job`` DENY rule fires under normal profile."""
+    def test_tool_registry_registers_scheduler_tools(self, real_agent_config, mock_llm_create):
+        """Scheduler tools must land under ``scheduler_tools`` so the
+        ``scheduler_tools.delete_job`` DENY rule fires under normal profile."""
         _add_scheduler_config(real_agent_config)
         with patch(_SCHEDULER_TOOLS_PATCH, return_value=_make_mock_scheduler_tools()):
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
             node = SchedulerAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-            mapping = node._tool_category_map()
-            tool_names = {t.name for t in mapping.get("scheduler_tools", [])}
-            assert "submit_sql_job" in tool_names
-            assert "trigger_scheduler_job" in tool_names
-            fs_tool_names = {t.name for t in mapping.get("filesystem_tools", [])}
-            assert "write_file" in fs_tool_names
+            node._populate_tool_registry()
+            registry = node.tool_registry.to_dict()
+            assert registry.get("submit_sql_job") == "scheduler_tools"
+            assert registry.get("trigger_scheduler_job") == "scheduler_tools"
+            assert registry.get("delete_job") == "scheduler_tools"
+            assert registry.get("write_file") == "filesystem_tools"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
@@ -175,7 +175,7 @@ class TestSkillCreatorAgenticNodeTools:
         assert "list_tables" in tool_names
         assert "describe_table" in tool_names
 
-    def test_tool_category_map_splits_filesystem_db_and_skills(self, real_agent_config, mock_llm_create):
+    def test_tool_registry_splits_filesystem_db_and_skills(self, real_agent_config, mock_llm_create):
         """Filesystem, db, and skill-loading tools must each land in their own
         permission category so profile rules route correctly."""
         from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
@@ -187,11 +187,11 @@ class TestSkillCreatorAgenticNodeTools:
             agent_config=real_agent_config,
             node_name="gen_skill",
         )
-        mapping = node._tool_category_map()
-        assert "filesystem_tools" in mapping
-        assert "db_tools" in mapping
-        skill_names = {t.name for t in mapping.get("skills", [])}
-        assert "load_skill" in skill_names
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry.get("write_file") == "filesystem_tools"
+        assert registry.get("read_query") == "db_tools"
+        assert registry.get("load_skill") == "skills"
 
     def test_has_ask_user_tool(self, real_agent_config, mock_llm_create):
         """Node should have ask_user tool."""

--- a/tests/unit_tests/agent/node/test_tool_category_maps.py
+++ b/tests/unit_tests/agent/node/test_tool_category_maps.py
@@ -64,6 +64,7 @@ class TestPermissionCategoryDeclarations:
             ("datus.tools.func_tool.generation_tools", "GenerationTools", "semantic_tools"),
             ("datus.tools.func_tool.semantic_discovery_tools", "SemanticDiscoveryTools", "semantic_tools"),
             ("datus.tools.func_tool.context_search", "ContextSearchTools", "context_search_tools"),
+            ("datus.tools.func_tool.bi_tools", "BIFuncTool", "bi_tools"),
             (
                 "datus.tools.func_tool.reference_template_tools",
                 "ReferenceTemplateTools",

--- a/tests/unit_tests/agent/node/test_tool_category_maps.py
+++ b/tests/unit_tests/agent/node/test_tool_category_maps.py
@@ -2,29 +2,28 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""``_tool_category_map`` coverage for write-capable subagent nodes.
+"""Tool registry population coverage for the permission system.
 
-These methods are pure routing — no setup needed beyond hand-stubbed
-attributes. Covering them at this tier keeps the regression surface
-for ``db_tools.*`` / ``filesystem_tools.*`` / ``scheduler_tools.*``
-profile rules under unit tests that finish in milliseconds, instead of
-only through nightly-marked flows that spin up real DB
-connectors and drive the OpenAI Agents SDK tool loop.
+Categories are declared once at each tool class's definition site via
+``permission_category``; ``AgenticNode._populate_tool_registry`` introspects
+node attributes and registers every group's full name surface
+(``all_tools_name()`` preferred over ``available_tools()``). These tests pin
+both halves of that contract:
 
-``trans_to_function_tool`` (the OpenAI Agents SDK wrapper) introspects
-``func.__name__`` / the docstring, so any attribute wrapped via it must
-be a *real* callable — a bare ``MagicMock`` raises ``AttributeError``.
+* the declaration table — a tool class drifting to the wrong category would
+  silently re-route its profile rules;
+* the introspection — a mounted group that the scanner misses falls back to
+  the ``tools`` catch-all at hook time (default ASK on normal/auto), which is
+  exactly the historical ``task``-tool bug this design removes.
 """
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 
-def _stub(*names):
-    """Stub tool registry returning named FunctionTool-like instances."""
-    bucket = MagicMock()
-    bucket.available_tools = MagicMock(return_value=[_named(n) for n in names])
-    return bucket
+from datus.agent.node.agentic_node import AgenticNode
+from datus.tools.registry.tool_registry import ToolRegistry
 
 
 def _named(name):
@@ -33,207 +32,215 @@ def _named(name):
     return t
 
 
-def _fn(name):
-    """Real callable with ``__name__`` set — required by ``trans_to_function_tool``.
+def _group(category, *names, with_all_tools_name=False):
+    """Tool-group stand-in with an explicit string category.
 
-    Parameter names must be public: Pydantic treats leading-underscore
-    names as private attributes and rejects them when ``function_schema``
-    builds its input model from the signature.
+    ``permission_category`` must be a plain string for the scanner to pick
+    the group up — Mock auto-attributes are excluded by design.
     """
+    group = SimpleNamespace(
+        permission_category=category,
+        available_tools=lambda: [_named(n) for n in names],
+    )
+    if with_all_tools_name:
+        group.all_tools_name = lambda: list(names)
+    return group
 
-    def _impl() -> None:
-        return None
 
-    _impl.__name__ = name
-    _impl.__doc__ = f"{name} stub"
-    return _impl
+def _bare_node():
+    node = AgenticNode.__new__(AgenticNode)
+    node.tool_registry = ToolRegistry()
+    return node
 
 
-class TestGenTableToolCategoryMap:
-    def test_db_and_filesystem_buckets_with_ddl_helper(self):
-        from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
+class TestPermissionCategoryDeclarations:
+    """Every tool class declares its category at the definition site."""
 
-        node = GenTableAgenticNode.__new__(GenTableAgenticNode)
-        node.skill_func_tool = None
-        node.ask_user_tool = _stub("ask_user")
-        node.filesystem_func_tool = _stub("read_file", "write_file")
+    @pytest.mark.parametrize(
+        "import_path,class_name,expected_category",
+        [
+            ("datus.tools.func_tool.database", "DBFuncTool", "db_tools"),
+            ("datus.tools.func_tool.semantic_tools", "SemanticTools", "semantic_tools"),
+            ("datus.tools.func_tool.generation_tools", "GenerationTools", "semantic_tools"),
+            ("datus.tools.func_tool.semantic_discovery_tools", "SemanticDiscoveryTools", "semantic_tools"),
+            ("datus.tools.func_tool.context_search", "ContextSearchTools", "context_search_tools"),
+            (
+                "datus.tools.func_tool.reference_template_tools",
+                "ReferenceTemplateTools",
+                "reference_template_tools",
+            ),
+            ("datus.tools.func_tool.filesystem_tools", "FilesystemFuncTool", "filesystem_tools"),
+            ("datus.tools.func_tool.memory_filesystem_tools", "MemoryFilesystemFuncTool", "filesystem_tools"),
+            ("datus.tools.func_tool.metric_filesystem_tools", "MetricFilesystemFuncTool", "filesystem_tools"),
+            ("datus.tools.func_tool.memory_tools", "MemoryFuncTool", "memory_tools"),
+            ("datus.tools.func_tool.scheduler_tools", "SchedulerTools", "scheduler_tools"),
+            ("datus.tools.func_tool.bash_tool", "BashTool", "bash_tools"),
+            ("datus.tools.func_tool.date_parsing_tools", "DateParsingTools", "date_parsing_tools"),
+            ("datus.tools.func_tool.sub_agent_task_tool", "SubAgentTaskTool", "sub_agent_tools"),
+            ("datus.tools.func_tool.ask_user_tools", "AskUserTool", "tools"),
+            ("datus.tools.func_tool.platform_doc_search", "PlatformDocSearchTool", "platform_doc_tools"),
+            ("datus.tools.func_tool.plan_tools", "PlanTool", "tools"),
+            ("datus.tools.func_tool.plan_tools", "ConfirmPlanTool", "tools"),
+            ("datus.tools.func_tool.session_search_tool", "SessionSearchTool", "tools"),
+            ("datus.tools.func_tool.skill_validate_tool", "SkillValidateTool", "tools"),
+            ("datus.tools.func_tool.orchestrator_tools", "OrchestratorIssueTools", "tools"),
+            ("datus.tools.func_tool.dashboard_artifact_tools", "DashboardArtifactTools", "artifact_tools"),
+            ("datus.tools.func_tool.report_artifact_tools", "ReportArtifactTools", "artifact_tools"),
+            ("datus.tools.skill_tools.skill_func_tool", "SkillFuncTool", "skills"),
+        ],
+    )
+    def test_class_declares_category(self, import_path, class_name, expected_category):
+        module = __import__(import_path, fromlist=[class_name])
+        cls = getattr(module, class_name)
+        assert cls.permission_category == expected_category
 
-        # ``db_func_tool`` needs ``execute_ddl`` as a real callable — the node
-        # wraps it via ``trans_to_function_tool`` which introspects ``__name__``.
-        node.db_func_tool = SimpleNamespace(
+    def test_artifact_filesystem_subclasses_inherit_filesystem_category(self):
+        """Artifact/report fs tools inherit ``filesystem_tools`` so the
+        PathZone gate in ``PermissionHooks._handle_filesystem_zone`` engages."""
+        from datus.tools.func_tool.dashboard_artifact_tools import DashboardFilesystemFuncTool
+        from datus.tools.func_tool.report_artifact_tools import ReportFilesystemFuncTool
+
+        assert DashboardFilesystemFuncTool.permission_category == "filesystem_tools"
+        assert ReportFilesystemFuncTool.permission_category == "filesystem_tools"
+
+    def test_base_tool_defaults_to_catch_all(self):
+        from datus.tools.base import BaseTool
+
+        assert BaseTool.permission_category == "tools"
+
+
+class TestPopulateToolRegistry:
+    def test_registers_groups_under_declared_categories(self):
+        node = _bare_node()
+        node.db_func_tool = _group("db_tools", "read_query", "execute_ddl", with_all_tools_name=True)
+        node.filesystem_func_tool = _group("filesystem_tools", "read_file", "write_file")
+        node.ask_user_tool = _group("tools", "ask_user")
+
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry["read_query"] == "db_tools"
+        assert registry["execute_ddl"] == "db_tools"
+        assert registry["read_file"] == "filesystem_tools"
+        assert registry["write_file"] == "filesystem_tools"
+        assert registry["ask_user"] == "tools"
+
+    def test_task_tool_registered_outside_chat(self):
+        """The historical bug: only chat declared ``sub_agent_tools``, so the
+        ``task`` tool fell into the catch-all (default ASK) on gen_sql,
+        gen_report, feedback and the visual artifact nodes. Declaration-site
+        categories make the mapping node-independent."""
+        node = _bare_node()
+        node.sub_agent_task_tool = _group("sub_agent_tools", "task")
+
+        node._populate_tool_registry()
+        assert node.tool_registry.to_dict()["task"] == "sub_agent_tools"
+
+    def test_prefers_all_tools_name_superset(self):
+        """``all_tools_name()`` wins over ``available_tools()`` so method-level
+        wrappers (e.g. gen_job mounting ``DBFuncTool.execute_write`` directly)
+        and conditionally-hidden tools are still classified."""
+        node = _bare_node()
+        group = SimpleNamespace(
+            permission_category="db_tools",
             available_tools=lambda: [_named("read_query")],
-            execute_ddl=_fn("execute_ddl"),
+            all_tools_name=lambda: ["read_query", "execute_write", "transfer_query_result"],
         )
+        node.db_func_tool = group
 
-        mapping = node._tool_category_map()
-        assert [t.name for t in mapping["db_tools"] if hasattr(t, "name")][0] == "read_query"
-        assert len(mapping["db_tools"]) == 2
-        assert [t.name for t in mapping["filesystem_tools"]] == ["read_file", "write_file"]
-        assert mapping["tools"][0].name == "ask_user"
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry["execute_write"] == "db_tools"
+        assert registry["transfer_query_result"] == "db_tools"
 
+    def test_falls_back_to_available_tools_when_all_tools_name_raises(self):
+        node = _bare_node()
 
-class TestSchedulerToolCategoryMap:
-    def test_scheduler_bucket_plus_ask_user(self):
-        from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
+        def _boom():
+            raise RuntimeError("no introspection")
 
-        node = SchedulerAgenticNode.__new__(SchedulerAgenticNode)
-        node.skill_func_tool = None
-        node.scheduler_tools = _stub("list_jobs", "delete_job")
-        node.ask_user_tool = _stub("ask_user")
-
-        mapping = node._tool_category_map()
-        assert [t.name for t in mapping["scheduler_tools"]] == ["list_jobs", "delete_job"]
-        assert mapping["tools"][0].name == "ask_user"
-
-    def test_missing_scheduler_tools_omits_bucket(self):
-        from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
-
-        node = SchedulerAgenticNode.__new__(SchedulerAgenticNode)
-        node.skill_func_tool = None
-        node.scheduler_tools = None
-        node.ask_user_tool = None
-
-        assert node._tool_category_map() == {}
-
-
-class TestSqlSummaryToolCategoryMap:
-    def test_filesystem_and_semantic_helpers(self):
-        from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
-
-        node = SqlSummaryAgenticNode.__new__(SqlSummaryAgenticNode)
-        node.skill_func_tool = None
-        node.filesystem_func_tool = _stub("read_file")
-        # ``generate_sql_summary_id`` gets wrapped — needs ``__name__``.
-        node.generation_tools = SimpleNamespace(
-            generate_sql_summary_id=_fn("generate_sql_summary_id"),
+        group = SimpleNamespace(
+            permission_category="scheduler_tools",
+            available_tools=lambda: [_named("list_scheduler_jobs")],
+            all_tools_name=_boom,
         )
+        node.scheduler_tools = group
 
-        mapping = node._tool_category_map()
-        assert mapping["filesystem_tools"][0].name == "read_file"
-        assert len(mapping["semantic_tools"]) == 1
+        node._populate_tool_registry()
+        assert node.tool_registry.to_dict()["list_scheduler_jobs"] == "scheduler_tools"
 
+    def test_skips_groups_without_string_category(self):
+        """Mock auto-attributes are not strings, so bare mocks (common in node
+        tests) never pollute the registry with bogus categories."""
+        node = _bare_node()
+        node.some_mock = MagicMock()
+        node.real_group = _group("memory_tools", "add_memory")
 
-class TestGenJobToolCategoryMap:
-    def test_db_bucket_includes_write_helpers(self):
-        from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry == {"add_memory": "memory_tools"}
 
-        node = GenJobAgenticNode.__new__(GenJobAgenticNode)
-        node.skill_func_tool = None
-        node.ask_user_tool = _stub("ask_user")
-        node.filesystem_func_tool = _stub("read_file")
-
-        # All wrapped helpers must have real ``__name__``.
-        node.db_func_tool = SimpleNamespace(
-            available_tools=lambda: [_named("read_query")],
-            execute_ddl=_fn("execute_ddl"),
-            execute_write=_fn("execute_write"),
-            transfer_query_result=_fn("transfer_query_result"),
-            get_migration_capabilities=_fn("get_migration_capabilities"),
-            suggest_table_layout=_fn("suggest_table_layout"),
-            validate_ddl=_fn("validate_ddl"),
-        )
-
-        mapping = node._tool_category_map()
-        # 1 available + 6 wrapped helpers = 7.
-        assert len(mapping["db_tools"]) == 7
-        assert mapping["filesystem_tools"][0].name == "read_file"
-        assert mapping["tools"][0].name == "ask_user"
-
-
-class TestGenMetricsToolCategoryMap:
-    def test_semantic_bucket_combines_adapters_and_generation_helpers(self):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        node = GenMetricsAgenticNode.__new__(GenMetricsAgenticNode)
-        node.skill_func_tool = None
-        node.db_func_tool = _stub("read_query")
-        node.semantic_tools = _stub("query_metrics")
-        node.generation_tools = SimpleNamespace(
-            check_semantic_object_exists=_fn("check_semantic_object_exists"),
-            end_metric_generation=_fn("end_metric_generation"),
-            end_semantic_model_generation=_fn("end_semantic_model_generation"),
-        )
-        node.semantic_discovery_tools = _stub("build_measure")
-        node.filesystem_func_tool = _stub("read_file")
-        node.ask_user_tool = _stub("ask_user")
-
-        mapping = node._tool_category_map()
-        # 1 (query_metrics) + 3 (generation helpers) + 1 (build_measure) = 5.
-        assert len(mapping["semantic_tools"]) == 5
-        assert mapping["db_tools"][0].name == "read_query"
-        assert mapping["filesystem_tools"][0].name == "read_file"
-        assert mapping["tools"][0].name == "ask_user"
-
-    def test_semantic_bucket_omitted_when_empty(self):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        node = GenMetricsAgenticNode.__new__(GenMetricsAgenticNode)
-        node.skill_func_tool = None
+    def test_skips_none_and_class_attributes(self):
+        node = _bare_node()
         node.db_func_tool = None
-        node.semantic_tools = None
-        node.generation_tools = None
-        node.semantic_discovery_tools = None
-        node.filesystem_func_tool = None
-        node.ask_user_tool = None
+        node.tool_cls = SimpleNamespace  # a type, not an instance
 
-        assert node._tool_category_map() == {}
+        node._populate_tool_registry()
+        assert node.tool_registry.to_dict() == {}
 
+    def test_same_group_referenced_twice_registered_once(self):
+        """Aliased attributes (e.g. ``semantic_func_tool`` aliasing
+        ``semantic_tools`` on gen_semantic_model) must not double-register."""
+        node = _bare_node()
+        group = _group("semantic_tools", "list_metrics")
+        node.semantic_tools = group
+        node.semantic_func_tool = group
 
-class TestSkillCreatorToolCategoryMap:
-    def test_registers_filesystem_db_skill_loader_and_catchall(self):
-        from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
+        node._populate_tool_registry()
+        assert node.tool_registry.to_dict() == {"list_metrics": "semantic_tools"}
 
-        node = SkillCreatorAgenticNode.__new__(SkillCreatorAgenticNode)
-        node.skill_func_tool = None
-        node.filesystem_func_tool = _stub("read_file")
-        node.db_func_tool = _stub("read_query")
-        node.skill_func_tool_instance = _stub("load_skill")
-        node.ask_user_tool = _stub("ask_user")
-        node.skill_validate_tool = _stub("validate_skill")
-        node._session_search_tool = _stub("search_sessions")
+    def test_real_classes_register_via_class_level_introspection(self):
+        """End-to-end over real classes: ``all_tools_name()`` is class-level
+        on the core tools, so bare instances classify their full surface."""
+        from datus.tools.func_tool.database import DBFuncTool
+        from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 
-        mapping = node._tool_category_map()
-        assert mapping["filesystem_tools"][0].name == "read_file"
-        assert mapping["db_tools"][0].name == "read_query"
-        assert mapping["skills"][0].name == "load_skill"
-        assert {t.name for t in mapping["tools"]} == {"ask_user", "validate_skill", "search_sessions"}
+        node = _bare_node()
+        node.db_func_tool = DBFuncTool.__new__(DBFuncTool)
+        node.filesystem_func_tool = FilesystemFuncTool.__new__(FilesystemFuncTool)
 
-    def test_catchall_omitted_when_nothing_to_add(self):
-        from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
-
-        node = SkillCreatorAgenticNode.__new__(SkillCreatorAgenticNode)
-        node.skill_func_tool = None
-        node.filesystem_func_tool = None
-        node.db_func_tool = None
-        node.skill_func_tool_instance = None
-        node.ask_user_tool = None
-        node.skill_validate_tool = None
-        node._session_search_tool = None
-
-        assert node._tool_category_map() == {}
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry["read_query"] == "db_tools"
+        assert registry["execute_ddl"] == "db_tools"
+        assert registry["execute_write"] == "db_tools"
+        assert registry["read_file"] == "filesystem_tools"
+        assert registry["write_file"] == "filesystem_tools"
+        assert registry["delete_file"] == "filesystem_tools"
 
 
-class TestBaseMemoryToolCategoryMap:
-    """The base map classifies the dedicated memory tools so nodes without a
-    ``_tool_category_map`` override (notably the feedback node, which mounts
-    ``add_memory`` / ``edit_memory`` for its caller) are governed by the
-    ``memory_tools.*`` profile rules rather than the ``tools`` catch-all."""
+class TestFeedbackMemoryRegistration:
+    """The feedback node mounts ``add_memory`` / ``edit_memory`` for its
+    caller; the scanner must classify them under ``memory_tools`` so the
+    ``memory_tools.*`` ALLOW rule governs them rather than the catch-all."""
 
     def test_feedback_registers_memory_tools(self):
         from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
 
         node = FeedbackAgenticNode.__new__(FeedbackAgenticNode)
-        node.skill_func_tool = None
-        node.memory_func_tool = _stub("add_memory", "edit_memory")
+        node.tool_registry = ToolRegistry()
+        node.memory_func_tool = _group("memory_tools", "add_memory", "edit_memory")
 
-        mapping = node._tool_category_map()
-        assert {t.name for t in mapping["memory_tools"]} == {"add_memory", "edit_memory"}
+        node._populate_tool_registry()
+        registry = node.tool_registry.to_dict()
+        assert registry["add_memory"] == "memory_tools"
+        assert registry["edit_memory"] == "memory_tools"
 
-    def test_memory_bucket_omitted_when_tool_absent(self):
+    def test_memory_entries_absent_when_tool_absent(self):
         from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
 
         node = FeedbackAgenticNode.__new__(FeedbackAgenticNode)
-        node.skill_func_tool = None
+        node.tool_registry = ToolRegistry()
         node.memory_func_tool = None
 
-        assert "memory_tools" not in node._tool_category_map()
+        node._populate_tool_registry()
+        assert "memory_tools" not in node.tool_registry.to_dict().values()

--- a/tests/unit_tests/tools/permission/test_permission_manager.py
+++ b/tests/unit_tests/tools/permission/test_permission_manager.py
@@ -215,6 +215,33 @@ class TestPermissionManagerFilterTools:
         # ASK tools should be included (only DENY is filtered)
         assert len(filtered) == 2
 
+    def test_filter_tools_without_category_uses_catch_all(self):
+        """Without an explicit category the ``tools`` catch-all applies.
+
+        The old name-prefix auto-detection was removed when categories moved
+        to the tool classes' ``permission_category`` declarations; callers
+        that know the category must pass it explicitly.
+        """
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ALLOW,
+            rules=[
+                PermissionRule(tool="tools", pattern="execute_sql", permission=PermissionLevel.DENY),
+                PermissionRule(tool="db_tools", pattern="list_tables", permission=PermissionLevel.DENY),
+            ],
+        )
+        manager = PermissionManager(global_config=config)
+
+        class MockTool:
+            def __init__(self, name):
+                self.name = name
+
+        tools = [MockTool("execute_sql"), MockTool("list_tables")]
+        filtered = manager.filter_available_tools(tools, "chatbot")
+
+        # ``tools.execute_sql`` DENY matches via the catch-all; the
+        # ``db_tools.list_tables`` rule does NOT (no prefix guessing).
+        assert [t.name for t in filtered] == ["list_tables"]
+
 
 class TestPermissionManagerFilterSkills:
     """Tests for PermissionManager.filter_available_skills()."""

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -112,6 +112,34 @@ class TestNormalProfile:
         assert _resolve(config, "semantic_tools", "attribution_analyze") == PermissionLevel.ALLOW
         assert _resolve(config, "semantic_tools", "future_semantic_tool") == PermissionLevel.ALLOW
 
+    def test_reference_template_tools_allowed(self):
+        """All reference-template helpers are read-only end to end —
+        ``execute_reference_template`` renders Jinja then runs
+        ``db_tools.read_query``."""
+        config = NORMAL
+        assert _resolve(config, "reference_template_tools", "search_reference_template") == PermissionLevel.ALLOW
+        assert _resolve(config, "reference_template_tools", "get_reference_template") == PermissionLevel.ALLOW
+        assert _resolve(config, "reference_template_tools", "render_reference_template") == PermissionLevel.ALLOW
+        assert _resolve(config, "reference_template_tools", "execute_reference_template") == PermissionLevel.ALLOW
+
+    def test_artifact_tools_allowed(self):
+        """Artifact authoring helpers are subagent-internal state mutations;
+        the user reviews the artifact as a whole via the rendered preview."""
+        config = NORMAL
+        assert _resolve(config, "artifact_tools", "start_new_report") == PermissionLevel.ALLOW
+        assert _resolve(config, "artifact_tools", "bind_existing_dashboard") == PermissionLevel.ALLOW
+        assert _resolve(config, "artifact_tools", "save_query_template") == PermissionLevel.ALLOW
+        assert _resolve(config, "artifact_tools", "validate_render") == PermissionLevel.ALLOW
+
+    def test_platform_doc_reads_allowed_web_search_asks(self):
+        """Doc lookups are local reads; ``web_search_document`` reaches the
+        network (Tavily) and stays at the profile default."""
+        config = NORMAL
+        assert _resolve(config, "platform_doc_tools", "list_document_nav") == PermissionLevel.ALLOW
+        assert _resolve(config, "platform_doc_tools", "get_document") == PermissionLevel.ALLOW
+        assert _resolve(config, "platform_doc_tools", "search_document") == PermissionLevel.ALLOW
+        assert _resolve(config, "platform_doc_tools", "web_search_document") == PermissionLevel.ASK
+
 
 class TestAutoProfile:
     def test_inherits_normal_reads(self):


### PR DESCRIPTION
## Why

The tool → permission-category mapping was maintained in 17 hand-written `_tool_category_map()` overrides across the agentic nodes, plus two name-prefix fallback maps (`PermissionManager._get_tool_category`, `AgenticNode._get_tool_category`). This design was fail-silent: a node that forgot to declare a tool let it fall into the `tools` catch-all, where the profile default (ASK on normal/auto) applies.

Concrete fallout:

- The `task` (sub-agent delegation) tool triggered a Permission Request on every node except chat — `gen_sql`, `gen_report`, `feedback`, and both visual artifact nodes create the tool but never registered it, so the `sub_agent_tools.* → ALLOW` rule in `profiles.py` never matched.
- The same tools were classified differently per node: reference template tools were `reference_template_tools` (ASK via catch-all default) in chat but lumped into `semantic_tools` (ALLOW) in gen_sql; platform doc tools were `tools` in chat but `platform_doc_tools` (no rules → ASK) in ask_metrics.
- Both prefix-fallback maps had drifted, referencing tools that no longer exist (`execute_sql`, `get_sample_data`, `parse_date`); `AgenticNode._get_tool_category` had zero production callers.
- Four nodes carried near-identical docstring warnings about the catch-all fallback — every author had to rediscover the same trap.

## Solution

Move the category declaration to the tool's definition site so the mapping is deterministic and node-independent:

1. **Declaration-site categories.** `BaseTool` gains a default `permission_category = "tools"`; every tool-group class (24 classes incl. the plain `@mcp_tool_class` ones) declares its category once. Subclasses inherit (e.g. `MetricFilesystemFuncTool` and the artifact filesystem tools get `filesystem_tools` for free, keeping the PathZone gate engaged).
2. **Generic registration.** `AgenticNode._populate_tool_registry()` now introspects node attributes for objects exposing a *string* `permission_category` plus `available_tools()` (the isinstance-str guard keeps bare `Mock()` stand-ins in tests out of the registry), and registers each group's full name surface — preferring `all_tools_name()` over `available_tools()` so method-level wrappers (gen_job's `execute_ddl` / `execute_write`) and conditionally-hidden tools are still classified. Registering a superset is safe: the registry is a name → category lookup consulted per call. All 17 `_tool_category_map` overrides and the base implementation are deleted.
3. **Dedicated categories instead of lumping**, with normal-profile rules:
   - `reference_template_tools.* → ALLOW` — read-only end to end (`execute_reference_template` renders Jinja then calls `db_tools.read_query`).
   - `artifact_tools.* → ALLOW` — subagent-internal artifact-tree mutations, reviewed via the rendered preview (mirrors the historical lumping into `semantic_tools`).
   - `platform_doc_tools`: `list_*` / `get_*` / `search_*` → ALLOW; `web_search_document` stays at the profile default (ASK) since it reaches the network (Tavily).
4. **Dead code removal.** Both drifted prefix maps are gone; `filter_available_tools` without an explicit category now applies the `tools` catch-all, matching `PermissionHooks._get_category_and_pattern`.

Intentional behavior changes (all toward the more consistent posture): `task` no longer prompts outside chat; chat's reference-template tools go ASK → ALLOW (aligning with gen_sql's existing posture, justified by their read-only contract); ask_metrics' platform-doc reads go ASK → ALLOW (aligning with chat).

Tradeoff: the registry now holds a superset of names per category rather than the exact mounted subset. Narrowness of the actual tool surface is still enforced by `node.tools`; unmounted names are never queried.

## Test Cases

- `tests/unit_tests/agent/node/test_tool_category_maps.py` — rewritten as the two-layer contract: a parametrized declaration table pinning every tool class's `permission_category` (24 classes + inheritance checks), and `_populate_tool_registry` introspection coverage (superset preference, `all_tools_name()` failure fallback, Mock exclusion, alias dedup, the `task`-outside-chat regression, real-class end-to-end registration).
- `tests/unit_tests/tools/permission/test_profiles.py` — new rules pinned: reference-template ALLOW, artifact ALLOW, platform-doc reads ALLOW / web search ASK.
- `tests/unit_tests/tools/permission/test_permission_manager.py` — new test pinning the catch-all fallback in `filter_available_tools` (no more prefix guessing).
- Node tests (`gen_dashboard`, `gen_job`, `gen_table`, `gen_metrics`, `scheduler`, `skill_creator`, visual report/dashboard, explore, ask_metrics, agentic_node_skills) migrated from map assertions to registry assertions; dead `_get_tool_category` test classes removed.
- Full run: node unit tests 1635 passed; PR harness (acceptance + impacted unit) 173/173, diff coverage 89%; test-quality audit P0=0 on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

# Release Notes

**Refactor**
* Restructured tool permission categorization system: tools now declare their permission categories directly, replacing previous hard-coded category mappings. Dynamic tool group discovery improves maintainability without changing user-facing permissions or tool availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tools now expose explicit permission-category metadata and are discovered dynamically; internal hard-coded category maps removed.
* **Permissions**
  * Permission profiles updated to allow additional read/list/search actions for reference, artifact, and platform-doc toolsets.
* **Tests**
  * Unit tests updated to validate the new tool registry and permission-category behavior end-to-end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->