### PR TITLE
[BugFix] metric preview returns physical database, not datasource id

### DIFF
--- a/datus/api/models/explorer_models.py
+++ b/datus/api/models/explorer_models.py
@@ -160,7 +160,7 @@ class MetricPreviewData(BaseModel):
 
     metric: str = Field(..., description="Metric name")
     sql: Optional[str] = Field(None, description="Runnable SQL compiled from the metric definition")
-    datasource: Optional[str] = Field(None, description="Datasource the SQL should run against")
+    database: Optional[str] = Field(None, description="Physical database the SQL should run against")
     preflight_error: Optional[MetricDimensionPreflight] = Field(
         None, description="Set instead of sql when the requested dimensions are invalid"
     )

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -725,8 +725,10 @@ class ExplorerService:
                         errorMessage=f"Failed to compile SQL for metric '{metric_name}'.",
                     )
                 # The datasource id (logical key) is not a physical database; return the
-                # datasource's real default database so callers can run the SQL as-is.
-                database = self.agent_config.current_db_config().database or None
+                # bound datasource's real default database so callers can run the SQL as-is.
+                # Pin the lookup to this service's datasource_id (not the implicit "current")
+                # so a multi-datasource config can never return another datasource's database.
+                database = self.agent_config.current_db_config(self.datasource_id).database or None
                 return Result[MetricPreviewData](
                     success=True,
                     data=MetricPreviewData(metric=metric_name, sql=sql, database=database),

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -724,9 +724,12 @@ class ExplorerService:
                         errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
                         errorMessage=f"Failed to compile SQL for metric '{metric_name}'.",
                     )
+                # The datasource id (logical key) is not a physical database; return the
+                # datasource's real default database so callers can run the SQL as-is.
+                database = self.agent_config.current_db_config().database or None
                 return Result[MetricPreviewData](
                     success=True,
-                    data=MetricPreviewData(metric=metric_name, sql=sql, datasource=self.datasource_id or None),
+                    data=MetricPreviewData(metric=metric_name, sql=sql, database=database),
                 )
 
             # A dimension preflight failure carries structured detail; surface it

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -998,7 +998,8 @@ class TestExplorerServicePreviewMetric:
         assert result.success is True
         assert result.data.metric == "revenue"
         assert result.data.sql == "SELECT 1 AS revenue"
-        assert result.data.datasource == svc.datasource_id
+        # Carries the bound datasource's physical database, not the logical datasource id.
+        assert result.data.database == (real_agent_config.current_db_config(svc.datasource_id).database or None)
         assert result.data.preflight_error is None
         # dry_run must be requested so nothing actually executes.
         assert query_metrics.call_args.kwargs["dry_run"] is True


### PR DESCRIPTION
## Why

`/api/v1/subject/metric/preview` returned the **logical datasource id** (e.g. `baisheng`) in its `datasource` field. The frontend forwarded that value to `/api/v1/sql/execute` as `database_name`, which calls `switch_context(database_name=...)` → `USE baisheng`. Since `baisheng` is a datasource key, not a physical database, StarRocks rejects it:

```
(5501, "Unknown database 'baisheng'")
```

The datasource's real physical database is `ai_dianzhang` (per `catalog/list` and the connection uri `…:9030/ai_dianzhang`).

## Solution

- Rename `MetricPreviewData.datasource` → `database` to reflect its true meaning (a physical database, not a logical datasource id).
- Populate it from `current_db_config().database` — the datasource's real default database — so callers can run the compiled SQL as-is whether or not the SQL is fully schema-qualified.

Frontend counterpart (Datus-saas) switches to the new `database` field in a separate PR.

## Test Cases

No new automated test added: the change swaps one response field's source value and name; behavior is covered end-to-end by the manual repro (preview → run) that originally surfaced the bug. The preview path has no existing unit test harness with a mocked semantic adapter to extend cheaply; happy to add one if preferred.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

* **Refactor**
  * Updated metric preview to use database configuration instead of datasource identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated metric preview responses to use configured database information instead of a datasource identifier.
  * The metric preview payload now reports a `database` value (when available), replacing the prior `datasource` field.
* **Tests**
  * Adjusted unit tests to validate the new `database` field in metric preview results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->