### PR TITLE
[BugFix] Preserve structured tool result in Claude native loop for benchmark provenance

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -805,18 +805,30 @@ class ClaudeModel(OpenAICompatibleModel):
                             result_summary = (
                                 self._format_tool_result(result_text, block.name) if tool_executed else "Failed"
                             )
+                            tool_output = {
+                                "success": tool_executed,
+                                "raw_output": result_text,
+                                "summary": result_summary,
+                                "status_message": result_summary,
+                            }
+                            # Keep the structured records (raw_output is stringified
+                            # for the Anthropic message). Unwrap the FuncToolResult
+                            # envelope so benchmark trajectory evaluation can read
+                            # source_context_id provenance.
+                            structured_result = None
+                            if isinstance(hook_result, dict):
+                                structured_result = hook_result.get("result", hook_result)
+                            elif isinstance(hook_result, list):
+                                structured_result = hook_result
+                            if isinstance(structured_result, (dict, list)):
+                                tool_output["result"] = structured_result
                             complete_action = ActionHistory(
                                 action_id=f"complete_{block.id}",
                                 role=ActionRole.TOOL,
                                 messages=f"Tool call: {block.name}('{args_str}...')",
                                 action_type=block.name,
                                 input={"function_name": block.name, "arguments": block.input},
-                                output={
-                                    "success": tool_executed,
-                                    "raw_output": result_text,
-                                    "summary": result_summary,
-                                    "status_message": result_summary,
-                                },
+                                output=tool_output,
                                 status=ActionStatus.SUCCESS if tool_executed else ActionStatus.FAILED,
                             )
                             complete_action.end_time = datetime.now()

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -808,6 +808,69 @@ class TestGenerateWithMcpStream:
         assert actions[2].role == ActionRole.ASSISTANT
 
     @pytest.mark.asyncio
+    async def test_structured_tool_result_preserves_provenance_in_action_output(self):
+        """Regression: search_reference_sql results carrying source_context_id must
+        be recorded as structured records under output["result"], not only as a
+        stringified raw_output. Benchmark trajectory evaluation reads this
+        provenance; when it was a JSON string only, every task became
+        source_context_id_missing and reference_sql ranking scored 0%.
+        """
+        from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        tool_block = _make_tool_use_block(
+            name="search_reference_sql", block_id="call_1", input_data={"query": "orders"}
+        )
+        resp_tool = _make_response([tool_block])
+        resp_final = _make_response([_make_text_block("done")])
+        model.anthropic_client.messages.create.side_effect = [resp_tool, resp_final]
+
+        # Real shape: trans_to_function_tool returns FuncToolResult.model_dump(),
+        # an envelope dict whose records live under "result" — not a bare list.
+        records = [
+            {"name": "task:0", "sql": "SELECT 1", "summary": "x", "tags": [], "source_context_id": "refsql:task:0"},
+            {"name": "task:9", "sql": "SELECT 2", "summary": "y", "tags": [], "source_context_id": "refsql:task:9"},
+        ]
+        envelope = {"success": 1, "error": None, "result": records}
+        func_tool = MagicMock()
+        func_tool.name = "search_reference_sql"
+        func_tool.description = "Search reference SQL"
+        func_tool.params_json_schema = {"type": "object"}
+        func_tool.on_invoke_tool = AsyncMock(return_value=envelope)
+
+        ahm = ActionHistoryManager()
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for action in model._generate_with_mcp_stream(
+                prompt="test",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                func_tools=[func_tool],
+                action_history_manager=ahm,
+            ):
+                actions.append(action)
+
+        success = [a for a in actions if a.role == ActionRole.TOOL and a.status == ActionStatus.SUCCESS]
+        assert len(success) == 1
+        output = success[0].output
+
+        # Must be the unwrapped records list (what the benchmark trajectory provider
+        # reads), not the envelope — a wrapped envelope has no source_context_id.
+        assert output.get("result") == records
+        ids = [item["source_context_id"] for item in output["result"]]
+        assert ids == ["refsql:task:0", "refsql:task:9"]
+
+        # Backward-compat: the stringified raw_output is still present for display
+        # and message reconstruction.
+        assert isinstance(output["raw_output"], str)
+        assert "refsql:task:0" in output["raw_output"]
+
+    @pytest.mark.asyncio
     async def test_func_tool_receives_tool_call_id_matching_block_id(self):
         """The func tool must be invoked with a context whose ``tool_call_id``
         equals the tool_use block id (== the PROCESSING action's ``action_id``).


### PR DESCRIPTION
## Why

Benchmark runs on `claude_subscription` (e.g. [#240 claude-opus-4-8](https://github.com/Datus-ai/datus-benchmark/actions/runs/28095244106), [#238 claude-sonnet-4-6](https://github.com/Datus-ai/datus-benchmark/actions/runs/28084052607)) scored `reference_sql_context_ranking` **0.0% (0/32)** with every task classified `source_context_id_missing`, even though query scores were normal (84.4%) and the agent did call `search_reference_sql`. Models on the SDK/litellm path (codex, openrouter, deepseek, …) scored retrieval normally with the same benchmark commit.

Root cause: the Claude **native Anthropic SDK tool loop** (`claude_model._generate_with_mcp_stream`) recorded tool results into `action_history` only as a stringified `raw_output` (`json.dumps(...)`, required for the Anthropic API message). Benchmark trajectory evaluation reads `source_context_id` provenance from the **structured** tool result; a JSON string is not parsed (the extractor only handles dict/list), so all provenance was lost → retrieval scored 0%. The SDK/litellm path stores the structured envelope dict, so it was unaffected.

## Solution

Keep the structured tool result alongside the stringified `raw_output`. `trans_to_function_tool` serializes `FuncToolResult` to an envelope dict `{"success", "error", "result"}`; the actual records (carrying `source_context_id`) live under `result`. We unwrap `result` and store it under `output["result"]`, which is exactly the structured slot the benchmark trajectory provider reads — matching the records the SDK/litellm path already exposes.

- `raw_output` stays a string → CLI display, message reconstruction, and backward compatibility are unaffected.
- Only attaches structured data when the tool returned a dict/list (MCP string-result path unchanged).

Verified end-to-end: real `_generate_with_mcp_stream` output → YAML round-trip → the benchmark's real `trajectory_provider` recovers `['refsql:task:0', 'refsql:task:9']` (was empty before the fix).

## Test Cases

Added unit regression `test_structured_tool_result_preserves_provenance_in_action_output` in `tests/unit_tests/models/test_claude_model.py`. It drives `_generate_with_mcp_stream` with a `search_reference_sql` tool returning the **real** `FuncToolResult.model_dump()` envelope shape (not a bare list) and asserts the recorded action `output["result"]` is the unwrapped records list with recoverable `source_context_id`, while `raw_output` remains a string. Fails before the fix, passes after. Full `test_claude_model.py` suite: 101 passed; test-quality audit P0=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **New Features**
  * Tool completion responses can now include richer structured results alongside the existing text summary.
  * Provenance details from tool outputs are preserved when available, making results easier to inspect and trace.
* **Bug Fixes**
  * Improved consistency of tool execution records so successful actions retain both structured data and readable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool completion outputs can now carry richer structured `result` data in addition to the existing text-based fields.
* **Bug Fixes**
  * Improved consistency of successful tool action records by ensuring structured results are attached (when provided) while keeping `raw_output` as a readable string.
  * Provenance-related fields from tool results are preserved for easier inspection.
* **Tests**
  * Added a regression test to verify structured tool results keep expected provenance and remain backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->