### PR TITLE
[BugFix] Stop treating datasource name as a physical database

### DIFF
--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -151,6 +151,10 @@ class ChatInput(BaseModel):
     )
 
     # Database context fields
+    datasource: Optional[str] = Field(
+        None,
+        description="Datasource (connection profile) override; selects which configured datasource to use",
+    )
     catalog: Optional[str] = Field(None, description="Database catalog for context")
     database: Optional[str] = Field(None, description="Database name for context")
     db_schema: Optional[str] = Field(None, description="Database schema for context")

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -340,6 +340,10 @@ class ChatTaskManager:
                 agent_config.set_active_custom(model_id, persist=False)
             else:
                 agent_config.set_active_provider_model(provider, model_id, persist=False)
+        # Per-request datasource override (e.g. an IM channel pinned to a datasource).
+        # Switches the connection profile; the setter validates it exists in config.
+        if request.datasource:
+            agent_config.current_datasource = request.datasource
         request.catalog, request.database, request.db_schema = _fill_database_context(
             agent_config,
             catalog=request.catalog,

--- a/datus/gateway/bridge.py
+++ b/datus/gateway/bridge.py
@@ -150,9 +150,12 @@ class ChannelBridge:
 
         request = StreamChatInput(message=msg.text, session_id=session_id, stream_response=adapter.supports_streaming)
 
-        # Apply channel-level datasource override
+        # Apply channel-level datasource override. This selects the connection
+        # profile (datasource), not a physical database within it — routing it
+        # through ``database`` would mis-set the connection's database to the
+        # datasource name.
         if channel_config and channel_config.datasource:
-            request.database = channel_config.datasource
+            request.datasource = channel_config.datasource
 
         has_error = False
         # Start the agentic loop

--- a/datus/schemas/gen_dashboard_agentic_node_models.py
+++ b/datus/schemas/gen_dashboard_agentic_node_models.py
@@ -20,7 +20,7 @@ class GenDashboardNodeInput(BaseInput):
     """Input model for GenDashboardAgenticNode."""
 
     user_message: str = Field(..., description="User's dashboard request (required)")
-    database: Optional[str] = Field(None, description="Source datasource")
+    database: Optional[str] = Field(None, description="Database name for context")
     prompt_version: Optional[str] = Field(None, description="Prompt template version")
 
 

--- a/datus/schemas/scheduler_agentic_node_models.py
+++ b/datus/schemas/scheduler_agentic_node_models.py
@@ -20,7 +20,7 @@ class SchedulerNodeInput(BaseInput):
     """Input model for SchedulerAgenticNode."""
 
     user_message: str = Field(..., description="User's scheduler request (required)")
-    database: Optional[str] = Field(None, description="Source datasource")
+    database: Optional[str] = Field(None, description="Database name for context")
     prompt_version: Optional[str] = Field(None, description="Prompt template version")
 
 

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -212,13 +212,32 @@ class DBManager:
         datasource yields its single configured database. Callers that probe health or list
         databases must iterate the map so multi-database datasources aren't reduced to one.
         """
-        return {db_name: self._init_connection(datasource, db_name) for db_name in self.get_db_uris(datasource)}
+        cfg = self._db_configs.get(datasource)
+        # Only a glob datasource's keys are genuine per-file database names safe to pass back
+        # as an override. A single datasource's key may be a display fallback (the datasource
+        # name when ``database`` is unconfigured); feeding that back would mis-set the
+        # connection's database to the datasource name, so resolve it via the default path.
+        if cfg is not None and cfg.path_pattern:
+            return {db_name: self._init_connection(datasource, db_name) for db_name in self.get_db_uris(datasource)}
+        return {db_name: self._init_connection(datasource, "") for db_name in self.get_db_uris(datasource)}
 
     def first_conn(self, datasource: str) -> BaseSqlConnector:
         return self._init_connection(datasource, "")
 
     def first_conn_with_name(self, datasource: str) -> Tuple[str, BaseSqlConnector]:
-        return datasource, self._init_connection(datasource, "")
+        """Default connector for ``datasource`` plus its resolved database name.
+
+        The name is the *database* name (a glob datasource's first file, or a server
+        datasource's configured ``database``), not the datasource name — empty when no
+        database is configured. Callers needing a display label must fall back to the
+        datasource name themselves rather than relying on this slot.
+        """
+        connector = self._init_connection(datasource, "")
+        resolved, _ = self._resolve_db_config(datasource, "")
+        # Prefer the connector's own database name (e.g. SQLite/DuckDB derive it from the
+        # file path, which ``cfg.database`` doesn't carry); fall back to the config-resolved
+        # name. Both are real database names — never the datasource name.
+        return (connector.database_name or resolved), connector
 
     def get_db_uris(self, datasource: str) -> Dict[str, str]:
         cfg = self._db_configs.get(datasource)
@@ -383,10 +402,10 @@ class DBManager:
 
 
 def db_config_name(datasource: str, db_type: str, name: str = "") -> str:
-    if db_type == DBType.SQLITE or db_type == DBType.DUCKDB:
-        return f"{datasource}::{name}"
-    # fix local snowflake
-    return f"{datasource}::{datasource}"
+    # ``datasource::<database>`` for every dialect. The second component is the physical
+    # database name (empty when unspecified); the datasource name is never duplicated into
+    # it — a datasource is a connection profile, not a database.
+    return f"{datasource}::{name}"
 
 
 # External factory for DBManager creation (used by SaaS backend for connection pooling)

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1951,8 +1951,10 @@ class DBFuncTool:
         ``TableTarget.database`` gets the *physical* database the transfer
         wrote into — taken from the parsed ``target_table`` identifier when
         it carries a ``db.schema.table`` qualifier, otherwise from the
-        target connector's active namespace (``target_active_database``),
-        with a final fallback to the datasource key for backward compat.
+        target connector's active namespace (``target_active_database``).
+        It is left empty when neither is available: the datasource key is a
+        connection profile, not a database, and must not stand in for one
+        (connector routing already uses ``target_datasource``).
         """
         from datus.utils.sql_utils import parse_table_name_parts
         from datus.validation.report import DBRef, TableTarget, TransferTarget
@@ -1961,7 +1963,7 @@ class DBFuncTool:
         parsed_db = parts.get("database_name") or parts.get("catalog_name") or None
         schema = parts.get("schema_name") or None
         table = parts.get("table_name") or target_table
-        effective_database = parsed_db or target_active_database or target_datasource
+        effective_database = parsed_db or target_active_database or ""
 
         tgt = TransferTarget(
             source=DBRef(name=source_datasource),

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -930,7 +930,13 @@ class SubAgentTaskTool:
     # ── input building ─────────────────────────────────────────────────
 
     def _build_node_input(self, node, prompt: str):
-        """Build the appropriate input object for the given node."""
+        """Build the appropriate input object for the given node.
+
+        The ``database`` context field is intentionally left unset: it denotes a physical
+        database name, not a datasource. Each node is constructed with ``agent_config`` and
+        routes through ``current_datasource``'s default database on its own, so stuffing the
+        datasource name into ``database`` here would only mislabel the context.
+        """
         from datus.agent.node.explore_agentic_node import ExploreAgenticNode
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
         from datus.schemas.explore_agentic_node_models import ExploreNodeInput
@@ -939,13 +945,11 @@ class SubAgentTaskTool:
         if isinstance(node, ExploreAgenticNode):
             return ExploreNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         if isinstance(node, GenSQLAgenticNode):
             return GenSQLNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
@@ -955,7 +959,6 @@ class SubAgentTaskTool:
 
             return AskMetricsNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         # Built-in system subagent input types
@@ -970,7 +973,6 @@ class SubAgentTaskTool:
 
             return SemanticNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         if isinstance(node, (GenSemanticModelAgenticNode, GenMetricsAgenticNode)):
@@ -978,7 +980,6 @@ class SubAgentTaskTool:
 
             return SemanticNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         if isinstance(node, SqlSummaryAgenticNode):
@@ -986,7 +987,6 @@ class SubAgentTaskTool:
 
             return SqlSummaryNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
@@ -996,7 +996,6 @@ class SubAgentTaskTool:
 
             return GenDashboardNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.scheduler_agentic_node import SchedulerAgenticNode
@@ -1006,7 +1005,6 @@ class SubAgentTaskTool:
 
             return SchedulerNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.gen_report_agentic_node import GenReportAgenticNode
@@ -1016,7 +1014,6 @@ class SubAgentTaskTool:
 
             return GenReportNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.gen_visual_report_agentic_node import GenVisualReportAgenticNode
@@ -1026,7 +1023,6 @@ class SubAgentTaskTool:
 
             return GenVisualReportNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.gen_visual_dashboard_agentic_node import GenVisualDashboardAgenticNode
@@ -1036,7 +1032,6 @@ class SubAgentTaskTool:
 
             return GenVisualDashboardNodeInput(
                 user_message=prompt,
-                database=self.agent_config.current_datasource,
             )
 
         from datus.agent.node.gen_skill_agentic_node import SkillCreatorAgenticNode

--- a/datus/validation/report.py
+++ b/datus/validation/report.py
@@ -47,7 +47,8 @@ class TableTarget(BaseModel):
     )
     database: str = Field(
         ...,
-        description="Database identifier — historically the datasource key; may also be a physical DB for three-part DDL",
+        description="Physical database the table lives in; empty when the SQL/connector did not "
+        "specify one (the datasource key is NOT used as a fallback — see ``datasource``)",
     )
     db_schema: Optional[str] = Field(
         default=None,

--- a/datus/validation/target_extractor.py
+++ b/datus/validation/target_extractor.py
@@ -217,10 +217,11 @@ def _table_to_target(
 
     datasource_key = datasource or None
     catalog: Optional[str] = None
-    # Default the *physical* database to the connector's active namespace,
-    # fall back to the datasource key only when active_database is empty
-    # (tests / adapters that don't expose one).
-    effective_db = active_database or datasource or ""
+    # The *physical* database is the connector's active namespace. We deliberately do NOT
+    # fall back to the datasource key: a datasource name is not a database, and feeding it
+    # into ``TableTarget.database`` (which flows to ``describe_table`` for existence checks)
+    # would query a bogus namespace. Connector routing already uses ``datasource_key``.
+    effective_db = active_database or ""
     effective_schema = schema
     if sql_catalog_slot:
         if _dialect_has_catalog(dialect):

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -453,11 +453,15 @@ class TestGenDashboardPermissionWiring:
         _bi_core_mock.adapter_registry.get.return_value = lambda **kwargs: FullMockAdapter()
         with patch.dict(sys.modules, _BI_MODULES_PATCH):
             from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
+            from datus.tools.permission.permission_hooks import CompositeHooks, PermissionHooks
 
             node = GenDashboardAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
             hooks = node._compose_hooks()
-            assert hooks is not None
-            assert node.permission_hooks is not None
+            # Workflow mode wires permission + compact + token_usage hooks, so the
+            # result must be a CompositeHooks bundle, and the permission gate must
+            # be a real PermissionHooks (not None, not some other hook type).
+            assert isinstance(hooks, CompositeHooks)
+            assert isinstance(node.permission_hooks, PermissionHooks)
 
     def test_tool_registry_routes_delete_chart_to_bi_tools(self, real_agent_config, mock_llm_create):
         """After ``_ensure_permission_hooks`` runs, registry must classify ``delete_chart``.

--- a/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py
@@ -729,7 +729,9 @@ class TestGenDashboardRegistration:
             result = tool._build_node_input(node, "List all dashboards")
             assert isinstance(result, GenDashboardNodeInput)
             assert result.user_message == "List all dashboards"
-            assert result.database == real_agent_config.current_datasource
+            # ``database`` is a physical-database context field, not a datasource slot; the
+            # builder leaves it unset rather than mislabeling it with current_datasource.
+            assert result.database is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_scheduler_agentic_node.py
@@ -396,7 +396,9 @@ class TestSchedulerRegistration:
             result = tool._build_node_input(node, "List all jobs")
             assert isinstance(result, SchedulerNodeInput)
             assert result.user_message == "List all jobs"
-            assert result.database == real_agent_config.current_datasource
+            # ``database`` is a physical-database context field, not a datasource slot; the
+            # builder leaves it unset rather than mislabeling it with current_datasource.
+            assert result.database is None
 
     def test_node_factory_with_input_data(self, real_agent_config, mock_llm_create):
         """Node.new_instance with input_data should set node.input."""

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -1707,3 +1707,49 @@ class TestStartChatRemoteSourceHardening:
         assert cfg.filesystem_strict is True
         assert cfg.bash_tool_enabled is True
         assert cfg._client_source is None
+
+
+class TestStartChatDatasourceOverride:
+    """A per-request ``datasource`` (e.g. an IM channel override) switches the
+    connection profile without leaking into the physical ``database`` slot."""
+
+    @pytest.mark.asyncio
+    async def test_request_datasource_switches_current_datasource(self, real_agent_config, monkeypatch):
+        import copy as _copy
+
+        from datus.api.models.cli_models import StreamChatInput
+
+        # Inject a second datasource so the switch is observable (not a no-op).
+        sources = real_agent_config.services.datasources
+        sources["analytics"] = _copy.deepcopy(sources["california_schools"])
+        assert real_agent_config.current_datasource == "california_schools"
+
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", session_id="ds-override", datasource="analytics")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+
+        cfg = captured["agent_config"]
+        # The cloned config switched datasource; the datasource name never landed in database
+        # (database, if filled by _fill_database_context, is the resolved physical db name).
+        assert cfg.current_datasource == "analytics"
+        assert request.database != "analytics"
+        # Original config untouched because start_chat deep-copies.
+        assert real_agent_config.current_datasource == "california_schools"
+
+    @pytest.mark.asyncio
+    async def test_invalid_request_datasource_raises(self, real_agent_config, monkeypatch):
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.utils.exceptions import DatusException
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", lambda *a, **k: None)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", session_id="ds-invalid", datasource="nonexistent")
+        with pytest.raises(DatusException):
+            await manager.start_chat(real_agent_config, request)

--- a/tests/unit_tests/gateway/test_bridge.py
+++ b/tests/unit_tests/gateway/test_bridge.py
@@ -309,7 +309,10 @@ class TestChannelBridge:
 
         call_args = task_manager.start_chat.call_args
         request = call_args.args[1]
-        assert request.database == "prod"
+        # Channel datasource override selects the connection profile via ``datasource``,
+        # never ``database`` (which would mis-set the connection's physical database).
+        assert request.datasource == "prod"
+        assert request.database is None
         assert call_args.kwargs.get("sub_agent_id") == "agent_x"
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -282,8 +282,15 @@ class TestDbConfigName:
         assert result == "ns::myfile"
 
     def test_other(self):
-        result = db_config_name("ns", "mysql", "ignored")
-        assert result == "ns::ns"
+        # The physical database name is honored for every dialect; the datasource name is
+        # never duplicated into the database slot (no more "ns::ns").
+        result = db_config_name("ns", "mysql", "mydb")
+        assert result == "ns::mydb"
+
+    def test_other_without_name_leaves_database_empty(self):
+        # No physical database given → empty second component, not the datasource name.
+        result = db_config_name("ns", "mysql")
+        assert result == "ns::"
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +339,53 @@ class TestDBManager:
             connections = mgr.get_connections("ns")
         assert isinstance(connections, dict)
         assert set(connections.keys()) == {"a", "b"}
+
+    def test_get_connections_unconfigured_database_not_set_to_datasource_name(self):
+        # Regression: a single (server) datasource with no ``database`` configured must not
+        # have the datasource name leak into the connection's database. get_db_uris keys the
+        # map on the datasource name as a display fallback, but that label must not be fed
+        # back as a database override.
+        from datus.configuration.agent_config import DbConfig
+
+        configs = {"mypg": DbConfig(type="postgresql", host="h", port="5432", uri="postgresql://h:5432/")}
+        mgr = DBManager(configs)
+        built = {}
+
+        def _capture(cfg):
+            built["database"] = cfg.database
+            return MagicMock()
+
+        with patch.object(mgr, "_build_conn", side_effect=_capture):
+            connections = mgr.get_connections("mypg")
+        # Display key still reflects the datasource label.
+        assert set(connections.keys()) == {"mypg"}
+        # But the connector is built without the datasource name as its database.
+        assert built["database"] == ""
+
+    def test_first_conn_with_name_returns_database_name_not_datasource(self):
+        # Regression: first_conn_with_name must return the resolved *database* name, never the
+        # datasource name. A server datasource with no configured database yields an empty name.
+        from datus.configuration.agent_config import DbConfig
+
+        mgr = DBManager({"mypg": DbConfig(type="postgresql", host="h", uri="postgresql://h/")})
+        connector = MagicMock()
+        connector.database_name = ""
+        with patch.object(mgr, "_build_conn", return_value=connector):
+            name, conn = mgr.first_conn_with_name("mypg")
+        assert name == ""  # not "mypg"
+        assert conn is connector
+
+    def test_first_conn_with_name_prefers_connector_derived_name(self):
+        # SQLite/DuckDB derive the database name from the file path on the connector, which
+        # cfg.database does not carry; first_conn_with_name must surface that real name.
+        from datus.configuration.agent_config import DbConfig
+
+        mgr = DBManager({"school": DbConfig(type="sqlite", uri="sqlite:///x/california_schools.sqlite")})
+        connector = MagicMock()
+        connector.database_name = "california_schools"
+        with patch.object(mgr, "_build_conn", return_value=connector):
+            name, _ = mgr.first_conn_with_name("school")
+        assert name == "california_schools"  # not "school"
 
     def test_duckdb_config_includes_extra_runtime_options(self):
         mgr = DBManager({})

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -269,7 +269,9 @@ class TestResolveNodeType:
             f"input builder returned wrong type: {type(node_input).__name__}"
         )
         assert node_input.user_message == prompt
-        assert node_input.database == "test_db"
+        # The ``database`` context field denotes a physical database, not a datasource, so the
+        # builder must not stuff the datasource name ("test_db") into it; it stays unset.
+        assert node_input.database is None
 
     def test_gen_visual_report_rejects_session_id(self, task_tool):
         """gen_visual_report has the same no-resume contract as
@@ -336,9 +338,9 @@ class TestResolveNodeType:
             f"input builder returned wrong type: {type(node_input).__name__}"
         )
         assert node_input.user_message == prompt
-        # ``database`` is sourced from ``agent_config.current_datasource``
-        # which the fixture pins to "test_db".
-        assert node_input.database == "test_db"
+        # ``database`` denotes a physical database, not a datasource, so the builder leaves it
+        # unset rather than stuffing in ``current_datasource`` ("test_db").
+        assert node_input.database is None
 
     def test_gen_visual_dashboard_rejects_session_id(self, task_tool):
         """``_create_builtin_node`` for gen_visual_dashboard MUST fail
@@ -576,7 +578,7 @@ class TestBuildNodeInput:
 
         assert isinstance(result, GenSQLNodeInput)
         assert result.user_message == "Show all users"
-        assert result.database == "test_db"
+        assert result.database is None
 
     def test_ask_metrics_node_input(self, task_tool):
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
@@ -587,7 +589,7 @@ class TestBuildNodeInput:
 
         assert isinstance(result, AskMetricsNodeInput)
         assert result.user_message == "Show revenue by month"
-        assert result.database == "test_db"
+        assert result.database is None
 
 
 # ── _convert_to_func_result ───────────────────────────────────────
@@ -761,7 +763,7 @@ class TestSubAgentTaskAcceptance:
         assert result.result["sql"] == "SELECT SUM(amount) FROM sales"
         create_node.assert_called_once_with("sales_analyst", session_id=None)
         assert mock_node.input.user_message == "Summarize sales"
-        assert mock_node.input.database == "test_db"
+        assert mock_node.input.database is None
 
 
 # ── task execution ─────────────────────────────────────────────────
@@ -1598,7 +1600,7 @@ class TestBuildNodeInputBuiltIn:
         result = task_tool._build_node_input(mock_node, "orders table")
         assert isinstance(result, SemanticNodeInput)
         assert result.user_message == "orders table"
-        assert result.database == "test_db"
+        assert result.database is None
 
     def test_metrics_node_input(self, task_tool):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
@@ -1608,7 +1610,7 @@ class TestBuildNodeInputBuiltIn:
         result = task_tool._build_node_input(mock_node, "SELECT SUM(amount) FROM orders")
         assert isinstance(result, SemanticNodeInput)
         assert result.user_message == "SELECT SUM(amount) FROM orders"
-        assert result.database == "test_db"
+        assert result.database is None
 
     def test_sql_summary_node_input(self, task_tool):
         from datus.agent.node.sql_summary_agentic_node import SqlSummaryAgenticNode
@@ -1618,7 +1620,7 @@ class TestBuildNodeInputBuiltIn:
         result = task_tool._build_node_input(mock_node, "SELECT * FROM users")
         assert isinstance(result, SqlSummaryNodeInput)
         assert result.user_message == "SELECT * FROM users"
-        assert result.database == "test_db"
+        assert result.database is None
 
     def test_gen_table_node_input(self, task_tool):
         from datus.agent.node.gen_table_agentic_node import GenTableAgenticNode
@@ -1628,7 +1630,7 @@ class TestBuildNodeInputBuiltIn:
         result = task_tool._build_node_input(mock_node, "Create wide table from orders and customers")
         assert isinstance(result, SemanticNodeInput)
         assert result.user_message == "Create wide table from orders and customers"
-        assert result.database == "test_db"
+        assert result.database is None
 
     def test_ask_metrics_node_input(self, task_tool):
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
@@ -1639,7 +1641,7 @@ class TestBuildNodeInputBuiltIn:
 
         assert isinstance(result, AskMetricsNodeInput)
         assert result.user_message == "Show active users"
-        assert result.database == "test_db"
+        assert result.database is None
 
 
 # ── Built-in subagent: _build_task_description ─────────────────────

--- a/tests/unit_tests/validation/test_target_extractor.py
+++ b/tests/unit_tests/validation/test_target_extractor.py
@@ -50,30 +50,32 @@ def _register_test_capabilities():
 class TestExtractDDLTarget:
     def test_basic_create_table(self):
         t = extract_ddl_target("CREATE TABLE staging.users (id INT)", "main")
-        assert t == TableTarget(datasource="main", database="main", db_schema="staging", table="users")
+        # No active database and the SQL names no database → database is empty, NOT the
+        # datasource name "main" (which is not a physical database).
+        assert t == TableTarget(datasource="main", database="", db_schema="staging", table="users")
 
     def test_if_not_exists(self):
         t = extract_ddl_target("CREATE TABLE IF NOT EXISTS orders (id INT)", "main")
-        assert t == TableTarget(datasource="main", database="main", table="orders")
+        assert t == TableTarget(datasource="main", database="", table="orders")
 
     def test_create_or_replace(self):
         t = extract_ddl_target("CREATE OR REPLACE TABLE analytics.revenue (m TEXT)", "prod")
-        assert t == TableTarget(datasource="prod", database="prod", db_schema="analytics", table="revenue")
+        assert t == TableTarget(datasource="prod", database="", db_schema="analytics", table="revenue")
 
     def test_temporary(self):
         t = extract_ddl_target("CREATE TEMPORARY TABLE tmp_foo (x INT)", "db1")
-        assert t == TableTarget(datasource="db1", database="db1", table="tmp_foo")
+        assert t == TableTarget(datasource="db1", database="", table="tmp_foo")
 
     def test_ctas(self):
         t = extract_ddl_target(
             "CREATE TABLE analytics.revenue_monthly AS SELECT * FROM staging.sales",
             "db1",
         )
-        assert t == TableTarget(datasource="db1", database="db1", db_schema="analytics", table="revenue_monthly")
+        assert t == TableTarget(datasource="db1", database="", db_schema="analytics", table="revenue_monthly")
 
     def test_quoted_identifier(self):
         t = extract_ddl_target('CREATE TABLE "My Schema"."My Table" (x INT)', "db1")
-        assert t == TableTarget(datasource="db1", database="db1", db_schema="My Schema", table="My Table")
+        assert t == TableTarget(datasource="db1", database="", db_schema="My Schema", table="My Table")
 
     def test_three_part_identifier_default_dialect(self):
         """Empty dialect defaults to catalog-tier semantics (the safer bet —
@@ -141,12 +143,12 @@ class TestExtractDDLTarget:
     def test_two_part_identifier_catalog_is_none(self):
         """Two-part ``schema.table`` leaves catalog unset."""
         t = extract_ddl_target("CREATE TABLE analytics.users (x INT)", "db1")
-        assert t == TableTarget(datasource="db1", database="db1", db_schema="analytics", table="users")
+        assert t == TableTarget(datasource="db1", database="", db_schema="analytics", table="users")
 
     def test_one_part_identifier_catalog_is_none(self):
         """Bare table name leaves catalog unset."""
         t = extract_ddl_target("CREATE TABLE users (x INT)", "db1")
-        assert t == TableTarget(datasource="db1", database="db1", table="users")
+        assert t == TableTarget(datasource="db1", database="", table="users")
 
     def test_drop_table_returns_none(self):
         assert extract_ddl_target("DROP TABLE foo", "db1") is None
@@ -172,15 +174,15 @@ class TestExtractDDLTarget:
 class TestExtractDMLTarget:
     def test_insert(self):
         t = extract_dml_target("INSERT INTO staging.users (id) VALUES (1)", "main")
-        assert t == TableTarget(datasource="main", database="main", db_schema="staging", table="users")
+        assert t == TableTarget(datasource="main", database="", db_schema="staging", table="users")
 
     def test_update(self):
         t = extract_dml_target("UPDATE orders SET status = 'done' WHERE id = 1", "db")
-        assert t == TableTarget(datasource="db", database="db", table="orders")
+        assert t == TableTarget(datasource="db", database="", table="orders")
 
     def test_delete(self):
         t = extract_dml_target("DELETE FROM orders WHERE id = 1", "db")
-        assert t == TableTarget(datasource="db", database="db", table="orders")
+        assert t == TableTarget(datasource="db", database="", table="orders")
 
     def test_select_returns_none(self):
         """SELECT is not a mutating tool — no target."""


### PR DESCRIPTION
## Why

When a datasource had no `database` configured, the datasource name leaked into the physical-database slot and propagated to real connections and table lookups. Root causes spanned the connection layer, the IM gateway, subagent node inputs, and the validation target extractor.

## Solution

- db_manager: `get_connections` no longer feeds the get_db_uris display fallback (datasource name) back as a `database` override for single datasources; `first_conn_with_name` returns the resolved physical database name (`connector.database_name` or config-resolved), never the datasource.
- gateway/bridge: add a `datasource` field to `ChatInput`; the IM channel override now selects the connection profile via `request.datasource` (routed to `current_datasource` in `start_chat`) instead of poisoning `request.database`.
- sub_agent_task_tool: stop stuffing `current_datasource` into node-input `database` fields (a physical-db context field); leave it unset. Realign the GenDashboard/Scheduler field descriptions accordingly.
- validation: drop the `or datasource` fallback in `target_extractor` and the `or target_datasource` fallback in `_build_transfer_target` so `TableTarget.database` is the real physical database (empty when unknown), not the datasource key; update the field doc.
- db_manager.db_config_name: emit `datasource::<database>` for every dialect instead of duplicating the datasource name.

## Test Cases

- Regression tests for `get_connections` / `first_conn_with_name` not leaking the datasource name, and `db_config_name` using the physical db name.
- bridge + chat_task_manager tests: channel override routes via `datasource`, switches `current_datasource`, and rejects an invalid datasource.
- Updated sub_agent / dashboard / scheduler node-input tests to expect an unset `database`, and target_extractor tests to expect an empty database when no active database is present.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for per-request datasource override in chat requests, allowing users to dynamically select a connection profile without changing global configuration.

* **Bug Fixes**
  * Fixed configuration errors caused by treating datasource names as physical database identifiers.
  * Corrected channel-level configuration application to properly route datasource selections.

* **Documentation**
  * Improved field descriptions to clarify the distinction between datasource (connection profile) and database (physical database name).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-request datasource override support for chat requests, enabling dynamic selection of the connection profile.

* **Bug Fixes**
  * Prevented datasource names from being incorrectly treated as physical database names in generated targets and connector setup.
  * Corrected channel-level configuration so datasource routing is applied to the right request fields.

* **Documentation**
  * Updated model/field descriptions to clearly distinguish datasource (connection profile) from database (physical database name).

* **Tests**
  * Expanded coverage to enforce the new datasource/database context behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->