### PR TITLE
[Feature] Unify web_tool group with provider-agnostic result schema

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1104,6 +1104,7 @@ class AgenticNode(Node):
         self._ensure_skill_tools_in_tools()
         self._ensure_bash_tool_in_tools()
         self._ensure_memory_tool_in_tools()
+        self._ensure_web_tools_in_tools()
 
     def _runtime_context_current_date(self) -> str:
         """Current-date reference rendered into the shared runtime-context block.
@@ -2327,6 +2328,45 @@ class AgenticNode(Node):
             f"{[t.name for t in self.bash_tool.available_tools()]}"
         )
 
+    def _ensure_web_tools_in_tools(self) -> None:
+        """Mount the unified ``web_tool`` group per the active provider.
+
+        Mirrors :meth:`_ensure_skill_tools_in_tools`. The active model decides
+        whether each capability is served by a vendor-native tool (then the local
+        function tool is suppressed and the model layer injects the hosted tool)
+        or by the local backend. Re-runs per request so a runtime ``/model``
+        switch re-resolves the backends; stale local web tools are dropped first.
+        """
+        from datus.tools.func_tool.web_tool import WebTool
+
+        try:
+            model = self.model
+        except Exception:
+            model = None
+        search_builtin = bool(getattr(model, "supports_builtin_web_search", lambda: False)()) if model else False
+        fetch_builtin = bool(getattr(model, "supports_builtin_web_fetch", lambda: False)()) if model else False
+        self._builtin_web_tools = {"web_search": search_builtin, "web_fetch": fetch_builtin}
+
+        self._web_tool = WebTool(
+            self.agent_config,
+            sub_agent_name=getattr(self, "sub_agent_name", None),
+            expose_local_search=not search_builtin,
+            expose_local_fetch=not fetch_builtin,
+        )
+        desired = self._web_tool.available_tools()
+        web_names = set(WebTool.all_tools_name())
+
+        # Drop previously-mounted web tools so a provider switch can't leave a
+        # stale local backend behind, then mount the current desired set.
+        existing = [t for t in (getattr(self, "tools", None) or []) if getattr(t, "name", None) not in web_names]
+        existing.extend(desired)
+        self.tools = existing
+        if desired:
+            logger.info(
+                f"Web tools injected into node '{self.get_node_name()}': "
+                f"{[t.name for t in desired]} (builtin={self._builtin_web_tools})"
+            )
+
     def _ensure_memory_tool_in_tools(self) -> None:
         """Ensure ``add_memory`` / ``edit_memory`` are in ``self.tools`` for a main agent.
 
@@ -2778,6 +2818,7 @@ class AgenticNode(Node):
             async for stream_action in self.model.generate_with_tools_stream(
                 prompt=ctx.user_prompt,
                 tools=self.tools or [],
+                builtin_web_tools=getattr(self, "_builtin_web_tools", None),
                 mcp_servers=self.mcp_servers,
                 instruction=ctx.system_instruction,
                 max_turns=effective_max_turns,

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -176,6 +176,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         "date_parsing_tools": "date_parsing_tools",
         "filesystem_tools": "filesystem_func_tool",
         "platform_doc_tools": "_platform_doc_tool",
+        "web_tool": "_web_tool",
         "bash_tools": "bash_tool",
         "skills": "skill_func_tool",
     }
@@ -452,6 +453,26 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         if not self._group_whitelisted("skills"):
             return
         super()._ensure_skill_tools_in_tools()
+
+    def _ensure_web_tools_in_tools(self) -> None:
+        """Gate :class:`AgenticNode`'s lazy web-tool re-injection on the whitelist.
+
+        Same prompt-build / snapshot-replay bypass as bash and skills (see
+        :meth:`_ensure_bash_tool_in_tools`): the base injector re-adds
+        ``web_search`` / ``web_fetch`` (and resolves provider-native builtins)
+        on every rebuild, which would silently grant web access to an ask_*
+        agent whose ``tools`` whitelist never requested ``web_tool``. Skip — and
+        scrub any stale local web tools + builtin flags — unless whitelisted.
+        """
+        if not self._group_whitelisted("web_tool"):
+            from datus.tools.func_tool.web_tool import WebTool
+
+            web_names = set(WebTool.all_tools_name())
+            self.tools = [t for t in (self.tools or []) if getattr(t, "name", None) not in web_names]
+            self._builtin_web_tools = {"web_search": False, "web_fetch": False}
+            self._web_tool = None
+            return
+        super()._ensure_web_tools_in_tools()
 
     def _get_available_skills_context(self) -> str:
         """Suppress the skills XML when ``skills`` isn't whitelisted.
@@ -856,7 +877,8 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # Ask consultants never carry the task() delegation tool; set it
         # explicitly so a shared partial can't advertise a tool they lack.
         context["has_task_tool"] = False
-        context["has_web_tools"] = bool({"web_search", "web_fetch"} & exposed)
+        # Web tools are not advertised in the prompt (see ChatAgenticNode):
+        # their tool-schema descriptions document usage on their own.
         context["active_profile"] = getattr(self.agent_config, "active_profile_name", None) or "normal"
         from datus.utils.time_utils import get_default_current_date
 
@@ -903,11 +925,12 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         otherwise), the skills XML (suppressed unless ``skills`` is
         whitelisted), and the response-language directive.
         """
-        # Re-inject whitelisted bash / skill tools (gated; no-op when the
+        # Re-inject whitelisted bash / skill / web tools (gated; no-op when the
         # whitelist didn't grant them). These add to ``self.tools``, not prompt
         # text — needed so a whitelist that DID grant them still works.
         self._ensure_skill_tools_in_tools()
         self._ensure_bash_tool_in_tools()
+        self._ensure_web_tools_in_tools()
         if self.skill_func_tool:
             skills_xml = self._get_available_skills_context()
             if skills_xml:

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -856,6 +856,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
         # Ask consultants never carry the task() delegation tool; set it
         # explicitly so a shared partial can't advertise a tool they lack.
         context["has_task_tool"] = False
+        context["has_web_tools"] = bool({"web_search", "web_fetch"} & exposed)
         context["active_profile"] = getattr(self.agent_config, "active_profile_name", None) or "normal"
         from datus.utils.time_utils import get_default_current_date
 

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -426,7 +426,10 @@ class ChatAgenticNode(AgenticNode):
         )
         context["has_task_tool"] = bool(self.sub_agent_task_tool)
         context["has_ask_user_tool"] = "ask_user" in exposed
-        context["has_web_tools"] = bool({"web_search", "web_fetch"} & exposed)
+        # Web tools (web_search / web_fetch) are NOT advertised in the system
+        # prompt: their own tool-schema descriptions document usage, and prompt
+        # advertisement can't track per-tool availability (builtin-only vs
+        # local-only, Tavily key absent) without drifting from the real tool set.
         # No per-turn values here: the current date lives in the shared
         # runtime-context block, the current datasource/dialect in the user
         # turn's <system_reminder>, and the permission profile is enforced by

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -426,6 +426,7 @@ class ChatAgenticNode(AgenticNode):
         )
         context["has_task_tool"] = bool(self.sub_agent_task_tool)
         context["has_ask_user_tool"] = "ask_user" in exposed
+        context["has_web_tools"] = bool({"web_search", "web_fetch"} & exposed)
         # No per-turn values here: the current date lives in the shared
         # runtime-context block, the current datasource/dialect in the user
         # turn's <system_reminder>, and the permission profile is enforced by

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -264,7 +264,8 @@ _TOOL_ARGS_FORMATTERS: Dict[str, Callable[[dict], str]] = {
     "list_document_nav": lambda _a: "",
     "get_document": lambda a: _format_positional(a, "doc_id", "doc_name", "name"),
     "search_document": lambda a: _format_positional(a, "query", "query_text"),
-    "web_search_document": lambda a: _format_positional(a, "query", "query_text"),
+    "web_search": lambda a: _format_positional(a, "keywords", "query", "query_text"),
+    "web_fetch": lambda a: _format_positional(a, "url"),
     # Skill tools
     "load_skill": lambda a: _format_positional(a, "skill_name", "name"),
     "execute_command": lambda a: _format_kw(a, "command"),
@@ -1199,8 +1200,85 @@ def _build_simple_action(action: ActionHistory, verbose: bool, success_label: st
     return tc
 
 
+def _build_web_search(action: ActionHistory, verbose: bool) -> ToolCallContent:
+    """web_search: compact = canonical shortDesc; verbose = full results list.
+
+    Renders the provider-agnostic ``web_search`` schema
+    (``{query, result_count, results: [{title, url, snippet, age}]}``) the same
+    way regardless of which backend (Tavily / Anthropic / OpenAI hosted) served
+    the call.
+    """
+    from datus.schemas.web_result import web_search_short_summary
+
+    tc = make_base_content(action)
+    data = parse_output_data(action.output)
+    result = data.get("result") if isinstance(data, dict) else None
+    if not isinstance(result, dict):
+        set_error_as_result(tc, action)
+        return tc
+
+    if verbose:
+        tc.args_lines = extract_args_markup(action)
+        lines: List[str] = []
+        query = str(result.get("query") or "").strip()
+        if query:
+            lines.append(f"[bold]query[/bold]: {_escape_markup(query)}")
+        results = result.get("results") if isinstance(result.get("results"), list) else []
+        for idx, item in enumerate(results, 1):
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get("title") or "").strip()
+            url = str(item.get("url") or "").strip()
+            age = item.get("age")
+            header = f"{idx}. {_escape_markup(title)}" if title else f"{idx}. {_escape_markup(url)}"
+            if age:
+                header += f"  [dim]· {_escape_markup(str(age))}[/dim]"
+            lines.append(header)
+            if title and url:
+                lines.append(f"   [dim]{_escape_markup(url)}[/dim]")
+            snippet = str(item.get("snippet") or "").strip()
+            if snippet:
+                lines.append(f"   {_escape_markup(snippet)}")
+        tc.output_lines = lines or _format_result_only_markup(action.output)
+    else:
+        tc.compact_result = web_search_short_summary(result)
+    return tc
+
+
+def _build_web_fetch(action: ActionHistory, verbose: bool) -> ToolCallContent:
+    """web_fetch: compact = ``Title (N chars)``; verbose = title/url + full text."""
+    from datus.schemas.web_result import web_fetch_short_summary
+
+    tc = make_base_content(action)
+    data = parse_output_data(action.output)
+    result = data.get("result") if isinstance(data, dict) else None
+    if not isinstance(result, dict):
+        set_error_as_result(tc, action)
+        return tc
+
+    if verbose:
+        tc.args_lines = extract_args_markup(action)
+        lines = []
+        title = str(result.get("title") or "").strip()
+        url = str(result.get("url") or "").strip()
+        if title:
+            lines.append(f"[bold]{_escape_markup(title)}[/bold]")
+        if url:
+            suffix = " [dim](truncated)[/dim]" if result.get("truncated") else ""
+            lines.append(f"[dim]{_escape_markup(url)}[/dim]{suffix}")
+        content = result.get("content")
+        if isinstance(content, str) and content:
+            lines.append("")
+            for line in content.split("\n"):
+                lines.append(_escape_markup(line))
+        tc.output_lines = lines or _format_result_only_markup(action.output)
+    else:
+        tc.compact_result = web_fetch_short_summary(result)
+    return tc
+
+
 def _build_doc_search_result(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """Shared builder for search_document / web_search_document — use result['doc_count']."""
+    """Shared builder for search_document / web_search — use result['doc_count']."""
     tc = make_base_content(action)
     if verbose:
         tc.args_lines = extract_args_markup(action)
@@ -2018,7 +2096,10 @@ class ToolCallContentBuilder:
         # Platform document tools
         self._registry["list_document_nav"] = _build_list_document_nav
         self._registry["get_document"] = _build_get_document
-        self._registry["web_search_document"] = _build_doc_search_result
+
+        # Web tool group (provider-agnostic canonical schema)
+        self._registry["web_search"] = _build_web_search
+        self._registry["web_fetch"] = _build_web_fetch
 
         # Plan tools
         self._registry["todo_list"] = _build_todo_list

--- a/datus/models/base.py
+++ b/datus/models/base.py
@@ -241,6 +241,24 @@ class LLMBaseModel(ABC):  # Changed from BaseModel to LLMBaseModel
         self.workflow = workflow
         self.current_node = current_node
 
+    def supports_builtin_web_search(self) -> bool:
+        """Whether this provider serves web search through a vendor-native tool.
+
+        When True, the node suppresses the local ``web_tool.web_search`` function
+        tool and the model layer injects the hosted/server-side web search tool
+        instead. Defaults to False — most providers rely on the local backend.
+        """
+        return False
+
+    def supports_builtin_web_fetch(self) -> bool:
+        """Whether this provider serves web fetch through a vendor-native tool.
+
+        When True, the node suppresses the local ``web_tool.web_fetch`` function
+        tool and the model layer injects the hosted/server-side fetch tool.
+        Defaults to False — the local httpx backend is used.
+        """
+        return False
+
     @abstractmethod
     def token_count(self, prompt: str) -> int:
         pass

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -71,6 +71,83 @@ def wrap_prompt_cache(messages):
     return messages_copy
 
 
+def _extract_document_text(node, depth: int = 0) -> str:
+    """Best-effort recursive pull of readable text from a web_fetch document block.
+
+    Anthropic's ``web_fetch_result`` wraps the fetched page as a document block
+    whose text can sit at ``.source.data`` (text media type) or in a nested
+    ``.content[].text`` list, depending on the page. We probe both, bounded by
+    depth so a pathological structure can't recurse without end.
+    """
+    if node is None or depth > 6:
+        return ""
+
+    def _get(obj, key):
+        return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+
+    # Direct text payloads.
+    text = _get(node, "text")
+    if isinstance(text, str) and text:
+        return text
+    source = _get(node, "source")
+    if source is not None:
+        data = _get(source, "data")
+        if isinstance(data, str) and data and (_get(source, "type") in (None, "text")):
+            return data
+    # Recurse into a nested content list / single child.
+    child = _get(node, "content")
+    if isinstance(child, list):
+        return "\n".join(filter(None, (_extract_document_text(c, depth + 1) for c in child)))
+    if child is not None:
+        return _extract_document_text(child, depth + 1)
+    return ""
+
+
+def summarize_web_tool_result(res_block, query: str = ""):
+    """Normalize an Anthropic ``web_search_tool_result`` / ``web_fetch_tool_result``.
+
+    Returns ``(summary, canonical_result)`` where ``summary`` is the compact
+    one-liner (SSE ``shortDesc`` / TUI compact line) and ``canonical_result`` is
+    the provider-agnostic schema from :mod:`datus.schemas.web_result` — so a
+    Claude server-tool call renders identically to the local Tavily / httpx
+    backends and the OpenAI hosted path.
+    """
+    from datus.schemas.web_result import (
+        normalize_fetch_result,
+        normalize_search_results,
+        web_fetch_short_summary,
+        web_search_short_summary,
+    )
+
+    content = getattr(res_block, "content", None) if res_block is not None else None
+
+    # web_search: ``content`` is a list of result blocks (title/url/page_age).
+    if isinstance(content, list):
+        items = []
+        for item in content:
+            items.append(
+                {
+                    "title": getattr(item, "title", None) or "",
+                    "url": getattr(item, "url", None) or "",
+                    "snippet": "",  # Anthropic returns encrypted_content; no readable snippet.
+                    "age": getattr(item, "page_age", None),
+                }
+            )
+        canonical = normalize_search_results(query, items)
+        return web_search_short_summary(canonical), canonical
+
+    # web_fetch: ``content`` is a single document-bearing result block.
+    if content is not None:
+        url = getattr(content, "url", None) or getattr(res_block, "url", None) or ""
+        doc = getattr(content, "content", None)
+        title = getattr(doc, "title", None) or getattr(content, "title", None) or ""
+        text = _extract_document_text(doc)
+        canonical = normalize_fetch_result(url=url, title=title, content=text, truncated=False)
+        return web_fetch_short_summary(canonical), canonical
+
+    return "completed", {}
+
+
 def convert_tools_for_anthropic(mcp_tools):
     """Convert MCP tools to Anthropic tool format.
 
@@ -123,6 +200,10 @@ class ClaudeModel(OpenAICompatibleModel):
         "oauth-2025-04-20",
         "interleaved-thinking-2025-05-14",
         "prompt-caching-scope-2026-01-05",
+        # Enables the server-side ``web_fetch_20250910`` tool on the native path.
+        # Harmless when web_fetch isn't requested — Anthropic ignores betas for
+        # tools absent from the request. (web_search_20250305 is GA, no beta.)
+        "web-fetch-2025-09-10",
     ]
 
     # Claude Code client headers — required for subscription tokens to be accepted.
@@ -153,6 +234,15 @@ class ClaudeModel(OpenAICompatibleModel):
 
         # Initialize native Anthropic client (always available for prompt caching)
         self._init_anthropic_client()
+
+    def supports_builtin_web_search(self) -> bool:
+        # Anthropic web_search_20250305 (GA) runs server-side via the native path,
+        # which is available for both OAuth and API-key auth. Prefer it over Tavily.
+        return True
+
+    def supports_builtin_web_fetch(self) -> bool:
+        # Anthropic web_fetch_20250910 (beta) runs server-side via the native path.
+        return True
 
     def _get_api_key(self) -> str:
         """Get Anthropic API key from config or environment."""
@@ -321,7 +411,18 @@ class ClaudeModel(OpenAICompatibleModel):
                 "Async Anthropic client is not initialized; streaming unavailable",
             )
         if self._is_oauth_token:
+            # OAuth client already carries the OAuth + web-fetch betas in its
+            # default headers; beta.messages is required for that path.
             return self.async_anthropic_client.beta.messages.stream(**kwargs)
+        # API-key path: web_search_20250305 is GA, but web_fetch_20250910 is beta
+        # and must go through beta.messages with the web-fetch beta header (the
+        # API-key client carries no default betas).
+        tools = kwargs.get("tools") or []
+        if any(isinstance(t, dict) and t.get("type") == "web_fetch_20250910" for t in tools):
+            extra = dict(kwargs.pop("extra_headers", {}) or {})
+            existing_beta = extra.get("anthropic-beta")
+            extra["anthropic-beta"] = ",".join(filter(None, [existing_beta, "web-fetch-2025-09-10"]))
+            return self.async_anthropic_client.beta.messages.stream(extra_headers=extra, **kwargs)
         return self.async_anthropic_client.messages.stream(**kwargs)
 
     def _diagnose_oauth_401(self, original_error: Exception) -> None:
@@ -514,11 +615,23 @@ class ClaudeModel(OpenAICompatibleModel):
                             }
                         )
                         func_tool_map[ft.name] = ft
-                    # Re-apply cache control on last tool
-                    if tools:
-                        for t in tools:
-                            t.pop("cache_control", None)
-                        tools[-1]["cache_control"] = {"type": "ephemeral"}
+
+                # Append Anthropic server-side web tools when the node opts in.
+                # These run server-side (the results come back as
+                # web_search_tool_result / web_fetch_tool_result content blocks),
+                # so they are NOT registered in func_tool_map.
+                builtin_web = kwargs.get("builtin_web_tools") or {}
+                if builtin_web.get("web_search"):
+                    tools.append({"type": "web_search_20250305", "name": "web_search", "max_uses": 5})
+                if builtin_web.get("web_fetch"):
+                    tools.append({"type": "web_fetch_20250910", "name": "web_fetch", "max_uses": 5})
+
+                # Re-apply cache control so the ephemeral marker lands on the final
+                # tool, whatever its source (MCP / func / server-side web).
+                if tools:
+                    for t in tools:
+                        t.pop("cache_control", None)
+                    tools[-1]["cache_control"] = {"type": "ephemeral"}
                 # Load prior turns from the session so multi-turn chat works.
                 # Native Anthropic loop is not driven by openai-agents Runner, so
                 # we replay session history into ``messages`` ourselves.
@@ -582,6 +695,12 @@ class ClaudeModel(OpenAICompatibleModel):
                         temperature=kwargs.get("temperature", anthropic.NOT_GIVEN),
                     )
 
+                    # Track server-side web tool calls emitted in real time during
+                    # streaming so the post-stream scan (and the non-streaming
+                    # fallback) doesn't double-emit them.
+                    emitted_server_ids: set = set()
+                    server_tool_names: dict = {}
+                    server_tool_queries: dict = {}
                     if self.async_anthropic_client is not None:
                         # Streaming path: yield text deltas as ``thinking_delta``
                         # ActionHistory in real time (parity with
@@ -600,9 +719,54 @@ class ClaudeModel(OpenAICompatibleModel):
                                 event_type = getattr(event, "type", None)
                                 if event_type == "content_block_start":
                                     block_start = getattr(event, "content_block", None)
-                                    if block_start is not None and getattr(block_start, "type", None) == "text":
+                                    bs_type = getattr(block_start, "type", None) if block_start is not None else None
+                                    if bs_type == "text":
                                         thinking_stream_id = f"thinking_stream_{uuid.uuid4().hex[:8]}"
                                         thinking_accumulated = ""
+                                    elif bs_type == "server_tool_use":
+                                        # Server-side web tool call — surface it in real
+                                        # time (interleaved where it happens) instead of
+                                        # only after the stream completes.
+                                        sid = getattr(block_start, "id", None) or f"srv_{uuid.uuid4().hex[:8]}"
+                                        sname = getattr(block_start, "name", None) or "web_search"
+                                        server_tool_names[sid] = sname
+                                        emitted_server_ids.add(sid)
+                                        s_input = getattr(block_start, "input", {}) or {}
+                                        if isinstance(s_input, dict):
+                                            server_tool_queries[sid] = str(
+                                                s_input.get("query") or s_input.get("url") or ""
+                                            )
+                                        yield ActionHistory(
+                                            action_id=sid,
+                                            role=ActionRole.TOOL,
+                                            messages=f"Tool call: {sname}",
+                                            action_type=sname,
+                                            input={"function_name": sname, "arguments": s_input},
+                                            output={},
+                                            status=ActionStatus.PROCESSING,
+                                        )
+                                    elif bs_type in ("web_search_tool_result", "web_fetch_tool_result"):
+                                        tid = getattr(block_start, "tool_use_id", None)
+                                        sname = server_tool_names.get(tid, "web_search")
+                                        summary, canonical = summarize_web_tool_result(
+                                            block_start, query=server_tool_queries.get(tid, "")
+                                        )
+                                        complete = ActionHistory(
+                                            action_id=f"complete_{tid}",
+                                            role=ActionRole.TOOL,
+                                            messages=f"Tool call: {sname}",
+                                            action_type=sname,
+                                            input={"function_name": sname, "arguments": {}},
+                                            output={
+                                                "success": True,
+                                                "raw_output": {"success": True, "result": canonical},
+                                                "summary": summary,
+                                                "status_message": summary,
+                                            },
+                                            status=ActionStatus.SUCCESS,
+                                        )
+                                        complete.end_time = datetime.now()
+                                        yield complete
                                 elif event_type == "content_block_delta":
                                     delta = getattr(event, "delta", None)
                                     if delta is None or getattr(delta, "type", None) != "text_delta":
@@ -694,6 +858,60 @@ class ClaudeModel(OpenAICompatibleModel):
                         await self._invoke_hook(hooks, "on_llm_end", run_ctx, hook_agent, response)
 
                     message = response.content
+
+                    # Surface server-side tool calls (Anthropic web_search /
+                    # web_fetch) as TOOL ActionHistory. The streaming path already
+                    # emits these in real time (tracked in ``emitted_server_ids``);
+                    # this post-stream pass only covers the non-streaming fallback,
+                    # so it skips ids already emitted to avoid duplicates.
+                    server_results = {
+                        getattr(b, "tool_use_id", None): b
+                        for b in message
+                        if getattr(b, "type", None) in ("web_search_tool_result", "web_fetch_tool_result")
+                    }
+                    for block in message:
+                        if getattr(block, "type", None) != "server_tool_use":
+                            continue
+                        if block.id in emitted_server_ids:
+                            continue
+                        block_input = getattr(block, "input", {}) or {}
+                        s_args = json.dumps(block_input, ensure_ascii=False)[:80]
+                        q = (
+                            block_input.get("query") or block_input.get("url") or ""
+                            if isinstance(block_input, dict)
+                            else ""
+                        )
+                        summary, canonical = summarize_web_tool_result(server_results.get(block.id), query=q)
+                        start_action = ActionHistory(
+                            action_id=block.id,
+                            role=ActionRole.TOOL,
+                            messages=f"Tool call: {block.name}('{s_args}...')",
+                            action_type=block.name,
+                            input={"function_name": block.name, "arguments": block_input},
+                            output={},
+                            status=ActionStatus.PROCESSING,
+                        )
+                        if action_history_manager is not None:
+                            action_history_manager.add_action(start_action)
+                        yield start_action
+                        complete_action = ActionHistory(
+                            action_id=f"complete_{block.id}",
+                            role=ActionRole.TOOL,
+                            messages=f"Tool call: {block.name}('{s_args}...')",
+                            action_type=block.name,
+                            input={"function_name": block.name, "arguments": block_input},
+                            output={
+                                "success": True,
+                                "raw_output": {"success": True, "result": canonical},
+                                "summary": summary,
+                                "status_message": summary,
+                            },
+                            status=ActionStatus.SUCCESS,
+                        )
+                        complete_action.end_time = datetime.now()
+                        if action_history_manager is not None:
+                            action_history_manager.add_action(complete_action)
+                        yield complete_action
 
                     # If no tool calls, conversation is complete
                     if not any(block.type == "tool_use" for block in message):
@@ -853,6 +1071,15 @@ class ClaudeModel(OpenAICompatibleModel):
                                 }
                             )
                             tool_use_blocks.append(block)
+                        else:
+                            # Preserve server-side blocks (server_tool_use /
+                            # web_search_tool_result / web_fetch_tool_result) verbatim
+                            # so a mixed turn (server web tool + local tool_use) keeps a
+                            # valid assistant message when replayed to Anthropic next turn.
+                            try:
+                                content.append(block.model_dump(mode="json"))
+                            except Exception:
+                                logger.debug("Skipping non-serializable content block: %s", getattr(block, "type", "?"))
 
                     if content:
                         messages.append({"role": "assistant", "content": content})
@@ -1223,9 +1450,14 @@ class ClaudeModel(OpenAICompatibleModel):
         Routes to native Anthropic API for OAuth subscription tokens,
         otherwise uses parent class LiteLLM implementation.
         """
-        # For OAuth tokens, use native path (LiteLLM sends x-api-key which is incompatible)
-        # Directly iterate the async generator for real-time tool call display
-        if self.use_native_api and self._is_oauth_token:
+        # Route to the native Anthropic path for (a) OAuth subscription tokens
+        # (LiteLLM sends x-api-key which is incompatible with Bearer auth), or
+        # (b) whenever vendor-native web tools are requested — server tools can
+        # only be expressed as raw tool dicts on the native Messages API, not via
+        # the agents-SDK LiteLLM tool list. Non-web calls (e.g. compaction
+        # summarization, which passes no builtin_web_tools) stay on LiteLLM.
+        _want_builtin_web = any((kwargs.get("builtin_web_tools") or {}).values())
+        if (self.use_native_api and self._is_oauth_token) or _want_builtin_web:
             if action_history_manager is None:
                 action_history_manager = ActionHistoryManager()
             async for action in self._generate_with_mcp_stream(

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -12,7 +12,7 @@ import uuid
 from contextlib import nullcontext
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
-from agents import Agent, ModelSettings, Runner, SQLiteSession, Tool
+from agents import Agent, ModelSettings, Runner, SQLiteSession, Tool, WebSearchTool
 from agents.exceptions import MaxTurnsExceeded
 from agents.mcp import MCPServerStdio
 from agents.models.openai_responses import OpenAIResponsesModel
@@ -107,6 +107,14 @@ class CodexModel(LLMBaseModel):
         # conversation (with a real timestamp) and reused for every LLM call so
         # the backend routes them to one cache node. See _stable_prompt_cache_key.
         self._prompt_cache_keys: Dict[str, str] = {}
+
+    def supports_builtin_web_search(self) -> bool:
+        # OpenAI Responses API exposes a hosted ``web_search`` tool.
+        return True
+
+    def supports_builtin_web_fetch(self) -> bool:
+        # OpenAI Responses has no hosted fetch tool; web_fetch uses the local backend.
+        return False
 
     @staticmethod
     def _resolve_config_api_key(api_key: str | None) -> str | None:
@@ -436,6 +444,8 @@ class CodexModel(LLMBaseModel):
                 agent_kwargs["mcp_servers"] = list(connected_servers.values())
             if tools:
                 agent_kwargs["tools"] = tools
+            if (kwargs.get("builtin_web_tools") or {}).get("web_search"):
+                agent_kwargs["tools"] = [*(agent_kwargs.get("tools") or []), WebSearchTool()]
             if kwargs.get("hooks"):
                 agent_kwargs["hooks"] = kwargs["hooks"]
 
@@ -524,6 +534,8 @@ class CodexModel(LLMBaseModel):
                 agent_kwargs["mcp_servers"] = list(connected_servers.values())
             if tools:
                 agent_kwargs["tools"] = tools
+            if (kwargs.get("builtin_web_tools") or {}).get("web_search"):
+                agent_kwargs["tools"] = [*(agent_kwargs.get("tools") or []), WebSearchTool()]
             if hooks:
                 agent_kwargs["hooks"] = hooks
 
@@ -541,6 +553,10 @@ class CodexModel(LLMBaseModel):
             early_assistant_yielded = False
             thinking_stream_id: Optional[str] = None
             thinking_accumulated = ""
+            # Hosted web_search completions are deferred to stream end so we can
+            # attach the assistant message's url_citation results (the call item
+            # itself carries no results). See the flush after the stream loop.
+            pending_hosted_searches: List[dict] = []
 
             try:
                 while not result.is_complete:
@@ -640,13 +656,25 @@ class CodexModel(LLMBaseModel):
                             if raw_item:
                                 # Normalize access: raw_item can be dict (Responses API) or object
                                 if isinstance(raw_item, dict):
-                                    tool_name = raw_item.get("name", "unknown")
+                                    tool_name = raw_item.get("name")
                                     call_id = raw_item.get("call_id")
                                     arguments = raw_item.get("arguments", "{}")
                                 else:
-                                    tool_name = getattr(raw_item, "name", "unknown")
+                                    tool_name = getattr(raw_item, "name", None)
                                     call_id = getattr(raw_item, "call_id", None)
                                     arguments = getattr(raw_item, "arguments", "{}")
+                                is_hosted = False
+                                if not tool_name:
+                                    # Server-side hosted tools (web_search_call, …) carry no
+                                    # name/arguments; resolve a friendly label + query.
+                                    from datus.models.openai_compatible import describe_hosted_tool_item
+
+                                    hosted = describe_hosted_tool_item(raw_item)
+                                    if hosted:
+                                        tool_name, call_id, arguments = hosted
+                                        is_hosted = True
+                                    else:
+                                        tool_name = "unknown"
                                 if not call_id:
                                     call_id = f"tool_{uuid.uuid4().hex[:8]}"
                                 args_str = str(arguments)[:80]
@@ -668,6 +696,30 @@ class CodexModel(LLMBaseModel):
                                 )
                                 action_history_manager.add_action(action)
                                 yield action
+
+                                # Hosted tools run server-side with no separate
+                                # output item; their results arrive as url_citation
+                                # annotations on the assistant message, so defer the
+                                # completion until the stream ends (flush below).
+                                if is_hosted:
+                                    temp_tool_calls.pop(call_id, None)
+                                    from datus.schemas.web_result import extract_action_sources, hosted_action_query
+
+                                    raw_action = (
+                                        raw_item.get("action")
+                                        if isinstance(raw_item, dict)
+                                        else getattr(raw_item, "action", None)
+                                    )
+                                    pending_hosted_searches.append(
+                                        {
+                                            "call_id": call_id,
+                                            "tool_name": tool_name,
+                                            "arguments": arguments,
+                                            "args_str": args_str,
+                                            "query": str(hosted_action_query(raw_action) or ""),
+                                            "sources": extract_action_sources(raw_action),
+                                        }
+                                    )
 
                         elif item_type == "tool_call_output_item":
                             raw_item = getattr(event.item, "raw_item", None)
@@ -698,6 +750,12 @@ class CodexModel(LLMBaseModel):
                                 )
                                 action_history_manager.add_action(action)
                                 yield action
+
+                # Flush deferred hosted web_search completions with the canonical
+                # results read back from the assistant message's url_citations.
+                for hosted_done in self._build_hosted_search_completions(pending_hosted_searches, result):
+                    action_history_manager.add_action(hosted_done)
+                    yield hosted_done
             except MaxTurnsExceeded as e:
                 raise DatusException(ErrorCode.MODEL_MAX_TURNS_EXCEEDED, message_args={"max_turns": max_turns}) from e
             except Exception as e:
@@ -747,6 +805,55 @@ class CodexModel(LLMBaseModel):
             )
             action_history_manager.add_action(final_action)
             yield final_action
+
+    @staticmethod
+    def _build_hosted_search_completions(pending: List[dict], result) -> List[ActionHistory]:
+        """Build deferred completions for hosted ``web_search`` calls.
+
+        Results are not on the call item; the title+url pairs the model used
+        surface as ``url_citation`` annotations on the assistant message. We read
+        them back from ``result.to_input_list()`` and attach the turn's full
+        citation set as each hosted search's canonical results (falling back to
+        the call's own ``action.sources`` URLs when there were no citations).
+        """
+        from datus.schemas.web_result import (
+            collect_citations_from_input_list,
+            normalize_search_results,
+            web_search_short_summary,
+        )
+
+        if not pending:
+            return []
+
+        citations: List[dict] = []
+        try:
+            if hasattr(result, "to_input_list"):
+                citations = collect_citations_from_input_list(result.to_input_list())
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Failed to collect web_search citations: {e}")
+
+        actions: List[ActionHistory] = []
+        for call in pending:
+            items = citations or call.get("sources") or []
+            canonical = normalize_search_results(call.get("query", ""), items)
+            summary = web_search_short_summary(canonical)
+            actions.append(
+                ActionHistory(
+                    action_id=f"complete_{call['call_id']}",
+                    role=ActionRole.TOOL,
+                    messages=f"Tool call: {call['tool_name']}('{call['args_str']}...')",
+                    action_type=call["tool_name"],
+                    input={"function_name": call["tool_name"], "arguments": call["arguments"]},
+                    output={
+                        "success": True,
+                        "raw_output": {"success": True, "result": canonical},
+                        "summary": summary,
+                        "status_message": summary,
+                    },
+                    status=ActionStatus.SUCCESS,
+                )
+            )
+        return actions
 
     def _extract_usage_info(self, source) -> dict:
         """Extract usage info from an SDK ``RunResult`` or ``Usage`` object.

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -269,6 +269,10 @@ class CodexModel(LLMBaseModel):
         return ModelSettings(
             store=False,
             include_usage=True,
+            # Mirror the OpenAI Responses path: when the hosted web_search tool
+            # runs, echo the per-call source URLs (``action.sources``) so they are
+            # available as a fallback for the richer url_citation results.
+            response_include=["web_search_call.action.sources"],
             extra_args={"prompt_cache_key": key},
             extra_headers=extra_headers,
         )

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -46,24 +46,29 @@ from datus.utils.trace_context import build_agents_run_config_kwargs, build_trac
 logger = get_logger(__name__)
 
 
-def describe_hosted_tool_item(raw_item):
-    """Resolve display fields for an OpenAI Responses hosted tool run-item.
+def describe_hosted_tool_item(raw_item: Any) -> Optional[tuple[str, Optional[str], str]]:
+    """Resolve display fields for an OpenAI Responses hosted ``web_search`` run-item.
 
-    Hosted tools (``web_search_call`` / ``file_search_call`` / ``image_generation_call``
-    / ``code_interpreter_call`` …) are executed server-side, so their run-item is NOT
-    a ``function_call`` and carries no ``name``/``call_id``/``arguments`` — leaving the
-    stream converter to label them ``unknown``. Map them to a friendly tool name and
-    surface the query/url so the CLI/web event stream shows e.g. ``web_search(...)``.
+    The hosted ``web_search`` tool runs server-side, so its run-item is NOT a
+    ``function_call`` and carries no ``name``/``call_id``/``arguments`` — leaving
+    the stream converter to label it ``unknown``. Map it to ``web_search`` and
+    surface the query/url so the CLI/web event stream shows ``web_search(...)``.
 
-    Returns ``(name, call_id, arguments_json)`` for a hosted tool item, or ``None``
-    when the item is a regular function call (handled by the normal path).
+    Restricted to ``web_search_call``: the downstream deferred path normalizes
+    every hosted completion through :func:`normalize_search_results`, so other
+    hosted ``*_call`` items (``file_search_call`` / ``image_generation_call`` /
+    ``code_interpreter_call`` …) must NOT be routed here until they get their own
+    completion handling.
+
+    Returns ``(name, call_id, arguments_json)`` for a hosted ``web_search`` item,
+    or ``None`` for anything else (handled by the normal function-call path).
     """
     itype = raw_item.get("type") if isinstance(raw_item, dict) else getattr(raw_item, "type", None)
-    if not itype or itype == "function_call" or not itype.endswith("_call"):
+    if itype != "web_search_call":
         return None
     name = itype[: -len("_call")]  # "web_search_call" -> "web_search"
 
-    def _get(obj, key):
+    def _get(obj: Any, key: str) -> Any:
         return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
 
     call_id = _get(raw_item, "id") or _get(raw_item, "call_id")
@@ -781,7 +786,11 @@ class OpenAICompatibleModel(LLMBaseModel):
         return tools
 
     @staticmethod
-    async def _flush_pending_hosted_searches(pending: List[dict], result, action_history_manager):
+    async def _flush_pending_hosted_searches(
+        pending: List[Dict[str, Any]],
+        result: Any,
+        action_history_manager: Optional[ActionHistoryManager],
+    ) -> AsyncGenerator[ActionHistory, None]:
         """Emit deferred completions for hosted ``web_search`` calls.
 
         OpenAI's hosted search returns no results on the call item; the title+url
@@ -1467,9 +1476,17 @@ class OpenAICompatibleModel(LLMBaseModel):
                             final_assistant_yielded = False
                             raw_item = getattr(event.item, "raw_item", None)
                             if raw_item:
-                                tool_name = getattr(raw_item, "name", None)
-                                arguments = getattr(raw_item, "arguments", "{}")
-                                call_id = getattr(raw_item, "call_id", None)
+                                # ``raw_item`` may be a dict (e.g. function_call
+                                # replayed from an input list) or an SDK object;
+                                # mirror the tool_call_output_item handling below.
+                                if isinstance(raw_item, dict):
+                                    tool_name = raw_item.get("name")
+                                    arguments = raw_item.get("arguments", "{}")
+                                    call_id = raw_item.get("call_id")
+                                else:
+                                    tool_name = getattr(raw_item, "name", None)
+                                    arguments = getattr(raw_item, "arguments", "{}")
+                                    call_id = getattr(raw_item, "call_id", None)
                                 is_hosted = False
                                 if not tool_name:
                                     hosted = describe_hosted_tool_item(raw_item)
@@ -1527,7 +1544,11 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     temp_tool_calls.pop(call_id, None)
                                     from datus.schemas.web_result import extract_action_sources, hosted_action_query
 
-                                    raw_action = getattr(raw_item, "action", None)
+                                    raw_action = (
+                                        raw_item.get("action")
+                                        if isinstance(raw_item, dict)
+                                        else getattr(raw_item, "action", None)
+                                    )
                                     pending_hosted_searches.append(
                                         {
                                             "call_id": call_id,

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -18,7 +18,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 import httpx
 import litellm
 import yaml
-from agents import Agent, ModelSettings, Runner, Tool
+from agents import Agent, ModelSettings, Runner, Tool, WebSearchTool
 from agents.exceptions import MaxTurnsExceeded, ModelBehaviorError
 from agents.extensions.memory import AdvancedSQLiteSession
 from agents.mcp import MCPServerStdio
@@ -44,6 +44,37 @@ from datus.utils.text_utils import LitellmPlaceholderStreamFilter, strip_litellm
 from datus.utils.trace_context import build_agents_run_config_kwargs, build_trace_span_attributes
 
 logger = get_logger(__name__)
+
+
+def describe_hosted_tool_item(raw_item):
+    """Resolve display fields for an OpenAI Responses hosted tool run-item.
+
+    Hosted tools (``web_search_call`` / ``file_search_call`` / ``image_generation_call``
+    / ``code_interpreter_call`` …) are executed server-side, so their run-item is NOT
+    a ``function_call`` and carries no ``name``/``call_id``/``arguments`` — leaving the
+    stream converter to label them ``unknown``. Map them to a friendly tool name and
+    surface the query/url so the CLI/web event stream shows e.g. ``web_search(...)``.
+
+    Returns ``(name, call_id, arguments_json)`` for a hosted tool item, or ``None``
+    when the item is a regular function call (handled by the normal path).
+    """
+    itype = raw_item.get("type") if isinstance(raw_item, dict) else getattr(raw_item, "type", None)
+    if not itype or itype == "function_call" or not itype.endswith("_call"):
+        return None
+    name = itype[: -len("_call")]  # "web_search_call" -> "web_search"
+
+    def _get(obj, key):
+        return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+
+    call_id = _get(raw_item, "id") or _get(raw_item, "call_id")
+    action = _get(raw_item, "action")
+    args: dict = {}
+    if action is not None:
+        query = _get(action, "query") or _get(action, "queries") or _get(action, "url")
+        if query:
+            args["query"] = query
+    return name, call_id, json.dumps(args, ensure_ascii=False)
+
 
 # LiteLLM configuration
 # Enable dropping unsupported parameters for providers that don't support them
@@ -732,6 +763,72 @@ class OpenAICompatibleModel(LLMBaseModel):
 
             return {"error": "Failed to parse JSON response", "raw_response": response_text}
 
+    @staticmethod
+    def _maybe_add_builtin_web_search(tools: Optional[List[Tool]], kwargs: dict) -> Optional[List[Tool]]:
+        """Append the OpenAI hosted ``WebSearchTool`` when the node opts in.
+
+        Only OpenAIModel sets ``supports_builtin_web_search`` (the node then passes
+        ``builtin_web_tools={"web_search": True}``), so this is a no-op for every
+        other OpenAI-compatible provider. The hosted tool is served by the OpenAI
+        Responses API; the local ``web_search`` function tool is suppressed by the
+        node when this is active. Idempotent.
+        """
+        if not (kwargs.get("builtin_web_tools") or {}).get("web_search"):
+            return tools
+        tools = list(tools or [])
+        if not any(isinstance(t, WebSearchTool) for t in tools):
+            tools.append(WebSearchTool())
+        return tools
+
+    @staticmethod
+    async def _flush_pending_hosted_searches(pending: List[dict], result, action_history_manager):
+        """Emit deferred completions for hosted ``web_search`` calls.
+
+        OpenAI's hosted search returns no results on the call item; the title+url
+        pairs the model used surface as ``url_citation`` annotations on the
+        assistant message. We read them back from ``result.to_input_list()``
+        (annotations preserved) and, per the agreed model, attach the turn's full
+        citation set as each hosted search's canonical results — falling back to
+        the call's own ``action.sources`` URLs when no citations were produced.
+        """
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+        from datus.schemas.web_result import (
+            collect_citations_from_input_list,
+            normalize_search_results,
+            web_search_short_summary,
+        )
+
+        citations: List[dict] = []
+        try:
+            if hasattr(result, "to_input_list"):
+                citations = collect_citations_from_input_list(result.to_input_list())
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Failed to collect web_search citations: {e}")
+
+        for call in pending:
+            items = citations or call.get("sources") or []
+            canonical = normalize_search_results(call.get("query", ""), items)
+            summary = web_search_short_summary(canonical)
+            done_action = ActionHistory(
+                action_id=f"complete_{call['call_id']}",
+                role=ActionRole.TOOL,
+                messages=f"Tool call: {call['tool_name']}('{call['args_str']}...')",
+                action_type=call["tool_name"],
+                input={"function_name": call["tool_name"], "arguments": call["arguments"]},
+                output={
+                    "success": True,
+                    "raw_output": {"success": True, "result": canonical},
+                    "summary": summary,
+                    "status_message": summary,
+                },
+                status=ActionStatus.SUCCESS,
+                start_time=call.get("start_time"),
+            )
+            done_action.end_time = datetime.now()
+            if action_history_manager is not None:
+                action_history_manager.add_action(done_action)
+            yield done_action
+
     async def generate_with_tools(
         self,
         prompt: Union[str, List[Dict[str, str]]],
@@ -764,6 +861,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         Returns:
             Dict with content and sql_contexts
         """
+        tools = self._maybe_add_builtin_web_search(tools, kwargs)
         # Use the internal method that returns a Dict
         result = await self._generate_with_tools_internal(
             prompt,
@@ -829,6 +927,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         if action_history_manager is None:
             action_history_manager = ActionHistoryManager()
 
+        tools = self._maybe_add_builtin_web_search(tools, kwargs)
         async for action in self._generate_with_tools_stream_internal(
             prompt,
             mcp_servers,
@@ -1013,6 +1112,15 @@ class OpenAICompatibleModel(LLMBaseModel):
                 existing_extra_args = model_settings_kwargs.get("extra_args", {})
                 existing_extra_args["prompt_cache_key"] = prompt_cache_key
                 model_settings_kwargs["extra_args"] = existing_extra_args
+
+        # When the hosted web_search tool is in play, ask the Responses API to
+        # echo the per-call source URLs (``action.sources``). They are a fallback
+        # for the richer url_citation results we read off the assistant message.
+        if tools and any(isinstance(t, WebSearchTool) for t in tools):
+            existing_include = list(model_settings_kwargs.get("response_include") or [])
+            if "web_search_call.action.sources" not in existing_include:
+                existing_include.append("web_search_call.action.sources")
+            model_settings_kwargs["response_include"] = existing_include
 
         agent_kwargs["model_settings"] = ModelSettings(**model_settings_kwargs)
 
@@ -1229,6 +1337,10 @@ class OpenAICompatibleModel(LLMBaseModel):
                 tool_output_seen = False
                 final_assistant_yielded = False
                 last_assistant_text = ""
+                # Hosted web_search calls run server-side and expose no results on
+                # the call item; we defer their completion until after the stream
+                # so we can attach the assistant message's url_citation results.
+                pending_hosted_searches: List[dict] = []
 
                 # Streaming thinking state: accumulate text deltas for real-time output
                 thinking_stream_id: Optional[str] = None
@@ -1356,12 +1468,19 @@ class OpenAICompatibleModel(LLMBaseModel):
                             raw_item = getattr(event.item, "raw_item", None)
                             if raw_item:
                                 tool_name = getattr(raw_item, "name", None)
-                                if not tool_name:
-                                    logger.warning(f"Tool call has no name field: {type(raw_item)}, {dir(raw_item)}")
-                                    tool_name = "unknown"
-
                                 arguments = getattr(raw_item, "arguments", "{}")
                                 call_id = getattr(raw_item, "call_id", None)
+                                is_hosted = False
+                                if not tool_name:
+                                    hosted = describe_hosted_tool_item(raw_item)
+                                    if hosted:
+                                        tool_name, call_id, arguments = hosted
+                                        is_hosted = True
+                                    else:
+                                        logger.warning(
+                                            f"Tool call has no name field: {type(raw_item)}, {dir(raw_item)}"
+                                        )
+                                        tool_name = "unknown"
 
                                 # Generate call_id if missing
                                 if not call_id:
@@ -1369,6 +1488,7 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     logger.warning(f"Tool call missing call_id, generated: {call_id}")
 
                                 # Try to format arguments
+                                args_dict: dict = {}
                                 try:
                                     args_dict = json.loads(arguments) if arguments else {}
                                     args_str = to_str(args_dict)[:80]
@@ -1396,6 +1516,31 @@ class OpenAICompatibleModel(LLMBaseModel):
                                 )
                                 action_history_manager.add_action(start_action)
                                 yield start_action
+
+                                # Hosted tools (web_search, …) run server-side and
+                                # emit no ``tool_call_output_item``. The results
+                                # are not on the call item — they arrive as
+                                # url_citation annotations on the assistant
+                                # message — so defer the completion until the
+                                # stream ends (see the pending-hosted flush below).
+                                if is_hosted:
+                                    temp_tool_calls.pop(call_id, None)
+                                    from datus.schemas.web_result import extract_action_sources, hosted_action_query
+
+                                    raw_action = getattr(raw_item, "action", None)
+                                    pending_hosted_searches.append(
+                                        {
+                                            "call_id": call_id,
+                                            "tool_name": tool_name,
+                                            "arguments": arguments,
+                                            "args_str": args_str,
+                                            "query": str(
+                                                hosted_action_query(raw_action) or args_dict.get("query") or ""
+                                            ),
+                                            "sources": extract_action_sources(raw_action),
+                                            "start_time": datetime.now(),
+                                        }
+                                    )
 
                         # Handle tool call completion
                         elif item_type == "tool_call_output_item":
@@ -1524,6 +1669,16 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     action_history_manager.add_action(thinking_action)
                                     yield thinking_action
                                     mark_assistant_response(text_content, is_thinking)
+
+                # Flush deferred hosted web_search completions. The url_citation
+                # results live on the assistant message(s); read them back from
+                # the final input list (which preserves annotations) and attach
+                # them as the canonical web_search result for the turn's calls.
+                if pending_hosted_searches:
+                    async for hosted_done in self._flush_pending_hosted_searches(
+                        pending_hosted_searches, result, action_history_manager
+                    ):
+                        yield hosted_done
 
                 final_output = getattr(result, "final_output", "") or ""
                 if not isinstance(final_output, str):

--- a/datus/models/openai_model.py
+++ b/datus/models/openai_model.py
@@ -27,6 +27,15 @@ class OpenAIModel(OpenAICompatibleModel):
         """
         super().__init__(model_config, **kwargs)
 
+    def supports_builtin_web_search(self) -> bool:
+        # OpenAI Responses API exposes a hosted ``web_search`` tool (works with a
+        # standard API key, billed per call). Prefer it over the local Tavily backend.
+        return True
+
+    def supports_builtin_web_fetch(self) -> bool:
+        # OpenAI Responses has no hosted fetch tool; web_fetch uses the local backend.
+        return False
+
     def _get_api_key(self) -> str:
         """Get OpenAI API key from config or environment."""
         api_key = self.model_config.api_key or os.environ.get("OPENAI_API_KEY")

--- a/datus/prompts/prompt_templates/_ask_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_ask_artifact_common.j2
@@ -61,7 +61,12 @@ questions.
 {% if has_platform_doc_tools -%}
 
 **Platform documentation tools** (if SQL questions touch dialect specifics):
-- `list_document_nav`, `get_document`, `search_document`, `web_search_document`.
+- `list_document_nav`, `get_document`, `search_document`.
+{% endif %}
+{% if has_web_tools -%}
+
+**Web tools** (when local knowledge/docs are insufficient):
+- `web_search` (find sources), `web_fetch` (read a specific page).
 {% endif %}
 
 ## Conversation conventions

--- a/datus/prompts/prompt_templates/_ask_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_ask_artifact_common.j2
@@ -63,11 +63,6 @@ questions.
 **Platform documentation tools** (if SQL questions touch dialect specifics):
 - `list_document_nav`, `get_document`, `search_document`.
 {% endif %}
-{% if has_web_tools -%}
-
-**Web tools** (when local knowledge/docs are insufficient):
-- `web_search` (find sources), `web_fetch` (read a specific page).
-{% endif %}
 
 ## Conversation conventions
 

--- a/datus/prompts/prompt_templates/chat_system_1.1.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.1.j2
@@ -13,7 +13,11 @@ You have access to:
   - `list_document_nav`: Browse the documentation navigation tree for the target platform. Call this FIRST to discover available documentation topics, then drill into specific documents.
   - `get_document`: Retrieve the full content of a specific document by its hierarchy path. Pass parent group(s) + document title (e.g., titles=["DDL", "CREATE TABLE"]). To retrieve multiple documents, call this tool multiple times — do NOT pass multiple document titles in a single call.
   - `search_document`: Search documentation using natural language keywords when you are unsure of exact titles (e.g., keywords=["window functions", "partitioning"]).
-  - `web_search_document`: Search the web for platform documentation or technical information when local docs are insufficient. Supports domain filtering (e.g., include_domains=["docs.snowflake.com"]).
+{% endif -%}
+{% if has_web_tools -%}
+- Web Tools for retrieving information from the public internet:
+  - `web_search`: Search the web for up-to-date information or technical references. Supports domain filtering (e.g., include_domains=["docs.snowflake.com"]).
+  - `web_fetch`: Fetch and read the full text of a specific web page by URL (e.g., a result from `web_search`).
 {% endif -%}
 
 Before generating SQL queries, you should:
@@ -24,7 +28,9 @@ Before generating SQL queries, you should:
 - When writing SQL for a specific platform (e.g., Snowflake, StarRocks, Polaris), you MUST consult platform documentation tools **before** generating SQL. Do NOT guess platform-specific syntax. Use them in this priority order:
   1. `list_document_nav` → `get_document` — browse the documentation tree and retrieve specific pages (most complete content)
   2. `search_document` — search by keywords when you already know what to look for or browsing did not surface the right document
-  3. `web_search_document` — fallback to web search when local docs do not cover the topic
+{% endif -%}
+{% if has_web_tools -%}
+- When local knowledge and documentation are insufficient, use `web_search` to find authoritative sources and `web_fetch` to read a specific page in full.
 {% endif -%}
 
 Guidelines:

--- a/datus/prompts/prompt_templates/chat_system_1.1.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.1.j2
@@ -14,11 +14,6 @@ You have access to:
   - `get_document`: Retrieve the full content of a specific document by its hierarchy path. Pass parent group(s) + document title (e.g., titles=["DDL", "CREATE TABLE"]). To retrieve multiple documents, call this tool multiple times — do NOT pass multiple document titles in a single call.
   - `search_document`: Search documentation using natural language keywords when you are unsure of exact titles (e.g., keywords=["window functions", "partitioning"]).
 {% endif -%}
-{% if has_web_tools -%}
-- Web Tools for retrieving information from the public internet:
-  - `web_search`: Search the web for up-to-date information or technical references. Supports domain filtering (e.g., include_domains=["docs.snowflake.com"]).
-  - `web_fetch`: Fetch and read the full text of a specific web page by URL (e.g., a result from `web_search`).
-{% endif -%}
 
 Before generating SQL queries, you should:
 - Use `search_table` when table information is missing or unclear
@@ -28,9 +23,6 @@ Before generating SQL queries, you should:
 - When writing SQL for a specific platform (e.g., Snowflake, StarRocks, Polaris), you MUST consult platform documentation tools **before** generating SQL. Do NOT guess platform-specific syntax. Use them in this priority order:
   1. `list_document_nav` → `get_document` — browse the documentation tree and retrieve specific pages (most complete content)
   2. `search_document` — search by keywords when you already know what to look for or browsing did not surface the right document
-{% endif -%}
-{% if has_web_tools -%}
-- When local knowledge and documentation are insufficient, use `web_search` to find authoritative sources and `web_fetch` to read a specific page in full.
 {% endif -%}
 
 Guidelines:

--- a/datus/prompts/prompt_templates/chat_system_1.2.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.2.j2
@@ -19,7 +19,12 @@ You have access to:
   - `list_document_nav`: Browse the documentation navigation tree for the target platform. Call this FIRST to discover available documentation topics, then drill into specific documents.
   - `get_document`: Retrieve the full content of a specific document by its hierarchy path. Pass parent group(s) + document title (e.g., titles=["DDL", "CREATE TABLE"]). To retrieve multiple documents, call this tool multiple times — do NOT pass multiple document titles in a single call.
   - `search_document`: Search documentation using natural language keywords when you are unsure of exact titles (e.g., keywords=["window functions", "partitioning"]).
-  - `web_search_document`: Search the web for platform documentation or technical information when local docs are insufficient. Supports domain filtering (e.g., include_domains=["docs.snowflake.com"]).
+{% endif -%}
+
+{% if has_web_tools -%}
+- Web Tools for retrieving information from the public internet:
+  - `web_search`: Search the web for up-to-date information or technical references. Supports domain filtering (e.g., include_domains=["docs.snowflake.com"]).
+  - `web_fetch`: Fetch and read the full text of a specific web page by URL (e.g., a result from `web_search`).
 {% endif -%}
 
 {% if has_task_tool -%}
@@ -38,7 +43,9 @@ Match by deliverable ownership and intent, not by keyword or perceived complexit
 - When writing SQL for a specific platform (e.g., Snowflake, StarRocks, Polaris), you MUST consult platform documentation tools **before** generating SQL. Do NOT guess platform-specific syntax. Use them in this priority order:
   1. `list_document_nav` → `get_document` — browse the documentation tree and retrieve specific pages (most complete content)
   2. `search_document` — search by keywords when you already know what to look for or browsing did not surface the right document
-  3. `web_search_document` — fallback to web search when local docs do not cover the topic
+{% endif -%}
+{% if has_web_tools -%}
+- When local knowledge and documentation are insufficient, use `web_search` to find authoritative sources and `web_fetch` to read a specific page in full.
 {% endif -%}
 
 {% if rules|length > 0 %}

--- a/datus/prompts/prompt_templates/chat_system_1.2.j2
+++ b/datus/prompts/prompt_templates/chat_system_1.2.j2
@@ -21,12 +21,6 @@ You have access to:
   - `search_document`: Search documentation using natural language keywords when you are unsure of exact titles (e.g., keywords=["window functions", "partitioning"]).
 {% endif -%}
 
-{% if has_web_tools -%}
-- Web Tools for retrieving information from the public internet:
-  - `web_search`: Search the web for up-to-date information or technical references. Supports domain filtering (e.g., include_domains=["docs.snowflake.com"]).
-  - `web_fetch`: Fetch and read the full text of a specific web page by URL (e.g., a result from `web_search`).
-{% endif -%}
-
 {% if has_task_tool -%}
 - Task delegation tool (`task`) for specialized subagent execution. The `task` tool's own description is the authoritative routing reference — it enumerates every available subagent type with its When-to-use / Do-NOT-use rubric and session-resume contract, so that detail is intentionally NOT duplicated here.
 
@@ -43,9 +37,6 @@ Match by deliverable ownership and intent, not by keyword or perceived complexit
 - When writing SQL for a specific platform (e.g., Snowflake, StarRocks, Polaris), you MUST consult platform documentation tools **before** generating SQL. Do NOT guess platform-specific syntax. Use them in this priority order:
   1. `list_document_nav` → `get_document` — browse the documentation tree and retrieve specific pages (most complete content)
   2. `search_document` — search by keywords when you already know what to look for or browsing did not surface the right document
-{% endif -%}
-{% if has_web_tools -%}
-- When local knowledge and documentation are insufficient, use `web_search` to find authoritative sources and `web_fetch` to read a specific page in full.
 {% endif -%}
 
 {% if rules|length > 0 %}

--- a/datus/prompts/prompt_templates/gen_sql_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_sql_system_1.2.j2
@@ -101,9 +101,10 @@ When platform-specific syntax, functions, data types, advanced features, or plat
 {% if "search_document" in tools %}
 - Use `search_document` when you know the feature but not the document title.
 {% endif %}
-{% if "web_search_document" in tools %}
-- Use `web_search_document` only as a fallback when local documentation is insufficient.
 {% endif %}
+{% if "web_search" in tools or "web_fetch" in tools %}
+## Web
+- Use `web_search` to find authoritative sources and `web_fetch` to read a specific result page, only as a fallback when local knowledge and documentation are insufficient.
 {% endif %}
 
 ## SQL Generation

--- a/datus/prompts/prompt_templates/gen_sql_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_sql_system_1.2.j2
@@ -102,10 +102,6 @@ When platform-specific syntax, functions, data types, advanced features, or plat
 - Use `search_document` when you know the feature but not the document title.
 {% endif %}
 {% endif %}
-{% if "web_search" in tools or "web_fetch" in tools %}
-## Web
-- Use `web_search` to find authoritative sources and `web_fetch` to read a specific result page, only as a fallback when local knowledge and documentation are insufficient.
-{% endif %}
 
 ## SQL Generation
 - Generate only the columns needed to answer the user.

--- a/datus/schemas/tool_summary.py
+++ b/datus/schemas/tool_summary.py
@@ -34,7 +34,10 @@ logger = get_logger(__name__)
 SUMMARY_TEXT_MAX_CHARS = 19
 SUMMARY_ERROR_MAX_CHARS = 19
 
-FS_TOOLS_NO_CLIP = frozenset({"read_file", "write_file", "edit_file", "glob", "grep"})
+# Filesystem tools want full path/count visibility; web tools want their
+# result titles / page label visible on the compact line rather than clipped
+# to a handful of characters.
+FS_TOOLS_NO_CLIP = frozenset({"read_file", "write_file", "edit_file", "glob", "grep", "web_search", "web_fetch"})
 
 
 # ── Generic helpers (public API) ────────────────────────────────────────
@@ -1018,7 +1021,13 @@ def _fmt_search_document(result: Any) -> str:
     return ""
 
 
-def _fmt_web_search_document(result: Any) -> str:
+def _fmt_web_search(result: Any) -> str:
+    # Canonical schema (datus.schemas.web_result): {query, result_count, results}.
+    from datus.schemas.web_result import web_search_short_summary
+
+    if isinstance(result, dict) and ("results" in result or "query" in result):
+        return web_search_short_summary(result)
+    # Legacy fallbacks (older docs/doc_count shape, or a bare list).
     if isinstance(result, list):
         return pluralize(len(result), "web result")
     if isinstance(result, dict):
@@ -1027,6 +1036,14 @@ def _fmt_web_search_document(result: Any) -> str:
             n = len(result["docs"])
         if isinstance(n, int):
             return pluralize(n, "web result")
+    return ""
+
+
+def _fmt_web_fetch(result: Any) -> str:
+    from datus.schemas.web_result import web_fetch_short_summary
+
+    if isinstance(result, dict) and isinstance(result.get("content"), str):
+        return web_fetch_short_summary(result)
     return ""
 
 
@@ -1206,7 +1223,8 @@ def _register_builtins(registry: ToolSummaryRegistry) -> None:
         "list_document_nav": _fmt_list_document_nav,
         "get_document": _fmt_get_document,
         "search_document": _fmt_search_document,
-        "web_search_document": _fmt_web_search_document,
+        "web_search": _fmt_web_search,
+        "web_fetch": _fmt_web_fetch,
     }
     for name, fn in builtins.items():
         registry.register(name, fn)

--- a/datus/schemas/web_result.py
+++ b/datus/schemas/web_result.py
@@ -1,0 +1,221 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Canonical result schema + summaries for the ``web_tool`` capability group.
+
+Every web backend (local Tavily / httpx, Anthropic server tools, OpenAI hosted
+``web_search``) normalizes into ONE shape here so the TUI, API SSE and
+``datus -p`` event payloads render identically regardless of which provider
+served the call.
+
+Canonical shapes (stored as the tool ``result`` / ``raw_output.result``):
+
+``web_search``::
+
+    {
+        "query": "duckdb latest release",
+        "result_count": 3,
+        "results": [
+            {"title": "...", "url": "https://...", "snippet": "...", "age": "2 days ago"},
+            ...
+        ],
+    }
+
+``web_fetch``::
+
+    {
+        "url": "https://...",
+        "title": "DuckDB 1.5 Release Notes",
+        "content": "<full extracted text>",
+        "truncated": false,
+        "char_count": 12431,
+    }
+
+The two ``*_short_summary`` helpers produce the compact one-liner used as the
+SSE ``shortDesc`` and the TUI compact ``└─`` line — the only place the short
+form is ever used.
+"""
+
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+# Cap a single result snippet so the full-result payload stays bounded while
+# still being far richer than the compact shortDesc.
+_SNIPPET_MAX_CHARS = 500
+
+
+def _domain(url: str) -> str:
+    """Best-effort host label from a URL (``https://a.b/c`` -> ``a.b``)."""
+    try:
+        host = urlparse(url).netloc
+        return host[4:] if host.startswith("www.") else host
+    except Exception:
+        return ""
+
+
+def normalize_search_results(query: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the canonical ``web_search`` result from raw per-result dicts.
+
+    Each ``items`` entry may carry ``title`` / ``url`` / ``snippet`` (or
+    ``content``) / ``age``; missing fields normalize to empty. Entries with no
+    title, url AND snippet are dropped so empty rows never reach the UI.
+    """
+    results: List[Dict[str, Any]] = []
+    for it in items or []:
+        if not isinstance(it, dict):
+            continue
+        title = str(it.get("title") or "").strip()
+        url = str(it.get("url") or "").strip()
+        snippet = str(it.get("snippet") or it.get("content") or "").strip()
+        if len(snippet) > _SNIPPET_MAX_CHARS:
+            snippet = snippet[:_SNIPPET_MAX_CHARS].rstrip() + "…"
+        if not (title or url or snippet):
+            continue
+        results.append({"title": title, "url": url, "snippet": snippet, "age": it.get("age")})
+    return {"query": str(query or "").strip(), "result_count": len(results), "results": results}
+
+
+def normalize_fetch_result(
+    url: str,
+    title: str,
+    content: str,
+    truncated: bool,
+) -> Dict[str, Any]:
+    """Build the canonical ``web_fetch`` result."""
+    content = content or ""
+    return {
+        "url": str(url or "").strip(),
+        "title": str(title or "").strip(),
+        "content": content,
+        "truncated": bool(truncated),
+        "char_count": len(content),
+    }
+
+
+def _result_label(item: Dict[str, Any]) -> str:
+    """Short label for one search result: title, else domain, else raw url."""
+    title = str(item.get("title") or "").strip()
+    if title:
+        return title
+    url = str(item.get("url") or "").strip()
+    return _domain(url) or url
+
+
+def web_search_short_summary(result: Any) -> str:
+    """Compact one-liner for a ``web_search`` result.
+
+    ``3 web results: Title A; Title B; Title C`` when results carry labels;
+    falls back to ``searched: "<query>"`` when the backend exposes only the
+    query (OpenAI hosted with no citations yet).
+    """
+    if not isinstance(result, dict):
+        return ""
+    results = result.get("results")
+    if isinstance(results, list) and results:
+        labels = [lbl for lbl in (_result_label(r) for r in results[:3]) if lbl]
+        n = result.get("result_count", len(results))
+        noun = "web result" if n == 1 else "web results"
+        if labels:
+            return f"{n} {noun}: " + "; ".join(labels)
+        return f"{n} {noun}"
+    query = str(result.get("query") or "").strip()
+    if query:
+        return f'searched: "{query}"'
+    return "completed"
+
+
+def web_fetch_short_summary(result: Any) -> str:
+    """Compact one-liner for a ``web_fetch`` result: ``Title (12,431 chars)``."""
+    if not isinstance(result, dict):
+        return ""
+    label = str(result.get("title") or "").strip() or _domain(str(result.get("url") or "")) or "fetched"
+    char_count = result.get("char_count")
+    if not isinstance(char_count, int):
+        content = result.get("content")
+        char_count = len(content) if isinstance(content, str) else 0
+    suffix = " (truncated)" if result.get("truncated") else ""
+    return f"{label} ({char_count:,} chars){suffix}"
+
+
+def extract_url_citations(content_parts: Any) -> List[Dict[str, Any]]:
+    """Collect ``url_citation`` annotations from an OpenAI message's content.
+
+    OpenAI hosted ``web_search`` does not surface results on the
+    ``web_search_call`` item; the title+url pairs the model actually used come
+    back as ``url_citation`` annotations on the assistant message. Each yields a
+    ``{title, url, snippet}`` row (snippet left empty — annotations carry only a
+    text span index, not the source text).
+    """
+    citations: List[Dict[str, Any]] = []
+    seen: set = set()
+    for part in content_parts or []:
+        annotations = getattr(part, "annotations", None)
+        if annotations is None and isinstance(part, dict):
+            annotations = part.get("annotations")
+        for ann in annotations or []:
+            atype = getattr(ann, "type", None) if not isinstance(ann, dict) else ann.get("type")
+            if atype != "url_citation":
+                continue
+            url = (getattr(ann, "url", None) if not isinstance(ann, dict) else ann.get("url")) or ""
+            title = (getattr(ann, "title", None) if not isinstance(ann, dict) else ann.get("title")) or ""
+            url = str(url).strip()
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            citations.append({"title": str(title).strip(), "url": url, "snippet": ""})
+    return citations
+
+
+def extract_action_sources(action: Any) -> List[Dict[str, Any]]:
+    """Collect source URLs from a hosted ``web_search_call.action.sources`` list.
+
+    Present only when the request set ``include=['web_search_call.action.sources']``.
+    These carry a URL but no title, so they are a fallback for / supplement to
+    the richer :func:`extract_url_citations` rows.
+    """
+    sources = getattr(action, "sources", None) if not isinstance(action, dict) else (action or {}).get("sources")
+    rows: List[Dict[str, Any]] = []
+    for src in sources or []:
+        url = (getattr(src, "url", None) if not isinstance(src, dict) else src.get("url")) or ""
+        url = str(url).strip()
+        if url:
+            rows.append({"title": "", "url": url, "snippet": ""})
+    return rows
+
+
+def collect_citations_from_input_list(input_list: Any) -> List[Dict[str, Any]]:
+    """Aggregate ``url_citation`` rows across every assistant message in a turn.
+
+    OpenAI's hosted ``web_search`` does not attach results to the
+    ``web_search_call`` item; the title+url pairs the model used surface as
+    ``url_citation`` annotations on the assistant message(s). After the run we
+    read ``RunResultStreaming.to_input_list()`` (which preserves annotations) and
+    fold all citations together — they become the canonical results for the
+    turn's hosted search call(s).
+    """
+    citations: List[Dict[str, Any]] = []
+    seen: set = set()
+    for item in input_list or []:
+        role = item.get("role") if isinstance(item, dict) else getattr(item, "role", None)
+        itype = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+        if role != "assistant" and itype != "message":
+            continue
+        content = item.get("content") if isinstance(item, dict) else getattr(item, "content", None)
+        for row in extract_url_citations(content):
+            if row["url"] in seen:
+                continue
+            seen.add(row["url"])
+            citations.append(row)
+    return citations
+
+
+def hosted_action_query(action: Any) -> Optional[str]:
+    """Pull a human-readable query / url out of a hosted ``web_search_call`` action."""
+    if action is None:
+        return None
+
+    def _get(key: str) -> Any:
+        return action.get(key) if isinstance(action, dict) else getattr(action, key, None)
+
+    return _get("query") or _get("url") or _get("queries")

--- a/datus/schemas/web_result.py
+++ b/datus/schemas/web_result.py
@@ -199,7 +199,13 @@ def collect_citations_from_input_list(input_list: Any) -> List[Dict[str, Any]]:
     for item in input_list or []:
         role = item.get("role") if isinstance(item, dict) else getattr(item, "role", None)
         itype = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
-        if role != "assistant" and itype != "message":
+        # Aggregate citations from assistant messages only. Accept across payload
+        # variants: when ``role`` is present it must be ``assistant``; when it is
+        # omitted upstream, fall back to the message type.
+        if role is not None:
+            if role != "assistant":
+                continue
+        elif itype != "message":
             continue
         content = item.get("content") if isinstance(item, dict) else getattr(item, "content", None)
         for row in extract_url_citations(content):

--- a/datus/tools/func_tool/__init__.py
+++ b/datus/tools/func_tool/__init__.py
@@ -19,6 +19,7 @@ from datus.tools.func_tool.report_artifact_tools import ReportArtifactTools, Rep
 from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
 from datus.tools.func_tool.semantic_tools import SemanticTools
 from datus.tools.func_tool.sub_agent_task_tool import SubAgentTaskTool
+from datus.tools.func_tool.web_tool import WebTool
 
 __all__ = [
     "trans_to_function_tool",
@@ -45,6 +46,7 @@ __all__ = [
     "PlatformDocSearchTool",
     "SubAgentTaskTool",
     "OrchestratorIssueTools",
+    "WebTool",
 ]
 
 try:

--- a/datus/tools/func_tool/platform_doc_search.py
+++ b/datus/tools/func_tool/platform_doc_search.py
@@ -16,17 +16,17 @@ _NAME = "platform_doc_search_tools"
 _NAME_LIST_NAV = "platform_doc_search_tools.list_document_nav"
 _NAME_GET_DOC = "platform_doc_search_tools.get_document"
 _NAME_SEARCH_DOC = "platform_doc_search_tools.search_document"
-_NAME_WEB_SEARCH = "platform_doc_search_tools.web_search"
 
 
 class PlatformDocSearchTool:
     """Function-call tool for platform documentation search.
 
-    Exposes four LLM-callable functions:
+    Exposes three LLM-callable functions:
     - list_document_nav: Browse the documentation navigation tree
     - get_document: Retrieve document chunks by title
     - search_document: Semantic search across documentation
-    - web_search_document: Web search via Tavily
+
+    Web search now lives in the unified ``web_tool`` group (``web_tool.web_search``).
     """
 
     permission_category: str = "platform_doc_tools"
@@ -36,20 +36,16 @@ class PlatformDocSearchTool:
 
     @staticmethod
     def all_tools_name() -> List[str]:
-        return ["list_document_nav", "get_document", "search_document", "web_search_document"]
+        return ["list_document_nav", "get_document", "search_document"]
 
     def available_tools(self) -> List[Tool]:
         """Return platform doc search tools, filtered by backing resource availability.
 
-        - Doc search trio (``list_document_nav`` / ``get_document`` /
-          ``search_document``) is exposed only when at least one platform
-          has an indexed docstore directory under the active project.
-        - ``web_search_document`` is exposed only when a Tavily key is
-          resolvable from ``agent_config.tavily_api_key`` or the
-          ``TAVILY_API_KEY`` environment variable.
+        The doc search trio (``list_document_nav`` / ``get_document`` /
+        ``search_document``) is exposed only when at least one platform has an
+        indexed docstore directory under the active project. Web search has moved
+        to the unified ``web_tool`` group.
         """
-        import os
-
         from datus.storage.document.store import list_indexed_platforms
 
         tools: List[Tool] = []
@@ -62,14 +58,6 @@ class PlatformDocSearchTool:
             logger.info(
                 "Skipping list_document_nav / get_document / search_document: "
                 "no indexed docstore found for the active project."
-            )
-
-        tavily_key = getattr(self.agent_config, "tavily_api_key", None) or os.environ.get("TAVILY_API_KEY")
-        if tavily_key:
-            tools.append(trans_to_function_tool(self.web_search_document))
-        else:
-            logger.info(
-                "Skipping web_search_document: neither agent.document.tavily_api_key nor TAVILY_API_KEY env var is set."
             )
 
         return tools
@@ -221,60 +209,4 @@ class PlatformDocSearchTool:
             )
         except Exception as e:
             logger.error(f"Failed to search documents for keywords {keywords}: {e}")
-            return FuncToolResult(success=0, error=str(e))
-
-    def web_search_document(
-        self,
-        keywords: List[str],
-        max_results: int = 5,
-        include_domains: Optional[List[str]] = None,
-    ) -> FuncToolResult:
-        """
-        Search the web for platform documentation or technical information using Tavily.
-
-        Use this tool when local documentation is insufficient or when you need
-        the latest information from official websites, blogs, or community resources.
-
-        Requires tavily_api_key in agent.document config or TAVILY_API_KEY env var.
-
-        Args:
-            keywords: Search queries (e.g., ["StarRocks materialized view syntax", "Snowflake COPY INTO options"])
-            max_results: Maximum number of results to return, 1-20 (default: 5)
-            include_domains: Restrict search to specific domains (optional),
-                e.g., ["docs.snowflake.com", "docs.starrocks.io"]
-
-        Returns:
-            FuncToolResult with search results as a list of text content
-        """
-        try:
-            from datus.tools.search_tools.search_tool import search_by_tavily
-
-            # Get tavily_api_key from config (priority) or fall back to env var
-            tavily_key = getattr(self.agent_config, "tavily_api_key", None)
-            if not tavily_key:
-                logger.warning("TAVILY_API_KEY env var not set")
-                return FuncToolResult(success=1, result=[])
-
-            result = search_by_tavily(
-                keywords=keywords,
-                max_results=max_results,
-                search_depth="advanced",
-                include_answer="basic",
-                include_raw_content="markdown",
-                include_domains=include_domains,
-                api_key=tavily_key,
-            )
-
-            if not result.success:
-                return FuncToolResult(success=0, error=result.error)
-
-            return FuncToolResult(
-                success=1,
-                result={
-                    "docs": result.docs,
-                    "doc_count": result.doc_count,
-                },
-            )
-        except Exception as e:
-            logger.error(f"Web search failed for keywords {keywords}: {e}")
             return FuncToolResult(success=0, error=str(e))

--- a/datus/tools/func_tool/web_tool.py
+++ b/datus/tools/func_tool/web_tool.py
@@ -1,0 +1,254 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+# -*- coding: utf-8 -*-
+"""Unified web tool group (``web_tool.web_search`` / ``web_tool.web_fetch``).
+
+The agent always sees a single pair of web capabilities. The backend is chosen
+per active provider, but that decision lives outside this module:
+
+* For providers that expose a vendor-native web tool (Codex / OpenAI Responses
+  ``web_search``; Claude native ``web_search_20250305`` / ``web_fetch_20250910``),
+  the model layer injects the hosted tool and the node suppresses the matching
+  *local* function tool here via ``expose_local_search`` / ``expose_local_fetch``.
+* For every other provider, the local backends below are used:
+  ``web_search`` calls Tavily (needs a key) and ``web_fetch`` pulls the page
+  directly with httpx — no third-party API.
+
+This class deliberately does NOT inspect the provider; it only owns the local
+backends and exposes whichever ones the node asks for.
+"""
+
+import os
+from typing import List, Optional
+
+import httpx
+from agents import Tool
+from bs4 import BeautifulSoup
+
+from datus.configuration.agent_config import AgentConfig
+from datus.schemas.web_result import normalize_fetch_result, normalize_search_results
+from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+_NAME = "web_tool"
+_NAME_WEB_SEARCH = "web_tool.web_search"
+_NAME_WEB_FETCH = "web_tool.web_fetch"
+
+# Tags that hold boilerplate rather than the main content of a page.
+_NOISE_TAGS = ("script", "style", "noscript", "nav", "footer", "header", "aside", "form")
+
+_DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; DatusAgent/1.0; +https://datus.ai) Python-httpx web_fetch"
+
+
+class WebTool:
+    """Function-call tool group for web access.
+
+    Exposes up to two LLM-callable functions:
+    - web_search: Search the web (local backend = Tavily).
+    - web_fetch: Fetch and extract the readable text of a single URL (httpx).
+
+    Which functions are exposed locally is controlled by ``expose_local_search``
+    / ``expose_local_fetch`` — the node turns the local backend off when the
+    active provider serves that capability through a vendor-native tool.
+    """
+
+    permission_category: str = "web_tool"
+
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        sub_agent_name: Optional[str] = None,
+        expose_local_search: bool = True,
+        expose_local_fetch: bool = True,
+    ):
+        self.agent_config = agent_config
+        self.sub_agent_name = sub_agent_name
+        self.expose_local_search = expose_local_search
+        self.expose_local_fetch = expose_local_fetch
+
+    @classmethod
+    def create_dynamic(cls, agent_config: AgentConfig, sub_agent_name: Optional[str] = None) -> "WebTool":
+        return cls(agent_config, sub_agent_name=sub_agent_name)
+
+    @classmethod
+    def create_static(
+        cls,
+        agent_config: AgentConfig,
+        sub_agent_name: Optional[str] = None,
+        database_name: Optional[str] = None,
+    ) -> "WebTool":
+        return cls(agent_config, sub_agent_name=sub_agent_name)
+
+    @staticmethod
+    def all_tools_name() -> List[str]:
+        # Full surface, independent of runtime availability — used by the node's
+        # tool registry so ``web_search`` / ``web_fetch`` always map to the
+        # ``web_tool`` permission category even when one is suppressed.
+        return ["web_search", "web_fetch"]
+
+    def _tavily_key(self) -> Optional[str]:
+        return getattr(self.agent_config, "tavily_api_key", None) or os.environ.get("TAVILY_API_KEY")
+
+    def available_tools(self) -> List[Tool]:
+        """Return the locally-served web tools, filtered by backend availability.
+
+        - ``web_search`` is exposed only when ``expose_local_search`` is set
+          AND a Tavily key is resolvable. When the provider serves search via a
+          hosted tool, ``expose_local_search`` is False and we skip it.
+        - ``web_fetch`` is exposed whenever ``expose_local_fetch`` is set; the
+          httpx backend needs no key, so it is always available locally.
+        """
+        tools: List[Tool] = []
+
+        if self.expose_local_search:
+            if self._tavily_key():
+                tools.append(trans_to_function_tool(self.web_search))
+            else:
+                logger.info(
+                    "Skipping web_tool.web_search: neither agent.document.tavily_api_key "
+                    "nor TAVILY_API_KEY env var is set, and no vendor-native search is available."
+                )
+
+        if self.expose_local_fetch:
+            tools.append(trans_to_function_tool(self.web_fetch))
+
+        return tools
+
+    def web_search(
+        self,
+        keywords: List[str],
+        max_results: int = 5,
+        include_domains: Optional[List[str]] = None,
+    ) -> FuncToolResult:
+        """
+        Search the web for up-to-date information or technical documentation.
+
+        Use this when local knowledge is insufficient or you need the latest
+        information from official sites, blogs, or community resources. Returns
+        ranked results with markdown content; pair it with ``web_fetch`` to pull
+        the full text of a specific result URL.
+
+        Args:
+            keywords: Search queries (e.g., ["StarRocks materialized view syntax"]).
+            max_results: Maximum number of results to return, 1-20 (default: 5).
+            include_domains: Restrict the search to specific domains (optional),
+                e.g., ["docs.snowflake.com", "docs.starrocks.io"].
+
+        Returns:
+            FuncToolResult with the canonical ``web_search`` result
+            (``{"query", "result_count", "results": [{"title", "url", "snippet", "age"}]}``).
+        """
+        try:
+            from datus.tools.search_tools.search_tool import search_by_tavily
+
+            tavily_key = self._tavily_key()
+            if not tavily_key:
+                return FuncToolResult(
+                    success=0,
+                    error="Web search is unavailable: set agent.document.tavily_api_key or TAVILY_API_KEY.",
+                )
+
+            result = search_by_tavily(
+                keywords=keywords,
+                max_results=max_results,
+                search_depth="advanced",
+                include_answer="basic",
+                include_raw_content="markdown",
+                include_domains=include_domains,
+                api_key=tavily_key,
+                structured=True,
+            )
+
+            if not result.success:
+                return FuncToolResult(success=0, error=result.error)
+
+            # ``structured=True`` keys results by the tab-joined query; flatten
+            # to the canonical schema so every backend renders identically.
+            query = "\t".join(keywords)
+            items = result.docs.get(query) if result.docs else None
+            if items is None and result.docs:
+                items = next(iter(result.docs.values()), [])
+            return FuncToolResult(
+                success=1,
+                result=normalize_search_results(", ".join(keywords), items or []),
+            )
+        except Exception as e:
+            logger.error(f"Web search failed for keywords {keywords}: {e}")
+            return FuncToolResult(success=0, error=str(e))
+
+    def web_fetch(
+        self,
+        url: str,
+        max_chars: int = 20000,
+    ) -> FuncToolResult:
+        """
+        Fetch a single web page and return its readable text content.
+
+        Pulls the URL directly over HTTP (no third-party API), strips scripts,
+        styles, navigation, and other boilerplate, and returns the main text.
+        Use this to read a specific page — e.g. a URL surfaced by ``web_search``
+        or provided by the user.
+
+        Args:
+            url: Absolute http(s) URL to fetch.
+            max_chars: Truncate the extracted text to this many characters
+                (default: 20000). The ``truncated`` flag reports whether the
+                content was cut off.
+
+        Returns:
+            FuncToolResult with the canonical ``web_fetch`` result
+            (``{"url", "title", "content", "truncated", "char_count"}``).
+        """
+        if not isinstance(url, str) or not url.lower().startswith(("http://", "https://")):
+            return FuncToolResult(success=0, error=f"Invalid URL (must start with http:// or https://): {url!r}")
+
+        try:
+            response = httpx.get(
+                url,
+                follow_redirects=True,
+                timeout=30,
+                headers={"User-Agent": _DEFAULT_USER_AGENT},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            return FuncToolResult(success=0, error=f"HTTP {e.response.status_code} fetching {url}")
+        except httpx.HTTPError as e:
+            return FuncToolResult(success=0, error=f"Failed to fetch {url}: {e}")
+
+        content_type = (response.headers.get("content-type") or "").lower()
+        if content_type and not any(t in content_type for t in ("text/html", "application/xhtml", "text/plain")):
+            return FuncToolResult(
+                success=0,
+                error=f"Unsupported content-type '{content_type}' for {url}; web_fetch handles HTML/text only.",
+            )
+
+        try:
+            soup = BeautifulSoup(response.text, "lxml")
+            for tag in soup(list(_NOISE_TAGS)):
+                tag.decompose()
+
+            title = soup.title.get_text(strip=True) if soup.title else ""
+            text = soup.get_text(separator="\n", strip=True)
+            # Collapse runs of blank lines left behind by stripped tags.
+            lines = [line for line in (ln.strip() for ln in text.splitlines()) if line]
+            text = "\n".join(lines)
+
+            truncated = len(text) > max_chars
+            if truncated:
+                text = text[:max_chars]
+
+            return FuncToolResult(
+                success=1,
+                result=normalize_fetch_result(
+                    url=str(response.url),
+                    title=title,
+                    content=text,
+                    truncated=truncated,
+                ),
+            )
+        except Exception as e:
+            logger.error(f"Failed to parse content from {url}: {e}")
+            return FuncToolResult(success=0, error=f"Failed to parse {url}: {e}")

--- a/datus/tools/func_tool/web_tool.py
+++ b/datus/tools/func_tool/web_tool.py
@@ -19,8 +19,10 @@ This class deliberately does NOT inspect the provider; it only owns the local
 backends and exposes whichever ones the node asks for.
 """
 
+import ipaddress
 import os
 from typing import List, Optional
+from urllib.parse import urlparse
 
 import httpx
 from agents import Tool
@@ -41,6 +43,51 @@ _NAME_WEB_FETCH = "web_tool.web_fetch"
 _NOISE_TAGS = ("script", "style", "noscript", "nav", "footer", "header", "aside", "form")
 
 _DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; DatusAgent/1.0; +https://datus.ai) Python-httpx web_fetch"
+
+# Hard cap on a fetched response body (declared via Content-Length). Independent
+# of ``max_chars`` (which bounds the *extracted text*, not the raw HTML): a small
+# ``max_chars`` must still allow fetching a normal-sized page. Bodies larger than
+# this are refused before parsing to avoid memory exhaustion on hostile pages.
+_MAX_FETCH_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+
+# Hostnames that always denote the local machine / an internal zone.
+_INTERNAL_HOSTNAMES = {"localhost", "ip6-localhost", "ip6-loopback"}
+_INTERNAL_HOST_SUFFIXES = (".localhost", ".local", ".internal")
+
+
+def _is_public_web_target(url: str) -> bool:
+    """True unless ``url`` targets an obviously non-public host.
+
+    Guards ``web_fetch`` against SSRF (CWE-918): the tool issues requests on
+    behalf of an LLM whose URL may be attacker-influenced. We block the realistic
+    vectors that need no resolver — **literal-IP** loopback, cloud metadata
+    (``169.254.169.254``), RFC1918 private ranges, reserved/multicast/unspecified
+    addresses — plus the internal hostnames (``localhost`` / ``*.local`` / …).
+
+    We deliberately do NOT pre-resolve hostnames via DNS: it is both TOCTOU-weak
+    (the resolver result can differ from the connection's) and unreliable behind
+    split / fake-ip proxies (which map every public domain to a private-looking
+    address), where it would block all legitimate fetches. The residual
+    DNS-rebinding gap (a hostname that resolves to a private IP) is accepted.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+
+    host = parsed.hostname
+    lowered = host.lower()
+    if lowered in _INTERNAL_HOSTNAMES or lowered.endswith(_INTERNAL_HOST_SUFFIXES):
+        return False
+
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # A hostname (resolved at fetch time, not here) — allow.
+        return True
+    return not (
+        ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+    )
 
 
 class WebTool:
@@ -202,8 +249,17 @@ class WebTool:
             FuncToolResult with the canonical ``web_fetch`` result
             (``{"url", "title", "content", "truncated", "char_count"}``).
         """
+        if not isinstance(max_chars, int) or isinstance(max_chars, bool) or max_chars <= 0:
+            return FuncToolResult(success=0, error=f"Invalid max_chars: {max_chars!r}. Must be a positive integer.")
+
         if not isinstance(url, str) or not url.lower().startswith(("http://", "https://")):
             return FuncToolResult(success=0, error=f"Invalid URL (must start with http:// or https://): {url!r}")
+
+        if not _is_public_web_target(url):
+            return FuncToolResult(
+                success=0,
+                error=f"Refusing to fetch non-public URL target (SSRF protection): {url!r}",
+            )
 
         try:
             response = httpx.get(
@@ -223,6 +279,19 @@ class WebTool:
             return FuncToolResult(
                 success=0,
                 error=f"Unsupported content-type '{content_type}' for {url}; web_fetch handles HTML/text only.",
+            )
+
+        # Refuse oversized bodies before parsing to bound memory use. Relies on a
+        # server-declared Content-Length; absent the header we fall through and
+        # let ``max_chars`` bound the extracted text.
+        content_length = response.headers.get("content-length")
+        if content_length and content_length.isdigit() and int(content_length) > _MAX_FETCH_BYTES:
+            return FuncToolResult(
+                success=0,
+                error=(
+                    f"Response too large for {url}: {int(content_length):,} bytes "
+                    f"exceeds the {_MAX_FETCH_BYTES:,}-byte web_fetch limit."
+                ),
             )
 
         try:

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -137,13 +137,15 @@ _NORMAL_RULES = [
     _rule("platform_doc_tools", "list_*", PermissionLevel.ALLOW),
     _rule("platform_doc_tools", "get_*", PermissionLevel.ALLOW),
     _rule("platform_doc_tools", "search_*", PermissionLevel.ALLOW),
-    # web_tool reaches the network (Tavily search / httpx fetch), so it stays at
-    # ASK in normal/auto. NOTE: vendor-native web tools (Codex hosted web_search,
-    # Anthropic web_search_20250305 / web_fetch_20250910) run server-side and do
-    # NOT pass through local PermissionHooks — these rules gate only the local
-    # backends.
-    _rule("web_tool", "web_search", PermissionLevel.ASK),
-    _rule("web_tool", "web_fetch", PermissionLevel.ASK),
+    # web_tool reaches the public network (Tavily search / httpx fetch), but it is
+    # read-only retrieval and ``web_fetch`` is hardened against SSRF (non-public
+    # targets are refused). ALLOW keeps it from prompting on every lookup. NOTE:
+    # vendor-native web tools (Codex hosted web_search, Anthropic web_search_20250305
+    # / web_fetch_20250910) run server-side and do NOT pass through local
+    # PermissionHooks at all — gating the local backends at ASK could not be
+    # enforced on the native ones anyway, so we keep both consistently at ALLOW.
+    _rule("web_tool", "web_search", PermissionLevel.ALLOW),
+    _rule("web_tool", "web_fetch", PermissionLevel.ALLOW),
     # mcp: ASK; skill loading ALLOW.
     _rule("mcp.*", "*", PermissionLevel.ASK),
     _rule("skills", "*", PermissionLevel.ALLOW),

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -133,12 +133,17 @@ _NORMAL_RULES = [
     # a whole via the rendered preview, not per-call prompts. Mirrors the
     # historical lumping into ``semantic_tools``.
     _rule("artifact_tools", "*", PermissionLevel.ALLOW),
-    # platform doc lookups are read-only; ``web_search_document`` reaches
-    # the network (Tavily) and stays at the profile default (ASK in
-    # normal/auto).
+    # platform doc lookups are read-only local reads.
     _rule("platform_doc_tools", "list_*", PermissionLevel.ALLOW),
     _rule("platform_doc_tools", "get_*", PermissionLevel.ALLOW),
     _rule("platform_doc_tools", "search_*", PermissionLevel.ALLOW),
+    # web_tool reaches the network (Tavily search / httpx fetch), so it stays at
+    # ASK in normal/auto. NOTE: vendor-native web tools (Codex hosted web_search,
+    # Anthropic web_search_20250305 / web_fetch_20250910) run server-side and do
+    # NOT pass through local PermissionHooks — these rules gate only the local
+    # backends.
+    _rule("web_tool", "web_search", PermissionLevel.ASK),
+    _rule("web_tool", "web_fetch", PermissionLevel.ASK),
     # mcp: ASK; skill loading ALLOW.
     _rule("mcp.*", "*", PermissionLevel.ASK),
     _rule("skills", "*", PermissionLevel.ALLOW),

--- a/datus/tools/search_tools/search_tool.py
+++ b/datus/tools/search_tools/search_tool.py
@@ -553,11 +553,11 @@ def search_by_tavily(
 
         if structured:
             # Preserve per-result title/url/snippet so callers can build the
-            # canonical web_search schema. The answer (if any) leads as a
-            # title-less synthesized entry.
+            # canonical web_search schema. The synthesized ``answer`` is NOT a
+            # search result and is intentionally dropped here: including it as a
+            # title-less row would inflate ``result_count`` and diverge from
+            # provider-native backends (which surface only real results).
             items: List[Dict[str, Any]] = []
-            if answer:
-                items.append({"title": "", "url": "", "snippet": answer, "raw_content": answer})
             for item in raw_results:
                 items.append(
                     {

--- a/datus/tools/search_tools/search_tool.py
+++ b/datus/tools/search_tools/search_tool.py
@@ -475,6 +475,7 @@ def search_by_tavily(
     include_raw_content: Literal[False, "text", "markdown"] = False,
     include_domains: Optional[List[str]] = None,
     api_key: Optional[str] = None,
+    structured: bool = False,
 ) -> DocSearchResult:
     """Search external documents using the Tavily Search API.
 
@@ -498,6 +499,10 @@ def search_by_tavily(
         include_domains: Restrict search to specific domains (max 300),
             e.g. ["docs.snowflake.com", "stackoverflow.com"].
         api_key: Tavily API key. Falls back to TAVILY_API_KEY env var if not provided.
+        structured: When True, ``docs[query]`` holds per-result dicts
+            (``{"title", "url", "snippet", "raw_content"}``) so callers can build
+            the canonical ``web_search`` schema with title/url preserved. When
+            False (default), ``docs[query]`` holds plain text blobs (legacy).
 
     Returns:
         DocSearchResult with matched documents.
@@ -543,10 +548,30 @@ def search_by_tavily(
         response.raise_for_status()
 
         result = response.json()
-        texts = [(item.get("raw_content") or item.get("content") or "") for item in result.get("results", [])]
+        raw_results = result.get("results", [])
+        answer = result.get("answer")
+
+        if structured:
+            # Preserve per-result title/url/snippet so callers can build the
+            # canonical web_search schema. The answer (if any) leads as a
+            # title-less synthesized entry.
+            items: List[Dict[str, Any]] = []
+            if answer:
+                items.append({"title": "", "url": "", "snippet": answer, "raw_content": answer})
+            for item in raw_results:
+                items.append(
+                    {
+                        "title": item.get("title") or "",
+                        "url": item.get("url") or "",
+                        "snippet": item.get("content") or "",
+                        "raw_content": item.get("raw_content") or "",
+                    }
+                )
+            return DocSearchResult(success=True, docs={query: items}, doc_count=len(items))
+
+        texts = [(item.get("raw_content") or item.get("content") or "") for item in raw_results]
 
         # Prepend the generated answer if available
-        answer = result.get("answer")
         if answer:
             texts.insert(0, answer)
 

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -771,8 +771,9 @@ class TestSkillIntegrationEdgeCases:
 
         # Should have all tools: 2 existing + 1 skill tool + 1 bash tool +
         # 2 memory tools (this node is a main agent, so add_memory/edit_memory
-        # are lazy-injected alongside skills and bash).
-        assert len(node.tools) == 6
+        # are lazy-injected alongside skills and bash) + 2 web tools
+        # (web_search/web_fetch, mounted unconditionally for the local backend).
+        assert len(node.tools) == 8
         tool_names = [t.name for t in node.tools]
         assert "tool1" in tool_names
         assert "tool2" in tool_names
@@ -780,6 +781,8 @@ class TestSkillIntegrationEdgeCases:
         assert "execute_command" in tool_names
         assert "add_memory" in tool_names
         assert "edit_memory" in tool_names
+        assert "web_search" in tool_names
+        assert "web_fetch" in tool_names
 
     def test_setup_exception_handling(self, mock_agent_config):
         """Test that setup exceptions are handled gracefully."""

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -749,6 +749,9 @@ class TestSkillIntegrationEdgeCases:
         # permissive config so the lazy injector includes ``execute_command``.
         mock_agent_config.permissions_config = PermissionConfig(default_permission=PermissionLevel.ALLOW)
         mock_agent_config.active_profile_name = "normal"
+        # Local web_search is mounted only when a Tavily key resolves; pin one so
+        # the count is deterministic without depending on the CI env (no keys).
+        mock_agent_config.tavily_api_key = "test-key"
 
         node = MinimalAgenticNode(
             node_id="test24",

--- a/tests/unit_tests/agent/node/test_agentic_node_web_tools.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_web_tools.py
@@ -1,0 +1,88 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Tests for AgenticNode._ensure_web_tools_in_tools backend assembly.
+
+Exercises the node-layer coordination as an unbound method against a Mock
+``self`` to avoid full node construction. Verifies the provider-driven choice
+between local function tools and vendor-native (suppressed-local) tools, plus
+reconciliation on a runtime provider switch.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from datus.agent.node.agentic_node import AgenticNode
+
+
+def _node(search_builtin, fetch_builtin, tavily="k", model=True):
+    n = Mock()
+    if model:
+        n.model.supports_builtin_web_search.return_value = search_builtin
+        n.model.supports_builtin_web_fetch.return_value = fetch_builtin
+    else:
+        n.model = None
+    n.agent_config = SimpleNamespace(tavily_api_key=tavily)
+    n.sub_agent_name = None
+    n.tools = []
+    n.get_node_name.return_value = "t"
+    return n
+
+
+def _names(n):
+    return {t.name for t in n.tools}
+
+
+def test_local_both_when_no_builtin():
+    n = _node(False, False)
+    AgenticNode._ensure_web_tools_in_tools(n)
+    assert n._builtin_web_tools == {"web_search": False, "web_fetch": False}
+    assert _names(n) == {"web_search", "web_fetch"}
+
+
+def test_builtin_search_suppresses_local_search():
+    n = _node(True, False)
+    AgenticNode._ensure_web_tools_in_tools(n)
+    assert n._builtin_web_tools["web_search"] is True
+    assert _names(n) == {"web_fetch"}
+
+
+def test_builtin_both_no_local_tools():
+    n = _node(True, True)
+    AgenticNode._ensure_web_tools_in_tools(n)
+    assert _names(n) == set()
+
+
+def test_no_tavily_key_drops_local_search(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    n = _node(False, False, tavily=None)
+    AgenticNode._ensure_web_tools_in_tools(n)
+    assert _names(n) == {"web_fetch"}
+
+
+def test_model_unavailable_defaults_to_local():
+    n = _node(False, False, model=False)
+    AgenticNode._ensure_web_tools_in_tools(n)
+    assert n._builtin_web_tools == {"web_search": False, "web_fetch": False}
+    assert _names(n) == {"web_search", "web_fetch"}
+
+
+def test_reconcile_drops_stale_web_tool_on_switch():
+    # A prior turn mounted a local web_search; provider then switches to builtin
+    # search. The stale local web_search must be removed, unrelated tools kept.
+    n = _node(True, False)
+    stale = Mock()
+    stale.name = "web_search"
+    other = Mock()
+    other.name = "read_query"
+    n.tools = [other, stale]
+    AgenticNode._ensure_web_tools_in_tools(n)
+    assert _names(n) == {"read_query", "web_fetch"}
+
+
+def test_idempotent_no_duplicate_mounts():
+    n = _node(False, False)
+    AgenticNode._ensure_web_tools_in_tools(n)
+    AgenticNode._ensure_web_tools_in_tools(n)
+    web = sorted(t.name for t in n.tools if t.name in {"web_search", "web_fetch"})
+    assert web == ["web_fetch", "web_search"]

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -2199,6 +2199,28 @@ class TestChatDecoupling:
         node._get_system_prompt()
         assert "load_skill" in _tool_names(node)
 
+    def test_web_tools_not_reinjected_after_prompt_build(self, real_agent_config):
+        """web_search/web_fetch stay out across a prompt build when ``web_tool``
+        isn't whitelisted — the same lazy-injection / snapshot-replay leak as
+        bash and skills, on the unified web tool group."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "date_parsing_tools.*,filesystem_tools.*", name="ask_noweb", slug="noweb"
+        )
+        node._get_system_prompt()  # runs the lazy web-tool re-injection path
+        leaked = {"web_search", "web_fetch"} & _tool_names(node)
+        assert not leaked, f"web tools leaked via prompt-build lazy injection: {sorted(leaked)}"
+        assert node._web_tool is None
+        assert node._builtin_web_tools == {"web_search": False, "web_fetch": False}
+
+    def test_web_tools_present_when_whitelisted(self, real_agent_config):
+        """Symmetric to bash/skills: ``web_tool.*`` lets the web group mount
+        through the prompt build (the base injector resolves the backends)."""
+        node = _make_ask_report_with_tools(
+            real_agent_config, "web_tool.*,filesystem_tools.*", name="ask_web", slug="withweb"
+        )
+        node._get_system_prompt()
+        assert node._web_tool is not None  # gate passed through to the base injector
+
     def test_no_db_boundary_statement_gated_on_db_exposure(self, real_agent_config):
         """A db-less whitelist gets the explicit 'no live database access'
         boundary (countering DB-capability hallucination); a db whitelist omits

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -1740,7 +1740,7 @@ class TestAllToolsRegistered:
         # Platform doc
         "list_document_nav",
         "get_document",
-        "web_search_document",
+        "web_search",
         # Plan
         "todo_read",
         "todo_write",

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -56,6 +56,8 @@ from datus.cli.action_display.tool_content import (
     _build_todo_update,
     _build_todo_write,
     _build_validate_semantic,
+    _build_web_fetch,
+    _build_web_search,
     _build_write_file,
     _format_csv_preview,
     _format_describe_table_output_verbose,
@@ -1330,6 +1332,123 @@ class TestBuildGetDocument:
         tc = _build_get_document(a, verbose=False)
         assert "Overview" in tc.compact_result
         assert "3 chunks" in tc.compact_result
+
+
+# ── Web tools ─────────────────────────────────────────────────────
+
+
+@pytest.mark.ci
+class TestBuildWebSearch:
+    def test_compact(self):
+        a = _make(
+            input_data={"function_name": "web_search"},
+            output_data={
+                "raw_output": {
+                    "success": True,
+                    "result": {
+                        "query": "duckdb release",
+                        "result_count": 2,
+                        "results": [
+                            {"title": "DuckDB", "url": "https://duckdb.org", "snippet": "db", "age": None},
+                            {"title": "Notes", "url": "https://x.io", "snippet": "", "age": "2d"},
+                        ],
+                    },
+                }
+            },
+        )
+        tc = _build_web_search(a, verbose=False)
+        assert "2 web results" in tc.compact_result
+        assert "DuckDB" in tc.compact_result
+
+    def test_verbose_lists_results(self):
+        a = _make(
+            input_data={"function_name": "web_search"},
+            output_data={
+                "raw_output": {
+                    "success": True,
+                    "result": {
+                        "query": "duckdb release",
+                        "result_count": 1,
+                        "results": [
+                            "not-a-dict-row",  # skipped by the builder
+                            {"title": "DuckDB", "url": "https://duckdb.org", "snippet": "fast db", "age": "2d"},
+                        ],
+                    },
+                }
+            },
+        )
+        tc = _build_web_search(a, verbose=True)
+        blob = "\n".join(tc.output_lines)
+        assert "query" in blob and "duckdb release" in blob
+        assert "DuckDB" in blob
+        assert "https://duckdb.org" in blob
+        assert "fast db" in blob
+        assert "2d" in blob
+
+    def test_error_when_result_missing(self):
+        a = _make(
+            status=ActionStatus.FAILED,
+            input_data={"function_name": "web_search"},
+            output_data={"raw_output": {"success": False, "error": "boom"}, "error": "boom"},
+        )
+        tc = _build_web_search(a, verbose=False)
+        # No canonical result dict -> error path surfaces the error message.
+        assert "boom" in tc.compact_result
+
+
+@pytest.mark.ci
+class TestBuildWebFetch:
+    def test_compact(self):
+        a = _make(
+            input_data={"function_name": "web_fetch"},
+            output_data={
+                "raw_output": {
+                    "success": True,
+                    "result": {
+                        "url": "https://duckdb.org",
+                        "title": "DuckDB",
+                        "content": "hello world",
+                        "truncated": False,
+                        "char_count": 11,
+                    },
+                }
+            },
+        )
+        tc = _build_web_fetch(a, verbose=False)
+        assert "DuckDB" in tc.compact_result
+        assert "11" in tc.compact_result
+
+    def test_verbose_shows_title_url_and_content(self):
+        a = _make(
+            input_data={"function_name": "web_fetch"},
+            output_data={
+                "raw_output": {
+                    "success": True,
+                    "result": {
+                        "url": "https://duckdb.org",
+                        "title": "DuckDB",
+                        "content": "line one\nline two",
+                        "truncated": True,
+                        "char_count": 17,
+                    },
+                }
+            },
+        )
+        tc = _build_web_fetch(a, verbose=True)
+        blob = "\n".join(tc.output_lines)
+        assert "DuckDB" in blob
+        assert "https://duckdb.org" in blob
+        assert "truncated" in blob
+        assert "line one" in blob and "line two" in blob
+
+    def test_error_when_result_missing(self):
+        a = _make(
+            status=ActionStatus.FAILED,
+            input_data={"function_name": "web_fetch"},
+            output_data={"raw_output": {"success": False, "error": "nope"}, "error": "nope"},
+        )
+        tc = _build_web_fetch(a, verbose=False)
+        assert "nope" in tc.compact_result
 
 
 # ── Plan tools ────────────────────────────────────────────────────

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -1741,6 +1741,7 @@ class TestAllToolsRegistered:
         "list_document_nav",
         "get_document",
         "web_search",
+        "web_fetch",
         # Plan
         "todo_read",
         "todo_write",

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -10,12 +10,17 @@ the methods as unbound functions against a stand-in ``self`` to avoid the OAuth
 exercised by nightly tests against real APIs.
 """
 
+from datetime import datetime
 from unittest.mock import Mock
+
+import pytest
 
 from datus.models.base import LLMBaseModel
 from datus.models.claude_model import ClaudeModel
 from datus.models.codex_model import CodexModel
 from datus.models.openai_model import OpenAIModel
+
+_NOW = datetime(2026, 1, 1, 0, 0, 0)
 
 
 def test_base_defaults_false():
@@ -194,6 +199,71 @@ def test_describe_hosted_tool_item_ignores_function_call():
         describe_hosted_tool_item({"type": "function_call", "name": "read_query", "call_id": "c1", "arguments": "{}"})
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_openai_flush_pending_hosted_searches_uses_citations():
+    """OpenAI deferred hosted web_search completion builds the canonical result
+    from the assistant message's url_citation annotations."""
+    from types import SimpleNamespace
+
+    from datus.models.openai_compatible import OpenAICompatibleModel
+
+    pending = [
+        {
+            "call_id": "ws_1",
+            "tool_name": "web_search",
+            "arguments": "{}",
+            "args_str": "",
+            "query": "duckdb latest",
+            "sources": [{"title": "", "url": "https://fallback", "snippet": ""}],
+            "start_time": _NOW,
+        }
+    ]
+    result = SimpleNamespace(
+        to_input_list=lambda: [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "annotations": [{"type": "url_citation", "title": "DuckDB", "url": "https://duckdb.org"}],
+                    }
+                ],
+            }
+        ]
+    )
+    actions = [a async for a in OpenAICompatibleModel._flush_pending_hosted_searches(pending, result, None)]
+    assert len(actions) == 1
+    done = actions[0]
+    assert done.action_id == "complete_ws_1"
+    canonical = done.output["raw_output"]["result"]
+    assert canonical["query"] == "duckdb latest"
+    assert canonical["results"] == [{"title": "DuckDB", "url": "https://duckdb.org", "snippet": "", "age": None}]
+
+
+@pytest.mark.asyncio
+async def test_openai_flush_pending_hosted_searches_falls_back_to_sources():
+    """With no assistant citations, the call's own action.sources become results."""
+    from types import SimpleNamespace
+
+    from datus.models.openai_compatible import OpenAICompatibleModel
+
+    pending = [
+        {
+            "call_id": "ws_2",
+            "tool_name": "web_search",
+            "arguments": "{}",
+            "args_str": "",
+            "query": "q",
+            "sources": [{"title": "", "url": "https://only-source", "snippet": ""}],
+            "start_time": _NOW,
+        }
+    ]
+    result = SimpleNamespace(to_input_list=lambda: [])
+    actions = [a async for a in OpenAICompatibleModel._flush_pending_hosted_searches(pending, result, None)]
+    canonical = actions[0].output["raw_output"]["result"]
+    assert canonical["results"] == [{"title": "", "url": "https://only-source", "snippet": "", "age": None}]
 
 
 def test_describe_hosted_tool_item_ignores_non_web_hosted_calls():

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -1,0 +1,196 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Capability-method contract tests for vendor-native web tools.
+
+These methods drive the node-layer backend choice (local function tool vs.
+vendor-hosted tool), so the truth table is the critical contract. We exercise
+the methods as unbound functions against a stand-in ``self`` to avoid the OAuth
+/ SDK setup a full model instance needs. The actual hosted-tool injection is
+exercised by nightly tests against real APIs.
+"""
+
+from unittest.mock import Mock
+
+from datus.models.base import LLMBaseModel
+from datus.models.claude_model import ClaudeModel
+from datus.models.codex_model import CodexModel
+from datus.models.openai_model import OpenAIModel
+
+
+def test_base_defaults_false():
+    s = Mock()
+    assert LLMBaseModel.supports_builtin_web_search(s) is False
+    assert LLMBaseModel.supports_builtin_web_fetch(s) is False
+
+
+def test_codex_search_yes_fetch_no():
+    s = Mock()
+    # OpenAI Responses exposes hosted web_search but no hosted fetch.
+    assert CodexModel.supports_builtin_web_search(s) is True
+    assert CodexModel.supports_builtin_web_fetch(s) is False
+
+
+def test_openai_search_yes_fetch_no():
+    s = Mock()
+    # API-key OpenAI also uses the Responses hosted web_search; no hosted fetch.
+    assert OpenAIModel.supports_builtin_web_search(s) is True
+    assert OpenAIModel.supports_builtin_web_fetch(s) is False
+
+
+def test_claude_enables_both():
+    s = Mock()
+    # Claude serves both server tools via the native path (OAuth and API key).
+    assert ClaudeModel.supports_builtin_web_search(s) is True
+    assert ClaudeModel.supports_builtin_web_fetch(s) is True
+
+
+def test_describe_hosted_tool_item_web_search_dict():
+    from datus.models.openai_compatible import describe_hosted_tool_item
+
+    name, call_id, args = describe_hosted_tool_item(
+        {"type": "web_search_call", "id": "ws_1", "action": {"query": "duckdb news"}}
+    )
+    assert name == "web_search"
+    assert call_id == "ws_1"
+    assert "duckdb news" in args
+
+
+def test_describe_hosted_tool_item_object():
+    from openai.types.responses import ResponseFunctionWebSearch
+    from openai.types.responses.response_function_web_search import ActionSearch
+
+    from datus.models.openai_compatible import describe_hosted_tool_item
+
+    item = ResponseFunctionWebSearch(
+        id="ws_2", type="web_search_call", status="completed", action=ActionSearch(type="search", query="q")
+    )
+    name, call_id, args = describe_hosted_tool_item(item)
+    assert name == "web_search"
+    assert call_id == "ws_2"
+
+
+def test_summarize_web_tool_result_extracts_titles():
+    from types import SimpleNamespace
+
+    from datus.models.claude_model import summarize_web_tool_result
+
+    block = SimpleNamespace(
+        content=[
+            SimpleNamespace(title="DuckDB 1.5 released", url="https://duckdb.org/x", page_age="2 days ago"),
+            SimpleNamespace(title="Release notes", url="https://github.com/duckdb", page_age=None),
+        ]
+    )
+    summary, canonical = summarize_web_tool_result(block, query="duckdb release")
+    # Compact summary lists result titles.
+    assert summary.startswith("2 web results:")
+    assert "DuckDB 1.5 released" in summary
+    # Canonical schema carries the full structured results.
+    assert canonical["query"] == "duckdb release"
+    assert canonical["result_count"] == 2
+    assert canonical["results"][0]["title"] == "DuckDB 1.5 released"
+    assert canonical["results"][0]["url"] == "https://duckdb.org/x"
+    assert canonical["results"][0]["age"] == "2 days ago"
+
+
+def test_summarize_web_tool_result_web_fetch_extracts_content():
+    from types import SimpleNamespace
+
+    from datus.models.claude_model import summarize_web_tool_result
+
+    # web_fetch result: content is a single document block (not a list).
+    block = SimpleNamespace(
+        content=SimpleNamespace(
+            url="https://duckdb.org/notes",
+            content=SimpleNamespace(
+                title="Release Notes",
+                source=SimpleNamespace(type="text", data="Full page body text here."),
+            ),
+        )
+    )
+    summary, canonical = summarize_web_tool_result(block)
+    assert canonical["url"] == "https://duckdb.org/notes"
+    assert canonical["content"] == "Full page body text here."
+    assert canonical["char_count"] == len("Full page body text here.")
+    assert "chars" in summary
+
+
+def test_summarize_web_tool_result_handles_missing():
+    from datus.models.claude_model import summarize_web_tool_result
+
+    assert summarize_web_tool_result(None) == ("completed", {})
+
+
+def test_codex_hosted_completion_attaches_citations():
+    """Deferred hosted web_search completion carries the canonical result built
+    from the assistant message's url_citation annotations."""
+    from types import SimpleNamespace
+
+    from datus.models.codex_model import CodexModel
+
+    pending = [
+        {
+            "call_id": "ws_1",
+            "tool_name": "web_search",
+            "arguments": "{}",
+            "args_str": "",
+            "query": "duckdb latest",
+            "sources": [{"title": "", "url": "https://fallback", "snippet": ""}],
+        }
+    ]
+    result = SimpleNamespace(
+        to_input_list=lambda: [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "...",
+                        "annotations": [{"type": "url_citation", "title": "DuckDB", "url": "https://duckdb.org"}],
+                    }
+                ],
+            }
+        ]
+    )
+    actions = CodexModel._build_hosted_search_completions(pending, result)
+    assert len(actions) == 1
+    done = actions[0]
+    assert done.action_id == "complete_ws_1"
+    assert done.action_type == "web_search"
+    canonical = done.output["raw_output"]["result"]
+    assert canonical["query"] == "duckdb latest"
+    # url_citations win over the action.sources fallback.
+    assert canonical["results"] == [{"title": "DuckDB", "url": "https://duckdb.org", "snippet": "", "age": None}]
+    assert done.output["summary"] == "1 web result: DuckDB"
+
+
+def test_codex_hosted_completion_falls_back_to_sources():
+    """With no citations, the call's own action.sources URLs become the results."""
+    from types import SimpleNamespace
+
+    from datus.models.codex_model import CodexModel
+
+    pending = [
+        {
+            "call_id": "ws_2",
+            "tool_name": "web_search",
+            "arguments": "{}",
+            "args_str": "",
+            "query": "q",
+            "sources": [{"title": "", "url": "https://only-source", "snippet": ""}],
+        }
+    ]
+    result = SimpleNamespace(to_input_list=lambda: [])  # no assistant citations
+    actions = CodexModel._build_hosted_search_completions(pending, result)
+    canonical = actions[0].output["raw_output"]["result"]
+    assert canonical["results"] == [{"title": "", "url": "https://only-source", "snippet": "", "age": None}]
+
+
+def test_describe_hosted_tool_item_ignores_function_call():
+    from datus.models.openai_compatible import describe_hosted_tool_item
+
+    # Regular function tools are handled by the normal path, not this helper.
+    assert (
+        describe_hosted_tool_item({"type": "function_call", "name": "read_query", "call_id": "c1", "arguments": "{}"})
+        is None
+    )

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -194,3 +194,13 @@ def test_describe_hosted_tool_item_ignores_function_call():
         describe_hosted_tool_item({"type": "function_call", "name": "read_query", "call_id": "c1", "arguments": "{}"})
         is None
     )
+
+
+def test_describe_hosted_tool_item_ignores_non_web_hosted_calls():
+    from datus.models.openai_compatible import describe_hosted_tool_item
+
+    # Only web_search_call is normalized through the hosted-search path. Other
+    # hosted *_call items must NOT be routed here (they would be force-fit into
+    # the web_search canonical schema by the deferred completion logic).
+    for itype in ("file_search_call", "image_generation_call", "code_interpreter_call", "computer_call"):
+        assert describe_hosted_tool_item({"type": itype, "id": "x"}) is None

--- a/tests/unit_tests/models/test_openai_compatible_stream_order.py
+++ b/tests/unit_tests/models/test_openai_compatible_stream_order.py
@@ -694,3 +694,36 @@ class TestRawEventEarlyCapture:
         ids = {a.action_id for a in delta_actions}
         assert len(ids) == 1  # All share same stream ID
         assert delta_actions[0].action_id.startswith("thinking_stream_")
+
+
+# ---------------------------------------------------------------------------
+# Tests: dict-shaped function_call run items (not just SDK objects)
+# ---------------------------------------------------------------------------
+
+
+def _make_dict_tool_call_event(call_id="call_dict", tool_name="read_query", arguments='{"sql":"select 1"}'):
+    """tool_call_item whose raw_item is a plain dict (e.g. replayed function_call)."""
+    raw = {"type": "function_call", "name": tool_name, "call_id": call_id, "arguments": arguments}
+    return FakeEvent(item=FakeItem(type="tool_call_item", raw_item=raw))
+
+
+@pytest.mark.ci
+class TestDictShapedFunctionCall:
+    """A dict-shaped function_call must preserve its name/call_id (not become 'unknown')."""
+
+    @pytest.mark.asyncio
+    async def test_dict_function_call_preserves_name_and_call_id(self):
+        events = [
+            _make_dict_tool_call_event(call_id="call_dict", tool_name="read_query"),
+            _make_tool_output_event(call_id="call_dict", output="rows"),
+        ]
+
+        actions = await _collect_actions(events)
+
+        start = next(a for a in actions if a.status == ActionStatus.PROCESSING)
+        assert start.action_type == "read_query"
+        assert start.action_id == "call_dict"
+
+        complete = next(a for a in actions if a.role == ActionRole.TOOL and a.status == ActionStatus.SUCCESS)
+        assert complete.action_type == "read_query"
+        assert complete.action_id == "complete_call_dict"

--- a/tests/unit_tests/schemas/test_tool_summary.py
+++ b/tests/unit_tests/schemas/test_tool_summary.py
@@ -902,6 +902,12 @@ def test_failure_path_uniform(tool: str):
         ("list_document_nav", {"total_docs": 5}, "5 docs"),
         ("get_document", {"chunks": [1, 2, 3]}, "3 chunks"),
         ("search_document", {"docs": [1]}, "1 doc match"),
+        # Canonical web_search schema (query/results keys) → labelled summary.
+        (
+            "web_search",
+            {"query": "q", "result_count": 1, "results": [{"title": "T", "url": "https://u", "snippet": "s"}]},
+            "1 web result: T",
+        ),
         # web_search / web_fetch legacy fallbacks (bare list / docs shape, no
         # canonical query/results keys).
         ("web_search", [1, 2, 3], "3 web results"),

--- a/tests/unit_tests/schemas/test_tool_summary.py
+++ b/tests/unit_tests/schemas/test_tool_summary.py
@@ -902,8 +902,14 @@ def test_failure_path_uniform(tool: str):
         ("list_document_nav", {"total_docs": 5}, "5 docs"),
         ("get_document", {"chunks": [1, 2, 3]}, "3 chunks"),
         ("search_document", {"docs": [1]}, "1 doc match"),
-        ("web_search_document", [1, 2, 3], "3 web results"),
-        ("web_search_document", {"docs": [1, 2]}, "2 web results"),
+        # web_search / web_fetch legacy fallbacks (bare list / docs shape, no
+        # canonical query/results keys).
+        ("web_search", [1, 2, 3], "3 web results"),
+        ("web_search", {"docs": [1, 2]}, "2 web results"),
+        # Canonical web_fetch schema → "<label> (N chars)" (web tools bypass the
+        # 19-char clip, like filesystem tools).
+        ("web_fetch", {"content": "abcde"}, "fetched (5 chars)"),
+        ("web_fetch", {"content": "abcde", "truncated": True}, "fetched (5 chars) (truncated)"),
     ],
 )
 def test_per_tool_fallback_branches(tool: str, payload: Any, expected: str):
@@ -1007,7 +1013,8 @@ _LENGTH_CONTRACT_SAMPLES: list[tuple[str, Any]] = [
     ("list_document_nav", {"platform": "snowflake", "total_docs": 99999}),
     ("get_document", {"platform": "snowflake", "chunk_count": 99999}),
     ("search_document", {"docs": [{}] * 999}),
-    ("web_search_document", [{}] * 999),
+    # web_search / web_fetch are intentionally exempt (in FS_TOOLS_NO_CLIP) so
+    # their result titles / page label stay visible — not part of this contract.
 ]
 
 

--- a/tests/unit_tests/schemas/test_web_result.py
+++ b/tests/unit_tests/schemas/test_web_result.py
@@ -86,6 +86,37 @@ def test_web_fetch_summary_truncated_and_domain_fallback():
 # ── OpenAI hosted extraction (objects and dicts) ────────────────────
 
 
+def test_normalize_search_results_skips_non_dict_items():
+    out = normalize_search_results("q", ["not-a-dict", {"title": "Ok", "url": "https://o", "snippet": "s"}])
+    assert out["result_count"] == 1
+    assert out["results"][0]["title"] == "Ok"
+
+
+def test_web_search_summary_non_dict_returns_empty():
+    assert web_search_short_summary("nope") == ""
+    assert web_search_short_summary(None) == ""
+
+
+def test_web_search_summary_results_without_labels():
+    # Results present but each lacks title/url -> count only, no label list.
+    result = {"result_count": 2, "results": [{"snippet": "a"}, {"snippet": "b"}]}
+    assert web_search_short_summary(result) == "2 web results"
+
+
+def test_web_search_summary_completed_when_empty():
+    assert web_search_short_summary({}) == "completed"
+
+
+def test_web_fetch_summary_non_dict_returns_empty():
+    assert web_fetch_short_summary(["x"]) == ""
+
+
+def test_web_fetch_summary_counts_content_when_char_count_missing():
+    # char_count absent -> derived from content length.
+    result = {"title": "", "url": "https://duckdb.org", "content": "abcd"}
+    assert web_fetch_short_summary(result) == "duckdb.org (4 chars)"
+
+
 def test_extract_url_citations_dedups_and_skips_non_citation():
     parts = [
         SimpleNamespace(

--- a/tests/unit_tests/schemas/test_web_result.py
+++ b/tests/unit_tests/schemas/test_web_result.py
@@ -130,3 +130,37 @@ def test_collect_citations_from_input_list_folds_assistant_messages():
     ]
     rows = collect_citations_from_input_list(input_list)
     assert rows == [{"title": "DuckDB", "url": "https://duckdb.org", "snippet": ""}]
+
+
+def test_collect_citations_ignores_user_message_annotations():
+    # A user (non-assistant) message that itself carries url_citation annotations
+    # must NOT contribute to the hosted web_search canonical results.
+    input_list = [
+        {
+            "role": "user",
+            "type": "message",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [
+                        {"type": "url_citation", "title": "Bad", "url": "https://example.com/bad"},
+                    ],
+                }
+            ],
+        },
+        {
+            "role": "assistant",
+            "type": "message",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [
+                        {"type": "url_citation", "title": "Good", "url": "https://duckdb.org"},
+                    ],
+                }
+            ],
+        },
+    ]
+    assert collect_citations_from_input_list(input_list) == [
+        {"title": "Good", "url": "https://duckdb.org", "snippet": ""}
+    ]

--- a/tests/unit_tests/schemas/test_web_result.py
+++ b/tests/unit_tests/schemas/test_web_result.py
@@ -1,0 +1,132 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Contract tests for the canonical web_tool result schema + summaries.
+
+These guarantee every backend (Tavily / Anthropic / OpenAI hosted) renders the
+same shape, and that the compact one-liners behave across the present/absent
+field combinations each backend produces.
+"""
+
+from types import SimpleNamespace
+
+from datus.schemas.web_result import (
+    collect_citations_from_input_list,
+    extract_action_sources,
+    extract_url_citations,
+    hosted_action_query,
+    normalize_fetch_result,
+    normalize_search_results,
+    web_fetch_short_summary,
+    web_search_short_summary,
+)
+
+# ── normalize_search_results ────────────────────────────────────────
+
+
+def test_normalize_search_results_fills_fields_and_drops_empty():
+    out = normalize_search_results(
+        "duckdb",
+        [
+            {"title": "A", "url": "https://a.com", "snippet": "s", "age": "1d"},
+            {"content": "from-content-key"},  # snippet falls back to ``content``
+            {},  # fully empty -> dropped
+            {"title": "", "url": "", "snippet": ""},  # blank -> dropped
+        ],
+    )
+    assert out["query"] == "duckdb"
+    assert out["result_count"] == 2
+    assert out["results"][0] == {"title": "A", "url": "https://a.com", "snippet": "s", "age": "1d"}
+    assert out["results"][1]["snippet"] == "from-content-key"
+    assert out["results"][1]["age"] is None
+
+
+def test_normalize_search_results_clips_long_snippet():
+    out = normalize_search_results("q", [{"url": "https://x", "snippet": "z" * 999}])
+    snippet = out["results"][0]["snippet"]
+    assert snippet.endswith("…")
+    assert len(snippet) <= 501
+
+
+# ── normalize_fetch_result ──────────────────────────────────────────
+
+
+def test_normalize_fetch_result_sets_char_count():
+    out = normalize_fetch_result(url="https://x", title="T", content="hello", truncated=True)
+    assert out == {"url": "https://x", "title": "T", "content": "hello", "truncated": True, "char_count": 5}
+
+
+# ── summaries ───────────────────────────────────────────────────────
+
+
+def test_web_search_summary_lists_titles():
+    result = normalize_search_results("q", [{"title": "Alpha", "url": "u1"}, {"title": "Beta", "url": "u2"}])
+    assert web_search_short_summary(result) == "2 web results: Alpha; Beta"
+
+
+def test_web_search_summary_falls_back_to_domain_then_query():
+    # No titles -> domain labels.
+    result = normalize_search_results("q", [{"url": "https://docs.example.com/x"}])
+    assert web_search_short_summary(result) == "1 web result: docs.example.com"
+    # No results at all -> the query (OpenAI hosted before citations).
+    empty = normalize_search_results("duckdb latest", [])
+    assert web_search_short_summary(empty) == 'searched: "duckdb latest"'
+
+
+def test_web_fetch_summary_uses_title_and_char_count():
+    result = normalize_fetch_result(url="https://x", title="Release Notes", content="x" * 12431, truncated=False)
+    assert web_fetch_short_summary(result) == "Release Notes (12,431 chars)"
+
+
+def test_web_fetch_summary_truncated_and_domain_fallback():
+    result = normalize_fetch_result(url="https://www.duckdb.org/p", title="", content="abc", truncated=True)
+    assert web_fetch_short_summary(result) == "duckdb.org (3 chars) (truncated)"
+
+
+# ── OpenAI hosted extraction (objects and dicts) ────────────────────
+
+
+def test_extract_url_citations_dedups_and_skips_non_citation():
+    parts = [
+        SimpleNamespace(
+            annotations=[
+                SimpleNamespace(type="url_citation", title="T1", url="https://a"),
+                SimpleNamespace(type="url_citation", title="dup", url="https://a"),  # dup url
+                SimpleNamespace(type="file_citation", title="ignored", url="https://b"),
+            ]
+        )
+    ]
+    rows = extract_url_citations(parts)
+    assert rows == [{"title": "T1", "url": "https://a", "snippet": ""}]
+
+
+def test_extract_action_sources_objects_and_dicts():
+    action = {"sources": [{"type": "url", "url": "https://a"}, {"type": "url", "url": ""}]}
+    assert extract_action_sources(action) == [{"title": "", "url": "https://a", "snippet": ""}]
+
+
+def test_hosted_action_query_prefers_query_then_url():
+    assert hosted_action_query({"query": "q"}) == "q"
+    assert hosted_action_query({"url": "https://x"}) == "https://x"
+    assert hosted_action_query(None) is None
+
+
+def test_collect_citations_from_input_list_folds_assistant_messages():
+    input_list = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {"type": "web_search_call", "action": {"query": "duckdb"}},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "...",
+                    "annotations": [
+                        {"type": "url_citation", "title": "DuckDB", "url": "https://duckdb.org"},
+                    ],
+                }
+            ],
+        },
+    ]
+    rows = collect_citations_from_input_list(input_list)
+    assert rows == [{"title": "DuckDB", "url": "https://duckdb.org", "snippet": ""}]

--- a/tests/unit_tests/tools/func_tool/test_platform_doc_search.py
+++ b/tests/unit_tests/tools/func_tool/test_platform_doc_search.py
@@ -11,7 +11,6 @@ from datus.tools.func_tool.platform_doc_search import PlatformDocSearchTool
 
 # Patch targets for locally-imported symbols inside platform_doc_search.py methods
 _SEARCH_TOOL_PATH = "datus.tools.search_tools.search_tool.SearchTool"
-_TAVILY_PATH = "datus.tools.search_tools.search_tool.search_by_tavily"
 _LIST_PLATFORMS_PATH = "datus.storage.document.store.list_indexed_platforms"
 _TRANS_PATH = "datus.tools.func_tool.platform_doc_search.trans_to_function_tool"
 
@@ -34,13 +33,14 @@ class TestAllToolsName:
         assert "list_document_nav" in names
         assert "get_document" in names
         assert "search_document" in names
-        assert "web_search_document" in names
-        assert len(names) == 4
+        # web search moved to the unified web_tool group; no longer here.
+        assert "web_search_document" not in names
+        assert len(names) == 3
 
 
 class TestAvailableTools:
-    """Availability filter matrix: trio gated by indexed platforms,
-    web_search_document gated by tavily key (config OR env)."""
+    """Availability filter matrix: the doc trio is gated by indexed platforms.
+    Web search/fetch now live in the unified ``web_tool`` group, not here."""
 
     @staticmethod
     def _tool_names(tools):
@@ -58,7 +58,17 @@ class TestAvailableTools:
             mock_trans.side_effect = _fake
             yield mock_trans
 
-    def test_all_available(self, mock_agent_config, _patch_trans, monkeypatch):
+    def test_trio_available_with_platforms(self, mock_agent_config, _patch_trans, monkeypatch):
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
+
+        with patch(_LIST_PLATFORMS_PATH, return_value=["duckdb"]):
+            tools = tool.available_tools()
+
+        assert self._tool_names(tools) == ["list_document_nav", "get_document", "search_document"]
+
+    def test_no_web_search_document_even_with_tavily(self, mock_agent_config, _patch_trans, monkeypatch):
+        # A Tavily key must NOT resurrect web_search_document here anymore.
         mock_agent_config.tavily_api_key = "k"
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
         tool = PlatformDocSearchTool(agent_config=mock_agent_config)
@@ -66,41 +76,9 @@ class TestAvailableTools:
         with patch(_LIST_PLATFORMS_PATH, return_value=["duckdb"]):
             tools = tool.available_tools()
 
-        names = self._tool_names(tools)
-        assert names == [
-            "list_document_nav",
-            "get_document",
-            "search_document",
-            "web_search_document",
-        ]
+        assert "web_search_document" not in self._tool_names(tools)
 
-    def test_only_web_when_no_platforms(self, mock_agent_config, _patch_trans, monkeypatch, caplog):
-        mock_agent_config.tavily_api_key = "k"
-        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
-        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
-
-        with caplog.at_level(logging.INFO, logger="datus.tools.func_tool.platform_doc_search"):
-            with patch(_LIST_PLATFORMS_PATH, return_value=[]):
-                tools = tool.available_tools()
-
-        assert self._tool_names(tools) == ["web_search_document"]
-        assert any("no indexed docstore" in rec.message for rec in caplog.records)
-        assert not any("web_search_document" in rec.message and "Skipping" in rec.message for rec in caplog.records)
-
-    def test_only_trio_when_no_tavily(self, mock_agent_config, _patch_trans, monkeypatch, caplog):
-        mock_agent_config.tavily_api_key = None
-        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
-        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
-
-        with caplog.at_level(logging.INFO, logger="datus.tools.func_tool.platform_doc_search"):
-            with patch(_LIST_PLATFORMS_PATH, return_value=["duckdb"]):
-                tools = tool.available_tools()
-
-        assert self._tool_names(tools) == ["list_document_nav", "get_document", "search_document"]
-        assert any("Skipping web_search_document" in rec.message for rec in caplog.records)
-
-    def test_empty_when_nothing_available(self, mock_agent_config, _patch_trans, monkeypatch, caplog):
-        mock_agent_config.tavily_api_key = None
+    def test_empty_when_no_platforms(self, mock_agent_config, _patch_trans, monkeypatch, caplog):
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
         tool = PlatformDocSearchTool(agent_config=mock_agent_config)
 
@@ -109,19 +87,7 @@ class TestAvailableTools:
                 tools = tool.available_tools()
 
         assert tools == []
-        messages = " | ".join(rec.message for rec in caplog.records)
-        assert "no indexed docstore" in messages
-        assert "Skipping web_search_document" in messages
-
-    def test_tavily_env_fallback(self, mock_agent_config, _patch_trans, monkeypatch):
-        mock_agent_config.tavily_api_key = None
-        monkeypatch.setenv("TAVILY_API_KEY", "envkey")
-        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
-
-        with patch(_LIST_PLATFORMS_PATH, return_value=[]):
-            tools = tool.available_tools()
-
-        assert self._tool_names(tools) == ["web_search_document"]
+        assert any("no indexed docstore" in rec.message for rec in caplog.records)
 
 
 class TestListDocumentNav:
@@ -270,87 +236,3 @@ class TestSearchDocument:
 
         assert result.success == 0
         assert "timeout" in result.error
-
-
-class TestWebSearchDocument:
-    @pytest.fixture
-    def tavily_tool(self):
-        """Tool with tavily_api_key set so web_search_document reaches the Tavily call."""
-        config = Mock()
-        config.tavily_api_key = "test-tavily-key"
-        return PlatformDocSearchTool(agent_config=config)
-
-    def test_no_tavily_key_returns_empty(self, doc_search_tool):
-        """When tavily_api_key is None, should return early with empty result."""
-        result = doc_search_tool.web_search_document(keywords=["test"])
-        assert result.success == 1
-        assert result.result == []
-
-    def test_success(self, tavily_tool):
-        mock_result = Mock()
-        mock_result.success = True
-        mock_result.docs = ["doc1 content", "doc2 content"]
-        mock_result.doc_count = 2
-
-        with patch(_TAVILY_PATH, return_value=mock_result):
-            result = tavily_tool.web_search_document(keywords=["snowflake COPY INTO"], max_results=5)
-
-        assert result.success == 1
-        assert result.result["doc_count"] == 2
-
-    def test_success_with_include_domains(self, tavily_tool):
-        mock_result = Mock()
-        mock_result.success = True
-        mock_result.docs = ["content"]
-        mock_result.doc_count = 1
-
-        with patch(_TAVILY_PATH, return_value=mock_result) as mock_fn:
-            result = tavily_tool.web_search_document(
-                keywords=["query"],
-                max_results=3,
-                include_domains=["docs.snowflake.com"],
-            )
-
-        assert result.success == 1
-        mock_fn.assert_called_once_with(
-            keywords=["query"],
-            max_results=3,
-            search_depth="advanced",
-            include_answer="basic",
-            include_raw_content="markdown",
-            include_domains=["docs.snowflake.com"],
-            api_key="test-tavily-key",
-        )
-
-    def test_uses_tavily_key_from_config(self, mock_agent_config):
-        mock_agent_config.tavily_api_key = "my-tavily-key"
-        tool = PlatformDocSearchTool(agent_config=mock_agent_config)
-
-        mock_result = Mock()
-        mock_result.success = True
-        mock_result.docs = []
-        mock_result.doc_count = 0
-
-        with patch(_TAVILY_PATH, return_value=mock_result) as mock_fn:
-            tool.web_search_document(keywords=["test"])
-
-        call_kwargs = mock_fn.call_args.kwargs
-        assert call_kwargs["api_key"] == "my-tavily-key"
-
-    def test_search_fails(self, tavily_tool):
-        mock_result = Mock()
-        mock_result.success = False
-        mock_result.error = "Tavily API error"
-
-        with patch(_TAVILY_PATH, return_value=mock_result):
-            result = tavily_tool.web_search_document(keywords=["test"])
-
-        assert result.success == 0
-        assert result.error == "Tavily API error"
-
-    def test_exception_returns_failure(self, tavily_tool):
-        with patch(_TAVILY_PATH, side_effect=Exception("network error")):
-            result = tavily_tool.web_search_document(keywords=["test"])
-
-        assert result.success == 0
-        assert "network error" in result.error

--- a/tests/unit_tests/tools/func_tool/test_web_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_web_tool.py
@@ -1,0 +1,181 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Unit tests for the unified web tool group (web_tool.web_search / web_fetch).
+
+All external calls are mocked (Tavily via ``search_by_tavily``; HTTP via
+``httpx.get``). Deterministic, no network — CI tier.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from datus.tools.func_tool.web_tool import WebTool
+
+
+def _cfg(tavily=None):
+    return SimpleNamespace(tavily_api_key=tavily)
+
+
+def _names(tool):
+    return {t.name for t in tool.available_tools()}
+
+
+# --- available_tools backend gating -------------------------------------------------
+
+
+def test_available_tools_local_both_with_key():
+    tool = WebTool(_cfg("k"), expose_local_search=True, expose_local_fetch=True)
+    assert _names(tool) == {"web_search", "web_fetch"}
+
+
+def test_available_tools_no_tavily_key(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    tool = WebTool(_cfg(None), expose_local_search=True, expose_local_fetch=True)
+    # web_search suppressed without a key; web_fetch always available locally.
+    assert _names(tool) == {"web_fetch"}
+
+
+def test_available_tools_builtin_search_suppresses_local():
+    tool = WebTool(_cfg("k"), expose_local_search=False, expose_local_fetch=True)
+    assert _names(tool) == {"web_fetch"}
+
+
+def test_available_tools_builtin_both_empty():
+    tool = WebTool(_cfg("k"), expose_local_search=False, expose_local_fetch=False)
+    assert _names(tool) == set()
+
+
+def test_all_tools_name_full_surface():
+    assert WebTool.all_tools_name() == ["web_search", "web_fetch"]
+
+
+def test_env_var_key_enables_search(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "envkey")
+    tool = WebTool(_cfg(None), expose_local_search=True, expose_local_fetch=False)
+    assert _names(tool) == {"web_search"}
+
+
+# --- web_search (Tavily backend) ----------------------------------------------------
+
+
+def test_web_search_passes_tavily_params_and_maps_result():
+    tool = WebTool(_cfg("key123"))
+    # structured=True keys results by the tab-joined query; web_search maps them
+    # into the canonical {query, result_count, results:[{title,url,snippet,age}]}.
+    query = "foo\tbar"
+    fake = SimpleNamespace(
+        success=True,
+        docs={query: [{"title": "T1", "url": "https://a.com", "snippet": "snip", "raw_content": "raw"}]},
+        doc_count=1,
+        error=None,
+    )
+    with patch("datus.tools.search_tools.search_tool.search_by_tavily", return_value=fake) as m:
+        res = tool.web_search(["foo", "bar"], max_results=3, include_domains=["x.com"])
+    assert res.success == 1
+    assert res.result["query"] == "foo, bar"
+    assert res.result["result_count"] == 1
+    assert res.result["results"] == [{"title": "T1", "url": "https://a.com", "snippet": "snip", "age": None}]
+    kwargs = m.call_args.kwargs
+    assert kwargs["keywords"] == ["foo", "bar"]
+    assert kwargs["max_results"] == 3
+    assert kwargs["search_depth"] == "advanced"
+    assert kwargs["include_answer"] == "basic"
+    assert kwargs["include_raw_content"] == "markdown"
+    assert kwargs["include_domains"] == ["x.com"]
+    assert kwargs["api_key"] == "key123"
+    assert kwargs["structured"] is True
+
+
+def test_web_search_backend_failure_returns_error():
+    tool = WebTool(_cfg("key"))
+    fake = SimpleNamespace(success=False, docs={}, doc_count=0, error="rate limited")
+    with patch("datus.tools.search_tools.search_tool.search_by_tavily", return_value=fake):
+        res = tool.web_search(["q"])
+    assert res.success == 0
+    assert res.error == "rate limited"
+
+
+def test_web_search_without_key_fails(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    tool = WebTool(_cfg(None))
+    res = tool.web_search(["q"])
+    assert res.success == 0
+    assert "tavily" in res.error.lower()
+
+
+# --- web_fetch (httpx backend) ------------------------------------------------------
+
+
+def _resp(text="", content_type="text/html; charset=utf-8", url="http://e.com"):
+    r = Mock()
+    r.text = text
+    r.headers = {"content-type": content_type}
+    r.url = url
+    r.raise_for_status = Mock()
+    return r
+
+
+def test_web_fetch_extracts_text_and_strips_noise():
+    html = (
+        "<html><head><title>My Page</title></head>"
+        "<body><nav>menu</nav><script>evil()</script>"
+        "<p>Hello world</p><footer>foot</footer></body></html>"
+    )
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get", return_value=_resp(html)):
+        res = tool.web_fetch("http://e.com/page")
+    assert res.success == 1
+    assert res.result["title"] == "My Page"
+    assert "Hello world" in res.result["content"]
+    assert "evil" not in res.result["content"]
+    assert "menu" not in res.result["content"]
+    assert "foot" not in res.result["content"]
+    assert res.result["truncated"] is False
+
+
+def test_web_fetch_truncates_long_content():
+    html = "<html><body><p>" + ("A" * 500) + "</p></body></html>"
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get", return_value=_resp(html)):
+        res = tool.web_fetch("http://e.com", max_chars=100)
+    assert res.success == 1
+    assert len(res.result["content"]) == 100
+    assert res.result["truncated"] is True
+
+
+def test_web_fetch_http_status_error():
+    tool = WebTool(_cfg())
+    r = _resp()
+    r.raise_for_status.side_effect = httpx.HTTPStatusError("boom", request=Mock(), response=Mock(status_code=404))
+    with patch("datus.tools.func_tool.web_tool.httpx.get", return_value=r):
+        res = tool.web_fetch("http://e.com/missing")
+    assert res.success == 0
+    assert "404" in res.error
+
+
+def test_web_fetch_transport_error():
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get", side_effect=httpx.ConnectError("no route")):
+        res = tool.web_fetch("http://e.com")
+    assert res.success == 0
+    assert "Failed to fetch" in res.error
+
+
+def test_web_fetch_rejects_non_html_content_type():
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get", return_value=_resp("{}", content_type="application/json")):
+        res = tool.web_fetch("http://e.com/data.json")
+    assert res.success == 0
+    assert "content-type" in res.error.lower()
+
+
+@pytest.mark.parametrize("bad", ["ftp://x", "/local/path", "example.com", ""])
+def test_web_fetch_rejects_non_http_url(bad):
+    tool = WebTool(_cfg())
+    res = tool.web_fetch(bad)
+    assert res.success == 0
+    assert "URL" in res.error

--- a/tests/unit_tests/tools/func_tool/test_web_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_web_tool.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock, patch
 import httpx
 import pytest
 
-from datus.tools.func_tool.web_tool import WebTool
+from datus.tools.func_tool.web_tool import WebTool, _is_public_web_target
 
 
 def _cfg(tavily=None):
@@ -51,6 +51,29 @@ def test_available_tools_builtin_both_empty():
 
 def test_all_tools_name_full_surface():
     assert WebTool.all_tools_name() == ["web_search", "web_fetch"]
+
+
+def test_create_dynamic_and_static_factories():
+    cfg = _cfg("k")
+    dyn = WebTool.create_dynamic(cfg, sub_agent_name="a")
+    stat = WebTool.create_static(cfg, sub_agent_name="b", database_name="db")
+    assert isinstance(dyn, WebTool) and dyn.sub_agent_name == "a"
+    assert isinstance(stat, WebTool) and stat.sub_agent_name == "b"
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://duckdb.org", True),
+        ("http://example.com/path", True),
+        ("ftp://example.com", False),  # non-http scheme
+        ("http://", False),  # no hostname
+        ("https://127.0.0.1", False),  # literal loopback
+        ("https://10.1.2.3", False),  # literal private
+    ],
+)
+def test_is_public_web_target_direct(url, expected):
+    assert _is_public_web_target(url) is expected
 
 
 def test_env_var_key_enables_search(monkeypatch):
@@ -105,6 +128,42 @@ def test_web_search_without_key_fails(monkeypatch):
     res = tool.web_search(["q"])
     assert res.success == 0
     assert "tavily" in res.error.lower()
+
+
+def test_web_search_falls_back_to_first_docs_value_when_query_key_absent():
+    # When the backend keys results by something other than the joined query,
+    # web_search falls back to the first docs value.
+    tool = WebTool(_cfg("key"))
+    fake = SimpleNamespace(
+        success=True,
+        docs={"some-other-key": [{"title": "T", "url": "https://u", "snippet": "s"}]},
+        doc_count=1,
+        error=None,
+    )
+    with patch("datus.tools.search_tools.search_tool.search_by_tavily", return_value=fake):
+        res = tool.web_search(["foo", "bar"])
+    assert res.success == 1
+    assert res.result["results"][0]["title"] == "T"
+
+
+def test_web_search_unexpected_exception_returns_error():
+    tool = WebTool(_cfg("key"))
+    with patch("datus.tools.search_tools.search_tool.search_by_tavily", side_effect=RuntimeError("kaboom")):
+        res = tool.web_search(["q"])
+    assert res.success == 0
+    assert "kaboom" in res.error
+
+
+def test_web_fetch_parse_error_returns_error():
+    tool = WebTool(_cfg())
+    html = "<html><body><p>hi</p></body></html>"
+    with (
+        patch("datus.tools.func_tool.web_tool.httpx.get", return_value=_resp(html)),
+        patch("datus.tools.func_tool.web_tool.BeautifulSoup", side_effect=ValueError("bad parser")),
+    ):
+        res = tool.web_fetch("https://duckdb.org/x")
+    assert res.success == 0
+    assert "Failed to parse" in res.error
 
 
 # --- web_fetch (httpx backend) ------------------------------------------------------

--- a/tests/unit_tests/tools/func_tool/test_web_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_web_tool.py
@@ -179,3 +179,72 @@ def test_web_fetch_rejects_non_http_url(bad):
     res = tool.web_fetch(bad)
     assert res.success == 0
     assert "URL" in res.error
+
+
+@pytest.mark.parametrize(
+    "blocked",
+    [
+        "http://127.0.0.1",  # loopback
+        "http://127.0.0.1:8080/admin",
+        "http://[::1]/",  # IPv6 loopback
+        "http://169.254.169.254/latest/meta-data/",  # link-local (cloud metadata)
+        "http://10.0.0.1",  # private
+        "http://192.168.1.1",  # private
+        "http://172.16.0.5",  # private
+        "http://0.0.0.0",  # unspecified
+    ],
+)
+def test_web_fetch_rejects_ssrf_targets(blocked):
+    # Literal-IP hosts are validated directly (no DNS), so the request must be
+    # refused before any httpx call is made.
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get") as m:
+        res = tool.web_fetch(blocked)
+    assert res.success == 0
+    assert "SSRF" in res.error
+    m.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "blocked_host",
+    ["http://localhost/x", "http://localhost:9000", "http://db.internal/q", "http://myhost.local/"],
+)
+def test_web_fetch_rejects_internal_hostnames(blocked_host):
+    # Internal hostnames are refused without any DNS resolution.
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get") as m:
+        res = tool.web_fetch(blocked_host)
+    assert res.success == 0
+    assert "SSRF" in res.error
+    m.assert_not_called()
+
+
+def test_web_fetch_allows_public_hostname():
+    # Public hostnames are allowed (resolution happens at fetch time, not in the
+    # guard) — so the mocked httpx path runs normally.
+    html = "<html><head><title>OK</title></head><body><p>hi</p></body></html>"
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get", return_value=_resp(html)):
+        res = tool.web_fetch("https://duckdb.org/")
+    assert res.success == 1
+    assert res.result["title"] == "OK"
+
+
+@pytest.mark.parametrize("bad_max", [0, -1, -100, 3.5, True, "20"])
+def test_web_fetch_rejects_invalid_max_chars(bad_max):
+    tool = WebTool(_cfg())
+    with patch("datus.tools.func_tool.web_tool.httpx.get") as m:
+        res = tool.web_fetch("http://e.com", max_chars=bad_max)
+    assert res.success == 0
+    assert "max_chars" in res.error
+    m.assert_not_called()
+
+
+def test_web_fetch_rejects_oversized_content_length():
+    tool = WebTool(_cfg())
+    r = _resp("<html><body><p>hi</p></body></html>")
+    r.headers = {"content-type": "text/html", "content-length": str(50 * 1024 * 1024)}
+    with patch("datus.tools.func_tool.web_tool.httpx.get", return_value=r):
+        res = tool.web_fetch("http://e.com/huge")
+    assert res.success == 0
+    assert "too large" in res.error.lower()

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -131,14 +131,15 @@ class TestNormalProfile:
         assert _resolve(config, "artifact_tools", "save_query_template") == PermissionLevel.ALLOW
         assert _resolve(config, "artifact_tools", "validate_render") == PermissionLevel.ALLOW
 
-    def test_platform_doc_reads_allowed_web_search_asks(self):
-        """Doc lookups are local reads; ``web_search_document`` reaches the
-        network (Tavily) and stays at the profile default."""
+    def test_platform_doc_reads_allowed_web_tool_asks(self):
+        """Doc lookups are local reads; ``web_tool`` reaches the network and
+        stays at the profile default (ASK)."""
         config = NORMAL
         assert _resolve(config, "platform_doc_tools", "list_document_nav") == PermissionLevel.ALLOW
         assert _resolve(config, "platform_doc_tools", "get_document") == PermissionLevel.ALLOW
         assert _resolve(config, "platform_doc_tools", "search_document") == PermissionLevel.ALLOW
-        assert _resolve(config, "platform_doc_tools", "web_search_document") == PermissionLevel.ASK
+        assert _resolve(config, "web_tool", "web_search") == PermissionLevel.ASK
+        assert _resolve(config, "web_tool", "web_fetch") == PermissionLevel.ASK
 
 
 class TestAutoProfile:

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -131,15 +131,16 @@ class TestNormalProfile:
         assert _resolve(config, "artifact_tools", "save_query_template") == PermissionLevel.ALLOW
         assert _resolve(config, "artifact_tools", "validate_render") == PermissionLevel.ALLOW
 
-    def test_platform_doc_reads_allowed_web_tool_asks(self):
-        """Doc lookups are local reads; ``web_tool`` reaches the network and
-        stays at the profile default (ASK)."""
+    def test_platform_doc_reads_and_web_tool_allowed(self):
+        """Doc lookups are local reads; ``web_tool`` is read-only retrieval
+        (web_fetch hardened against SSRF) and provider-native web tools bypass
+        local hooks anyway, so both are ALLOW rather than ASK."""
         config = NORMAL
         assert _resolve(config, "platform_doc_tools", "list_document_nav") == PermissionLevel.ALLOW
         assert _resolve(config, "platform_doc_tools", "get_document") == PermissionLevel.ALLOW
         assert _resolve(config, "platform_doc_tools", "search_document") == PermissionLevel.ALLOW
-        assert _resolve(config, "web_tool", "web_search") == PermissionLevel.ASK
-        assert _resolve(config, "web_tool", "web_fetch") == PermissionLevel.ASK
+        assert _resolve(config, "web_tool", "web_search") == PermissionLevel.ALLOW
+        assert _resolve(config, "web_tool", "web_fetch") == PermissionLevel.ALLOW
 
 
 class TestAutoProfile:

--- a/tests/unit_tests/tools/search_tools/test_search_tool.py
+++ b/tests/unit_tests/tools/search_tools/test_search_tool.py
@@ -415,6 +415,42 @@ class TestSearchByTavily:
             result = search_by_tavily(["q"])
         assert result.success is True
 
+    def test_structured_maps_per_result_fields(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"title": "DuckDB", "url": "https://duckdb.org", "content": "snip", "raw_content": "raw"},
+                {"title": "Notes", "url": "https://x.io", "content": "", "raw_content": None},
+            ],
+            "answer": None,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response):
+            result = search_by_tavily(["a", "b"], api_key="key", structured=True)
+
+        assert result.success is True
+        items = result.docs["a\tb"]
+        assert items[0] == {"title": "DuckDB", "url": "https://duckdb.org", "snippet": "snip", "raw_content": "raw"}
+        assert items[1]["title"] == "Notes" and items[1]["raw_content"] == ""
+
+    def test_structured_does_not_count_answer_as_result(self):
+        # An answer must NOT be prepended as a synthetic row in structured mode
+        # (it would inflate result_count and diverge from provider-native backends).
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [{"title": "Only", "url": "https://only", "content": "c"}],
+            "answer": "synthesized answer",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response):
+            result = search_by_tavily(["q"], api_key="key", include_answer="basic", structured=True)
+
+        assert result.doc_count == 1  # the answer is dropped, not counted
+        items = result.docs["q"]
+        assert all(it["url"] for it in items)  # no title-less/url-less answer row
+
     def test_include_domains_added_to_payload(self):
         mock_response = MagicMock()
         mock_response.json.return_value = {"results": [], "answer": None}


### PR DESCRIPTION
## Why

Datus had a single Tavily-only `platform_doc_search.web_search`, no `web_fetch`, and ignored vendor-native web tools. Once multiple backends existed, each produced a *different* result shape, so tool-call events rendered inconsistently across providers — OpenAI hosted search showed only `completed`, Claude `web_fetch` showed nothing, and the local Tavily path dropped per-result title/url. We want one tool surface and an identical event payload regardless of which provider (built-in or third-party) serves the call.

## Solution

Expose one `web_tool.web_search` / `web_tool.web_fetch` pair; the backend is chosen per active provider at the node layer, and **every backend normalizes into one canonical schema** (`datus/schemas/web_result.py`):

```
web_search -> {query, result_count, results:[{title,url,snippet,age}]}
web_fetch  -> {url, title, content, truncated, char_count}
```

Backend mapping:
- **Local** — Tavily (`search_by_tavily(structured=True)` now preserves title/url/snippet) + httpx fetch (no third-party API).
- **Claude native** — `web_search_20250305` / `web_fetch_20250910` server tools; `summarize_web_tool_result` returns the canonical dict and recursively extracts the fetched document text (fixes the previously-empty web_fetch result).
- **OpenAI / Codex hosted** — the call item carries no results, so the completion is deferred to stream end and built from the assistant message's `url_citation` annotations (with `action.sources` as fallback; OpenAI path requests `web_search_call.action.sources`).

Delivery split (the core ask):
- **`datus -p` + API SSE events** carry the **full canonical result** in the `result` field (via `raw_output={"success":True,"result":canonical}`, the same envelope local FuncTools use, so both converters unwrap it unchanged).
- **TUI** gets new `_build_web_search` / `_build_web_fetch` builders: compact mode shows a one-liner, verbose renders the full results list / fetched text.
- **shortDesc** / TUI compact line come from a single source in `tool_summary`; web tools are added to `FS_TOOLS_NO_CLIP` so result titles aren't truncated to 19 chars.

Also: web tools decoupled from `platform_doc_tools` in prompts, `ASK` permission rules added for `web_tool.*`, and the legacy `platform_doc_search.web_search` retired.

Known limitation (documented): OpenAI hosted search exposes no snippet text (only title+url from citations) and results land after the answer text; the field structure is still identical across backends so consumers need zero branching.

## Test Cases

New unit tests (all external calls mocked):
- `tests/unit_tests/schemas/test_web_result.py` — schema normalization, summaries across present/absent-field combos, `url_citation` / `action.sources` extraction, input-list folding.
- `tests/unit_tests/tools/func_tool/test_web_tool.py` — Tavily param passthrough + canonical mapping, httpx fetch parsing/truncation/errors.
- `tests/unit_tests/models/test_builtin_web_tools.py` — capability truth table, hosted-search deferred completion (citations win, sources fallback), Claude web_fetch document extraction.
- `tests/unit_tests/agent/node/test_agentic_node_web_tools.py` — node-layer backend selection.

Updated: `test_tool_summary.py`, `test_tool_content.py`, `test_platform_doc_search.py`, `test_profiles.py`, `test_agentic_node_skills.py`.

Full unit suite: **15148 passed, 2 skipped, 1 xfailed**. Provider request/response shapes were verified against the real APIs during development (OpenAI Responses `web_search_call` action + `url_citation` annotations); CI itself uses zero keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
## Summary by CodeRabbit

* **New Features**
  * Unified web search and fetch capabilities under a single tool interface.
  * Added support for provider-native web tools with automatic capability detection—local web tools are suppressed when the model provides built-in equivalents.
  * Improved provider-specific web tool routing for Anthropic and OpenAI models.

* **Improvements**
  * Enhanced system prompts to reflect updated web tool structure and model capabilities.
  * Consistent web result formatting and normalization across all providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified web search and web fetch under a single web tool interface (`web_search`, `web_fetch`).

* **Improvements**
  * Provider-native web tooling support with automatic capability detection (local tools are used only when native equivalents aren’t available).
  * Updated system prompts and platform doc guidance to remove legacy web-search fallbacks.
  * Improved web tool output rendering and normalized summaries, including hosted web-search flows.

* **Bug Fixes / Reliability**
  * Prevented stale or re-injected web tools when switching models mid-session.
  * Hardened web fetching with stronger URL/SSRF protection and safer content handling.

* **Tests**
  * Expanded coverage for tool mounting, hosted web-search behavior, and web formatting/length contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->