### PR TITLE
[Enhancement] Add ssl_verify config to trust private/self-signed CA endpoints

### DIFF
--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -2416,7 +2416,29 @@ def load_model_config(data: dict) -> ModelConfig:
         top_p=float(top_p) if top_p is not None else None,
         auth_type=data.get("auth_type", "api_key"),
         use_native_api=data.get("use_native_api", False),
-        ssl_verify=resolve_env(data["ssl_verify"]) if "ssl_verify" in data else None,
+        ssl_verify=_load_ssl_verify(data),
+    )
+
+
+def _load_ssl_verify(data: dict) -> Optional[Union[bool, str]]:
+    """Resolve and type-check the optional ``ssl_verify`` model field.
+
+    Fails fast on invalid types (anything other than bool / str) rather than
+    silently dropping the value, so a misconfigured endpoint surfaces at load
+    time instead of as a confusing TLS error later.
+    """
+    if "ssl_verify" not in data:
+        return None
+    value = resolve_env(data["ssl_verify"])
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    raise DatusException(
+        ErrorCode.COMMON_FIELD_INVALID,
+        message_args={
+            "field_name": "ssl_verify",
+            "except_values": "bool or str (true/false or a CA bundle path)",
+            "your_value": type(value).__name__,
+        },
     )
 
 

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -7,7 +7,7 @@ import os
 import re
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from datus.configuration.node_type import NodeType
 from datus.observability.config import ObservabilityConfig
@@ -338,6 +338,12 @@ class ModelConfig:
     top_p: Optional[float] = None  # Some models like kimi-k2.5 require top_p=0.95
     auth_type: str = "api_key"  # "api_key" | "oauth" | "subscription"
     use_native_api: bool = False  # Use native Anthropic client instead of LiteLLM
+    # SSL/TLS verification for this model's endpoint. Mirrors httpx/litellm `verify`:
+    #   True  -> verify against system/certifi CAs (default)
+    #   False -> disable verification (discouraged; MITM-exposed)
+    #   str   -> path to a CA bundle (PEM) to additionally trust (e.g. a private gateway CA)
+    # When set, takes priority over the SSL_VERIFY / SSL_CERT_FILE environment variables.
+    ssl_verify: Optional[Union[bool, str]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -2410,6 +2416,7 @@ def load_model_config(data: dict) -> ModelConfig:
         top_p=float(top_p) if top_p is not None else None,
         auth_type=data.get("auth_type", "api_key"),
         use_native_api=data.get("use_native_api", False),
+        ssl_verify=resolve_env(data["ssl_verify"]) if "ssl_verify" in data else None,
     )
 
 

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -176,13 +176,21 @@ class ClaudeModel(OpenAICompatibleModel):
         self.proxy_client = None
         self.async_proxy_client = None
 
-        if proxy_url:
+        # SSL verification (e.g. a private gateway CA) resolved by the parent
+        # __init__. The native client takes no `verify` argument, so we must pass a
+        # custom http_client. Only do so when a proxy is set or ssl_verify is
+        # configured; otherwise leave http_client=None to preserve default behavior
+        # (the Anthropic SDK's httpx client honors the standard SSL_CERT_FILE env var).
+        verify = getattr(self, "ssl_verify", None)
+        if proxy_url or verify is not None:
+            verify_kwargs = {} if verify is None else {"verify": verify}
+            proxy_kwargs = {"proxy": httpx.Proxy(url=proxy_url)} if proxy_url else {}
             self.proxy_client = httpx.Client(
-                transport=httpx.HTTPTransport(proxy=httpx.Proxy(url=proxy_url)),
+                transport=httpx.HTTPTransport(**verify_kwargs, **proxy_kwargs),
                 timeout=60.0,
             )
             self.async_proxy_client = httpx.AsyncClient(
-                transport=httpx.AsyncHTTPTransport(proxy=httpx.Proxy(url=proxy_url)),
+                transport=httpx.AsyncHTTPTransport(**verify_kwargs, **proxy_kwargs),
                 timeout=60.0,
             )
 

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -36,6 +36,7 @@ from datus.schemas.action_history import ActionHistory, ActionHistoryManager, Ac
 from datus.schemas.node_models import SQLContext
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
+from datus.utils.ssl_utils import is_ssl_cert_verification_error
 from datus.utils.traceable_utils import optional_traceable
 
 logger = get_logger(__name__)
@@ -428,6 +429,8 @@ class ClaudeModel(OpenAICompatibleModel):
             self._diagnose_oauth_401(e)  # raises specific DatusException for OAuth tokens
             raise
         except Exception as e:
+            if is_ssl_cert_verification_error(e):
+                raise DatusException(ErrorCode.MODEL_SSL_CERT_ERROR) from e
             logger.error(f"Error generating with Anthropic: {str(e)}")
             raise
 
@@ -966,6 +969,8 @@ class ClaudeModel(OpenAICompatibleModel):
             self._diagnose_oauth_401(e)
             raise
         except Exception as e:
+            if is_ssl_cert_verification_error(e):
+                raise DatusException(ErrorCode.MODEL_SSL_CERT_ERROR) from e
             logger.error(f"Error in _generate_with_mcp_stream: {str(e)}")
             raise
 

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -139,6 +139,15 @@ def classify_openai_compatible_error(error: Exception) -> tuple[ErrorCode, bool]
     """Classify OpenAI-compatible API errors and return error code and whether it's retryable."""
     error_msg = str(error).lower()
 
+    # TLS certificate failures must be detected first: the litellm SSL error
+    # string contains "internal" (from InternalServerError) and would otherwise
+    # be misclassified as a retryable MODEL_API_ERROR. Not retryable — retrying a
+    # cert mismatch never helps. The dedicated code carries the ssl_verify hint.
+    from datus.utils.ssl_utils import is_ssl_cert_verification_error
+
+    if is_ssl_cert_verification_error(error):
+        return ErrorCode.MODEL_SSL_CERT_ERROR, False
+
     if isinstance(error, APIError):
         # Handle specific HTTP status codes and error types
         if any(indicator in error_msg for indicator in ["401", "unauthorized", "authentication"]):

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -243,6 +243,14 @@ class OpenAICompatibleModel(LLMBaseModel):
         # SSL_VERIFY so litellm honors it across both the agents-SDK LitellmModel path
         # (whose __init__ accepts no ssl argument) and direct litellm.completion calls.
         # The native Anthropic client (ClaudeModel) reads self.ssl_verify directly.
+        #
+        # Why a process-level env var and not a per-request kwarg: litellm does NOT
+        # thread a per-call ``ssl_verify`` into the Anthropic provider's HTTP client
+        # (verified — the kwarg is silently ignored), and a scoped set/restore around
+        # each call would break the agents-SDK streaming path (Runner.run_streamed does
+        # its network I/O after returning). A process global is the only mechanism that
+        # works across all paths. Blast radius is limited: ``SSL_VERIFY`` is a
+        # litellm-specific variable that standard libraries (requests/httpx/curl) ignore.
         from datus.utils.ssl_utils import normalize_ssl_verify, ssl_verify_to_env
 
         ssl_verify_cfg = getattr(self.model_config, "ssl_verify", None)

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -7,6 +7,7 @@
 import asyncio
 import hashlib
 import json
+import os
 import threading
 import time
 from contextlib import nullcontext
@@ -226,6 +227,23 @@ class OpenAICompatibleModel(LLMBaseModel):
         self.api_key = self._get_api_key()
         self.base_url = self._get_base_url()
         self.default_headers = dict(self.model_config.default_headers) if self.model_config.default_headers else None
+
+        # Resolve SSL/TLS verification for this endpoint (e.g. a private gateway CA).
+        # When configured, it takes priority over the SSL_VERIFY / SSL_CERT_FILE env
+        # vars (house convention: config first, env fallback). We materialize it into
+        # SSL_VERIFY so litellm honors it across both the agents-SDK LitellmModel path
+        # (whose __init__ accepts no ssl argument) and direct litellm.completion calls.
+        # The native Anthropic client (ClaudeModel) reads self.ssl_verify directly.
+        from datus.utils.ssl_utils import normalize_ssl_verify, ssl_verify_to_env
+
+        ssl_verify_cfg = getattr(self.model_config, "ssl_verify", None)
+        # Only act on real bool/str config values; a non-(bool|str) (e.g. unset, or a
+        # test double) leaves behavior untouched.
+        if isinstance(ssl_verify_cfg, (bool, str)):
+            self.ssl_verify = normalize_ssl_verify(ssl_verify_cfg)
+            os.environ["SSL_VERIFY"] = ssl_verify_to_env(self.ssl_verify)
+        else:
+            self.ssl_verify = None
 
         # Initialize LiteLLM adapter for unified LLM calls
         self.litellm_adapter = LiteLLMAdapter(

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -56,6 +56,13 @@ class ErrorCode(Enum):
         "300023",
         "Model returned response in illegal format. Response: '{response_preview}' (length: {response_length})",
     )
+    MODEL_SSL_CERT_ERROR = (
+        "300024",
+        "TLS certificate verification failed for the model endpoint. If it uses a private or "
+        "self-signed CA, set `ssl_verify: <path-to-ca.pem>` on the model in agent.yml (or export "
+        "SSL_CERT_FILE=<path-to-ca.pem>). Avoid `ssl_verify: false`, which disables verification. "
+        "See docs/configuration/agent.md (Private or self-signed certificates).",
+    )
 
     # OAuth authentication errors
     OAUTH_NOT_AUTHENTICATED = ("300030", "Not authenticated. Please run OAuth login first.")

--- a/datus/utils/ssl_utils.py
+++ b/datus/utils/ssl_utils.py
@@ -19,6 +19,7 @@ same setting as the native client path.
 
 from typing import Union
 
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -42,6 +43,15 @@ def normalize_ssl_verify(value: Union[bool, str]) -> Union[bool, str]:
     elif isinstance(value, str):
         stripped = value.strip()
         lowered = stripped.lower()
+        if not stripped:
+            raise DatusException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                message_args={
+                    "field_name": "ssl_verify",
+                    "except_values": "true/false or a CA bundle path",
+                    "your_value": "(empty string)",
+                },
+            )
         if lowered in _TRUE_STRINGS:
             verify = True
         elif lowered in _FALSE_STRINGS:
@@ -51,7 +61,14 @@ def normalize_ssl_verify(value: Union[bool, str]) -> Union[bool, str]:
             # configuration errors surface as an explicit TLS error at call time.
             verify = stripped
     else:
-        raise TypeError(f"ssl_verify must be bool or str, got {type(value).__name__}")
+        raise DatusException(
+            ErrorCode.COMMON_FIELD_INVALID,
+            message_args={
+                "field_name": "ssl_verify",
+                "except_values": "bool or str",
+                "your_value": type(value).__name__,
+            },
+        )
 
     if verify is False:
         logger.warning(

--- a/datus/utils/ssl_utils.py
+++ b/datus/utils/ssl_utils.py
@@ -17,7 +17,7 @@ paths (which only accept SSL configuration via env / module globals) honor the
 same setting as the native client path.
 """
 
-from typing import Union
+from typing import Optional, Union
 
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -80,6 +80,42 @@ def normalize_ssl_verify(value: Union[bool, str]) -> Union[bool, str]:
         logger.debug("ssl_verify resolved to custom CA bundle: %s", verify)
 
     return verify
+
+
+# Substrings that identify a TLS certificate-verification failure, regardless of
+# which layer (litellm, httpx, anthropic SDK, stdlib ssl) raised it.
+_SSL_CERT_ERROR_MARKERS = (
+    "certificate_verify_failed",
+    "certificate verify failed",
+    "self-signed certificate",
+    "self signed certificate",
+)
+
+
+def is_ssl_cert_verification_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` (or anything in its cause/context chain) is a TLS
+    certificate-verification failure.
+
+    The chain is walked because higher layers wrap the original
+    ``SSLCertVerificationError`` — e.g. the native Anthropic client surfaces only
+    ``APIConnectionError("Connection error.")`` at the top level, with the SSL
+    detail nested in ``__cause__``.
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    # Bound the walk: real exception chains are short, and the depth cap also
+    # protects against pathological/non-terminating chains (e.g. mock objects
+    # whose ``__cause__`` lazily yields a fresh child on every access).
+    for _ in range(20):
+        if cur is None or id(cur) in seen:
+            break
+        seen.add(id(cur))
+        text = str(cur).lower()
+        if any(marker in text for marker in _SSL_CERT_ERROR_MARKERS):
+            return True
+        nxt = cur.__cause__ or cur.__context__
+        cur = nxt if isinstance(nxt, BaseException) else None
+    return False
 
 
 def ssl_verify_to_env(value: Union[bool, str]) -> str:

--- a/datus/utils/ssl_utils.py
+++ b/datus/utils/ssl_utils.py
@@ -1,0 +1,76 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Helpers for resolving SSL/TLS verification configuration for LLM endpoints.
+
+The ``ssl_verify`` model setting mirrors the ``verify`` argument of httpx and
+litellm:
+
+* ``True``  -> verify against the system / certifi CA bundle (default)
+* ``False`` -> disable verification entirely (discouraged; MITM-exposed)
+* ``str``   -> path to a CA bundle (PEM) to trust, e.g. a private gateway CA
+
+These helpers normalize a user-supplied value into that ``bool | str`` shape and
+render it back for the ``SSL_VERIFY`` environment variable so the litellm code
+paths (which only accept SSL configuration via env / module globals) honor the
+same setting as the native client path.
+"""
+
+from typing import Union
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# String spellings accepted as booleans (case-insensitive), matching litellm.
+_TRUE_STRINGS = {"true"}
+_FALSE_STRINGS = {"false"}
+
+
+def normalize_ssl_verify(value: Union[bool, str]) -> Union[bool, str]:
+    """Normalize a configured ``ssl_verify`` value into an httpx ``verify`` value.
+
+    * ``bool`` is returned as-is.
+    * ``"true"`` / ``"false"`` (any case) are coerced to ``bool``.
+    * Any other non-empty string is treated as a CA bundle path.
+
+    A warning is logged when verification is disabled.
+    """
+    if isinstance(value, bool):
+        verify: Union[bool, str] = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        lowered = stripped.lower()
+        if lowered in _TRUE_STRINGS:
+            verify = True
+        elif lowered in _FALSE_STRINGS:
+            verify = False
+        else:
+            # Treat as a path to a CA bundle. Existence is not enforced here so
+            # configuration errors surface as an explicit TLS error at call time.
+            verify = stripped
+    else:
+        raise TypeError(f"ssl_verify must be bool or str, got {type(value).__name__}")
+
+    if verify is False:
+        logger.warning(
+            "ssl_verify is disabled — TLS certificate verification is OFF for this "
+            "endpoint. This is insecure (MITM-exposed); prefer pointing ssl_verify at "
+            "a CA bundle path instead."
+        )
+    elif isinstance(verify, str):
+        logger.debug("ssl_verify resolved to custom CA bundle: %s", verify)
+
+    return verify
+
+
+def ssl_verify_to_env(value: Union[bool, str]) -> str:
+    """Render a normalized verify value for the ``SSL_VERIFY`` environment variable.
+
+    Booleans become ``"true"`` / ``"false"`` (litellm-compatible spellings); a CA
+    bundle path is returned unchanged.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -101,6 +101,7 @@ The `agent.models` section is used for self-hosted or private-deployment LLM end
 - **`base_url`** — API endpoint URL
 - **`api_key`** — API key (supports `${ENV_VAR}` substitution)
 - **`model`** — Model name / SKU
+- **`ssl_verify`** *(optional)* — TLS verification for this endpoint: `true` (default), `false` to disable (discouraged), or a path to a CA-bundle PEM to trust a private/self-signed gateway CA. Takes priority over the `SSL_VERIFY` / `SSL_CERT_FILE` environment variables. See [Private or self-signed certificates](#private-or-self-signed-certificates).
 
 ```yaml
 agent:
@@ -122,6 +123,49 @@ agent:
     # Not recommended for production
     api_key: "sk-your-actual-key-here"
     ```
+
+### Private or self-signed certificates {#private-or-self-signed-certificates}
+
+When pointing Datus at an internal LLM gateway or staging endpoint whose TLS
+certificate is signed by a **private CA** (one not in the public trust store),
+requests fail with:
+
+```
+litellm.InternalServerError: AnthropicException - [SSL: CERTIFICATE_VERIFY_FAILED]
+certificate verify failed: self-signed certificate in certificate chain
+```
+
+The cause is that Python's bundled `certifi` trust store only contains public
+CAs — it does not read the OS trust store — so a private CA is never trusted
+automatically. Point Datus at the CA bundle instead of disabling verification:
+
+```yaml
+agent:
+  models:
+    claude-staging:
+      type: claude
+      base_url: https://ai.internal.example.com
+      api_key: ${ANTHROPIC_API_KEY}
+      model: claude-3-7-sonnet
+      ssl_verify: /etc/ssl/internal-ca.pem   # trust the private CA; verification stays ON
+```
+
+**Resolution precedence** (first match wins):
+
+```
+ssl_verify (agent.yml)  →  SSL_VERIFY env  →  SSL_CERT_FILE env  →  certifi default
+```
+
+- `ssl_verify` is the project-level setting and takes priority over the env vars.
+- The standard `SSL_CERT_FILE` / `SSL_VERIFY` environment variables work as a
+  no-config alternative (e.g. when IT provisions the CA path machine-wide).
+- To extract a server's CA chain:
+  `openssl s_client -showcerts -connect host:443 </dev/null | openssl x509 -outform PEM > ca.pem`
+
+!!! warning "Do not disable verification"
+    `ssl_verify: false` (or `SSL_VERIFY=false`) turns TLS certificate
+    verification **off** entirely, leaving the connection exposed to
+    man-in-the-middle attacks. Always prefer trusting the CA bundle.
 
 ## Supported LLM Providers
 

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -130,7 +130,7 @@ When pointing Datus at an internal LLM gateway or staging endpoint whose TLS
 certificate is signed by a **private CA** (one not in the public trust store),
 requests fail with:
 
-```
+```text
 litellm.InternalServerError: AnthropicException - [SSL: CERTIFICATE_VERIFY_FAILED]
 certificate verify failed: self-signed certificate in certificate chain
 ```
@@ -152,7 +152,7 @@ agent:
 
 **Resolution precedence** (first match wins):
 
-```
+```text
 ssl_verify (agent.yml)  →  SSL_VERIFY env  →  SSL_CERT_FILE env  →  certifi default
 ```
 

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -162,10 +162,11 @@ ssl_verify (agent.yml)  →  SSL_VERIFY env  →  SSL_CERT_FILE env  →  certif
 - To extract a server's CA chain:
   `openssl s_client -showcerts -connect host:443 </dev/null | openssl x509 -outform PEM > ca.pem`
 
-!!! warning "Do not disable verification"
+!!! warning "Never disable verification"
     `ssl_verify: false` (or `SSL_VERIFY=false`) turns TLS certificate
     verification **off** entirely, leaving the connection exposed to
-    man-in-the-middle attacks. Always prefer trusting the CA bundle.
+    man-in-the-middle attacks. **Do not disable verification** — always resolve
+    certificate problems by trusting the CA bundle instead.
 
 ## Supported LLM Providers
 

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -62,7 +62,7 @@ agent:
 
 当 Datus 连接的是内部 LLM 网关或测试环境，而其 TLS 证书由**私有 CA**（不在公共信任库中）签发时，请求会失败并报错：
 
-```
+```text
 litellm.InternalServerError: AnthropicException - [SSL: CERTIFICATE_VERIFY_FAILED]
 certificate verify failed: self-signed certificate in certificate chain
 ```
@@ -82,7 +82,7 @@ agent:
 
 **解析优先级**（取首个命中项）：
 
-```
+```text
 ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环境变量  →  certifi 默认
 ```
 

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -91,8 +91,8 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 - 提取服务端 CA 证书链：
   `openssl s_client -showcerts -connect host:443 </dev/null | openssl x509 -outform PEM > ca.pem`
 
-!!! warning "请勿关闭校验"
-    `ssl_verify: false`（或 `SSL_VERIFY=false`）会**完全关闭** TLS 证书校验，使连接暴露于中间人攻击。请始终优先选择信任 CA 证书包。
+!!! warning "切勿关闭校验"
+    `ssl_verify: false`（或 `SSL_VERIFY=false`）会**完全关闭** TLS 证书校验，使连接暴露于中间人攻击。**请勿关闭校验**，务必通过信任 CA 证书包来解决证书问题。
 
 ## 支持的提供方
 

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -37,6 +37,7 @@ Chat API 请求可通过请求体中的 `language` 字段按任务覆盖该默�
 - `base_url`：接口基础地址
 - `api_key`：访问密钥（支持环境变量）
 - `model`：具体模型名
+- `ssl_verify`（可选）：该端点的 TLS 校验方式。`true`（默认）、`false`（关闭校验，不推荐），或指向 CA 证书包（PEM）的路径以信任私有/自签名网关 CA。优先级高于 `SSL_VERIFY` / `SSL_CERT_FILE` 环境变量。参见[私有或自签名证书](#private-or-self-signed-certificates)。
 
 ```yaml
 agent:
@@ -56,6 +57,42 @@ agent:
     # 不建议在生产中明文写入
     api_key: "sk-your-actual-key-here"
     ```
+
+### 私有或自签名证书 {#private-or-self-signed-certificates}
+
+当 Datus 连接的是内部 LLM 网关或测试环境，而其 TLS 证书由**私有 CA**（不在公共信任库中）签发时，请求会失败并报错：
+
+```
+litellm.InternalServerError: AnthropicException - [SSL: CERTIFICATE_VERIFY_FAILED]
+certificate verify failed: self-signed certificate in certificate chain
+```
+
+根因是 Python 自带的 `certifi` 信任库只包含公共 CA，且不会读取操作系统信任库，因此私有 CA 永远不会被自动信任。正确做法是让 Datus 信任该 CA 证书包，而不是关闭校验：
+
+```yaml
+agent:
+  models:
+    claude-staging:
+      type: claude
+      base_url: https://ai.internal.example.com
+      api_key: ${ANTHROPIC_API_KEY}
+      model: claude-3-7-sonnet
+      ssl_verify: /etc/ssl/internal-ca.pem   # 信任私有 CA，校验保持开启
+```
+
+**解析优先级**（取首个命中项）：
+
+```
+ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环境变量  →  certifi 默认
+```
+
+- `ssl_verify` 是项目级配置，优先级高于环境变量。
+- 标准的 `SSL_CERT_FILE` / `SSL_VERIFY` 环境变量可作为免配置的替代方案（例如 IT 在机器层面统一下发 CA 路径时）。
+- 提取服务端 CA 证书链：
+  `openssl s_client -showcerts -connect host:443 </dev/null | openssl x509 -outform PEM > ca.pem`
+
+!!! warning "请勿关闭校验"
+    `ssl_verify: false`（或 `SSL_VERIFY=false`）会**完全关闭** TLS 证书校验，使连接暴露于中间人攻击。请始终优先选择信任 CA 证书包。
 
 ## 支持的提供方
 

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -536,6 +536,11 @@ class TestLoadModelConfig:
         cfg = load_model_config({"type": "claude", "model": "claude", "ssl_verify": "${MY_CA}"})
         assert cfg.ssl_verify == "/etc/ssl/from-env.pem"
 
+    @pytest.mark.parametrize("value", [123, ["x"], {"a": 1}])
+    def test_load_ssl_verify_invalid_type_raises(self, value):
+        with pytest.raises(DatusException):
+            load_model_config({"type": "claude", "model": "claude", "ssl_verify": value})
+
     @pytest.mark.parametrize("value", ["/etc/ssl/ca.pem", True, False])
     def test_ssl_verify_round_trips(self, value):
         cfg = ModelConfig(type="claude", api_key="sk", model="claude", ssl_verify=value)

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -518,6 +518,30 @@ class TestLoadModelConfig:
         assert d["type"] == "openai"
         assert d["model"] == "gpt-4"
 
+    def test_ssl_verify_defaults_none(self):
+        cfg = ModelConfig(type="openai", api_key="sk", model="gpt-4")
+        assert cfg.ssl_verify is None
+        assert cfg.to_dict()["ssl_verify"] is None
+
+    def test_load_ssl_verify_passthrough(self):
+        cfg = load_model_config({"type": "claude", "model": "claude", "ssl_verify": "/etc/ssl/ca.pem"})
+        assert cfg.ssl_verify == "/etc/ssl/ca.pem"
+
+    def test_load_ssl_verify_absent_is_none(self):
+        cfg = load_model_config({"type": "claude", "model": "claude"})
+        assert cfg.ssl_verify is None
+
+    def test_load_ssl_verify_env_substitution(self, monkeypatch):
+        monkeypatch.setenv("MY_CA", "/etc/ssl/from-env.pem")
+        cfg = load_model_config({"type": "claude", "model": "claude", "ssl_verify": "${MY_CA}"})
+        assert cfg.ssl_verify == "/etc/ssl/from-env.pem"
+
+    @pytest.mark.parametrize("value", ["/etc/ssl/ca.pem", True, False])
+    def test_ssl_verify_round_trips(self, value):
+        cfg = ModelConfig(type="claude", api_key="sk", model="claude", ssl_verify=value)
+        assert cfg.ssl_verify == value
+        assert cfg.to_dict()["ssl_verify"] == value
+
 
 class TestAgentConfigServiceSelectors:
     def _make(self, tmp_path, *, services=None, agentic_nodes=None):

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -2674,3 +2674,81 @@ class TestAcloseAsyncClients:
         assert any("async anthropic client" in w.lower() and "already closed" in w for w in warned), (
             f"Expected warning naming 'async anthropic client' with the underlying error, got: {warned}"
         )
+
+
+# ---------------------------------------------------------------------------
+# ssl_verify (private/self-signed CA support)
+# ---------------------------------------------------------------------------
+
+
+class TestSslVerify:
+    """``ssl_verify`` config wires into both the litellm path (SSL_VERIFY env
+    materialization) and the native Anthropic client (custom httpx http_client)."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_ssl_env(self):
+        import os
+
+        saved = {k: os.environ.get(k) for k in ("SSL_VERIFY", "SSL_CERT_FILE")}
+        os.environ.pop("SSL_VERIFY", None)
+        os.environ.pop("SSL_CERT_FILE", None)
+        yield
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_ca_path_builds_native_client_and_materializes_env(self):
+        import os
+
+        cfg = _make_model_config(base_url="https://internal.example.com")
+        cfg.ssl_verify = "/etc/ssl/internal-ca.pem"
+        # Patch the transports so we assert verify propagation without httpx
+        # eagerly validating the (fake) CA path on the filesystem.
+        with (
+            patch("httpx.HTTPTransport") as sync_tx,
+            patch("httpx.AsyncHTTPTransport") as async_tx,
+        ):
+            model = _make_claude_model(cfg)
+
+        assert model.ssl_verify == "/etc/ssl/internal-ca.pem"
+        # litellm path: materialized into the SSL_VERIFY env var.
+        assert os.environ["SSL_VERIFY"] == "/etc/ssl/internal-ca.pem"
+        # native path: a custom httpx client is built once with our verify value.
+        assert sync_tx.call_count == 1
+        assert async_tx.call_count == 1
+        assert sync_tx.call_args.kwargs.get("verify") == "/etc/ssl/internal-ca.pem"
+        assert async_tx.call_args.kwargs.get("verify") == "/etc/ssl/internal-ca.pem"
+        # no proxy configured -> the transport carries no proxy.
+        assert "proxy" not in sync_tx.call_args.kwargs
+
+    def test_ssl_verify_false_materializes_false(self):
+        import os
+
+        cfg = _make_model_config()
+        cfg.ssl_verify = False
+        with (
+            patch("httpx.HTTPTransport") as sync_tx,
+            patch("httpx.AsyncHTTPTransport"),
+        ):
+            model = _make_claude_model(cfg)
+
+        assert model.ssl_verify is False
+        assert os.environ["SSL_VERIFY"] == "false"
+        # verify=False still needs an explicit client carrying verify=False.
+        assert sync_tx.call_count == 1
+        assert sync_tx.call_args.kwargs.get("verify") is False
+
+    def test_unset_preserves_default_behavior(self):
+        import os
+
+        cfg = _make_model_config()
+        cfg.ssl_verify = None
+        model = _make_claude_model(cfg)
+
+        assert model.ssl_verify is None
+        # No proxy + no ssl_verify -> no custom client, env untouched.
+        assert model.proxy_client is None
+        assert model.async_proxy_client is None
+        assert "SSL_VERIFY" not in os.environ

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -2689,9 +2689,13 @@ class TestSslVerify:
     def _restore_ssl_env(self):
         import os
 
-        saved = {k: os.environ.get(k) for k in ("SSL_VERIFY", "SSL_CERT_FILE")}
-        os.environ.pop("SSL_VERIFY", None)
-        os.environ.pop("SSL_CERT_FILE", None)
+        # Clear proxy vars too: a stray HTTP(S)_PROXY in CI/dev shells would make
+        # the native path build a proxy transport and break the "no proxy" /
+        # "no custom client" assertions below.
+        keys = ("SSL_VERIFY", "SSL_CERT_FILE", "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")
+        saved = {k: os.environ.get(k) for k in keys}
+        for k in keys:
+            os.environ.pop(k, None)
         yield
         for k, v in saved.items():
             if v is None:

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -134,6 +134,20 @@ class TestClassifyOpenAICompatibleError:
         assert code == ErrorCode.MODEL_AUTHENTICATION_ERROR
         assert retryable is False
 
+    def test_ssl_cert_error_detected_and_not_retryable(self):
+        # The litellm SSL message contains "internal" (InternalServerError) and would
+        # otherwise be misclassified as retryable MODEL_API_ERROR — SSL must win first.
+        err = MagicMock(spec=APIError)
+        err.__str__ = lambda self: (
+            "litellm.InternalServerError: AnthropicException - Cannot connect to host "
+            "ai.staging.example:443 ssl:True [SSLCertVerificationError: [SSL: "
+            "CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate "
+            "in certificate chain]"
+        )
+        code, retryable = classify_openai_compatible_error(err)
+        assert code == ErrorCode.MODEL_SSL_CERT_ERROR
+        assert retryable is False
+
     def test_403_returns_permission_error(self):
         err = MagicMock(spec=APIError)
         err.__str__ = lambda self: "403 forbidden"

--- a/tests/unit_tests/utils/test_ssl_utils.py
+++ b/tests/unit_tests/utils/test_ssl_utils.py
@@ -6,6 +6,7 @@
 
 import pytest
 
+from datus.utils.exceptions import DatusException
 from datus.utils.ssl_utils import normalize_ssl_verify, ssl_verify_to_env
 
 
@@ -38,7 +39,12 @@ class TestNormalizeSslVerify:
 
     @pytest.mark.parametrize("value", [1, 0, None, ["x"], {"a": 1}])
     def test_invalid_type_raises(self, value):
-        with pytest.raises(TypeError):
+        with pytest.raises(DatusException):
+            normalize_ssl_verify(value)
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_empty_string_raises(self, value):
+        with pytest.raises(DatusException):
             normalize_ssl_verify(value)
 
 

--- a/tests/unit_tests/utils/test_ssl_utils.py
+++ b/tests/unit_tests/utils/test_ssl_utils.py
@@ -1,0 +1,58 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/utils/ssl_utils.py. Pure, no network."""
+
+import pytest
+
+from datus.utils.ssl_utils import normalize_ssl_verify, ssl_verify_to_env
+
+
+class TestNormalizeSslVerify:
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_passthrough(self, value):
+        assert normalize_ssl_verify(value) is value
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "  true  "])
+    def test_true_strings_coerced(self, value):
+        assert normalize_ssl_verify(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", " false "])
+    def test_false_strings_coerced(self, value):
+        assert normalize_ssl_verify(value) is False
+
+    def test_path_string_returned_stripped(self):
+        assert normalize_ssl_verify("  /etc/ssl/ca.pem ") == "/etc/ssl/ca.pem"
+
+    def test_path_string_not_coerced_to_bool(self):
+        # A path that merely contains "true"/"false" substrings stays a path.
+        assert normalize_ssl_verify("/etc/ssl/true-ca.pem") == "/etc/ssl/true-ca.pem"
+
+    def test_disable_logs_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            assert normalize_ssl_verify(False) is False
+        assert any("disabled" in r.message.lower() for r in caplog.records)
+
+    @pytest.mark.parametrize("value", [1, 0, None, ["x"], {"a": 1}])
+    def test_invalid_type_raises(self, value):
+        with pytest.raises(TypeError):
+            normalize_ssl_verify(value)
+
+
+class TestSslVerifyToEnv:
+    def test_true(self):
+        assert ssl_verify_to_env(True) == "true"
+
+    def test_false(self):
+        assert ssl_verify_to_env(False) == "false"
+
+    def test_path(self):
+        assert ssl_verify_to_env("/etc/ssl/ca.pem") == "/etc/ssl/ca.pem"
+
+    def test_round_trip_path(self):
+        # Rendering a normalized path and re-normalizing yields the same path.
+        v = normalize_ssl_verify("/etc/ssl/ca.pem")
+        assert normalize_ssl_verify(ssl_verify_to_env(v)) == "/etc/ssl/ca.pem"

--- a/tests/unit_tests/utils/test_ssl_utils.py
+++ b/tests/unit_tests/utils/test_ssl_utils.py
@@ -7,7 +7,11 @@
 import pytest
 
 from datus.utils.exceptions import DatusException
-from datus.utils.ssl_utils import normalize_ssl_verify, ssl_verify_to_env
+from datus.utils.ssl_utils import (
+    is_ssl_cert_verification_error,
+    normalize_ssl_verify,
+    ssl_verify_to_env,
+)
 
 
 class TestNormalizeSslVerify:
@@ -62,3 +66,37 @@ class TestSslVerifyToEnv:
         # Rendering a normalized path and re-normalizing yields the same path.
         v = normalize_ssl_verify("/etc/ssl/ca.pem")
         assert normalize_ssl_verify(ssl_verify_to_env(v)) == "/etc/ssl/ca.pem"
+
+
+class TestIsSslCertVerificationError:
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate",
+            "litellm.InternalServerError: AnthropicException - ... CERTIFICATE_VERIFY_FAILED ...",
+            "certificate verify failed: self signed certificate in certificate chain",
+        ],
+    )
+    def test_direct_message_detected(self, msg):
+        assert is_ssl_cert_verification_error(Exception(msg)) is True
+
+    def test_detected_through_cause_chain(self):
+        # Native Anthropic path: top-level is generic, SSL detail nested in __cause__.
+        inner = Exception("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate")
+        try:
+            try:
+                raise inner
+            except Exception as cause:
+                raise ValueError("Connection error.") from cause
+        except Exception as wrapped:
+            assert is_ssl_cert_verification_error(wrapped) is True
+
+    @pytest.mark.parametrize("msg", ["429 rate limit exceeded", "Connection error.", "401 unauthorized"])
+    def test_unrelated_errors_not_detected(self, msg):
+        assert is_ssl_cert_verification_error(Exception(msg)) is False
+
+    def test_self_referential_chain_terminates(self):
+        # A cyclic __context__ must not loop forever.
+        e = Exception("boom")
+        e.__context__ = e
+        assert is_ssl_cert_verification_error(e) is False


### PR DESCRIPTION
## Why

When Datus is pointed at an internal LLM gateway or staging endpoint whose TLS certificate is signed by a **private CA** (one not in the public `certifi` trust store), every request fails with:

```
litellm.InternalServerError: AnthropicException - [SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: self-signed certificate in certificate chain
```

Today the only way to trust such a CA is the standard `SSL_CERT_FILE` env var, or the blunt `SSL_VERIFY=false` (which disables verification entirely, MITM-exposed). Both depend on ambient shell env — there was **no way to configure TLS trust from `agent.yml`** at the project level.

Root cause of the original error: Python's bundled `certifi` only contains public CAs and does not read the OS trust store, so a private CA is never trusted automatically.

> Note: this is an **enhancement** (a new config parameter), not a bug fix — the existing `SSL_CERT_FILE` env var already worked on both code paths. This adds a first-class, project-level way to express the same intent.

## Before / After

What a user can do to trust a private-CA endpoint:

| | Before | After |
|---|---|---|
| Configure TLS trust in `agent.yml` | ❌ not possible | ✅ `ssl_verify: /path/ca.pem` (or `true` / `false`) |
| Trust a private CA without shell env | ❌ impossible (env only) | ✅ project-level config |
| Disable verification | `SSL_VERIFY=false` (global, insecure) | `ssl_verify: false` (per-model) — discouraged, with warning |
| `SSL_CERT_FILE` env (litellm + native paths) | ✅ honored | ✅ honored (unchanged) |
| `SSL_VERIFY` env (litellm path) | ✅ honored | ✅ honored (unchanged) |
| `SSL_VERIFY` env (native Anthropic path) | ❌ ignored | ❌ ignored (unchanged; out of scope) |
| Precedence | env only | **config-first → env fallback** (`agent.yml ssl_verify → SSL_VERIFY → SSL_CERT_FILE → certifi default`) |

```yaml
# After: agent.yml
agent:
  models:
    claude-staging:
      type: claude
      base_url: https://ai.internal.example.com
      api_key: ${ANTHROPIC_API_KEY}
      model: claude-3-7-sonnet
      ssl_verify: /etc/ssl/internal-ca.pem   # trust the private CA; verification stays ON
```

## Solution

Add a model-level `ssl_verify` setting (value `true` / `false` / path-to-CA-bundle, mirroring httpx/litellm `verify` semantics) that keeps verification **on** while trusting the private CA.

- **`ModelConfig.ssl_verify`** + wired into `load_model_config` (explicit field mapping would otherwise drop it), with `${ENV}` substitution.
- **`datus/utils/ssl_utils.py`** (new): `normalize_ssl_verify` / `ssl_verify_to_env`; warns when verification is disabled.
- **Litellm paths** (`OpenAICompatibleModel`): materializes the resolved value into `SSL_VERIFY` so both the agents-SDK `LitellmModel` path (whose `__init__` accepts no ssl arg) and direct `litellm.completion` honor it.
- **Native Anthropic path** (`ClaudeModel`): builds the httpx transport with `verify=` when configured; **default behavior preserved** — no config and no proxy still leaves `http_client=None`.
- **Precedence is config-first, env-fallback**, matching the existing `model_config.api_key or os.environ.get(...)` house convention. There is no "env overrides yaml" pattern in the codebase.
- **Docs**: `docs/configuration/agent.md` field entry + a "Private or self-signed certificates" section.

Tradeoff: materializing into process env is the only lever for the agents-SDK `LitellmModel` path, whose `__init__` accepts no ssl argument; with multiple differently-configured models the last-initialized active target wins (same global nature as litellm's own `ssl_verify`). Only triggers when `ssl_verify` is explicitly set.

Out of scope: provider-level `ssl_verify`, and client-cert/mTLS (only server-CA trust is addressed).

## Test Cases

CI-level unit tests (no network, no API keys):

- `tests/unit_tests/utils/test_ssl_utils.py` — `normalize_ssl_verify` / `ssl_verify_to_env`: bool passthrough, `'true'`/`'false'` (any case) coercion, path handling, disable-warning, invalid-type guard, round-trip.
- `tests/unit_tests/configuration/test_agent_config.py` — `ModelConfig.ssl_verify` default/round-trip and `load_model_config` passthrough incl. `${ENV}` substitution.
- `tests/unit_tests/models/test_claude_model.py::TestSslVerify` — native httpx transport built with the configured `verify`; `SSL_VERIFY` env materialized for the litellm path; `ssl_verify=false`; and unset → default behavior preserved (no custom client, env untouched).

Verified end-to-end against a local self-signed HTTPS server through the real `load_model_config → ClaudeModel` flow: with `ssl_verify` set both the native and litellm paths trust the CA; with no config behavior is unchanged. Full impacted unit suites pass (994), ruff clean, test-quality audit P0=0/P1=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional per-model `ssl_verify` (`true`, `false`, or a CA bundle PEM path) to control TLS certificate verification.
  * Supports `${...}` placeholder expansion and takes precedence over `SSL_VERIFY` / `SSL_CERT_FILE`.
  * When set to `false`, TLS verification is disabled and a warning is emitted.

* **Bug Fixes**
  * Claude endpoint connections now honor `ssl_verify` even when no proxy is configured.

* **Documentation**
  * Updated agent configuration docs (including private/self-signed certificate guidance and precedence/security notes).

* **Tests**
  * Added/extended unit tests for parsing, normalization, environment propagation, and endpoint wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
