### PR TITLE
[Feature] Add data access policy provider hook

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -353,6 +353,49 @@ flow_groups:
             notes: Baisheng weekly benchmark runs Datus queries against StarRocks.
         gaps: []
 
+      - id: data_access.policy_enforcement
+        title: Request-scoped data-access policy enforcement
+        priority: p0
+        quality_sensitive: true
+        docs:
+          - docs/configuration/data_access_policy.md
+          - docs/API/introduction.md
+        entrypoints:
+          - "REST API: /api/v1/chat/stream"
+          - "REST API header: X-Datus-Principal"
+          - DBFuncTool data-access enforcement
+        contracts:
+          - The default API auth provider parses request principals from X-Datus-Principal JSON.
+          - X-Datus-User-Id remains session identity and does not satisfy data-access principal fields.
+          - Enabled data-access policies fail fast when required principal fields are missing.
+          - Custom data-access providers can rewrite or deny protected read queries before database execution.
+        coverage:
+          pr_acceptance:
+            status: covered
+            nodeids:
+              - tests/unit_tests/api/auth/test_no_auth_provider.py
+              - tests/unit_tests/api/routes/test_chat_routes.py::TestStreamChatDataAccessPreCheck
+              - tests/unit_tests/tools/test_data_access_policy.py
+          merge_queue:
+            status: covered
+            nodeids:
+              - tests/unit_tests/api/auth/test_no_auth_provider.py
+              - tests/unit_tests/api/routes/test_chat_routes.py::TestStreamChatDataAccessPreCheck
+              - tests/unit_tests/tools/test_data_access_policy.py
+          nightly:
+            status: covered
+            notes: >
+              Nightly API and adapter jobs exercise chat streaming and database reads; deterministic unit
+              tests cover request-principal parsing and the open-source provider contract without requiring
+              a live private policy provider deployment.
+            nodeids:
+              - tests/integration/api/test_api_chat.py
+              - tests/integration/adapters/test_starrocks.py
+          weekly_benchmark:
+            status: covered
+            notes: Baisheng weekly benchmark can run against StarRocks with request-scoped market filters.
+        gaps: []
+
       - id: data_access.adapter_contracts
         title: DB, BI, scheduler, and semantic adapter contracts
         priority: p0

--- a/datus/api/auth/context.py
+++ b/datus/api/auth/context.py
@@ -1,7 +1,7 @@
 """Application context — request authentication and configuration."""
 
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
 
 from datus.configuration.agent_config import AgentConfig
 
@@ -16,8 +16,12 @@ class AppContext:
       (default) project.
     - ``config``: optional preloaded ``AgentConfig``; when ``None``,
       ``get_datus_service`` loads it on demand.
+    - ``principal``: request-scoped data-access attributes consumed by
+      data-access policies. This is separate from ``user_id`` because one
+      authenticated identity can carry many business scopes.
     """
 
     user_id: Optional[str] = None
     project_id: Optional[str] = None
     config: Optional[AgentConfig] = None
+    principal: Dict[str, Any] = field(default_factory=dict)

--- a/datus/api/auth/no_auth_provider.py
+++ b/datus/api/auth/no_auth_provider.py
@@ -1,10 +1,13 @@
 """Open-source default auth provider — header-based identification, no secret."""
 
+import json
+from typing import Any
+
 from fastapi import Request
 
 from datus.api.auth.context import AppContext
 from datus.api.auth.provider import EvictCallback
-from datus.api.constants import HEADER_USER_ID, USER_ID_PATTERN
+from datus.api.constants import HEADER_PRINCIPAL, HEADER_USER_ID, USER_ID_PATTERN
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -12,12 +15,11 @@ logger = get_logger(__name__)
 
 
 class NoAuthProvider:
-    """Open-source default provider — identifies the caller via HTTP header.
+    """Open-source default provider — reads optional request context headers.
 
-    Reads ``X-Datus-User-Id`` from the request. When present and valid it is
-    used as ``AppContext.user_id`` (and downstream as ``SessionManager.scope``
-    for per-user session isolation). When absent, ``user_id`` is ``None`` and
-    sessions fall back to the default (unscoped) directory.
+    ``X-Datus-User-Id`` is optional caller identity for per-user session
+    isolation. ``X-Datus-Principal`` is an optional JSON object whose fields are
+    exposed to data-access policies as ``AppContext.principal``.
 
     Auth provider only handles identification, not config loading.
     Config is loaded on-demand by ``get_datus_service``.
@@ -27,23 +29,63 @@ class NoAuthProvider:
         self._evict_callbacks: list[EvictCallback] = []
 
     async def authenticate(self, request: Request) -> AppContext:
-        raw = request.headers.get(HEADER_USER_ID)
-        user_id: str | None = None
-        if raw is not None:
-            candidate = raw.strip()
-            if candidate:
-                if not USER_ID_PATTERN.match(candidate):
-                    raise DatusException(
-                        ErrorCode.COMMON_VALIDATION_FAILED,
-                        message=(
-                            f"Invalid {HEADER_USER_ID} header value: {candidate!r}. "
-                            "Only letters, digits, underscore and hyphen are allowed."
-                        ),
-                    )
-                user_id = candidate
-        principal = {"user_id": user_id} if user_id else {}
+        user_id = self._read_user_id(request)
+        principal = self._read_principal(request)
         return AppContext(user_id=user_id, project_id=None, config=None, principal=principal)
 
     def on_evict(self, callback: EvictCallback) -> None:
         """Register eviction callback (no-op for no-auth provider)."""
         self._evict_callbacks.append(callback)
+
+    @staticmethod
+    def _read_user_id(request: Request) -> str | None:
+        raw = request.headers.get(HEADER_USER_ID)
+        if raw is None:
+            return None
+        candidate = raw.strip()
+        if not candidate:
+            return None
+        if not USER_ID_PATTERN.match(candidate):
+            raise DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message=(
+                    f"Invalid {HEADER_USER_ID} header value: {candidate!r}. "
+                    "Only letters, digits, underscore and hyphen are allowed."
+                ),
+            )
+        return candidate
+
+    @staticmethod
+    def _read_principal(request: Request) -> dict[str, Any]:
+        raw = request.headers.get(HEADER_PRINCIPAL)
+        if raw is None or not raw.strip():
+            return {}
+
+        try:
+            principal = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message=(
+                    f"Invalid {HEADER_PRINCIPAL} header value: expected a JSON object with "
+                    f"data-access principal fields ({e.msg})."
+                ),
+            ) from e
+
+        if not isinstance(principal, dict):
+            raise DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message=(
+                    f"Invalid {HEADER_PRINCIPAL} header value: expected a JSON object with "
+                    "data-access principal fields."
+                ),
+            )
+        if "user_id" in principal:
+            raise DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message=(
+                    f"Invalid {HEADER_PRINCIPAL} header value: field 'user_id' is reserved for "
+                    f"{HEADER_USER_ID}; use a business principal field for data-access policy."
+                ),
+            )
+        return principal

--- a/datus/api/auth/no_auth_provider.py
+++ b/datus/api/auth/no_auth_provider.py
@@ -41,7 +41,8 @@ class NoAuthProvider:
                         ),
                     )
                 user_id = candidate
-        return AppContext(user_id=user_id, project_id=None, config=None)
+        principal = {"user_id": user_id} if user_id else {}
+        return AppContext(user_id=user_id, project_id=None, config=None, principal=principal)
 
     def on_evict(self, callback: EvictCallback) -> None:
         """Register eviction callback (no-op for no-auth provider)."""

--- a/datus/api/constants.py
+++ b/datus/api/constants.py
@@ -7,6 +7,9 @@ from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
 # Header carrying the caller's user identifier for the open-source default auth.
 HEADER_USER_ID = "X-Datus-User-Id"
 
+# Header carrying JSON request principal fields for data-access policies.
+HEADER_PRINCIPAL = "X-Datus-Principal"
+
 # Allowed characters for header-provided user_id (also used as SessionManager scope).
 USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 

--- a/datus/api/deps.py
+++ b/datus/api/deps.py
@@ -2,13 +2,14 @@
 
 from typing import Annotated, Optional
 
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Request
 
 from datus.api.auth.context import AppContext
 from datus.api.auth.provider import AuthProvider
 from datus.api.services.datus_service import DatusService
 from datus.api.services.datus_service_cache import DatusServiceCache
 from datus.configuration.agent_config_loader import load_agent_config
+from datus.utils.exceptions import DatusException
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -60,7 +61,10 @@ async def get_datus_service(request: Request) -> DatusService:
     if _service_cache is None:
         raise RuntimeError("Service cache not initialized. Call init_deps() in lifespan.")
 
-    ctx: AppContext = await _auth_provider.authenticate(request)
+    try:
+        ctx: AppContext = await _auth_provider.authenticate(request)
+    except DatusException as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     request.state.app_context = ctx
 
     expected_fp = DatusService.compute_fingerprint(ctx.config) if ctx.config is not None else None

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -11,7 +11,7 @@ asyncio.Task so that client disconnects do not cancel the computation.
 """
 
 import asyncio
-from typing import Annotated, Any, AsyncGenerator, Optional
+from typing import TYPE_CHECKING, Annotated, Any, AsyncGenerator, Optional
 
 from fastapi import APIRouter, HTTPException, Path, Query, Request
 from fastapi.responses import StreamingResponse
@@ -51,6 +51,10 @@ from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
 
+if TYPE_CHECKING:
+    from datus.api.auth.context import AppContext
+    from datus.api.services.datus_service import DatusService
+
 router = APIRouter(prefix="/api/v1/chat", tags=["chat"])
 
 
@@ -77,7 +81,7 @@ def _is_valid_subagent_id(svc, subagent_id: str) -> bool:
     return False
 
 
-def _data_access_principal_pre_check(svc, ctx) -> Optional[ChatPreCheckOutcome]:
+def _data_access_principal_pre_check(svc: "DatusService", ctx: "AppContext") -> Optional[ChatPreCheckOutcome]:
     """Fail fast when enabled data-access policies need missing principal fields."""
     agent_config = getattr(svc, "agent_config", None)
     data_access_config = getattr(agent_config, "data_access_config", None)
@@ -87,7 +91,7 @@ def _data_access_principal_pre_check(svc, ctx) -> Optional[ChatPreCheckOutcome]:
     principal = getattr(ctx, "principal", None) or {}
     required_paths = _required_principal_paths(data_access_config.raw)
     missing_paths = _missing_principal_paths(principal, required_paths)
-    if not missing_paths and (principal or required_paths):
+    if not missing_paths:
         return None
 
     detail = ""

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -111,7 +111,7 @@ async def stream_chat(
 
     async def generate_sse():
         async for chunk in _stream_with_post_hook(
-            svc.chat.stream_chat(request, sub_agent_id=sub_agent_id, user_id=ctx.user_id),
+            svc.chat.stream_chat(request, sub_agent_id=sub_agent_id, user_id=ctx.user_id, principal=ctx.principal),
             http_request=http_request,
             request=request,
             user_id=ctx.user_id,
@@ -154,7 +154,9 @@ async def stream_chat_feedback(
     )
 
     async def generate_sse():
-        async for event in svc.chat.stream_chat(stream_input, sub_agent_id="feedback", user_id=ctx.user_id):
+        async for event in svc.chat.stream_chat(
+            stream_input, sub_agent_id="feedback", user_id=ctx.user_id, principal=ctx.principal
+        ):
             yield f"id: {event.id}\nevent: {event.event}\ndata: {event.data.model_dump_json()}\n\n"
 
     return StreamingResponse(generate_sse(), media_type="text/event-stream", headers=_sse_headers())

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -11,7 +11,7 @@ asyncio.Task so that client disconnects do not cancel the computation.
 """
 
 import asyncio
-from typing import Annotated, AsyncGenerator, Optional
+from typing import Annotated, Any, AsyncGenerator, Optional
 
 from fastapi import APIRouter, HTTPException, Path, Query, Request
 from fastapi.responses import StreamingResponse
@@ -44,6 +44,7 @@ from datus.api.models.cli_models import (
     StreamChatInput,
     UserInteractionInput,
 )
+from datus.tools.data_access_policy import DataAccessConfig
 from datus.utils.feedback_prompt import build_reaction_feedback_prompt
 from datus.utils.loggings import get_logger
 from datus.utils.time_utils import now_utc_iso
@@ -76,6 +77,68 @@ def _is_valid_subagent_id(svc, subagent_id: str) -> bool:
     return False
 
 
+def _data_access_principal_pre_check(svc, ctx) -> Optional[ChatPreCheckOutcome]:
+    """Fail fast when enabled data-access policies need missing principal fields."""
+    agent_config = getattr(svc, "agent_config", None)
+    data_access_config = getattr(agent_config, "data_access_config", None)
+    if not isinstance(data_access_config, DataAccessConfig) or not data_access_config.enabled:
+        return None
+
+    principal = getattr(ctx, "principal", None) or {}
+    required_paths = _required_principal_paths(data_access_config.raw)
+    missing_paths = _missing_principal_paths(principal, required_paths)
+    if not missing_paths and (principal or required_paths):
+        return None
+
+    detail = ""
+    if missing_paths:
+        missing_fields = ", ".join(f"principal.{path}" for path in missing_paths)
+        detail = f" Missing principal field(s): {missing_fields}."
+    return ChatPreCheckOutcome(
+        allow=False,
+        error=(
+            "Data access is enabled, but this request is missing principal data required by policy."
+            f"{detail} "
+            "Authenticate the request with a provider that populates principal fields required by "
+            "agent.data_access policies. The agent cannot infer or set request principal from SQL."
+        ),
+        error_type="DATA_ACCESS_PRINCIPAL_REQUIRED",
+    )
+
+
+def _required_principal_paths(raw: Any) -> list[str]:
+    paths: set[str] = set()
+
+    def visit(value: Any) -> None:
+        if isinstance(value, dict):
+            value_from = value.get("value_from")
+            if isinstance(value_from, str) and value_from.startswith("principal."):
+                path = value_from[len("principal.") :].strip()
+                if path:
+                    paths.add(path)
+            for child in value.values():
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(raw)
+    return sorted(paths)
+
+
+def _missing_principal_paths(principal: dict[str, Any], required_paths: list[str]) -> list[str]:
+    return [path for path in required_paths if not _principal_path_exists(principal, path)]
+
+
+def _principal_path_exists(principal: dict[str, Any], path: str) -> bool:
+    current: Any = principal
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return current not in (None, "", [])
+
+
 # ========== Stream Chat ==========
 
 
@@ -96,6 +159,14 @@ async def stream_chat(
         raise HTTPException(
             status_code=404,
             detail=f"Subagent '{sub_agent_id}' not found",
+        )
+
+    data_access_denial = _data_access_principal_pre_check(svc, ctx)
+    if data_access_denial:
+        return StreamingResponse(
+            _emit_pre_check_denial(request, data_access_denial),
+            media_type="text/event-stream",
+            headers=_sse_headers(),
         )
 
     hooks = get_chat_hooks()
@@ -152,6 +223,13 @@ async def stream_chat_feedback(
         message=rendered_message,
         subagent_id="feedback",
     )
+    data_access_denial = _data_access_principal_pre_check(svc, ctx)
+    if data_access_denial:
+        return StreamingResponse(
+            _emit_pre_check_denial(stream_input, data_access_denial),
+            media_type="text/event-stream",
+            headers=_sse_headers(),
+        )
 
     async def generate_sse():
         async for event in svc.chat.stream_chat(

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -7,7 +7,7 @@ read from disk each time (no in-memory state).
 """
 
 import uuid
-from typing import AsyncGenerator, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
 from datus.api.models.base_models import Result
@@ -62,6 +62,7 @@ class ChatService:
         request: StreamChatInput,
         sub_agent_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        principal: Optional[Dict[str, Any]] = None,
     ) -> AsyncGenerator[SSEEvent, None]:
         """Start a background chat task and yield SSE events."""
         task_manager = self._task_manager
@@ -71,6 +72,7 @@ class ChatService:
                 request,
                 sub_agent_id=sub_agent_id,
                 user_id=user_id,
+                principal=principal,
             )
         except (ValueError, DatusException) as e:
             error_code = e.code.name if isinstance(e, DatusException) else ErrorCode.COMMON_VALIDATION_FAILED.name

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -11,7 +11,7 @@ import asyncio
 import copy
 import uuid
 from datetime import datetime
-from typing import AsyncGenerator, Dict, List, Literal, Optional
+from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.api.models.cli_models import (
@@ -301,6 +301,7 @@ class ChatTaskManager:
         request: StreamChatInput,
         sub_agent_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        principal: Optional[Dict[str, Any]] = None,
     ) -> ChatTask:
         """Create a background task for the agentic loop.
             :param sub_agent_id: builtin name or custom sub-agent DB ID
@@ -308,6 +309,7 @@ class ChatTaskManager:
         """
         # Clone config to avoid cross-request mutation of shared AgentConfig
         agent_config = copy.deepcopy(agent_config)
+        agent_config.principal = dict(principal or {})
         # API surface has no interactive broker to confirm EXTERNAL file
         # access, so force filesystem strict mode — every node constructed
         # below reads this flag via AgenticNode._resolve_filesystem_strict().
@@ -357,7 +359,13 @@ class ChatTaskManager:
         self._tasks[session_id] = task
 
         asyncio_task = asyncio.create_task(
-            self._run_loop(task, agent_config, request, sub_agent_id=sub_agent_id, user_id=user_id)
+            self._run_loop(
+                task,
+                agent_config,
+                request,
+                sub_agent_id=sub_agent_id,
+                user_id=user_id,
+            )
         )
         task.asyncio_task = asyncio_task
         return task

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -905,6 +905,14 @@ class AgentConfig:
         # Initialize unified permission system
         self.permissions_config = self._init_permissions_config(kwargs.get("permissions", {}))
 
+        # Data access policies are enforced at the DB tool boundary. The config
+        # is static, while the request-scoped principal is attached later by
+        # API/gateway callers to the per-request AgentConfig copy.
+        from datus.tools.data_access_policy import DataAccessConfig
+
+        self.data_access_config = DataAccessConfig.from_dict(kwargs.get("data_access", {}))
+        self.principal: Dict[str, Any] = {}
+
         # Initialize skills configuration
         self.skills_config = self._init_skills_config(kwargs.get("skills", {}))
 

--- a/datus/tools/data_access_policy.py
+++ b/datus/tools/data_access_policy.py
@@ -13,26 +13,35 @@ from __future__ import annotations
 
 import importlib
 from copy import deepcopy
-from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Protocol
 
+from pydantic import BaseModel, ConfigDict, Field
 
-@dataclass(frozen=True)
-class DataAccessConfig:
+from datus.utils.exceptions import DatusException, ErrorCode
+
+
+class DataAccessConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     enabled: bool = False
     provider: Optional[str] = None
-    raw: Dict[str, Any] = field(default_factory=dict)
+    raw: Dict[str, Any] = Field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "DataAccessConfig":
-        if not raw:
+        if raw is None:
             return cls()
         if not isinstance(raw, dict):
-            raise ValueError("agent.data_access must be a mapping")
+            raise DatusException(ErrorCode.COMMON_FIELD_INVALID, message="agent.data_access must be a mapping")
+        if not raw:
+            return cls()
 
         enabled = raw.get("enabled", False)
         if not isinstance(enabled, bool):
-            raise ValueError("agent.data_access.enabled must be a boolean")
+            raise DatusException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                message="agent.data_access.enabled must be a boolean",
+            )
 
         provider = raw.get("provider")
         provider_name = str(provider).strip() if provider is not None else None
@@ -43,12 +52,13 @@ class DataAccessConfig:
         )
 
 
-@dataclass(frozen=True)
-class EnforcementResult:
+class EnforcementResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     allowed: bool
     sql: Optional[str] = None
     reason: Optional[str] = None
-    applied_policies: list[str] = field(default_factory=list)
+    applied_policies: list[str] = Field(default_factory=list)
 
 
 class DataAccessEnforcer(Protocol):
@@ -63,8 +73,11 @@ class DataAccessEnforcer(Protocol):
         """Return a rewritten SQL statement or a denial."""
 
 
-class DataAccessProviderError(RuntimeError):
+class DataAccessProviderError(DatusException):
     """Raised when enabled data-access policy cannot load its provider."""
+
+    def __init__(self, message: str):
+        super().__init__(ErrorCode.COMMON_CONFIG_ERROR, message_args={"config_error": message})
 
 
 class NoopDataAccessEnforcer:
@@ -97,7 +110,8 @@ def load_data_access_enforcer(config: Optional[DataAccessConfig]) -> DataAccessE
     except TypeError as e:
         raise DataAccessProviderError(f"Failed to initialize data-access provider {config.provider!r}: {e}") from e
 
-    if not hasattr(provider, "enforce_read"):
+    enforce_read = getattr(provider, "enforce_read", None)
+    if not callable(enforce_read):
         raise DataAccessProviderError(f"Data-access provider {config.provider!r} must implement enforce_read")
     return provider
 

--- a/datus/tools/data_access_policy.py
+++ b/datus/tools/data_access_policy.py
@@ -1,0 +1,118 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Data-access policy extension points.
+
+The open-source package owns the stable configuration shape and provider
+loading contract. Concrete policy engines can live in separate packages and be
+registered with ``agent.data_access.provider``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol
+
+
+@dataclass(frozen=True)
+class DataAccessConfig:
+    enabled: bool = False
+    provider: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "DataAccessConfig":
+        if not raw:
+            return cls()
+        if not isinstance(raw, dict):
+            raise ValueError("agent.data_access must be a mapping")
+
+        enabled = raw.get("enabled", False)
+        if not isinstance(enabled, bool):
+            raise ValueError("agent.data_access.enabled must be a boolean")
+
+        provider = raw.get("provider")
+        provider_name = str(provider).strip() if provider is not None else None
+        return cls(
+            enabled=enabled,
+            provider=provider_name or None,
+            raw=deepcopy(raw),
+        )
+
+
+@dataclass(frozen=True)
+class EnforcementResult:
+    allowed: bool
+    sql: Optional[str] = None
+    reason: Optional[str] = None
+    applied_policies: list[str] = field(default_factory=list)
+
+
+class DataAccessEnforcer(Protocol):
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: Optional[Dict[str, Any]],
+    ) -> EnforcementResult:
+        """Return a rewritten SQL statement or a denial."""
+
+
+class DataAccessProviderError(RuntimeError):
+    """Raised when enabled data-access policy cannot load its provider."""
+
+
+class NoopDataAccessEnforcer:
+    def __init__(self, config: Optional[DataAccessConfig] = None):
+        self.config = config or DataAccessConfig()
+
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: Optional[Dict[str, Any]],
+    ) -> EnforcementResult:
+        return EnforcementResult(allowed=True, sql=sql)
+
+
+def load_data_access_enforcer(config: Optional[DataAccessConfig]) -> DataAccessEnforcer:
+    config = config or DataAccessConfig()
+    if not config.enabled:
+        return NoopDataAccessEnforcer(config)
+    if not config.provider:
+        raise DataAccessProviderError(
+            "agent.data_access.enabled is true but agent.data_access.provider is not configured"
+        )
+
+    provider_cls = _load_provider_class(config.provider)
+    try:
+        provider = provider_cls(config)
+    except TypeError as e:
+        raise DataAccessProviderError(f"Failed to initialize data-access provider {config.provider!r}: {e}") from e
+
+    if not hasattr(provider, "enforce_read"):
+        raise DataAccessProviderError(f"Data-access provider {config.provider!r} must implement enforce_read")
+    return provider
+
+
+def _load_provider_class(provider: str) -> type:
+    module_name, _, class_name = provider.partition(":")
+    if not module_name or not class_name:
+        raise DataAccessProviderError(
+            "agent.data_access.provider must be a Python path like 'package.module:ProviderClass'"
+        )
+    try:
+        module = importlib.import_module(module_name)
+        provider_cls = getattr(module, class_name)
+    except Exception as e:
+        raise DataAccessProviderError(f"Failed to load data-access provider {provider!r}: {e}") from e
+    if not isinstance(provider_cls, type):
+        raise DataAccessProviderError(f"Data-access provider {provider!r} must reference a class")
+    return provider_cls

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -109,6 +109,7 @@ class DBFuncTool:
         default_database: Optional[str] = None,
         sub_agent_name: Optional[str] = None,
         scoped_tables: Optional[Iterable[str]] = None,
+        principal: Optional[Dict[str, Any]] = None,
         connector_cache_size: int = DEFAULT_CONNECTOR_CACHE_SIZE,
     ):
         """
@@ -124,6 +125,8 @@ class DBFuncTool:
                               configured for its datasource); defaults to the datasource config's ``database``.
             sub_agent_name: Optional sub-agent name for scoped context
             scoped_tables: Optional explicit table scope patterns
+            principal: Request-scoped data-access attributes. When omitted,
+                       falls back to ``agent_config.principal`` if present.
             connector_cache_size: Max connectors to cache (LRU eviction), default 8
         """
         if connector_or_manager is None:
@@ -150,6 +153,8 @@ class DBFuncTool:
         model_name = agent_config.active_model().model if agent_config else "gpt-3.5-turbo"
         self.compressor = DataCompressor(model_name=model_name)
         self.agent_config = agent_config
+        principal_source = principal if principal is not None else getattr(agent_config, "principal", {})
+        self.principal: Dict[str, Any] = dict(principal_source) if isinstance(principal_source, dict) else {}
         self.sub_agent_name = sub_agent_name
         self.schema_rag = SchemaWithValueRAG(agent_config, sub_agent_name) if agent_config else None
         self._field_order = self._determine_field_order()
@@ -1161,6 +1166,11 @@ class DBFuncTool:
                 )
 
             logger.info("read_query", sql_type=sql_type.value, datasource=datasource or "default")
+            sql = self._enforce_data_access_policy(
+                sql,
+                datasource=datasource or self._default_datasource or "default",
+                dialect=connector.dialect,
+            )
             result = connector.execute_query(sql, result_format="arrow" if connector.dialect == "snowflake" else "list")
             if result.success:
                 data = result.sql_return
@@ -1169,6 +1179,30 @@ class DBFuncTool:
                 return FuncToolResult(success=0, error=result.error)
         except Exception as e:
             return FuncToolResult(success=0, error=str(e))
+
+    def _enforce_data_access_policy(self, sql: str, datasource: str, dialect: str) -> str:
+        if not self.agent_config:
+            return sql
+        data_access_config = getattr(self.agent_config, "data_access_config", None)
+        if not data_access_config or not getattr(data_access_config, "enabled", False):
+            return sql
+        from datus.tools.data_access_policy import load_data_access_enforcer
+
+        enforced = load_data_access_enforcer(data_access_config).enforce_read(
+            sql,
+            datasource=datasource,
+            dialect=dialect,
+            principal=self.principal,
+        )
+        if not enforced.allowed:
+            raise PermissionError(enforced.reason or "SQL data-access policy denied the query")
+        if enforced.applied_policies:
+            logger.info(
+                "Applied SQL data-access policies",
+                policies=enforced.applied_policies,
+                datasource=datasource,
+            )
+        return enforced.sql or sql
 
     @mcp_tool()
     def get_table_ddl(

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1118,59 +1118,27 @@ class DBFuncTool:
             FuncToolResult with result=self.compressor.compress(rows) when successful. On failure success=0 with the
             underlying error message from the connector.
         """
-        from datus.utils.sql_utils import _first_statement, parse_sql_type
-
         try:
             # Support SQL file path: if sql is a simple path ending with .sql, read from file
             sql_stripped = sql.strip()
             if sql_stripped.endswith(".sql") and "\n" not in sql_stripped and " " not in sql_stripped:
                 sql = self._read_sql_from_file(sql_stripped)
 
-            # Reject multi-statement SQL to prevent read-only bypass (e.g. "SELECT 1; DELETE ...")
-            from datus.utils.sql_utils import strip_sql_comments
-
-            cleaned = strip_sql_comments(sql).strip()
-            normalized_sql = cleaned.rstrip(";").strip()
-            if normalized_sql and _first_statement(normalized_sql) != normalized_sql:
-                return FuncToolResult(
-                    success=0,
-                    error="Multi-statement SQL is not allowed. Please submit one query at a time.",
-                )
-
-            # Enforce read-only: only SELECT, SHOW/DESCRIBE, and EXPLAIN are allowed
             connector = self._get_connector(datasource, database)
-            sql_type = parse_sql_type(sql, connector.dialect)
-            _READONLY_SQL_TYPES = {SQLType.SELECT, SQLType.METADATA_SHOW, SQLType.EXPLAIN}
-            if sql_type not in _READONLY_SQL_TYPES:
-                return FuncToolResult(
-                    success=0,
-                    error=f"Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed. "
-                    f"Detected SQL type: {sql_type.value}",
-                )
-
-            # Reject writable PRAGMAs (e.g. "PRAGMA journal_mode=WAL")
-            if sql_type == SQLType.METADATA_SHOW:
-                first_word = cleaned.split()[0].upper() if cleaned else ""
-                if first_word == "PRAGMA" and "=" in cleaned:
-                    return FuncToolResult(
-                        success=0,
-                        error="Writable PRAGMA statements are not allowed in read-only mode.",
-                    )
-
-            # Check table scope — reject queries referencing out-of-scope tables
-            out_of_scope = self._check_sql_table_scope(sql)
-            if out_of_scope:
-                return FuncToolResult(
-                    success=0,
-                    error=f"Query references tables outside scoped context: {', '.join(out_of_scope)}",
-                )
+            validation_error, sql_type = self._validate_read_sql(sql, connector)
+            if validation_error:
+                return validation_error
 
             logger.info("read_query", sql_type=sql_type.value, datasource=datasource or "default")
+            effective_datasource = self._resolve_effective_datasource(datasource)
             sql = self._enforce_data_access_policy(
                 sql,
-                datasource=datasource or self._default_datasource or "default",
+                datasource=effective_datasource,
                 dialect=connector.dialect,
             )
+            validation_error, _ = self._validate_read_sql(sql, connector)
+            if validation_error:
+                return validation_error
             result = connector.execute_query(sql, result_format="arrow" if connector.dialect == "snowflake" else "list")
             if result.success:
                 data = result.sql_return
@@ -1180,13 +1148,69 @@ class DBFuncTool:
         except Exception as e:
             return FuncToolResult(success=0, error=str(e))
 
+    def _resolve_effective_datasource(self, datasource: Optional[str]) -> str:
+        effective_datasource = datasource or self._default_datasource
+        if not effective_datasource and self.agent_config:
+            services = getattr(self.agent_config, "services", None)
+            effective_datasource = getattr(services, "default_datasource", "") or ""
+        return effective_datasource or "default"
+
+    def _validate_read_sql(self, sql: str, connector: BaseSqlConnector) -> tuple[Optional[FuncToolResult], SQLType]:
+        from datus.utils.sql_utils import _first_statement, parse_sql_type, strip_sql_comments
+
+        cleaned = strip_sql_comments(sql).strip()
+        normalized_sql = cleaned.rstrip(";").strip()
+        if normalized_sql and _first_statement(normalized_sql) != normalized_sql:
+            return (
+                FuncToolResult(
+                    success=0,
+                    error="Multi-statement SQL is not allowed. Please submit one query at a time.",
+                ),
+                SQLType.UNKNOWN,
+            )
+
+        sql_type = parse_sql_type(sql, connector.dialect)
+        readonly_sql_types = {SQLType.SELECT, SQLType.METADATA_SHOW, SQLType.EXPLAIN}
+        if sql_type not in readonly_sql_types:
+            return (
+                FuncToolResult(
+                    success=0,
+                    error=f"Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed. "
+                    f"Detected SQL type: {sql_type.value}",
+                ),
+                sql_type,
+            )
+
+        if sql_type == SQLType.METADATA_SHOW:
+            first_word = cleaned.split()[0].upper() if cleaned else ""
+            if first_word == "PRAGMA" and "=" in cleaned:
+                return (
+                    FuncToolResult(
+                        success=0,
+                        error="Writable PRAGMA statements are not allowed in read-only mode.",
+                    ),
+                    sql_type,
+                )
+
+        out_of_scope = self._check_sql_table_scope(sql)
+        if out_of_scope:
+            return (
+                FuncToolResult(
+                    success=0,
+                    error=f"Query references tables outside scoped context: {', '.join(out_of_scope)}",
+                ),
+                sql_type,
+            )
+        return None, sql_type
+
     def _enforce_data_access_policy(self, sql: str, datasource: str, dialect: str) -> str:
         if not self.agent_config:
             return sql
         data_access_config = getattr(self.agent_config, "data_access_config", None)
-        if not data_access_config or not getattr(data_access_config, "enabled", False):
+        from datus.tools.data_access_policy import DataAccessConfig, load_data_access_enforcer
+
+        if not isinstance(data_access_config, DataAccessConfig) or not data_access_config.enabled:
             return sql
-        from datus.tools.data_access_policy import load_data_access_enforcer
 
         enforced = load_data_access_enforcer(data_access_config).enforce_read(
             sql,
@@ -1195,7 +1219,10 @@ class DBFuncTool:
             principal=self.principal,
         )
         if not enforced.allowed:
-            raise PermissionError(enforced.reason or "SQL data-access policy denied the query")
+            raise DatusException(
+                ErrorCode.TOOL_INVALID_INPUT,
+                message=enforced.reason or "SQL data-access policy denied the query",
+            )
         if enforced.applied_policies:
             logger.info(
                 "Applied SQL data-access policies",

--- a/docs/API/introduction.md
+++ b/docs/API/introduction.md
@@ -22,6 +22,10 @@ default unscoped session; when present, the user id is used to isolate chat sess
 X-Datus-User-Id: alice
 ```
 
+Data-access policies use a separate request principal. When `agent.data_access.enabled` is `true`, send business
+scope fields in `X-Datus-Principal` as a JSON object, for example `{"market_code":"MKT300"}`. `X-Datus-User-Id`
+does not populate data-access principal fields. See [Data Access Policy](../configuration/data_access_policy.md).
+
 Datasource isolation is controlled separately by the `--datasource` CLI flag (or `DATUS_DATASOURCE` env var) and selects
 which datasource from `agent.yml` is used to load databases and knowledge.
 

--- a/docs/API/introduction.md
+++ b/docs/API/introduction.md
@@ -25,6 +25,7 @@ X-Datus-User-Id: alice
 Data-access policies use a separate request principal. When `agent.data_access.enabled` is `true`, send business
 scope fields in `X-Datus-Principal` as a JSON object, for example `{"market_code":"MKT300"}`. `X-Datus-User-Id`
 does not populate data-access principal fields. See [Data Access Policy](../configuration/data_access_policy.md).
+Do not include `user_id` in `X-Datus-Principal`; that field is reserved for `X-Datus-User-Id` and will be rejected.
 
 Datasource isolation is controlled separately by the `--datasource` CLI flag (or `DATUS_DATASOURCE` env var) and selects
 which datasource from `agent.yml` is used to load databases and knowledge.

--- a/docs/API/introduction.zh.md
+++ b/docs/API/introduction.zh.md
@@ -20,6 +20,10 @@ API 服务与 `datus` CLI、`datus-mcp` MCP 服务共享同一套配置、知识
 X-Datus-User-Id: alice
 ```
 
+数据访问策略使用单独的请求 principal。启用 `agent.data_access.enabled` 后，请通过 `X-Datus-Principal` 传入业务范围字段，
+header 值必须是 JSON object，例如 `{"market_code":"MKT300"}`。`X-Datus-User-Id` 不会写入 data-access principal。
+详见[数据访问策略](../configuration/data_access_policy.zh.md)。
+
 Datasource 隔离由 `--datasource` CLI 参数(或 `DATUS_DATASOURCE` 环境变量)单独控制,决定加载 `agent.yml`
 中的哪个 datasource 的数据库与知识库。
 

--- a/docs/API/introduction.zh.md
+++ b/docs/API/introduction.zh.md
@@ -22,6 +22,7 @@ X-Datus-User-Id: alice
 
 数据访问策略使用单独的请求 principal。启用 `agent.data_access.enabled` 后，请通过 `X-Datus-Principal` 传入业务范围字段，
 header 值必须是 JSON object，例如 `{"market_code":"MKT300"}`。`X-Datus-User-Id` 不会写入 data-access principal。
+注意：`X-Datus-Principal` 中不允许包含 `user_id` 字段；该字段保留给 `X-Datus-User-Id`，否则会触发 400 校验错误。
 详见[数据访问策略](../configuration/data_access_policy.zh.md)。
 
 Datasource 隔离由 `--datasource` CLI 参数(或 `DATUS_DATASOURCE` 环境变量)单独控制,决定加载 `agent.yml`

--- a/docs/configuration/data_access_policy.md
+++ b/docs/configuration/data_access_policy.md
@@ -1,0 +1,186 @@
+# Data Access Policy
+
+Data access policies restrict SQL reads before they reach the database. Use them when the API must answer questions only within a caller's business scope, such as a market, tenant, region, or store list.
+
+The open-source agent provides the data-access extension point, configuration loading, request-principal handling, and API fail-fast checks. It does not ship private policy implementations. To enforce a policy, implement and install your own provider package.
+
+## What the Open-Source Agent Provides
+
+When `agent.data_access.enabled` is `true`, Datus:
+
+- Loads the Python class configured in `agent.data_access.provider`.
+- Passes the full `agent.data_access` mapping to the provider as `DataAccessConfig.raw`.
+- Calls the provider before read queries are executed.
+- Passes request-scoped principal fields from the API request to the provider.
+- Fails chat requests before the agent starts when policy config references missing `principal.*` fields.
+
+The provider decides the policy schema and enforcement behavior.
+
+## Implement a Provider
+
+Create a Python package importable by the same environment that runs `datus-api`. The provider class must implement `enforce_read(...)`.
+
+```python
+from typing import Any, Optional
+
+from datus.tools.data_access_policy import DataAccessConfig, EnforcementResult
+
+
+class MyDataAccessProvider:
+    def __init__(self, config: Optional[DataAccessConfig] = None):
+        self.config = config or DataAccessConfig()
+        self.policies = self.config.raw.get("policies", []) or []
+
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: Optional[dict[str, Any]],
+    ) -> EnforcementResult:
+        principal = principal or {}
+
+        # Implement your policy logic here:
+        # - inspect datasource, sql, and self.policies
+        # - resolve values from principal
+        # - rewrite SQL with a parser, or deny the query
+        # - return the SQL that should be executed
+        return EnforcementResult(allowed=True, sql=sql)
+```
+
+Return values:
+
+```python
+EnforcementResult(allowed=True, sql=rewritten_sql, applied_policies=["market_scope"])
+EnforcementResult(allowed=False, reason="Missing principal.market_code")
+```
+
+Use a SQL parser or database-safe query builder for rewrites. Avoid ad hoc string concatenation for policy SQL.
+
+## Configure the Provider
+
+Point `agent.data_access.provider` at your provider class:
+
+```yaml
+agent:
+  data_access:
+    enabled: true
+    provider: my_company.datus_policies:MyDataAccessProvider
+    policies:
+      - name: market_scope
+        type: row_filter
+        applies_to:
+          datasources: ["starrocks"]
+          tables: ["v_udata_ac_info"]
+        condition:
+          column: market_code
+          operator: eq
+          value_from: principal.market_code
+        enforcement:
+          on_read: filter
+          on_unhandled: deny
+```
+
+Only `enabled` and `provider` are interpreted by the open-source agent. The rest of the policy shape is passed through to your provider in `DataAccessConfig.raw`.
+
+If your policy config contains `value_from: principal.market_code`, the API pre-check requires the request principal to contain `market_code` before the agent starts. This recursive `value_from` scan is generic and does not depend on a specific policy type.
+
+## Send the Request Principal
+
+For the default API auth provider, send data-access attributes in the `X-Datus-Principal` header as a JSON object:
+
+```bash
+curl -N "http://127.0.0.1:8000/api/v1/chat/stream" \
+  -H "Content-Type: application/json" \
+  -H 'X-Datus-Principal: {"market_code":"MKT300"}' \
+  -d '{
+    "message": "Show June new product campaigns",
+    "subagent_id": "baisheng_metadata"
+  }'
+```
+
+`X-Datus-Principal` becomes `AppContext.principal`:
+
+```python
+{"market_code": "MKT300"}
+```
+
+Your provider receives that dict in `enforce_read(..., principal=...)`.
+
+`X-Datus-User-Id` is separate. It is optional and only identifies the caller for session isolation. It does not populate data-access principal fields and cannot satisfy `principal.market_code`.
+
+## Multi-Value Scope
+
+If your provider supports multi-value scopes, use a principal array:
+
+```yaml
+condition:
+  column: market_code
+  operator: in
+  value_from: principal.market_codes
+```
+
+Send:
+
+```bash
+curl -N "http://127.0.0.1:8000/api/v1/chat/stream" \
+  -H "Content-Type: application/json" \
+  -H 'X-Datus-Principal: {"market_codes":["MKT300","MKT301"]}' \
+  -d '{"message":"Show June new product campaigns"}'
+```
+
+The open-source agent only passes this array through. Your provider decides how `operator: in` is enforced.
+
+## Nested Principal Fields
+
+The request principal can contain nested JSON objects:
+
+```http
+X-Datus-Principal: {"tenant":{"id":"tenant_001"}}
+```
+
+Policy config can reference that path:
+
+```yaml
+condition:
+  column: tenant_id
+  operator: eq
+  value_from: principal.tenant.id
+```
+
+The API pre-check treats empty strings, empty arrays, and `null` as missing.
+
+## Provider Contract
+
+| Item | Contract |
+|------|----------|
+| `agent.data_access.enabled` | Enables data-access enforcement. |
+| `agent.data_access.provider` | Python class path in `module:Class` format. Required when enabled. |
+| `DataAccessConfig.raw` | Full raw `agent.data_access` mapping passed to the provider. |
+| `enforce_read(sql, datasource, dialect, principal)` | Called before read queries execute. |
+| `EnforcementResult.allowed=True` | Query may continue. Return `sql` to execute the original or rewritten SQL. |
+| `EnforcementResult.allowed=False` | Query is denied. Return `reason` for the tool/model-facing error. |
+| `X-Datus-Principal` | JSON object parsed into `AppContext.principal` for API requests. |
+| `value_from: principal.*` | Optional convention used by API pre-check to detect missing principal fields. |
+
+## Error Behavior
+
+If data access is enabled and policy config requires a missing principal field, the chat API fails before the agent starts:
+
+```text
+DATA_ACCESS_PRINCIPAL_REQUIRED
+```
+
+The error message includes the missing field, for example `principal.market_code`.
+
+If `X-Datus-Principal` is not valid JSON, the API returns HTTP 400 because the request context is malformed.
+
+If the provider denies a query, the tool returns the provider's `reason` to the agent.
+
+## Limits
+
+- Open-source Datus does not include a built-in row-filter implementation.
+- Current built-in request-principal input is the API header `X-Datus-Principal`.
+- CLI requests do not have HTTP headers. Use the REST API for request-scoped data-access principal enforcement, or implement an auth provider that populates `AppContext.principal` for your deployment.
+- Do not put `user_id` inside `X-Datus-Principal`; `user_id` is reserved for `X-Datus-User-Id`.

--- a/docs/configuration/data_access_policy.zh.md
+++ b/docs/configuration/data_access_policy.zh.md
@@ -1,0 +1,186 @@
+# 数据访问策略
+
+数据访问策略会在 SQL 到达数据库前限制读查询。适用于 API 需要按调用方的业务范围回答问题的场景，例如市场、租户、区域或门店列表。
+
+开源 Agent 提供 data-access 扩展点、配置加载、请求 principal 处理和 API fail-fast 检查。开源版不包含私有策略实现。要真正执行策略，需要实现并安装自己的 provider 包。
+
+## 开源 Agent 提供什么
+
+当 `agent.data_access.enabled` 为 `true` 时，Datus 会：
+
+- 加载 `agent.data_access.provider` 配置的 Python class。
+- 将完整的 `agent.data_access` mapping 作为 `DataAccessConfig.raw` 传给 provider。
+- 在读查询执行前调用 provider。
+- 将 API 请求中的 request-scoped principal 字段传给 provider。
+- 当策略配置引用了缺失的 `principal.*` 字段时，在 Agent 启动前拒绝 chat 请求。
+
+provider 自己决定策略 schema 和 enforcement 行为。
+
+## 实现 Provider
+
+创建一个能被 `datus-api` 所在 Python 环境 import 到的包。provider class 必须实现 `enforce_read(...)`。
+
+```python
+from typing import Any, Optional
+
+from datus.tools.data_access_policy import DataAccessConfig, EnforcementResult
+
+
+class MyDataAccessProvider:
+    def __init__(self, config: Optional[DataAccessConfig] = None):
+        self.config = config or DataAccessConfig()
+        self.policies = self.config.raw.get("policies", []) or []
+
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: Optional[dict[str, Any]],
+    ) -> EnforcementResult:
+        principal = principal or {}
+
+        # 在这里实现你的策略逻辑：
+        # - 检查 datasource、sql 和 self.policies
+        # - 从 principal 中解析策略值
+        # - 用 SQL parser 改写 SQL，或拒绝查询
+        # - 返回最终应该执行的 SQL
+        return EnforcementResult(allowed=True, sql=sql)
+```
+
+返回值示例：
+
+```python
+EnforcementResult(allowed=True, sql=rewritten_sql, applied_policies=["market_scope"])
+EnforcementResult(allowed=False, reason="Missing principal.market_code")
+```
+
+改写 SQL 时建议使用 SQL parser 或数据库安全的 query builder，不要用简单字符串拼接来生成策略 SQL。
+
+## 配置 Provider
+
+将 `agent.data_access.provider` 指向你自己的 provider class：
+
+```yaml
+agent:
+  data_access:
+    enabled: true
+    provider: my_company.datus_policies:MyDataAccessProvider
+    policies:
+      - name: market_scope
+        type: row_filter
+        applies_to:
+          datasources: ["starrocks"]
+          tables: ["v_udata_ac_info"]
+        condition:
+          column: market_code
+          operator: eq
+          value_from: principal.market_code
+        enforcement:
+          on_read: filter
+          on_unhandled: deny
+```
+
+开源 Agent 只解释 `enabled` 和 `provider`。其他 policy 结构会原样放进 `DataAccessConfig.raw`，由你的 provider 自己解释。
+
+如果策略配置中包含 `value_from: principal.market_code`，API pre-check 会要求请求 principal 中必须包含 `market_code`，然后才允许 Agent 启动。这个递归 `value_from` 扫描是通用逻辑，不依赖特定 policy type。
+
+## 发送请求 Principal
+
+默认 API auth provider 通过 `X-Datus-Principal` header 接收 data-access 属性。header 值必须是 JSON object：
+
+```bash
+curl -N "http://127.0.0.1:8000/api/v1/chat/stream" \
+  -H "Content-Type: application/json" \
+  -H 'X-Datus-Principal: {"market_code":"MKT300"}' \
+  -d '{
+    "message": "查询6月新产品活动",
+    "subagent_id": "baisheng_metadata"
+  }'
+```
+
+`X-Datus-Principal` 会变成 `AppContext.principal`：
+
+```python
+{"market_code": "MKT300"}
+```
+
+你的 provider 会在 `enforce_read(..., principal=...)` 中收到这个 dict。
+
+`X-Datus-User-Id` 是另一件事。它是可选的调用者身份字段，只用于会话隔离；它不会写入 data-access principal，也不能满足 `principal.market_code`。
+
+## 多值范围
+
+如果你的 provider 支持多值范围，可以使用 principal array：
+
+```yaml
+condition:
+  column: market_code
+  operator: in
+  value_from: principal.market_codes
+```
+
+请求里发送：
+
+```bash
+curl -N "http://127.0.0.1:8000/api/v1/chat/stream" \
+  -H "Content-Type: application/json" \
+  -H 'X-Datus-Principal: {"market_codes":["MKT300","MKT301"]}' \
+  -d '{"message":"查询6月新产品活动"}'
+```
+
+开源 Agent 只负责传递这个数组。`operator: in` 如何执行，由你的 provider 决定。
+
+## 嵌套 Principal 字段
+
+request principal 可以包含嵌套 JSON object：
+
+```http
+X-Datus-Principal: {"tenant":{"id":"tenant_001"}}
+```
+
+策略配置可以引用这个路径：
+
+```yaml
+condition:
+  column: tenant_id
+  operator: eq
+  value_from: principal.tenant.id
+```
+
+API pre-check 会把空字符串、空数组和 `null` 当作缺失值。
+
+## Provider 契约
+
+| 项 | 契约 |
+|----|------|
+| `agent.data_access.enabled` | 启用 data-access enforcement。 |
+| `agent.data_access.provider` | Python class path，格式为 `module:Class`。启用时必填。 |
+| `DataAccessConfig.raw` | 完整的原始 `agent.data_access` mapping，会传给 provider。 |
+| `enforce_read(sql, datasource, dialect, principal)` | 在读查询执行前调用。 |
+| `EnforcementResult.allowed=True` | 查询可以继续。通过 `sql` 返回原始或改写后的 SQL。 |
+| `EnforcementResult.allowed=False` | 查询被拒绝。通过 `reason` 返回给 tool/model 的错误原因。 |
+| `X-Datus-Principal` | API 请求中会被解析为 `AppContext.principal` 的 JSON object。 |
+| `value_from: principal.*` | 可选约定，用于 API pre-check 检查缺失的 principal 字段。 |
+
+## 错误行为
+
+如果 data access 已启用，而策略配置需要的 principal 字段缺失，chat API 会在 Agent 启动前失败：
+
+```text
+DATA_ACCESS_PRINCIPAL_REQUIRED
+```
+
+错误信息会包含缺失字段，例如 `principal.market_code`。
+
+如果 `X-Datus-Principal` 不是合法 JSON，API 会返回 HTTP 400，因为请求上下文本身格式错误。
+
+如果 provider 拒绝查询，tool 会把 provider 返回的 `reason` 传给 Agent。
+
+## 限制
+
+- 开源版 Datus 不包含内置 row-filter 实现。
+- 当前内置请求 principal 入口是 API header `X-Datus-Principal`。
+- CLI 请求没有 HTTP header。需要请求级 data-access principal enforcement 时请使用 REST API，或者在部署中实现能填充 `AppContext.principal` 的 auth provider。
+- 不要把 `user_id` 放进 `X-Datus-Principal`；`user_id` 是 `X-Datus-User-Id` 的保留字段。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - Context Compaction: configuration/compact.md
       - Workflow: configuration/workflow.md
       - Benchmark: configuration/benchmark.md
+      - Data Access Policy: configuration/data_access_policy.md
       - Services:
         - Datasources: configuration/datasources.md
         - Semantic Layer: configuration/semantic_layer.md
@@ -163,6 +164,7 @@ plugins:
             BI Adapters: BI 适配器
             Scheduler Adapters: Scheduler 适配器
             Benchmark: 基准测试
+            Data Access Policy: 数据访问策略
             Metricflow: MetricFlow
             Integration: 集成
             MCP: MCP

--- a/tests/unit_tests/api/auth/test_no_auth_provider.py
+++ b/tests/unit_tests/api/auth/test_no_auth_provider.py
@@ -6,7 +6,7 @@ import pytest
 
 from datus.api.auth.context import AppContext
 from datus.api.auth.no_auth_provider import NoAuthProvider
-from datus.api.constants import HEADER_USER_ID
+from datus.api.constants import HEADER_PRINCIPAL, HEADER_USER_ID
 from datus.utils.exceptions import DatusException
 
 
@@ -32,6 +32,7 @@ class TestNoAuthProviderAuthenticate:
         assert ctx.user_id is None
         assert ctx.project_id is None
         assert ctx.config is None
+        assert ctx.principal == {}
 
     async def test_valid_header_populates_user_id(self):
         """Valid header → user_id reflects the header value."""
@@ -39,17 +40,46 @@ class TestNoAuthProviderAuthenticate:
         ctx = await provider.authenticate(_make_request({HEADER_USER_ID: "alice"}))
         assert ctx.user_id == "alice"
         assert ctx.project_id is None
+        assert ctx.principal == {}
 
     async def test_whitespace_header_treated_as_missing(self):
         provider = NoAuthProvider()
         ctx = await provider.authenticate(_make_request({HEADER_USER_ID: "   "}))
         assert ctx.user_id is None
+        assert ctx.principal == {}
+
+    async def test_principal_header_populates_request_principal(self):
+        provider = NoAuthProvider()
+        ctx = await provider.authenticate(
+            _make_request({HEADER_PRINCIPAL: '{"market_code": "MKT300", "market_codes": ["MKT300", "MKT301"]}'})
+        )
+        assert ctx.user_id is None
+        assert ctx.principal == {"market_code": "MKT300", "market_codes": ["MKT300", "MKT301"]}
+
+    async def test_user_id_header_does_not_populate_data_access_principal(self):
+        provider = NoAuthProvider()
+        ctx = await provider.authenticate(
+            _make_request({HEADER_USER_ID: "alice", HEADER_PRINCIPAL: '{"market_code": "MKT300"}'})
+        )
+        assert ctx.user_id == "alice"
+        assert ctx.principal == {"market_code": "MKT300"}
 
     async def test_invalid_header_raises(self):
         """Header with disallowed characters → DatusException."""
         provider = NoAuthProvider()
         with pytest.raises(DatusException):
             await provider.authenticate(_make_request({HEADER_USER_ID: "bad user!"}))
+
+    async def test_invalid_principal_header_raises(self):
+        provider = NoAuthProvider()
+        with pytest.raises(DatusException):
+            await provider.authenticate(_make_request({HEADER_PRINCIPAL: "not-json"}))
+
+        with pytest.raises(DatusException):
+            await provider.authenticate(_make_request({HEADER_PRINCIPAL: '["MKT300"]'}))
+
+        with pytest.raises(DatusException):
+            await provider.authenticate(_make_request({HEADER_PRINCIPAL: '{"user_id": "alice"}'}))
 
 
 class TestNoAuthProviderOnEvict:

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -261,6 +261,32 @@ class TestStreamChatDataAccessPreCheck:
         assert svc.chat.stream_chat.call_args.kwargs["principal"] == {"market_code": "MKT300"}
 
     @pytest.mark.asyncio
+    async def test_enabled_data_access_without_principal_paths_allows_service_call(self):
+        async def empty_stream(*_args, **_kwargs):
+            if False:
+                yield
+
+        svc = _mock_svc_with_nodes()
+        svc.agent_config.data_access_config = DataAccessConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "x:Y",
+                "policies": [{"name": "static_policy", "condition": {"value_from": "literal.MKT300"}}],
+            }
+        )
+        svc.chat.stream_chat = MagicMock(return_value=empty_stream())
+        ctx = MagicMock(user_id=None)
+        ctx.principal = {}
+        request = StreamChatInput(message="hi")
+
+        response = await stream_chat(request, svc, ctx, MagicMock())
+        async for _ in response.body_iterator:
+            pass
+
+        svc.chat.stream_chat.assert_called_once()
+        assert svc.chat.stream_chat.call_args.kwargs["principal"] == {}
+
+    @pytest.mark.asyncio
     async def test_user_id_only_does_not_satisfy_required_business_principal(self):
         svc = _mock_svc_with_nodes()
         svc.agent_config.data_access_config = DataAccessConfig.from_dict(

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -4,6 +4,7 @@
 
 """Unit tests for datus/api/routes/chat_routes.py — submit_user_interaction endpoint."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from datus.api.routes.chat_routes import (
     stream_chat,
     submit_user_interaction,
 )
+from datus.tools.data_access_policy import DataAccessConfig
 
 
 def _mock_svc(task=None):
@@ -195,6 +197,96 @@ class TestStreamChat404Gate:
         assert isinstance(response, StreamingResponse)
         assert response.status_code == 200
         assert response.media_type == "text/event-stream"
+
+
+class TestStreamChatDataAccessPreCheck:
+    """Data-access enabled chat requests must carry required request principal fields."""
+
+    @pytest.mark.asyncio
+    async def test_enabled_data_access_without_principal_returns_sse_error(self):
+        svc = _mock_svc_with_nodes()
+        svc.agent_config.data_access_config = DataAccessConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "x:Y",
+                "policies": [{"condition": {"value_from": "principal.market_code"}}],
+            }
+        )
+        svc.chat.stream_chat = MagicMock(side_effect=AssertionError("upstream invoked"))
+        ctx = MagicMock(user_id=None)
+        ctx.principal = {}
+        request = StreamChatInput(message="hi")
+
+        response = await stream_chat(request, svc, ctx, MagicMock())
+
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+        assert len(chunks) == 1
+        assert "event: error" in chunks[0]
+        payload = json.loads(
+            next(line for line in chunks[0].splitlines() if line.startswith("data: "))[len("data: ") :]
+        )
+        assert payload["error_type"] == "DATA_ACCESS_PRINCIPAL_REQUIRED"
+        assert "principal.market_code" in payload["error"]
+        assert "provider that populates principal fields" in payload["error"]
+        assert "agent.data_access policies" in payload["error"]
+        svc.chat.stream_chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_data_access_with_required_principal_allows_service_call(self):
+        async def empty_stream(*_args, **_kwargs):
+            if False:
+                yield
+
+        svc = _mock_svc_with_nodes()
+        svc.agent_config.data_access_config = DataAccessConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "x:Y",
+                "policies": [{"condition": {"value_from": "principal.market_code"}}],
+            }
+        )
+        svc.chat.stream_chat = MagicMock(return_value=empty_stream())
+        ctx = MagicMock(user_id=None)
+        ctx.principal = {"market_code": "MKT300"}
+        request = StreamChatInput(message="hi")
+
+        response = await stream_chat(request, svc, ctx, MagicMock())
+        async for _ in response.body_iterator:
+            pass
+
+        svc.chat.stream_chat.assert_called_once()
+        assert svc.chat.stream_chat.call_args.kwargs["principal"] == {"market_code": "MKT300"}
+
+    @pytest.mark.asyncio
+    async def test_user_id_only_does_not_satisfy_required_business_principal(self):
+        svc = _mock_svc_with_nodes()
+        svc.agent_config.data_access_config = DataAccessConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "x:Y",
+                "policies": [{"condition": {"value_from": "principal.market_code"}}],
+            }
+        )
+        svc.chat.stream_chat = MagicMock(side_effect=AssertionError("upstream invoked"))
+        ctx = MagicMock(user_id="alice")
+        ctx.principal = {}
+        request = StreamChatInput(message="hi")
+
+        response = await stream_chat(request, svc, ctx, MagicMock())
+
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+        payload = json.loads(
+            next(line for line in chunks[0].splitlines() if line.startswith("data: "))[len("data: ") :]
+        )
+        assert payload["error_type"] == "DATA_ACCESS_PRINCIPAL_REQUIRED"
+        assert "principal.market_code" in payload["error"]
+        svc.chat.stream_chat.assert_not_called()
 
 
 @pytest.mark.acceptance

--- a/tests/unit_tests/api/routes/test_chat_routes_feedback.py
+++ b/tests/unit_tests/api/routes/test_chat_routes_feedback.py
@@ -4,12 +4,14 @@
 
 """Unit tests for POST /api/v1/chat/feedback endpoint."""
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
 
 from datus.api.models.cli_models import FeedbackChatInput, StreamChatInput
 from datus.api.routes.chat_routes import stream_chat_feedback
+from datus.tools.data_access_policy import DataAccessConfig
 
 
 def _build_svc():
@@ -27,6 +29,7 @@ def _build_svc():
 def _build_ctx(user_id="tester"):
     ctx = MagicMock()
     ctx.user_id = user_id
+    ctx.principal = {}
     return ctx
 
 
@@ -106,3 +109,36 @@ async def test_feedback_endpoint_appends_optional_reaction_msg():
     stream_input: StreamChatInput = svc.chat.stream_chat.call_args.args[0]
     assert stream_input.message.endswith("Please recheck the metric definition")
     assert "[thumbsdown]" in stream_input.message
+
+
+@pytest.mark.asyncio
+async def test_feedback_endpoint_denies_when_data_access_enabled_without_principal():
+    svc = _build_svc()
+    svc.agent_config.data_access_config = DataAccessConfig.from_dict(
+        {
+            "enabled": True,
+            "provider": "x:Y",
+            "policies": [{"condition": {"value_from": "principal.market_code"}}],
+        }
+    )
+    svc.chat.stream_chat = MagicMock(side_effect=AssertionError("upstream invoked"))
+    ctx = _build_ctx(user_id=None)
+    request = FeedbackChatInput(
+        source_session_id="chat_session_abc",
+        reaction_emoji="thumbsup",
+        reference_msg="Here is your SQL result",
+    )
+
+    response = await stream_chat_feedback(request, svc, ctx)
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    assert len(chunks) == 1
+    assert "event: error" in chunks[0]
+    payload = json.loads(next(line for line in chunks[0].splitlines() if line.startswith("data: "))[len("data: ") :])
+    assert payload["error_type"] == "DATA_ACCESS_PRINCIPAL_REQUIRED"
+    assert "principal.market_code" in payload["error"]
+    assert "provider that populates principal fields" in payload["error"]
+    assert "agent.data_access policies" in payload["error"]
+    svc.chat.stream_chat.assert_not_called()

--- a/tests/unit_tests/api/test_deps.py
+++ b/tests/unit_tests/api/test_deps.py
@@ -3,11 +3,13 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import HTTPException
 
 from datus.api import deps
 from datus.api.auth.context import AppContext
 from datus.api.deps import get_datus_service, init_deps
 from datus.api.services.datus_service_cache import DatusServiceCache
+from datus.utils.exceptions import DatusException, ErrorCode
 
 
 @pytest.fixture(autouse=True)
@@ -134,6 +136,31 @@ class TestGetDatusService:
         call_args = mock_cache.get_or_create.call_args
         assert call_args[0][0] == "proj-1"
         assert call_args.kwargs["expected_fingerprint"] == "fp-xyz"
+
+    async def test_auth_validation_error_returns_bad_request(self):
+        """Auth-provider request validation errors are API 400s, not internal errors."""
+        mock_auth = MagicMock()
+        mock_auth.authenticate = AsyncMock(
+            side_effect=DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message="Invalid X-Datus-Principal header value: expected a JSON object.",
+            )
+        )
+        mock_cache = MagicMock(spec=DatusServiceCache)
+        mock_cache.get_or_create = AsyncMock()
+
+        deps._auth_provider = mock_auth
+        deps._service_cache = mock_cache
+
+        request = MagicMock()
+        request.state = MagicMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_datus_service(request)
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid X-Datus-Principal header value" in exc_info.value.detail
+        mock_cache.get_or_create.assert_not_called()
 
     async def test_no_fingerprint_when_config_is_none(self):
         """When ctx.config is None, expected_fingerprint passed as None."""

--- a/tests/unit_tests/tools/test_data_access_policy.py
+++ b/tests/unit_tests/tools/test_data_access_policy.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datus.tools.data_access_policy import (
+    DataAccessConfig,
+    DataAccessProviderError,
+    EnforcementResult,
+    NoopDataAccessEnforcer,
+    load_data_access_enforcer,
+)
+from datus.tools.func_tool.database import DBFuncTool
+
+
+class FakeDataAccessEnforcer:
+    last_config = None
+
+    def __init__(self, config: DataAccessConfig):
+        self.config = config
+        FakeDataAccessEnforcer.last_config = config
+
+    def enforce_read(self, sql, *, datasource, dialect, principal):
+        assert datasource == "default"
+        assert dialect == "sqlite"
+        assert principal == {"store_ids": ["S001"]}
+        return EnforcementResult(
+            allowed=True,
+            sql="SELECT * FROM orders WHERE store_id = 'S001'",
+            applied_policies=["store_scope"],
+        )
+
+
+def _provider_config() -> DataAccessConfig:
+    return DataAccessConfig.from_dict(
+        {
+            "enabled": True,
+            "provider": "tests.unit_tests.tools.test_data_access_policy:FakeDataAccessEnforcer",
+            "policies": [
+                {
+                    "name": "store_scope",
+                    "type": "row_filter",
+                    "applies_to": {
+                        "datasources": ["default"],
+                        "tables": ["orders", "store_sales"],
+                    },
+                    "condition": {
+                        "column": "store_id",
+                        "operator": "in",
+                        "value_from": "principal.store_ids",
+                    },
+                    "enforcement": {
+                        "on_read": "filter",
+                        "on_unhandled": "deny",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_data_access_config_preserves_provider_and_raw_policy_config():
+    config = _provider_config()
+
+    assert config.enabled is True
+    assert config.provider == "tests.unit_tests.tools.test_data_access_policy:FakeDataAccessEnforcer"
+    assert config.raw["policies"][0]["name"] == "store_scope"
+
+
+def test_disabled_data_access_uses_noop_enforcer():
+    result = load_data_access_enforcer(DataAccessConfig()).enforce_read(
+        "SELECT * FROM orders",
+        datasource="default",
+        dialect="sqlite",
+        principal=None,
+    )
+
+    assert isinstance(load_data_access_enforcer(DataAccessConfig()), NoopDataAccessEnforcer)
+    assert result.allowed is True
+    assert result.sql == "SELECT * FROM orders"
+
+
+def test_enabled_data_access_requires_provider():
+    config = DataAccessConfig.from_dict({"enabled": True})
+
+    with pytest.raises(DataAccessProviderError, match="provider is not configured"):
+        load_data_access_enforcer(config)
+
+
+def test_data_access_enabled_must_be_boolean():
+    with pytest.raises(ValueError, match="enabled must be a boolean"):
+        DataAccessConfig.from_dict({"enabled": "false"})
+
+
+def test_data_access_provider_requires_colon_path():
+    config = DataAccessConfig.from_dict(
+        {
+            "enabled": True,
+            "provider": "tests.unit_tests.tools.test_data_access_policy.FakeDataAccessEnforcer",
+        }
+    )
+
+    with pytest.raises(DataAccessProviderError, match="package.module:ProviderClass"):
+        load_data_access_enforcer(config)
+
+
+def test_data_access_provider_can_be_loaded_from_config():
+    enforcer = load_data_access_enforcer(_provider_config())
+
+    assert isinstance(enforcer, FakeDataAccessEnforcer)
+    assert FakeDataAccessEnforcer.last_config.raw["policies"][0]["type"] == "row_filter"
+
+
+def test_db_func_tool_applies_data_access_provider_before_query_execution():
+    connector = Mock()
+    connector.dialect = "sqlite"
+    connector.get_databases.return_value = []
+    query_result = Mock()
+    query_result.success = True
+    query_result.sql_return = [{"order_id": 1}]
+    connector.execute_query.return_value = query_result
+
+    agent_config = SimpleNamespace(
+        active_model=lambda: SimpleNamespace(model="test-model"),
+        data_access_config=_provider_config(),
+        principal={"store_ids": ["S001"]},
+    )
+
+    with (
+        patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+        patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+    ):
+        mock_rag.return_value.schema_store.table_size.return_value = 0
+        mock_sem.return_value.get_size.return_value = 0
+        tool = DBFuncTool(connector, agent_config=agent_config)
+
+    result = tool.read_query("SELECT * FROM orders", datasource="default")
+
+    assert result.success == 1
+    executed_sql = connector.execute_query.call_args.args[0]
+    assert executed_sql == "SELECT * FROM orders WHERE store_id = 'S001'"

--- a/tests/unit_tests/tools/test_data_access_policy.py
+++ b/tests/unit_tests/tools/test_data_access_policy.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,16 +12,24 @@ from datus.tools.data_access_policy import (
     load_data_access_enforcer,
 )
 from datus.tools.func_tool.database import DBFuncTool
+from datus.utils.exceptions import DatusException
 
 
 class FakeDataAccessEnforcer:
-    last_config = None
+    last_config: DataAccessConfig | None = None
 
-    def __init__(self, config: DataAccessConfig):
+    def __init__(self, config: DataAccessConfig) -> None:
         self.config = config
         FakeDataAccessEnforcer.last_config = config
 
-    def enforce_read(self, sql, *, datasource, dialect, principal):
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: dict[str, Any] | None,
+    ) -> EnforcementResult:
         assert datasource == "default"
         assert dialect == "sqlite"
         assert principal == {"store_ids": ["S001"]}
@@ -29,6 +38,61 @@ class FakeDataAccessEnforcer:
             sql="SELECT * FROM orders WHERE store_id = 'S001'",
             applied_policies=["store_scope"],
         )
+
+
+class NonCallableDataAccessEnforcer:
+    def __init__(self, config: DataAccessConfig) -> None:
+        self.config = config
+
+    enforce_read = None
+
+
+class DatasourceCaptureEnforcer:
+    last_datasource: str | None = None
+
+    def __init__(self, config: DataAccessConfig) -> None:
+        self.config = config
+
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: dict[str, Any] | None,
+    ) -> EnforcementResult:
+        DatasourceCaptureEnforcer.last_datasource = datasource
+        return EnforcementResult(allowed=True, sql=sql)
+
+
+class DenyDataAccessEnforcer:
+    def __init__(self, config: DataAccessConfig) -> None:
+        self.config = config
+
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: dict[str, Any] | None,
+    ) -> EnforcementResult:
+        return EnforcementResult(allowed=False, reason="store scope missing")
+
+
+class UnsafeRewriteEnforcer:
+    def __init__(self, config: DataAccessConfig) -> None:
+        self.config = config
+
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: dict[str, Any] | None,
+    ) -> EnforcementResult:
+        return EnforcementResult(allowed=True, sql="DELETE FROM orders")
 
 
 def _provider_config() -> DataAccessConfig:
@@ -67,6 +131,11 @@ def test_data_access_config_preserves_provider_and_raw_policy_config():
     assert config.raw["policies"][0]["name"] == "store_scope"
 
 
+def test_data_access_config_rejects_non_mapping():
+    with pytest.raises(DatusException, match="agent.data_access must be a mapping"):
+        DataAccessConfig.from_dict(False)  # type: ignore[arg-type]
+
+
 def test_disabled_data_access_uses_noop_enforcer():
     result = load_data_access_enforcer(DataAccessConfig()).enforce_read(
         "SELECT * FROM orders",
@@ -88,7 +157,7 @@ def test_enabled_data_access_requires_provider():
 
 
 def test_data_access_enabled_must_be_boolean():
-    with pytest.raises(ValueError, match="enabled must be a boolean"):
+    with pytest.raises(DatusException, match="enabled must be a boolean"):
         DataAccessConfig.from_dict({"enabled": "false"})
 
 
@@ -109,6 +178,18 @@ def test_data_access_provider_can_be_loaded_from_config():
 
     assert isinstance(enforcer, FakeDataAccessEnforcer)
     assert FakeDataAccessEnforcer.last_config.raw["policies"][0]["type"] == "row_filter"
+
+
+def test_data_access_provider_must_implement_callable_enforce_read():
+    config = DataAccessConfig.from_dict(
+        {
+            "enabled": True,
+            "provider": "tests.unit_tests.tools.test_data_access_policy:NonCallableDataAccessEnforcer",
+        }
+    )
+
+    with pytest.raises(DataAccessProviderError, match="must implement enforce_read"):
+        load_data_access_enforcer(config)
 
 
 def test_db_func_tool_applies_data_access_provider_before_query_execution():
@@ -139,3 +220,127 @@ def test_db_func_tool_applies_data_access_provider_before_query_execution():
     assert result.success == 1
     executed_sql = connector.execute_query.call_args.args[0]
     assert executed_sql == "SELECT * FROM orders WHERE store_id = 'S001'"
+
+
+def test_db_func_tool_ignores_mock_data_access_config():
+    connector = Mock()
+    connector.dialect = "sqlite"
+    connector.get_databases.return_value = []
+    query_result = Mock()
+    query_result.success = True
+    query_result.sql_return = [{"order_id": 1}]
+    connector.execute_query.return_value = query_result
+
+    agent_config = Mock()
+    agent_config.active_model.return_value = SimpleNamespace(model="test-model")
+
+    with (
+        patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+        patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+    ):
+        mock_rag.return_value.schema_store.table_size.return_value = 0
+        mock_sem.return_value.get_size.return_value = 0
+        tool = DBFuncTool(connector, agent_config=agent_config)
+
+    result = tool.read_query("SELECT * FROM orders", datasource="default")
+
+    assert result.success == 1
+    connector.execute_query.assert_called_once()
+
+
+def test_db_func_tool_uses_configured_default_datasource_for_policy_enforcement():
+    connector = Mock()
+    connector.dialect = "sqlite"
+    connector.get_databases.return_value = []
+    query_result = Mock()
+    query_result.success = True
+    query_result.sql_return = [{"order_id": 1}]
+    connector.execute_query.return_value = query_result
+
+    agent_config = SimpleNamespace(
+        active_model=lambda: SimpleNamespace(model="test-model"),
+        data_access_config=DataAccessConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "tests.unit_tests.tools.test_data_access_policy:DatasourceCaptureEnforcer",
+            }
+        ),
+        principal={},
+        services=SimpleNamespace(default_datasource="analytics"),
+    )
+
+    with (
+        patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+        patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+    ):
+        mock_rag.return_value.schema_store.table_size.return_value = 0
+        mock_sem.return_value.get_size.return_value = 0
+        tool = DBFuncTool(connector, agent_config=agent_config)
+
+    result = tool.read_query("SELECT * FROM orders")
+
+    assert result.success == 1
+    assert DatasourceCaptureEnforcer.last_datasource == "analytics"
+
+
+def test_db_func_tool_returns_datus_error_when_policy_denies_query():
+    connector = Mock()
+    connector.dialect = "sqlite"
+    connector.get_databases.return_value = []
+
+    agent_config = SimpleNamespace(
+        active_model=lambda: SimpleNamespace(model="test-model"),
+        data_access_config=DataAccessConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "tests.unit_tests.tools.test_data_access_policy:DenyDataAccessEnforcer",
+            }
+        ),
+        principal={},
+    )
+
+    with (
+        patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+        patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+    ):
+        mock_rag.return_value.schema_store.table_size.return_value = 0
+        mock_sem.return_value.get_size.return_value = 0
+        tool = DBFuncTool(connector, agent_config=agent_config)
+
+    result = tool.read_query("SELECT * FROM orders", datasource="default")
+
+    assert result.success == 0
+    assert "error_code=400002" in result.error
+    assert "store scope missing" in result.error
+    connector.execute_query.assert_not_called()
+
+
+def test_db_func_tool_revalidates_sql_after_policy_rewrite():
+    connector = Mock()
+    connector.dialect = "sqlite"
+    connector.get_databases.return_value = []
+
+    agent_config = SimpleNamespace(
+        active_model=lambda: SimpleNamespace(model="test-model"),
+        data_access_config=DataAccessConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "tests.unit_tests.tools.test_data_access_policy:UnsafeRewriteEnforcer",
+            }
+        ),
+        principal={},
+    )
+
+    with (
+        patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+        patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+    ):
+        mock_rag.return_value.schema_store.table_size.return_value = 0
+        mock_sem.return_value.get_size.return_value = 0
+        tool = DBFuncTool(connector, agent_config=agent_config)
+
+    result = tool.read_query("SELECT * FROM orders", datasource="default")
+
+    assert result.success == 0
+    assert "Only read-only queries" in result.error
+    connector.execute_query.assert_not_called()


### PR DESCRIPTION
## Summary

- Add an open-source data-access policy extension point that loads configured providers with `package.module:ClassName`.
- Carry request-scoped `principal` from API auth context through chat task config into `DBFuncTool`.
- Enforce configured read policies at the DB tool boundary before executing SQL.
- Add focused unit coverage for provider loading, config validation, and DB query rewriting.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q -p no:cacheprovider tests/unit_tests/tools/test_data_access_policy.py`
- `git diff --check upstream/main...HEAD`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added data-access policy enforcement system that restricts database query results based on user context
  * Implemented per-request principal tracking throughout the API
  * Database queries can now be automatically filtered based on configured access policies
  * Support for pluggable policy enforcement providers

* **Tests**
  * Added comprehensive test coverage for the new data-access policy framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request-scoped data-access principal support via the `X-Datus-Principal` JSON header and new principal handling in auth context.
  * Propagated principal through chat streaming/feedback into chat service/task execution.
  * Introduced a pluggable data-access policy enforcement framework that can allow, deny, or safely rewrite read SQL; integrated into database read execution.
  * Added SSE fail-fast pre-checks that deny streaming when required principal fields are missing.
* **Bug Fixes**
  * Auth validation failures now consistently return HTTP 400 with clear details.
* **Documentation**
  * Added/updated data-access policy documentation (EN/中文) and navigation.
* **Tests**
  * Expanded unit/integration coverage for principal parsing, provider loading, enforcement outcomes, SQL rewrite re-validation, and SSE denial behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->