### PR TITLE
[Tool] Add async task stack dump via SIGUSR1 for diagnosing hangs

### DIFF
--- a/datus/api/service.py
+++ b/datus/api/service.py
@@ -452,6 +452,14 @@ async def lifespan(app: FastAPI):
         stream_thinking=getattr(args, "stream_thinking", False),
     )
 
+    # Install a SIGUSR1 handler so operators can dump async task stacks from a
+    # running (possibly daemonised) server: ``kill -USR1 <pid>`` writes the
+    # snapshot to the log. Useful when a request hangs on an interaction that
+    # never resolves — the loop is alive but a coroutine is parked.
+    from datus.utils.async_debug import install_task_dump_signal_handler
+
+    install_task_dump_signal_handler()
+
     logger.info("Datus API Service started")
     try:
         yield

--- a/datus/utils/async_debug.py
+++ b/datus/utils/async_debug.py
@@ -1,0 +1,236 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Async task stack dumping for diagnosing hangs.
+
+When a request appears stuck — e.g. a tool awaiting an
+:class:`~datus.cli.execution_state.InteractionBroker` confirmation that never
+arrives in a non-interactive surface — the event loop itself is *not* blocked:
+it keeps running while some coroutine sits on ``await future``. This module
+walks every live :class:`asyncio.Task` and renders its stack so we can see
+exactly which coroutine is parked and where.
+
+Two entry points:
+
+* :func:`format_async_tasks` / :func:`dump_async_tasks_to_log` — pull the
+  snapshot on demand (e.g. from a debug HTTP endpoint that still responds
+  because the loop is alive).
+* :func:`install_task_dump_signal_handler` — install a ``SIGUSR1`` handler so
+  an operator can ``kill -USR1 <pid>`` a daemonised server and get the dump in
+  the log without an open HTTP connection.
+"""
+
+import asyncio
+import gc
+import io
+import linecache
+import signal
+from types import FrameType
+from typing import Any, List, Optional
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Loop captured at signal-handler install time. ``asyncio.all_tasks()`` needs a
+# loop reference, and a signal handler firing inside the running loop cannot
+# rely on ``get_running_loop()`` being callable, so we stash it here.
+_dump_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+def _resolve_loop(loop: Optional[asyncio.AbstractEventLoop]) -> Optional[asyncio.AbstractEventLoop]:
+    """Pick the loop to introspect: explicit arg, then running, then captured."""
+    if loop is not None:
+        return loop
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return _dump_loop
+
+
+def _frame_of(obj: Any) -> Optional[FrameType]:
+    """Return the code frame backing a coroutine / async-gen / generator."""
+    for attr in ("cr_frame", "ag_frame", "gi_frame"):
+        frame = getattr(obj, attr, None)
+        if frame is not None:
+            return frame
+    return None
+
+
+def _next_awaitable(obj: Any) -> Any:
+    """Follow what ``obj`` is currently awaiting / yielding from, if anything.
+
+    Coroutines/async-gens/generators expose the link directly. The
+    ``async_generator_asend`` wrapper produced by ``async for`` / ``__anext__``
+    exposes nothing (a CPython dead end), so we bridge it via ``gc`` referents:
+    the wrapper holds a reference to the underlying async generator, which does
+    carry a frame and ``ag_await``. Without this hop the chain would stop at the
+    ``async for`` consumer and never reach the generator's real block.
+    """
+    for attr in ("cr_await", "ag_await", "gi_yieldfrom"):
+        nxt = getattr(obj, attr, None)
+        if nxt is not None:
+            return nxt
+    # Bridge async-generator boundaries: find a frame-bearing referent.
+    if hasattr(obj, "__await__") and _frame_of(obj) is None:
+        try:
+            for ref in gc.get_referents(obj):
+                if _frame_of(ref) is not None:
+                    return ref
+        except Exception:  # pragma: no cover - defensive
+            return None
+    return None
+
+
+def _format_await_chain(root: Any, limit: Optional[int] = None) -> str:
+    """Render the *suspended* frame chain reachable from ``root``.
+
+    ``Task.print_stack`` stops at the directly-suspended coroutine and does not
+    descend across async-generator (``async for``) or nested-await boundaries —
+    so a consumer parked on ``async for action in gen`` shows only that line,
+    hiding where ``gen`` itself is actually blocked. This walks the
+    ``cr_await`` / ``ag_await`` / ``gi_yieldfrom`` links to surface the deepest
+    frame (e.g. the ``await broker.request(...)`` that never returns).
+
+    Returns one ``File ... line ... in ...`` block per frame, innermost last,
+    mirroring ``traceback`` ordering. Cycle- and depth-guarded so a malformed
+    chain can never spin.
+    """
+    lines: List[str] = []
+    seen: set[int] = set()
+    obj = root
+    max_depth = 200  # hard backstop independent of ``limit``
+    while obj is not None and id(obj) not in seen and len(lines) < max_depth:
+        seen.add(id(obj))
+        frame = _frame_of(obj)
+        if frame is not None:
+            code = frame.f_code
+            lineno = frame.f_lineno
+            src = linecache.getline(code.co_filename, lineno).strip()
+            lines.append(f'  File "{code.co_filename}", line {lineno}, in {code.co_name}')
+            if src:
+                lines.append(f"    {src}")
+        obj = _next_awaitable(obj)
+
+    if limit is not None and limit > 0:
+        # Keep the innermost ``limit`` frames (2 text lines each) — those are
+        # the ones nearest the actual block.
+        lines = lines[-(limit * 2) :]
+    if not lines:
+        return "  <no descendable frames; coroutine may be awaiting a bare Future>\n"
+    return "\n".join(lines) + "\n"
+
+
+def format_async_tasks(loop: Optional[asyncio.AbstractEventLoop] = None, limit: Optional[int] = None) -> str:
+    """Render every live asyncio task on ``loop`` with its full suspended chain.
+
+    For each task this prints two views:
+
+    * the ``Task.print_stack`` output (the caller chain up to the directly
+      suspended coroutine), and
+    * an ``await chain`` that descends across ``async for`` / nested-await
+      boundaries to the innermost parked frame — the part ``print_stack`` omits
+      and where the real block (e.g. ``await broker.request(...)``) lives.
+
+    Args:
+        loop: Event loop to introspect. Defaults to the running loop, falling
+            back to the loop captured by :func:`install_task_dump_signal_handler`.
+        limit: Max stack frames per view (``None`` for the full stack).
+
+    Returns:
+        A human-readable multi-task dump. Never raises — introspection errors
+        are folded into the returned text so callers (signal handler, HTTP
+        endpoint) stay simple.
+    """
+    target = _resolve_loop(loop)
+    if target is None:
+        return "async-task-dump: no event loop available to introspect\n"
+
+    try:
+        tasks: List[asyncio.Task] = list(asyncio.all_tasks(target))
+    except Exception as e:  # pragma: no cover - defensive
+        return f"async-task-dump: failed to enumerate tasks: {e!r}\n"
+
+    buf = io.StringIO()
+    buf.write(f"=== async task dump: {len(tasks)} live task(s) ===\n")
+    # Stable, readable ordering: done tasks last, otherwise by name.
+    for task in sorted(tasks, key=lambda t: (t.done(), t.get_name())):
+        coro = task.get_coro()
+        coro_name = getattr(coro, "__qualname__", repr(coro))
+        buf.write(f"\n--- Task {task.get_name()!r} done={task.done()} coro={coro_name} ---\n")
+        try:
+            task.print_stack(limit=limit, file=buf)
+        except Exception as e:  # pragma: no cover - defensive
+            buf.write(f"<failed to print stack: {e!r}>\n")
+        # The await chain is the diagnostically useful part: it crosses the
+        # async-generator boundary that print_stack stops at.
+        try:
+            chain = _format_await_chain(coro, limit=limit)
+        except Exception as e:  # pragma: no cover - defensive
+            chain = f"  <failed to walk await chain: {e!r}>\n"
+        buf.write("await chain (innermost last):\n")
+        buf.write(chain)
+    buf.write("\n=== end async task dump ===\n")
+    return buf.getvalue()
+
+
+def dump_async_tasks_to_log(loop: Optional[asyncio.AbstractEventLoop] = None, limit: Optional[int] = None) -> str:
+    """Format the task dump and emit it to the logger at WARNING.
+
+    Returns the same text it logs so HTTP callers can echo it back.
+    """
+    text = format_async_tasks(loop=loop, limit=limit)
+    logger.warning("Async task stack dump requested:\n%s", text)
+    return text
+
+
+def install_task_dump_signal_handler(
+    loop: Optional[asyncio.AbstractEventLoop] = None, sig: int = signal.SIGUSR1
+) -> bool:
+    """Install a signal handler that dumps async task stacks to the log.
+
+    Captures ``loop`` (or the running loop) so the dump works even when the
+    handler fires while the loop is mid-iteration. ``SIGUSR1`` is unused by
+    uvicorn/Datus, so it is safe to repurpose for diagnostics.
+
+    Returns ``True`` if the handler was installed. Returns ``False`` on
+    platforms without the signal (e.g. Windows lacks ``SIGUSR1``) or when no
+    loop can be resolved — never raises, so server startup is unaffected.
+    """
+    global _dump_loop
+
+    resolved = _resolve_loop(loop)
+    if resolved is None:
+        logger.debug("Task-dump signal handler not installed: no event loop available")
+        return False
+    _dump_loop = resolved
+
+    if not hasattr(signal, "Signals") or sig is None:  # pragma: no cover - defensive
+        return False
+
+    def _handler(*_args) -> None:
+        # Keep the handler body minimal and exception-proof: a raise here would
+        # propagate into whatever the loop was running.
+        try:
+            dump_async_tasks_to_log(loop=_dump_loop)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error("Async task dump signal handler failed: %r", e)
+
+    # Prefer loop.add_signal_handler (runs in the loop thread, async-safe).
+    # Fall back to signal.signal where the loop API is unavailable (e.g. the
+    # handler is installed off the main thread on some platforms).
+    try:
+        resolved.add_signal_handler(sig, _handler)
+        logger.info("Installed async task-dump handler on signal %s (send: kill -%s <pid>)", sig, int(sig))
+        return True
+    except (NotImplementedError, RuntimeError, ValueError) as e:
+        logger.debug("loop.add_signal_handler unavailable (%r); falling back to signal.signal", e)
+
+    try:
+        signal.signal(sig, _handler)
+        logger.info("Installed async task-dump handler on signal %s via signal.signal", sig)
+        return True
+    except (OSError, ValueError, RuntimeError) as e:
+        logger.debug("Task-dump signal handler not installed: %r", e)
+        return False

--- a/datus/utils/async_debug.py
+++ b/datus/utils/async_debug.py
@@ -33,6 +33,11 @@ from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
 
+# Resolved at import time so the default is safe on platforms lacking ``SIGUSR1``
+# (e.g. Windows): ``getattr`` yields ``None`` there instead of raising, letting
+# ``install_task_dump_signal_handler`` return ``False`` gracefully.
+DEFAULT_TASK_DUMP_SIGNAL: Optional[int] = getattr(signal, "SIGUSR1", None)
+
 # Loop captured at signal-handler install time. ``asyncio.all_tasks()`` needs a
 # loop reference, and a signal handler firing inside the running loop cannot
 # rely on ``get_running_loop()`` being callable, so we stash it here.
@@ -186,7 +191,7 @@ def dump_async_tasks_to_log(loop: Optional[asyncio.AbstractEventLoop] = None, li
 
 
 def install_task_dump_signal_handler(
-    loop: Optional[asyncio.AbstractEventLoop] = None, sig: int = signal.SIGUSR1
+    loop: Optional[asyncio.AbstractEventLoop] = None, sig: Optional[int] = DEFAULT_TASK_DUMP_SIGNAL
 ) -> bool:
     """Install a signal handler that dumps async task stacks to the log.
 
@@ -206,7 +211,7 @@ def install_task_dump_signal_handler(
         return False
     _dump_loop = resolved
 
-    if not hasattr(signal, "Signals") or sig is None:  # pragma: no cover - defensive
+    if sig is None or not hasattr(signal, "Signals"):  # pragma: no cover - defensive
         return False
 
     def _handler(*_args) -> None:

--- a/tests/unit_tests/utils/test_async_debug.py
+++ b/tests/unit_tests/utils/test_async_debug.py
@@ -1,0 +1,179 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for :mod:`datus.utils.async_debug`."""
+
+import asyncio
+import os
+import signal
+
+import pytest
+
+from datus.utils import async_debug
+from datus.utils.async_debug import (
+    dump_async_tasks_to_log,
+    format_async_tasks,
+    install_task_dump_signal_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_captured_loop():
+    """Each test should start with no captured loop and restore afterwards."""
+    async_debug._dump_loop = None
+    yield
+    async_debug._dump_loop = None
+    # Best-effort: ensure the suite-wide SIGUSR1 handler is reset so a handler
+    # bound to a closed test loop never fires later.
+    if hasattr(signal, "SIGUSR1"):
+        signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+
+
+def test_format_no_loop_returns_message():
+    """Outside any running loop and with nothing captured -> explicit notice."""
+    text = format_async_tasks()
+    assert "no event loop available" in text
+
+
+@pytest.mark.asyncio
+async def test_format_includes_parked_task_and_name():
+    """A task parked on an unresolved future must appear in the dump."""
+    loop = asyncio.get_running_loop()
+    parked_fut = loop.create_future()
+
+    async def parked():
+        await parked_fut
+
+    task = asyncio.create_task(parked(), name="parked-worker")
+    await asyncio.sleep(0)  # let the task start and park on the future
+
+    try:
+        text = format_async_tasks()
+        # Task name surfaces so the operator can identify the stuck coroutine.
+        assert "parked-worker" in text
+        # The coroutine qualname is rendered, not just repr().
+        assert "parked" in text
+        # Header reports the live task count (>= our task + current task).
+        assert "live task(s)" in text
+        assert "end async task dump" in text
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_format_limit_caps_frames():
+    """``limit`` is forwarded to ``Task.print_stack`` and bounds frame output."""
+    loop = asyncio.get_running_loop()
+    parked_fut = loop.create_future()
+
+    async def parked():
+        await parked_fut
+
+    task = asyncio.create_task(parked(), name="limited")
+    await asyncio.sleep(0)
+    try:
+        full = format_async_tasks(limit=None)
+        capped = format_async_tasks(limit=1)
+        # The capped dump should never be longer than the full one.
+        assert len(capped) <= len(full)
+        assert "limited" in capped
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_dump_to_log_emits_warning_and_returns_text(caplog):
+    """``dump_async_tasks_to_log`` logs at WARNING and returns the same text."""
+    with caplog.at_level("WARNING", logger="datus.utils.async_debug"):
+        text = dump_async_tasks_to_log()
+    assert "async task dump" in text
+    assert any("Async task stack dump requested" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_install_captures_running_loop():
+    """Installation records the running loop so later dumps can resolve it."""
+    installed = install_task_dump_signal_handler()
+    if not hasattr(signal, "SIGUSR1"):
+        # Platform without SIGUSR1 (Windows): install must report False, no raise.
+        assert installed is False
+        return
+    assert installed is True
+    assert async_debug._dump_loop is asyncio.get_running_loop()
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGUSR1"), reason="SIGUSR1 unavailable on this platform")
+@pytest.mark.asyncio
+async def test_signal_handler_triggers_dump(caplog):
+    """Sending SIGUSR1 routes through the loop handler and logs a dump."""
+    parked_fut = asyncio.get_running_loop().create_future()
+
+    async def parked():
+        await parked_fut
+
+    task = asyncio.create_task(parked(), name="signal-target")
+    await asyncio.sleep(0)
+    assert install_task_dump_signal_handler() is True
+
+    try:
+        with caplog.at_level("WARNING", logger="datus.utils.async_debug"):
+            os.kill(os.getpid(), signal.SIGUSR1)
+            # Yield control so the loop services the signal handler callback.
+            await asyncio.sleep(0.1)
+        joined = "\n".join(r.message for r in caplog.records)
+        assert "Async task stack dump requested" in joined
+        assert "signal-target" in joined
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_await_chain_descends_through_async_generator():
+    """The await chain must cross the ``async for`` boundary to the real block.
+
+    ``Task.print_stack`` stops at the consumer's ``async for`` line; the await
+    chain has to descend into the generator and the coroutine it awaits to
+    surface the innermost parked frame. This is the whole point of the feature
+    for diagnosing the ``execute_write`` hang.
+    """
+    parked_fut = asyncio.get_running_loop().create_future()
+
+    async def deep_block():
+        await parked_fut  # the real block, inside a nested coroutine
+
+    async def producer():
+        await deep_block()
+        yield 1
+
+    async def consumer():
+        async for _ in producer():
+            pass
+
+    task = asyncio.create_task(consumer(), name="chain-consumer")
+    await asyncio.sleep(0)  # let it park
+    try:
+        text = format_async_tasks()
+        # All three frames of the chain must appear, innermost included.
+        assert "in consumer" in text
+        assert "in producer" in text
+        assert "in deep_block" in text
+        assert "await chain (innermost last):" in text
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_explicit_loop_arg_overrides_capture():
+    """An explicit loop argument is honored over the captured/running loop."""
+    loop = asyncio.get_running_loop()
+    text = format_async_tasks(loop=loop)
+    assert "async task dump" in text

--- a/tests/unit_tests/utils/test_async_debug.py
+++ b/tests/unit_tests/utils/test_async_debug.py
@@ -99,12 +99,11 @@ async def test_dump_to_log_emits_warning_and_returns_text(caplog):
 async def test_install_captures_running_loop():
     """Installation records the running loop so later dumps can resolve it."""
     installed = install_task_dump_signal_handler()
-    if not hasattr(signal, "SIGUSR1"):
-        # Platform without SIGUSR1 (Windows): install must report False, no raise.
-        assert installed is False
-        return
-    assert installed is True
-    assert async_debug._dump_loop is asyncio.get_running_loop()
+    # On platforms without SIGUSR1 (e.g. Windows) install must report False and
+    # capture no loop; everywhere else it installs and captures the running loop.
+    has_sigusr1 = hasattr(signal, "SIGUSR1")
+    assert installed is has_sigusr1
+    assert (async_debug._dump_loop is asyncio.get_running_loop()) is has_sigusr1
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGUSR1"), reason="SIGUSR1 unavailable on this platform")


### PR DESCRIPTION
## Why

When an API request appears stuck — e.g. a tool awaiting a permission confirmation that never arrives — the event loop is **not** blocked; a coroutine is simply parked on an `await`. There was no way to see *which* coroutine and *where* on a running server, making such hangs hard to diagnose. (This tool is what surfaced the root cause fixed in the per-broker permission-lock PR.)

## Solution

Add `datus.utils.async_debug`:

- `format_async_tasks()` walks every live `asyncio.Task` and renders its stack.
- It descends across `async for` (async-generator) and nested-await boundaries by following `cr_await` / `ag_await` / `gi_yieldfrom` links, bridging the `async_generator_asend` dead end via `gc.get_referents`, to surface the **innermost parked frame** — the part `Task.print_stack` omits. This is what pinpoints the actual blocking `await`.
- All introspection is exception-folded so it never raises into the caller.

The API server installs a `SIGUSR1` handler at startup (`install_task_dump_signal_handler`), so an operator can `kill -USR1 <pid>` a running (possibly daemonised) server and get the dump written to the log. `SIGUSR1` is unused by uvicorn/Datus; returns `False` without raising on platforms lacking it (e.g. Windows).

## Test Cases

Added `tests/unit_tests/utils/test_async_debug.py` (8 tests):

- parked task appears in the dump with its name and coroutine qualname
- `limit` caps frames per task
- `dump_async_tasks_to_log` logs at WARNING and returns the text
- install captures the running loop / reports `False` where `SIGUSR1` is absent
- sending `SIGUSR1` routes through the loop handler and logs a dump
- **await chain descends through an `async for` boundary** to the innermost parked frame (the key capability)
- no-loop and explicit-loop argument paths

Diagnostic-only tool; no nightly/integration coverage needed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
## Summary by CodeRabbit

* **New Features**
  * Service startup now installs a signal handler enabling operators to trigger async task stack trace dumps on demand
  * New async task diagnostics utilities for capturing live task information

* **Tests**
  * Added comprehensive test coverage for async debugging functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service startup now installs a SIGUSR1 signal handler that triggers a live async task stack-trace dump to logs on demand.
  * Added async task diagnostics utilities to format and log current running task details, including await-chain context.
* **Tests**
  * Added comprehensive unit tests covering task dump formatting, logging output, signal-handler behavior, await-chain traversal, and frame limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->