### PR TITLE
[BugFix] catalog/list: scope to datasource's configured database

### DIFF
--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -116,10 +116,11 @@ class DatasourceService:
     ) -> List[DatabaseInfo]:
         """Get connection information for a database connector.
 
-        Enumerates all databases (and schemas if supported), marks the
-        connector's configured database as ``current``.  Request-level
-        filters (database_name, schema_name, catalog_name) narrow the
-        result set when provided.
+        Lists the database(s) this connector is scoped to — its configured
+        database, or the whole server only when no database is configured —
+        resolves schemas if supported, and marks the connector's configured
+        database as ``current``. Request-level filters (database_name,
+        schema_name, catalog_name) narrow the result set when provided.
         """
         from datus_db_core import connector_registry
 
@@ -148,17 +149,24 @@ class DatasourceService:
             logger.exception("Connection test failed for %s", connector.database_name)
             return [_disconnected(connector.database_name)]
 
-        # 1) Enumerate databases — fatal if this fails since we have nothing to iterate.
+        # 1) Resolve which databases to list — fatal if this fails since we have nothing
+        # to iterate. A datasource is a connection profile scoped to its configured
+        # database(s): get_connections() already yields one connector per config-known
+        # database (a server datasource's configured ``database``, or one connector per
+        # glob file). So list the database this connector is bound to, NOT every database
+        # on the server — otherwise a single project datasource leaks the whole instance.
         try:
             if request.database_name:
                 db_names = [request.database_name]
+            elif connector.database_name:
+                db_names = [connector.database_name]
             elif hasattr(connector, "get_databases"):
+                # No database configured for this datasource — fall back to enumerating
+                # the server so the user can still browse what the connection can reach.
                 db_names = connector.get_databases(
                     catalog_name=catalog_name,
                     include_sys=request.include_sys_schemas,
                 )
-            elif connector.database_name:
-                db_names = [connector.database_name]
             else:
                 db_names = []
         except Exception as e:

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -163,6 +163,82 @@ class TestListDatabases:
         assert result.data.current_database == "california_schools"
 
 
+class _FakeServerConnector:
+    """No-schema (server-style) connector that distinguishes its configured
+    database from every database reachable on the instance.
+
+    ``get_databases`` mimics ``SHOW DATABASES`` (the whole server); a scoped
+    listing must NOT call it when a database is configured.
+    """
+
+    dialect = "starrocks"
+    catalog_name = "default_catalog"
+    connection_string = "mysql+pymysql://u:p@host:9030/benchmark"
+
+    def __init__(self, database_name: str):
+        self.database_name = database_name
+        self.get_databases_calls = 0
+
+    def test_connection(self) -> bool:
+        return True
+
+    def get_databases(self, catalog_name: str = "", include_sys: bool = False):
+        self.get_databases_calls += 1
+        return ["benchmark", "ga4", "olist", "fund_poc"]
+
+    def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = ""):
+        return ["t2", "t1"]
+
+
+@pytest.fixture
+def _no_schema_dialect(monkeypatch):
+    """Force the server-style (no per-database schema) code path."""
+    from datus_db_core import connector_registry
+
+    monkeypatch.setattr(connector_registry, "support_schema", lambda dialect: False)
+
+
+class TestGetConnectionInfoScoping:
+    """A datasource is a connection profile scoped to its configured database;
+    listing must not leak every database on the server."""
+
+    def test_configured_database_is_listed_without_enumerating_server(self, real_agent_config, _no_schema_dialect):
+        """With a configured database, only that database is returned and the
+        server-wide ``get_databases`` enumeration is never invoked."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeServerConnector(database_name="benchmark")
+
+        infos = svc._get_connection_info(connector, "benchmark", ListDatabasesInput())
+
+        assert [i.name for i in infos] == ["benchmark"]
+        assert connector.get_databases_calls == 0
+        assert infos[0].current is True
+        # tables are surfaced (and sorted) for the scoped database
+        assert infos[0].tables == ["t1", "t2"]
+
+    def test_falls_back_to_server_enumeration_when_unconfigured(self, real_agent_config, _no_schema_dialect):
+        """Only when no database is configured do we enumerate the server so the
+        connection's reachable databases stay browsable."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeServerConnector(database_name="")
+
+        infos = svc._get_connection_info(connector, "ds", ListDatabasesInput())
+
+        assert connector.get_databases_calls == 1
+        assert [i.name for i in infos] == ["benchmark", "ga4", "olist", "fund_poc"]
+
+    def test_request_database_name_filter_takes_precedence(self, real_agent_config, _no_schema_dialect):
+        """An explicit database_name filter wins over the configured database and
+        still avoids the server-wide enumeration."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeServerConnector(database_name="benchmark")
+
+        infos = svc._get_connection_info(connector, "benchmark", ListDatabasesInput(database_name="ga4"))
+
+        assert [i.name for i in infos] == ["ga4"]
+        assert connector.get_databases_calls == 0
+
+
 class TestGetTableSchema:
     """Tests for get_table_schema with real SQLite connection."""
 

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -179,7 +179,7 @@ class _FakeServerConnector:
         self.database_name = database_name
         self.get_databases_calls = 0
 
-    def test_connection(self) -> bool:
+    def test_connection(self) -> bool:  # audit-noqa: zero_assert_test — connector API stub, not a test
         return True
 
     def get_databases(self, catalog_name: str = "", include_sys: bool = False):


### PR DESCRIPTION
## Why

`GET /api/v1/catalog/list` returned **every database on a server instance**, not just the database the project's datasource is bound to. For a StarRocks/MySQL datasource configured for a single database (e.g. `benchmark`), the response listed every other database on the same server (`ga4`, `olist`, `fund_poc`, …, all sharing the same `…/benchmark` URI).

Root cause: `DatasourceService._get_connection_info` unconditionally called `connector.get_databases()` (i.e. `SHOW DATABASES`) whenever no `database_name` filter was supplied, so a single server datasource leaked the whole instance. This has been present since the API module was introduced (#520); it isn't a recent regression.

## Solution

A datasource is a connection profile scoped to its configured database(s). `DBManager.get_connections()` already yields one connector per config-known database (a server datasource's configured `database`, or one connector per glob file), consistent with `AgentConfig.list_databases()` whose contract is "config-known databases; server-side enumeration beyond config is done via the connector, not here."

So `_get_connection_info` now lists the database the connector is bound to instead of enumerating the server:

- Resolution order in `_get_connection_info`: `request.database_name` (explicit filter) → `connector.database_name` (the datasource's configured database) → `connector.get_databases()` **only** when no database is configured (preserves browsability for unconfigured server datasources) → `[]`.
- No change to glob (SQLite/DuckDB) datasources: they already fan out to one connector per file via `get_connections()`, and each is now listed by its real `database_name`.
- The `current` flag and schema/table resolution paths are unchanged.

## Test Cases

Added `TestGetConnectionInfoScoping` in `tests/unit_tests/api/services/test_database_service.py` (uses a fake server-style, no-schema connector that distinguishes its configured database from the instance-wide `get_databases()` result):

- `test_configured_database_is_listed_without_enumerating_server` — with a configured database, only that database is returned and `get_databases()` is never called; tables are surfaced and sorted.
- `test_falls_back_to_server_enumeration_when_unconfigured` — only when no database is configured do we enumerate the server.
- `test_request_database_name_filter_takes_precedence` — an explicit `database_name` filter wins over the configured database and still avoids the server-wide enumeration.

Existing `TestListDatabases` / `test_database_routes.py` continue to pass (34 in the two API test files; 94 including `db_manager`).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database listing behavior so the requested database is shown first when specified, otherwise the configured database is used, and server-wide enumeration is only used when needed.
  * Clarified connection details to better reflect current database and schema visibility in supported environments.

* **Tests**
  * Added coverage for connection-scoping behavior in environments without schema-per-database support, including database filtering and fallback listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database listing behavior: when a database filter is provided, results are scoped to that database first; otherwise the configured database is used.
  * Server-wide database enumeration now happens only when no database is configured, with clearer connection details reflecting current database and schema visibility.
* **Tests**
  * Added unit test coverage for scoped connection behavior when schema-per-database support is disabled, including precedence of explicit filters and correct fallback enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->