### PR TITLE
[Doc] Add 0.3.6 release notes

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,25 @@
 
 ## 0.3
 
+### 0.3.6
+
+**Enhancements**
+
+- **Scoped `/init` and `/build-kb` Runs** - `/init` now accepts optional scope text, and `/build-kb` can skip confirmation for clearly scoped or automated knowledge-base builds. [#1033](https://github.com/Datus-ai/Datus-agent/pull/1033) [init docs](https://docs.datus.ai/0.3/cli/init_command/) [build-kb docs](https://docs.datus.ai/0.3/cli/build_kb_command/)
+- **Model-Level SSL Verification** - Model providers can set `ssl_verify` to `true`, `false`, or a CA bundle path for private CA and self-signed LLM endpoints; the model-level setting takes precedence over `SSL_VERIFY` and `SSL_CERT_FILE`. [#1043](https://github.com/Datus-ai/Datus-agent/pull/1043) [docs](https://docs.datus.ai/0.3/configuration/agent/)
+- **Runtime Stack Dumps for API Diagnostics** - The API server can dump live async task stacks to logs with `SIGUSR1`, making production hangs easier to diagnose without stopping the process. [#1037](https://github.com/Datus-ai/Datus-agent/pull/1037)
+
+**Bug Fixes**
+
+- **Responsive Session and Catalog APIs** - Slow blocking filesystem or datasource calls in session and catalog endpoints now run off the event loop with bounded timeouts, so one slow request no longer stalls the API process. [#1036](https://github.com/Datus-ai/Datus-agent/pull/1036)
+- **Datasource Overrides Preserve Database Context** - Fixed datasource names being treated as physical database names; chat requests now carry datasource overrides and database context separately through connection, gateway, subagent, and validation paths. [#1048](https://github.com/Datus-ai/Datus-agent/pull/1048)
+- **Release and Test Stability** - The Prepare Release workflow now regenerates `uv.lock` before locked sync, and BIRD SQLite fixtures are isolated in temporary directories so tests no longer contaminate each other. [#1039](https://github.com/Datus-ai/Datus-agent/pull/1039) [#1047](https://github.com/Datus-ai/Datus-agent/pull/1047)
+
+**Upgrade Notes**
+
+- **Skill Execution** - Skills now execute through `load_skill`; the legacy `skill_execute_command` path and `allowed_commands` in skill config have been removed. [#1033](https://github.com/Datus-ai/Datus-agent/pull/1033)
+- **Database Schema Tools** - `get_table_ddl` is no longer exposed as an agent/MCP tool. Use `describe_table` and `read_query` for schema and sample-data inspection. [#1031](https://github.com/Datus-ai/Datus-agent/pull/1031)
+
 ### 0.3.5
 
 **New Features**

--- a/docs/release_notes.zh.md
+++ b/docs/release_notes.zh.md
@@ -2,6 +2,25 @@
 
 ## 0.3
 
+### 0.3.6
+
+**增强**
+
+- **可限定范围的 `/init` 与 `/build-kb`** - `/init` 现在支持传入可选 scope 文本，`/build-kb` 支持跳过确认步骤，便于在明确范围或自动化场景中更直接地构建知识库。[#1033](https://github.com/Datus-ai/Datus-agent/pull/1033) [init 文档](https://docs.datus.ai/0.3/zh/cli/init_command/) [build-kb 文档](https://docs.datus.ai/0.3/zh/cli/build_kb_command/)
+- **模型级 SSL 校验配置** - 模型 provider 可通过 `ssl_verify` 配置 `true`、`false` 或 CA bundle 路径，以连接私有 CA 或自签名证书的 LLM endpoint；模型级配置优先级高于 `SSL_VERIFY` 和 `SSL_CERT_FILE` 环境变量。[#1043](https://github.com/Datus-ai/Datus-agent/pull/1043) [文档](https://docs.datus.ai/0.3/zh/configuration/agent/)
+- **API 运行时堆栈诊断** - API server 支持通过 `SIGUSR1` 将 live async task stack dump 到日志中，便于在不停止进程的情况下排查生产环境卡住问题。[#1037](https://github.com/Datus-ai/Datus-agent/pull/1037)
+
+**Bug 修复**
+
+- **Session 与 Catalog API 响应更稳定** - session 和 catalog endpoint 中较慢的同步文件系统或 datasource 调用会移出 event loop 并设置有界超时，避免单个慢请求拖住整个 API 进程。[#1036](https://github.com/Datus-ai/Datus-agent/pull/1036)
+- **Datasource Override 保留 Database 上下文** - 修复 datasource 名称被当作物理 database 名称使用的问题；Chat 请求现在会把 datasource override 与 database context 分开传递，connection、gateway、subagent 和 validation 路径都会保留这两个概念的区别。[#1048](https://github.com/Datus-ai/Datus-agent/pull/1048)
+- **Release 与测试稳定性** - Prepare Release workflow 现在会在 locked sync 前重新生成 `uv.lock`；BIRD SQLite fixtures 会隔离到临时目录，避免测试之间互相污染。[#1039](https://github.com/Datus-ai/Datus-agent/pull/1039) [#1047](https://github.com/Datus-ai/Datus-agent/pull/1047)
+
+**升级说明**
+
+- **Skill 执行方式** - Skill 现在通过 `load_skill` 执行；旧的 `skill_execute_command` 路径和 skill config 中的 `allowed_commands` 字段已移除。[#1033](https://github.com/Datus-ai/Datus-agent/pull/1033)
+- **数据库 Schema 工具** - `get_table_ddl` 不再作为面向 agent/MCP 的工具暴露。用户侧 schema 和样例数据检查请使用 `describe_table` 和 `read_query`。[#1031](https://github.com/Datus-ai/Datus-agent/pull/1031)
+
 ### 0.3.5
 
 **新功能**


### PR DESCRIPTION

Add release notes for Datus 0.3.6 in English and Chinese.


## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [x] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scoped `/init` runs and an option to skip confirmation in `/build-kb`.
  - Added support for model-level SSL verification settings, including CA bundle paths.
  - Added runtime async stack dumps triggered by `SIGUSR1`.

- **Bug Fixes**
  - Improved responsiveness of Session and Catalog APIs during slow operations.
  - Fixed datasource override handling in multi-layer paths.
  - Improved release and test stability with more reliable lockfile and fixture handling.

- **Upgrade Notes**
  - Skill execution now uses the newer loading flow; the legacy command path is removed.
  - `get_table_ddl` is no longer available; use `describe_table` or `read_query` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->