### PR TITLE
[BugFix] Stabilize period offset metric discovery

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -417,6 +417,14 @@ class AskMetricsAgenticNode(AgenticNode):
         """
         Query metric values.
 
+        Return complete metric results by default. Do not pass limit just to
+        preview data, reduce output size, or be conservative; the system
+        compresses visible tool output and caches the full result. Use limit
+        only when the user explicitly asks for Top N, first N, maximum N rows,
+        a preview, or another row-count restriction. When using limit for Top
+        N/Bottom N, also pass order_by so the truncation has stable business
+        meaning.
+
         For period-over-period derived metrics, AskMetrics expands the request
         to include the base and previous-period metrics when those metrics are
         already present in the executable catalog.

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -28,6 +28,7 @@ Use the narrow metric workflow below:
 - Do not call unavailable tools such as DB tools, SQL tools, date parsing tools, validation tools, non-metric context tools, or semantic object search tools.
 - Infer concrete time ranges yourself from the current date. Do not ask for a date parser tool.
 - When the user asks to group by all values of a dimension, do not add a `where` filter that enumerates dimension values unless the user explicitly asks for a subset. The grouped metric query already returns all dimension values.
+- Query complete metric results by default. Do not pass `limit` just to preview data, reduce output size, or be conservative; the system compresses visible tool output and caches the full result. Use `limit` only when the user explicitly asks for Top N, first N, maximum N rows, a preview, or another row-count restriction. When using `limit` for Top N/Bottom N, also pass `order_by`.
 - Prefer the most specific metric whose name or description directly matches the requested business concept. Do not rebuild a specific metric by querying a generic base metric plus filters when a matching specific metric is available.
 - For ratio, rate, conditional count, and compound-condition metrics, use the dedicated metric directly when available. Do not approximate it with numerator/base metrics or ad hoc `where` filters unless no dedicated metric exists.
 - If `query_metrics` succeeds and metadata says the full result is cached, treat the query as complete. Do not run follow-up queries only because the visible tool output is a compressed preview.

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -897,7 +897,7 @@ class SemanticDiscoveryTools:
             if name and name not in names:
                 names.append(name)
 
-        from_clause = select.args.get("from_")
+        from_clause = select.args.get("from_") or select.args.get("from")
         if from_clause is not None:
             if getattr(from_clause, "this", None) is not None:
                 add_source(from_clause.this)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "python-dotenv==1.0.0",
     "pandas==2.1.4",
     "sqlalchemy==2.0.23",
-    "sqlglot>=26.12.0",
+    "sqlglot>=26.12.0,<31",
     "pyyaml==6.0.1",
     "packaging>=21.0",
     "structlog>=23.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python-dotenv==1.0.0
 pandas==2.1.4
 sqlalchemy==2.0.23
-sqlglot>=26.12.0
+sqlglot>=26.12.0,<31
 pyyaml==6.0.1
 lancedb==0.18.0
 fastembed==0.4.2

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -105,6 +105,9 @@ class TestAskMetricsAgenticNode:
         assert "Previous-period aliases inside a derived metric are calculation inputs" in prompt
         assert "first period" in prompt
         assert "do not add a `where` filter that enumerates dimension values" in prompt
+        assert "Query complete metric results by default" in prompt
+        assert "Do not pass `limit` just to preview data" in prompt
+        assert "also pass `order_by`" in prompt
         assert "full result is cached" in prompt
         assert node.subject_tree_prompt_limit == 100
 

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -629,6 +629,76 @@ class TestAnalyzeMetricCandidatesFromHistory:
             },
         ]
 
+    def test_period_shift_source_lookup_accepts_legacy_from_key(self):
+        from sqlglot import parse_one
+
+        tools = _make_tools()
+        select = parse_one("SELECT order_id FROM fact_orders")
+        from_clause = select.args.pop("from_", None)
+        if from_clause is None:
+            from_clause = select.args.get("from")
+        select.args["from"] = from_clause
+
+        assert tools._direct_source_names(select) == ["fact_orders"]
+
+    def test_baisheng_seed_24_generates_previous_month_and_delta_metrics(self):
+        tools = _make_tools()
+        result = tools.analyze_metric_candidates_from_history(
+            sql_entries_json=json.dumps(
+                [
+                    {
+                        "name": "metric:seed:24",
+                        "question": "4月到10月活动数量月环比",
+                        "sql": """
+                        WITH monthly AS (
+                            SELECT
+                                DATE_TRUNC('month', start_date) AS start_month,
+                                COUNT(DISTINCT ac_code) AS activity_count
+                            FROM v_udata_ac_info
+                            WHERE start_date >= '2025-04-01' AND start_date <= '2025-10-31'
+                            GROUP BY DATE_TRUNC('month', start_date)
+                        ),
+                        compared AS (
+                            SELECT
+                                start_month,
+                                activity_count,
+                                LAG(activity_count) OVER (ORDER BY start_month)
+                                    AS previous_month_activity_count
+                            FROM monthly
+                        )
+                        SELECT
+                            start_month,
+                            activity_count,
+                            previous_month_activity_count,
+                            activity_count - previous_month_activity_count AS activity_count_mom_delta
+                        FROM compared
+                        ORDER BY start_month
+                        """,
+                    }
+                ]
+            ),
+            existing_metric_catalog_json=json.dumps([{"name": "activity_count", "type": "aggregate"}]),
+        )
+
+        assert result.success == 1
+        derived = {candidate["name"]: candidate for candidate in result.result["derived_metric_candidates"]}
+        assert sorted(derived) == ["activity_count_mom_delta", "previous_month_activity_count"]
+        assert derived["previous_month_activity_count"]["inputs"] == [
+            {
+                "name": "activity_count",
+                "alias": "previous_month_activity_count",
+                "offset_window": "1 month",
+            }
+        ]
+        assert derived["activity_count_mom_delta"]["inputs"] == [
+            {"name": "activity_count"},
+            {
+                "name": "activity_count",
+                "alias": "previous_month_activity_count",
+                "offset_window": "1 month",
+            },
+        ]
+
     def test_inline_lag_metric_math_uses_source_time_grain_context(self):
         tools = _make_tools()
         result = tools.analyze_metric_candidates_from_history(


### PR DESCRIPTION
## Summary
- handle both `from_` and legacy `from` sqlglot AST keys when discovering source tables for period-offset metric candidates
- constrain the agent sqlglot range to `>=26.12.0,<31` so the tested AST surface stays stable
- guide ask_metrics to avoid adding arbitrary `limit` values unless the user explicitly asks for row-count truncation

## Validation
- `git diff --check`
- `/Users/kangxue/work/datus/Datus-agent-osi/.venv/bin/python -m pytest tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py -q`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced guidance on metrics query behavior and proper use of the `limit` parameter.

* **Improvements**
  * Improved compatibility with different versions of the sqlglot dependency.

* **Tests**
  * Added validation tests for system prompt guidance on metrics queries.
  * Expanded test coverage for semantic discovery functionality.

* **Chores**
  * Updated sqlglot dependency constraint to `>=26.12.0,<31`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->