### PR TITLE
[BugFix] keep busy DatusService alive on AgentConfig fingerprint change

### DIFF
--- a/datus/api/services/datus_service_cache.py
+++ b/datus/api/services/datus_service_cache.py
@@ -52,7 +52,21 @@ class DatusServiceCache:
                 if expected_fingerprint is None or cached.config_fingerprint == expected_fingerprint:
                     self._cache.move_to_end(project_id)
                     return cached
-                # Fingerprint mismatch — evict stale entry and rebuild
+                # Fingerprint mismatch. Rebuilding now would orphan any in-flight
+                # chat task: its interaction broker lives in this instance's
+                # task_manager, so a later /chat/user_interaction answer would
+                # hit a fresh, empty manager and fail with "No active task found
+                # for this session". Defer the config swap while the instance is
+                # busy — keep serving it until its tasks drain, after which the
+                # next request rebuilds with the new config.
+                if cached.has_active_tasks():
+                    self._cache.move_to_end(project_id)
+                    logger.info(
+                        f"Deferring DatusService rebuild for project {project_id}: "
+                        f"AgentConfig fingerprint changed but tasks are still active"
+                    )
+                    return cached
+                # Idle instance — safe to evict and rebuild with the new config.
                 stale_svc = self._cache.pop(project_id)
                 logger.info(f"Evicting DatusService for project {project_id} due to AgentConfig fingerprint mismatch")
 

--- a/tests/unit_tests/api/services/test_datus_service_cache.py
+++ b/tests/unit_tests/api/services/test_datus_service_cache.py
@@ -178,18 +178,43 @@ class TestFingerprintEviction:
         old.shutdown.assert_awaited_once()
         assert cache._cache["p"] is new
 
-    async def test_mismatched_fingerprint_with_active_tasks_defers(self):
+    async def test_mismatched_fingerprint_with_active_tasks_defers_rebuild(self):
+        """Fingerprint changes are deferred while tasks are active.
+
+        Rebuilding would orphan the in-flight task's interaction broker, so the
+        existing instance must keep serving requests (e.g. a pending
+        /chat/user_interaction answer) until its tasks drain.
+        """
         cache = DatusServiceCache()
         old = _mock_service("p", has_active=True, fingerprint="fp-old")
         await cache.get_or_create("p", AsyncMock(return_value=old))
 
-        new = _mock_service("p", fingerprint="fp-new")
-        await cache.get_or_create("p", AsyncMock(return_value=new), expected_fingerprint="fp-new")
+        factory = AsyncMock()
+        result = await cache.get_or_create("p", factory, expected_fingerprint="fp-new")
 
-        # Old was not immediately shut down; deferred via active-tasks path
+        # No rebuild: the busy instance is preserved and returned as-is.
+        factory.assert_not_called()
         old.shutdown.assert_not_awaited()
-        await asyncio.sleep(0.05)
-        old.task_manager.wait_all_tasks.assert_awaited()
+        assert result is old
+        assert cache._cache["p"] is old
+
+    async def test_mismatched_fingerprint_rebuilds_after_tasks_drain(self):
+        """Once the busy instance goes idle, the next request rebuilds."""
+        cache = DatusServiceCache()
+        old = _mock_service("p", has_active=True, fingerprint="fp-old")
+        await cache.get_or_create("p", AsyncMock(return_value=old))
+
+        # First mismatched request is deferred (tasks still active).
+        await cache.get_or_create("p", AsyncMock(return_value=_mock_service("p")), expected_fingerprint="fp-new")
+        assert cache._cache["p"] is old
+
+        # Task drained — the next mismatched request evicts and rebuilds.
+        old.has_active_tasks.return_value = False
+        new = _mock_service("p", fingerprint="fp-new")
+        result = await cache.get_or_create("p", AsyncMock(return_value=new), expected_fingerprint="fp-new")
+
+        assert result is new
+        old.shutdown.assert_awaited_once()
         assert cache._cache["p"] is new
 
     async def test_none_fingerprint_preserves_legacy_behavior(self):


### PR DESCRIPTION
## Why

In prod, `/api/v1/chat/user_interaction` intermittently returns
`SESSION_NOT_FOUND` — "No active task found for this session" — even
though the user is answering a live interactive prompt.

Root cause traced from CloudWatch: the per-project `DatusServiceCache`
rebuilds the `DatusService` whenever the request's `AgentConfig`
fingerprint differs from the cached instance's. For a heavy interactive
session we saw this fire repeatedly (`Evicting DatusService … due to
AgentConfig fingerprint mismatch`), interleaved with the failing
`user_interaction` calls and a tell-tale `deferring shutdown — active
tasks` line.

The in-flight chat run's `interaction_broker` lives inside the *old*
instance's `task_manager`. The previous code deferred only the
**shutdown** of the old instance but still swapped it out of the cache,
so the next request (the user's answer) was served by a fresh, empty
`task_manager` → `get_task()` returns `None` → `SESSION_NOT_FOUND`. The
orphaned run keeps executing in the background, unreachable.

(The fingerprint itself flips because `compute_fingerprint` hashes the
whole `AgentConfig` blob, so any per-request/host-injected variation
churns it — but the cache must not destroy live tasks regardless of why
the fingerprint changed, which is what this PR fixes.)

## Solution

In `DatusServiceCache.get_or_create`, when the fingerprint mismatches but
the cached instance `has_active_tasks()`, **defer the rebuild**: keep
serving the existing instance and return it as-is. Once its tasks drain,
the next mismatched request evicts and rebuilds with the new config as
before. Idle instances still rebuild immediately, so config changes
apply promptly when nothing is running.

This guarantees a pending `/chat/user_interaction` answer always reaches
the same instance that owns the running task.

## Test Cases

`tests/unit_tests/api/services/test_datus_service_cache.py`:
- Rewrote `test_mismatched_fingerprint_with_active_tasks_defers_rebuild`
  to assert the busy instance is preserved (factory not called, no
  shutdown, cache still holds the old instance) — the previous test
  encoded the buggy behavior (cache swapped to the new instance).
- Added `test_mismatched_fingerprint_rebuilds_after_tasks_drain`: once
  the instance goes idle, the next mismatched request evicts and rebuilds.

Full `tests/unit_tests/api/` suite passes (1077 passed); ruff format +
check clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [x] release/0.3.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service stability by deferring updates when operations are active. Services will no longer be interrupted during ongoing tasks and will be rebuilt only after all work completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->