### PR TITLE
[BugFix] Inject current date into runtime context

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1062,11 +1062,10 @@ class AgenticNode(Node):
         Returns:
             Prompt with skills XML and memory context appended
         """
-        # Inject the shared runtime-context block (session-start date,
-        # datasource catalog, sql files root) for DB-capable nodes. Replaces
-        # the per-template "Current context" stanzas; the *current* datasource
+        # Inject session-stable runtime context. The current datasource
         # selection lives in the per-turn user message instead.
         base_prompt = self._inject_runtime_context(base_prompt)
+        base_prompt = self._inject_datasource_runtime_context(base_prompt)
 
         # Inject AGENTS.md project context if present in cwd
         agents_md = self._load_agents_md()
@@ -1107,7 +1106,7 @@ class AgenticNode(Node):
         self._ensure_memory_tool_in_tools()
 
     def _runtime_context_current_date(self) -> str:
-        """Session-start date rendered into the shared runtime-context block.
+        """Current-date reference rendered into the shared runtime-context block.
 
         Defaults to today. Subclasses with a reference-date concept (e.g.
         GenSQL/AskMetrics, which honor a benchmark/replay ``reference_date``)
@@ -1119,16 +1118,30 @@ class AgenticNode(Node):
         return get_default_current_date(None)
 
     def _inject_runtime_context(self, base_prompt: str) -> str:
-        """Append the shared runtime-context block for DB-capable nodes.
+        """Append the shared runtime-context block.
 
-        Renders ``runtime_context_1.0.j2`` with the session-stable values that
-        used to be duplicated inline across the node templates: the
-        session-start date, the configured datasource catalog, and the sql
-        files root. Gated on ``db_func_tool`` so non-DB nodes (e.g.
-        report/dashboard writers without a connector) are unaffected. The
-        *current* datasource selection and its dialect are NOT here — they are
-        injected per turn into the user message (see
-        :meth:`_build_datasource_reminder`).
+        Renders ``runtime_context_1.0.j2`` with date-only session-stable
+        context. Date context is runtime input, not DB-tool capability.
+        """
+        agent_config = getattr(self, "agent_config", None)
+        try:
+            section = get_prompt_manager(agent_config=agent_config).render_template(
+                template_name="runtime_context",
+                version=None,
+                current_date=self._runtime_context_current_date(),
+            )
+        except Exception as e:
+            logger.warning(f"Failed to inject runtime context: {e}")
+            return base_prompt
+        if section and section.strip():
+            base_prompt = base_prompt + "\n\n" + section.strip()
+        return base_prompt
+
+    def _inject_datasource_runtime_context(self, base_prompt: str) -> str:
+        """Append datasource/sql-root context for DB-tool-capable nodes.
+
+        This preserves the old scope for datasource catalog and sql-root hints
+        while allowing date context to be injected independently.
         """
         if getattr(self, "db_func_tool", None) is None:
             return base_prompt
@@ -1138,14 +1151,13 @@ class AgenticNode(Node):
 
             ds_ctx = build_datasource_prompt_context(agent_config) if agent_config else {}
             section = get_prompt_manager(agent_config=agent_config).render_template(
-                template_name="runtime_context",
+                template_name="datasource_runtime_context",
                 version=None,
-                current_date=self._runtime_context_current_date(),
                 available_datasources=ds_ctx.get("available_datasources") or {},
                 workspace_root=self._resolve_workspace_root(),
             )
         except Exception as e:
-            logger.warning(f"Failed to inject runtime context: {e}")
+            logger.warning(f"Failed to inject datasource runtime context: {e}")
             return base_prompt
         if section and section.strip():
             base_prompt = base_prompt + "\n\n" + section.strip()

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -364,10 +364,6 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             context.update(build_datasource_prompt_context(self.agent_config))
             context["db_name"] = context.get("datasource")
 
-        from datus.utils.time_utils import get_default_current_date
-
-        context["current_date"] = get_default_current_date(None)
-
         version = None if prompt_version in (None, "") else str(prompt_version)
         system_prompt_name = self.node_config.get("system_prompt") or self.get_node_name()
         template_name = f"{system_prompt_name}_system"

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -249,7 +249,6 @@ class SkillCreatorAgenticNode(AgenticNode):
     def _get_system_prompt(self, prompt_version: Optional[str] = None) -> str:
         """Get the system prompt for the skill creator node."""
         from datus.prompts.prompt_manager import get_prompt_manager
-        from datus.utils.time_utils import get_default_current_date
 
         version = prompt_version or self.node_config.get("prompt_version")
         template_name = "skill_creator_system"
@@ -283,7 +282,6 @@ class SkillCreatorAgenticNode(AgenticNode):
             "skill_directories": skill_directories,
             "existing_skills": existing_skills,
             "workspace_root": self._resolve_workspace_root(),
-            "current_date": get_default_current_date(None),
             **build_datasource_prompt_context(self.agent_config),
         }
 

--- a/datus/prompts/prompt_templates/_visual_artifact_context.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_context.j2
@@ -1,7 +1,8 @@
-{# Shared runtime-context blocks for both gen_visual_report and
+{# Shared context blocks for both gen_visual_report and
    gen_visual_dashboard system prompts: project rules injected by the
    subagent config, the agent's role override (when set), and the
-   datasource / current-date / conversation-summary footer.
+   datasource / conversation-summary footer. Current date is injected by the
+   shared runtime_context partial during prompt finalization.
 
    Kept in lockstep with the inline blocks that used to live at the end of
    each parent prompt — moved here to eliminate verbatim duplication
@@ -19,9 +20,6 @@
 {% endif %}
 
 ## Context
-{% if current_date -%}
-- Current date: {{ current_date }}
-{% endif -%}
 {% if datasource -%}
 {% if current_datasource_dialect -%}
 - Current datasource: {{ datasource }} ({{ current_datasource_dialect }})

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -27,6 +27,9 @@ Use the narrow metric workflow below:
 - Prefer `get_dimensions` and `query_metrics` after a direct subject-tree match; only retrieve metric details when the answer depends on the definition text.
 - Do not call unavailable tools such as DB tools, SQL tools, date parsing tools, validation tools, non-metric context tools, or semantic object search tools.
 - Infer concrete time ranges yourself from the current date. Do not ask for a date parser tool.
+- Use the `Current date` from the runtime context as the reference date for relative or year-omitted time expressions.
+- For date periods without an explicit year, use the year from `Current date` unless the user explicitly states another year or a relative year.
+- Prefer closed calendar periods for standalone period mentions. Use open-ended ranges only when the user explicitly asks for cumulative or since-style results.
 - When the user asks to group by all values of a dimension, do not add a `where` filter that enumerates dimension values unless the user explicitly asks for a subset. The grouped metric query already returns all dimension values.
 - Query complete metric results by default. Do not pass `limit` just to preview data, reduce output size, or be conservative; the system compresses visible tool output and caches the full result. Use `limit` only when the user explicitly asks for Top N, first N, maximum N rows, a preview, or another row-count restriction. When using `limit` for Top N/Bottom N, also pass `order_by`.
 - Prefer the most specific metric whose name or description directly matches the requested business concept. Do not rebuild a specific metric by querying a generic base metric plus filters when a matching specific metric is available.

--- a/datus/prompts/prompt_templates/datasource_runtime_context_1.0.j2
+++ b/datus/prompts/prompt_templates/datasource_runtime_context_1.0.j2
@@ -1,0 +1,14 @@
+{# Datasource-scoped runtime context appended only for nodes whose tool surface
+   can act on database/sql-file context. These values are frozen into the
+   per-session system-prompt snapshot. The *current* datasource selection and
+   its dialect are NOT here - they are live per-turn values injected into the
+   user message's ``<system_reminder>`` envelope so a mid-session switch stays
+   correct without invalidating the cached prefix. #}
+Datasource context:
+{% if available_datasources and available_datasources|length > 0 -%}
+- Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
+
+{% endif -%}
+{% if workspace_root -%}
+- Current sql files root directory: {{ workspace_root }}
+{% endif -%}

--- a/datus/prompts/prompt_templates/runtime_context_1.0.j2
+++ b/datus/prompts/prompt_templates/runtime_context_1.0.j2
@@ -1,19 +1,8 @@
-{# Shared runtime-context block appended uniformly by ``_finalize_system_prompt``
-   for DB-capable nodes. Holds the session-stable context that used to be
-   duplicated inline across the ``*_system_*.j2`` templates: the session-start
-   date, the configured datasource catalog, and the sql files root. These
-   values are frozen into the per-session system-prompt snapshot. The *current*
-   datasource selection and its dialect are NOT here — they are live per-turn
-   values injected into the user message's ``<system_reminder>`` envelope so a
-   mid-session switch stays correct without invalidating the cached prefix. #}
+{# Shared runtime-context block appended uniformly by ``_finalize_system_prompt``.
+   Holds session-stable context that every agentic node may need. Datasource
+   catalog and sql-root hints live in ``datasource_runtime_context`` so date
+   injection does not require or imply DB-tool capability. #}
 Current context:
 {% if current_date -%}
 - Current date: {{ current_date }}
-{% endif -%}
-{% if available_datasources and available_datasources|length > 0 -%}
-- Available datasources: {% for ds_name, ds_type in available_datasources.items() %}{{ ds_name }} ({{ ds_type }}){% if not loop.last %}, {% endif %}{% endfor %}
-
-{% endif -%}
-{% if workspace_root -%}
-- Current sql files root directory: {{ workspace_root }}
 {% endif -%}

--- a/datus/prompts/prompt_templates/skill_creator_system_1.0.j2
+++ b/datus/prompts/prompt_templates/skill_creator_system_1.0.j2
@@ -50,9 +50,6 @@ A single unified filesystem tool covers both browsing the project and writing sk
 - `search_skill_usage` — search historical sessions for a skill's usage patterns, tool calls, and errors. Pass the skill name to find sessions where it was loaded.
 
 ## Context
-{% if current_date -%}
-- Current date: {{ current_date }}
-{% endif -%}
 {% if workspace_root -%}
 - Workspace root: {{ workspace_root }}
 {% endif -%}

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -145,8 +145,8 @@ def create_test_node(node_id, mock_agent_config):
 class TestFinalizeSystemPrompt:
     """Test suite for _finalize_system_prompt method."""
 
-    def test_no_skill_func_tool_returns_prompt_unchanged(self, mock_agent_config, monkeypatch):
-        """When skill_func_tool is None, returns base_prompt as-is (memory injection mocked out)."""
+    def test_no_skill_func_tool_only_appends_runtime_context(self, mock_agent_config, monkeypatch):
+        """Without skill_func_tool, finalization still appends shared runtime context."""
         node = MinimalAgenticNode(
             node_id="test1",
             description="Test node",
@@ -160,7 +160,12 @@ class TestFinalizeSystemPrompt:
         base_prompt = "This is the base system prompt."
         result = node._finalize_system_prompt(base_prompt)
 
-        assert result == base_prompt
+        assert result.startswith(base_prompt)
+        assert "Current context:" in result
+        assert "Current date:" in result
+        assert "Available datasources:" not in result
+        assert "Current sql files root directory:" not in result
+        assert "<available_skills>" not in result
 
     def test_with_skill_func_tool_appends_xml(self, mock_agent_config, skill_manager):
         """When skill_func_tool exists and _get_available_skills_context() returns XML, it's appended."""

--- a/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
@@ -13,9 +13,11 @@ Covers:
 - ``_build_datasource_reminder``: live per-turn datasource + dialect line for
   the user-message ``<system_reminder>`` envelope; never mentions the
   permission profile.
-- ``_inject_runtime_context``: gated on ``db_func_tool``; renders the shared
-  ``runtime_context`` partial (session-start date + datasource catalog +
-  workspace root) WITHOUT the current datasource selection.
+- ``_inject_runtime_context``: renders date-only shared runtime context
+  WITHOUT requiring a DB tool.
+- ``_inject_datasource_runtime_context``: renders datasource catalog +
+  workspace root only for DB-tool-capable nodes and WITHOUT the current
+  datasource selection.
 - Template hygiene: the active node templates no longer inline the per-turn
   volatile variables.
 
@@ -328,38 +330,107 @@ class TestDatasourceReminder:
 
 
 class TestInjectRuntimeContext:
-    def test_skipped_without_db_tool(self, session_manager):
+    def test_appends_date_without_db_tool(self, session_manager):
         node = _SnapshotNode(session_manager, _agent_config(), db_func_tool=None)
-        assert node._inject_runtime_context("BASE") == "BASE"
+        out = node._inject_runtime_context("BASE")
+        assert out.startswith("BASE")
+        assert "Current context:" in out
+        assert re.search(r"Current date: \d{4}-\d{2}-\d{2}", out)
+        assert "Available datasources:" not in out
+        assert "Current sql files root directory:" not in out
 
-    def test_appends_date_catalog_and_workspace_for_db_node(self, session_manager):
+    def test_runtime_context_render_failure_returns_base_prompt(self, session_manager, monkeypatch):
+        from datus.agent.node import agentic_node as agentic_node_module
+
+        calls = []
+
+        class RaisingPromptManager:
+            def render_template(self, **kwargs):
+                calls.append(kwargs)
+                raise RuntimeError("template unavailable")
+
+        monkeypatch.setattr(
+            agentic_node_module,
+            "get_prompt_manager",
+            lambda **_: RaisingPromptManager(),
+        )
+
+        node = _SnapshotNode(session_manager, _agent_config(), db_func_tool=None)
+        node._runtime_context_current_date = lambda: "2024-06-15"
+
+        assert node._inject_runtime_context("BASE") == "BASE"
+        assert calls == [
+            {
+                "template_name": "runtime_context",
+                "version": None,
+                "current_date": "2024-06-15",
+            }
+        ]
+
+    def test_skips_datasource_runtime_context_without_db_tool(self, session_manager):
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="snowflake")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=None)
+        assert node._inject_datasource_runtime_context("BASE") == "BASE"
+
+    def test_appends_datasource_catalog_and_workspace_for_db_tool(self, session_manager):
         services = SimpleNamespace(
             datasources={"main": SimpleNamespace(type="snowflake"), "dev": SimpleNamespace(type="duckdb")}
         )
         cfg = _agent_config(current_datasource="main", services=services)
         node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
-        out = node._inject_runtime_context("BASE")
+        out = node._inject_datasource_runtime_context("BASE")
         assert out.startswith("BASE")
-        assert "Current context:" in out
-        assert re.search(r"Current date: \d{4}-\d{2}-\d{2}", out)
+        assert "Datasource context:" in out
+        assert "Current date:" not in out
         assert "Available datasources:" in out
         assert "main (snowflake)" in out
         assert "dev (duckdb)" in out
         assert "/tmp/ws" in out
+
+    def test_datasource_runtime_context_render_failure_returns_base_prompt(self, session_manager, monkeypatch):
+        from datus.agent.node import agentic_node as agentic_node_module
+
+        calls = []
+
+        class RaisingPromptManager:
+            def render_template(self, **kwargs):
+                calls.append(kwargs)
+                raise RuntimeError("template unavailable")
+
+        monkeypatch.setattr(
+            agentic_node_module,
+            "get_prompt_manager",
+            lambda **_: RaisingPromptManager(),
+        )
+
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="snowflake")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+
+        assert node._inject_datasource_runtime_context("BASE") == "BASE"
+        assert calls == [
+            {
+                "template_name": "datasource_runtime_context",
+                "version": None,
+                "available_datasources": {"main": "snowflake"},
+                "workspace_root": "/tmp/ws",
+            }
+        ]
 
     def test_does_not_pin_current_datasource_selection(self, session_manager):
         """The frozen prompt lists the catalog but never the live selection."""
         services = SimpleNamespace(datasources={"main": SimpleNamespace(type="snowflake")})
         cfg = _agent_config(current_datasource="main", services=services)
         node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
-        out = node._inject_runtime_context("BASE")
+        out = node._inject_datasource_runtime_context("BASE")
         assert "Current datasource:" not in out
 
     def test_runtime_context_date_hook_is_overridable(self, session_manager):
         """Subclasses (GenSQL/AskMetrics) pin a reference date into the snapshot."""
         services = SimpleNamespace(datasources={"main": SimpleNamespace(type="duckdb")})
         cfg = _agent_config(current_datasource="main", services=services)
-        node = _SnapshotNode(session_manager, cfg, db_func_tool=object())
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=None)
         node._runtime_context_current_date = lambda: "1999-12-31"
         out = node._inject_runtime_context("BASE")
         assert "Current date: 1999-12-31" in out
@@ -399,5 +470,13 @@ class TestTemplateHygiene:
     def test_runtime_context_partial_has_no_current_selection(self):
         source = (TEMPLATE_DIR / "runtime_context_1.0.j2").read_text(encoding="utf-8")
         assert "{{ current_date }}" in source
+        assert "available_datasources" not in source
+        assert "workspace_root" not in source
+        assert "Current datasource: {{ datasource }}" not in source
+
+    def test_datasource_runtime_context_partial_has_no_current_selection(self):
+        source = (TEMPLATE_DIR / "datasource_runtime_context_1.0.j2").read_text(encoding="utf-8")
+        assert "{{ current_date }}" not in source
         assert "available_datasources" in source
+        assert "workspace_root" in source
         assert "Current datasource: {{ datasource }}" not in source

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -33,7 +33,7 @@ def _context_tools(tree):
     return tools
 
 
-def _make_node(real_agent_config, *, tree, adapter=True, node_config=None, node_name="ask_metrics"):
+def _make_node(real_agent_config, *, tree, adapter=True, node_config=None, node_name="ask_metrics", input_data=None):
     from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
 
     if node_config is not None:
@@ -50,6 +50,7 @@ def _make_node(real_agent_config, *, tree, adapter=True, node_config=None, node_
             node_id="ask_metrics_test",
             description="Ask metrics",
             node_type=NodeType.TYPE_ASK_METRICS,
+            input_data=input_data,
             agent_config=real_agent_config,
             node_name=node_name,
         )
@@ -110,6 +111,25 @@ class TestAskMetricsAgenticNode:
         assert "also pass `order_by`" in prompt
         assert "full result is cached" in prompt
         assert node.subject_tree_prompt_limit == 100
+
+    def test_reference_date_is_injected_into_runtime_context(self, real_agent_config, mock_llm_create):
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["activity_count"]}}},
+            input_data=AskMetricsNodeInput(
+                user_message="How many activities started in June?",
+                reference_date="2025-12-31",
+            ),
+        )
+
+        prompt = node._get_system_prompt()
+
+        assert "Current context:" in prompt
+        assert "Current date: 2025-12-31" in prompt
+        assert "Available datasources:" not in prompt
+        assert "Current sql files root directory:" not in prompt
 
     def test_large_subject_tree_exposes_list_subject_tree_tool(self, real_agent_config, mock_llm_create):
         tree = {


### PR DESCRIPTION
## Summary

- decouple shared runtime current-date injection from DB-tool capability
- split datasource/sql-root prompt context into a DB-tool-scoped runtime partial
- pass AskMetrics reference dates through the shared runtime context and add regression coverage

## Root Cause

AskMetrics did not mount DB tools, so the previous runtime-context injection path skipped its current-date hook. Benchmark runs could pass a reference date into AskMetrics, but the system prompt still lacked that date anchor, leaving year-omitted and relative periods to model inference.

## Validation

- `uv run ruff check datus/agent/node/agentic_node.py datus/agent/node/base_visual_artifact_agentic_node.py datus/agent/node/gen_skill_agentic_node.py tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py tests/unit_tests/agent/node/test_agentic_node_skills.py`
- `uv run pytest tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py tests/unit_tests/agent/node/test_agentic_node_skills.py tests/unit_tests/agent/test_plan.py -q`
- `uv run pytest tests/unit_tests/agent/node/test_visual_artifact_finalize.py tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py -q`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
## Summary by CodeRabbit

* **New Features**
  * Improved date handling in metrics queries with explicit instructions for interpreting relative dates and applying current date context to year-omitted time expressions.

* **Refactor**
  * Reorganized system prompt context injection into separate runtime and datasource stages for better modularity and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced metrics date handling: relative and year-omitted expressions now reference the runtime “Current date” and apply its year rules consistently.
* **Refactor**
  * System-prompt “current context” is now built in separate stages: a date-only snapshot plus optional datasource-scoped context when applicable.
* **Bug Fixes**
  * Improved resilience: if prompt rendering fails, the system prompt now falls back to the original content.
* **Tests**
  * Updated and expanded unit tests to verify the new context staging and template hygiene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->