### PR TITLE
[BugFix] Sync uv lock for nightly dependency bounds

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -643,7 +643,7 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "rich", specifier = "==14.0.0" },
     { name = "sqlalchemy", specifier = "==2.0.23" },
-    { name = "sqlglot", specifier = ">=26.12.0" },
+    { name = "sqlglot", specifier = ">=26.12.0,<31" },
     { name = "structlog", specifier = ">=23.1.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tantivy", specifier = ">=0.22.2" },


### PR DESCRIPTION
## Summary
- sync `uv.lock` with the current `sqlglot>=26.12.0,<31` dependency bound in `pyproject.toml`
- fix nightly `uv sync --locked` failing before tests start

## Root cause
Nightly run https://github.com/Datus-ai/Datus-agent/actions/runs/27580025448 failed in `Install dependencies` with:

```text
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

## Validation
- `uv lock --check`
- `uv sync --locked`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
