### PR TITLE
[BugFix] Isolate BIRD SQLite test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import argparse
 import os
+import shutil
+import sqlite3
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -19,6 +21,8 @@ TEST_CONF_DIR = Path(__file__).parent / "conf"
 RERUN_LOG_MAX_LINES = int(os.getenv("DATUS_RERUN_LOG_MAX_LINES", "80"))
 RERUN_CAPTURE_LOG_MAX_LINES = int(os.getenv("DATUS_RERUN_CAPTURE_LOG_MAX_LINES", "40"))
 _DATUS_RERUN_REPORTS: list[dict[str, object]] = []
+_BIRD_DEV_DATABASES = Path("benchmark/bird/dev_20240627/dev_databases")
+_GENERATED_SQLITE_TABLES = ("mf_time_spine",)
 
 
 @pytest.fixture
@@ -146,6 +150,86 @@ def load_acceptance_config(datasource: str = "snowflake", home: str = "") -> Age
     return load_agent_config(
         config=str(TEST_CONF_DIR / "agent.yml"), datasource=datasource, home=home, reload=True, force=True, yes=True
     )
+
+
+def _sqlite_uri_to_path(uri: str) -> Path:
+    if uri.startswith("sqlite:///"):
+        return Path(uri.removeprefix("sqlite:///")).resolve()
+    return Path(uri).expanduser().resolve()
+
+
+def _sqlite_path_to_uri(path: Path) -> str:
+    return f"sqlite:///{path.resolve().as_posix()}"
+
+
+def _drop_generated_sqlite_tables(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        for table in _GENERATED_SQLITE_TABLES:
+            conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def isolate_bird_sqlite_databases(
+    agent_config: AgentConfig,
+    tmp_root: Path,
+    database_names: Iterable[str],
+    *,
+    reuse_existing: bool = False,
+) -> Path:
+    """Repoint BIRD SQLite datasources at isolated writable database copies.
+
+    Nightly/acceptance configs intentionally reference the developer or CI
+    benchmark checkout under ``~/benchmark``. Tests that initialize adapters
+    capable of DDL, such as MetricFlow, must not write support tables back into
+    that shared fixture. This helper copies the requested databases into a
+    tmp-root benchmark layout, removes known generated support tables from the
+    copies, and rewrites both the ``bird_sqlite`` glob datasource and any
+    single-file datasource that points at a copied database.
+    """
+    names = tuple(dict.fromkeys(database_names))
+    if not names:
+        raise ValueError("database_names must contain at least one database")
+
+    source_root = Path.home() / _BIRD_DEV_DATABASES
+    if not source_root.exists():
+        pytest.skip(f"BIRD benchmark database root not found: {source_root}")
+
+    dest_root = Path(tmp_root) / _BIRD_DEV_DATABASES
+    copied_paths: dict[str, Path] = {}
+    for name in names:
+        src = source_root / name / f"{name}.sqlite"
+        if not src.exists():
+            pytest.skip(f"BIRD benchmark SQLite database not found: {src}")
+        dst = dest_root / name / src.name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if not reuse_existing or not dst.exists():
+            shutil.copy2(src, dst)
+        _drop_generated_sqlite_tables(dst)
+        copied_paths[name] = dst.resolve()
+
+    for cfg in agent_config.services.datasources.values():
+        if cfg.path_pattern:
+            pattern_path = Path(os.path.expanduser(cfg.path_pattern)).resolve()
+            if source_root in pattern_path.parents or pattern_path == source_root:
+                cfg.path_pattern = str(dest_root / "**/*.sqlite")
+
+        if not cfg.uri:
+            continue
+        try:
+            db_path = _sqlite_uri_to_path(cfg.uri)
+        except Exception:
+            continue
+        copied = copied_paths.get(db_path.stem)
+        if copied and source_root in db_path.parents:
+            cfg.uri = _sqlite_path_to_uri(copied)
+
+    from datus.tools.db_tools import db_manager as _db_manager
+
+    _db_manager._cli_cache.clear()
+    return dest_root
 
 
 def _tail_lines(text: str, max_lines: int) -> list[str]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -239,15 +239,18 @@ NIGHTLY_SUB_AGENT_NAMES = ["nightly_test", "nightly_n7_test"]
 
 
 @pytest.fixture
-def nightly_agent_config() -> AgentConfig:
+def nightly_agent_config(tmp_path) -> AgentConfig:
     """Load acceptance config for nightly sub-agent tests.
 
     Function-scoped with deepcopy of agentic_nodes to prevent test mutations
-    from leaking into the configuration_manager cache.
+    from leaking into the configuration_manager cache. The SQLite benchmark
+    datasource is also function-scoped so adapters that create support tables
+    cannot mutate the shared ``~/benchmark`` fixture.
     """
-    from tests.conftest import load_acceptance_config
+    from tests.conftest import isolate_bird_sqlite_databases, load_acceptance_config
 
     config = load_acceptance_config(datasource="bird_school")
+    isolate_bird_sqlite_databases(config, tmp_path, ("california_schools",))
     config.rag_base_path = "tests/data"
     config.agentic_nodes = copy.deepcopy(config.agentic_nodes)
     return config

--- a/tests/unit_tests/agent/node/test_node.py
+++ b/tests/unit_tests/agent/node/test_node.py
@@ -1,3 +1,4 @@
+import copy
 import glob
 import json
 import time
@@ -29,7 +30,7 @@ from datus.schemas.search_metrics_node_models import SearchMetricsInput, SearchM
 from datus.tools.func_tool import db_function_tools
 from datus.utils.constants import DBType
 from datus.utils.loggings import get_logger
-from tests.conftest import TEST_DATA_DIR, load_acceptance_config
+from tests.conftest import TEST_DATA_DIR, isolate_bird_sqlite_databases, load_acceptance_config
 from tests.unit_tests.mock_llm_model import (
     MockLLMResponse,
     MockToolCall,
@@ -105,14 +106,33 @@ def search_metrics_input() -> List[Dict[str, Any]]:
 #    }
 
 
+@pytest.fixture(scope="module")
+def isolated_bird_sqlite_root(tmp_path_factory) -> Path:
+    return tmp_path_factory.mktemp("bird_sqlite")
+
+
+@pytest.fixture(scope="module")
+def isolated_metricflow_duckdb_path(tmp_path_factory) -> Path:
+    return init_metricflow_db(tmp_path_factory.mktemp("metricflow_duckdb") / "duck.db")
+
+
 @pytest.fixture
-def agent_config() -> AgentConfig:
+def agent_config(isolated_bird_sqlite_root, isolated_metricflow_duckdb_path) -> AgentConfig:
     # Post-refactor (PR #542) legacy configs with `path_pattern` expand into
     # one database per matched file (keyed by logic name). The old "bird_sqlite" key is no
     # longer valid, so the loader drops it; individual tests override `current_datasource` as
     # needed. Seed a valid default here so fixtures that touch the DB (e.g. `function_tools`)
     # can initialize.
     agent_config = load_acceptance_config(datasource="bird_sqlite")
+    isolate_bird_sqlite_databases(
+        agent_config,
+        isolated_bird_sqlite_root,
+        ("california_schools", "financial", "toxicology", "card_games"),
+        reuse_existing=True,
+    )
+    if "duckdb" in agent_config.services.datasources:
+        agent_config.services.datasources["duckdb"].uri = str(isolated_metricflow_duckdb_path)
+    agent_config.agentic_nodes = copy.deepcopy(agent_config.agentic_nodes)
     if not agent_config.current_datasource and agent_config.services.datasources:
         agent_config.current_datasource = "bird_school"
     Path(agent_config.rag_storage_path()).mkdir(parents=True, exist_ok=True)
@@ -130,28 +150,29 @@ def function_tools(agent_config: AgentConfig) -> List[Tool]:
     return db_function_tools(agent_config)
 
 
-def init_metricflow_db() -> None:
-    db_dir = TEST_DATA_DIR / "datus_metricflow_db"
-    db_path = db_dir / "duck.db"
-    if not db_dir.exists():
-        db_dir.mkdir(parents=True, exist_ok=True)
+def init_metricflow_db(db_path: Path) -> Path:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        db_path.unlink()
     csv_path: Path = Path(__file__).parent / "data/metricflow_csv" / "*.csv"
     conn = duckdb.connect(db_path)
-    conn.execute("CREATE SCHEMA IF NOT EXISTS mf_demo;")
-    csv_files = glob.glob(str(csv_path))
-    for csv_file in csv_files:
-        full_file_name = Path(csv_file).name
-        file_name = full_file_name.split(".")[0]
-        table_name = f"mf_demo.{file_name}"
-        conn.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM read_csv_auto('{csv_file}', header=TRUE)")
-    conn.close()
+    try:
+        conn.execute("CREATE SCHEMA IF NOT EXISTS mf_demo;")
+        csv_files = glob.glob(str(csv_path))
+        for csv_file in csv_files:
+            full_file_name = Path(csv_file).name
+            file_name = full_file_name.split(".")[0]
+            table_name = f"mf_demo.{file_name}"
+            conn.execute(
+                f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM read_csv_auto('{csv_file}', header=TRUE)"
+            )
+    finally:
+        conn.close()
+    return db_path
 
 
 class TestNodeFactory:
     """Test suite for Node class"""
-
-    def setup_method(self) -> None:
-        init_metricflow_db()
 
     def test_node_initialization(self, agent_config):
         """Test node initialization"""

--- a/tests/unit_tests/test_bird_sqlite_isolation.py
+++ b/tests/unit_tests/test_bird_sqlite_isolation.py
@@ -1,0 +1,61 @@
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+from datus.configuration.agent_config import DbConfig
+from tests.conftest import isolate_bird_sqlite_databases
+
+
+def _table_names(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    finally:
+        conn.close()
+    return {row[0] for row in rows}
+
+
+def test_isolate_bird_sqlite_databases_copies_and_sanitizes_generated_tables(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    source_root = fake_home / "benchmark" / "bird" / "dev_20240627" / "dev_databases"
+    source_db = source_root / "california_schools" / "california_schools.sqlite"
+    source_db.parent.mkdir(parents=True)
+
+    conn = sqlite3.connect(str(source_db))
+    try:
+        conn.execute("CREATE TABLE schools (id INT)")
+        conn.execute("CREATE TABLE mf_time_spine (ds DATETIME)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    agent_config = SimpleNamespace(
+        services=SimpleNamespace(
+            datasources={
+                "bird_sqlite": DbConfig(
+                    type="sqlite",
+                    path_pattern=str(source_root / "**/*.sqlite"),
+                ),
+                "bird_school": DbConfig(
+                    type="sqlite",
+                    uri=f"sqlite:///{source_db}",
+                    database="california_schools",
+                ),
+            }
+        )
+    )
+
+    isolated_root = isolate_bird_sqlite_databases(
+        agent_config,
+        tmp_path / "isolated",
+        ("california_schools",),
+    )
+    isolated_db = isolated_root / "california_schools" / "california_schools.sqlite"
+
+    assert isolated_db.exists()
+    assert agent_config.services.datasources["bird_sqlite"].path_pattern == str(isolated_root / "**/*.sqlite")
+    assert agent_config.services.datasources["bird_school"].uri == f"sqlite:///{isolated_db.resolve().as_posix()}"
+    assert _table_names(isolated_db) == {"schools"}
+    assert _table_names(source_db) == {"schools", "mf_time_spine"}


### PR DESCRIPTION
## Summary
- copy BIRD SQLite fixtures into pytest tmp dirs before tests initialize writable adapters
- sanitize generated MetricFlow support tables from isolated copies
- repoint nightly/unit BIRD datasource config to the isolated copies and clear DB manager cache

## Validation
- uv run pytest tests/unit_tests/test_bird_sqlite_isolation.py tests/unit_tests/agent/node/test_node.py::TestNodeFactory::test_schema_linking_node tests/integration/agent/test_ask_metrics_agentic.py::TestAskMetricsAgentic::test_metric_catalog_is_available --tb=short -q
- uv run pytest tests/unit_tests/agent/node/test_node.py --tb=short -q
- uv run ruff check tests/conftest.py tests/integration/conftest.py tests/unit_tests/agent/node/test_node.py tests/unit_tests/test_bird_sqlite_isolation.py
- uv run ruff format --check tests/conftest.py tests/integration/conftest.py tests/unit_tests/agent/node/test_node.py tests/unit_tests/test_bird_sqlite_isolation.py

## CI machine data repair
- restored /home/datus_ci/benchmark/bird/dev_20240627/dev_databases from dev_databases.zip
- verified 11 SQLite DBs and no mf_% tables
- reran the previously failing schema_linking unit test on the CI host successfully

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
## Summary by CodeRabbit

* **Tests**
  * Enhanced database isolation for test suites to prevent cross-test interference.
  * Improved test fixtures for better management of SQLite databases.
  * Added validation tests for database isolation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SQLite benchmark isolation to prevent test-to-test mutations by copying and sanitizing benchmark SQLite files into per-run temp locations.
  * Updated integration and unit test fixtures to isolate configured Bird SQLite datasources (including URI/path rewrites) and to use fresh DuckDB instances.
  * Added a dedicated unit test covering the isolation behavior and verification that only expected tables remain in the isolated database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->