### PR TITLE
[BugFix] Accept canonical metric_time evidence for queryability publish gate

### DIFF
--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -446,8 +446,17 @@ def _sql_contains_time_group(sql: str, base_expr: str, grain: str) -> bool:
 def _sql_contains_base_expr_text(sql: str, base_expr: str) -> bool:
     normalized_sql = _normalize_sql_text(sql)
     normalized_base = _normalize_sql_text(base_expr)
-    if normalized_base and normalized_base in normalized_sql:
-        return True
+    if normalized_base:
+        # A bare identifier must match on identifier boundaries (against the
+        # whitespace-preserving SQL, since _normalize_sql_text would fuse it with
+        # the next token) so e.g. ``ordered_at`` matches a real column reference
+        # but not ``preordered_at`` / ``ordered_at_utc``. Richer expressions
+        # (containing parens/operators) are safe to match as a substring.
+        if re.fullmatch(r"[a-z_][a-z0-9_]*", normalized_base):
+            if re.search(rf"\b{re.escape(normalized_base)}\b", str(sql or "").lower()):
+                return True
+        elif normalized_base in normalized_sql:
+            return True
     leaf = _last_identifier(base_expr)
     normalized_leaf = _normalize_sql_text(leaf)
     return bool(

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -378,17 +378,24 @@ def _dry_run_satisfies_time_group(dry_run: Dict[str, Any], time_hint: Dict[str, 
         return True
 
     sql = dry_run.get("sql", "")
+    # MetricFlow canonicalizes the time dimension to metric_time, so accept it from
+    # either the recorded dimensions or the compiled SQL.
     if (
         isinstance(sql, str)
         and base_expr
         and dimensions
         and _sql_contains_base_expr_text(sql, base_expr)
-        and any(_is_metric_time_dimension(dimension) for dimension in dimensions)
+        and (any(_is_metric_time_dimension(dimension) for dimension in dimensions) or _sql_references_metric_time(sql))
     ):
         return True
     if not isinstance(sql, str) or not _sql_contains_time_group(sql, base_expr, grain):
         return False
     return True
+
+
+def _sql_references_metric_time(sql: str) -> bool:
+    """True when the compiled SQL references MetricFlow's metric_time column (any grain)."""
+    return bool(re.search(r"\bmetric_time(?:__\w+)?\b", str(sql or ""), flags=re.IGNORECASE))
 
 
 def _normalize_time_grain(value: Any) -> str:

--- a/datus/tools/func_tool/metric_queryability.py
+++ b/datus/tools/func_tool/metric_queryability.py
@@ -66,7 +66,15 @@ def summarize_queryability_contracts(contracts: Iterable[Dict[str, Any]]) -> str
         dimensions = ", ".join(contract.get("dimension_hints") or [])
         metrics = ", ".join(contract.get("metric_hints") or [])
         if dimensions:
-            parts.append(f"{contract.get('source') or 'source SQL'} group-by [{dimensions}] metrics [{metrics}]")
+            part = f"{contract.get('source') or 'source SQL'} group-by [{dimensions}] metrics [{metrics}]"
+            grains = [
+                h.get("grain")
+                for h in (contract.get("time_group_hints") or [])
+                if isinstance(h, dict) and h.get("grain")
+            ]
+            if grains:
+                part += f" (dry-run with time_granularity='{', '.join(dict.fromkeys(grains))}')"
+            parts.append(part)
     return "; ".join(parts)
 
 

--- a/tests/unit_tests/tools/func_tool/test_generation_evidence.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_evidence.py
@@ -293,3 +293,61 @@ class TestGenerationEvidence:
         result = {"success": 1, "result": {"metadata": {"sql": "SELECT 1"}}}
         ev.record_metric_dry_run(["revenue_total"], result)
         assert "revenue_total" in ev.metric_sqls
+
+
+class TestMetricTimeCanonicalizationContract:
+    """Regression: a day-grain dry-run must satisfy a metric_date time-group contract."""
+
+    # MetricFlow day-grain output: groups by metric_time via CAST, no date_trunc.
+    COMPILED_SQL = (
+        "SELECT metric_time, "
+        "CAST(gross_order_value AS DOUBLE) / CAST(NULLIF(order_count, 0) AS DOUBLE) "
+        "AS average_gross_order_value "
+        "FROM ("
+        "  SELECT metric_time, SUM(gross_order_value) AS gross_order_value, "
+        "  SUM(order_count) AS order_count "
+        "  FROM ("
+        "    SELECT CAST(ordered_at AS DATETIME) AS metric_time, "
+        "    order_total / 100.0 AS gross_order_value, 1 AS order_count "
+        "    FROM jeff_shop.raw_orders raw_orders_src_26"
+        "  ) subq_94 "
+        "  GROUP BY metric_time"
+        ") subq_95"
+    )
+
+    def _evidence_with_contract(self):
+        ev = GenerationEvidence()
+        ev.set_metric_queryability_contracts(
+            [
+                {
+                    "source": "sql_1",
+                    "dimension_hints": ["metric_date"],
+                    "metric_hints": ["average_gross_order_value"],
+                    "time_group_hints": [{"alias": "metric_date", "base_expr": "ordered_at", "grain": "day"}],
+                }
+            ]
+        )
+        return ev
+
+    def test_grain_dry_run_satisfies_time_group_contract(self):
+        ev = self._evidence_with_contract()
+        ev.record_metric_dry_run(
+            ["average_gross_order_value"],
+            {"success": 1, "result": {"metadata": {"explain": True, "sql": self.COMPILED_SQL}}},
+            dimensions=["metric_date"],
+            time_granularity="day",
+        )
+        assert ev.has_required_queryability_dry_runs(["average_gross_order_value"]) is True
+        assert ev.missing_queryability_contracts(["average_gross_order_value"]) == []
+
+    def test_grain_dry_run_does_not_satisfy_unrelated_time_column(self):
+        # A metric_time dry-run built from a different base column must not match.
+        ev = self._evidence_with_contract()
+        unrelated_sql = self.COMPILED_SQL.replace("ordered_at", "shipped_at")
+        ev.record_metric_dry_run(
+            ["average_gross_order_value"],
+            {"success": 1, "result": {"metadata": {"explain": True, "sql": unrelated_sql}}},
+            dimensions=["metric_date"],
+            time_granularity="day",
+        )
+        assert ev.has_required_queryability_dry_runs(["average_gross_order_value"]) is False

--- a/tests/unit_tests/tools/func_tool/test_generation_evidence.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_evidence.py
@@ -11,6 +11,7 @@ from datus.tools.func_tool.generation_evidence import (
     _normalized_metric_alias_map,
     _result_payload,
     _result_success,
+    _sql_contains_base_expr_text,
 )
 
 
@@ -351,3 +352,16 @@ class TestMetricTimeCanonicalizationContract:
             time_granularity="day",
         )
         assert ev.has_required_queryability_dry_runs(["average_gross_order_value"]) is False
+
+
+class TestSqlContainsBaseExprText:
+    def test_bare_identifier_matches_standalone_occurrence(self):
+        assert _sql_contains_base_expr_text("SELECT CAST(ordered_at AS DATETIME) AS m", "ordered_at") is True
+
+    def test_bare_identifier_does_not_match_partial_identifier(self):
+        assert _sql_contains_base_expr_text("SELECT preordered_at AS m", "ordered_at") is False
+        assert _sql_contains_base_expr_text("SELECT ordered_at_utc AS m", "ordered_at") is False
+
+    def test_complex_expression_matches_via_substring(self):
+        sql = "SELECT CAST(ordered_at AS DATETIME) AS metric_time GROUP BY metric_time"
+        assert _sql_contains_base_expr_text(sql, "CAST(ordered_at AS DATETIME)") is True

--- a/tests/unit_tests/tools/func_tool/test_metric_queryability.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_queryability.py
@@ -1,0 +1,40 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for metric queryability contract helpers."""
+
+from datus.tools.func_tool.metric_queryability import summarize_queryability_contracts
+
+
+class TestSummarizeQueryabilityContracts:
+    def test_formats_parts(self):
+        contracts = [
+            {"source": "sql_1", "dimension_hints": ["order_date"], "metric_hints": ["revenue"]},
+            {"source": "sql_2", "dimension_hints": ["region"], "metric_hints": ["orders"]},
+        ]
+        result = summarize_queryability_contracts(contracts)
+        assert "sql_1 group-by [order_date] metrics [revenue]" in result
+        assert "sql_2 group-by [region] metrics [orders]" in result
+
+    def test_empty(self):
+        assert summarize_queryability_contracts([]) == ""
+
+    def test_includes_time_grain_guidance(self):
+        contracts = [
+            {
+                "source": "sql_1",
+                "dimension_hints": ["metric_date"],
+                "metric_hints": ["revenue"],
+                "time_group_hints": [
+                    {"alias": "metric_date", "base_expr": "CAST(ordered_at AS DATETIME)", "grain": "day"}
+                ],
+            }
+        ]
+        result = summarize_queryability_contracts(contracts)
+        assert "sql_1 group-by [metric_date] metrics [revenue]" in result
+        assert "time_granularity='day'" in result
+
+    def test_without_time_hints_has_no_grain_guidance(self):
+        contracts = [{"source": "sql_1", "dimension_hints": ["region"], "metric_hints": ["orders"]}]
+        assert "time_granularity" not in summarize_queryability_contracts(contracts)


### PR DESCRIPTION
## Why

`end_metric_generation` could loop until the agent hit its max-turn limit whenever the source SQL grouped by a time-truncation alias (e.g. `date_trunc('day', ordered_at) AS metric_date`). The agent dry-runs the metric with the source alias + `time_granularity`, but MetricFlow canonicalizes the time dimension to its reserved `metric_time` column and compiles day grain as `CAST(ordered_at AS DATETIME) AS metric_time` — with no `date_trunc` literal. As a result `_dry_run_satisfies_time_group` matched none of its paths (the recorded dimension is the raw `metric_date`, and the compiled SQL has no `date_trunc`), so the publish gate rejected every `end_metric_generation` attempt.

Observed in a real run: 14 consecutive `end_metric_generation` failures, max-turns hit, a continuation task spawned — ~1.5M input tokens spent to publish a single ratio metric.

## Solution

- `generation_evidence.py`: in `_dry_run_satisfies_time_group`, accept `metric_time` when it appears in the **compiled dry-run SQL** (new `_sql_references_metric_time()` helper), not only in the recorded dimensions. Still gated on the compiled SQL referencing the time-group hint's base column, so it cannot match an unrelated time column.
- `metric_queryability.py`: the queryability error summary now appends `(dry-run with time_granularity='<grain>')`, telling the agent which grain to dry-run with instead of guessing dimensions.

## Test Cases

- `test_generation_evidence.py::TestMetricTimeCanonicalizationContract` — a day-grain dry-run with the source alias now satisfies the contract (regression for the dead-loop), plus a guard that a dry-run built from a different base column does NOT match.
- `test_metric_queryability.py::TestSummarizeQueryabilityContracts` — grain guidance appears when the contract has `time_group_hints`, and is absent otherwise.
- Verified end-to-end against the original failing trace's real source + compiled SQL: BEFORE = publish rejected (loops), AFTER = publish accepted.
- Full `tests/unit_tests/tools/func_tool/` green; PR harness: 1581 passed / 0 failed, diff coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced metric time validation to recognize additional SQL patterns when referencing the canonical metric_time column.

* **Improvements**
  * Updated queryability contract summaries to include time granularity guidance from available time group hints.

* **Tests**
  * Added comprehensive test coverage for metric time canonicalization and queryability contract summarization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric time validation for dry-runs by detecting references to the canonical metric time column (including common variants) and tightening base-expression matching.

* **Improvements**
  * Enhanced queryability contract summaries to include additional time granularity guidance when time group hints are available.

* **Tests**
  * Added unit coverage for metric time canonicalization behavior and for queryability contract summary formatting (including presence/absence of time granularity guidance).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->