### PR TITLE
[Doc] Organize semantic adapter documentation

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -31,8 +31,6 @@ docs_coverage_policy:
       reason: Configuration section overview, not a discrete flow.
     - path: docs/knowledge_base/introduction.md
       reason: Knowledge base section overview, not a discrete flow.
-    - path: docs/metricflow/introduction.md
-      reason: MetricFlow section overview; the semantic layer flow owns the concrete pages.
 flow_groups:
   onboarding:
     description: First-run and documented bootstrap flows.
@@ -536,6 +534,8 @@ flow_groups:
           - docs/subagent/gen_metrics.md
           - docs/subagent/ask_metrics.md
           - docs/configuration/semantic_layer.md
+          - docs/adapters/metricflow_semantic_adapter.md
+          - docs/adapters/osi_semantic_adapter.md
         entrypoints:
           - CLI bootstrap
           - Gen semantic model subagent

--- a/docs/adapters/metricflow_semantic_adapter.md
+++ b/docs/adapters/metricflow_semantic_adapter.md
@@ -1,0 +1,120 @@
+# MetricFlow Semantic Adapter
+
+The MetricFlow semantic adapter connects Datus Agent to MetricFlow-native semantic model and metric YAML files.
+
+Use this adapter when you want generated semantic assets to be MetricFlow YAML and you expect MetricFlow to be the source format maintained by users or automation.
+
+## Installation
+
+```bash
+pip install datus-semantic-metricflow
+```
+
+From source:
+
+```bash
+pip install -e ../datus-semantic-adapter/datus-semantic-core
+pip install -e ../datus-semantic-adapter/datus-semantic-metricflow
+```
+
+## Configuration
+
+```yaml
+agent:
+  services:
+    semantic_layer:
+      metricflow:
+        timeout: 300
+        config_path: ./conf/agent.yml   # optional advanced override
+        default: true
+
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: metricflow
+
+    gen_metrics:
+      semantic_adapter: metricflow
+
+    ask_metrics:
+      semantic_adapter: metricflow
+```
+
+`config_path` is optional. In normal use, Datus builds the MetricFlow runtime config from:
+
+1. the selected datasource in `services.datasources`
+2. the current project semantic model directory
+3. the active `agent.home`
+
+## Semantic Model Directory
+
+By default, Datus points MetricFlow at the current project's semantic model directory:
+
+```text
+{project_root}/subject/semantic_models/
+```
+
+Generated YAML under this directory is included in validation, even when the files are project-local or gitignored.
+
+## Authoring Model
+
+MetricFlow mode authors MetricFlow YAML directly.
+
+Semantic model files use `data_source` documents:
+
+```yaml
+data_source:
+  name: orders
+  sql_table: public.orders
+  identifiers:
+    - name: order_id
+      type: primary
+      expr: order_id
+  dimensions:
+    - name: order_date
+      type: time
+      type_params:
+        is_primary: true
+        time_granularity: day
+  measures:
+    - name: revenue_sum
+      agg: sum
+      expr: amount
+```
+
+Metric files use `metric` documents:
+
+```yaml
+metric:
+  name: revenue
+  type: measure_proxy
+  type_params:
+    measures:
+      - revenue_sum
+```
+
+## Generation Flow
+
+With `semantic_adapter: metricflow`:
+
+1. `gen_semantic_model` writes MetricFlow semantic model YAML.
+2. `gen_metrics` writes MetricFlow metric YAML.
+3. `validate_semantic()` validates the full MetricFlow model.
+4. `query_metrics(..., dry_run=True)` verifies generated metrics can compile to SQL.
+5. `end_semantic_model_generation` and `end_metric_generation` sync validated assets to the Knowledge Base.
+
+## Supported Query Features
+
+The adapter supports the common semantic adapter methods:
+
+- `list_metrics`
+- `get_dimensions`
+- `query_metrics`
+- `validate_semantic`
+
+MetricFlow handles SQL generation, joins, time granularity, metric constraints, cumulative metrics, ratio metrics, expression metrics, and derived metrics according to the MetricFlow model.
+
+For the underlying MetricFlow engine concepts and supported warehouses, see [Datus-MetricFlow Introduction](../metricflow/introduction.md).
+
+## When to Use OSI Instead
+
+Use [OSI Semantic Adapter](osi_semantic_adapter.md) when you want the authored source files to be strict OSI core YAML and want Datus/MetricFlow-specific execution hints isolated in `custom_extensions`.

--- a/docs/adapters/metricflow_semantic_adapter.zh.md
+++ b/docs/adapters/metricflow_semantic_adapter.zh.md
@@ -1,0 +1,120 @@
+# MetricFlow 语义适配器
+
+MetricFlow 语义适配器把 Datus Agent 连接到 MetricFlow 原生的 semantic model 和 metric YAML 文件。
+
+当你希望生成的语义资产就是 MetricFlow YAML，并且团队会直接维护 MetricFlow 源文件时，适合使用这个适配器。
+
+## 安装
+
+```bash
+pip install datus-semantic-metricflow
+```
+
+从源码安装：
+
+```bash
+pip install -e ../datus-semantic-adapter/datus-semantic-core
+pip install -e ../datus-semantic-adapter/datus-semantic-metricflow
+```
+
+## 配置
+
+```yaml
+agent:
+  services:
+    semantic_layer:
+      metricflow:
+        timeout: 300
+        config_path: ./conf/agent.yml   # 可选高级覆盖项
+        default: true
+
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: metricflow
+
+    gen_metrics:
+      semantic_adapter: metricflow
+
+    ask_metrics:
+      semantic_adapter: metricflow
+```
+
+`config_path` 是可选项。正常情况下，Datus 会从以下信息构造 MetricFlow 运行时配置：
+
+1. `services.datasources` 中选中的数据源
+2. 当前项目的 semantic model 目录
+3. 当前生效的 `agent.home`
+
+## 语义模型目录
+
+默认情况下，Datus 会把 MetricFlow 指向当前项目的语义模型目录：
+
+```text
+{project_root}/subject/semantic_models/
+```
+
+该目录下生成的 YAML 都会参与验证，即使这些文件是项目本地文件或被 gitignore 忽略。
+
+## Authoring 模型
+
+MetricFlow 模式直接编写 MetricFlow YAML。
+
+语义模型文件使用 `data_source` 文档：
+
+```yaml
+data_source:
+  name: orders
+  sql_table: public.orders
+  identifiers:
+    - name: order_id
+      type: primary
+      expr: order_id
+  dimensions:
+    - name: order_date
+      type: time
+      type_params:
+        is_primary: true
+        time_granularity: day
+  measures:
+    - name: revenue_sum
+      agg: sum
+      expr: amount
+```
+
+指标文件使用 `metric` 文档：
+
+```yaml
+metric:
+  name: revenue
+  type: measure_proxy
+  type_params:
+    measures:
+      - revenue_sum
+```
+
+## 生成流程
+
+配置 `semantic_adapter: metricflow` 后：
+
+1. `gen_semantic_model` 写入 MetricFlow semantic model YAML。
+2. `gen_metrics` 写入 MetricFlow metric YAML。
+3. `validate_semantic()` 校验完整 MetricFlow model。
+4. `query_metrics(..., dry_run=True)` 确认生成指标可以编译成 SQL。
+5. `end_semantic_model_generation` 和 `end_metric_generation` 将通过校验的资产同步到 Knowledge Base。
+
+## 支持的查询能力
+
+该适配器支持通用 semantic adapter 方法：
+
+- `list_metrics`
+- `get_dimensions`
+- `query_metrics`
+- `validate_semantic`
+
+MetricFlow 按自身模型处理 SQL 生成、join、时间粒度、metric constraint、cumulative metric、ratio metric、expression metric 和 derived metric。
+
+底层 MetricFlow 引擎概念和支持的数据仓库见 [Datus-MetricFlow 介绍](../metricflow/introduction.zh.md)。
+
+## 什么时候改用 OSI
+
+如果你希望源文件是 strict OSI core YAML，并且希望 Datus / MetricFlow 执行提示隔离在 `custom_extensions` 中，请使用 [OSI 语义适配器](osi_semantic_adapter.zh.md)。

--- a/docs/adapters/osi_semantic_adapter.md
+++ b/docs/adapters/osi_semantic_adapter.md
@@ -1,0 +1,292 @@
+# OSI Semantic Adapter
+
+This page describes Datus support for OSI (Open Semantic Interchange) semantic models and metrics. The implementation spans two repositories:
+
+- `datus-agent`: generates strict OSI core YAML with LLM agents, validates and dry-runs generated assets, then syncs them to the Knowledge Base for `ask_metrics`.
+- `datus-semantic-adapter`: provides the `datus-semantic-osi` adapter. It loads OSI YAML, validates the OSI core schema, compiles the document into Datus Semantic IR, and lowers it to an execution backend. The current backend is MetricFlow.
+
+## Positioning
+
+In Datus, OSI is the authoring format for semantic models and metrics. MetricFlow is the default execution backend that renders SQL and executes metric queries.
+
+```text
+gen_semantic_model / gen_metrics
+        |
+        v
+strict OSI core YAML + DATUS custom_extensions
+        |
+        v
+datus-semantic-osi: validate -> compile IR -> lower to MetricFlow
+        |
+        v
+validate_semantic / query_metrics / ask_metrics
+```
+
+Users and LLM agents should not write MetricFlow YAML fields in OSI mode, such as `data_source`, `measures`, `measure_proxy`, or `type_params`. The OSI adapter generates those backend artifacts internally. They are disposable execution artifacts, not the source files users maintain.
+
+## Installation
+
+Install the OSI adapter from the `datus-semantic-adapter` repository.
+
+From a released package:
+
+```bash
+pip install "datus-semantic-osi[metricflow]"
+```
+
+From source:
+
+```bash
+pip install -e ../datus-semantic-adapter/datus-semantic-core
+pip install -e "../datus-semantic-adapter/datus-semantic-metricflow"
+pip install -e "../datus-semantic-adapter/datus-semantic-osi[metricflow]"
+```
+
+The `metricflow` extra installs dependencies required by the MetricFlow execution backend. Static OSI compilation and validation can work without the extra, but metric querying through Datus requires an available execution backend.
+
+## Configuration
+
+Configure the semantic layer as `osi` in `agent.yml`, and point semantic nodes to `semantic_adapter: osi`.
+
+```yaml
+agent:
+  services:
+    datasources:
+      starrocks:
+        type: starrocks
+        host: 127.0.0.1
+        port: "9030"
+        username: admin
+        password: ${STARROCKS_PASSWORD}
+        database: ac_manage
+        default: true
+
+    semantic_layer:
+      osi:
+        execution_backend: metricflow
+        default: true
+
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: osi
+      # authoring_format is optional; semantic_adapter=osi enables OSI authoring.
+      # authoring_format: osi
+
+    gen_metrics:
+      semantic_adapter: osi
+
+    ask_metrics:
+      semantic_adapter: osi
+```
+
+`datus-agent` resolves the authoring format in this order:
+
+1. Use `authoring_format: osi` when explicitly configured on the node.
+2. Use OSI authoring when the resolved `semantic_adapter` is `osi`.
+3. Otherwise, keep the default MetricFlow authoring path.
+
+## Semantic Model Generation
+
+In OSI mode, `gen_semantic_model` writes a strict OSI core document. The root shape is fixed:
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: orders
+        primary_key: [order_id]
+        fields:
+          - name: order_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_date
+            dimension:
+              is_time: true
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"type":"time","time_granularity":"day"}'
+          - name: channel
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: channel
+            dimension:
+              is_time: false
+            description: "Order channel"
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"type":"categorical"}'
+```
+
+Key rules:
+
+- Use one canonical dataset per physical table. Do not declare separate datasets for different queries or different metrics over the same table.
+- Use OSI core `fields`, not MetricFlow `dimensions`.
+- Dataset `source` is a table-name string, not `{table: ...}`.
+- Declare primary keys in `primary_key`.
+- Mark time fields with `dimension.is_time: true`; put Datus time-granularity hints in `custom_extensions`.
+- Declare relationships under the semantic model object, not inside datasets.
+
+## Metric Generation
+
+In OSI mode, `gen_metrics` appends metrics under `semantic_model[0].metrics`. Business expressions live in OSI core `expression`; Datus execution hints live in `custom_extensions`.
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: orders
+        primary_key: [order_id]
+        fields: [...]
+    metrics:
+      - name: revenue
+        description: "Total paid order revenue"
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: "SUM(amount)"
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"dataset":"orders","time_dimension":"order_date","unit":"CNY"}'
+```
+
+Supported metric patterns:
+
+| Pattern | OSI authoring | Backend lowering |
+|---------|---------------|------------------|
+| Basic aggregate | `SUM`, `COUNT`, `COUNT(DISTINCT)`, `AVG`, `MIN`, `MAX` | MetricFlow `measure_proxy` |
+| Conditional aggregate | `COUNT(DISTINCT CASE WHEN ... THEN id END)` | Backing measure + metric |
+| Expression metric | Arithmetic over aggregate results | MetricFlow `expr` |
+| Ratio | Aggregate division, or DATUS `numerator` / `denominator` hints | MetricFlow `ratio` |
+| Rolling / cumulative | Base aggregate + DATUS `window` or `grain_to_date` | MetricFlow `cumulative` |
+| Period-over-period | Derived metric + input metric `offset_window` | MetricFlow `derived` |
+| Joined dimensions | OSI relationship + joined dimension | MetricFlow join identifier |
+
+## Period-over-period and offset_window
+
+Do not write SQL window functions directly in OSI metric expressions:
+
+```sql
+LAG(revenue) OVER (...)
+ROW_NUMBER() OVER (...)
+```
+
+Model period-over-period metrics as a base metric plus derived metrics. For example:
+
+```yaml
+metrics:
+  - name: revenue
+    description: "Monthly revenue"
+    expression:
+      dialects:
+        - dialect: ANSI_SQL
+          expression: "SUM(amount)"
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"dataset":"orders","time_dimension":"order_month"}'
+
+  - name: revenue_previous_month
+    description: "Revenue in previous month"
+    expression:
+      dialects:
+        - dialect: ANSI_SQL
+          expression: "revenue_previous_month"
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"metric_kind":"derived","inputs":[{"name":"revenue","alias":"revenue_previous_month","offset_window":"1 month"}]}'
+
+  - name: revenue_mom_delta
+    description: "Revenue month-over-month delta"
+    expression:
+      dialects:
+        - dialect: ANSI_SQL
+          expression: "revenue - revenue_previous_month"
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"metric_kind":"derived","inputs":[{"name":"revenue"},{"name":"revenue","alias":"revenue_previous_month","offset_window":"1 month"}]}'
+```
+
+OSI metrics describe reusable business semantics, not one-off query SQL. `offset_window` expresses "the same metric shifted by a prior period" as semantic metadata; the execution backend is responsible for rendering an equivalent query plan.
+
+## Multi-table Joins
+
+Multi-table joins are represented with OSI core relationships:
+
+```yaml
+relationships:
+  - name: orders_to_customers
+    from: orders
+    to: customers
+    from_columns: [customer_id]
+    to_columns: [customer_id]
+```
+
+The current Datus execution profile supports single-column relationships, primarily `many_to_one` and `one_to_one`. When lowering to MetricFlow, the adapter creates a foreign identifier on the `from` dataset so fact metrics can be grouped or filtered by fields from the dimension dataset.
+
+Joined dimension names usually include the target dataset's primary identifier prefix, for example:
+
+```text
+customer_id__country
+```
+
+`ask_metrics` discovers these queryable dimensions through `list_metrics` and `get_dimensions`.
+
+## Validation and Publishing
+
+Datus enforces validation before publishing OSI assets:
+
+1. `validate_semantic(scope="semantic_model")` validates generated semantic models.
+2. `validate_semantic(scope="all")` validates the full semantic layer.
+3. `query_metrics(..., dry_run=True)` validates generated metrics by rendering SQL.
+4. `end_semantic_model_generation` / `end_metric_generation` sync semantic objects and metrics to the Knowledge Base.
+
+If validation or dry-run fails, Datus does not publish the metric to the Knowledge Base. This ensures `ask_metrics` only queries validated metrics.
+
+## ask_metrics Queries
+
+`ask_metrics` uses the unified semantic adapter interface. With the OSI adapter, it still calls:
+
+- `list_metrics`
+- `get_dimensions`
+- `query_metrics`
+- `validate_semantic`
+
+The OSI adapter returns Datus metadata for each metric, such as:
+
+- `dataset`
+- `time_dimension`
+- `metric_kind`
+- `expr`
+- `inputs`
+- `offset_window`
+- `window`
+- `grain_to_date`
+- `format`
+- `unit`
+
+This metadata helps `ask_metrics` choose the correct metrics, dimensions, and query parameters.
+
+## SQL That Should Not Become Metrics
+
+`gen_metrics` does not force these SQL patterns into OSI metrics:
+
+- Detail lists: `SELECT col1, col2 ...`
+- Distinct detail lists: `SELECT DISTINCT ...`
+- Ranking lists: `ROW_NUMBER()`, `RANK()`, or `DENSE_RANK()` producing row-level output
+- TopN per group, such as "top N activities per channel"
+- Queries whose main output is row-level records rather than aggregate metrics
+
+These patterns may be modeled later with derived datasets, materialized views, or a query layer, but they are outside the current `gen_metrics` metric-generation scope.
+
+## Current Limits
+
+- The OSI adapter currently defaults to the MetricFlow execution backend.
+- The current relationship execution profile supports single-column joins. Composite joins require future extension.
+- SQL window functions cannot be written directly in OSI metric expressions. Use `offset_window` for period comparisons; ranking and TopN detail queries need a query layer or precomputed dataset.
+- When a semantic model has multiple datasets, each metric must declare its owning `dataset` in the DATUS custom extension.
+- Datus execution information outside OSI core must be encoded in `custom_extensions[{vendor_name: DATUS}]`, not as top-level OSI fields.

--- a/docs/adapters/osi_semantic_adapter.zh.md
+++ b/docs/adapters/osi_semantic_adapter.zh.md
@@ -1,0 +1,292 @@
+# OSI 语义适配器
+
+本文面向使用 Datus 生成和查询指标的用户，说明当前 Datus 对 OSI（Open Semantic Interchange）语义模型的支持方式。这里的 OSI 支持由两部分组成：
+
+- `datus-agent`：负责用 LLM 生成严格 OSI core YAML，把生成结果校验、dry-run，并同步到 Knowledge Base，供 `ask_metrics` 查询。
+- `datus-semantic-adapter`：提供 `datus-semantic-osi` 适配器，负责加载 OSI YAML、校验 OSI core schema、编译到 Datus Semantic IR，再降低到执行后端。目前执行后端是 MetricFlow。
+
+## 当前定位
+
+OSI 在 Datus 里是语义模型和指标的 authoring format，也就是用户和 LLM 书写的源格式。MetricFlow 是默认 execution backend，也就是实际生成 SQL 和执行查询的后端。
+
+```text
+gen_semantic_model / gen_metrics
+        |
+        v
+strict OSI core YAML + DATUS custom_extensions
+        |
+        v
+datus-semantic-osi: validate -> compile IR -> lower to MetricFlow
+        |
+        v
+validate_semantic / query_metrics / ask_metrics
+```
+
+用户不需要、也不应该在 OSI 模式下手写 MetricFlow YAML 字段，例如 `data_source`、`measures`、`measure_proxy`、`type_params`。这些字段由 OSI adapter 在后端产物里生成，生成物是 disposable artifact，不是用户维护的源文件。
+
+## 安装
+
+使用 OSI 需要安装 OSI adapter。当前 OSI adapter 位于 `datus-semantic-adapter` 仓库的 `datus-semantic-osi` 包。
+
+从发布包安装时：
+
+```bash
+pip install "datus-semantic-osi[metricflow]"
+```
+
+从源码安装时：
+
+```bash
+pip install -e ../datus-semantic-adapter/datus-semantic-core
+pip install -e "../datus-semantic-adapter/datus-semantic-metricflow"
+pip install -e "../datus-semantic-adapter/datus-semantic-osi[metricflow]"
+```
+
+`metricflow` extra 会安装 MetricFlow 执行后端需要的依赖。只做 OSI 编译或静态校验时可以不安装 extra，但要通过 Datus 查询指标时需要可用的执行后端。
+
+## 配置
+
+在 `agent.yml` 里把 semantic layer 配成 `osi`，并让相关节点使用 `semantic_adapter: osi`。
+
+```yaml
+agent:
+  services:
+    datasources:
+      starrocks:
+        type: starrocks
+        host: 127.0.0.1
+        port: "9030"
+        username: admin
+        password: ${STARROCKS_PASSWORD}
+        database: ac_manage
+        default: true
+
+    semantic_layer:
+      osi:
+        execution_backend: metricflow
+        default: true
+
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: osi
+      # authoring_format 可省略；semantic_adapter=osi 时会自动使用 OSI authoring。
+      # authoring_format: osi
+
+    gen_metrics:
+      semantic_adapter: osi
+
+    ask_metrics:
+      semantic_adapter: osi
+```
+
+`datus-agent` 的 authoring format 解析规则是：
+
+1. 如果节点显式配置 `authoring_format: osi`，使用 OSI。
+2. 如果节点使用的 `semantic_adapter` 解析为 `osi`，自动使用 OSI。
+3. 否则保持默认 MetricFlow authoring。
+
+## 生成语义模型
+
+在 OSI 模式下，`gen_semantic_model` 生成的是严格 OSI core document。根结构固定为：
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: orders
+        primary_key: [order_id]
+        fields:
+          - name: order_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_date
+            dimension:
+              is_time: true
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"type":"time","time_granularity":"day"}'
+          - name: channel
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: channel
+            dimension:
+              is_time: false
+            description: "Order channel"
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"type":"categorical"}'
+```
+
+关键规则：
+
+- 一个物理表对应一个 canonical dataset。不要为不同 SQL 或不同指标重复声明同一张表。
+- dataset 使用 OSI core 的 `fields`，不是 MetricFlow 的 `dimensions`。
+- dataset `source` 是表名字符串，不是 `{table: ...}`。
+- 主键写在 `primary_key`。
+- 时间字段用 `dimension.is_time: true` 标记，Datus 的时间粒度写进 `custom_extensions`。
+- 关系写在 semantic model 对象的 `relationships` 下，不要写进 dataset。
+
+## 生成指标
+
+在 OSI 模式下，`gen_metrics` 会把指标追加到 OSI core document 的 `semantic_model[0].metrics` 下。指标的业务表达写在 OSI core 的 `expression` 中，Datus 执行提示写在 `custom_extensions`。
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: orders
+        primary_key: [order_id]
+        fields: [...]
+    metrics:
+      - name: revenue
+        description: "Total paid order revenue"
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: "SUM(amount)"
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"dataset":"orders","time_dimension":"order_date","unit":"CNY"}'
+```
+
+支持的常见指标类型：
+
+| 类型 | OSI 写法 | 后端 lowering |
+|------|----------|---------------|
+| 基础聚合 | `SUM`、`COUNT`、`COUNT(DISTINCT)`、`AVG`、`MIN`、`MAX` | MetricFlow `measure_proxy` |
+| 条件聚合 | `COUNT(DISTINCT CASE WHEN ... THEN id END)` | backing measure + metric |
+| 表达式指标 | 聚合结果之间的加减乘除 | MetricFlow `expr` |
+| 比率 | 聚合除法，或 DATUS hints 中的 `numerator` / `denominator` | MetricFlow `ratio` |
+| 累计 / 滚动窗口 | 基础聚合 + DATUS `window` 或 `grain_to_date` | MetricFlow `cumulative` |
+| 同比 / 环比 | derived metric + input metric `offset_window` | MetricFlow `derived` |
+| 多表维度查询 | OSI relationship + joined dimension | MetricFlow join identifier |
+
+## 同比、环比和 offset_window
+
+OSI 指标里不要直接写 SQL 窗口函数：
+
+```sql
+LAG(revenue) OVER (...)
+ROW_NUMBER() OVER (...)
+```
+
+环比和同比应拆成基础指标和 derived 指标。比如月收入和上月收入：
+
+```yaml
+metrics:
+  - name: revenue
+    description: "Monthly revenue"
+    expression:
+      dialects:
+        - dialect: ANSI_SQL
+          expression: "SUM(amount)"
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"dataset":"orders","time_dimension":"order_month"}'
+
+  - name: revenue_previous_month
+    description: "Revenue in previous month"
+    expression:
+      dialects:
+        - dialect: ANSI_SQL
+          expression: "revenue_previous_month"
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"metric_kind":"derived","inputs":[{"name":"revenue","alias":"revenue_previous_month","offset_window":"1 month"}]}'
+
+  - name: revenue_mom_delta
+    description: "Revenue month-over-month delta"
+    expression:
+      dialects:
+        - dialect: ANSI_SQL
+          expression: "revenue - revenue_previous_month"
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"metric_kind":"derived","inputs":[{"name":"revenue"},{"name":"revenue","alias":"revenue_previous_month","offset_window":"1 month"}]}'
+```
+
+原因是 OSI 指标表达的是可复用的业务指标，而不是一段查询 SQL。`offset_window` 把“取上一周期同一指标”表达为语义关系，执行后端再负责生成等价查询计划。
+
+## 多表 join
+
+多表 join 通过 OSI core relationship 表达：
+
+```yaml
+relationships:
+  - name: orders_to_customers
+    from: orders
+    to: customers
+    from_columns: [customer_id]
+    to_columns: [customer_id]
+```
+
+当前 Datus execution profile 支持单列关系，类型主要是 `many_to_one` 和 `one_to_one`。降低到 MetricFlow 时，adapter 会在 `from` dataset 上生成 foreign identifier，使 fact 指标可以按 dimension dataset 的字段分组或过滤。
+
+查询时 joined dimension 的名字通常会带上目标 dataset 的主 identifier 前缀，例如：
+
+```text
+customer_id__country
+```
+
+`ask_metrics` 会通过 `list_metrics` 和 `get_dimensions` 发现这些可查询维度。
+
+## 校验和发布流程
+
+OSI 模式下，Datus 在发布前会做硬性校验：
+
+1. `validate_semantic(scope="semantic_model")` 校验语义模型。
+2. `validate_semantic(scope="all")` 校验完整语义层。
+3. `query_metrics(..., dry_run=True)` 对生成的指标做 SQL dry-run。
+4. `end_semantic_model_generation` / `end_metric_generation` 把 OSI semantic objects 和 metrics 同步到 Knowledge Base。
+
+如果 validation 或 dry-run 失败，Datus 不会发布该指标到 Knowledge Base。这样 `ask_metrics` 只会查询已经通过语义层验证的指标。
+
+## ask_metrics 查询
+
+`ask_metrics` 面向统一的 semantic adapter 接口工作。使用 OSI adapter 时，它仍然调用同一组工具：
+
+- `list_metrics`
+- `get_dimensions`
+- `query_metrics`
+- `validate_semantic`
+
+OSI adapter 返回的 metric metadata 会包含 Datus hints，例如：
+
+- `dataset`
+- `time_dimension`
+- `metric_kind`
+- `expr`
+- `inputs`
+- `offset_window`
+- `window`
+- `grain_to_date`
+- `format`
+- `unit`
+
+这些 metadata 用来帮助 `ask_metrics` 选择正确指标、维度和查询参数。
+
+## 不适合作为指标生成的 SQL
+
+以下 SQL 类型不会被 `gen_metrics` 强行生成为 OSI metric：
+
+- 明细列表：`SELECT col1, col2 ...`
+- 去重明细：`SELECT DISTINCT ...`
+- 排名列表：`ROW_NUMBER()`、`RANK()`、`DENSE_RANK()` 输出明细行
+- TopN per group，例如“每个渠道排名前 N 的活动”
+- 主要产出是行级记录，而不是聚合指标的查询
+
+这些查询可以作为后续的 derived dataset、物化视图或 query layer 能力来表达，但不属于当前 `gen_metrics` 的指标生成范围。
+
+## 当前限制
+
+- OSI adapter 当前默认执行后端是 MetricFlow。
+- relationship 当前执行 profile 支持单列 join。多列复合 join 需要后续扩展。
+- SQL 窗口函数不能直接写进 OSI metric expression；周期对比使用 `offset_window`，排名/TopN 明细需要 query layer 或预计算数据集。
+- 当 semantic model 包含多个 dataset 时，metric 必须通过 DATUS custom extension 明确 `dataset`。
+- OSI core 之外的 Datus 执行信息必须写入 `custom_extensions[{vendor_name: DATUS}]`，不要写成 OSI core 顶层字段。

--- a/docs/adapters/semantic_adapters.md
+++ b/docs/adapters/semantic_adapters.md
@@ -1,245 +1,126 @@
 # Semantic Adapters
 
-Datus Agent supports connecting to various semantic layer services through a plugin-based adapter system. This document explains the available adapters, how to install them, and how to configure semantic layer connections.
+Datus Agent uses semantic adapters to connect metric generation, validation, discovery, and querying to a concrete semantic layer implementation.
+
+This page is the adapter overview. For adapter-specific behavior, use:
+
+- [MetricFlow Semantic Adapter](metricflow_semantic_adapter.md)
+- [OSI Semantic Adapter](osi_semantic_adapter.md)
 
 ## Overview
 
-Datus uses a modular semantic adapter architecture that allows you to connect to different semantic layer backends:
+Semantic adapters provide a unified interface for:
 
-- **MetricFlow**: dbt's semantic layer for metrics and dimensions
+- listing executable metrics
+- discovering dimensions for a metric
+- querying metric values
+- validating semantic assets before publishing
+- syncing validated semantic assets into the Datus Knowledge Base
 
-This design provides a unified interface for metric discovery, querying, and validation across different semantic layer implementations.
+Two adapters are currently supported:
+
+| Adapter | Package | Authoring format | Execution backend | Status |
+|---------|---------|------------------|-------------------|--------|
+| MetricFlow | `datus-semantic-metricflow` | MetricFlow YAML | MetricFlow | Ready |
+| OSI | `datus-semantic-osi` | strict OSI core YAML + DATUS custom extensions | MetricFlow by default | Ready |
+
+MetricFlow and OSI are peer semantic adapters. The difference is what users and generation agents author:
+
+- MetricFlow mode authors MetricFlow YAML directly.
+- OSI mode authors OSI core YAML and lets `datus-semantic-osi` compile it to Datus Semantic IR before lowering to MetricFlow.
 
 ## Architecture
 
 ```text
-datus-agent (Core)
-├── Semantic Tools Layer
-│   ├── BaseSemanticAdapter (Abstract)
-│   ├── SemanticAdapterRegistry (Factory)
-│   └── Data Models (MetricDefinition, QueryResult, etc.)
+datus-agent
+├── Semantic tools
+│   ├── list_metrics
+│   ├── get_dimensions
+│   ├── query_metrics
+│   └── validate_semantic
 │
-└── Plugin System (Entry Points)
-    └── datus-semantic-metricflow
-        └── MetricFlowAdapter
+├── SemanticAdapterRegistry
+│
+└── Adapter packages
+    ├── datus-semantic-metricflow
+    │   └── MetricFlowAdapter
+    └── datus-semantic-osi
+        └── DatusOSIAdapter
 ```
 
-The adapter system uses Python's entry points mechanism for automatic discovery. When you install an adapter package, it registers itself with Datus Agent and becomes available for use.
-
-## Supported Semantic Layers
-
-| Semantic Layer | Package | Installation | Status |
-|----------------|---------|-------------|--------|
-| MetricFlow | datus-semantic-metricflow | `pip install datus-semantic-metricflow` | Ready |
-
-## Installation
-
-### MetricFlow Adapter
-
-```bash
-# Install MetricFlow adapter
-pip install datus-semantic-metricflow
-
-# Or install from source
-pip install -e ../datus-semantic-adapter/datus-semantic-metricflow
-```
-
-Once installed, Datus Agent will automatically detect and load the adapter.
+Adapters are discovered through Python entry points under `datus.semantic_adapters`.
 
 ## Configuration
 
-Configure semantic adapters under `agent.services.semantic_layer` in `agent.yml`:
-
-The entire `semantic_layer` block is optional when you use MetricFlow with default settings. In that case Datus defaults to `metricflow` automatically.
-
-### MetricFlow
+Configure semantic adapters under `agent.services.semantic_layer` in `agent.yml`.
 
 ```yaml
 agent:
   services:
     semantic_layer:
       metricflow:
-        timeout: 300  # optional, default is 300 seconds
-        config_path: /path/to/agent.yml  # optional advanced override
+        default: true
+
+      osi:
+        execution_backend: metricflow
 
   agentic_nodes:
     gen_semantic_model:
       semantic_adapter: metricflow
+
     gen_metrics:
+      semantic_adapter: metricflow
+
+    ask_metrics:
       semantic_adapter: metricflow
 ```
 
-**Semantic Model File Location**:
-By default, Datus points MetricFlow at the current project's semantic model directory:
-```text
-{project_root}/subject/semantic_models/
-```
-- `project_root` is the active Datus project root.
-- The configured semantic model directory is treated as authoritative. Generated YAML files under project-local or gitignored directories are still included in MetricFlow validation.
+The key under `services.semantic_layer` must equal the adapter type, for example `metricflow` or `osi`. If a `type:` field is present, it must match the key.
 
-### Selection Rules
+See [Semantic Layer Configuration](../configuration/semantic_layer.md) for selection rules, defaults, and project-level pins.
 
-- The key under `services.semantic_layer` **must equal the adapter type** (for example `metricflow`). If a `type:` field is present, it must match the key; otherwise Datus raises a configuration error at startup. Comparison is case-insensitive and trims surrounding whitespace, so `MetricFlow` and ` metricflow ` also match.
-- Semantic nodes choose the adapter with `semantic_adapter`.
-- If both `services.semantic_layer` and `semantic_adapter` are omitted, Datus defaults to `metricflow`.
-- If `semantic_adapter` is omitted and only one semantic layer is configured, Datus uses that adapter automatically.
-- If multiple semantic layers are configured, set `semantic_adapter` explicitly.
+## Core Interface
 
-### About `config_path`
+All semantic adapters implement these methods:
 
-`config_path` is optional. The normal runtime path builds MetricFlow config from:
+| Method | Purpose |
+|--------|---------|
+| `list_metrics(path, limit, offset)` | List executable metrics. |
+| `get_dimensions(metric_name, path)` | Return dimensions that can be used with a metric. |
+| `query_metrics(metrics, dimensions, ...)` | Query metrics or render SQL with `dry_run=True`. |
+| `validate_semantic(scope)` | Validate semantic assets and backend compatibility. |
 
-1. the selected datasource in `services.datasources`
-2. the current project's semantic model directory
-3. the active `agent.home`
+Optional semantic-model methods include `get_semantic_model()` and `list_semantic_models()`.
 
-Use `config_path` only when you explicitly need MetricFlow to initialize from a different agent config file.
+## Choosing an Adapter
 
-## Core Interfaces
+Use MetricFlow when:
 
-### Metrics Interface
+- you already have MetricFlow YAML
+- you want generated files to be MetricFlow-native
+- your team expects to inspect or maintain MetricFlow assets directly
 
-All semantic adapters implement these core async methods:
+Use OSI when:
 
-| Method | Description | Return Type |
-|--------|-------------|-------------|
-| `list_metrics(path, limit, offset)` | List available metrics with filtering | `List[MetricDefinition]` |
-| `get_dimensions(metric_name, path)` | Get dimensions for a metric | `List[DimensionInfo]` |
-| `query_metrics(metrics, dimensions, ...)` | Query metrics with filters, time range, where clause | `QueryResult` |
-| `validate_semantic()` | Validate semantic layer configuration | `ValidationResult` |
-
-### Semantic Model Interface (Optional)
-
-| Method | Description | Return Type |
-|--------|-------------|-------------|
-| `get_semantic_model(table_name, ...)` | Get semantic model for a table | `Optional[Dict]` |
-| `list_semantic_models(...)` | List available semantic models | `List[str]` |
-
-## Data Models
-
-| Model | Key Fields |
-|-------|------------|
-| `MetricDefinition` | `name`, `description`, `type`, `dimensions`, `measures`, `unit`, `format`, `path` |
-| `QueryResult` | `columns`, `data`, `metadata` |
-| `ValidationResult` | `valid`, `issues` |
-| `ValidationIssue` | `severity`, `message`, `location` |
-| `DimensionInfo` | `name`, `description` |
-
-## Usage Examples
-
-### Direct Adapter Usage
-
-```python
-import asyncio
-from datus.tools.semantic_tools import semantic_adapter_registry
-from datus_semantic_metricflow.config import MetricFlowConfig
-
-async def main():
-    config = MetricFlowConfig(datasource="my_project")
-    adapter = semantic_adapter_registry.create_adapter("metricflow", config)
-
-    metrics = await adapter.list_metrics(limit=10)
-    dimensions = await adapter.get_dimensions(metric_name="revenue")
-    result = await adapter.query_metrics(
-        metrics=["revenue"], dimensions=["date"], time_start="2024-01-01"
-    )
-
-asyncio.run(main())
-```
-
-### Dry Run (SQL Preview)
-
-```python
-async def dry_run_example():
-    result = await adapter.query_metrics(metrics=["revenue"], dry_run=True)
-    print(result.data[0]["sql"])
-
-asyncio.run(dry_run_example())
-```
-
-### Bootstrap from Adapter
-
-```bash
-datus-agent bootstrap-kb --datasource my_project --components metrics \
-  --from_adapter metricflow --kb-update-strategy overwrite
-```
-
-## Features by Adapter
-
-### Common Features
-
-All semantic adapters support:
-
-- Metric discovery and listing
-- Dimension retrieval per metric
-- Metric querying with filters
-- Configuration validation
-- Storage sync for caching
-
-### MetricFlow Adapter
-
-- Full MetricFlow API integration
-- YAML-based semantic model files
-- Three-stage validation (lint, parse, semantic)
-- Validation reports YAML issues even when the MetricFlow client cannot be fully initialized from invalid generated files
-- SQL generation and explain
-- Time range filtering with granularity
+- you want the authored source to follow OSI core schema
+- you want Datus-specific execution hints isolated in `custom_extensions`
+- you want LLM generation to avoid backend YAML fields such as `measure_proxy`, `type_params`, and `data_source`
+- you still want to execute through MetricFlow today
 
 ## Implementing a Custom Adapter
 
-You can implement your own semantic adapter by extending `BaseSemanticAdapter` and registering it via Python entry points.
-
-### Required Methods
-
-Your adapter must implement these abstract methods:
-
-| Method | Description | Return Type |
-|--------|-------------|-------------|
-| `list_metrics()` | List available metrics with optional filtering | `List[MetricDefinition]` |
-| `get_dimensions()` | Get queryable dimensions for a metric | `List[DimensionInfo]` |
-| `query_metrics()` | Execute metric queries with filters | `QueryResult` |
-| `validate_semantic()` | Validate semantic layer configuration | `ValidationResult` |
-
-### Optional Methods
-
-| Method | Description | Default |
-|--------|-------------|---------|
-| `get_semantic_model()` | Get semantic model for a table | Returns `None` |
-| `list_semantic_models()` | List available semantic models | Returns `[]` |
-
-### Package Structure
-
-```text
-datus_semantic_myservice/
-├── pyproject.toml
-└── datus_semantic_myservice/
-    ├── __init__.py    # register() function
-    ├── adapter.py     # MyServiceAdapter
-    └── config.py      # MyServiceConfig
-```
-
-### Entry Point Configuration
+Implement a semantic adapter by extending `BaseSemanticAdapter` and registering it through an entry point:
 
 ```toml
-# pyproject.toml
 [project.entry-points."datus.semantic_adapters"]
 myservice = "datus_semantic_myservice:register"
 ```
 
-### Reference Implementation
+Required methods:
 
-See the MetricFlow adapter implementation for a complete example:
-- [datus-semantic-metricflow](https://github.com/Datus-ai/datus-semantic-adapter)
-
-## Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| Adapter not found | Install the adapter: `pip install datus-semantic-metricflow` |
-| Connection issues | Verify `agent.yml` config, check the selected database and semantic model directory |
-| Validation errors | Run `adapter.validate_semantic()` to check configuration |
-
-## Next Steps
-
-- [MetricFlow Configuration](../metricflow/introduction.md) - Detailed MetricFlow setup
-- [Configuration Reference](../configuration/introduction.md) - General configuration options
+| Method | Return Type |
+|--------|-------------|
+| `list_metrics()` | `List[MetricDefinition]` |
+| `get_dimensions()` | `List[DimensionInfo]` |
+| `query_metrics()` | `QueryResult` |
+| `validate_semantic()` | `ValidationResult` |

--- a/docs/adapters/semantic_adapters.zh.md
+++ b/docs/adapters/semantic_adapters.zh.md
@@ -1,245 +1,126 @@
 # 语义层适配器
 
-Datus Agent 通过插件化的适配器系统支持连接各种语义层服务。本文档介绍可用的适配器、安装方法以及语义层连接配置。
+Datus Agent 通过语义层适配器，把指标生成、校验、发现和查询连接到具体的语义层实现。
+
+本文是适配器总览。具体适配器请看：
+
+- [MetricFlow 语义适配器](metricflow_semantic_adapter.zh.md)
+- [OSI 语义适配器](osi_semantic_adapter.zh.md)
 
 ## 概述
 
-Datus 采用模块化的语义层适配器架构，支持连接不同的语义层后端：
+语义层适配器提供统一接口，用于：
 
-- **MetricFlow**: dbt 的语义层，用于指标和维度管理
+- 列出可执行指标
+- 获取指标可用维度
+- 查询指标值
+- 发布前校验语义资产
+- 将已校验的语义资产同步到 Datus Knowledge Base
 
-这种设计为不同的语义层实现提供了统一的指标发现、查询和验证接口。
+当前支持两个适配器：
+
+| 适配器 | 包名 | Authoring format | 执行后端 | 状态 |
+|--------|------|------------------|----------|------|
+| MetricFlow | `datus-semantic-metricflow` | MetricFlow YAML | MetricFlow | 可用 |
+| OSI | `datus-semantic-osi` | strict OSI core YAML + DATUS custom extensions | 默认 MetricFlow | 可用 |
+
+MetricFlow 和 OSI 是并列的 semantic adapter。区别在于用户和生成 agent 维护的源格式：
+
+- MetricFlow 模式直接编写 MetricFlow YAML。
+- OSI 模式编写 OSI core YAML，由 `datus-semantic-osi` 编译到 Datus Semantic IR，再降低到 MetricFlow。
 
 ## 架构
 
 ```text
-datus-agent (核心)
-├── 语义层工具层
-│   ├── BaseSemanticAdapter (抽象基类)
-│   ├── SemanticAdapterRegistry (工厂)
-│   └── 数据模型 (MetricDefinition, QueryResult 等)
+datus-agent
+├── Semantic tools
+│   ├── list_metrics
+│   ├── get_dimensions
+│   ├── query_metrics
+│   └── validate_semantic
 │
-└── 插件系统 (Entry Points)
-    └── datus-semantic-metricflow
-        └── MetricFlowAdapter
+├── SemanticAdapterRegistry
+│
+└── Adapter packages
+    ├── datus-semantic-metricflow
+    │   └── MetricFlowAdapter
+    └── datus-semantic-osi
+        └── DatusOSIAdapter
 ```
 
-适配器系统使用 Python 的 entry points 机制进行自动发现。安装适配器包后，它会自动注册到 Datus Agent 并可供使用。
-
-## 支持的语义层
-
-| 语义层 | 包名 | 安装方式 | 状态 |
-|--------|------|---------|------|
-| MetricFlow | datus-semantic-metricflow | `pip install datus-semantic-metricflow` | 可用 |
-
-## 安装
-
-### MetricFlow 适配器
-
-```bash
-# 安装 MetricFlow 适配器
-pip install datus-semantic-metricflow
-
-# 或从源码安装
-pip install -e ../datus-semantic-adapter/datus-semantic-metricflow
-```
-
-安装后，Datus Agent 会自动检测并加载适配器。
+适配器通过 `datus.semantic_adapters` Python entry point 自动发现。
 
 ## 配置
 
-在 `agent.yml` 的 `agent.services.semantic_layer` 中配置语义层适配器：
-
-如果你使用的是 MetricFlow 的默认配置，整个 `semantic_layer` 段也可以省略；此时 Datus 会自动默认使用 `metricflow`。
-
-### MetricFlow
+在 `agent.yml` 的 `agent.services.semantic_layer` 下配置语义层适配器。
 
 ```yaml
 agent:
   services:
     semantic_layer:
       metricflow:
-        timeout: 300  # 可选，默认 300 秒
-        config_path: /path/to/agent.yml  # 可选的高级覆盖项
+        default: true
+
+      osi:
+        execution_backend: metricflow
 
   agentic_nodes:
     gen_semantic_model:
       semantic_adapter: metricflow
+
     gen_metrics:
+      semantic_adapter: metricflow
+
+    ask_metrics:
       semantic_adapter: metricflow
 ```
 
-**语义模型文件位置**：
-默认情况下，Datus 会把 MetricFlow 指向当前项目的语义模型目录：
-```text
-{project_root}/subject/semantic_models/
-```
-- `project_root` 是当前 Datus 项目的根目录。
-- 配置中的语义模型目录会被视为权威来源。即使生成的 YAML 位于项目本地或被 gitignore 忽略的目录中，也会参与 MetricFlow 验证。
+`services.semantic_layer` 下的 key 必须等于 adapter type，例如 `metricflow` 或 `osi`。如果同时写了 `type:` 字段，其值必须与 key 一致。
 
-### 选择规则
-
-- `services.semantic_layer` 下的 key **必须等于 adapter type**（例如 `metricflow`）。如果同时写了 `type:` 字段，其值必须与 key 一致，否则 Datus 会在启动时抛出配置错误。比较时会先对 key 与 `type` 做 lowercase + trim 处理，因此 `MetricFlow` 或 ` metricflow ` 也会被视为与 `metricflow` 匹配。
-- 语义相关节点通过 `semantic_adapter` 选择适配器。
-- 如果 `services.semantic_layer` 和 `semantic_adapter` 都省略，Datus 会默认使用 `metricflow`。
-- 如果只配置了一个 semantic layer，省略 `semantic_adapter` 时会自动使用它。
-- 如果配置了多个 semantic layer，则必须显式填写 `semantic_adapter`。
-
-### 关于 `config_path`
-
-`config_path` 是可选项。正常运行时，Datus 会从以下上下文构造 MetricFlow 配置：
-
-1. `services.datasources` 中当前选中的数据源
-2. 当前项目的语义模型目录
-3. 当前生效的 `agent.home`
-
-只有在你明确希望 MetricFlow 从另一份 agent 配置文件初始化时，才需要填写 `config_path`。
+选择规则、默认适配器和项目级 pin 见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
 ## 核心接口
 
-### 指标接口
+所有语义层适配器都实现以下方法：
 
-所有语义层适配器实现以下核心异步方法：
+| 方法 | 作用 |
+|------|------|
+| `list_metrics(path, limit, offset)` | 列出可执行指标。 |
+| `get_dimensions(metric_name, path)` | 返回指标可用维度。 |
+| `query_metrics(metrics, dimensions, ...)` | 查询指标，或通过 `dry_run=True` 渲染 SQL。 |
+| `validate_semantic(scope)` | 校验语义资产和后端兼容性。 |
 
-| 方法 | 描述 | 返回类型 |
-|------|------|---------|
-| `list_metrics(path, limit, offset)` | 列出可用指标，支持过滤 | `List[MetricDefinition]` |
-| `get_dimensions(metric_name, path)` | 获取指标的维度 | `List[DimensionInfo]` |
-| `query_metrics(metrics, dimensions, ...)` | 查询指标，支持过滤、时间范围、where 子句 | `QueryResult` |
-| `validate_semantic()` | 验证语义层配置 | `ValidationResult` |
+可选语义模型接口包括 `get_semantic_model()` 和 `list_semantic_models()`。
 
-### 语义模型接口（可选）
+## 如何选择适配器
 
-| 方法 | 描述 | 返回类型 |
-|------|------|---------|
-| `get_semantic_model(table_name, ...)` | 获取表的语义模型 | `Optional[Dict]` |
-| `list_semantic_models(...)` | 列出可用的语义模型 | `List[str]` |
+适合使用 MetricFlow 的情况：
 
-## 数据模型
+- 已经有 MetricFlow YAML
+- 希望生成文件就是 MetricFlow 原生格式
+- 团队会直接查看或维护 MetricFlow 资产
 
-| 模型 | 主要字段 |
-|------|---------|
-| `MetricDefinition` | `name`, `description`, `type`, `dimensions`, `measures`, `unit`, `format`, `path` |
-| `QueryResult` | `columns`, `data`, `metadata` |
-| `ValidationResult` | `valid`, `issues` |
-| `ValidationIssue` | `severity`, `message`, `location` |
-| `DimensionInfo` | `name`, `description` |
+适合使用 OSI 的情况：
 
-## 使用示例
-
-### 直接使用适配器
-
-```python
-import asyncio
-from datus.tools.semantic_tools import semantic_adapter_registry
-from datus_semantic_metricflow.config import MetricFlowConfig
-
-async def main():
-    config = MetricFlowConfig(datasource="my_project")
-    adapter = semantic_adapter_registry.create_adapter("metricflow", config)
-
-    metrics = await adapter.list_metrics(limit=10)
-    dimensions = await adapter.get_dimensions(metric_name="revenue")
-    result = await adapter.query_metrics(
-        metrics=["revenue"], dimensions=["date"], time_start="2024-01-01"
-    )
-
-asyncio.run(main())
-```
-
-### Dry Run（SQL 预览）
-
-```python
-async def dry_run_example():
-    result = await adapter.query_metrics(metrics=["revenue"], dry_run=True)
-    print(result.data[0]["sql"])
-
-asyncio.run(dry_run_example())
-```
-
-### 从适配器同步数据
-
-```bash
-datus-agent bootstrap-kb --datasource my_project --components metrics \
-  --from_adapter metricflow --kb-update-strategy overwrite
-```
-
-## 适配器功能
-
-### 通用功能
-
-所有语义层适配器支持：
-
-- 指标发现和列表
-- 按指标获取维度
-- 带过滤条件的指标查询
-- 配置验证
-- 存储同步缓存
-
-### MetricFlow 适配器
-
-- 完整的 MetricFlow API 集成
-- 基于 YAML 的语义模型文件
-- 三阶段验证（lint、parse、semantic）
-- 即使无效 YAML 导致 MetricFlow client 无法完整初始化，验证也会返回具体 YAML 问题
-- SQL 生成和执行计划
-- 支持时间粒度的时间范围过滤
+- 希望源文件遵循 OSI core schema
+- 希望 Datus 执行提示隔离在 `custom_extensions` 中
+- 希望 LLM 生成时避免 `measure_proxy`、`type_params`、`data_source` 等后端 YAML 字段
+- 当前仍希望通过 MetricFlow 执行
 
 ## 实现自定义适配器
 
-你可以通过继承 `BaseSemanticAdapter` 并通过 Python entry points 注册来实现自己的语义层适配器。
-
-### 必须实现的方法
-
-你的适配器必须实现以下抽象方法：
-
-| 方法 | 描述 | 返回类型 |
-|------|------|---------|
-| `list_metrics()` | 列出可用指标，支持过滤 | `List[MetricDefinition]` |
-| `get_dimensions()` | 获取指标的可查询维度 | `List[DimensionInfo]` |
-| `query_metrics()` | 执行带过滤条件的指标查询 | `QueryResult` |
-| `validate_semantic()` | 验证语义层配置 | `ValidationResult` |
-
-### 可选方法
-
-| 方法 | 描述 | 默认行为 |
-|------|------|---------|
-| `get_semantic_model()` | 获取表的语义模型 | 返回 `None` |
-| `list_semantic_models()` | 列出可用的语义模型 | 返回 `[]` |
-
-### 包结构
-
-```text
-datus_semantic_myservice/
-├── pyproject.toml
-└── datus_semantic_myservice/
-    ├── __init__.py    # register() 函数
-    ├── adapter.py     # MyServiceAdapter
-    └── config.py      # MyServiceConfig
-```
-
-### Entry Point 配置
+可以通过继承 `BaseSemanticAdapter` 并注册 entry point 来实现自定义语义层适配器：
 
 ```toml
-# pyproject.toml
 [project.entry-points."datus.semantic_adapters"]
 myservice = "datus_semantic_myservice:register"
 ```
 
-### 参考实现
+必须实现的方法：
 
-完整示例请参考 MetricFlow 适配器实现：
-- [datus-semantic-metricflow](https://github.com/Datus-ai/datus-semantic-adapter)
-
-## 故障排除
-
-| 问题 | 解决方案 |
-|------|---------|
-| 适配器未找到 | 安装适配器：`pip install datus-semantic-metricflow` |
-| 连接问题 | 验证 `agent.yml` 配置，检查当前数据库选择与语义模型目录 |
-| 验证错误 | 运行 `adapter.validate_semantic()` 检查配置 |
-
-## 下一步
-
-- [MetricFlow 配置](../metricflow/introduction.md) - MetricFlow 详细配置
-- [配置参考](../configuration/introduction.md) - 通用配置选项
+| 方法 | 返回类型 |
+|------|----------|
+| `list_metrics()` | `List[MetricDefinition]` |
+| `get_dimensions()` | `List[DimensionInfo]` |
+| `query_metrics()` | `QueryResult` |
+| `validate_semantic()` | `ValidationResult` |

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -23,6 +23,9 @@ agent:
         config_path: ./conf/agent.yml   # optional advanced override
         default: true                   # global default — picked when no project pin set
 
+      osi:
+        execution_backend: metricflow   # optional OSI authoring adapter
+
   agentic_nodes:
     gen_semantic_model:
       semantic_adapter: metricflow
@@ -61,6 +64,13 @@ Comparison is case-insensitive and trims surrounding whitespace.
 - MetricFlow validation reads YAML files from the configured project semantic model directory directly, including generated files under gitignored project paths.
 - `config_path` is only needed when you want MetricFlow to read a specific `agent.yml` file directly.
 
+## OSI Notes
+
+- OSI is a peer semantic adapter to MetricFlow.
+- OSI mode authors strict OSI core YAML and stores Datus execution hints in `custom_extensions`.
+- The current OSI execution backend is MetricFlow, configured with `execution_backend: metricflow`.
+- Use `semantic_adapter: osi` on `gen_semantic_model`, `gen_metrics`, or `ask_metrics` to select this path.
+
 ## Configuring through the CLI (`/services`)
 
 Run `/services semantic` inside the Datus REPL (or press `Tab` from any
@@ -68,11 +78,10 @@ other tab) to enter the configuration TUI on the **Semantic** tab. The
 tab lets you:
 
 - Add a new semantic layer by pressing `Enter` on the trailing `+ Add
-  new semantic` row. Only `metricflow` (`datus-semantic-metricflow`)
-  ships today and **takes no parameters** — picking it from the type
-  picker is enough. If the adapter package isn't installed, Datus runs
-  `pip install datus-semantic-metricflow` for you and hot-reloads the
-  registry — no restart needed.
+  new semantic` row. Choose the adapter type, such as `metricflow` or
+  `osi`. If the adapter package isn't installed, install the matching
+  package first, for example `datus-semantic-metricflow` or
+  `datus-semantic-osi`.
 - Delete an entry with `x` and run a registration probe with `t`.
 - Toggle the **global** `default: true` flag with `d`. Pressing `d`
   marks the current row as default and clears the flag from every other
@@ -81,7 +90,7 @@ tab lets you:
   `./.datus/config.yml` as `semantic: <name>` and outranks the global
   flag for the current project only. Press `p` again on the pinned row
   to clear it.
-- `e edit` is hidden on this tab: metricflow has no editable fields.
+- `e edit` is hidden for adapters that have no editable fields.
 
 Service definitions are written to `~/.datus/conf/agent.yml` as
 `services.semantic_layer.<type>: {type: <type>}`.

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -15,6 +15,9 @@ agent:
         config_path: ./conf/agent.yml   # 可选的高级覆盖项
         default: true                   # 全局默认:无 project pin 时被选用
 
+      osi:
+        execution_backend: metricflow   # 可选 OSI authoring 适配器
+
   agentic_nodes:
     gen_semantic_model:
       semantic_adapter: metricflow
@@ -44,15 +47,22 @@ agent:
 - MetricFlow 验证会直接读取配置中的项目语义模型目录，包括位于 gitignore 项目路径下的生成 YAML。
 - 仅当你需要 MetricFlow 直接读取某个指定的 `agent.yml` 时才需要设置 `config_path`。
 
+## OSI 说明
+
+- OSI 是和 MetricFlow 并列的 semantic adapter。
+- OSI 模式编写 strict OSI core YAML，并把 Datus 执行提示放在 `custom_extensions` 中。
+- 当前 OSI 执行后端是 MetricFlow，通过 `execution_backend: metricflow` 配置。
+- 在 `gen_semantic_model`、`gen_metrics` 或 `ask_metrics` 上设置 `semantic_adapter: osi` 即可选择该路径。
+
 ## 通过 CLI 配置（`/services`）
 
 在 Datus REPL 中运行 `/services semantic`（或者从其他 tab 按 `Tab` 切过来）会进入配置 TUI 的 **Semantic** tab。该 tab 支持：
 
-- 在尾部的 `+ Add new semantic` 行按 `Enter` 新增一个语义层。目前仅支持 `metricflow`（`datus-semantic-metricflow`），并且**无需任何参数** —— 在 type picker 中选中它即可。如果适配器包尚未安装，Datus 会自动执行 `pip install datus-semantic-metricflow` 并热加载注册表，无需重启进程。
+- 在尾部的 `+ Add new semantic` 行按 `Enter` 新增一个语义层。选择 adapter type，例如 `metricflow` 或 `osi`。如果适配器包尚未安装，请先安装对应包，例如 `datus-semantic-metricflow` 或 `datus-semantic-osi`。
 - 用 `x` 删除条目；用 `t` 触发一次注册探测。
 - `d` 切换**全局** `default: true`:按 `d` 把光标项设为默认,并自动清掉其他条目的 default。
 - `p` 设置**项目级** default:值写入 `./.datus/config.yml` 的 `semantic: <name>`,只对当前项目生效,优先级高于全局标记。在已 pin 的行上再按一次 `p` 清除。
-- 此 tab 不显示 `e edit`:metricflow 当前没有可编辑字段。
+- 对没有可编辑字段的 adapter，此 tab 不显示 `e edit`。
 
 新建条目会写入 `~/.datus/conf/agent.yml`，形态为 `services.semantic_layer.<type>: {type: <type>}`。
 

--- a/docs/subagent/ask_metrics.md
+++ b/docs/subagent/ask_metrics.md
@@ -17,7 +17,7 @@ AskMetrics is intentionally narrow. If no existing metric can answer the questio
 
 AskMetrics needs a configured semantic layer and published metrics.
 
-For MetricFlow, configure the semantic adapter in `agent.yml`:
+Configure a semantic adapter in `agent.yml`. For example, MetricFlow:
 
 ```yaml
 agent:
@@ -28,7 +28,7 @@ agent:
 
 See [Semantic Layer Configuration](../configuration/semantic_layer.md) for full semantic adapter options.
 
-Metrics can come from existing MetricFlow YAML or from the [Generate Metrics](gen_metrics.md) subagent. A metric subject tree is optional, but recommended because AskMetrics uses it as a routing catalog before searching.
+Metrics can come from existing semantic-layer assets or from the [Generate Metrics](gen_metrics.md) subagent. With OSI, `ask_metrics` uses the same adapter tools but queries OSI-authored metrics through the configured execution backend. A metric subject tree is optional, but recommended because AskMetrics uses it as a routing catalog before searching.
 
 ## Quick Start
 

--- a/docs/subagent/ask_metrics.zh.md
+++ b/docs/subagent/ask_metrics.zh.md
@@ -17,7 +17,7 @@ AskMetrics 的能力边界刻意保持较窄。如果没有现有指标能够回
 
 AskMetrics 需要已配置的语义层和已发布的指标。
 
-以 MetricFlow 为例，在 `agent.yml` 中配置语义层：
+在 `agent.yml` 中配置语义层。以 MetricFlow 为例：
 
 ```yaml
 agent:
@@ -28,7 +28,7 @@ agent:
 
 完整配置见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
-指标可以来自已有 MetricFlow YAML，也可以由 [Generate Metrics](gen_metrics.zh.md) subagent 生成。主题树不是必需的，但建议使用，因为 AskMetrics 会先把主题树作为指标路由目录，再决定是否搜索指标。
+指标可以来自已有语义层资产，也可以由 [Generate Metrics](gen_metrics.zh.md) subagent 生成。使用 OSI 时，`ask_metrics` 仍然使用同一组 adapter tools，但会通过配置的执行后端查询 OSI-authored metrics。主题树不是必需的，但建议使用，因为 AskMetrics 会先把主题树作为指标路由目录，再决定是否搜索指标。
 
 ## 快速开始
 

--- a/docs/subagent/gen_metrics.md
+++ b/docs/subagent/gen_metrics.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The metrics generation feature helps you convert SQL queries into reusable MetricFlow metric definitions. Using an AI assistant, you can analyze SQL business logic and automatically generate standardized YAML metric configurations that can be queried consistently across your organization.
+The metrics generation feature helps you convert SQL queries into reusable metric definitions. The authored YAML format is selected by the configured semantic adapter: `metricflow` generates MetricFlow metric YAML, while `osi` generates strict OSI core metrics with Datus execution hints in `custom_extensions`. Using an AI assistant, you can analyze SQL business logic and automatically generate standardized metric configurations that can be queried consistently across your organization.
 
 ## What is a Metric?
 
@@ -17,21 +17,24 @@ A **metric** is a reusable business calculation built on top of semantic models.
 
 ## Important Limitations
 
-**⚠️ Single Table Queries Only**
+**⚠️ Adapter-dependent SQL coverage**
 
-The current version **only supports generating metrics from single-table SQL queries**. Multi-table JOINs are not supported.
+Metric generation is intended for aggregate metric definitions. Detail lists, ranking rows, and TopN-per-group row lists should not be forced into metrics.
 
-**Supported**:
+MetricFlow authoring is most reliable for single-table aggregate SQL. OSI authoring can express joined dimensions when the semantic model defines OSI relationships.
+
+**Good metric-generation inputs**:
 ```sql
 SELECT SUM(revenue) FROM transactions WHERE status = 'completed'
 SELECT COUNT(DISTINCT customer_id) / COUNT(*) FROM orders
 ```
 
-**Not Supported**:
+**Do not force into metrics**:
 ```sql
-SELECT SUM(o.amount)
-FROM orders o
-JOIN customers c ON o.customer_id = c.id  -- ❌ JOIN not supported
+SELECT customer_id, order_id, revenue
+FROM orders
+ORDER BY revenue DESC
+LIMIT 100
 ```
 
 ## How It Works
@@ -55,7 +58,7 @@ Runs dry-run SQL → Syncs to Knowledge Base
 Before publishing, the agent must pass both checks:
 
 - `validate_semantic()` validates the semantic model and metric YAML.
-- `query_metrics(..., dry_run=True)` verifies that MetricFlow can compile SQL for the generated metric.
+- `query_metrics(..., dry_run=True)` verifies that the configured semantic adapter can compile SQL for the generated metric.
 
 After those checks pass, `end_metric_generation` syncs the generated metric to the Knowledge Base automatically.
 
@@ -81,10 +84,12 @@ agent:
 
 See [Semantic Layer Configuration](../configuration/semantic_layer.md) for the full set of options.
 
+For OSI authoring, see [OSI Semantic Adapter](../adapters/osi_semantic_adapter.md).
+
 **Built-in configurations** (automatically enabled):
 - **Tools**: Generation tools and filesystem tools
 - **Hooks**: Validation evidence tracking and Knowledge Base sync
-- **MCP Server**: MetricFlow validation server
+- **Semantic Adapter**: validation through the configured semantic layer
 - **System Prompt**: Built-in template; the latest available version is used unless `prompt_version` is set
 - **Workspace**: `~/.datus/data/{datasource}/semantic_models`
 
@@ -262,10 +267,10 @@ After validation and dry-run SQL succeed, the metric is synced to the Knowledge 
 
 The metrics generation feature provides:
 
-✅ **SQL-to-Metric Conversion**: Analyze SQL queries and generate MetricFlow metrics
+✅ **SQL-to-Metric Conversion**: Analyze SQL queries and generate semantic metrics
 ✅ **Intelligent Type Detection**: Automatically selects the right metric type
 ✅ **Duplicate Prevention**: Checks for existing metrics before generation
-✅ **Validation**: MetricFlow validation ensures correctness
+✅ **Validation**: Semantic adapter validation ensures correctness
 ✅ **Publish Gate**: Syncs only after semantic validation and dry-run SQL succeed
 ✅ **Knowledge Base Integration**: Semantic search for metric discovery
 ✅ **File Management**: Organizes metrics in dedicated files separate from semantic models

--- a/docs/subagent/gen_metrics.zh.md
+++ b/docs/subagent/gen_metrics.zh.md
@@ -2,7 +2,7 @@
 
 ## 概览
 
-指标生成功能帮助你将 SQL 查询转换为可复用的 MetricFlow 指标定义。使用 AI 助手，你可以分析 SQL 业务逻辑并自动生成标准化的 YAML 指标配置，组织内可一致查询。
+指标生成功能帮助你将 SQL 查询转换为可复用的指标定义。具体 YAML authoring format 由配置的 semantic adapter 决定：`metricflow` 生成 MetricFlow metric YAML，`osi` 生成 strict OSI core metrics，并把 Datus 执行提示写入 `custom_extensions`。使用 AI 助手，你可以分析 SQL 业务逻辑并自动生成标准化的指标配置，组织内可一致查询。
 
 ## 什么是指标？
 
@@ -17,21 +17,24 @@
 
 ## 重要限制
 
-**⚠️ 仅支持单表查询**
+**⚠️ SQL 覆盖范围取决于适配器**
 
-当前版本**仅支持从单表 SQL 查询生成指标**。不支持多表 JOIN。
+指标生成面向聚合指标定义。明细列表、排名行、TopN per group 这类行级结果不应强行生成为指标。
 
-**支持**：
+MetricFlow authoring 对单表聚合 SQL 最可靠。OSI authoring 在语义模型定义了 OSI relationships 时，可以表达 join 维度。
+
+**适合生成指标的输入**：
 ```sql
 SELECT SUM(revenue) FROM transactions WHERE status = 'completed'
 SELECT COUNT(DISTINCT customer_id) / COUNT(*) FROM orders
 ```
 
-**不支持**：
+**不要强行生成为指标**：
 ```sql
-SELECT SUM(o.amount)
-FROM orders o
-JOIN customers c ON o.customer_id = c.id  -- ❌ 不支持 JOIN
+SELECT customer_id, order_id, revenue
+FROM orders
+ORDER BY revenue DESC
+LIMIT 100
 ```
 
 ## 工作原理
@@ -55,7 +58,7 @@ JOIN customers c ON o.customer_id = c.id  -- ❌ 不支持 JOIN
 发布前会经过两项检查：
 
 - `validate_semantic()` 校验语义模型和指标 YAML。
-- `query_metrics(..., dry_run=True)` 确认 MetricFlow 能为生成的指标编译 SQL。
+- `query_metrics(..., dry_run=True)` 确认配置的 semantic adapter 能为生成的指标编译 SQL。
 
 两项检查都通过后，`end_metric_generation` 会自动把指标同步到知识库。
 
@@ -79,10 +82,12 @@ agent:
 
 完整配置项见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
+OSI authoring 见 [OSI 语义适配器](../adapters/osi_semantic_adapter.zh.md)。
+
 **内置配置**（自动启用）：
 - **工具**：生成工具和文件系统工具
 - **Hooks**：验证证据记录和知识库同步
-- **MCP 服务器**：MetricFlow 验证服务器
+- **Semantic Adapter**：通过配置的语义层进行验证
 - **系统提示**：内置模板；未显式设置 `prompt_version` 时使用最新可用版本
 - **工作空间**：`~/.datus/data/{datasource}/semantic_models`
 
@@ -253,11 +258,11 @@ metric:
 
 指标生成功能提供：
 
-✅ **SQL 到指标转换**：分析 SQL 查询并生成 MetricFlow 指标
+✅ **SQL 到指标转换**：分析 SQL 查询并生成语义指标
 ✅ **智能类型检测**：自动选择正确的指标类型
 ✅ **防止重复**：生成前检查现有指标
 ✅ **主题树支持**：按 domain/layer1/layer2 组织，支持预定义或学习模式
-✅ **验证**：MetricFlow 验证确保正确性
+✅ **验证**：semantic adapter 校验确保正确性
 ✅ **发布门禁**：语义验证和 dry-run SQL 通过后才同步
 ✅ **知识库集成**：语义搜索以发现指标
 ✅ **文件管理**：将指标组织在独立于语义模型的专用文件中

--- a/docs/subagent/gen_semantic_model.md
+++ b/docs/subagent/gen_semantic_model.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The semantic model generation feature helps you create MetricFlow semantic models from database tables through an AI-powered assistant. The assistant analyzes your table structure and generates comprehensive YAML configuration files that define metrics, dimensions, and relationships.
+The semantic model generation feature helps you create semantic models from database tables through an AI-powered assistant. The authored YAML format is selected by the configured semantic adapter: `metricflow` generates MetricFlow YAML, while `osi` generates strict OSI core YAML. The assistant analyzes your table structure and generates configuration files for the selected adapter.
 
 ## What is a Semantic Model?
 
@@ -29,7 +29,7 @@ When you request a semantic model, the AI assistant:
 1. Retrieves your table's DDL (structure)
 2. Checks if a semantic model already exists
 3. Generates a comprehensive YAML file
-4. Validates the configuration using MetricFlow
+4. Validates the configuration using the configured semantic adapter
 5. Syncs it to the Knowledge Base after validation passes
 
 ### Generation Workflow
@@ -64,10 +64,12 @@ agent:
 
 See [Semantic Layer Configuration](../configuration/semantic_layer.md) for the full set of options.
 
+For OSI authoring, see [OSI Semantic Adapter](../adapters/osi_semantic_adapter.md).
+
 **Built-in configurations** (automatically enabled):
 - **Tools**: Database tools, generation tools, and filesystem tools
 - **Hooks**: Validation evidence tracking and Knowledge Base sync
-- **MCP Server**: MetricFlow validation server
+- **Semantic Adapter**: validation through the configured semantic layer
 - **System Prompt**: Built-in template; the latest available version is used unless `prompt_version` is set
 - **Workspace**: `~/.datus/data/{datasource}/semantic_models`
 
@@ -129,4 +131,4 @@ The semantic model generation feature provides:
 - ✓ Automatic sync after validation passes
 - ✓ Knowledge Base integration
 - ✓ Duplicate prevention
-- ✓ MetricFlow compatibility
+- ✓ Semantic adapter compatibility

--- a/docs/subagent/gen_semantic_model.zh.md
+++ b/docs/subagent/gen_semantic_model.zh.md
@@ -2,7 +2,7 @@
 
 ## 概览
 
-语义模型生成功能帮助你通过 AI 助手从数据库表创建 MetricFlow 语义模型。助手分析你的表结构并生成全面的 YAML 配置文件，定义指标、维度和关系。
+语义模型生成功能帮助你通过 AI 助手从数据库表创建语义模型。具体 YAML authoring format 由配置的 semantic adapter 决定：`metricflow` 生成 MetricFlow YAML，`osi` 生成 strict OSI core YAML。助手会分析表结构，并按所选适配器生成配置文件。
 
 ## 什么是语义模型？
 
@@ -29,7 +29,7 @@
 1. 检索你的表的 DDL（结构）
 2. 检查是否已存在语义模型
 3. 生成全面的 YAML 文件
-4. 使用 MetricFlow 验证配置
+4. 使用配置的 semantic adapter 验证配置
 5. 验证通过后同步到知识库
 
 ### 生成工作流
@@ -62,10 +62,12 @@ agent:
 
 完整配置项见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
+OSI authoring 见 [OSI 语义适配器](../adapters/osi_semantic_adapter.zh.md)。
+
 **内置配置**（自动启用）：
 - **工具**：数据库工具、生成工具和文件系统工具
 - **Hooks**：验证证据记录和知识库同步
-- **MCP 服务器**：MetricFlow 验证服务器
+- **Semantic Adapter**：通过配置的语义层进行验证
 - **系统提示**：内置模板；未显式设置 `prompt_version` 时使用最新可用版本
 - **工作空间**：`~/.datus/data/{datasource}/semantic_models`
 
@@ -120,4 +122,4 @@ data_source:
 - ✓ 验证通过后自动同步
 - ✓ 知识库集成
 - ✓ 防止重复
-- ✓ MetricFlow 兼容性
+- ✓ Semantic adapter 兼容性

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,13 +73,14 @@ nav:
       - Nodes: configuration/nodes.md
     - Adapters:
       - Database Adapters: adapters/db_adapters.md
-      - Semantic Adapters: adapters/semantic_adapters.md
+      - Semantic Adapters:
+        - Overview: adapters/semantic_adapters.md
+        - MetricFlow Semantic Adapter: adapters/metricflow_semantic_adapter.md
+        - OSI Semantic Adapter: adapters/osi_semantic_adapter.md
       - BI Adapters: adapters/bi_adapters.md
       - Scheduler Adapters: adapters/scheduler_adapters.md
     - Benchmark:
       - Introduction: benchmark/benchmark_manual.md
-    - Metricflow:
-      - Introduction: metricflow/introduction.md
     - Integration:
       - MCP: integration/mcp.md
       - Skills: integration/skills.md
@@ -161,11 +162,12 @@ plugins:
             Adapters: 适配器
             Database Adapters: 数据库适配器
             Semantic Adapters: 语义层适配器
+            MetricFlow Semantic Adapter: MetricFlow 语义适配器
+            OSI Semantic Adapter: OSI 语义适配器
             BI Adapters: BI 适配器
             Scheduler Adapters: Scheduler 适配器
             Benchmark: 基准测试
             Data Access Policy: 数据访问策略
-            Metricflow: MetricFlow
             Integration: 集成
             MCP: MCP
             Skills: Skills


### PR DESCRIPTION
## Summary
- reorganize semantic adapter docs so MetricFlow and OSI are peer adapter pages under the Semantic Adapters section
- add dedicated MetricFlow and OSI adapter docs in English and Chinese
- update semantic layer and subagent docs to describe adapter-aware generation/querying

## Validation
- uv run mkdocs build --strict

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for MetricFlow and OSI semantic adapters
  * Updated semantic layer configuration documentation to support adapter selection
  * Revised feature documentation for adapter-agnostic usage patterns
  * Improved documentation organization and navigation structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added dedicated guides for MetricFlow and OSI semantic adapters, including setup, authoring examples, supported query/SQL patterns, and validation/dry-run behavior
  * Expanded semantic-layer configuration to support selecting an OSI adapter (including execution-backend guidance) and updated the Semantic configuration TUI behavior
  * Updated subagent docs for adapter-dependent flows in `gen_semantic_model`, `gen_metrics`, and `ask_metrics`
  * Improved docs navigation and structure for semantic adapters (including English/Chinese pages)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->