### PR TITLE
[Enhancement] Remove slow_span from nightly trace diagnostic findings

### DIFF
--- a/ci/collect_nightly_trace_summary.py
+++ b/ci/collect_nightly_trace_summary.py
@@ -225,19 +225,6 @@ def summarize_observations(
                 "message": str(item.get("statusMessage") or item.get("error") or "Trace span failed"),
             }
         )
-    for duration, item in slowest:
-        if duration >= slow_span_threshold_seconds:
-            findings.append(
-                {
-                    "type": "slow_span",
-                    "severity": "info",
-                    "name": item.get("name"),
-                    "span_type": _observation_type(item),
-                    "duration_seconds": duration,
-                    "threshold_seconds": slow_span_threshold_seconds,
-                }
-            )
-
     if observations and type_counts.get("GENERATION", 0) == 0:
         findings.append(
             {

--- a/tests/unit_tests/ci/test_collect_nightly_trace_summary.py
+++ b/tests/unit_tests/ci/test_collect_nightly_trace_summary.py
@@ -46,7 +46,7 @@ def test_summarize_observations_reports_counts_tokens_and_findings():
     assert summary["tool_span_count"] == 1
     assert summary["failed_span_count"] == 1
     assert summary["token_usage"] == {"input": 12, "output": 8, "total": 20}
-    assert summary["finding_type_counts"] == {"failed_span": 1, "slow_span": 1}
+    assert summary["finding_type_counts"] == {"failed_span": 1}
 
 
 def test_build_process_diagnostics_groups_by_suite():


### PR DESCRIPTION
## Why

`slow_span` appears in the vast majority of nightly trace diagnostic findings. It is expected behavior for agent runs, not a regression signal, and adds noise to the Process Diagnostics section of the nightly report without providing actionable information.

## Solution

Remove the `slow_span` finding generation from `summarize_observations` in `ci/collect_nightly_trace_summary.py`. The `slow_span_threshold_seconds` argument and the `slowest_spans` field in the output are retained since they remain useful for raw data inspection.

## Test Cases

Updated `tests/unit_tests/ci/test_collect_nightly_trace_summary.py`: the `finding_type_counts` assertion in `test_summarize_observations_reports_counts_tokens_and_findings` no longer expects `slow_span`.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted trace summary reporting so slow spans are still listed as the slowest observations, but they no longer appear as separate diagnostic findings.
  * Updated summary counts to reflect only actual failure-related findings in this case, making the reported results clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->