### PR TITLE
[BugFix] offload blocking sync route handlers to thread pool

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -58,6 +58,10 @@ if TYPE_CHECKING:
 
 router = APIRouter(prefix="/api/v1/chat", tags=["chat"])
 
+# Timeout for JuiceFS FUSE operations: os.listdir + sqlite3.connect per session file.
+# Slightly above fuse_meta_op's 10 s default to give directory scans extra headroom.
+_FUSE_IO_TIMEOUT = 15.0
+
 # Additional builtin subagents accepted by ``stream_chat`` beyond the canonical
 # ``BUILTIN_SUBAGENTS`` set — these are wired directly in
 # ``ChatTaskManager._create_node`` but are not listed as user-creatable agents
@@ -330,7 +334,15 @@ async def list_sessions(
         description="Filter by subagent id; 'chat' selects the default chat agent",
     ),
 ) -> Result[ChatSessionData]:
-    return await asyncio.to_thread(svc.chat.list_sessions, user_id=ctx.user_id, subagent_id=subagent_id)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(svc.chat.list_sessions, user_id=ctx.user_id, subagent_id=subagent_id),
+            timeout=_FUSE_IO_TIMEOUT,
+        )
+    except TimeoutError:
+        return Result[ChatSessionData](
+            success=False, errorCode="REQUEST_TIMEOUT", errorMessage="Session list timed out"
+        )
 
 
 @router.delete(
@@ -344,7 +356,15 @@ async def delete_session(
     svc: ServiceDep,
     ctx: AppContextDep,
 ) -> Result[ChatSessionData]:
-    return await asyncio.to_thread(svc.chat.delete_session, session_id, user_id=ctx.user_id)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(svc.chat.delete_session, session_id, user_id=ctx.user_id),
+            timeout=_FUSE_IO_TIMEOUT,
+        )
+    except TimeoutError:
+        return Result[ChatSessionData](
+            success=False, errorCode="REQUEST_TIMEOUT", errorMessage="Session delete timed out"
+        )
 
 
 # ========== Chat History (GET /api/v1/history/chat?session_id=xxx) ==========
@@ -361,7 +381,15 @@ async def get_chat_history(
     ctx: AppContextDep,
     session_id: str = Query(..., description="Session ID to retrieve history for"),
 ) -> Result[ChatHistoryData]:
-    return await asyncio.to_thread(svc.chat.get_history, session_id, user_id=ctx.user_id)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(svc.chat.get_history, session_id, user_id=ctx.user_id),
+            timeout=_FUSE_IO_TIMEOUT,
+        )
+    except TimeoutError:
+        return Result[ChatHistoryData](
+            success=False, errorCode="REQUEST_TIMEOUT", errorMessage="History fetch timed out"
+        )
 
 
 # ========== User Interaction ==========

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -330,7 +330,7 @@ async def list_sessions(
         description="Filter by subagent id; 'chat' selects the default chat agent",
     ),
 ) -> Result[ChatSessionData]:
-    return svc.chat.list_sessions(user_id=ctx.user_id, subagent_id=subagent_id)
+    return await asyncio.to_thread(svc.chat.list_sessions, user_id=ctx.user_id, subagent_id=subagent_id)
 
 
 @router.delete(
@@ -344,7 +344,7 @@ async def delete_session(
     svc: ServiceDep,
     ctx: AppContextDep,
 ) -> Result[ChatSessionData]:
-    return svc.chat.delete_session(session_id, user_id=ctx.user_id)
+    return await asyncio.to_thread(svc.chat.delete_session, session_id, user_id=ctx.user_id)
 
 
 # ========== Chat History (GET /api/v1/history/chat?session_id=xxx) ==========
@@ -361,7 +361,7 @@ async def get_chat_history(
     ctx: AppContextDep,
     session_id: str = Query(..., description="Session ID to retrieve history for"),
 ) -> Result[ChatHistoryData]:
-    return svc.chat.get_history(session_id, user_id=ctx.user_id)
+    return await asyncio.to_thread(svc.chat.get_history, session_id, user_id=ctx.user_id)
 
 
 # ========== User Interaction ==========

--- a/datus/api/routes/database_routes.py
+++ b/datus/api/routes/database_routes.py
@@ -17,6 +17,11 @@ from datus.api.models.database_models import (
 
 router = APIRouter(prefix="/api/v1", tags=["databases"])
 
+# Timeout for datasource network I/O (test_connection, get_databases, get_schemas,
+# get_tables). Matches the adapter-level timeout_seconds=30 so the connector gets
+# a chance to surface its own error before we give up at the route layer.
+_DB_IO_TIMEOUT = 30.0
+
 # Pre-configured parameters to avoid definition-time evaluation in defaults
 DATASOURCE_QUERY = Query("", description="Datasource to list databases from")
 DATABASE_NAME_QUERY = Query("", description="Database name")
@@ -47,7 +52,13 @@ async def list_catalogs(
         schema_name=schema_name,
         include_sys_schemas=include_sys_schemas,
     )
-    databases: Result[ListDatabasesData] = await asyncio.to_thread(svc.datasource.list_databases, request)
+    try:
+        databases: Result[ListDatabasesData] = await asyncio.wait_for(
+            asyncio.to_thread(svc.datasource.list_databases, request),
+            timeout=_DB_IO_TIMEOUT,
+        )
+    except TimeoutError:
+        return Result(success=False, errorCode="REQUEST_TIMEOUT", errorMessage="Datasource query timed out")
     if not databases.success or databases.data is None:
         return Result(
             success=False,

--- a/datus/api/routes/database_routes.py
+++ b/datus/api/routes/database_routes.py
@@ -2,6 +2,7 @@
 API routes for Database Management endpoints.
 """
 
+import asyncio
 from typing import Optional
 
 from fastapi import APIRouter, Query
@@ -46,7 +47,7 @@ async def list_catalogs(
         schema_name=schema_name,
         include_sys_schemas=include_sys_schemas,
     )
-    databases: Result[ListDatabasesData] = svc.datasource.list_databases(request)
+    databases: Result[ListDatabasesData] = await asyncio.to_thread(svc.datasource.list_databases, request)
     if not databases.success or databases.data is None:
         return Result(
             success=False,

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -5,7 +5,7 @@
 """Unit tests for datus/api/routes/chat_routes.py — submit_user_interaction endpoint."""
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -22,6 +22,7 @@ from datus.api.models.cli_models import (
     UserInteractionInput,
 )
 from datus.api.routes.chat_routes import (
+    _FUSE_IO_TIMEOUT,
     _is_valid_subagent_id,
     delete_session,
     get_chat_history,
@@ -30,6 +31,13 @@ from datus.api.routes.chat_routes import (
     submit_user_interaction,
 )
 from datus.tools.sql_policy import SqlPolicyConfig
+
+
+async def _timeout_wait_for(awaitable, timeout):
+    """Async stub for asyncio.wait_for that closes the awaitable before raising TimeoutError."""
+    if hasattr(awaitable, "close"):
+        awaitable.close()
+    raise TimeoutError
 
 
 def _mock_svc(task=None):
@@ -535,12 +543,13 @@ class TestListSessions:
         ctx = MagicMock()
         ctx.user_id = "user1"
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.chat_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await list_sessions(svc, ctx, subagent_id=None)
 
         assert result.success is False
         assert result.errorCode == "REQUEST_TIMEOUT"
         assert result.errorMessage == "Session list timed out"
+        mock_wf.assert_called_once_with(ANY, timeout=_FUSE_IO_TIMEOUT)
 
     @pytest.mark.asyncio
     async def test_forwards_subagent_id_filter(self):
@@ -561,11 +570,12 @@ class TestListSessions:
         ctx = MagicMock()
         ctx.user_id = "u1"
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.chat_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await list_sessions(svc, ctx, subagent_id=None)
 
         assert isinstance(result, Result)
         assert result.data is None
+        mock_wf.assert_called_once_with(ANY, timeout=_FUSE_IO_TIMEOUT)
 
 
 # ===========================================================================
@@ -596,12 +606,13 @@ class TestDeleteSession:
         ctx = MagicMock()
         ctx.user_id = "user1"
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.chat_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await delete_session("session123", svc, ctx)
 
         assert result.success is False
         assert result.errorCode == "REQUEST_TIMEOUT"
         assert result.errorMessage == "Session delete timed out"
+        mock_wf.assert_called_once_with(ANY, timeout=_FUSE_IO_TIMEOUT)
 
     @pytest.mark.asyncio
     async def test_timeout_result_type_is_result(self):
@@ -609,11 +620,12 @@ class TestDeleteSession:
         ctx = MagicMock()
         ctx.user_id = "u1"
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.chat_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await delete_session("sid", svc, ctx)
 
         assert isinstance(result, Result)
         assert result.data is None
+        mock_wf.assert_called_once_with(ANY, timeout=_FUSE_IO_TIMEOUT)
 
 
 # ===========================================================================
@@ -644,12 +656,13 @@ class TestGetChatHistory:
         ctx = MagicMock()
         ctx.user_id = "user1"
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.chat_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await get_chat_history(svc, ctx, session_id="sess1")
 
         assert result.success is False
         assert result.errorCode == "REQUEST_TIMEOUT"
         assert result.errorMessage == "History fetch timed out"
+        mock_wf.assert_called_once_with(ANY, timeout=_FUSE_IO_TIMEOUT)
 
     @pytest.mark.asyncio
     async def test_timeout_result_type_is_result(self):
@@ -657,8 +670,9 @@ class TestGetChatHistory:
         ctx = MagicMock()
         ctx.user_id = "u1"
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.chat_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await get_chat_history(svc, ctx, session_id="s1")
 
         assert isinstance(result, Result)
         assert result.data is None
+        mock_wf.assert_called_once_with(ANY, timeout=_FUSE_IO_TIMEOUT)

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -5,15 +5,27 @@
 """Unit tests for datus/api/routes/chat_routes.py — submit_user_interaction endpoint."""
 
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
-from datus.api.models.cli_models import SSEEndData, SSEEvent, SSESessionData, StreamChatInput, UserInteractionInput
+from datus.api.models.base_models import Result
+from datus.api.models.cli_models import (
+    ChatHistoryData,
+    ChatSessionData,
+    SSEEndData,
+    SSEEvent,
+    SSESessionData,
+    StreamChatInput,
+    UserInteractionInput,
+)
 from datus.api.routes.chat_routes import (
     _is_valid_subagent_id,
+    delete_session,
+    get_chat_history,
+    list_sessions,
     stream_chat,
     submit_user_interaction,
 )
@@ -493,3 +505,160 @@ class TestInsertMessageEndpoint:
 
         # Stripped form lands in the queue.
         assert task.node.pending_input_queue.snapshot() == ["padded"]
+
+
+# ===========================================================================
+# /api/v1/chat/sessions — list_sessions with FUSE timeout
+# ===========================================================================
+
+
+class TestListSessions:
+    """list_sessions offloads the blocking call to a thread and handles FUSE timeout."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_service_result(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user1"
+        expected = Result[ChatSessionData](success=True, data=ChatSessionData(sessions=[], total_count=0))
+        svc.chat.list_sessions.return_value = expected
+
+        result = await list_sessions(svc, ctx, subagent_id=None)
+
+        assert result.success is True
+        assert result is expected
+        svc.chat.list_sessions.assert_called_once_with(user_id="user1", subagent_id=None)
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_request_timeout_error(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user1"
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await list_sessions(svc, ctx, subagent_id=None)
+
+        assert result.success is False
+        assert result.errorCode == "REQUEST_TIMEOUT"
+        assert result.errorMessage == "Session list timed out"
+
+    @pytest.mark.asyncio
+    async def test_forwards_subagent_id_filter(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user2"
+        svc.chat.list_sessions.return_value = Result[ChatSessionData](
+            success=True, data=ChatSessionData(sessions=[], total_count=0)
+        )
+
+        await list_sessions(svc, ctx, subagent_id="gen_sql")
+
+        svc.chat.list_sessions.assert_called_once_with(user_id="user2", subagent_id="gen_sql")
+
+    @pytest.mark.asyncio
+    async def test_timeout_result_type_is_result(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "u1"
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await list_sessions(svc, ctx, subagent_id=None)
+
+        assert isinstance(result, Result)
+        assert result.data is None
+
+
+# ===========================================================================
+# DELETE /api/v1/chat/sessions/{session_id} — delete_session with FUSE timeout
+# ===========================================================================
+
+
+class TestDeleteSession:
+    """delete_session offloads the blocking call to a thread and handles FUSE timeout."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_service_result(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user1"
+        expected = Result[ChatSessionData](success=True, data=ChatSessionData(sessions=[], total_count=0))
+        svc.chat.delete_session.return_value = expected
+
+        result = await delete_session("session123", svc, ctx)
+
+        assert result.success is True
+        assert result is expected
+        svc.chat.delete_session.assert_called_once_with("session123", user_id="user1")
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_request_timeout_error(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user1"
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await delete_session("session123", svc, ctx)
+
+        assert result.success is False
+        assert result.errorCode == "REQUEST_TIMEOUT"
+        assert result.errorMessage == "Session delete timed out"
+
+    @pytest.mark.asyncio
+    async def test_timeout_result_type_is_result(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "u1"
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await delete_session("sid", svc, ctx)
+
+        assert isinstance(result, Result)
+        assert result.data is None
+
+
+# ===========================================================================
+# GET /api/v1/chat/history — get_chat_history with FUSE timeout
+# ===========================================================================
+
+
+class TestGetChatHistory:
+    """get_chat_history offloads the blocking call to a thread and handles FUSE timeout."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_service_result(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user1"
+        expected = Result[ChatHistoryData](success=True, data=ChatHistoryData(messages=[]))
+        svc.chat.get_history.return_value = expected
+
+        result = await get_chat_history(svc, ctx, session_id="sess1")
+
+        assert result.success is True
+        assert result is expected
+        svc.chat.get_history.assert_called_once_with("sess1", user_id="user1")
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_request_timeout_error(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user1"
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await get_chat_history(svc, ctx, session_id="sess1")
+
+        assert result.success is False
+        assert result.errorCode == "REQUEST_TIMEOUT"
+        assert result.errorMessage == "History fetch timed out"
+
+    @pytest.mark.asyncio
+    async def test_timeout_result_type_is_result(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "u1"
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await get_chat_history(svc, ctx, session_id="s1")
+
+        assert isinstance(result, Result)
+        assert result.data is None

--- a/tests/unit_tests/api/routes/test_database_routes.py
+++ b/tests/unit_tests/api/routes/test_database_routes.py
@@ -1,0 +1,166 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/api/routes/database_routes.py — list_catalogs endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datus.api.models.base_models import Result
+from datus.api.models.database_models import DatabaseInfo, DatabasesData, ListDatabasesData, ListDatabasesInput
+from datus.api.routes.database_routes import list_catalogs
+
+
+def _make_db_info(name: str = "main") -> DatabaseInfo:
+    return DatabaseInfo(
+        name=name,
+        uri=f"sqlite:///{name}.db",
+        type="sqlite",
+        current=True,
+        connection_status="connected",
+    )
+
+
+def _make_svc(list_databases_return=None, current_datasource: str = "default_ds") -> MagicMock:
+    svc = MagicMock()
+    svc.datasource.current_datasource = current_datasource
+    if list_databases_return is not None:
+        svc.datasource.list_databases.return_value = list_databases_return
+    return svc
+
+
+async def _call(svc, datasource_id="", catalog_name=None, database_name="", schema_name="", include_sys_schemas=False):
+    """Call list_catalogs with explicit defaults to bypass FastAPI Query() object resolution."""
+    return await list_catalogs(
+        svc,
+        datasource_id=datasource_id,
+        catalog_name=catalog_name,
+        database_name=database_name,
+        schema_name=schema_name,
+        include_sys_schemas=include_sys_schemas,
+    )
+
+
+class TestListCatalogs:
+    """list_catalogs wraps list_databases in a thread, maps to DatabasesData, and handles timeout."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_databases_data(self):
+        db = _make_db_info("main")
+        list_result = Result[ListDatabasesData](
+            success=True,
+            data=ListDatabasesData(databases=[db], total_count=1, current_database="main"),
+        )
+        svc = _make_svc(list_databases_return=list_result)
+
+        result = await _call(svc)
+
+        assert result.success is True
+        assert isinstance(result.data, DatabasesData)
+        assert len(result.data.databases) == 1
+        assert result.data.databases[0].name == "main"
+
+    @pytest.mark.asyncio
+    async def test_success_empty_list(self):
+        list_result = Result[ListDatabasesData](
+            success=True,
+            data=ListDatabasesData(databases=[], total_count=0, current_database=None),
+        )
+        svc = _make_svc(list_databases_return=list_result)
+
+        result = await _call(svc)
+
+        assert result.success is True
+        assert isinstance(result.data, DatabasesData)
+        assert result.data.databases == []
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_request_timeout_error(self):
+        svc = _make_svc()
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await _call(svc)
+
+        assert result.success is False
+        assert result.errorCode == "REQUEST_TIMEOUT"
+        assert result.errorMessage == "Datasource query timed out"
+
+    @pytest.mark.asyncio
+    async def test_timeout_result_type_is_result(self):
+        svc = _make_svc()
+
+        with patch("asyncio.wait_for", side_effect=TimeoutError):
+            result = await _call(svc)
+
+        assert isinstance(result, Result)
+        assert result.data is None
+
+    @pytest.mark.asyncio
+    async def test_service_error_propagates_error_code(self):
+        list_result = Result[ListDatabasesData](
+            success=False,
+            errorCode="DATASOURCE_NOT_FOUND",
+            errorMessage="Datasource not found",
+        )
+        svc = _make_svc(list_databases_return=list_result)
+
+        result = await _call(svc)
+
+        assert result.success is False
+        assert result.errorCode == "DATASOURCE_NOT_FOUND"
+        assert result.errorMessage == "Datasource not found"
+
+    @pytest.mark.asyncio
+    async def test_success_true_but_data_none_returns_error(self):
+        list_result = Result[ListDatabasesData](success=True, data=None)
+        svc = _make_svc(list_databases_return=list_result)
+
+        result = await _call(svc)
+
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_uses_current_datasource_when_datasource_id_empty(self):
+        list_result = Result[ListDatabasesData](
+            success=True,
+            data=ListDatabasesData(databases=[], total_count=0, current_database=None),
+        )
+        svc = _make_svc(list_databases_return=list_result, current_datasource="my_ds")
+
+        await _call(svc, datasource_id="")
+
+        call_arg = svc.datasource.list_databases.call_args[0][0]
+        assert isinstance(call_arg, ListDatabasesInput)
+        assert call_arg.datasource_id == "my_ds"
+
+    @pytest.mark.asyncio
+    async def test_uses_explicit_datasource_id_when_provided(self):
+        list_result = Result[ListDatabasesData](
+            success=True,
+            data=ListDatabasesData(databases=[], total_count=0, current_database=None),
+        )
+        svc = _make_svc(list_databases_return=list_result, current_datasource="other_ds")
+
+        await _call(svc, datasource_id="explicit_ds")
+
+        call_arg = svc.datasource.list_databases.call_args[0][0]
+        assert isinstance(call_arg, ListDatabasesInput)
+        assert call_arg.datasource_id == "explicit_ds"
+
+    @pytest.mark.asyncio
+    async def test_multiple_databases_all_returned(self):
+        dbs = [_make_db_info(f"db_{i}") for i in range(3)]
+        list_result = Result[ListDatabasesData](
+            success=True,
+            data=ListDatabasesData(databases=dbs, total_count=3, current_database="db_0"),
+        )
+        svc = _make_svc(list_databases_return=list_result)
+
+        result = await _call(svc)
+
+        assert result.success is True
+        assert len(result.data.databases) == 3
+        assert result.data.databases[0].name == "db_0"
+        assert result.data.databases[2].name == "db_2"

--- a/tests/unit_tests/api/routes/test_database_routes.py
+++ b/tests/unit_tests/api/routes/test_database_routes.py
@@ -4,13 +4,14 @@
 
 """Unit tests for datus/api/routes/database_routes.py — list_catalogs endpoint."""
 
-from unittest.mock import MagicMock, patch
+from typing import Optional
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from datus.api.models.base_models import Result
 from datus.api.models.database_models import DatabaseInfo, DatabasesData, ListDatabasesData, ListDatabasesInput
-from datus.api.routes.database_routes import list_catalogs
+from datus.api.routes.database_routes import _DB_IO_TIMEOUT, list_catalogs
 
 
 def _make_db_info(name: str = "main") -> DatabaseInfo:
@@ -23,7 +24,10 @@ def _make_db_info(name: str = "main") -> DatabaseInfo:
     )
 
 
-def _make_svc(list_databases_return=None, current_datasource: str = "default_ds") -> MagicMock:
+def _make_svc(
+    list_databases_return: Optional[Result[ListDatabasesData]] = None,
+    current_datasource: str = "default_ds",
+) -> MagicMock:
     svc = MagicMock()
     svc.datasource.current_datasource = current_datasource
     if list_databases_return is not None:
@@ -31,7 +35,21 @@ def _make_svc(list_databases_return=None, current_datasource: str = "default_ds"
     return svc
 
 
-async def _call(svc, datasource_id="", catalog_name=None, database_name="", schema_name="", include_sys_schemas=False):
+async def _timeout_wait_for(awaitable, timeout):
+    """Async stub for asyncio.wait_for that closes the awaitable before raising TimeoutError."""
+    if hasattr(awaitable, "close"):
+        awaitable.close()
+    raise TimeoutError
+
+
+async def _call(
+    svc: MagicMock,
+    datasource_id: str = "",
+    catalog_name: Optional[str] = None,
+    database_name: str = "",
+    schema_name: str = "",
+    include_sys_schemas: bool = False,
+) -> Result[DatabasesData]:
     """Call list_catalogs with explicit defaults to bypass FastAPI Query() object resolution."""
     return await list_catalogs(
         svc,
@@ -80,22 +98,24 @@ class TestListCatalogs:
     async def test_timeout_returns_request_timeout_error(self):
         svc = _make_svc()
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.database_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await _call(svc)
 
         assert result.success is False
         assert result.errorCode == "REQUEST_TIMEOUT"
         assert result.errorMessage == "Datasource query timed out"
+        mock_wf.assert_called_once_with(ANY, timeout=_DB_IO_TIMEOUT)
 
     @pytest.mark.asyncio
     async def test_timeout_result_type_is_result(self):
         svc = _make_svc()
 
-        with patch("asyncio.wait_for", side_effect=TimeoutError):
+        with patch("datus.api.routes.database_routes.asyncio.wait_for", side_effect=_timeout_wait_for) as mock_wf:
             result = await _call(svc)
 
         assert isinstance(result, Result)
         assert result.data is None
+        mock_wf.assert_called_once_with(ANY, timeout=_DB_IO_TIMEOUT)
 
     @pytest.mark.asyncio
     async def test_service_error_propagates_error_code(self):


### PR DESCRIPTION
## Why

Four async route handlers call synchronous service methods directly on the event loop thread, blocking it entirely:

- `list_sessions`, `delete_session`, `get_history` (chat routes) — open SQLite session files and run `os.listdir` / `os.stat` over a JuiceFS FUSE mount
- `list_catalogs` (database routes) — issues synchronous TCP queries against the configured datasource (`test_connection`, `get_databases`, `get_schemas`, `get_tables`)

When the JuiceFS metadata service is slow or the datasource is unreachable, any one of these calls freezes the entire event loop: the heartbeat stops ticking, all in-flight requests stall, and the process appears hung (container alive but unresponsive). Three concurrent page-load requests to these endpoints are enough to trigger a full process deadlock.

## Solution

Two changes:

**1. `asyncio.to_thread()` — move blocking I/O off the event loop**

Wrap the four synchronous service calls with `asyncio.to_thread()`, moving the blocking work onto the default thread-pool executor so the event loop thread remains free to handle other requests.

**2. `asyncio.wait_for()` — bound thread lifetime**

`asyncio.to_thread()` alone does not propagate task cancellation to the underlying thread: if a client disconnects while JuiceFS is hung, the thread keeps running until the sync function returns, allowing threads to accumulate and exhaust the pool under sustained load. Each `to_thread` call is therefore wrapped with `asyncio.wait_for` so requests fail fast with a `REQUEST_TIMEOUT` error instead of queuing indefinitely:

- Chat handlers (`list_sessions`, `delete_session`, `get_history`): **15 s** — slightly above `fuse_meta_op`'s 10 s default to give directory scans extra headroom
- Catalog handler (`list_catalogs`): **30 s** — matches the adapter-level `timeout_seconds=30` so the connector's own error surfaces before the route-layer ceiling

Changes:

- `datus/api/routes/database_routes.py`: add `import asyncio`; add `_DB_IO_TIMEOUT = 30.0`; wrap `svc.datasource.list_databases(request)` in `list_catalogs` with `asyncio.wait_for(asyncio.to_thread(…), timeout=_DB_IO_TIMEOUT)` + `except TimeoutError` returning a `REQUEST_TIMEOUT` Result
- `datus/api/routes/chat_routes.py`: add `_FUSE_IO_TIMEOUT = 15.0`; apply the same pattern to `list_sessions`, `delete_session`, and `get_history`

## Test Cases

No new integration tests added — this is a concurrency model fix with no business logic change. The issue can be reproduced by sending concurrent requests to the affected endpoints while JuiceFS metadata latency is elevated; after the fix, the event loop heartbeat (`/healthz/live`) remains responsive under the same conditions. Timeout paths return structured `Result(success=False, errorCode="REQUEST_TIMEOUT")` responses rather than hanging indefinitely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated chat session/history endpoints to run underlying work in background threads with a fixed per-endpoint request timeout.
  * Updated catalog listing to run datasource lookups in a background thread with a fixed request timeout.
* **Bug Fixes**
  * Timeout failures now consistently return `REQUEST_TIMEOUT` with clear, endpoint-specific messages (instead of returning the raw service outcome).
* **Tests**
  * Added unit test coverage for chat session/history and catalog listing, including success, timeout, and error-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
