### PR TITLE
[Tool] Nightly coverage gap detection + per-flow issue sync

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -432,6 +432,31 @@ jobs:
             nightly-process-diagnostics.json
           retention-days: 7
 
+      - name: Check documented coverage gaps
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Rollout step 2 (see docs/superpowers/specs/2026-06-20-nightly-coverage-gap-detection-design.md):
+          # runs in --dry-run, so it only writes the digest artifact and makes no
+          # GitHub issue changes. To enable per-flow issue sync, create the
+          # `coverage-gap` label once and drop the --dry-run flag below.
+          uv run python ci/harness/check_nightly_coverage.py \
+            --coverage-map ci/harness/coverage-map.yml \
+            --nightly-manifest nightly-manifest.json \
+            --output coverage-gap-report.md \
+            --repo "${{ github.repository }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --dry-run
+
+      - name: Upload coverage gap report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-gap-report-${{ github.run_number }}
+          path: coverage-gap-report.md
+          retention-days: 7
+
       - name: Send Feishu notification
         if: always()
         uses: actions/github-script@v7

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -434,6 +434,7 @@ jobs:
 
       - name: Check documented coverage gaps
         if: always()
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/ci/harness/check_nightly_coverage.py
+++ b/ci/harness/check_nightly_coverage.py
@@ -91,7 +91,9 @@ def build_ran_set(manifest: dict[str, Any]) -> set[str]:
     for suite in manifest.get("suites", []) or []:
         if not isinstance(suite, dict):
             continue
-        if suite.get("status") == "skipped":
+        # Only suites that were actually executed contribute nodeids; a
+        # whole-suite skip (or any non-executed status) does not.
+        if suite.get("status") not in ("passed", "failed"):
             continue
         collection = suite.get("collection")
         if not isinstance(collection, dict):
@@ -206,6 +208,10 @@ def render_issue_body(result: FlowResult, run_url: str = "") -> str:
     if result.notes:
         lines.append("")
         lines.append(f"**Map notes:** {result.notes}")
+    if result.gaps:
+        lines.append("")
+        lines.append("**Related gaps (from coverage-map):**")
+        lines.extend(f"- {gap}" for gap in result.gaps)
     if run_url:
         lines.append("")
         lines.append(f"Source nightly run: {run_url}")
@@ -238,6 +244,8 @@ def render_digest(results: list[FlowResult]) -> str:
         *table(drift),
         "## Declared gaps",
         *table(gaps),
+        "## OK / whitelisted",
+        *table(ok),
     ]
     return "\n".join(lines)
 
@@ -409,12 +417,22 @@ def main(argv: list[str] | None = None) -> int:
 
     coverage_map = load_coverage_map(Path(args.coverage_map))
     manifest = load_json(Path(args.nightly_manifest))
+    # A missing/corrupt manifest yields an empty ran set, which would make every
+    # covered flow look like drift. Never act on that in live mode — it would
+    # create a wave of false issues when the manifest was merely unavailable.
+    manifest_available = bool(manifest.get("suites"))
     ran_set = build_ran_set(manifest)
     results = classify_all(coverage_map, ran_set)
 
     digest = render_digest(results)
+    if not manifest_available:
+        digest = f"> ⚠️ nightly manifest unavailable or empty — drift results below are not reliable.\n\n{digest}"
     Path(args.output).write_text(digest + "\n", encoding="utf-8")
     print(digest)
+
+    if not manifest_available:
+        print("\n[warn] nightly manifest unavailable or empty; skipping issue sync")
+        return 0
 
     if args.dry_run:
         needs = [r for r in results if r.needs_issue]

--- a/ci/harness/check_nightly_coverage.py
+++ b/ci/harness/check_nightly_coverage.py
@@ -417,21 +417,22 @@ def main(argv: list[str] | None = None) -> int:
 
     coverage_map = load_coverage_map(Path(args.coverage_map))
     manifest = load_json(Path(args.nightly_manifest))
-    # A missing/corrupt manifest yields an empty ran set, which would make every
-    # covered flow look like drift. Never act on that in live mode — it would
-    # create a wave of false issues when the manifest was merely unavailable.
-    manifest_available = bool(manifest.get("suites"))
     ran_set = build_ran_set(manifest)
+    # Gate on actually-executed nodeids, not just a truthy ``suites`` field: a
+    # missing / corrupt / skipped-only / malformed manifest yields an empty ran
+    # set, which would make every covered flow look like drift and (in live mode)
+    # create a wave of false issues. No executed nodeids → skip issue sync.
+    manifest_available = bool(ran_set)
     results = classify_all(coverage_map, ran_set)
 
     digest = render_digest(results)
     if not manifest_available:
-        digest = f"> ⚠️ nightly manifest unavailable or empty — drift results below are not reliable.\n\n{digest}"
+        digest = f"> ⚠️ no executed nodeids in the nightly manifest — drift results below are not reliable.\n\n{digest}"
     Path(args.output).write_text(digest + "\n", encoding="utf-8")
     print(digest)
 
     if not manifest_available:
-        print("\n[warn] nightly manifest unavailable or empty; skipping issue sync")
+        print("\n[warn] nightly manifest unavailable or had no executed nodeids; skipping issue sync")
         return 0
 
     if args.dry_run:

--- a/ci/harness/check_nightly_coverage.py
+++ b/ci/harness/check_nightly_coverage.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Verify coverage-map nightly claims against the nightly manifest and sync issues.
+
+Two responsibilities (both non-blocking):
+
+A. Reality verification — cross-check each flow's ``coverage.nightly`` claim
+   against the nodeids the latest nightly run actually collected and executed
+   (from ``nightly-manifest.json``). A flow that claims ``covered`` but whose
+   nodeids were never collected/run is **drift**.
+B. Per-flow issue sync — for every flow that is ``drift`` or a declared gap
+   (``status in {gap, partial}``), maintain one GitHub tracking issue
+   (create/update/reopen), and close it once the flow is healthy again.
+
+Whitelist: ``status in {manual, external, not_applicable}`` are deliberate,
+PR-reviewed non-coverage decisions and never produce an issue.
+
+See docs/superpowers/specs/2026-06-20-nightly-coverage-gap-detection-design.md.
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+
+# Statuses that mean "intentionally not auto-covered" — never flagged/issued.
+WHITELIST_STATUSES = {"manual", "external", "not_applicable"}
+# Statuses that are a declared backlog gap — always tracked with an issue.
+GAP_STATUSES = {"gap", "partial"}
+
+ISSUE_LABEL = "coverage-gap"
+MARKER_RE = re.compile(r"<!--\s*coverage-flow:(?P<flow_id>[^\s>]+)\s*-->")
+
+
+# ── data model ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class FlowResult:
+    """Outcome of classifying one flow's nightly coverage."""
+
+    flow_id: str
+    group_id: str
+    title: str
+    priority: str
+    status: str
+    docs: list[str] = field(default_factory=list)
+    nightly_nodeids: list[str] = field(default_factory=list)
+    notes: str = ""
+    gaps: list[str] = field(default_factory=list)
+    # Classification outcome.
+    kind: str = "ok"  # one of: ok, drift, declared_gap
+    missing_nodeids: list[str] = field(default_factory=list)
+
+    @property
+    def needs_issue(self) -> bool:
+        return self.kind in ("drift", "declared_gap")
+
+
+# ── pure logic ──────────────────────────────────────────────────────────────
+
+
+def ran_covers(map_nodeid: str, ran_set: Iterable[str]) -> bool:
+    """Does any executed nodeid satisfy a coverage-map nodeid claim?
+
+    Matching is granularity-aware: a file/class claim is satisfied by any ran
+    nodeid *under* it; a function claim by an exact match or a parametrized
+    variant. The ``::`` / ``[`` boundaries avoid prefix false positives
+    (``test_x.py`` must not match ``test_x_extra.py``).
+    """
+    for ran in ran_set:
+        if ran == map_nodeid:
+            return True
+        if ran.startswith(map_nodeid + "::"):
+            return True
+        if ran.startswith(map_nodeid + "["):
+            return True
+    return False
+
+
+def build_ran_set(manifest: dict[str, Any]) -> set[str]:
+    """Union of collected nodeids across nightly suites that were executed.
+
+    A whole-suite ``skipped`` (e.g. filtered out by NIGHTLY_GROUP_FILTER)
+    contributes nothing. Suite red/green is a separate signal — drift only asks
+    "was it collected and run at all".
+    """
+    ran: set[str] = set()
+    for suite in manifest.get("suites", []) or []:
+        if not isinstance(suite, dict):
+            continue
+        if suite.get("status") == "skipped":
+            continue
+        collection = suite.get("collection")
+        if not isinstance(collection, dict):
+            continue
+        for nodeid in collection.get("nodeids", []) or []:
+            if isinstance(nodeid, str) and nodeid:
+                ran.add(nodeid)
+    return ran
+
+
+def iter_flow_dicts(coverage_map: dict[str, Any]) -> Iterable[tuple[str, dict[str, Any]]]:
+    """Yield ``(group_id, flow_dict)`` for every flow in the map."""
+    groups = coverage_map.get("flow_groups")
+    if not isinstance(groups, dict):
+        return
+    for group_id, group in groups.items():
+        if not isinstance(group, dict):
+            continue
+        for flow in group.get("flows", []) or []:
+            if isinstance(flow, dict):
+                yield str(group_id), flow
+
+
+def classify_flow(group_id: str, flow: dict[str, Any], ran_set: set[str]) -> FlowResult:
+    """Classify one flow's nightly coverage as ok / drift / declared_gap."""
+    coverage = flow.get("coverage") if isinstance(flow.get("coverage"), dict) else {}
+    nightly = coverage.get("nightly") if isinstance(coverage.get("nightly"), dict) else {}
+    status = str(nightly.get("status", "")) or "missing"
+    nodeids = [n for n in (nightly.get("nodeids") or []) if isinstance(n, str)]
+
+    result = FlowResult(
+        flow_id=str(flow.get("id", "")),
+        group_id=group_id,
+        title=str(flow.get("title", "")),
+        priority=str(flow.get("priority", "")),
+        status=status,
+        docs=[d for d in (flow.get("docs") or []) if isinstance(d, str)],
+        nightly_nodeids=nodeids,
+        notes=str(nightly.get("notes", "") or "").strip(),
+        gaps=[g for g in (flow.get("gaps") or []) if isinstance(g, str)],
+    )
+
+    if status in WHITELIST_STATUSES:
+        result.kind = "ok"
+    elif status in GAP_STATUSES:
+        result.kind = "declared_gap"
+    elif status == "covered":
+        missing = [nid for nid in nodeids if not ran_covers(nid, ran_set)]
+        if missing:
+            result.kind = "drift"
+            result.missing_nodeids = missing
+        else:
+            result.kind = "ok"
+    else:  # unknown / missing status — treat as a gap so it surfaces.
+        result.kind = "declared_gap"
+    return result
+
+
+def classify_all(coverage_map: dict[str, Any], ran_set: set[str]) -> list[FlowResult]:
+    return [classify_flow(group_id, flow, ran_set) for group_id, flow in iter_flow_dicts(coverage_map)]
+
+
+# ── rendering ───────────────────────────────────────────────────────────────
+
+
+def marker(flow_id: str) -> str:
+    return f"<!-- coverage-flow:{flow_id} -->"
+
+
+def parse_flow_id(body: str) -> str | None:
+    match = MARKER_RE.search(body or "")
+    return match.group("flow_id") if match else None
+
+
+def issue_title(result: FlowResult) -> str:
+    return f"[coverage] {result.title} ({result.flow_id})"
+
+
+def render_issue_body(result: FlowResult, run_url: str = "") -> str:
+    lines = [
+        marker(result.flow_id),
+        "",
+        "_Auto-maintained by `ci/harness/check_nightly_coverage.py`. Do not edit the marker above._",
+        "",
+        f"- **Flow:** `{result.flow_id}` — {result.title}",
+        f"- **Priority:** {result.priority}",
+        f"- **Nightly status (coverage-map):** `{result.status}`",
+        f"- **Classification:** `{result.kind}`",
+    ]
+    if result.kind == "drift":
+        lines.append("")
+        lines.append("### Drift: claimed covered but not run in the latest nightly")
+        lines.append("These nodeids are declared under `coverage.nightly` but were not collected/executed:")
+        lines.extend(f"- `{nid}`" for nid in result.missing_nodeids)
+        lines.append("")
+        lines.append(
+            "Resolve by either (a) fixing the test/marker so it runs in nightly, or "
+            "(b) re-statusing the flow to `manual`/`external`/`not_applicable` with a rationale."
+        )
+    elif result.kind == "declared_gap":
+        lines.append("")
+        lines.append(f"### Declared nightly gap (`{result.status}`)")
+        lines.append("This flow is documented but its nightly coverage is incomplete.")
+    if result.nightly_nodeids:
+        lines.append("")
+        lines.append("**Declared nightly nodeids:**")
+        lines.extend(f"- `{nid}`" for nid in result.nightly_nodeids)
+    if result.docs:
+        lines.append("")
+        lines.append("**Docs:**")
+        lines.extend(f"- `{doc}`" for doc in result.docs)
+    if result.notes:
+        lines.append("")
+        lines.append(f"**Map notes:** {result.notes}")
+    if run_url:
+        lines.append("")
+        lines.append(f"Source nightly run: {run_url}")
+    return "\n".join(lines)
+
+
+def render_digest(results: list[FlowResult]) -> str:
+    drift = [r for r in results if r.kind == "drift"]
+    gaps = [r for r in results if r.kind == "declared_gap"]
+    ok = [r for r in results if r.kind == "ok"]
+
+    def table(rows: list[FlowResult]) -> list[str]:
+        if not rows:
+            return ["_none_", ""]
+        out = ["| Flow | Priority | Status | Detail |", "|---|---|---|---|"]
+        for r in rows:
+            detail = ", ".join(f"`{n}`" for n in r.missing_nodeids) if r.kind == "drift" else (r.notes[:80] or "")
+            out.append(f"| `{r.flow_id}` | {r.priority} | `{r.status}` | {detail} |")
+        out.append("")
+        return out
+
+    lines = [
+        "# Nightly Coverage Gap Report",
+        "",
+        f"- drift (claimed covered, not run): **{len(drift)}**",
+        f"- declared gaps (gap/partial): **{len(gaps)}**",
+        f"- ok / whitelisted: **{len(ok)}**",
+        "",
+        "## Drift",
+        *table(drift),
+        "## Declared gaps",
+        *table(gaps),
+    ]
+    return "\n".join(lines)
+
+
+# ── GitHub issue sync ───────────────────────────────────────────────────────
+
+
+class IssueClient(Protocol):
+    """Minimal GitHub issue surface, injectable for tests."""
+
+    def list_issues(self, label: str) -> list[dict[str, Any]]:
+        """Return open+closed issues with ``label`` (each has number/state/body)."""
+
+    def create_issue(self, title: str, body: str, label: str) -> dict[str, Any]: ...
+
+    def update_issue(self, number: int, title: str, body: str) -> None: ...
+
+    def reopen_issue(self, number: int) -> None: ...
+
+    def comment_issue(self, number: int, body: str) -> None: ...
+
+    def close_issue(self, number: int) -> None: ...
+
+
+def _index_issues_by_flow(client: IssueClient) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for issue in client.list_issues(ISSUE_LABEL):
+        flow_id = parse_flow_id(issue.get("body", "") or "")
+        if flow_id and flow_id not in index:
+            index[flow_id] = issue
+    return index
+
+
+def sync_issues(
+    results: list[FlowResult],
+    client: IssueClient,
+    run_url: str = "",
+) -> list[dict[str, str]]:
+    """Reconcile per-flow tracking issues with the current classification.
+
+    Only touches issues carrying the ``coverage-flow`` marker + label; never
+    human-authored issues. Returns a list of ``{action, flow_id}`` for logging.
+    """
+    actions: list[dict[str, str]] = []
+    existing = _index_issues_by_flow(client)
+
+    for result in results:
+        try:
+            actions.append(_sync_one(result, existing.get(result.flow_id), client, run_url))
+        except Exception as exc:  # noqa: BLE001 - one flow's API failure must not abort the rest
+            actions.append({"action": "error", "flow_id": result.flow_id, "error": str(exc)})
+
+    return [a for a in actions if a["action"] != "noop"]
+
+
+def _sync_one(
+    result: FlowResult,
+    issue: dict[str, Any] | None,
+    client: IssueClient,
+    run_url: str,
+) -> dict[str, str]:
+    if result.needs_issue:
+        body = render_issue_body(result, run_url)
+        title = issue_title(result)
+        if issue is None:
+            client.create_issue(title, body, ISSUE_LABEL)
+            return {"action": "created", "flow_id": result.flow_id}
+        number = int(issue["number"])
+        if str(issue.get("state", "")).lower() == "closed":
+            client.reopen_issue(number)
+        client.update_issue(number, title, body)
+        return {"action": "updated", "flow_id": result.flow_id}
+
+    # Flow is healthy/whitelisted: close any open bot issue.
+    if issue is not None and str(issue.get("state", "")).lower() == "open":
+        number = int(issue["number"])
+        client.comment_issue(number, "Resolved: this flow is now covered or whitelisted. Closing automatically.")
+        client.close_issue(number)
+        return {"action": "closed", "flow_id": result.flow_id}
+    return {"action": "noop", "flow_id": result.flow_id}
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+class GitHubCliIssueClient:
+    """IssueClient backed by the ``gh`` CLI for a single repo (used by main())."""
+
+    def __init__(self, repo: str, *, limit: int = 1000) -> None:
+        self.repo = repo
+        self.limit = limit
+
+    def _run(self, *args: str, capture: bool = False) -> str:
+        import subprocess
+
+        result = subprocess.run(["gh", *args, "--repo", self.repo], check=True, text=True, capture_output=capture)
+        return result.stdout if capture else ""
+
+    def list_issues(self, label: str) -> list[dict[str, Any]]:
+        out = self._run(
+            "issue",
+            "list",
+            "--label",
+            label,
+            "--state",
+            "all",
+            "--limit",
+            str(self.limit),
+            "--json",
+            "number,state,title,body",
+            capture=True,
+        )
+        data = json.loads(out or "[]")
+        return data if isinstance(data, list) else []
+
+    def create_issue(self, title: str, body: str, label: str) -> dict[str, Any]:
+        url = self._run("issue", "create", "--title", title, "--body", body, "--label", label, capture=True)
+        return {"url": url.strip()}
+
+    def update_issue(self, number: int, title: str, body: str) -> None:
+        self._run("issue", "edit", str(number), "--title", title, "--body", body)
+
+    def reopen_issue(self, number: int) -> None:
+        self._run("issue", "reopen", str(number))
+
+    def comment_issue(self, number: int, body: str) -> None:
+        self._run("issue", "comment", str(number), "--body", body)
+
+    def close_issue(self, number: int) -> None:
+        self._run("issue", "close", str(number))
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def load_coverage_map(path: Path) -> dict[str, Any]:
+    import yaml
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--coverage-map", default="ci/harness/coverage-map.yml")
+    parser.add_argument("--nightly-manifest", default="nightly-manifest.json")
+    parser.add_argument("--output", default="coverage-gap-report.md")
+    parser.add_argument("--repo", default="Datus-ai/Datus-agent")
+    parser.add_argument("--run-url", default="")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Classify and write the digest, but make no GitHub writes.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+
+    coverage_map = load_coverage_map(Path(args.coverage_map))
+    manifest = load_json(Path(args.nightly_manifest))
+    ran_set = build_ran_set(manifest)
+    results = classify_all(coverage_map, ran_set)
+
+    digest = render_digest(results)
+    Path(args.output).write_text(digest + "\n", encoding="utf-8")
+    print(digest)
+
+    if args.dry_run:
+        needs = [r for r in results if r.needs_issue]
+        print(f"\n[dry-run] would sync {len(needs)} issue(s): {[r.flow_id for r in needs]}")
+        return 0
+
+    client = GitHubCliIssueClient(repo=args.repo)
+    actions = sync_issues(results, client, run_url=args.run_url)
+    for action in actions:
+        print(f"[issue] {action['action']}: {action['flow_id']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -470,7 +470,7 @@ flow_groups:
             nodeids:
               - tests/integration/tools/test_context_search.py
               - tests/integration/tools/test_context_injection.py
-              - tests/integration/tools/test_context_injection.py::TestContextRetrievalInjection::test_search_knowledge_returns_seeded_entry
+              - tests/integration/tools/test_context_injection.py::TestContextRetrievalInjection::test_search_semantic_objects_surfaces_catalog_table
               - tests/integration/tools/test_context_injection.py::TestContextRetrievalInjection::test_list_subject_tree_nests_all_sources
               - tests/integration/tools/test_context_injection.py::TestContextInjectionRealLLM::test_context_tools_wired_into_node
               - tests/integration/tools/test_context_injection.py::TestContextInjectionRealLLM::test_execute_stream_invokes_context_tools

--- a/docs/superpowers/specs/2026-06-20-nightly-coverage-gap-detection-design.md
+++ b/docs/superpowers/specs/2026-06-20-nightly-coverage-gap-detection-design.md
@@ -1,0 +1,230 @@
+# Nightly Coverage Gap Detection & Per-Flow Issue Sync — Design
+
+Date: 2026-06-20
+Status: Proposed
+
+## 1. Problem
+
+`ci/harness/coverage-map.yml` maps every documented core flow (from the mkdocs
+nav) to its test coverage across four layers (`pr_acceptance`, `merge_queue`,
+`nightly`, `weekly_benchmark`), with a `status` and a list of `nodeids` per
+layer. `ci/harness/validate_coverage_map.py` already gates on:
+
+- every mkdocs nav page being referenced by a flow's `docs:` or explicitly excluded;
+- every declared `nodeid` *existing* (file / class / function present);
+- `docs:` paths existing;
+- `gaps:` issue links being valid GitHub issues.
+
+Two things are **not** covered today:
+
+1. **Reality drift.** The validator confirms a claimed nodeid *exists*, but not
+   that it is actually `@pytest.mark.nightly` and actually *ran* in the latest
+   nightly. A flow can claim `nightly: covered` while its test silently stopped
+   running (no marker, deselected, collection error). This is exactly how
+   `tests/integration/storage/test_platform_doc.py` became an orphan: the file
+   existed, but carried no nightly marker, so nightly collected zero items from
+   it — undetectable by the current validator.
+
+2. **No automatic gap recording.** Declared gaps are hand-written
+   (`status: gap` + a manually pasted issue link). Nothing automatically opens
+   or maintains a tracking issue when a flow is a gap (or drifts), so gaps rely
+   on humans remembering to file and update issues.
+
+## 2. Goals / Non-Goals
+
+**Goals**
+
+- **A — Reality verification:** after each nightly run, cross-check the
+  coverage map's `nightly` layer against what the run *actually collected and
+  executed*, and detect **drift** (claimed-covered but not run).
+- **B — Per-flow issue sync:** for every flow that is a declared gap
+  (`status ∈ {gap, partial, manual}`) **or** has drift, maintain a single
+  GitHub tracking issue (create / update / close), idempotently.
+- Non-blocking: neither A nor B fails the nightly build.
+
+**Non-Goals**
+
+- Not replacing or weakening `validate_coverage_map.py` (it stays as the static
+  PR/merge-queue gate).
+- Not auto-editing `coverage-map.yml` (the job never commits to the repo).
+- Not managing human-authored issues (e.g. the shared `#910`).
+- No separate "waiver"/whitelist field: intentional non-coverage is expressed
+  with the existing `status` values `manual` / `external` / `not_applicable`
+  (see §4.4.1).
+- v1 does **not** distinguish "collected but always skipped" from "ran" (see
+  §7 Known Limitations).
+
+## 3. Existing Infrastructure (reused)
+
+- `ci/harness/coverage-map.yml` — source of truth for flow → coverage claims.
+- `nightly-manifest.json` — produced by `ci/run-nightly-tests.sh` via
+  `ci/nightly_manifest.py`. Per suite it records: `name`, `mode`, `kind`,
+  `status` (passed/failed/skipped), `command`, and — via
+  `record-collection` + `ci/pytest_manifest_plugin.py` (which prints
+  `DATUS_MANIFEST_NODEID <item.nodeid>` for each collected item) — the list of
+  **collected nodeids** for that suite.
+- `validate_coverage_map.py` helpers (`split_nodeid`, flow iteration) — reused
+  where convenient.
+
+## 4. Component: `ci/harness/check_nightly_coverage.py`
+
+A single, self-contained Python script (stdlib + the repo's existing deps).
+
+### 4.1 Inputs (CLI args)
+
+- `--coverage-map ci/harness/coverage-map.yml`
+- `--nightly-manifest nightly-manifest.json`
+- `--output coverage-gap-report.md` (digest artifact)
+- `--repo Datus-ai/Datus-agent`
+- `--github-token $GITHUB_TOKEN` (or env)
+- `--dry-run` (skip all GitHub writes; print intended actions) — default in
+  local/dev and on non-canonical repos.
+
+### 4.2 Build the "ran set"
+
+From the manifest, take the union of `collected nodeids` across every suite
+that was **executed** (status `passed` or `failed`; a whole-suite `skipped`
+contributes nothing). Suite red/green is a separate signal owned by the
+existing failure-classification step — drift only asks "was it collected & run
+at all".
+
+### 4.3 Granularity-aware match predicate
+
+Map nodeids may be file-, class-, or function-level; manifest nodeids are
+always function-level and may carry a `[param]` suffix.
+
+```python
+def ran_covers(map_nodeid: str, ran_set: set[str]) -> bool:
+    for r in ran_set:
+        if r == map_nodeid:                      # exact function match
+            return True
+        if r.startswith(map_nodeid + "::"):      # map is a file or class; r is under it
+            return True
+        if r.startswith(map_nodeid + "["):       # parametrized variant of a function
+            return True
+    return False
+```
+
+Matching is **at the granularity the map declares** (a class-level claim is not
+satisfied by a sibling class running). The `+ "::"` / `+ "["` boundaries avoid
+prefix false-positives (`test_x.py` vs `test_x_extra.py`).
+
+### 4.4 Per-flow classification
+
+For each flow, read `coverage.nightly` (`status`, `nodeids`):
+
+- **drift** — `status == "covered"` and `∃ nodeid: not ran_covers(nodeid, ran_set)`.
+  The drift detail is the list of uncovered nodeids.
+- **declared_gap** — `status ∈ {gap, partial}`.
+- **whitelisted / ok** — `covered` with all nodeids covered, **or**
+  `status ∈ {manual, external, not_applicable}`. These three are the
+  **whitelist**: deliberate, PR-reviewed "intentionally not auto-covered"
+  decisions (each carries a rationale in `notes`). They are never flagged and
+  never get an auto-issue.
+
+A flow "needs an issue" iff it is `drift` or `declared_gap`.
+
+### 4.4.1 Whitelisting (no separate waiver field)
+
+Whitelisting reuses the existing `status` vocabulary rather than a new field.
+To stop nagging on a flow that is currently `gap`/`partial`/drifting and is
+deliberately not going to be auto-covered, the author changes its `nightly`
+`status` to `manual` (or `external` / `not_applicable`) with a rationale in
+`notes`. This routes the decision through the existing coverage-map review
+governance (the change is reviewed in a PR), and the next nightly run
+auto-closes any tracking issue the flow had. A drifting flow is therefore
+resolved one of two ways: fix the test/marker so it actually runs (→ `covered`
+holds), or re-status it to a whitelist value (→ accepted, issue closed).
+
+### 4.5 Per-flow issue sync (B)
+
+Idempotency without repo writes: each bot issue carries a hidden marker in its
+body and a label.
+
+- Marker: `<!-- coverage-flow:<flow_id> -->`
+- Label: `coverage-gap`
+
+Lookup: list open+closed issues with label `coverage-gap`, index by the marker
+to find the issue for a `flow_id`.
+
+Lifecycle per flow:
+
+| Flow state | Existing bot issue? | Action |
+|---|---|---|
+| needs issue (drift / gap) | none | **create** (title, body, label, marker) |
+| needs issue | open | **update body** to current state (idempotent) |
+| needs issue | closed | **reopen** + update body |
+| ok | open | **comment** "resolved by nightly <date>" + **close** |
+| ok | none/closed | no-op |
+
+Issue body contains: flow id + title, priority, layer/status, `docs:` links,
+the declared `nightly` nodeids, the **drift detail** (claimed-but-not-run
+nodeids) when applicable, the map's `gaps:`/notes, the nightly run URL, and the
+marker. The job only ever touches issues that carry the marker+label — never
+human issues.
+
+### 4.6 Digest output
+
+Always write a markdown digest (`coverage-gap-report.md`): tables of `drift`,
+`declared_gap`, and `ok` flows, uploaded as a nightly artifact and usable as a
+job summary. This is produced even in `--dry-run`.
+
+## 5. CI Integration
+
+Add a step to the nightly workflow, **after** `run-nightly-tests.sh` (so
+`nightly-manifest.json` exists on disk), gated to run only:
+
+- on the canonical repo (`github.repository == 'Datus-ai/Datus-agent'`), and
+- on the scheduled nightly trigger (not PRs / forks).
+
+It uses `secrets.GITHUB_TOKEN` (has `issues: write` on the same repo). Outside
+those conditions it runs in `--dry-run` (report only, no GitHub writes). The
+step is non-blocking: it does not affect the nightly job's pass/fail.
+
+## 6. Error Handling
+
+- Missing/oversized/garbled manifest → emit digest noting "manifest
+  unavailable", skip issue sync, exit 0 with a warning.
+- GitHub API failure on one flow → log, continue to the next flow; never abort
+  the whole sync; exit 0.
+- The script exits non-zero **only** on its own programming error
+  (unhandled exception), so a bug is visible without flaking nightly.
+
+## 7. Known Limitations & Future Work
+
+- **Collected-but-always-skipped is not drift in v1.** `record-collection`
+  uses `--collect-only`, which lists `skipif`-skipped tests. So a flow whose
+  only nightly tests are credential/network-gated (e.g. the GitHub/Web
+  `test_platform_doc.py` classes) appears in the ran set and is *not* flagged.
+  These are legitimate external gates and are expected to be marked `manual` /
+  `gap` in the map. v1 catches the dangerous case — **never collected**
+  (true orphan) — which is what silently rots.
+- **Future enhancement (optional):** a per-nodeid outcome plugin run during the
+  *actual* nightly (not `--collect-only`) recording pass/skip/fail per nodeid,
+  letting A also flag "collected but always skipped". This is a larger change
+  to the nightly infra and is deferred.
+
+## 8. Testing
+
+Deterministic unit tests under `tests/unit_tests/ci/` (no network, GitHub API
+mocked):
+
+- `ran_covers` granularity matrix: file/class/function/parametrized × hit/miss,
+  prefix-boundary cases.
+- `build_ran_set`: skipped-suite contributes nothing; executed suites union.
+- classification: drift / declared_gap / ok from synthetic map + manifest,
+  including the `test_platform_doc.py`-orphan scenario (claims covered, file
+  not in ran set → drift), and the whitelist case (`manual` / `external` /
+  `not_applicable` → no issue even with no matching ran nodeids).
+- issue body rendering + marker/label round-trip (parse a rendered body back to
+  `flow_id`).
+- issue sync decision table (create/update/reopen/close) with a fake GitHub
+  client, asserting it never touches non-marker issues.
+
+## 9. Rollout
+
+1. Land the script + unit tests (no workflow change) — exercised via `--dry-run`.
+2. Wire the non-blocking nightly step in `--dry-run`; inspect the digest for a
+   few nights.
+3. Flip to live issue sync once the digest looks right; create the
+   `coverage-gap` label.

--- a/tests/unit_tests/ci/harness/test_check_nightly_coverage.py
+++ b/tests/unit_tests/ci/harness/test_check_nightly_coverage.py
@@ -281,3 +281,62 @@ def test_render_digest_counts_each_bucket() -> None:
     assert "drift (claimed covered, not run): **1**" in digest
     assert "declared gaps (gap/partial): **2**" in digest
     assert "ok / whitelisted: **1**" in digest
+
+
+def test_digest_includes_ok_whitelisted_section() -> None:
+    digest = cnc.render_digest([_result("kept.ok", "ok")])
+    assert "## OK / whitelisted" in digest
+    assert "`kept.ok`" in digest
+
+
+# ── review fixes ─────────────────────────────────────────────────────────────
+
+
+def test_build_ran_set_excludes_non_executed_status() -> None:
+    # Only passed/failed contribute; an unknown/errored status must not.
+    manifest = {
+        "suites": [
+            {"name": "ok", "status": "passed", "collection": {"nodeids": ["t/a.py::t1"]}},
+            {"name": "weird", "status": "errored", "collection": {"nodeids": ["t/b.py::t2"]}},
+        ]
+    }
+    assert cnc.build_ran_set(manifest) == {"t/a.py::t1"}
+
+
+def test_issue_body_includes_related_gaps() -> None:
+    flow = _flow(
+        "g.f",
+        "gap",
+        [],
+    )
+    result = cnc.classify_flow("g", flow, set())
+    result.gaps = ["https://github.com/Datus-ai/Datus-agent/issues/910"]
+    body = cnc.render_issue_body(result)
+    assert "Related gaps" in body
+    assert "issues/910" in body
+
+
+def test_main_skips_issue_sync_when_manifest_unavailable(tmp_path: Path) -> None:
+    # A missing manifest must NOT trigger issue sync (would mass-create issues).
+    cov_map = tmp_path / "coverage-map.yml"
+    cov_map.write_text(
+        "flow_groups:\n"
+        "  g:\n"
+        "    flows:\n"
+        "      - id: g.f\n"
+        "        title: F\n"
+        "        coverage:\n"
+        "          nightly:\n"
+        "            status: covered\n"
+        "            nodeids: [t/a.py::t1]\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.md"
+    # No --dry-run: the guard (not the dry-run path) must short-circuit before
+    # any GitHub client is constructed.
+    rc = cnc.main(
+        ["--coverage-map", str(cov_map), "--nightly-manifest", str(tmp_path / "missing.json"), "--output", str(out)]
+    )
+    assert rc == 0
+    report = out.read_text(encoding="utf-8")
+    assert "manifest unavailable" in report

--- a/tests/unit_tests/ci/harness/test_check_nightly_coverage.py
+++ b/tests/unit_tests/ci/harness/test_check_nightly_coverage.py
@@ -1,0 +1,283 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ci/harness/check_nightly_coverage.py (deterministic, no network)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[4] / "ci" / "harness" / "check_nightly_coverage.py"
+_spec = importlib.util.spec_from_file_location("check_nightly_coverage", _MODULE_PATH)
+cnc = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(cnc)
+
+
+# ── ran_covers: granularity matrix ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "map_nodeid, ran, expected",
+    [
+        # file-level claim
+        (
+            "tests/integration/storage/test_platform_doc.py",
+            {"tests/integration/storage/test_platform_doc.py::C::t"},
+            True,
+        ),
+        ("tests/integration/storage/test_platform_doc.py", {"tests/integration/storage/test_other.py::C::t"}, False),
+        # prefix boundary: must not match a sibling file with a longer name
+        ("tests/a/test_x.py", {"tests/a/test_x_extra.py::C::t"}, False),
+        # class-level claim
+        ("tests/a/test_x.py::TestA", {"tests/a/test_x.py::TestA::test_y"}, True),
+        ("tests/a/test_x.py::TestA", {"tests/a/test_x.py::TestB::test_y"}, False),
+        # function-level: exact
+        ("tests/a/test_x.py::TestA::test_y", {"tests/a/test_x.py::TestA::test_y"}, True),
+        # function-level: parametrized variant
+        ("tests/a/test_x.py::TestA::test_y", {"tests/a/test_x.py::TestA::test_y[case1]"}, True),
+        # function-level: a different function with a shared prefix must not match
+        ("tests/a/test_x.py::TestA::test_y", {"tests/a/test_x.py::TestA::test_y2"}, False),
+    ],
+)
+def test_ran_covers_granularity(map_nodeid: str, ran: set[str], expected: bool) -> None:
+    assert cnc.ran_covers(map_nodeid, ran) is expected
+
+
+# ── build_ran_set ───────────────────────────────────────────────────────────
+
+
+def test_build_ran_set_unions_executed_suites_and_skips_skipped() -> None:
+    manifest = {
+        "suites": [
+            {"name": "A", "status": "passed", "collection": {"nodeids": ["t/a.py::t1", "t/a.py::t2"]}},
+            {"name": "B", "status": "failed", "collection": {"nodeids": ["t/b.py::t1"]}},
+            # a whole-suite skip must contribute nothing even if it has a collection
+            {"name": "C", "status": "skipped", "collection": {"nodeids": ["t/c.py::t1"]}},
+            # a suite without a collection block is ignored
+            {"name": "D", "status": "passed"},
+        ]
+    }
+    assert cnc.build_ran_set(manifest) == {"t/a.py::t1", "t/a.py::t2", "t/b.py::t1"}
+
+
+def test_build_ran_set_handles_empty_or_garbled() -> None:
+    assert cnc.build_ran_set({}) == set()
+    assert cnc.build_ran_set({"suites": None}) == set()
+    assert cnc.build_ran_set({"suites": ["not-a-dict"]}) == set()
+
+
+# ── classification ──────────────────────────────────────────────────────────
+
+
+def _flow(flow_id: str, status: str, nodeids: list[str], **extra: Any) -> dict[str, Any]:
+    flow: dict[str, Any] = {
+        "id": flow_id,
+        "title": extra.get("title", flow_id),
+        "priority": extra.get("priority", "p1"),
+        "coverage": {"nightly": {"status": status, "nodeids": nodeids}},
+    }
+    if "notes" in extra:
+        flow["coverage"]["nightly"]["notes"] = extra["notes"]
+    if "docs" in extra:
+        flow["docs"] = extra["docs"]
+    return flow
+
+
+def test_classify_covered_and_ran_is_ok() -> None:
+    flow = _flow("g.f", "covered", ["t/a.py::t1"])
+    result = cnc.classify_flow("g", flow, {"t/a.py::t1"})
+    assert result.kind == "ok"
+    assert result.needs_issue is False
+
+
+def test_classify_covered_but_not_run_is_drift() -> None:
+    # The platform_doc-orphan scenario: claims covered, file never collected.
+    flow = _flow("kb.platform", "covered", ["tests/integration/storage/test_platform_doc.py"])
+    result = cnc.classify_flow("kb", flow, ran_set=set())
+    assert result.kind == "drift"
+    assert result.missing_nodeids == ["tests/integration/storage/test_platform_doc.py"]
+    assert result.needs_issue is True
+
+
+def test_classify_partial_drift_lists_only_missing_nodeids() -> None:
+    flow = _flow("g.f", "covered", ["t/a.py::t1", "t/b.py::t2"])
+    result = cnc.classify_flow("g", flow, {"t/a.py::t1"})  # only the first ran
+    assert result.kind == "drift"
+    assert result.missing_nodeids == ["t/b.py::t2"]
+
+
+@pytest.mark.parametrize("status", ["gap", "partial"])
+def test_classify_declared_gap_needs_issue(status: str) -> None:
+    result = cnc.classify_flow("g", _flow("g.f", status, []), set())
+    assert result.kind == "declared_gap"
+    assert result.needs_issue is True
+
+
+@pytest.mark.parametrize("status", ["manual", "external", "not_applicable"])
+def test_classify_whitelist_never_needs_issue(status: str) -> None:
+    # Even with declared nodeids that did not run, whitelist statuses are ok.
+    result = cnc.classify_flow("g", _flow("g.f", status, ["t/a.py::t1"]), set())
+    assert result.kind == "ok"
+    assert result.needs_issue is False
+
+
+def test_classify_unknown_status_surfaces_as_gap() -> None:
+    flow = {"id": "g.f", "title": "F", "coverage": {"nightly": {"status": "", "nodeids": []}}}
+    assert cnc.classify_flow("g", flow, set()).kind == "declared_gap"
+
+
+def test_classify_all_iterates_groups_and_flows() -> None:
+    coverage_map = {
+        "flow_groups": {
+            "g1": {"flows": [_flow("g1.a", "covered", ["t/a.py::t1"]), _flow("g1.b", "gap", [])]},
+            "g2": {"flows": [_flow("g2.c", "manual", [])]},
+        }
+    }
+    results = cnc.classify_all(coverage_map, {"t/a.py::t1"})
+    by_id = {r.flow_id: r.kind for r in results}
+    assert by_id == {"g1.a": "ok", "g1.b": "declared_gap", "g2.c": "ok"}
+
+
+# ── marker round-trip + rendering ───────────────────────────────────────────
+
+
+def test_marker_round_trips_through_issue_body() -> None:
+    flow = _flow("kb.platform_doc", "gap", ["t/a.py::t1"])
+    result = cnc.classify_flow("kb", flow, set())
+    body = cnc.render_issue_body(result, run_url="https://example/run/1")
+    assert cnc.parse_flow_id(body) == "kb.platform_doc"
+
+
+def test_drift_body_lists_missing_nodeids() -> None:
+    flow = _flow("g.f", "covered", ["t/a.py::missing"])
+    result = cnc.classify_flow("g", flow, set())
+    body = cnc.render_issue_body(result)
+    assert "Drift" in body
+    assert "t/a.py::missing" in body
+
+
+def test_parse_flow_id_returns_none_without_marker() -> None:
+    assert cnc.parse_flow_id("just some text, no marker") is None
+
+
+# ── sync_issues decision table ──────────────────────────────────────────────
+
+
+class FakeIssueClient:
+    """In-memory IssueClient double recording every call."""
+
+    def __init__(self, issues: list[dict[str, Any]] | None = None) -> None:
+        self.issues = issues or []
+        self.calls: list[tuple[str, Any]] = []
+        self._next_number = 1000
+
+    def list_issues(self, label: str) -> list[dict[str, Any]]:
+        self.calls.append(("list", label))
+        return list(self.issues)
+
+    def create_issue(self, title: str, body: str, label: str) -> dict[str, Any]:
+        self.calls.append(("create", title))
+        self._next_number += 1
+        return {"number": self._next_number}
+
+    def update_issue(self, number: int, title: str, body: str) -> None:
+        self.calls.append(("update", number))
+
+    def reopen_issue(self, number: int) -> None:
+        self.calls.append(("reopen", number))
+
+    def comment_issue(self, number: int, body: str) -> None:
+        self.calls.append(("comment", number))
+
+    def close_issue(self, number: int) -> None:
+        self.calls.append(("close", number))
+
+
+def _result(flow_id: str, kind: str) -> "cnc.FlowResult":
+    return cnc.FlowResult(flow_id=flow_id, group_id="g", title=flow_id, priority="p1", status=kind, kind=kind)
+
+
+def test_sync_creates_issue_when_gap_and_none_exists() -> None:
+    client = FakeIssueClient(issues=[])
+    actions = cnc.sync_issues([_result("g.f", "declared_gap")], client)
+    assert actions == [{"action": "created", "flow_id": "g.f"}]
+    assert ("create", cnc.issue_title(_result("g.f", "declared_gap"))) in client.calls
+
+
+def test_sync_updates_open_issue_when_still_gap() -> None:
+    issues = [{"number": 7, "state": "open", "body": cnc.marker("g.f")}]
+    client = FakeIssueClient(issues=issues)
+    actions = cnc.sync_issues([_result("g.f", "drift")], client)
+    assert actions == [{"action": "updated", "flow_id": "g.f"}]
+    assert ("update", 7) in client.calls
+    assert ("reopen", 7) not in client.calls
+
+
+def test_sync_reopens_then_updates_closed_issue_when_gap_returns() -> None:
+    issues = [{"number": 8, "state": "closed", "body": cnc.marker("g.f")}]
+    client = FakeIssueClient(issues=issues)
+    cnc.sync_issues([_result("g.f", "declared_gap")], client)
+    assert ("reopen", 8) in client.calls
+    assert ("update", 8) in client.calls
+
+
+def test_sync_closes_open_issue_when_flow_healthy() -> None:
+    issues = [{"number": 9, "state": "open", "body": cnc.marker("g.f")}]
+    client = FakeIssueClient(issues=issues)
+    actions = cnc.sync_issues([_result("g.f", "ok")], client)
+    assert actions == [{"action": "closed", "flow_id": "g.f"}]
+    assert ("comment", 9) in client.calls
+    assert ("close", 9) in client.calls
+
+
+def test_sync_ignores_healthy_flow_without_existing_issue() -> None:
+    client = FakeIssueClient(issues=[])
+    actions = cnc.sync_issues([_result("g.f", "ok")], client)
+    assert actions == []  # noop filtered out
+
+
+def test_sync_never_touches_unmarked_issues() -> None:
+    # A human issue carrying the label but no marker must be left alone.
+    issues = [{"number": 910, "state": "open", "body": "human-authored, no marker"}]
+    client = FakeIssueClient(issues=issues)
+    cnc.sync_issues([_result("g.f", "declared_gap")], client)
+    # It created a NEW issue (didn't reuse 910) and never updated/closed 910.
+    assert ("create", cnc.issue_title(_result("g.f", "declared_gap"))) in client.calls
+    assert all(call[0] not in ("update", "close", "comment", "reopen") or call[1] != 910 for call in client.calls)
+
+
+def test_sync_continues_after_one_flow_errors() -> None:
+    class FlakyClient(FakeIssueClient):
+        def create_issue(self, title: str, body: str, label: str) -> dict[str, Any]:
+            if "boom" in title:
+                raise RuntimeError("gh failed")
+            return super().create_issue(title, body, label)
+
+    client = FlakyClient(issues=[])
+    results = [_result("g.boom", "declared_gap"), _result("g.ok", "declared_gap")]
+    actions = cnc.sync_issues(results, client)
+    kinds = {a["flow_id"]: a["action"] for a in actions}
+    assert kinds["g.boom"] == "error"
+    assert kinds["g.ok"] == "created"
+
+
+# ── digest ──────────────────────────────────────────────────────────────────
+
+
+def test_render_digest_counts_each_bucket() -> None:
+    results = [
+        _result("a", "drift"),
+        _result("b", "declared_gap"),
+        _result("c", "declared_gap"),
+        _result("d", "ok"),
+    ]
+    digest = cnc.render_digest(results)
+    assert "drift (claimed covered, not run): **1**" in digest
+    assert "declared gaps (gap/partial): **2**" in digest
+    assert "ok / whitelisted: **1**" in digest

--- a/tests/unit_tests/ci/harness/test_check_nightly_coverage.py
+++ b/tests/unit_tests/ci/harness/test_check_nightly_coverage.py
@@ -316,10 +316,8 @@ def test_issue_body_includes_related_gaps() -> None:
     assert "issues/910" in body
 
 
-def test_main_skips_issue_sync_when_manifest_unavailable(tmp_path: Path) -> None:
-    # A missing manifest must NOT trigger issue sync (would mass-create issues).
-    cov_map = tmp_path / "coverage-map.yml"
-    cov_map.write_text(
+def _write_cov_map(path: Path) -> Path:
+    path.write_text(
         "flow_groups:\n"
         "  g:\n"
         "    flows:\n"
@@ -331,12 +329,29 @@ def test_main_skips_issue_sync_when_manifest_unavailable(tmp_path: Path) -> None
         "            nodeids: [t/a.py::t1]\n",
         encoding="utf-8",
     )
+    return path
+
+
+@pytest.mark.parametrize(
+    "manifest_text",
+    [
+        None,  # missing file
+        '{"suites": []}',  # empty
+        '{"suites": [{"status": "skipped", "collection": {"nodeids": ["t/a.py::t1"]}}]}',  # skipped-only
+        '{"suites": "bad"}',  # malformed but truthy
+    ],
+)
+def test_main_skips_issue_sync_without_executed_nodeids(tmp_path: Path, manifest_text: str | None) -> None:
+    # Any manifest that yields no *executed* nodeids must skip issue sync (else
+    # live mode would mass-create false-drift issues). No --dry-run: the guard
+    # must short-circuit before any GitHub client is constructed.
+    cov_map = _write_cov_map(tmp_path / "coverage-map.yml")
+    manifest = tmp_path / "manifest.json"
+    if manifest_text is not None:
+        manifest.write_text(manifest_text, encoding="utf-8")
     out = tmp_path / "report.md"
-    # No --dry-run: the guard (not the dry-run path) must short-circuit before
-    # any GitHub client is constructed.
-    rc = cnc.main(
-        ["--coverage-map", str(cov_map), "--nightly-manifest", str(tmp_path / "missing.json"), "--output", str(out)]
-    )
+
+    rc = cnc.main(["--coverage-map", str(cov_map), "--nightly-manifest", str(manifest), "--output", str(out)])
+
     assert rc == 0
-    report = out.read_text(encoding="utf-8")
-    assert "manifest unavailable" in report
+    assert "no executed nodeids" in out.read_text(encoding="utf-8")


### PR DESCRIPTION
## Why

`ci/harness/coverage-map.yml` + `validate_coverage_map.py` already gate that every
documented flow maps to tests and that declared nodeids *exist*. They do **not**
verify that a flow's claimed **nightly** coverage actually *ran*: a test can
silently stop running (no `@pytest.mark.nightly`, deselected, renamed) while the
map still says `covered` — which is exactly how `tests/integration/storage/test_platform_doc.py`
became an orphan. Declared gaps are also tracked entirely by hand.

## Solution

Add `ci/harness/check_nightly_coverage.py` (non-blocking, two responsibilities):

- **A — reality verification:** build the set of nodeids the latest nightly run
  actually collected/executed (from `nightly-manifest.json`) and cross-check each
  flow's `coverage.nightly` claim with a granularity-aware matcher
  (file/class/function + parametrized). A flow claiming `covered` whose nodeids
  were never collected is **drift**.
- **B — per-flow issue sync:** for each `drift`/`gap`/`partial` flow, maintain one
  GitHub tracking issue (create/update/reopen/close), idempotent via a hidden
  `<!-- coverage-flow:<id> -->` marker + `coverage-gap` label. Whitelist statuses
  (`manual`/`external`/`not_applicable`) never produce an issue, and the job never
  touches human-authored issues or edits the map.

Wired into `run-nightly.yml` after the nightly run, **in `--dry-run`** for now
(writes only the digest artifact). Enabling issue sync = create the `coverage-gap`
label and drop `--dry-run`.

Running the new check against a real 243-nodeid collection already surfaced a
stale map entry — `data_access.context_injection` claimed a nightly nodeid
(`...::test_search_knowledge_returns_seeded_entry`) that no longer exists — which
this PR also fixes.

Design spec: `docs/superpowers/specs/2026-06-20-nightly-coverage-gap-detection-design.md`.

## Test Cases

- `tests/unit_tests/ci/harness/test_check_nightly_coverage.py` — 31 deterministic
  unit tests (GitHub API mocked, no network): `ran_covers` granularity matrix,
  `build_ran_set` (skips whole-suite skips), classification (drift / declared_gap /
  whitelist, incl. the `test_platform_doc.py`-orphan drift scenario), marker
  round-trip, issue-sync decision table (create/update/reopen/close, never touches
  unmarked issues, per-flow error resilience), and digest rendering.
- No nightly/integration test added: this is a CI harness tool, validated by the
  unit suite plus a local run against a real nightly collection. `ci/` is outside
  the coverage source, so it adds no measured lines.

Local gates: ruff clean; `audit_tests --diff-only` P0=0/P1=0; `run-pr-tests` 358
passed, diff coverage 100%; `validate_coverage_map --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added design specification for nightly coverage gap detection, reporting, and automated issue tracking.

* **Tests**
  * Added comprehensive unit tests covering coverage analysis, gap detection, and issue synchronization logic.

* **Chores**
  * Configured nightly CI workflow to automatically detect coverage gaps, generate detailed reports, and upload artifacts with 7-day retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a design specification for detecting nightly coverage gaps and syncing per-flow tracking items.

* **New Features**
  * Nightly jobs now generate a coverage-gap report artifact that summarizes drift/declared gaps and OK/whitelisted flows.

* **Tests**
  * Expanded unit test coverage for nightly gap classification, digest rendering/parsing, issue-sync decisioning, and safe behavior when the nightly manifest has no executed nodeids.

* **Chores**
  * Enhanced nightly CI to run a non-blocking coverage-gap check and upload the report (7-day retention).
  * Updated the nightly coverage map to include an additional context-injection test nodeid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->