### PR TITLE
[Enhancement] Raise default max_turns to 50 for all agentic nodes

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -68,7 +68,7 @@ class AskMetricsAgenticNode(AgenticNode):
     ):
         self.execution_mode = execution_mode
         self.configured_node_name = node_name
-        self.max_turns = 12
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and node_name in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[node_name]
             if isinstance(agentic_node_config, dict):

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -78,11 +78,11 @@ class ChatAgenticNode(AgenticNode):
         self.configured_node_name = "chat"
 
         # Max turns from config
-        self.max_turns = 30
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and "chat" in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes["chat"]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         # Initialize tool attributes BEFORE calling parent constructor
         self.db_func_tool: Optional[DBFuncTool] = None

--- a/datus/agent/node/compare_agentic_node.py
+++ b/datus/agent/node/compare_agentic_node.py
@@ -66,12 +66,12 @@ class CompareAgenticNode(AgenticNode):
             session_id=session_id,
         )
 
-        # Get max_turns from agentic_nodes configuration, default to 30
-        self.max_turns = 30
+        # Get max_turns from agentic_nodes configuration, default to 50
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and node_name in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[node_name]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         self.setup_tools()
 

--- a/datus/agent/node/deliverable_node.py
+++ b/datus/agent/node/deliverable_node.py
@@ -127,7 +127,7 @@ class DeliverableAgenticNode(AgenticNode):
     NODE_TYPE: ClassVar[str] = ""
 
     #: Default max_turns cap; subclasses override when the flow is deeper.
-    DEFAULT_MAX_TURNS: ClassVar[int] = 20
+    DEFAULT_MAX_TURNS: ClassVar[int] = 50
 
     # Default ``result_class`` — gen_table / gen_job use SemanticNodeResult;
     # gen_dashboard / scheduler override with their specialised models.

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -68,13 +68,13 @@ class ExploreAgenticNode(AgenticNode):
         # otherwise block on a missing broker listener.
         self.execution_mode = execution_mode
 
-        # Default max_turns = 15, can be overridden by agent.yml
-        self.max_turns = 15
+        # Default max_turns = 50, can be overridden by agent.yml
+        self.max_turns = 50
         config_key = node_name or self.NODE_NAME
         if agent_config and hasattr(agent_config, "agentic_nodes") and config_key in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[config_key]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 15)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         # Initialize tool attributes before parent constructor
         self.db_func_tool: Optional[DBFuncTool] = None

--- a/datus/agent/node/feedback_agentic_node.py
+++ b/datus/agent/node/feedback_agentic_node.py
@@ -51,11 +51,11 @@ class FeedbackAgenticNode(AgenticNode):
         self.configured_node_name = "feedback"
 
         # Get max_turns from agentic_nodes configuration
-        self.max_turns = 30
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and "feedback" in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes["feedback"]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         # Tool holders BEFORE super().__init__()
         self.sub_agent_task_tool = None

--- a/datus/agent/node/gen_dashboard_agentic_node.py
+++ b/datus/agent/node/gen_dashboard_agentic_node.py
@@ -38,7 +38,7 @@ class GenDashboardAgenticNode(DeliverableAgenticNode):
     ACTION_TYPE: ClassVar[str] = "gen_dashboard_response"
     result_class = GenDashboardNodeResult
     PROMPT_TEMPLATE: ClassVar[str] = "gen_dashboard_system"
-    DEFAULT_MAX_TURNS: ClassVar[int] = 30
+    DEFAULT_MAX_TURNS: ClassVar[int] = 50
     # Dashboard skills are injected dynamically by ``_setup_dashboard_skills``
     # based on the configured BI platform — leave ``DEFAULT_SKILLS`` empty so
     # the base-class fallback does not over-expose unrelated platforms.

--- a/datus/agent/node/gen_job_agentic_node.py
+++ b/datus/agent/node/gen_job_agentic_node.py
@@ -44,7 +44,7 @@ class GenJobAgenticNode(DeliverableAgenticNode):
     DEFAULT_SKILLS: ClassVar[Optional[str]] = "gen-table, data-migration"
     PROMPT_TEMPLATE: ClassVar[str] = "gen_job_system"
     ACTION_TYPE: ClassVar[str] = "gen_job_response"
-    DEFAULT_MAX_TURNS: ClassVar[int] = 40
+    DEFAULT_MAX_TURNS: ClassVar[int] = 50
 
     def _setup_domain_tools(self) -> None:
         """Register read tools + DDL + DML + transfer + migration mixin wrappers."""

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -70,12 +70,12 @@ class GenMetricsAgenticNode(AgenticNode):
         self.execution_mode = execution_mode
         self.subject_tree = subject_tree
 
-        # Get max_turns from agentic_nodes configuration, default to 30
-        self.max_turns = 40
+        # Get max_turns from agentic_nodes configuration, default to 50
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and self.NODE_NAME in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[self.NODE_NAME]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 40)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         self.metrics_dir = str(agent_config.path_manager.semantic_model_path(agent_config.current_datasource))
         self.knowledge_base_dir = str(agent_config.path_manager.subject_dir)

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -75,11 +75,11 @@ class GenReportAgenticNode(AgenticNode):
         # Determine node name from node_type if not provided
         self.configured_node_name = node_name
 
-        self.max_turns = 30
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and node_name in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[node_name]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         # Initialize tool attributes BEFORE calling parent constructor
         # This is required because parent's __init__ calls _get_system_prompt()

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -62,12 +62,12 @@ class GenSemanticModelAgenticNode(AgenticNode):
         """
         self.execution_mode = execution_mode
 
-        # Get max_turns from agentic_nodes configuration, default to 30
-        self.max_turns = 40
+        # Get max_turns from agentic_nodes configuration, default to 50
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and self.NODE_NAME in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[self.NODE_NAME]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 40)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         self.semantic_model_dir = str(agent_config.path_manager.semantic_model_path(agent_config.current_datasource))
         # ``knowledge_base_dir`` is the sandbox root for FilesystemFuncTool. It

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -69,13 +69,13 @@ class SkillCreatorAgenticNode(AgenticNode):
         self._configured_node_name = node_name or self.NODE_NAME
         self.execution_mode = execution_mode
 
-        # Default max_turns = 30, can be overridden by agent.yml
-        self.max_turns = 30
+        # Default max_turns = 50, can be overridden by agent.yml
+        self.max_turns = 50
         config_key = self._configured_node_name
         if agent_config and hasattr(agent_config, "agentic_nodes") and config_key in (agent_config.agentic_nodes or {}):
             agentic_node_config = agent_config.agentic_nodes.get(config_key, {})
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         # Initialize tool attributes before parent constructor
         self.db_func_tool: Optional[DBFuncTool] = None

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -75,11 +75,11 @@ class GenSQLAgenticNode(AgenticNode):
         # Determine node name from node_type if not provided
         self.configured_node_name = node_name
 
-        self.max_turns = 30
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and node_name in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[node_name]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         # Initialize tool attributes BEFORE calling parent constructor
         # This is required because parent's __init__ calls _get_system_prompt()

--- a/datus/agent/node/gen_table_agentic_node.py
+++ b/datus/agent/node/gen_table_agentic_node.py
@@ -37,7 +37,7 @@ class GenTableAgenticNode(DeliverableAgenticNode):
     DEFAULT_SKILLS: ClassVar[Optional[str]] = "gen-table"
     PROMPT_TEMPLATE: ClassVar[str] = "gen_table_system"
     ACTION_TYPE: ClassVar[str] = "gen_table_response"
-    DEFAULT_MAX_TURNS: ClassVar[int] = 20
+    DEFAULT_MAX_TURNS: ClassVar[int] = 50
 
     def _setup_domain_tools(self) -> None:
         """DDL-only: read tools + ``execute_ddl``. No DML / no transfer."""

--- a/datus/agent/node/scheduler_agentic_node.py
+++ b/datus/agent/node/scheduler_agentic_node.py
@@ -32,7 +32,7 @@ class SchedulerAgenticNode(DeliverableAgenticNode):
     ACTION_TYPE: ClassVar[str] = "scheduler_response"
     result_class = SchedulerNodeResult
     PROMPT_TEMPLATE: ClassVar[str] = "scheduler_system"
-    DEFAULT_MAX_TURNS: ClassVar[int] = 30
+    DEFAULT_MAX_TURNS: ClassVar[int] = 50
     # Scheduler workflow + validation skills are injected dynamically based
     # on the configured platform. Leave ``DEFAULT_SKILLS`` empty so the
     # base-class fallback does not over-expose unrelated platforms.

--- a/datus/agent/node/sql_summary_agentic_node.py
+++ b/datus/agent/node/sql_summary_agentic_node.py
@@ -70,11 +70,11 @@ class SqlSummaryAgenticNode(AgenticNode):
         self.storage_type = storage_type
 
         # Get max_turns from agentic_nodes configuration
-        self.max_turns = 30
+        self.max_turns = 50
         if agent_config and hasattr(agent_config, "agentic_nodes") and node_name in agent_config.agentic_nodes:
             agentic_node_config = agent_config.agentic_nodes[node_name]
             if isinstance(agentic_node_config, dict):
-                self.max_turns = agentic_node_config.get("max_turns", 30)
+                self.max_turns = agentic_node_config.get("max_turns", 50)
 
         self.sql_summary_dir = str(agent_config.path_manager.sql_summary_path())
         self.knowledge_base_dir = str(agent_config.path_manager.subject_dir)

--- a/tests/unit_tests/agent/node/test_feedback_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_feedback_agentic_node.py
@@ -169,7 +169,7 @@ class TestFeedbackAgenticNodeInit:
         from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode
 
         node = FeedbackAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        assert node.max_turns == 30
+        assert node.max_turns == 50
 
     def test_execution_mode_stored(self, real_agent_config, mock_llm_create):
         from datus.agent.node.feedback_agentic_node import FeedbackAgenticNode

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -276,7 +276,7 @@ class TestGenDashboardAgenticNodeInit:
             assert node.max_turns == 25
 
     def test_max_turns_default(self, real_agent_config, mock_llm_create):
-        """Default max_turns is 30 when gen_dashboard not in agentic_nodes."""
+        """Default max_turns is 50 when gen_dashboard not in agentic_nodes."""
         # Add dashboard config but no gen_dashboard agentic node
         real_agent_config.dashboard_config["superset"] = DashboardConfig(
             platform="superset",
@@ -289,7 +289,7 @@ class TestGenDashboardAgenticNodeInit:
             from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
 
             node = GenDashboardAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-            assert node.max_turns == 30
+            assert node.max_turns == 50
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_job_agentic_node.py
@@ -111,8 +111,7 @@ class TestGenJobAgenticNodeInit:
     def test_default_max_turns(self, real_agent_config, mock_llm_create):  # audit-noqa
         from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
 
-        # 40 turns (absorbed from migration subagent) — cross-DB flows need more turns.
-        check_max_turns(GenJobAgenticNode, real_agent_config, 40)
+        check_max_turns(GenJobAgenticNode, real_agent_config, 50)
 
     def test_uses_dynamic_db_func_tool(self, real_agent_config, mock_llm_create):  # audit-noqa
         """gen_job should use create_dynamic for multi-connector support."""

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -93,7 +93,7 @@ class TestGenMetricsAgenticNodeInit:
         assert node.max_turns == 5
 
     def test_metrics_max_turns_default(self, real_agent_config, mock_llm_create):
-        """Test default max_turns is 30 when not configured."""
+        """Test default max_turns is 50 when not configured."""
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
         # Remove gen_metrics from agentic_nodes to test default
@@ -103,7 +103,7 @@ class TestGenMetricsAgenticNodeInit:
                 agent_config=real_agent_config,
                 execution_mode="workflow",
             )
-            assert node.max_turns == 40
+            assert node.max_turns == 50
         finally:
             if original is not None:
                 real_agent_config.agentic_nodes["gen_metrics"] = original

--- a/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_report_agentic_node.py
@@ -116,7 +116,7 @@ class TestGenReportAgenticNodeInit:
         assert node.max_turns == 5
 
     def test_report_max_turns_default(self, real_agent_config, mock_llm_create):
-        """Test default max_turns is 30 when node_name not in agentic_nodes."""
+        """Test default max_turns is 50 when node_name not in agentic_nodes."""
         from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
 
         node = GenReportAgenticNode(
@@ -127,7 +127,7 @@ class TestGenReportAgenticNodeInit:
             node_name="nonexistent_report_node",  # Not in agentic_nodes
         )
 
-        assert node.max_turns == 30
+        assert node.max_turns == 50
 
     def test_report_node_name_configurable(self, real_agent_config, mock_llm_create):
         """Test that node_name is configurable and affects get_node_name()."""

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -113,7 +113,7 @@ class TestGenSemanticModelAgenticNodeInit:
         assert node.max_turns == 5
 
     def test_semantic_model_max_turns_default(self, real_agent_config, mock_llm_create):
-        """Test default max_turns is 30 when not configured."""
+        """Test default max_turns is 50 when not configured."""
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 
         # Remove gen_semantic_model from agentic_nodes to test default
@@ -123,7 +123,7 @@ class TestGenSemanticModelAgenticNodeInit:
                 agent_config=real_agent_config,
                 execution_mode="workflow",
             )
-            assert node.max_turns == 40
+            assert node.max_turns == 50
         finally:
             if original is not None:
                 real_agent_config.agentic_nodes["gen_semantic_model"] = original

--- a/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_table_agentic_node.py
@@ -96,7 +96,7 @@ class TestGenTableAgenticNodeInit:
         original = real_agent_config.agentic_nodes.pop("gen_table", None)
         try:
             node = GenTableAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-            assert node.max_turns == 20
+            assert node.max_turns == 50
         finally:
             if original is not None:
                 real_agent_config.agentic_nodes["gen_table"] = original

--- a/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
@@ -204,7 +204,7 @@ class TestSchedulerAgenticNodeInit:
             assert node.max_turns == 25
 
     def test_max_turns_default(self, real_agent_config, mock_llm_create):
-        """Default max_turns is 30 when scheduler not in agentic_nodes."""
+        """Default max_turns is 50 when scheduler not in agentic_nodes."""
         # Add scheduler service config but no scheduler agentic node config
         real_agent_config.services.schedulers = {"airflow_local": _scheduler_service_config()}
         real_agent_config.init_scheduler_services(real_agent_config.services.schedulers)
@@ -212,7 +212,7 @@ class TestSchedulerAgenticNodeInit:
             from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
 
             node = SchedulerAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-            assert node.max_turns == 30
+            assert node.max_turns == 50
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
@@ -54,8 +54,8 @@ class TestSkillCreatorAgenticNodeInit:
         )
         assert node.get_node_name() == "gen_skill"
 
-    def test_default_max_turns_30(self, real_agent_config, mock_llm_create):
-        """Default max_turns should be 30."""
+    def test_default_max_turns_50(self, real_agent_config, mock_llm_create):
+        """Default max_turns should be 50."""
         from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode
 
         node = SkillCreatorAgenticNode(
@@ -65,7 +65,7 @@ class TestSkillCreatorAgenticNodeInit:
             agent_config=real_agent_config,
             node_name="gen_skill",
         )
-        assert node.max_turns == 30
+        assert node.max_turns == 50
 
     def test_model_is_mock(self, real_agent_config, mock_llm_create):
         """Model should be the mock model."""


### PR DESCRIPTION
Unified the floor for all nodes whose default was below 50 (ranging from 12 to 40) so agents have more headroom before hitting the turn cap. The max_turns=1 internal sub-call in agentic_node.py is unchanged.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized default maximum turn limits to 50 across all agentic node types, increased from previous values ranging from 12–40. This adjustment provides agents with enhanced iteration capacity for more comprehensive processing of complex requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized default maximum turn limits to **50** across agentic node types (previous defaults varied from **12–40**), while preserving existing per-node configuration overrides when `max_turns` is explicitly set.
  * Updated unit test expectations to match the new **50** default turn limits for the affected nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->