### PR TITLE
[BugFix] Warn on unknown --subagent names instead of silent gen_sql fallback

### DIFF
--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -8,10 +8,43 @@ Shared factory functions for creating interactive agentic nodes and their inputs
 Used by CLI print mode and interactive REPL to avoid duplicating node creation logic.
 """
 
+import logging
 from typing import TYPE_CHECKING, Literal, Optional
 
 if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
+
+
+logger = logging.getLogger(__name__)
+
+_BUILTIN_SUBAGENT_NAMES = frozenset(
+    {
+        "ask_dashboard",
+        "ask_metrics",
+        "ask_report",
+        "explore",
+        "feedback",
+        "gen_dashboard",
+        "gen_job",
+        "gen_metrics",
+        "gen_report",
+        "gen_semantic_model",
+        "gen_skill",
+        "gen_sql",
+        "gen_sql_summary",
+        "gen_table",
+        "gen_visual_dashboard",
+        "gen_visual_report",
+        "scheduler",
+    }
+)
+
+
+def _configured_agentic_node_names(agent_config: "AgentConfig") -> frozenset[str]:
+    agentic_nodes = getattr(agent_config, "agentic_nodes", None)
+    if not agentic_nodes or not hasattr(agentic_nodes, "keys"):
+        return frozenset()
+    return frozenset(str(name) for name in agentic_nodes.keys())
 
 
 def create_interactive_node(
@@ -265,6 +298,19 @@ def create_interactive_node(
             )
 
         else:
+            configured_agentic_node_names = _configured_agentic_node_names(agent_config)
+            if (
+                subagent_name not in _BUILTIN_SUBAGENT_NAMES
+                and subagent_name not in configured_agentic_node_names
+                and node_class_type not in _BUILTIN_SUBAGENT_NAMES
+            ):
+                available_names = ", ".join(sorted(_BUILTIN_SUBAGENT_NAMES | configured_agentic_node_names))
+                logger.warning(
+                    "Unknown subagent %r; falling back to gen_sql. Available subagents: %s",
+                    subagent_name,
+                    available_names,
+                )
+
             from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
 
             return GenSQLAgenticNode(

--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -8,36 +8,16 @@ Shared factory functions for creating interactive agentic nodes and their inputs
 Used by CLI print mode and interactive REPL to avoid duplicating node creation logic.
 """
 
-import logging
 from typing import TYPE_CHECKING, Literal, Optional
+
+from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS
+from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
 
 
-logger = logging.getLogger(__name__)
-
-_BUILTIN_SUBAGENT_NAMES = frozenset(
-    {
-        "ask_dashboard",
-        "ask_metrics",
-        "ask_report",
-        "explore",
-        "feedback",
-        "gen_dashboard",
-        "gen_job",
-        "gen_metrics",
-        "gen_report",
-        "gen_semantic_model",
-        "gen_skill",
-        "gen_sql",
-        "gen_sql_summary",
-        "gen_table",
-        "gen_visual_dashboard",
-        "gen_visual_report",
-        "scheduler",
-    }
-)
+logger = get_logger(__name__)
 
 
 def _configured_agentic_node_names(agent_config: "AgentConfig") -> frozenset[str]:
@@ -45,6 +25,31 @@ def _configured_agentic_node_names(agent_config: "AgentConfig") -> frozenset[str
     if not agentic_nodes or not hasattr(agentic_nodes, "keys"):
         return frozenset()
     return frozenset(str(name) for name in agentic_nodes.keys())
+
+
+def _visible_subagent_names(agent_config: "AgentConfig") -> frozenset[str]:
+    visible_names = set(SYS_SUB_AGENTS - HIDDEN_SYS_SUB_AGENTS)
+    agentic_nodes = getattr(agent_config, "agentic_nodes", None)
+    if not agentic_nodes or not hasattr(agentic_nodes, "items"):
+        return frozenset(visible_names)
+
+    current_db = getattr(agent_config, "current_datasource", None)
+    for name, sub_config in agentic_nodes.items():
+        name = str(name)
+        if name in SYS_SUB_AGENTS or name == "chat":
+            continue
+        if hasattr(sub_config, "model_dump"):
+            sub_config = sub_config.model_dump()
+        if isinstance(sub_config, dict):
+            scoped_context = sub_config.get("scoped_context") or {}
+            if hasattr(scoped_context, "model_dump"):
+                scoped_context = scoped_context.model_dump()
+            if isinstance(scoped_context, dict):
+                scoped_datasource = scoped_context.get("datasource")
+                if scoped_datasource and scoped_datasource != current_db:
+                    continue
+        visible_names.add(name)
+    return frozenset(visible_names)
 
 
 def create_interactive_node(
@@ -299,12 +304,8 @@ def create_interactive_node(
 
         else:
             configured_agentic_node_names = _configured_agentic_node_names(agent_config)
-            if (
-                subagent_name not in _BUILTIN_SUBAGENT_NAMES
-                and subagent_name not in configured_agentic_node_names
-                and node_class_type not in _BUILTIN_SUBAGENT_NAMES
-            ):
-                available_names = ", ".join(sorted(_BUILTIN_SUBAGENT_NAMES | configured_agentic_node_names))
+            if subagent_name not in SYS_SUB_AGENTS and subagent_name not in configured_agentic_node_names:
+                available_names = ", ".join(sorted(_visible_subagent_names(agent_config)))
                 logger.warning(
                     "Unknown subagent %r; falling back to gen_sql. Available subagents: %s",
                     subagent_name,

--- a/tests/unit_tests/agent/node/test_node_factory.py
+++ b/tests/unit_tests/agent/node/test_node_factory.py
@@ -12,7 +12,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from datus.agent.node.node import Node
-from datus.agent.node.node_factory import _resolve_node_class_type, create_interactive_node, create_node_input
+from datus.agent.node.node_factory import (
+    _configured_agentic_node_names,
+    _resolve_node_class_type,
+    _visible_subagent_names,
+    create_interactive_node,
+    create_node_input,
+)
 from datus.configuration.node_type import NodeType
 from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput, AskMetricsNodeResult
 
@@ -24,7 +30,16 @@ from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput, A
 def _mock_agent_config(**kwargs):
     config = MagicMock()
     config.agentic_nodes = kwargs.get("agentic_nodes", None)
+    config.current_datasource = kwargs.get("current_datasource", None)
     return config
+
+
+class _DumpableConfig:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def model_dump(self):
+        return self.payload
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +73,43 @@ class TestResolveNodeClassType:
         node_config.model_dump.return_value = {"node_class": "gen_report"}
         config = _mock_agent_config(agentic_nodes={"my_agent": node_config})
         assert _resolve_node_class_type("my_agent", config) == "gen_report"
+
+
+class TestSubagentValidationHelpers:
+    def test_configured_agentic_node_names_normalizes_keys(self):
+        config = _mock_agent_config(agentic_nodes={"my_agent": {}, 42: {}})
+
+        assert _configured_agentic_node_names(config) == frozenset({"my_agent", "42"})
+
+    def test_configured_agentic_node_names_handles_non_mapping(self):
+        config = _mock_agent_config(agentic_nodes=["my_agent"])
+
+        assert _configured_agentic_node_names(config) == frozenset()
+
+    def test_visible_subagent_names_filters_hidden_and_foreign_datasource_agents(self):
+        config = _mock_agent_config(
+            current_datasource="warehouse",
+            agentic_nodes={
+                "chat": {},
+                "feedback": {},
+                "warehouse_agent": {"scoped_context": {"datasource": "warehouse"}},
+                "sales_agent": _DumpableConfig({"scoped_context": _DumpableConfig({"datasource": "sales"})}),
+                "global_agent": {"scoped_context": {}},
+                42: {"scoped_context": {"datasource": "warehouse"}},
+                "object_config_agent": object(),
+            },
+        )
+
+        names = _visible_subagent_names(config)
+
+        assert "gen_metrics" in names
+        assert "feedback" not in names
+        assert "chat" not in names
+        assert "warehouse_agent" in names
+        assert "global_agent" in names
+        assert "42" in names
+        assert "object_config_agent" in names
+        assert "sales_agent" not in names
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +404,27 @@ class TestUnknownSubagentWarning:
         assert len(warning_messages) == 1
         assert "gen_metrics" in warning_messages[0]
         assert "my_custom" in warning_messages[0]
+
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_warning_available_names_filter_hidden_and_datasource_scoped_agents(self, mock_init, caplog):
+        config = _mock_agent_config(
+            current_datasource="warehouse",
+            agentic_nodes={
+                "feedback": {},
+                "warehouse_agent": {"scoped_context": {"datasource": "warehouse"}},
+                "sales_agent": {"scoped_context": {"datasource": "sales"}},
+            },
+        )
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            create_interactive_node("not_configured", config)
+
+        mock_init.assert_called_once()
+        warning_messages = self._unknown_subagent_warnings(caplog)
+        assert len(warning_messages) == 1
+        assert "warehouse_agent" in warning_messages[0]
+        assert "sales_agent" not in warning_messages[0]
+        assert "feedback" not in warning_messages[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_node_factory.py
+++ b/tests/unit_tests/agent/node/test_node_factory.py
@@ -6,6 +6,7 @@
 Unit tests for datus/agent/node/node_factory.py
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -156,7 +157,7 @@ class TestCreateInteractiveNode:
 
     @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
     def test_default_subagent_is_gen_sql(self, mock_init):
-        config = _mock_agent_config()
+        config = _mock_agent_config(agentic_nodes={"my_custom_sql": {}})
         create_interactive_node("my_custom_sql", config, node_id_suffix="_cli")
         mock_init.assert_called_once()
         call_kwargs = mock_init.call_args[1]
@@ -223,7 +224,7 @@ class TestCreateInteractiveNode:
     @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
     def test_execution_mode_workflow_propagates(self, mock_init):
         """API workflow callers pass execution_mode="workflow"; factory must forward it."""
-        config = _mock_agent_config()
+        config = _mock_agent_config(agentic_nodes={"my_custom_sql": {}})
         create_interactive_node("my_custom_sql", config, execution_mode="workflow")
         mock_init.assert_called_once()
         assert mock_init.call_args[1]["execution_mode"] == "workflow"
@@ -238,7 +239,7 @@ class TestCreateInteractiveNode:
     @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
     def test_node_id_override(self, mock_init):
         """node_id kwarg must take precedence over the auto-generated suffix."""
-        config = _mock_agent_config()
+        config = _mock_agent_config(agentic_nodes={"my_custom_sql": {}})
         create_interactive_node("my_custom_sql", config, node_id_suffix="_cli", node_id="api-session-42")
         assert mock_init.call_args[1]["node_id"] == "api-session-42"
 
@@ -280,6 +281,77 @@ class TestCreateInteractiveNode:
         config = _mock_agent_config()
         create_interactive_node("explore", config, execution_mode="workflow")
         assert mock_init.call_args[1]["execution_mode"] == "workflow"
+
+
+class TestUnknownSubagentWarning:
+    LOGGER_NAME = "datus.agent.node.node_factory"
+
+    @staticmethod
+    def _unknown_subagent_warnings(caplog):
+        return [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == TestUnknownSubagentWarning.LOGGER_NAME and "Unknown subagent" in record.getMessage()
+        ]
+
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_known_builtin_gen_sql_does_not_warn(self, mock_init, caplog):
+        config = _mock_agent_config()
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            create_interactive_node("gen_sql", config)
+
+        mock_init.assert_called_once()
+        assert self._unknown_subagent_warnings(caplog) == []
+
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_configured_agentic_node_key_does_not_warn(self, mock_init, caplog):
+        config = _mock_agent_config(agentic_nodes={"my_custom": {}})
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            create_interactive_node("my_custom", config)
+
+        mock_init.assert_called_once()
+        assert self._unknown_subagent_warnings(caplog) == []
+
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_unknown_subagent_warns_and_falls_back_to_gen_sql(self, mock_init, caplog):
+        config = _mock_agent_config()
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            create_interactive_node("totally_bogus_name_xyz", config)
+
+        mock_init.assert_called_once()
+        warning_messages = self._unknown_subagent_warnings(caplog)
+        assert len(warning_messages) == 1
+        assert "totally_bogus_name_xyz" in warning_messages[0]
+        assert "gen_sql" in warning_messages[0]
+        assert "Available subagents:" in warning_messages[0]
+
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_stale_generate_sql_name_warns(self, mock_init, caplog):
+        config = _mock_agent_config()
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            create_interactive_node("generate_sql", config)
+
+        mock_init.assert_called_once()
+        warning_messages = self._unknown_subagent_warnings(caplog)
+        assert len(warning_messages) == 1
+        assert "generate_sql" in warning_messages[0]
+
+    @patch("datus.agent.node.gen_sql_agentic_node.GenSQLAgenticNode.__init__", return_value=None)
+    def test_warning_available_names_include_builtins_and_configured_agents(self, mock_init, caplog):
+        config = _mock_agent_config(agentic_nodes={"my_custom": {}})
+
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            create_interactive_node("not_configured", config)
+
+        mock_init.assert_called_once()
+        warning_messages = self._unknown_subagent_warnings(caplog)
+        assert len(warning_messages) == 1
+        assert "gen_metrics" in warning_messages[0]
+        assert "my_custom" in warning_messages[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Closes #1009.

`datus -p ... --subagent <name>` did no validation of the subagent name. Any
unrecognized name (a typo, the stale pre-0.3.4 name `generate_sql`, or a bogus
string) silently fell through the catch-all `else` branch in
`create_interactive_node` (`datus/agent/node/node_factory.py`) and became a
`GenSQLAgenticNode`. The run exited 0 and answered normally, so users got no
signal that their intended custom subagent was never loaded; its system prompt
and tool whitelist were silently dropped.

## Solution

Implements the issue's lower-risk "Minimal" variant (warn, do not raise):

- Before constructing the fallback `GenSQLAgenticNode`, detect whether
  `subagent_name` is genuinely unrecognized. It is recognized if it is a
  built-in subagent name, a key in `agent_config.agentic_nodes`, or its
  resolved `node_class_type` maps to a built-in class.
- For a genuinely unknown name, emit a `logging.WARNING` naming the unknown
  subagent and listing the available names (sorted union of built-ins and
  configured `agentic_nodes` keys), e.g.
  `Unknown subagent 'generate_sql'; falling back to gen_sql. Available subagents: ...`.
- The `gen_sql` fallback is preserved so scripted callers do not break.

A module-level `_BUILTIN_SUBAGENT_NAMES` frozenset is the single source of truth
shared by the recognition check and the warning's "available" list. The fix
lives in the factory, so every caller of `create_interactive_node` (print mode,
REPL, the chat task manager) benefits without duplicated logic.

## Test Cases

Added unit coverage in `tests/unit_tests/agent/node/test_node_factory.py`
(asserted via `caplog`):

- A built-in name (`gen_sql`) constructs its node with no warning.
- A configured `agentic_nodes` key constructs with no warning.
- An unknown name (`totally_bogus_name_xyz`) still constructs the gen_sql
  fallback AND emits a warning listing available names.
- The stale pre-0.3.4 name `generate_sql` triggers the warning (surfaces the
  #935 rename regression as a migration signal).
- The warning text includes both built-in names and configured `agentic_nodes`
  keys so the message is actionable.

`python -m pytest tests/unit_tests/agent/node/test_node_factory.py -q` -> 49 passed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive node creation when an unknown subagent is requested by falling back more safely and logging a clear warning.
  * The warning now includes the unknown name and a list of available subagents, making it easier to choose a valid option.
  * Refined which subagents appear as available, so hidden or incompatible options are no longer shown in the interactive flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive node creation when an unknown subagent is requested by falling back more safely.
  * Added clearer warning logs that include the unknown name and a list of valid alternatives.
  * Refined which subagents are considered available so hidden or incompatible options are no longer presented during interactive flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->