### PR TITLE
[BugFix] keep busy DatusService alive on AgentConfig fingerprint change (backport #1032 to release/0.3.5)

### DIFF
--- a/datus/api/services/datus_service_cache.py
+++ b/datus/api/services/datus_service_cache.py
@@ -52,7 +52,21 @@ class DatusServiceCache:
                 if expected_fingerprint is None or cached.config_fingerprint == expected_fingerprint:
                     self._cache.move_to_end(project_id)
                     return cached
-                # Fingerprint mismatch — evict stale entry and rebuild
+                # Fingerprint mismatch. Rebuilding now would orphan any in-flight
+                # chat task: its interaction broker lives in this instance's
+                # task_manager, so a later /chat/user_interaction answer would
+                # hit a fresh, empty manager and fail with "No active task found
+                # for this session". Defer the config swap while the instance is
+                # busy — keep serving it until its tasks drain, after which the
+                # next request rebuilds with the new config.
+                if cached.has_active_tasks():
+                    self._cache.move_to_end(project_id)
+                    logger.info(
+                        f"Deferring DatusService rebuild for project {project_id}: "
+                        f"AgentConfig fingerprint changed but tasks are still active"
+                    )
+                    return cached
+                # Idle instance — safe to evict and rebuild with the new config.
                 stale_svc = self._cache.pop(project_id)
                 logger.info(f"Evicting DatusService for project {project_id} due to AgentConfig fingerprint mismatch")
 

--- a/tests/unit_tests/api/services/test_datus_service_cache.py
+++ b/tests/unit_tests/api/services/test_datus_service_cache.py
@@ -178,18 +178,43 @@ class TestFingerprintEviction:
         old.shutdown.assert_awaited_once()
         assert cache._cache["p"] is new
 
-    async def test_mismatched_fingerprint_with_active_tasks_defers(self):
+    async def test_mismatched_fingerprint_with_active_tasks_defers_rebuild(self):
+        """Fingerprint changes are deferred while tasks are active.
+
+        Rebuilding would orphan the in-flight task's interaction broker, so the
+        existing instance must keep serving requests (e.g. a pending
+        /chat/user_interaction answer) until its tasks drain.
+        """
         cache = DatusServiceCache()
         old = _mock_service("p", has_active=True, fingerprint="fp-old")
         await cache.get_or_create("p", AsyncMock(return_value=old))
 
-        new = _mock_service("p", fingerprint="fp-new")
-        await cache.get_or_create("p", AsyncMock(return_value=new), expected_fingerprint="fp-new")
+        factory = AsyncMock()
+        result = await cache.get_or_create("p", factory, expected_fingerprint="fp-new")
 
-        # Old was not immediately shut down; deferred via active-tasks path
+        # No rebuild: the busy instance is preserved and returned as-is.
+        factory.assert_not_called()
         old.shutdown.assert_not_awaited()
-        await asyncio.sleep(0.05)
-        old.task_manager.wait_all_tasks.assert_awaited()
+        assert result is old
+        assert cache._cache["p"] is old
+
+    async def test_mismatched_fingerprint_rebuilds_after_tasks_drain(self):
+        """Once the busy instance goes idle, the next request rebuilds."""
+        cache = DatusServiceCache()
+        old = _mock_service("p", has_active=True, fingerprint="fp-old")
+        await cache.get_or_create("p", AsyncMock(return_value=old))
+
+        # First mismatched request is deferred (tasks still active).
+        await cache.get_or_create("p", AsyncMock(return_value=_mock_service("p")), expected_fingerprint="fp-new")
+        assert cache._cache["p"] is old
+
+        # Task drained — the next mismatched request evicts and rebuilds.
+        old.has_active_tasks.return_value = False
+        new = _mock_service("p", fingerprint="fp-new")
+        result = await cache.get_or_create("p", AsyncMock(return_value=new), expected_fingerprint="fp-new")
+
+        assert result is new
+        old.shutdown.assert_awaited_once()
         assert cache._cache["p"] is new
 
     async def test_none_fingerprint_preserves_legacy_behavior(self):


### PR DESCRIPTION
## Why

Backport of #1032 to `release/0.3.5` (checked in that PR's backport checklist).

In prod, `/api/v1/chat/user_interaction` intermittently returned
`SESSION_NOT_FOUND` — "No active task found for this session" — even though
the user was answering a live interactive prompt. The per-project
`DatusServiceCache` rebuilt the `DatusService` whenever the request's
`AgentConfig` fingerprint differed from the cached instance's. The in-flight
chat run's `interaction_broker` lives inside the old instance's
`task_manager`; the previous code deferred only the shutdown of the old
instance but still swapped it out of the cache, so the next request (the
user's answer) was served by a fresh, empty `task_manager` →
`get_task()` returns `None` → `SESSION_NOT_FOUND`, and the orphaned run kept
executing unreachable in the background.

## Solution

Clean cherry-pick of merge commit `9d30140` (`git cherry-pick -x`). No
conflicts, no adaptation needed.

In `DatusServiceCache.get_or_create`, when the fingerprint mismatches but the
cached instance `has_active_tasks()`, defer the rebuild: keep serving the
existing instance and return it as-is. Once its tasks drain, the next
mismatched request evicts and rebuilds with the new config. Idle instances
still rebuild immediately, so config changes apply promptly when nothing is
running.

## Test Cases

Carried over from #1032 — `tests/unit_tests/api/services/test_datus_service_cache.py`:
- `test_mismatched_fingerprint_with_active_tasks_defers_rebuild` asserts the
  busy instance is preserved (factory not called, no shutdown, cache still
  holds the old instance).
- `test_mismatched_fingerprint_rebuilds_after_tasks_drain` asserts that once
  the instance goes idle, the next mismatched request evicts and rebuilds.
