### PR TITLE
[BugFix] Scope permission prompt lock per broker, not per event loop

### DIFF
--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -37,23 +37,59 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Per-event-loop locks to serialize permission prompts within a single loop.
-# A module-level ``asyncio.Lock()`` binds to the loop running on first ``await``
-# and then raises ``Lock is bound to a different event loop`` on every
-# subsequent ``asyncio.run()`` (the CLI creates a fresh loop per turn via
-# ``chat_commands.py``). Key the lock by the running loop so each turn gets its
-# own, while still serializing prompts from parallel tool calls inside one loop.
-_permission_prompt_locks: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = (
+# Per-broker locks to serialize permission prompts within a single agent run.
+#
+# The lock exists so several parallel tool calls in one LLM turn don't fire
+# multiple permission prompts at once. Those parallel calls all share the node's
+# single ``InteractionBroker``, so the broker is the correct serialization
+# scope.
+#
+# Keying by the running event loop instead (the previous design) is WRONG on a
+# long-lived multi-session server: uvicorn runs every request on one shared
+# loop, so a per-loop lock serializes prompts across *independent* sessions and
+# sub-agents. Because the lock is held across the user-response ``await`` inside
+# ``broker.request()``, while session A waits for its answer, sessions B/C/D
+# block inside ``on_tool_start`` *before* reaching ``broker.request()`` — they
+# emit the TOOL "processing" action (claude_model yields it before the gate) but
+# never the INTERACTION event, so their clients hang with no prompt to answer.
+#
+# An ``asyncio.Lock`` binds to the loop of its first ``await`` and then raises
+# "bound to a different event loop" if reused on another loop (the CLI creates a
+# fresh loop per turn via ``chat_commands.py``). We therefore cache ``(loop,
+# lock)`` per broker and rebuild when the loop changes, so a broker reused
+# across CLI turns still gets a loop-correct lock.
+_permission_prompt_locks: "weakref.WeakKeyDictionary[Any, Tuple[asyncio.AbstractEventLoop, asyncio.Lock]]" = (
     weakref.WeakKeyDictionary()
 )
+# Fallback locks for callers without a (weak-referenceable) broker, keyed by the
+# running loop to preserve the legacy behavior in that narrow case.
+_loop_fallback_locks: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = weakref.WeakKeyDictionary()
 
 
-def _get_permission_prompt_lock() -> asyncio.Lock:
+def _get_permission_prompt_lock(broker: Any = None) -> asyncio.Lock:
+    """Return the prompt-serialization lock for ``broker`` on the running loop.
+
+    Scoped per broker (i.e. per agent run / session) so concurrent sessions and
+    sub-agents on a shared event loop never block each other's permission
+    prompts. Falls back to a per-loop lock when ``broker`` is missing or not
+    weak-referenceable.
+    """
     loop = asyncio.get_running_loop()
-    lock = _permission_prompt_locks.get(loop)
+    if broker is not None:
+        try:
+            entry = _permission_prompt_locks.get(broker)
+            if entry is None or entry[0] is not loop:
+                lock = asyncio.Lock()
+                _permission_prompt_locks[broker] = (loop, lock)
+                return lock
+            return entry[1]
+        except TypeError:
+            # Broker is not weak-referenceable; fall through to a per-loop lock.
+            pass
+    lock = _loop_fallback_locks.get(loop)
     if lock is None:
         lock = asyncio.Lock()
-        _permission_prompt_locks[loop] = lock
+        _loop_fallback_locks[loop] = lock
     return lock
 
 
@@ -323,8 +359,11 @@ class PermissionHooks(AgentHooks):
                     logger.debug(f"Tool '{tool_name}' already approved for session (cache_key: {cache_key})")
                     return
 
-            # Use lock to prevent multiple prompts at once (for parallel tool calls)
-            async with _get_permission_prompt_lock():
+            # Use lock to prevent multiple prompts at once (for parallel tool
+            # calls within THIS run). Scoped per broker so concurrent sessions
+            # and sub-agents on a shared event loop don't serialize each other's
+            # prompts (see ``_get_permission_prompt_lock``).
+            async with _get_permission_prompt_lock(self.broker):
                 # Re-check cache after acquiring lock (another prompt may have approved it)
                 for cache_key in cache_keys:
                     if self.permission_manager._session_approvals.get(cache_key):
@@ -532,7 +571,7 @@ class PermissionHooks(AgentHooks):
             logger.debug("External path %s already approved for session", resolved.resolved)
             return True
 
-        async with _get_permission_prompt_lock():
+        async with _get_permission_prompt_lock(self.broker):
             if self.permission_manager._session_approvals.get(cache_key):
                 return True
 

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -1227,8 +1227,8 @@ class TestPermissionPromptLockPerLoop:
     A module-level ``asyncio.Lock()`` used to bind to whichever loop first
     awaited it, then raised ``Lock is bound to a different event loop`` on
     every subsequent ``asyncio.run()`` call (the CLI creates a fresh loop per
-    chat turn). These tests exercise the per-loop lock helper to make sure
-    the bug cannot silently regress.
+    chat turn). These tests exercise the lock helper's fallback (no-broker)
+    path to make sure the bug cannot silently regress.
     """
 
     def test_separate_asyncio_run_calls_do_not_reuse_lock(self):
@@ -1252,9 +1252,117 @@ class TestPermissionPromptLockPerLoop:
             return first, second
 
         first, second = asyncio.run(_collect())
-        # Within a single loop, concurrent tool calls must share one lock so
-        # the "one prompt at a time" invariant still holds.
+        # Within a single loop, the fallback (no-broker) lock is shared so the
+        # "one prompt at a time" invariant still holds for legacy callers.
         assert first is second
+
+
+class TestPermissionPromptLockPerBroker:
+    """The prompt lock is scoped per broker, not per event loop.
+
+    On a long-lived multi-session server every request shares one loop, so a
+    per-loop lock serialized prompts across independent sessions/sub-agents:
+    while one held the lock across its user-response ``await``, the others
+    blocked in ``on_tool_start`` and emitted the TOOL "processing" action but
+    never the INTERACTION event. Scoping per broker fixes that.
+    """
+
+    def test_same_broker_same_loop_returns_same_lock(self):
+        async def _collect():
+            broker = InteractionBroker()
+            first = permission_hooks_module._get_permission_prompt_lock(broker)
+            second = permission_hooks_module._get_permission_prompt_lock(broker)
+            return first, second
+
+        first, second = asyncio.run(_collect())
+        # Parallel tool calls within one run share a broker -> share a lock, so
+        # the "one prompt at a time" invariant still holds inside a run.
+        assert first is second
+
+    def test_distinct_brokers_same_loop_get_distinct_locks(self):
+        """The core fix: independent sessions must NOT share a prompt lock."""
+
+        async def _collect():
+            broker_a = InteractionBroker()
+            broker_b = InteractionBroker()
+            lock_a = permission_hooks_module._get_permission_prompt_lock(broker_a)
+            lock_b = permission_hooks_module._get_permission_prompt_lock(broker_b)
+            return lock_a, lock_b
+
+        lock_a, lock_b = asyncio.run(_collect())
+        assert lock_a is not lock_b
+
+    def test_concurrent_brokers_do_not_serialize(self):
+        """A broker holding its lock must not block a *different* broker's hook.
+
+        Reproduces the reported hang: session A parks while holding its prompt
+        lock; session B must still be able to acquire its own lock and proceed.
+        With the old per-loop lock, B's ``acquire`` would block on A forever.
+        """
+
+        async def _run():
+            broker_a = InteractionBroker()
+            broker_b = InteractionBroker()
+            b_acquired = asyncio.Event()
+
+            async def hold_a():
+                async with permission_hooks_module._get_permission_prompt_lock(broker_a):
+                    # Park "forever" while holding A's lock (mirrors awaiting a
+                    # user response that never arrives).
+                    await asyncio.sleep(3600)
+
+            async def acquire_b():
+                async with permission_hooks_module._get_permission_prompt_lock(broker_b):
+                    b_acquired.set()
+
+            holder = asyncio.create_task(hold_a())
+            await asyncio.sleep(0)  # let holder grab A's lock first
+            consumer = asyncio.create_task(acquire_b())
+            try:
+                # B must acquire its own lock despite A being parked.
+                await asyncio.wait_for(b_acquired.wait(), timeout=1.0)
+            finally:
+                holder.cancel()
+                consumer.cancel()
+                for t in (holder, consumer):
+                    try:
+                        await t
+                    except asyncio.CancelledError:
+                        pass
+            return b_acquired.is_set()
+
+        assert asyncio.run(_run()) is True
+
+    def test_same_broker_distinct_loops_rebinds_lock(self):
+        """A broker reused across CLI turns gets a loop-correct lock each turn."""
+        broker = InteractionBroker()
+
+        async def _acquire_once():
+            lock = permission_hooks_module._get_permission_prompt_lock(broker)
+            async with lock:  # would raise "bound to a different loop" if stale
+                return lock
+
+        lock_a = asyncio.run(_acquire_once())
+        lock_b = asyncio.run(_acquire_once())
+        assert lock_a is not lock_b
+
+    def test_unhashable_broker_falls_back_to_loop_lock(self):
+        """A non-weak-referenceable broker must not crash the helper."""
+
+        async def _collect():
+            # ``object()`` is weak-referenceable; use a type that is not by
+            # giving the helper something that raises in WeakKeyDictionary.
+            class _NoWeakref:
+                __slots__ = ()  # no __weakref__ slot -> not weak-referenceable
+
+            broker = _NoWeakref()
+            lock = permission_hooks_module._get_permission_prompt_lock(broker)
+            fallback = permission_hooks_module._get_permission_prompt_lock()
+            return lock, fallback
+
+        lock, fallback = asyncio.run(_collect())
+        # Falls back to the shared per-loop lock instead of raising.
+        assert lock is fallback
 
     def test_external_prompt_succeeds_across_separate_asyncio_runs(self, mock_broker, tmp_path):
         """End-to-end: two consecutive ``asyncio.run`` turns, each hitting the


### PR DESCRIPTION
## Why

On a long-lived multi-session API server (single uvicorn worker = one shared event loop), concurrent chat sessions and sub-agents would hang on permission prompts. Captured via an async task-stack dump: one session parked at `broker.request() -> await future` (holding the lock, having emitted its INTERACTION event), while another was parked at `_get_permission_prompt_lock() -> acquire`.

The prompt-serialization lock in `permission_hooks.py` was keyed by the running event loop. Since every request shares one loop, the per-loop lock serialized permission prompts across *independent* sessions. The lock is held across the user-response `await` inside `broker.request()`, so while session A waited for its answer, sessions B/C/D blocked inside `on_tool_start` *before* reaching `broker.request()` — they emitted the TOOL "processing" action (`claude_model` yields it before the permission gate) but never the INTERACTION event, so their clients hung with no prompt to answer.

## Solution

Key the lock by the node's `InteractionBroker` instead of by the event loop:

- Parallel tool calls within one run share a broker, so the "one prompt at a time" invariant **within a run** is preserved.
- Independent sessions/sub-agents have independent brokers, so they no longer block each other.
- Cache `(loop, lock)` per broker and rebuild on loop change, staying compatible with the CLI's fresh-loop-per-turn model (an `asyncio.Lock` binds to the loop of its first `await`).
- Fall back to a per-loop lock for callers without a weak-referenceable broker.

## Test Cases

Added `TestPermissionPromptLockPerBroker` in `tests/unit_tests/tools/permission/test_permission_hooks.py`:

- same broker + same loop → same lock (within-run serialization preserved)
- distinct brokers + same loop → distinct locks (the core fix)
- a broker parked while holding its lock does **not** block a different broker's hook (direct reproduction of the reported hang; asserts the second broker acquires within 1s)
- same broker across separate `asyncio.run` loops → loop-correct lock each time
- non-weak-referenceable broker → falls back to the per-loop lock instead of raising

Existing per-loop regression guards retained (now exercising the no-broker fallback path).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [x] release/0.3.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a hang issue where permission prompts from concurrent tool calls in separate agent sessions would unnecessarily block each other when running on shared infrastructure.

* **Improvements**
  * Enhanced permission prompt handling to be scoped per agent session rather than globally, improving concurrency between independent agents while maintaining prompt serialization safety within each session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->