### PR TITLE
[UT] Silence console bridge coroutine warning in tests

### DIFF
--- a/datus/cli/tui/console_bridge.py
+++ b/datus/cli/tui/console_bridge.py
@@ -46,7 +46,7 @@ def run_in_terminal_sync(func: Callable[[], None]) -> None:
     * **On the prompt_toolkit event loop of a non-full-screen
       Application** (e.g. legacy modals): if the app is still running,
       dispatch via :func:`run_in_terminal` and return immediately; if
-      the app is shutting down (``_is_running`` is ``False``), invoke
+      the app is shutting down (``is_running`` is ``False``), invoke
       directly to avoid orphaning a Task on the closing loop.
     * **Off-loop thread with a non-full-screen Application**: submit via
       :func:`asyncio.run_coroutine_threadsafe` and block on completion.
@@ -72,7 +72,7 @@ def run_in_terminal_sync(func: Callable[[], None]) -> None:
         on_event_loop = False
 
     if on_event_loop:
-        if not getattr(app, "_is_running", True):
+        if not getattr(app, "is_running", True):
             # The app is tearing down: loop.close() will call _ready.clear(),
             # discarding any newly scheduled Task's first __step before it
             # runs and leaving the inner coroutine GC'd unawaited.

--- a/tests/unit_tests/cli/tui/test_console_bridge.py
+++ b/tests/unit_tests/cli/tui/test_console_bridge.py
@@ -44,7 +44,7 @@ def test_schedules_via_run_in_terminal_when_on_event_loop() -> None:
     """
     fake_app = mock.MagicMock()
     fake_app.full_screen = False  # legacy modal path; full_screen path is exercised separately
-    fake_app._is_running = True
+    fake_app.is_running = True
     fake_loop = mock.MagicMock()
 
     with (
@@ -59,17 +59,17 @@ def test_schedules_via_run_in_terminal_when_on_event_loop() -> None:
 
 
 def test_calls_directly_when_app_is_shutting_down() -> None:
-    """On the event loop but with _is_running=False (app teardown), func must
+    """On the event loop but with is_running=False (app teardown), func must
     be called inline rather than scheduled.
 
     Root cause of #617: loop.close() calls _ready.clear(), discarding the
     Task's pending first __step before it runs. The inner coroutine is then
-    GC'd unawaited, emitting RuntimeWarning. Detecting _is_running=False and
+    GC'd unawaited, emitting RuntimeWarning. Detecting is_running=False and
     falling back to a direct call eliminates the race.
     """
     fake_app = mock.MagicMock()
     fake_app.full_screen = False
-    fake_app._is_running = False
+    fake_app.is_running = False
     called = {"count": 0}
 
     def _fn() -> None:
@@ -115,6 +115,7 @@ def test_submits_coroutine_from_off_loop_thread() -> None:
     mocked_submit.assert_called_once()
     _coro, loop_arg = mocked_submit.call_args.args
     assert loop_arg is fake_app.loop
+    _coro.close()
     fake_cf.result.assert_called_once()
 
 
@@ -143,6 +144,8 @@ def test_swallows_future_exceptions() -> None:
     # The bridge both scheduled the callback and awaited its result even
     # though the result raised — the exception was swallowed, not re-raised.
     mocked_submit.assert_called_once()
+    _coro, _loop_arg = mocked_submit.call_args.args
+    _coro.close()
     fake_cf.result.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

- use prompt_toolkit's public `Application.is_running` property in the console bridge shutdown guard
- close coroutine objects captured by mocked `asyncio.run_coroutine_threadsafe` in console bridge tests

## Why

PR #952 fixed the CLI teardown warning, but the focused unit test still emitted an unawaited coroutine `RuntimeWarning` because the test mocked `run_coroutine_threadsafe` without consuming the coroutine argument. That warning looked too similar to the regression signal from #617.

## Validation

- `uv run pytest -q -W error::RuntimeWarning tests/unit_tests/cli/tui/test_console_bridge.py`
- `uv run pytest -q tests/unit_tests/cli/tui/test_console_bridge.py`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal application state management for more reliable terminal shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->