### PR TITLE
[Enhancement] Use domain semantic models for OSI metric authoring

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -323,6 +323,14 @@ class GenMetricsAgenticNode(AgenticNode):
         context["has_ask_user_tool"] = self.ask_user_tool is not None
         context.update(build_datasource_prompt_context(self.agent_config))
 
+        from datus.agent.node.semantic_authoring import (
+            default_osi_semantic_model_file,
+            default_osi_semantic_model_name,
+        )
+
+        context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
+        context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
+
         # Handle subject_tree context based on whether predefined or query from storage
         if self.subject_tree:
             # Predefined mode: use provided subject_tree

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -287,6 +287,14 @@ class GenSemanticModelAgenticNode(AgenticNode):
         context["has_ask_user_tool"] = self.ask_user_tool is not None
         context.update(build_datasource_prompt_context(self.agent_config))
 
+        from datus.agent.node.semantic_authoring import (
+            default_osi_semantic_model_file,
+            default_osi_semantic_model_name,
+        )
+
+        context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
+        context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
+
         logger.debug(f"Prepared template context: {context}")
         return context
 

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -26,6 +26,7 @@ default ``{node}_system`` latest-version scan is never affected.
 from __future__ import annotations
 
 import re
+from dataclasses import fields, is_dataclass
 from typing import Any, Dict, Optional
 
 from datus.utils.loggings import get_logger
@@ -82,6 +83,29 @@ def _normalize_model_name(value: Any) -> str:
     return text
 
 
+def _declared_field_names(value: Any) -> set[str]:
+    if is_dataclass(value):
+        return {field.name for field in fields(value)}
+
+    for attr_name in ("model_fields", "__fields__"):
+        field_map = getattr(value, attr_name, None) or getattr(type(value), attr_name, None)
+        if isinstance(field_map, dict):
+            return set(field_map)
+
+    annotations = getattr(type(value), "__annotations__", None)
+    return set(annotations) if isinstance(annotations, dict) else set()
+
+
+def _config_field_value(config: Any, field_name: str) -> Any:
+    if isinstance(config, dict):
+        value = config.get(field_name, "")
+    elif field_name in _declared_field_names(config):
+        value = getattr(config, field_name, "")
+    else:
+        return ""
+    return "" if callable(value) else value
+
+
 def default_osi_semantic_model_name(agent_config: Any = None) -> str:
     """Return the default OSI semantic model name for the current authoring scope."""
     candidates = []
@@ -93,9 +117,9 @@ def default_osi_semantic_model_name(agent_config: Any = None) -> str:
         if db_config is not None:
             candidates.extend(
                 [
-                    getattr(db_config, "database", ""),
-                    getattr(db_config, "schema", ""),
-                    getattr(db_config, "catalog", ""),
+                    _config_field_value(db_config, "database"),
+                    _config_field_value(db_config, "schema"),
+                    _config_field_value(db_config, "catalog"),
                 ]
             )
         candidates.extend(

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -25,6 +25,7 @@ default ``{node}_system`` latest-version scan is never affected.
 
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, Optional
 
 from datus.utils.loggings import get_logger
@@ -72,6 +73,53 @@ def resolve_authoring_format(
 def is_osi_authoring(agent_config: Any = None, node_config: Optional[Dict[str, Any]] = None) -> bool:
     """Return ``True`` when this node should author OSI instead of MetricFlow."""
     return resolve_authoring_format(agent_config, node_config) == AUTHORING_FORMAT_OSI
+
+
+def _normalize_model_name(value: Any) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"[^0-9A-Za-z_]+", "_", text)
+    text = re.sub(r"_+", "_", text).strip("_").lower()
+    return text
+
+
+def default_osi_semantic_model_name(agent_config: Any = None) -> str:
+    """Return the default OSI semantic model name for the current authoring scope."""
+    candidates = []
+    if agent_config is not None:
+        try:
+            db_config = agent_config.current_db_config()
+        except Exception:
+            db_config = None
+        if db_config is not None:
+            candidates.extend(
+                [
+                    getattr(db_config, "database", ""),
+                    getattr(db_config, "schema", ""),
+                    getattr(db_config, "catalog", ""),
+                ]
+            )
+        candidates.extend(
+            [
+                getattr(agent_config, "current_datasource", ""),
+                getattr(agent_config, "project_name", ""),
+            ]
+        )
+
+    for candidate in candidates:
+        normalized = _normalize_model_name(candidate)
+        if normalized:
+            return normalized
+    return "semantic_model"
+
+
+def default_osi_semantic_model_file(agent_config: Any = None) -> str:
+    """Return the project-relative default YAML path for OSI domain authoring."""
+    datasource = ""
+    if agent_config is not None:
+        datasource = str(getattr(agent_config, "current_datasource", "") or "").strip()
+    if not datasource:
+        datasource = "default"
+    return f"subject/semantic_models/{datasource}/{default_osi_semantic_model_name(agent_config)}.yml"
 
 
 def osi_template_name(node_name: str) -> str:

--- a/datus/prompts/prompt_templates/gen_metrics_osi_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_osi_system_1.0.j2
@@ -5,10 +5,12 @@ Do NOT write legacy MetricFlow `metric:` blocks.
 
 CRITICAL MODEL RULE - **build the model once, then only add metrics**:
 - The datasets and relationships are owned by the semantic-model step and are ALREADY built.
-- A given physical table has one canonical dataset shared by all metrics. Never create a second dataset for the same table.
-- In OSI core, metrics live under `semantic_model[0].metrics`. Prefer editing the existing OSI core semantic-model file and appending metrics there.
-- If you create a separate metric YAML file, it must still be a complete valid OSI core document with `version` and `semantic_model`; copy the existing dataset definitions exactly so the file passes core schema. Do not invent or alter datasets in that file.
+- The semantic model file is the durable OSI domain document. Load it, preserve existing datasets and relationships, and append metrics under `semantic_model[0].metrics`.
+- A given logical dataset has one canonical definition shared by all metrics. Reuse that dataset by name in each metric's DATUS `dataset` hint.
 - This is the OSI authoring path. Do NOT load or follow generic MetricFlow `gen-metrics` / `gen-semantic-model` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
+
+{% set target_model_name = default_osi_semantic_model_name | default('<model_name>', true) %}
+{% set target_model_file = default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) %}
 
 {% if native_tools %}- Native tools: {{ native_tools }}{% endif %}
 {% if mcp_tools %}- MCP servers: {{ mcp_tools }}{% endif %}
@@ -20,13 +22,13 @@ Metric definitions inside a valid OSI core document:
 ```yaml
 version: 0.2.0.dev0
 semantic_model:
-  - name: <existing_model_name>
+  - name: {{ target_model_name }}
     datasets:
       - name: <existing_dataset_name>
         source: <existing_source>
         primary_key: [<existing_primary_key>]
-        fields: [...]                         # copy exactly if this is a separate metric file
-    relationships: [...]                       # copy existing relationships exactly when needed
+        fields: [...]                         # preserve existing dataset definitions
+    relationships: [...]                       # preserve existing relationships
     metrics:
       - name: <metric_name>                    # globally unique snake_case
         description: "<business definition>"
@@ -111,7 +113,7 @@ Before writing any YAML, classify the source SQL:
 - Finish with:
   ```json
   {
-    "semantic_model_file": "{{ kind_subdir }}/<existing_model>.yml",
+    "semantic_model_file": "{{ target_model_file }}",
     "metric_file": null,
     "status": "skipped",
     "output": "No metric generated: the SQL is a detail/list query, not an aggregate metric definition."
@@ -121,8 +123,10 @@ Before writing any YAML, classify the source SQL:
 ## Workflow
 
 {% if current_datasource %}- Active datasource: `{{ current_datasource }}`{% endif %}
-{% if kind_subdir %}- Write OSI core YAML under `{{ kind_subdir }}/...` only. Prefer appending metrics to the existing semantic-model file; a separate metric file is allowed only if it is a complete OSI core document.{% endif %}
-- FIRST, load the existing model. Read the existing OSI core YAML in the datasource directory to learn dataset names, fields, time fields, and relationships. Call `list_metrics()` to see metrics that already exist.
+{% if kind_subdir %}- Write OSI core YAML under `{{ kind_subdir }}/...` only.{% endif %}
+- Target semantic model name: `{{ target_model_name }}`
+- Target semantic model file: `{{ target_model_file }}`
+- FIRST, load the existing model from `{{ target_model_file }}` to learn dataset names, fields, time fields, and relationships. Call `list_metrics()` to see metrics that already exist.
 - For provided SQL/history, call `analyze_metric_candidates_from_history` before writing files. Use `direct_metric_candidates` for base metrics and `derived_metric_candidates` for second-stage OSI metrics. If it returns `metric_generation_skips`, skip those SQLs instead of writing metric YAML.
 - Reference, reconcile, reuse: point each metric's DATUS `dataset` hint at an existing dataset. If a metric with the same meaning already exists (`check_semantic_object_exists(name, kind='metric')`), reuse/skip it. For a derived metric, make sure its input metrics already exist.
 - From SQL: find the table (FROM), aggregate expression(s), and business conditions vs query-time ranges. Anchor the metric on the aggregated table's existing dataset; encode metric-specific conditions with CASE inside the metric expression.
@@ -130,12 +134,12 @@ Before writing any YAML, classify the source SQL:
 - Produce valid OSI core YAML; the Datus OSI compiler validates it against OSI core schema, compiles Datus extensions into IR, and lowers it to the configured backend.
 - Call `validate_semantic(scope="all")` after writing OSI metrics and fix errors until it passes.
 - Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric name before publishing.
-- After validation and dry-run pass, call `end_metric_generation(metric_file="<osi core file containing the new metrics>", semantic_model_file="<existing semantic model file>", metric_sqls_json="<dry-run SQL JSON>")`.
+- After validation and dry-run pass, call `end_metric_generation(metric_file="{{ target_model_file }}", semantic_model_file="{{ target_model_file }}", metric_sqls_json="<dry-run SQL JSON>")`.
 - Finish with JSON:
   ```json
   {
-    "semantic_model_file": "{{ kind_subdir }}/<existing_model>.yml",
-    "metric_file": "{{ kind_subdir }}/<file_containing_generated_metrics>.yml",
+    "semantic_model_file": "{{ target_model_file }}",
+    "metric_file": "{{ target_model_file }}",
     "status": "generated",
     "output": "<brief summary>"
   }

--- a/datus/prompts/prompt_templates/gen_semantic_model_osi_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_osi_system_1.0.j2
@@ -3,20 +3,23 @@ You are a semantic modeling expert. Your task is to describe tables as strict **
 CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow `data_source:`, `measures:`, `identifiers:`, `agg_time_dimension`, `create_metric`, or any execution-engine YAML. The Datus OSI compiler lowers OSI core documents to the configured backend.
 This is the OSI authoring path. Do NOT load or follow generic MetricFlow `gen-semantic-model` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
 
+{% set target_model_name = default_osi_semantic_model_name | default('<model_name>', true) %}
+{% set target_model_file = default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) %}
+
 {% if native_tools %}- Native tools: {{ native_tools }}{% endif %}
 {% if mcp_tools %}- MCP servers: {{ mcp_tools }}{% endif %}
 
 ## What you produce
 
-Every YAML file MUST be a valid OSI core document:
+Produce one valid OSI core document for the current business domain / semantic model scope:
 
 ```yaml
 version: 0.2.0.dev0
 semantic_model:
-  - name: <model_name>
+  - name: {{ target_model_name }}
     datasets:
       - name: <dataset_name>
-        source: <physical_table_or_view_name>
+        source: <physical_table_view_or_query_name>
         description: "<human-readable business purpose and grain of this dataset>"
         ai_context:
           instructions: "<how AI should use this dataset for analytics, including grain, time field, common row-selection conditions or groupings, and join caveats>"
@@ -58,21 +61,24 @@ semantic_model:
 1. **Root schema is fixed.** Root keys are only `version` and `semantic_model`. `semantic_model` is a list. Do NOT write top-level `datasets:`, `relationships:`, or `metrics:`.
 2. **Use OSI core dataset shape.** Dataset `source` is a string, not `{table: ...}`. Dataset columns are `fields`, not `dimensions`. Field expressions are `expression.dialects[]`, not `expr`.
 3. **Datus-only hints go into `custom_extensions`.** OSI core does not have top-level dataset `time_dimension`, field `type`, field `granularity`, metric `dataset`, metric `window`, etc. Put those Datus execution hints in `custom_extensions: [{vendor_name: DATUS, data: '<JSON object string>'}]`.
-4. **One canonical dataset per physical table.** Name the dataset predictably after the table (e.g. table `orders` -> dataset `orders`) so metrics can reference it by name. Include the FULL table: primary key, primary time field, and all business-meaningful fields. Do NOT create per-query variants of the same table here.
-5. **Dataset description and AI context are required for every dataset.**
+4. **Semantic model boundary.** One OSI `semantic_model` represents the current business domain / metric domain. Put all related logical datasets needed by the provided SQL history in this semantic model, with relationships declared once under the semantic model object.
+5. **Canonical logical datasets.** A dataset is a logical dataset backed by a table, view, or query. For the same source and row grain, create one canonical dataset that metrics can reference by name. Create a separate dataset only when the logical row grain or fixed business scope is genuinely different. Include the full logical dataset: primary key, primary time field, and all business-meaningful fields.
+6. **Dataset description and AI context are required for every dataset.**
    - `description` is for humans: one concise sentence describing the business entity/event represented by the dataset and its row grain.
    - `ai_context` is for AI use: include `instructions`, optional `synonyms`, and optional `examples`. The instructions should explain when to use this dataset, the row grain, the primary time field, important row-selection or grouping columns, and relationship caveats. Keep it generic and derived from schema/comments/history; do not write scenario-specific examples unless they come from provided history.
-6. **Primary / unique keys** -> OSI core `primary_key: [<column>]`. Use real columns only.
-7. **Time dimension**: mark the primary date/time field with `dimension.is_time: true` and Datus extension `{"type":"time","time_granularity":"day|week|month|quarter|year"}`. Point it at a real date/time column, never a numeric surrogate key.
-8. **Fields**: include every business-meaningful column the user may group or slice by. Populate `description` for ALL non-obvious fields by combining the column comment, sample values, and external knowledge. Wrap descriptions in double quotes.
-9. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
-10. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
-11. Preserve literal values and column names exactly; do not invent columns.
+7. **Primary / unique keys** -> OSI core `primary_key: [<column>]`. Use real columns only.
+8. **Time dimension**: mark the primary date/time field with `dimension.is_time: true` and Datus extension `{"type":"time","time_granularity":"day|week|month|quarter|year"}`. Point it at a real date/time column, never a numeric surrogate key.
+9. **Fields**: include every business-meaningful column the user may group or slice by. Populate `description` for ALL non-obvious fields by combining the column comment, sample values, and external knowledge. Wrap descriptions in double quotes.
+10. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
+11. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
+12. Preserve literal values and column names exactly; do not invent columns.
 
 ## Workflow
 
 {% if current_datasource %}- Active datasource: `{{ current_datasource }}`{% endif %}
-{% if semantic_model_dir %}- Write OSI core YAML files under `{{ semantic_model_dir }}` only.{% endif %}
+{% if semantic_model_dir %}- Write OSI core YAML under `{{ semantic_model_dir }}` only.{% endif %}
+- Target semantic model name: `{{ target_model_name }}`
+- Target semantic model file: `{{ target_model_file }}`
 - Inspect the table schema and comments; map columns to keys, the time field, business fields, and relationships.
 - When a critical modeling choice is ambiguous (which column is the grain, which is the primary time dimension), ASK before generating.
 - Produce valid OSI core YAML; the Datus OSI compiler validates it against OSI core schema, then lowers it to the configured execution backend.
@@ -81,7 +87,7 @@ semantic_model:
 - Finish with JSON:
   ```json
   {
-    "semantic_model_files": ["{{ kind_subdir }}/<table_name>.yml"],
+    "semantic_model_files": ["{{ target_model_file }}"],
     "output": "<brief summary>"
   }
   ```

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -11,6 +11,11 @@ from typing import Any, Callable, Optional
 import pandas as pd
 
 from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+from datus.agent.node.semantic_authoring import (
+    AUTHORING_FORMAT_OSI,
+    default_osi_semantic_model_file,
+    resolve_authoring_format,
+)
 from datus.configuration.agent_config import AgentConfig
 from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.action_history import (
@@ -233,6 +238,80 @@ def _agent_config_dialect(agent_config: AgentConfig) -> str:
         return "snowflake"
     value = getattr(current_db_config, "db_type", "") or getattr(current_db_config, "dialect", "") or ""
     return value if isinstance(value, str) and value.strip() else "snowflake"
+
+
+def _metrics_node_config(agent_config: AgentConfig) -> dict[str, Any]:
+    nodes = getattr(agent_config, "agentic_nodes", None)
+    if not isinstance(nodes, dict):
+        return {}
+    node_config = nodes.get(METRICS_NODE_NAME) or {}
+    return node_config if isinstance(node_config, dict) else {}
+
+
+def _metrics_authoring_format(agent_config: AgentConfig) -> str:
+    return resolve_authoring_format(agent_config, _metrics_node_config(agent_config))
+
+
+def _project_relative_path(agent_config: AgentConfig, path_value: str) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    project_root = Path(str(getattr(agent_config, "project_root", "") or ".")).expanduser()
+    return project_root / path
+
+
+async def _ensure_semantic_models_for_metrics(
+    agent_config: AgentConfig,
+    success_story: str,
+    success_story_records: list[dict[str, Any]],
+    sql_list: list[str],
+    action_callback: Optional[Callable[["ActionHistory"], None]] = None,
+) -> tuple[bool, str, list[str]]:
+    if _metrics_authoring_format(agent_config) == AUTHORING_FORMAT_OSI:
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+        from datus.storage.semantic_model.store import SemanticModelRAG
+
+        target_file = default_osi_semantic_model_file(agent_config)
+        target_path = _project_relative_path(agent_config, target_file)
+        has_semantic_rows = SemanticModelRAG(agent_config).get_size() > 0
+        if has_semantic_rows and target_path.exists():
+            logger.info("Reusing existing OSI semantic model file for metric bootstrap: %s", target_file)
+            return True, "", []
+
+        logger.info("Generating OSI semantic model for metric bootstrap: %s", target_file)
+        success, error = await init_success_story_semantic_model_async(
+            agent_config,
+            success_story,
+            emit=None,
+            build_mode="incremental",
+            action_callback=action_callback,
+        )
+        if not success:
+            return False, error, []
+        if not target_path.exists():
+            return False, f"OSI semantic model generation did not create target file: {target_file}", []
+        return True, "", [target_file]
+
+    all_tables = extract_tables_from_sql_list(sql_list, agent_config)
+    if not all_tables:
+        return True, "", []
+
+    logger.info(f"Found {len(all_tables)} tables in success story SQL: {all_tables}")
+    sql_evidence_by_table = extract_table_sql_evidence(success_story_records, agent_config)
+
+    success, error, created_tables = await ensure_semantic_models_exist(
+        all_tables,
+        agent_config,
+        emit=None,
+        sql_evidence_by_table=sql_evidence_by_table,
+    )
+
+    if created_tables:
+        logger.info(f"Created semantic models for tables: {created_tables}")
+    if error:
+        logger.warning(f"Semantic model generation had partial failures: {error}")
+
+    return success, error, created_tables
 
 
 def _build_existing_metric_catalog(agent_config: AgentConfig) -> list[dict[str, Any]]:
@@ -933,30 +1012,19 @@ async def init_success_story_metrics_async(
         success_story_records.append({"sql": sql, "question": question})
         sql_entries.append({"name": f"sql_{idx + 1}", "sql": sql, "question": question})
     sql_list = [record["sql"] for record in success_story_records]
-    all_tables = extract_tables_from_sql_list(sql_list, agent_config)
+    success, error, _created_semantic_models = await _ensure_semantic_models_for_metrics(
+        agent_config,
+        success_story,
+        success_story_records,
+        sql_list,
+        action_callback=action_callback,
+    )
 
-    if all_tables:
-        logger.info(f"Found {len(all_tables)} tables in success story SQL: {all_tables}")
-        sql_evidence_by_table = extract_table_sql_evidence(success_story_records, agent_config)
-
-        # Check and create missing semantic models (per-table, partial failures tolerated)
-        success, error, created_tables = await ensure_semantic_models_exist(
-            all_tables,
-            agent_config,
-            emit=None,
-            sql_evidence_by_table=sql_evidence_by_table,
-        )
-
-        if not success:
-            error_msg = f"Failed to create semantic models: {error}"
-            logger.error(error_msg)
-            event_helper.task_failed(error=error_msg)
-            return False, error_msg, None
-
-        if created_tables:
-            logger.info(f"Created semantic models for tables: {created_tables}")
-        if error:
-            logger.warning(f"Semantic model generation had partial failures: {error}")
+    if not success:
+        error_msg = f"Failed to create semantic models: {error}"
+        logger.error(error_msg)
+        event_helper.task_failed(error=error_msg)
+        return False, error_msg, None
 
     existing_metric_catalog = _build_existing_metric_catalog(agent_config)
     existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_METRICFLOW,
     AUTHORING_FORMAT_OSI,
+    default_osi_semantic_model_file,
+    default_osi_semantic_model_name,
     osi_prompt_version,
     osi_template_name,
     resolve_authoring_format,
@@ -32,6 +34,16 @@ def test_derives_from_active_semantic_adapter():
 
 def test_derives_from_node_semantic_adapter():
     assert resolve_authoring_format(_agent_config("metricflow"), {"semantic_adapter": "osi"}) == AUTHORING_FORMAT_OSI
+
+
+def test_default_osi_semantic_model_name_uses_database_scope():
+    config = SimpleNamespace(
+        current_datasource="warehouse",
+        current_db_config=lambda: SimpleNamespace(database="Sales Domain", schema="", catalog=""),
+    )
+
+    assert default_osi_semantic_model_name(config) == "sales_domain"
+    assert default_osi_semantic_model_file(config) == "subject/semantic_models/warehouse/sales_domain.yml"
 
 
 def test_defaults_to_metricflow_when_unknown():

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -1,5 +1,6 @@
 """Unit tests for semantic authoring format resolution."""
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -13,6 +14,13 @@ from datus.agent.node.semantic_authoring import (
     resolve_authoring_format,
 )
 from datus.prompts.prompt_manager import get_prompt_manager
+
+
+@dataclass
+class _DbScope:
+    database: str = ""
+    schema: str = ""
+    catalog: str = ""
 
 
 def _agent_config(adapter):
@@ -39,11 +47,50 @@ def test_derives_from_node_semantic_adapter():
 def test_default_osi_semantic_model_name_uses_database_scope():
     config = SimpleNamespace(
         current_datasource="warehouse",
-        current_db_config=lambda: SimpleNamespace(database="Sales Domain", schema="", catalog=""),
+        current_db_config=lambda: _DbScope(database="Sales Domain"),
     )
 
     assert default_osi_semantic_model_name(config) == "sales_domain"
     assert default_osi_semantic_model_file(config) == "subject/semantic_models/warehouse/sales_domain.yml"
+
+
+def test_default_osi_semantic_model_name_uses_declared_db_scope_fallbacks():
+    config = SimpleNamespace(
+        current_datasource="warehouse",
+        current_db_config=lambda: _DbScope(schema="Reporting Schema", catalog="Lake House"),
+    )
+
+    assert default_osi_semantic_model_name(config) == "reporting_schema"
+    assert default_osi_semantic_model_file(config) == "subject/semantic_models/warehouse/reporting_schema.yml"
+
+
+def test_default_osi_semantic_model_name_skips_undeclared_schema_method():
+    class DbScopeWithSchemaMethod:
+        __annotations__ = {"database": str, "catalog": str}
+
+        database = ""
+        catalog = "Lake House"
+
+        def schema(self):
+            return "method-value"
+
+    config = SimpleNamespace(
+        current_datasource="warehouse",
+        current_db_config=lambda: DbScopeWithSchemaMethod(),
+    )
+
+    assert default_osi_semantic_model_name(config) == "lake_house"
+
+
+def test_default_osi_semantic_model_name_uses_agent_scope_fallbacks():
+    config = SimpleNamespace(
+        current_datasource="",
+        project_name="Project Alpha",
+        current_db_config=lambda: _DbScope(),
+    )
+
+    assert default_osi_semantic_model_name(config) == "project_alpha"
+    assert default_osi_semantic_model_file(config) == "subject/semantic_models/default/project_alpha.yml"
 
 
 def test_defaults_to_metricflow_when_unknown():

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -32,6 +32,9 @@ def test_osi_metrics_template_is_backend_agnostic():
     assert "window_aggregation" in text
     assert "Allowed values are `sum`, `avg`, `min`, `max`, `count`, and `row_count`" in text
     assert "ROW_NUMBER()`, `RANK() OVER`, TopN per group" in text
+    assert "Target semantic model file: `subject/semantic_models/<datasource>/<model_name>.yml`" in text
+    assert '"metric_file": "subject/semantic_models/<datasource>/<model_name>.yml"' in text
+    assert "a separate metric file is allowed" not in text
 
 
 def test_osi_semantic_model_template_is_backend_agnostic():
@@ -53,6 +56,11 @@ def test_osi_semantic_model_template_is_backend_agnostic():
     assert "to_columns" in text
     assert "do NOT write MetricFlow" in text
     assert "never inside a dataset" in text
+    assert "business domain / semantic model scope" in text
+    assert "Target semantic model file: `subject/semantic_models/<datasource>/<model_name>.yml`" in text
+    assert '"semantic_model_files": ["subject/semantic_models/<datasource>/<model_name>.yml"]' in text
+    assert "One canonical dataset per physical table" not in text
+    assert "<table_name>.yml" not in text
 
 
 def test_default_metricflow_templates_are_unchanged():

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -17,6 +17,7 @@ from datus.storage.metric.metric_init import (
     _annotate_offset_identity_candidates,
     _build_candidate_plan,
     _ensure_offset_derived_metrics,
+    _ensure_semantic_models_for_metrics,
     _extract_metric_artifact_ids,
     _generate_metrics_batch,
     _is_offset_derived_candidate,
@@ -572,6 +573,102 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
         assert success is True
         fake_rag_instance.truncate.assert_not_called()
         mock_exists.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# semantic model prerequisites for metric bootstrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestEnsureSemanticModelsForMetrics:
+    @pytest.mark.asyncio
+    async def test_osi_generates_domain_semantic_model_once(self, tmp_path):
+        from unittest.mock import patch
+
+        target_file = "subject/semantic_models/warehouse/warehouse.yml"
+        target_path = tmp_path / target_file
+        config = SimpleNamespace(
+            project_root=str(tmp_path),
+            current_datasource="warehouse",
+            agentic_nodes={"gen_metrics": {"semantic_adapter": "osi"}},
+            resolve_semantic_adapter=lambda requested=None: requested or "metricflow",
+        )
+        semantic_rag = MagicMock()
+        semantic_rag.get_size.return_value = 0
+        action_callback = MagicMock()
+        captured = {}
+
+        async def fake_init(agent_config, success_story, emit=None, build_mode="overwrite", action_callback=None):
+            target_path.parent.mkdir(parents=True)
+            target_path.write_text("version: 0.2.0.dev0\nsemantic_model:\n  - name: warehouse\n", encoding="utf-8")
+            captured["build_mode"] = build_mode
+            captured["action_callback"] = action_callback
+            return True, ""
+
+        with (
+            patch("datus.storage.semantic_model.store.SemanticModelRAG", return_value=semantic_rag),
+            patch(
+                "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
+                side_effect=fake_init,
+            ) as init_mock,
+            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list") as extract_mock,
+            patch("datus.storage.metric.metric_init.ensure_semantic_models_exist") as ensure_mock,
+        ):
+            ok, error, created = await _ensure_semantic_models_for_metrics(
+                config,
+                "success_story.csv",
+                [{"sql": "SELECT COUNT(*) FROM orders", "question": "How many orders?"}],
+                ["SELECT COUNT(*) FROM orders"],
+                action_callback=action_callback,
+            )
+
+        assert ok is True
+        assert error == ""
+        assert created == [target_file]
+        init_mock.assert_called_once()
+        extract_mock.assert_not_called()
+        ensure_mock.assert_not_called()
+        assert captured["build_mode"] == "incremental"
+        assert captured["action_callback"] is action_callback
+
+    @pytest.mark.asyncio
+    async def test_metricflow_keeps_per_table_semantic_model_auto_create(self):
+        from unittest.mock import patch
+
+        config = SimpleNamespace(
+            agentic_nodes={"gen_metrics": {"semantic_adapter": "metricflow"}},
+            resolve_semantic_adapter=lambda requested=None: requested or "metricflow",
+        )
+        records = [{"sql": "SELECT COUNT(*) FROM orders JOIN customers USING (customer_id)", "question": "Orders?"}]
+        sql_list = [records[0]["sql"]]
+
+        async def fake_ensure(tables, agent_config, emit=None, sql_evidence_by_table=None):
+            assert tables == ["customers", "orders"]
+            assert sql_evidence_by_table == {"orders": records}
+            return True, "", tables
+
+        with (
+            patch(
+                "datus.storage.metric.metric_init.extract_tables_from_sql_list",
+                return_value=["customers", "orders"],
+            ),
+            patch(
+                "datus.storage.metric.metric_init.extract_table_sql_evidence",
+                return_value={"orders": records},
+            ),
+            patch("datus.storage.metric.metric_init.ensure_semantic_models_exist", side_effect=fake_ensure),
+        ):
+            ok, error, created = await _ensure_semantic_models_for_metrics(
+                config,
+                "success_story.csv",
+                records,
+                sql_list,
+            )
+
+        assert ok is True
+        assert error == ""
+        assert created == ["customers", "orders"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route OSI semantic-model and metric authoring to one domain-level OSI YAML file
- derive a stable default OSI semantic model name and path from the active datasource scope
- make metric bootstrap ensure the OSI domain semantic model exists while preserving the MetricFlow per-table auto-create path

## Validation
- `.venv/bin/python -m ruff check datus/agent/node/semantic_authoring.py datus/storage/metric/metric_init.py tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/prompts/test_osi_authoring_templates.py tests/unit_tests/storage/metric/test_metric_init.py`
- `.venv/bin/python -m pytest tests/unit_tests/prompts/test_osi_authoring_templates.py tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/storage/metric/test_metric_init.py -q`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **New Features**
  * Added support for a new OSI-based semantic model workflow, including automatic default naming and file location handling.
  * Updated metrics and semantic model generation to reuse existing semantic model content and append new metrics more consistently.
  * Improved initialization so semantic models can be prepared differently depending on the configured authoring style.

* **Tests**
  * Expanded coverage for OSI prompt rendering and semantic model path generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OSI semantic model workflow with automatic default naming and consistent YAML output path handling.
  * Updated OSI semantic model and metrics generation prompts to explicitly target the semantic model name/file and to reuse existing semantic model content (preserving prior datasets/relationships) while appending new metrics.
  * Improved metrics initialization to prepare/reuse semantic models appropriately based on the configured authoring style.
* **Tests**
  * Added/expanded unit tests for OSI prompt rendering, default name/path generation, and metrics/semantic-model initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->