### PR TITLE
[BugFix] Add runtime DB context for semantic adapters

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -547,6 +547,7 @@ flow_groups:
           - Bootstrap and agentic generation persist semantic objects that are available to query-time retrieval.
           - Metrics and semantic models remain separable by kind and datasource scope, and extracted knowledge is captured as markdown via the extract-knowledge skill.
           - Existing metrics can be queried through the metric-first AskMetrics subagent without falling back to raw SQL generation.
+          - Runtime database context is propagated into semantic adapter initialization so validation can use the selected catalog/database/schema without a static datasource database.
         coverage:
           pr_acceptance:
             status: covered
@@ -555,6 +556,8 @@ flow_groups:
               - tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
               - tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
               - tests/unit_tests/tools/func_tool/test_context_search.py
+              - tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigServiceSelectors::test_build_semantic_adapter_config_uses_runtime_database_when_datasource_omits_database
+              - tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestRuntimeDbContext::test_validate_semantic_initializes_adapter_with_runtime_database
           merge_queue:
             status: covered
             nodeids:
@@ -562,9 +565,13 @@ flow_groups:
               - tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
               - tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
               - tests/unit_tests/tools/func_tool/test_context_search.py
+              - tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigServiceSelectors::test_build_semantic_adapter_config_uses_runtime_database_when_datasource_omits_database
+              - tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestRuntimeDbContext::test_validate_semantic_initializes_adapter_with_runtime_database
           nightly:
             status: covered
             nodeids:
+              - tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigServiceSelectors::test_build_semantic_adapter_config_uses_runtime_database_when_datasource_omits_database
+              - tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestRuntimeDbContext::test_validate_semantic_initializes_adapter_with_runtime_database
               - tests/integration/agent/test_gen_semantic_model_agentic.py
               - tests/integration/agent/test_gen_metrics_agentic.py
           weekly_benchmark:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -730,6 +730,78 @@ class AgenticNode(Node):
             "target for this turn; generate SQL for THIS dialect."
         )
 
+    def _semantic_runtime_db_context(self) -> Dict[str, str]:
+        """Return the current datasource/catalog/database/schema for semantic adapter initialization."""
+        agent_config = getattr(self, "agent_config", None)
+        if not agent_config:
+            return {}
+
+        from datus.utils.node_utils import resolve_database_name_for_prompt
+
+        datasource = getattr(agent_config, "current_datasource", "") or ""
+        runtime_context: Dict[str, str] = {}
+        runtime_context_getter = getattr(agent_config, "runtime_db_context", None)
+        if callable(runtime_context_getter):
+            try:
+                runtime_context = runtime_context_getter() or {}
+            except Exception as e:
+                logger.debug("Unable to read runtime DB context for semantic adapter: %s", e)
+                runtime_context = {}
+        datasource = runtime_context.get("datasource") or datasource
+        context: Dict[str, str] = {}
+        if datasource:
+            context["datasource"] = datasource
+
+        db_config = None
+        try:
+            db_config = agent_config.current_db_config(datasource)
+        except Exception as e:
+            logger.debug("Unable to read current DB config for semantic adapter context: %s", e)
+
+        user_input = getattr(self, "input", None)
+        connector = getattr(getattr(self, "db_func_tool", None), "connector", None)
+
+        catalog = (
+            getattr(user_input, "catalog", "")
+            or runtime_context.get("catalog")
+            or runtime_context.get("catalog_name")
+            or getattr(db_config, "catalog", "")
+            or ""
+        )
+        if catalog:
+            context["catalog"] = str(catalog).strip()
+
+        requested_database = (
+            getattr(user_input, "database", "")
+            or runtime_context.get("database")
+            or runtime_context.get("database_name")
+            or ""
+        )
+        database = resolve_database_name_for_prompt(connector, requested_database)
+        database = (
+            database
+            or runtime_context.get("database")
+            or runtime_context.get("database_name")
+            or getattr(db_config, "database", "")
+            or ""
+        )
+        if database:
+            context["database"] = str(database).strip()
+
+        schema = (
+            getattr(user_input, "db_schema", "")
+            or runtime_context.get("schema")
+            or runtime_context.get("db_schema")
+            or runtime_context.get("schema_name")
+            or getattr(db_config, "schema", "")
+            or ""
+        )
+        if schema:
+            context["schema"] = str(schema).strip()
+            context["db_schema"] = str(schema).strip()
+
+        return {key: value for key, value in context.items() if value}
+
     def _build_enhanced_message(
         self,
         user_input: Any,

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -186,8 +186,9 @@ class AskMetricsAgenticNode(AgenticNode):
                 agent_config=self.agent_config,
                 sub_agent_name=sub_agent_name,
                 adapter_type=self._resolve_adapter_type(),
+                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
-            if self.semantic_tools.adapter is None:
+            if not self.semantic_tools._configured_adapter_type():
                 self.startup_error = self.semantic_tools._adapter_unavailable_message()
                 logger.warning("AskMetrics semantic adapter unavailable: %s", self.startup_error)
                 return

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -344,6 +344,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
                     agent_config=self.agent_config,
                     sub_agent_name=self.node_config.get("system_prompt"),
                     adapter_type=self.node_config.get("adapter_type", "metricflow"),
+                    runtime_db_context_provider=self._semantic_runtime_db_context,
                 )
             except Exception as exc:
                 logger.error("%s: failed to build whitelisted semantic_tools: %s", self.get_node_name(), exc)

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -270,6 +270,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
                 agent_config=self.agent_config,
                 sub_agent_name=self.node_config.get("system_prompt"),
                 adapter_type=adapter_type,
+                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
             self.tools.extend(self.semantic_tools.available_tools())
         except Exception as exc:
@@ -299,6 +300,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
                         agent_config=self.agent_config,
                         sub_agent_name=self.node_config.get("system_prompt"),
                         adapter_type=self.node_config.get("adapter_type", "metricflow"),
+                        runtime_db_context_provider=self._semantic_runtime_db_context,
                     )
                 tool_instance = self.semantic_tools
             elif tool_type == "db_tools":

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -233,6 +233,7 @@ class GenMetricsAgenticNode(AgenticNode):
                 sub_agent_name=self.NODE_NAME,
                 adapter_type=adapter_type,
                 generation_evidence=self.generation_evidence,
+                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
 
             # Add all available tools from semantic func tool

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -224,6 +224,7 @@ class GenReportAgenticNode(AgenticNode):
                 agent_config=self.agent_config,
                 sub_agent_name=self.node_config.get("system_prompt"),
                 adapter_type=adapter_type,
+                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
             self.tools.extend(self.semantic_tools.available_tools())
             logger.debug("Added semantic tools from SemanticTools")
@@ -260,6 +261,7 @@ class GenReportAgenticNode(AgenticNode):
                         agent_config=self.agent_config,
                         sub_agent_name=self.node_config.get("system_prompt"),
                         adapter_type=adapter_type,
+                        runtime_db_context_provider=self._semantic_runtime_db_context,
                     )
                 tool_instance = self.semantic_tools
             elif tool_type == "db_tools":

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -180,6 +180,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 sub_agent_name=self.NODE_NAME,
                 adapter_type=adapter_type,
                 generation_evidence=self.generation_evidence,
+                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
 
             # Add all available tools from semantic func tool

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -310,6 +310,7 @@ class GenSQLAgenticNode(AgenticNode):
                 agent_config=self.agent_config,
                 sub_agent_name=self.node_config.get("system_prompt"),
                 adapter_type=adapter_type,
+                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
             self.tools.extend(self.semantic_tools.available_tools())
         except Exception as e:
@@ -446,6 +447,7 @@ class GenSQLAgenticNode(AgenticNode):
                         agent_config=self.agent_config,
                         sub_agent_name=self.node_config.get("system_prompt"),
                         adapter_type=adapter_type,
+                        runtime_db_context_provider=self._semantic_runtime_db_context,
                     )
                 tool_instance = self.semantic_tools
             elif tool_type == "db_tools":

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -110,6 +110,25 @@ def default_osi_semantic_model_name(agent_config: Any = None) -> str:
     """Return the default OSI semantic model name for the current authoring scope."""
     candidates = []
     if agent_config is not None:
+        runtime_context = {}
+        runtime_context_getter = getattr(agent_config, "runtime_db_context", None)
+        if callable(runtime_context_getter):
+            try:
+                runtime_context = runtime_context_getter() or {}
+            except Exception:
+                runtime_context = {}
+        if isinstance(runtime_context, dict):
+            candidates.extend(
+                [
+                    runtime_context.get("database"),
+                    runtime_context.get("database_name"),
+                    runtime_context.get("schema"),
+                    runtime_context.get("db_schema"),
+                    runtime_context.get("schema_name"),
+                    runtime_context.get("catalog"),
+                    runtime_context.get("catalog_name"),
+                ]
+            )
         try:
             db_config = agent_config.current_db_config()
         except Exception:

--- a/datus/api/models/explorer_models.py
+++ b/datus/api/models/explorer_models.py
@@ -117,6 +117,9 @@ class MetricPreviewInput(BaseModel):
     """Preview a saved metric by compiling it to SQL (dry-run)."""
 
     subject_path: List[str] = Field(..., description="Path to the saved metric; the leaf is the metric name")
+    catalog: Optional[str] = Field(None, description="Current catalog context")
+    database: Optional[str] = Field(None, description="Current database context")
+    db_schema: Optional[str] = Field(None, description="Current schema context")
     dimensions: Optional[List[str]] = Field(None, description="Optional dimensions to group by")
     time_start: Optional[str] = Field(None, description="Optional start time (ISO or relative, e.g. '-7d')")
     time_end: Optional[str] = Field(None, description="Optional end time (ISO or relative, e.g. 'now')")
@@ -195,3 +198,6 @@ class SubjectPathInput(BaseModel):
     """Subject path input."""
 
     subject_path: List[str] = Field(..., description="Subject path name")
+    catalog: Optional[str] = Field(None, description="Current catalog context")
+    database: Optional[str] = Field(None, description="Current database context")
+    db_schema: Optional[str] = Field(None, description="Current schema context")

--- a/datus/api/models/table_models.py
+++ b/datus/api/models/table_models.py
@@ -64,6 +64,9 @@ class SemanticModelInput(BaseModel):
 
     table: str = Field(..., description="Full table name")
     yaml: str = Field(..., description="SemanticModel YAML content")
+    catalog: Optional[str] = Field(None, description="Current catalog context")
+    database: Optional[str] = Field(None, description="Current database context")
+    db_schema: Optional[str] = Field(None, description="Current schema context")
 
 
 class ValidateSemanticModelData(BaseModel):

--- a/datus/api/routes/explorer_routes.py
+++ b/datus/api/routes/explorer_routes.py
@@ -108,7 +108,7 @@ async def get_metric_dimensions(
     svc: ServiceDep,
 ) -> Result[MetricDimensionsData]:
     """List a metric's queryable dimensions."""
-    return await svc.explorer.get_metric_dimensions(request.subject_path)
+    return await svc.explorer.get_metric_dimensions(request)
 
 
 @router.post(

--- a/datus/api/routes/table_routes.py
+++ b/datus/api/routes/table_routes.py
@@ -53,9 +53,18 @@ async def get_semantic_model(
         ...,
         description="Full table name e.g. 'production_db.public.frpm' or 'db.schema.table'",
     ),
+    catalog: str | None = Query(None, description="Current catalog context"),
+    database: str | None = Query(None, description="Current database context"),
+    db_schema: str | None = Query(None, description="Current schema context"),
 ) -> Result[GetSemanticModelData]:
     """Get SemanticModel YAML."""
-    return await asyncio.to_thread(svc.datasource.get_semantic_model, table)
+    return await asyncio.to_thread(
+        svc.datasource.get_semantic_model,
+        table,
+        catalog=catalog,
+        database=database,
+        db_schema=db_schema,
+    )
 
 
 @router.post(

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -413,13 +413,20 @@ class DatasourceService:
                 errorMessage=str(e),
             )
 
-    def _get_semantic_model(self, full_name: str):
+    def _get_semantic_model(
+        self,
+        full_name: str,
+        *,
+        catalog: Optional[str] = None,
+        database: Optional[str] = None,
+        db_schema: Optional[str] = None,
+    ):
         # Parse table name parts
         name_parts = parse_table_name_parts(full_name, self.current_db_connector.get_type())
         current_db_config = self.agent_config.current_db_config()
-        catalog_name = name_parts["catalog_name"] or current_db_config.catalog
-        database_name = name_parts["database_name"] or self.current_db_name or current_db_config.database
-        schema_name = name_parts["schema_name"] or current_db_config.schema
+        catalog_name = name_parts["catalog_name"] or catalog or current_db_config.catalog
+        database_name = name_parts["database_name"] or database or self.current_db_name or current_db_config.database
+        schema_name = name_parts["schema_name"] or db_schema or current_db_config.schema
         table_name = name_parts["table_name"]
 
         # Get semantic model using SemanticMetricsRAG
@@ -431,7 +438,14 @@ class DatasourceService:
         )
         return semantic_model
 
-    def get_semantic_model(self, full_name: str) -> Result[GetSemanticModelData]:
+    def get_semantic_model(
+        self,
+        full_name: str,
+        *,
+        catalog: Optional[str] = None,
+        database: Optional[str] = None,
+        db_schema: Optional[str] = None,
+    ) -> Result[GetSemanticModelData]:
         """Get SemanticModel YAML.
 
         Business logic:
@@ -447,7 +461,12 @@ class DatasourceService:
             Result[GetSemanticModelData] with YAML content
         """
         try:
-            semantic_model = self._get_semantic_model(full_name)
+            semantic_model = self._get_semantic_model(
+                full_name,
+                catalog=catalog,
+                database=database,
+                db_schema=db_schema,
+            )
             if not semantic_model:
                 return Result[GetSemanticModelData](
                     success=True,
@@ -505,7 +524,12 @@ class DatasourceService:
             )
 
         # Step 2: Get semantic file path
-        semantic_model = self._get_semantic_model(request.table)
+        semantic_model = self._get_semantic_model(
+            request.table,
+            catalog=request.catalog,
+            database=request.database,
+            db_schema=request.db_schema,
+        )
         if not semantic_model:
             return Result[dict](
                 success=False,
@@ -571,7 +595,12 @@ class DatasourceService:
         logger.info("Validating semantic model YAML")
         try:
             full_name = request.table
-            semantic_model = self._get_semantic_model(full_name)
+            semantic_model = self._get_semantic_model(
+                full_name,
+                catalog=request.catalog,
+                database=request.database,
+                db_schema=request.db_schema,
+            )
             if not semantic_model:
                 return Result[ValidateSemanticModelData](
                     success=False,
@@ -590,6 +619,9 @@ class DatasourceService:
                 file_path=semantic_file_path,
                 datus_home=self.agent_config.home,
                 datasource=self.agent_config.current_datasource,
+                catalog=request.catalog,
+                database=request.database,
+                db_schema=request.db_schema,
             )
 
             if not is_valid:

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -424,9 +424,9 @@ class DatasourceService:
         # Parse table name parts
         name_parts = parse_table_name_parts(full_name, self.current_db_connector.get_type())
         current_db_config = self.agent_config.current_db_config()
-        catalog_name = name_parts["catalog_name"] or catalog or current_db_config.catalog
-        database_name = name_parts["database_name"] or database or self.current_db_name or current_db_config.database
-        schema_name = name_parts["schema_name"] or db_schema or current_db_config.schema
+        catalog_name = catalog or name_parts["catalog_name"] or current_db_config.catalog
+        database_name = database or name_parts["database_name"] or self.current_db_name or current_db_config.database
+        schema_name = db_schema or name_parts["schema_name"] or current_db_config.schema
         table_name = name_parts["table_name"]
 
         # Get semantic model using SemanticMetricsRAG

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -23,6 +23,7 @@ from datus.api.models.explorer_models import (
     RenameSubjectInput,
     SubjectListData,
     SubjectNode,
+    SubjectPathInput,
 )
 from datus.utils.loggings import get_logger
 
@@ -76,6 +77,30 @@ class ExplorerService:
                 ErrorCode.STORAGE_INVALID_ARGUMENT,
                 message_args={"error_message": "No datasource is selected; select a datasource first"},
             )
+
+    def _semantic_runtime_db_context(self, request=None) -> dict:
+        """Build runtime DB context for semantic adapter API calls."""
+        context = {}
+        if self.datasource_id:
+            context["datasource"] = self.datasource_id
+
+        db_config = None
+        try:
+            db_config = self.agent_config.current_db_config(self.datasource_id)
+        except Exception as e:
+            logger.debug("Unable to read current DB config for semantic API context: %s", e)
+
+        catalog = getattr(request, "catalog", None) or getattr(db_config, "catalog", "") or ""
+        database = getattr(request, "database", None) or getattr(db_config, "database", "") or ""
+        schema = getattr(request, "db_schema", None) or getattr(db_config, "schema", "") or ""
+        if catalog:
+            context["catalog"] = str(catalog).strip()
+        if database:
+            context["database"] = str(database).strip()
+        if schema:
+            context["schema"] = str(schema).strip()
+            context["db_schema"] = str(schema).strip()
+        return {key: value for key, value in context.items() if value}
 
     def _gen_reference_sql_id(self, sql: str) -> str:
         """Generate a stable identifier for reference SQL entries."""
@@ -608,7 +633,7 @@ class ExplorerService:
                 errorMessage=str(e),
             )
 
-    async def get_metric_dimensions(self, subject_path: List[str]) -> Result[MetricDimensionsData]:
+    async def get_metric_dimensions(self, request: SubjectPathInput) -> Result[MetricDimensionsData]:
         """List the queryable dimensions of a saved metric.
 
         Powers the preview panel's dimension picker, so the user only chooses
@@ -619,18 +644,21 @@ class ExplorerService:
         try:
             self._require_datasource()
 
-            if not subject_path:
+            if not request.subject_path:
                 return Result[MetricDimensionsData](
                     success=False,
                     errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
                     errorMessage="Subject path cannot be empty",
                 )
 
-            metric_name = subject_path[-1]
+            metric_name = request.subject_path[-1]
 
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
-            tools = SemanticTools(self.agent_config)
+            tools = SemanticTools(
+                self.agent_config,
+                runtime_db_context_provider=lambda: self._semantic_runtime_db_context(request),
+            )
             adapter = tools.adapter
             if adapter is None:
                 return Result[MetricDimensionsData](
@@ -687,7 +715,10 @@ class ExplorerService:
 
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
-            tools = SemanticTools(self.agent_config)
+            tools = SemanticTools(
+                self.agent_config,
+                runtime_db_context_provider=lambda: self._semantic_runtime_db_context(request),
+            )
             if tools.adapter is None:
                 return Result[MetricPreviewData](
                     success=False,

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -655,9 +655,10 @@ class ExplorerService:
 
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
+            runtime_db_context = self._semantic_runtime_db_context(request)
             tools = SemanticTools(
                 self.agent_config,
-                runtime_db_context_provider=lambda: self._semantic_runtime_db_context(request),
+                runtime_db_context_provider=lambda: runtime_db_context,
             )
             adapter = tools.adapter
             if adapter is None:
@@ -715,9 +716,10 @@ class ExplorerService:
 
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
+            runtime_db_context = self._semantic_runtime_db_context(request)
             tools = SemanticTools(
                 self.agent_config,
-                runtime_db_context_provider=lambda: self._semantic_runtime_db_context(request),
+                runtime_db_context_provider=lambda: runtime_db_context,
             )
             if tools.adapter is None:
                 return Result[MetricPreviewData](
@@ -755,11 +757,12 @@ class ExplorerService:
                         errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
                         errorMessage=f"Failed to compile SQL for metric '{metric_name}'.",
                     )
-                # The datasource id (logical key) is not a physical database; return the
-                # bound datasource's real default database so callers can run the SQL as-is.
-                # Pin the lookup to this service's datasource_id (not the implicit "current")
-                # so a multi-datasource config can never return another datasource's database.
-                database = self.agent_config.current_db_config(self.datasource_id).database or None
+                # Return the same runtime database context used to compile the SQL.
+                database = (
+                    runtime_db_context.get("database")
+                    or self.agent_config.current_db_config(self.datasource_id).database
+                    or None
+                )
                 return Result[MetricPreviewData](
                     success=True,
                     data=MetricPreviewData(metric=metric_name, sql=sql, database=database),

--- a/datus/api/utils/semantic_validation.py
+++ b/datus/api/utils/semantic_validation.py
@@ -52,6 +52,9 @@ def validate_semantic_yaml(
     file_path: str,
     datus_home: str,
     datasource: str,
+    catalog: Optional[str] = None,
+    database: Optional[str] = None,
+    db_schema: Optional[str] = None,
 ) -> Tuple[bool, List[str]]:
     """Validate semantic model / metric YAML content.
 
@@ -64,10 +67,14 @@ def validate_semantic_yaml(
             for replacement in the collected file list).
         datus_home: Datus home directory path.
         datasource: Current datasource for semantic model directory.
+        catalog: Optional runtime catalog context.
+        database: Optional runtime database context.
+        db_schema: Optional runtime schema context.
 
     Returns:
         ``(is_valid, error_messages)``
     """
+    del catalog, database, db_schema  # Reserved for warehouse-backed validation callers.
     if _check_metricflow():
         return _validate_deep(yaml_content, file_path, datus_home, datasource)
     return _validate_yaml_format(yaml_content)

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1543,9 +1543,14 @@ class AgentConfig:
         effective_runtime_db_context = (
             runtime_db_context if runtime_db_context is not None else self.runtime_db_context()
         )
+        runtime_datasource = _runtime_context_value(effective_runtime_db_context, "datasource")
 
         db_name = (
-            database_name or config.get("datasource") or self.current_datasource or self.services.default_datasource
+            database_name
+            or runtime_datasource
+            or config.get("datasource")
+            or self.current_datasource
+            or self.services.default_datasource
         )
         if db_name:
             config["datasource"] = db_name

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -7,7 +7,7 @@ import os
 import re
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from datus.configuration.node_type import NodeType
 from datus.observability.config import ObservabilityConfig
@@ -772,6 +772,7 @@ class AgentConfig:
         self._active_dashboard: Optional[str] = kwargs.get("active_dashboard") or None
         self._active_scheduler: Optional[str] = kwargs.get("active_scheduler") or None
         self._active_semantic: Optional[str] = kwargs.get("active_semantic") or None
+        self._runtime_db_context: Dict[str, str] = {}
         # Shared lazily-loaded ``conf/providers.yml`` catalog (metadata only:
         # default_model, base_url, api_key_env, type, model_overrides). Kept
         # as ``None`` until first access so tests that stub load paths can
@@ -1221,6 +1222,55 @@ class AgentConfig:
         """Returns all datasource configs."""
         return self.services.datasources
 
+    def set_runtime_db_context(self, runtime_db_context: Optional[Mapping[str, Any]] = None, **kwargs: Any) -> None:
+        """Pin a request/CLI scoped catalog/database/schema context for adapters."""
+        values: Dict[str, Any] = {}
+        if runtime_db_context:
+            values.update(runtime_db_context)
+        values.update({key: value for key, value in kwargs.items() if value is not None})
+
+        normalized: Dict[str, str] = {}
+        for key in (
+            "datasource",
+            "catalog",
+            "catalog_name",
+            "database",
+            "database_name",
+            "schema",
+            "db_schema",
+            "schema_name",
+        ):
+            value = values.get(key)
+            if value is None:
+                continue
+            text = value.strip() if isinstance(value, str) else str(value).strip()
+            if text:
+                normalized[key] = text
+
+        if "catalog" not in normalized and "catalog_name" in normalized:
+            normalized["catalog"] = normalized["catalog_name"]
+        if "catalog_name" not in normalized and "catalog" in normalized:
+            normalized["catalog_name"] = normalized["catalog"]
+        if "database" not in normalized and "database_name" in normalized:
+            normalized["database"] = normalized["database_name"]
+        if "database_name" not in normalized and "database" in normalized:
+            normalized["database_name"] = normalized["database"]
+        if "schema" not in normalized:
+            if "db_schema" in normalized:
+                normalized["schema"] = normalized["db_schema"]
+            elif "schema_name" in normalized:
+                normalized["schema"] = normalized["schema_name"]
+        if "db_schema" not in normalized and "schema" in normalized:
+            normalized["db_schema"] = normalized["schema"]
+        if "schema_name" not in normalized and "schema" in normalized:
+            normalized["schema_name"] = normalized["schema"]
+
+        self._runtime_db_context = normalized
+
+    def runtime_db_context(self) -> Dict[str, str]:
+        """Return the request/CLI scoped datasource context, if one is pinned."""
+        return dict(self._runtime_db_context)
+
     def list_databases(self, datasource: str = "") -> List[str]:
         """Config-known physical databases of a datasource.
 
@@ -1482,6 +1532,7 @@ class AgentConfig:
         self,
         adapter_type: Optional[str] = None,
         database_name: Optional[str] = None,
+        runtime_db_context: Optional[Mapping[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
         resolved_adapter = self.resolve_semantic_adapter(adapter_type)
         if not resolved_adapter:
@@ -1489,15 +1540,26 @@ class AgentConfig:
 
         config = self.get_semantic_layer_config(resolved_adapter)
         config.setdefault("type", resolved_adapter)
+        effective_runtime_db_context = (
+            runtime_db_context if runtime_db_context is not None else self.runtime_db_context()
+        )
 
         db_name = (
             database_name or config.get("datasource") or self.current_datasource or self.services.default_datasource
         )
         if db_name:
-            config.setdefault("datasource", db_name)
-            db_config = _db_config_to_semantic_adapter_config(self.current_db_config(db_name))
-            if db_config:
-                config.setdefault("db_config", db_config)
+            config["datasource"] = db_name
+            db_config_obj = self.current_db_config(db_name)
+            db_config = _merge_semantic_adapter_db_config(
+                _db_config_to_semantic_adapter_config(db_config_obj),
+                config.get("db_config"),
+            )
+            config_db_config = _apply_runtime_db_context_to_semantic_adapter_config(
+                db_config,
+                effective_runtime_db_context,
+            )
+            if config_db_config:
+                config["db_config"] = config_db_config
 
         datasource_name = config.get("datasource", self.current_datasource)
         config.setdefault("semantic_models_path", str(self.path_manager.semantic_model_path(datasource_name)))
@@ -1632,6 +1694,14 @@ class AgentConfig:
                 self.current_datasource = db_arg
             elif self.services.default_datasource:
                 self.current_datasource = self.services.default_datasource
+        runtime_db_context = {
+            "datasource": kwargs.get("datasource") or self.current_datasource,
+            "catalog": kwargs.get("catalog") or kwargs.get("catalog_name"),
+            "database": kwargs.get("database") or kwargs.get("database_name"),
+            "schema": kwargs.get("schema") or kwargs.get("db_schema") or kwargs.get("schema_name"),
+        }
+        if any(value for key, value in runtime_db_context.items() if key != "datasource"):
+            self.set_runtime_db_context(runtime_db_context)
         if kwargs.get("benchmark", ""):
             benchmark_platform = kwargs["benchmark"]
             # Validate benchmark is supported (will raise exception if not)
@@ -2271,7 +2341,7 @@ def _db_config_to_semantic_adapter_config(db_config: Optional[DbConfig]) -> Opti
     semantic_db_config = {
         key: str(value)
         for key, value in raw.items()
-        if value is not None and value != "" and key not in ("extra", "path_pattern", "catalog", "default")
+        if value is not None and value != "" and key not in ("extra", "path_pattern", "default")
     }
     # Merge connector-specific `extra` fields without overwriting explicit top-level keys
     if isinstance(extra, dict):
@@ -2280,6 +2350,52 @@ def _db_config_to_semantic_adapter_config(db_config: Optional[DbConfig]) -> Opti
                 continue
             semantic_db_config.setdefault(key, str(value))
     return semantic_db_config
+
+
+def _merge_semantic_adapter_db_config(
+    base_config: Optional[Dict[str, str]],
+    override_config: Any,
+) -> Optional[Dict[str, str]]:
+    if not isinstance(override_config, dict):
+        return base_config
+
+    merged = dict(base_config or {})
+    for key, value in override_config.items():
+        if value is None or value == "":
+            continue
+        merged[str(key)] = str(value)
+    return merged
+
+
+def _runtime_context_value(runtime_db_context: Optional[Mapping[str, Any]], *keys: str) -> str:
+    if not runtime_db_context:
+        return ""
+    for key in keys:
+        value = runtime_db_context.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+_RUNTIME_DB_CONTEXT_ALIASES = {
+    "catalog": ("catalog", "catalog_name"),
+    "database": ("database", "database_name"),
+    "schema": ("schema", "db_schema", "schema_name"),
+}
+
+
+def _apply_runtime_db_context_to_semantic_adapter_config(
+    db_config: Optional[Dict[str, str]],
+    runtime_db_context: Optional[Mapping[str, Any]],
+) -> Optional[Dict[str, str]]:
+    result = dict(db_config or {})
+
+    for canonical_key, aliases in _RUNTIME_DB_CONTEXT_ALIASES.items():
+        value = _runtime_context_value(runtime_db_context, *aliases)
+        if value:
+            result[canonical_key] = value
+
+    return result or db_config
 
 
 def _resolve_nested_value(value: Any) -> Any:

--- a/datus/main.py
+++ b/datus/main.py
@@ -245,6 +245,9 @@ def create_parser() -> argparse.ArgumentParser:
         help="Pull semantic models and metrics from semantic adapter (e.g., metricflow, dbt, cube)",
     )
     bootstrap_parser.add_argument("--catalog", type=str, help="Catalog of the success story")
+    bootstrap_parser.add_argument(
+        "--schema_name", type=str, help="Schema name to use for semantic validation/execution"
+    )
     bootstrap_parser.add_argument("--subject_path", type=str, help="Subject path of the success story")
     bootstrap_parser.add_argument(
         "--sql_dir", type=str, help="Directory containing SQL files for reference_sql component"

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -878,13 +878,23 @@ async def _generate_metrics_batch(
         batch_message = f"{batch_message}\n\n## Additional Instructions\n{extra_instructions}"
 
     current_db_config = agent_config.current_db_config()
+    runtime_db_context_getter = getattr(agent_config, "runtime_db_context", None)
+    runtime_db_context = runtime_db_context_getter() if callable(runtime_db_context_getter) else {}
+    runtime_db_context = runtime_db_context if isinstance(runtime_db_context, dict) else {}
     latest_prompt_version = get_prompt_manager(agent_config=agent_config).get_latest_version("gen_metrics_system")
 
     metrics_input = SemanticNodeInput(
         user_message=batch_message,
-        catalog=current_db_config.catalog,
-        database=current_db_config.database,
-        db_schema=current_db_config.schema,
+        catalog=runtime_db_context.get("catalog")
+        or runtime_db_context.get("catalog_name")
+        or current_db_config.catalog,
+        database=runtime_db_context.get("database")
+        or runtime_db_context.get("database_name")
+        or current_db_config.database,
+        db_schema=runtime_db_context.get("schema")
+        or runtime_db_context.get("db_schema")
+        or runtime_db_context.get("schema_name")
+        or current_db_config.schema,
         prompt_version=latest_prompt_version,
     )
 

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -112,6 +112,9 @@ async def init_success_story_semantic_model_async(
         context_message += f"SQL:\n{sql}\n\n"
 
     current_db_config = agent_config.current_db_config()
+    runtime_db_context_getter = getattr(agent_config, "runtime_db_context", None)
+    runtime_db_context = runtime_db_context_getter() if callable(runtime_db_context_getter) else {}
+    runtime_db_context = runtime_db_context if isinstance(runtime_db_context, dict) else {}
 
     # Emit task started event
     if emit:
@@ -125,9 +128,16 @@ async def init_success_story_semantic_model_async(
 
     semantic_input = SemanticNodeInput(
         user_message=context_message,
-        catalog=current_db_config.catalog,
-        database=current_db_config.database,
-        db_schema=current_db_config.schema,
+        catalog=runtime_db_context.get("catalog")
+        or runtime_db_context.get("catalog_name")
+        or current_db_config.catalog,
+        database=runtime_db_context.get("database")
+        or runtime_db_context.get("database_name")
+        or current_db_config.database,
+        db_schema=runtime_db_context.get("schema")
+        or runtime_db_context.get("db_schema")
+        or runtime_db_context.get("schema_name")
+        or current_db_config.schema,
     )
 
     action_history_manager = ActionHistoryManager()

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -1195,10 +1195,23 @@ class GenerationTools:
             current_db_config = agent_config.current_db_config()
         except Exception:
             current_db_config = object()
+        runtime_db_context_getter = getattr(agent_config, "runtime_db_context", None)
+        runtime_db_context = runtime_db_context_getter() if callable(runtime_db_context_getter) else {}
+        runtime_db_context = runtime_db_context if isinstance(runtime_db_context, dict) else {}
         return {
-            "catalog_name": getattr(current_db_config, "catalog", "") or "",
-            "database_name": getattr(current_db_config, "database", "") or "",
-            "schema_name": getattr(current_db_config, "schema", "") or "",
+            "catalog_name": runtime_db_context.get("catalog")
+            or runtime_db_context.get("catalog_name")
+            or getattr(current_db_config, "catalog", "")
+            or "",
+            "database_name": runtime_db_context.get("database")
+            or runtime_db_context.get("database_name")
+            or getattr(current_db_config, "database", "")
+            or "",
+            "schema_name": runtime_db_context.get("schema")
+            or runtime_db_context.get("db_schema")
+            or runtime_db_context.get("schema_name")
+            or getattr(current_db_config, "schema", "")
+            or "",
         }
 
     @staticmethod

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -14,7 +14,7 @@ import inspect
 import io
 import json
 from collections import OrderedDict
-from typing import Any, Dict, List, Literal, Optional, Set
+from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Set, Tuple
 
 from agents import Tool
 
@@ -301,6 +301,7 @@ class SemanticTools:
         sub_agent_name: Optional[str] = None,
         adapter_type: Optional[str] = None,
         generation_evidence: Optional[GenerationEvidence] = None,
+        runtime_db_context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
     ):
         """
         Initialize semantic function tool.
@@ -311,11 +312,15 @@ class SemanticTools:
             adapter_type: Optional adapter type (e.g., "metricflow"). If not provided, tools will use storage only.
             generation_evidence: Optional shared tracker for validate_semantic and query_metrics(dry_run=True)
                 publish-gate evidence.
+            runtime_db_context_provider: Optional callback that returns the per-turn datasource/catalog/database/schema
+                context used to initialize the semantic adapter.
         """
         self.agent_config = agent_config
         self.sub_agent_name = sub_agent_name
         self.adapter_type = adapter_type
         self.generation_evidence = generation_evidence
+        self._runtime_db_context_provider = runtime_db_context_provider
+        self._runtime_db_context_static: Dict[str, str] = {}
 
         # Keep storage handles for compatibility with older call sites, but
         # public SemanticTools methods use the semantic adapter as their source
@@ -330,6 +335,7 @@ class SemanticTools:
         self._adapter: Optional[BaseSemanticAdapter] = None
         self._attribution_tool: Optional[DimensionAttributionUtil] = None
         self._adapter_load_error: Optional[str] = None
+        self._adapter_context_key: Optional[Tuple[str, str, str, str, str]] = None
 
     @staticmethod
     def _query_data_row_count(data: Any) -> int:
@@ -413,6 +419,59 @@ class SemanticTools:
             self.adapter_type = resolved_adapter
         return resolved_adapter
 
+    @staticmethod
+    def _normalize_runtime_db_context(runtime_db_context: Optional[Mapping[str, Any]]) -> Dict[str, str]:
+        if not runtime_db_context:
+            return {}
+
+        normalized: Dict[str, str] = {}
+        for key in (
+            "datasource",
+            "catalog",
+            "catalog_name",
+            "database",
+            "database_name",
+            "schema",
+            "db_schema",
+            "schema_name",
+        ):
+            value = runtime_db_context.get(key)
+            if value is None:
+                continue
+            text = value.strip() if isinstance(value, str) else str(value).strip()
+            if text:
+                normalized[key] = text
+
+        if "catalog" not in normalized and "catalog_name" in normalized:
+            normalized["catalog"] = normalized["catalog_name"]
+        if "database" not in normalized and "database_name" in normalized:
+            normalized["database"] = normalized["database_name"]
+        if "schema" not in normalized:
+            if "db_schema" in normalized:
+                normalized["schema"] = normalized["db_schema"]
+            elif "schema_name" in normalized:
+                normalized["schema"] = normalized["schema_name"]
+        return normalized
+
+    def set_runtime_db_context(self, runtime_db_context: Optional[Mapping[str, Any]]) -> None:
+        """Set a static runtime DB context and invalidate any adapter built for the old context."""
+        normalized = self._normalize_runtime_db_context(runtime_db_context)
+        if normalized == self._runtime_db_context_static:
+            return
+        self._runtime_db_context_static = normalized
+        self._adapter = None
+        self._attribution_tool = None
+        self._adapter_context_key = None
+
+    def _runtime_db_context(self) -> Dict[str, str]:
+        if callable(self._runtime_db_context_provider):
+            try:
+                return self._normalize_runtime_db_context(self._runtime_db_context_provider())
+            except Exception as e:
+                logger.debug("Failed to resolve runtime DB context for semantic adapter: %s", e)
+                return {}
+        return dict(self._runtime_db_context_static)
+
     def _extract_db_config(self, datasource: str) -> Optional[dict]:
         """Extract db_config dict from the selected database config."""
         try:
@@ -426,7 +485,7 @@ class SemanticTools:
         db_config = {
             k: str(v)
             for k, v in raw.items()
-            if v is not None and v != "" and k not in ("extra", "path_pattern", "catalog", "default")
+            if v is not None and v != "" and k not in ("extra", "path_pattern", "default")
         }
         # Preserve connector-specific `extra` fields without overwriting explicit top-level keys
         if isinstance(extra, dict):
@@ -439,49 +498,76 @@ class SemanticTools:
     @property
     def adapter(self) -> Optional[BaseSemanticAdapter]:
         """Lazy load semantic adapter if configured."""
-        if self._adapter is None:
-            try:
-                resolved_adapter = self.adapter_type
-                resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
-                if callable(resolver):
-                    resolved_adapter = resolver(self.adapter_type)
-                if not resolved_adapter:
-                    return None
+        try:
+            resolved_adapter = self.adapter_type
+            resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
+            if callable(resolver):
+                resolved_adapter = resolver(self.adapter_type)
+            if not resolved_adapter:
+                return None
 
-                metadata = semantic_adapter_registry.get_metadata(resolved_adapter)
-                builder = getattr(self.agent_config, "build_semantic_adapter_config", None)
-                adapter_config = builder(resolved_adapter) if callable(builder) else None
-                if adapter_config is None:
-                    datasource = self.agent_config.current_datasource
-                    db_config = self._extract_db_config(datasource)
-                    semantic_models_path = str(self.agent_config.path_manager.semantic_model_path(datasource))
-
-                    if metadata and metadata.config_class:
-                        adapter_config = metadata.config_class(
-                            datasource=datasource,
-                            db_config=db_config,
-                            semantic_models_path=semantic_models_path,
-                        )
-                    else:
-                        from datus.tools.semantic_tools.config import SemanticAdapterConfig
-
-                        adapter_config = SemanticAdapterConfig(datasource=datasource)
-                elif isinstance(adapter_config, dict):
-                    if metadata and metadata.config_class:
-                        adapter_config = metadata.config_class(**adapter_config)
-                    else:
-                        from datus.tools.semantic_tools.config import SemanticAdapterConfig
-
-                        adapter_config = SemanticAdapterConfig(**adapter_config)
-
-                self.adapter_type = resolved_adapter
-                self._adapter = semantic_adapter_registry.create_adapter(resolved_adapter, adapter_config)
-                self._adapter_load_error = None
-                logger.info(f"Loaded semantic adapter: {resolved_adapter}")
-            except Exception as e:
-                logger.warning(f"Failed to load semantic adapter '{self.adapter_type}': {e}")
-                self._adapter_load_error = str(e)
+            runtime_db_context = self._runtime_db_context()
+            datasource = runtime_db_context.get("datasource") or self.agent_config.current_datasource
+            context_key = (
+                resolved_adapter,
+                datasource or "",
+                runtime_db_context.get("catalog", ""),
+                runtime_db_context.get("database", ""),
+                runtime_db_context.get("schema", ""),
+            )
+            if self._adapter is not None:
+                if self._adapter_context_key is None or self._adapter_context_key == context_key:
+                    return self._adapter
                 self._adapter = None
+                self._attribution_tool = None
+                self._adapter_context_key = None
+
+            metadata = semantic_adapter_registry.get_metadata(resolved_adapter)
+            builder = getattr(self.agent_config, "build_semantic_adapter_config", None)
+            adapter_config = None
+            if callable(builder):
+                builder_kwargs: Dict[str, Any] = {}
+                try:
+                    builder_params = inspect.signature(builder).parameters
+                    if "database_name" in builder_params:
+                        builder_kwargs["database_name"] = datasource or None
+                    if "runtime_db_context" in builder_params:
+                        builder_kwargs["runtime_db_context"] = runtime_db_context
+                except (TypeError, ValueError):
+                    pass
+                adapter_config = builder(resolved_adapter, **builder_kwargs)
+            if adapter_config is None:
+                db_config = self._extract_db_config(datasource)
+                semantic_models_path = str(self.agent_config.path_manager.semantic_model_path(datasource))
+
+                if metadata and metadata.config_class:
+                    adapter_config = metadata.config_class(
+                        datasource=datasource,
+                        db_config=db_config,
+                        semantic_models_path=semantic_models_path,
+                    )
+                else:
+                    from datus.tools.semantic_tools.config import SemanticAdapterConfig
+
+                    adapter_config = SemanticAdapterConfig(datasource=datasource)
+            elif isinstance(adapter_config, dict):
+                if metadata and metadata.config_class:
+                    adapter_config = metadata.config_class(**adapter_config)
+                else:
+                    from datus.tools.semantic_tools.config import SemanticAdapterConfig
+
+                    adapter_config = SemanticAdapterConfig(**adapter_config)
+
+            self.adapter_type = resolved_adapter
+            self._adapter = semantic_adapter_registry.create_adapter(resolved_adapter, adapter_config)
+            self._adapter_context_key = context_key
+            self._adapter_load_error = None
+            logger.info(f"Loaded semantic adapter: {resolved_adapter}")
+        except Exception as e:
+            logger.warning(f"Failed to load semantic adapter '{self.adapter_type}': {e}")
+            self._adapter_load_error = str(e)
+            self._adapter = None
+            self._adapter_context_key = None
         return self._adapter
 
     @property
@@ -532,6 +618,7 @@ class SemanticTools:
             # Clear cached adapter and attribution tool
             self._adapter = None
             self._attribution_tool = None
+            self._adapter_context_key = None
 
             # Force reload by accessing the property
             if self.adapter is not None:
@@ -552,7 +639,7 @@ class SemanticTools:
         Returns:
             List of Tool objects for LLM function calling
         """
-        if self.adapter is None:
+        if not self._configured_adapter_type():
             logger.warning("SemanticTools unavailable: %s", self._adapter_unavailable_message())
             return []
 

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -321,6 +321,7 @@ class SemanticTools:
         self.generation_evidence = generation_evidence
         self._runtime_db_context_provider = runtime_db_context_provider
         self._runtime_db_context_static: Dict[str, str] = {}
+        self._runtime_db_context_static_set = False
 
         # Keep storage handles for compatibility with older call sites, but
         # public SemanticTools methods use the semantic adapter as their source
@@ -456,9 +457,10 @@ class SemanticTools:
     def set_runtime_db_context(self, runtime_db_context: Optional[Mapping[str, Any]]) -> None:
         """Set a static runtime DB context and invalidate any adapter built for the old context."""
         normalized = self._normalize_runtime_db_context(runtime_db_context)
-        if normalized == self._runtime_db_context_static:
+        if normalized == self._runtime_db_context_static and self._runtime_db_context_static_set:
             return
         self._runtime_db_context_static = normalized
+        self._runtime_db_context_static_set = True
         self._adapter = None
         self._attribution_tool = None
         self._adapter_context_key = None
@@ -470,7 +472,15 @@ class SemanticTools:
             except Exception as e:
                 logger.debug("Failed to resolve runtime DB context for semantic adapter: %s", e)
                 return {}
-        return dict(self._runtime_db_context_static)
+        if self._runtime_db_context_static_set:
+            return dict(self._runtime_db_context_static)
+        runtime_context_getter = getattr(self.agent_config, "runtime_db_context", None)
+        if callable(runtime_context_getter):
+            try:
+                return self._normalize_runtime_db_context(runtime_context_getter())
+            except Exception as e:
+                logger.debug("Failed to resolve AgentConfig runtime DB context for semantic adapter: %s", e)
+        return {}
 
     def _extract_db_config(self, datasource: str) -> Optional[dict]:
         """Extract db_config dict from the selected database config."""

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -319,6 +319,66 @@ class TestSetupInputAgenticNode:
 
 
 # ---------------------------------------------------------------------------
+# TestSemanticRuntimeDbContext
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticRuntimeDbContext:
+    def test_returns_empty_without_agent_config(self):
+        node = _make_node(agent_config=None)
+
+        assert node._semantic_runtime_db_context() == {}
+
+    def test_uses_request_runtime_context_and_schema_alias(self):
+        cfg = MagicMock()
+        cfg.current_datasource = "static_ds"
+        cfg.runtime_db_context.return_value = {
+            "datasource": "runtime_ds",
+            "catalog_name": "runtime_catalog",
+            "database_name": "runtime_db",
+            "schema_name": "runtime_schema",
+        }
+        cfg.current_db_config.return_value = MagicMock(
+            catalog="configured_catalog",
+            database="configured_db",
+            schema="configured_schema",
+        )
+        db_tool = MagicMock()
+        db_tool.connector.database_name = "connector_db"
+        node = _make_node(agent_config=cfg, db_func_tool=db_tool)
+        node.input = MagicMock(catalog="", database="", db_schema="")
+
+        assert node._semantic_runtime_db_context() == {
+            "datasource": "runtime_ds",
+            "catalog": "runtime_catalog",
+            "database": "runtime_db",
+            "schema": "runtime_schema",
+            "db_schema": "runtime_schema",
+        }
+        cfg.current_db_config.assert_called_once_with("runtime_ds")
+
+    def test_uses_input_context_when_config_context_fails(self):
+        cfg = MagicMock()
+        cfg.current_datasource = "static_ds"
+        cfg.runtime_db_context.side_effect = RuntimeError("context unavailable")
+        cfg.current_db_config.side_effect = RuntimeError("config unavailable")
+        node = _make_node(agent_config=cfg, db_func_tool=MagicMock())
+        node.input = MagicMock(
+            catalog="input_catalog",
+            database="input_db",
+            db_schema="input_schema",
+        )
+
+        assert node._semantic_runtime_db_context() == {
+            "datasource": "static_ds",
+            "catalog": "input_catalog",
+            "database": "input_db",
+            "schema": "input_schema",
+            "db_schema": "input_schema",
+        }
+
+
+# ---------------------------------------------------------------------------
 # TestUpdateContextAgenticNode
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -20,8 +20,20 @@ def _semantic_tools(adapter=True):
     tools = Mock()
     tools.adapter = Mock() if adapter else None
     tools._adapter_unavailable_message.return_value = "semantic adapter missing"
+    tools._configured_adapter_type.return_value = "metricflow" if adapter else None
     for name in ("list_metrics", "get_dimensions", "query_metrics", "validate_semantic", "attribution_analyze"):
         setattr(tools, name, Mock(name=name))
+    tools.available_tools.return_value = (
+        [
+            _fake_function_tool(tools.list_metrics),
+            _fake_function_tool(tools.get_dimensions),
+            _fake_function_tool(tools.query_metrics),
+            _fake_function_tool(tools.validate_semantic),
+            _fake_function_tool(tools.attribution_analyze),
+        ]
+        if adapter
+        else []
+    )
     return tools
 
 

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -54,6 +54,17 @@ def test_default_osi_semantic_model_name_uses_database_scope():
     assert default_osi_semantic_model_file(config) == "subject/semantic_models/warehouse/sales_domain.yml"
 
 
+def test_default_osi_semantic_model_name_prefers_runtime_database_scope():
+    config = SimpleNamespace(
+        current_datasource="starrocks",
+        current_db_config=lambda: _DbScope(),
+        runtime_db_context=lambda: {"database": "ac_manage"},
+    )
+
+    assert default_osi_semantic_model_name(config) == "ac_manage"
+    assert default_osi_semantic_model_file(config) == "subject/semantic_models/starrocks/ac_manage.yml"
+
+
 def test_default_osi_semantic_model_name_uses_declared_db_scope_fallbacks():
     config = SimpleNamespace(
         current_datasource="warehouse",

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -76,6 +76,45 @@ class TestGetSemanticModel:
         # The table exists but may not have a semantic model file
         assert isinstance(result, Result)
 
+    def test_get_semantic_model_prefers_runtime_db_context(self, real_agent_config):
+        """Runtime catalog/database/schema context is used for semantic model lookup."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        call = {}
+
+        class FakeSemanticRag:
+            def get_semantic_model(
+                self,
+                *,
+                catalog_name: str,
+                database_name: str,
+                schema_name: str,
+                table_name: str,
+            ):
+                call.update(
+                    catalog_name=catalog_name,
+                    database_name=database_name,
+                    schema_name=schema_name,
+                    table_name=table_name,
+                )
+                return None
+
+        svc._ensure_semantic_rag = lambda: FakeSemanticRag()
+
+        result = svc.get_semantic_model(
+            "schools",
+            catalog="runtime_catalog",
+            database="runtime_db",
+            db_schema="runtime_schema",
+        )
+
+        assert isinstance(result, Result)
+        assert call == {
+            "catalog_name": "runtime_catalog",
+            "database_name": "runtime_db",
+            "schema_name": "runtime_schema",
+            "table_name": "schools",
+        }
+
     @pytest.mark.asyncio
     async def test_validate_semantic_model_nonexistent(self, real_agent_config):
         """validate_semantic_model for nonexistent table returns error."""

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -101,7 +101,7 @@ class TestGetSemanticModel:
         svc._ensure_semantic_rag = lambda: FakeSemanticRag()
 
         result = svc.get_semantic_model(
-            "schools",
+            "embedded_catalog.embedded_db.embedded_schema.schools",
             catalog="runtime_catalog",
             database="runtime_db",
             db_schema="runtime_schema",

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -970,9 +970,15 @@ class TestExplorerServicePreviewMetric:
         from types import SimpleNamespace
 
         tools_stub = SimpleNamespace(adapter=adapter, query_metrics=query_metrics)
+
+        def fake_semantic_tools(*args, **kwargs):
+            tools_stub.args = args
+            tools_stub.kwargs = kwargs
+            return tools_stub
+
         monkeypatch.setattr(
             "datus.tools.func_tool.semantic_tools.SemanticTools",
-            lambda *a, **k: tools_stub,
+            fake_semantic_tools,
         )
         return tools_stub
 
@@ -1010,19 +1016,24 @@ class TestExplorerServicePreviewMetric:
                 result={"metadata": {"explain": True, "sql": "SELECT 1 AS revenue"}, "data": []}
             )
         )
-        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
+        tools_stub = self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
 
         svc = ExplorerService(agent_config=real_agent_config)
         result = await svc.preview_metric(
-            MetricPreviewInput(subject_path=["Finance", "revenue"], dimensions=["region"], limit=100)
+            MetricPreviewInput(
+                subject_path=["Finance", "revenue"],
+                dimensions=["region"],
+                limit=100,
+                database="runtime_preview_db",
+            )
         )
 
         assert result.success is True
         assert result.data.metric == "revenue"
         assert result.data.sql == "SELECT 1 AS revenue"
-        # Carries the bound datasource's physical database, not the logical datasource id.
-        assert result.data.database == (real_agent_config.current_db_config(svc.datasource_id).database or None)
+        assert result.data.database == "runtime_preview_db"
         assert result.data.preflight_error is None
+        assert tools_stub.kwargs["runtime_db_context_provider"]()["database"] == "runtime_preview_db"
         # dry_run must be requested so nothing actually executes.
         assert query_metrics.call_args.kwargs["dry_run"] is True
         assert query_metrics.call_args.kwargs["metrics"] == ["revenue"]

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -12,6 +12,7 @@ from datus.api.models.explorer_models import (
     RenameSubjectInput,
     SubjectListData,
     SubjectNodeType,
+    SubjectPathInput,
 )
 from datus.api.services.explorer_service import ExplorerService
 
@@ -893,15 +894,22 @@ class TestExplorerServiceMetricDimensions:
         from types import SimpleNamespace
 
         tools_stub = SimpleNamespace(adapter=adapter)
+
+        def fake_semantic_tools(*args, **kwargs):
+            tools_stub.args = args
+            tools_stub.kwargs = kwargs
+            return tools_stub
+
         monkeypatch.setattr(
             "datus.tools.func_tool.semantic_tools.SemanticTools",
-            lambda *a, **k: tools_stub,
+            fake_semantic_tools,
         )
+        return tools_stub
 
     async def test_empty_subject_path_fails(self, real_agent_config):
         """Empty subject path is rejected before touching the adapter."""
         svc = ExplorerService(agent_config=real_agent_config)
-        result = await svc.get_metric_dimensions([])
+        result = await svc.get_metric_dimensions(SubjectPathInput(subject_path=[]))
         assert result.success is False
         assert "Subject path cannot be empty" in result.errorMessage
 
@@ -909,7 +917,7 @@ class TestExplorerServiceMetricDimensions:
         """A missing semantic adapter surfaces a clear error."""
         self._patch_adapter(monkeypatch, adapter=None)
         svc = ExplorerService(agent_config=real_agent_config)
-        result = await svc.get_metric_dimensions(["Finance", "revenue"])
+        result = await svc.get_metric_dimensions(SubjectPathInput(subject_path=["Finance", "revenue"]))
         assert result.success is False
         assert "adapter is not available" in result.errorMessage
 
@@ -925,10 +933,17 @@ class TestExplorerServiceMetricDimensions:
                 SimpleNamespace(name="metric_time", type="time", description=None, is_primary_key=None),
             ]
         )
-        self._patch_adapter(monkeypatch, adapter=adapter)
+        tools_stub = self._patch_adapter(monkeypatch, adapter=adapter)
 
         svc = ExplorerService(agent_config=real_agent_config)
-        result = await svc.get_metric_dimensions(["Finance", "revenue"])
+        result = await svc.get_metric_dimensions(
+            SubjectPathInput(
+                subject_path=["Finance", "revenue"],
+                catalog="runtime_catalog",
+                database="runtime_db",
+                db_schema="runtime_schema",
+            )
+        )
 
         assert result.success is True
         assert result.data.metric == "revenue"
@@ -936,6 +951,13 @@ class TestExplorerServiceMetricDimensions:
         assert result.data.dimensions[0].type == "string"
         assert result.data.dimensions[1].type == "time"
         assert adapter.get_dimensions.await_args.kwargs["metric_name"] == "revenue"
+        assert tools_stub.kwargs["runtime_db_context_provider"]() == {
+            "datasource": real_agent_config.current_datasource,
+            "catalog": "runtime_catalog",
+            "database": "runtime_db",
+            "schema": "runtime_schema",
+            "db_schema": "runtime_schema",
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -27,6 +27,8 @@ from datus.configuration.agent_config import (
     NodeConfig,
     ServicesConfig,
     ValidationConfig,
+    _apply_runtime_db_context_to_semantic_adapter_config,
+    _db_config_to_semantic_adapter_config,
     _parse_single_file_db,
     file_stem_from_uri,
     load_model_config,
@@ -207,6 +209,70 @@ class TestDbConfigFilterKwargs:
         kwargs = {"type": "postgresql", "host": "localhost", "custom_option": "${CUSTOM_TOKEN}"}
         cfg = DbConfig.filter_kwargs(DbConfig, kwargs)
         assert cfg.extra["custom_option"] == "token-value"
+
+
+class TestSemanticAdapterDbConfig:
+    def test_db_config_conversion_preserves_catalog(self):
+        cfg = DbConfig(type="trino", host="trino-host", catalog="hive", database="college_exam")
+
+        result = _db_config_to_semantic_adapter_config(cfg)
+
+        assert result["catalog"] == "hive"
+        assert result["database"] == "college_exam"
+
+    def test_runtime_context_overlay_uses_generic_aliases(self):
+        db_config = {"type": "mysql", "host": "localhost", "database": "configured_db"}
+
+        result = _apply_runtime_db_context_to_semantic_adapter_config(
+            db_config,
+            {
+                "catalog_name": "runtime_catalog",
+                "database_name": "runtime_db",
+                "db_schema": "runtime_schema",
+            },
+        )
+
+        assert result == {
+            "type": "mysql",
+            "host": "localhost",
+            "catalog": "runtime_catalog",
+            "database": "runtime_db",
+            "schema": "runtime_schema",
+        }
+
+    def test_override_by_args_pins_runtime_db_context_for_semantic_adapter(self, tmp_path):
+        cfg = AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            services={
+                "datasources": {
+                    "starrocks": {
+                        "type": "starrocks",
+                        "host": "127.0.0.1",
+                        "port": "9030",
+                        "username": "admin",
+                    }
+                },
+                "semantic_layer": {"metricflow": {"datasource": "starrocks"}},
+            },
+            skip_init_dirs=True,
+        )
+
+        cfg.override_by_args(
+            action="bootstrap-kb",
+            datasource="starrocks",
+            catalog="default_catalog",
+            database_name="ac_manage",
+            schema_name="public",
+        )
+        adapter_config = cfg.build_semantic_adapter_config(adapter_type="metricflow")
+
+        assert cfg.runtime_db_context()["database"] == "ac_manage"
+        assert adapter_config["db_config"]["database"] == "ac_manage"
+        assert adapter_config["db_config"]["catalog"] == "default_catalog"
+        assert adapter_config["db_config"]["schema"] == "public"
 
 
 # ---------------------------------------------------------------------------
@@ -666,6 +732,60 @@ class TestAgentConfigServiceSelectors:
         assert config["db_config"]["private_key_file"] == "/tmp/rsa_key.p8"
         assert config["db_config"]["private_key_file_pwd"] == "1234"
         assert "default" not in config["db_config"]
+
+    def test_build_semantic_adapter_config_runtime_datasource_overrides_configured_datasource(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {
+                    "static_ds": {
+                        "type": "mysql",
+                        "host": "mysql-static",
+                        "database": "static_db",
+                    },
+                    "runtime_ds": {
+                        "type": "mysql",
+                        "host": "mysql-runtime",
+                        "database": "runtime_db",
+                    },
+                },
+                "semantic_layer": {"metricflow": {"datasource": "static_ds"}},
+            },
+        )
+
+        config = cfg.build_semantic_adapter_config(adapter_type="metricflow", database_name="runtime_ds")
+
+        assert config["datasource"] == "runtime_ds"
+        assert config["db_config"]["host"] == "mysql-runtime"
+        assert config["db_config"]["database"] == "runtime_db"
+        assert config["semantic_models_path"].endswith("subject/semantic_models/runtime_ds")
+
+    def test_build_semantic_adapter_config_uses_runtime_database_when_datasource_omits_database(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {
+                    "college_exam": {
+                        "type": "mysql",
+                        "host": "mysql",
+                        "username": "user",
+                        "password": "pass",
+                        "default": True,
+                    },
+                },
+                "semantic_layer": {"metricflow": {"datasource": "college_exam"}},
+            },
+        )
+
+        config = cfg.build_semantic_adapter_config(
+            adapter_type="metricflow",
+            runtime_db_context={"database": "college_exam"},
+        )
+
+        assert config["datasource"] == "college_exam"
+        assert config["db_config"]["type"] == "mysql"
+        assert config["db_config"]["host"] == "mysql"
+        assert config["db_config"]["database"] == "college_exam"
 
     def test_file_datasource_preserves_adapter_specific_extra_fields(self, tmp_path):
         cfg = self._make(

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -29,6 +29,7 @@ from datus.configuration.agent_config import (
     ValidationConfig,
     _apply_runtime_db_context_to_semantic_adapter_config,
     _db_config_to_semantic_adapter_config,
+    _merge_semantic_adapter_db_config,
     _parse_single_file_db,
     file_stem_from_uri,
     load_model_config,
@@ -238,6 +239,59 @@ class TestSemanticAdapterDbConfig:
             "catalog": "runtime_catalog",
             "database": "runtime_db",
             "schema": "runtime_schema",
+        }
+
+    def test_runtime_context_normalizes_aliases(self, tmp_path):
+        cfg = AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            skip_init_dirs=True,
+        )
+
+        cfg.set_runtime_db_context(
+            {
+                "catalog_name": "runtime_catalog",
+                "database_name": "runtime_db",
+                "db_schema": "runtime_schema",
+            }
+        )
+
+        assert cfg.runtime_db_context() == {
+            "catalog_name": "runtime_catalog",
+            "catalog": "runtime_catalog",
+            "database_name": "runtime_db",
+            "database": "runtime_db",
+            "db_schema": "runtime_schema",
+            "schema": "runtime_schema",
+            "schema_name": "runtime_schema",
+        }
+
+        cfg.set_runtime_db_context({"schema_name": "runtime_schema_name"})
+        assert cfg.runtime_db_context() == {
+            "schema_name": "runtime_schema_name",
+            "schema": "runtime_schema_name",
+            "db_schema": "runtime_schema_name",
+        }
+
+    def test_merge_semantic_adapter_db_config_ignores_empty_overrides(self):
+        result = _merge_semantic_adapter_db_config(
+            {"type": "mysql", "host": "configured-host"},
+            {
+                "host": "override-host",
+                "database": "runtime_db",
+                "schema": "",
+                "empty": None,
+                "port": 3306,
+            },
+        )
+
+        assert result == {
+            "type": "mysql",
+            "host": "override-host",
+            "database": "runtime_db",
+            "port": "3306",
         }
 
     def test_override_by_args_pins_runtime_db_context_for_semantic_adapter(self, tmp_path):

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -760,6 +760,36 @@ class TestAgentConfigServiceSelectors:
         assert config["db_config"]["database"] == "runtime_db"
         assert config["semantic_models_path"].endswith("subject/semantic_models/runtime_ds")
 
+    def test_build_semantic_adapter_config_uses_runtime_context_datasource(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {
+                    "static_ds": {
+                        "type": "mysql",
+                        "host": "mysql-static",
+                        "database": "static_db",
+                    },
+                    "runtime_ds": {
+                        "type": "mysql",
+                        "host": "mysql-runtime",
+                        "database": "runtime_db",
+                    },
+                },
+                "semantic_layer": {"metricflow": {"datasource": "static_ds"}},
+            },
+        )
+
+        config = cfg.build_semantic_adapter_config(
+            adapter_type="metricflow",
+            runtime_db_context={"datasource": "runtime_ds"},
+        )
+
+        assert config["datasource"] == "runtime_ds"
+        assert config["db_config"]["host"] == "mysql-runtime"
+        assert config["db_config"]["database"] == "runtime_db"
+        assert config["semantic_models_path"].endswith("subject/semantic_models/runtime_ds")
+
     def test_build_semantic_adapter_config_uses_runtime_database_when_datasource_omits_database(self, tmp_path):
         cfg = self._make(
             tmp_path,

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -705,6 +705,24 @@ class TestValidateMetricFileHasBlocks:
 class TestSyncMetricToDb:
     """Tests for GenerationTools._sync_metric_to_db() private method."""
 
+    def test_current_db_parts_prefers_runtime_context(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        agent_config = SimpleNamespace(
+            current_db_config=lambda: SimpleNamespace(catalog="", database="", schema=""),
+            runtime_db_context=lambda: {
+                "catalog": "default_catalog",
+                "database": "ac_manage",
+                "schema": "public",
+            },
+        )
+
+        assert GenerationTools._current_db_parts(agent_config) == {
+            "catalog_name": "default_catalog",
+            "database_name": "ac_manage",
+            "schema_name": "public",
+        }
+
     def test_metric_file_not_found(self, generation_tools):
         result = generation_tools._sync_metric_to_db("/nonexistent/metric.yaml")
         assert result["success"] is False

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -1577,6 +1577,55 @@ class TestRuntimeDbContext:
             },
         ]
 
+    def test_adapter_config_uses_agent_config_runtime_context_when_provider_absent(self):
+        captured_builder_calls = []
+        adapter_config = object()
+        adapter = Mock()
+
+        def build_config(adapter_type=None, database_name=None, runtime_db_context=None):
+            captured_builder_calls.append(
+                {
+                    "adapter_type": adapter_type,
+                    "database_name": database_name,
+                    "runtime_db_context": dict(runtime_db_context or {}),
+                }
+            )
+            return adapter_config
+
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+            patch("datus.tools.func_tool.semantic_tools.semantic_adapter_registry.get_metadata", return_value=None),
+            patch(
+                "datus.tools.func_tool.semantic_tools.semantic_adapter_registry.create_adapter",
+                return_value=adapter,
+            ) as create_adapter,
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            config.current_datasource = "static_ds"
+            config.runtime_db_context.return_value = {
+                "datasource": "runtime_ds",
+                "database": "agent_ctx_db",
+            }
+            config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: adapter_type
+            config.build_semantic_adapter_config = build_config
+
+            tool = SemanticTools(agent_config=config, adapter_type="metricflow")
+
+            assert tool.adapter is adapter
+
+        assert create_adapter.call_count == 1
+        assert captured_builder_calls == [
+            {
+                "adapter_type": "metricflow",
+                "database_name": "runtime_ds",
+                "runtime_db_context": {"datasource": "runtime_ds", "database": "agent_ctx_db"},
+            }
+        ]
+
     def test_validate_semantic_initializes_adapter_with_runtime_database(self, tmp_path):
         from datus.configuration.agent_config import AgentConfig, NodeConfig
         from datus.tools.func_tool.semantic_tools import SemanticTools

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -13,7 +13,7 @@ from datus.tools.func_tool.base import FuncToolResult, normalize_null
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.metric_queryability import extract_metric_queryability_contracts
 from datus.tools.func_tool.semantic_tools import _run_async
-from datus.tools.semantic_tools.models import QueryResult
+from datus.tools.semantic_tools.models import QueryResult, ValidationResult
 
 
 class _Severity(Enum):
@@ -1423,7 +1423,7 @@ class TestAvailableTools:
             tools = semantic_tools_ext.available_tools()
         assert tools == []
 
-    def test_default_metricflow_adapter_load_failure_returns_no_tools(self):
+    def test_default_metricflow_adapter_does_not_load_during_tool_registration(self):
         with (
             patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
             patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
@@ -1451,7 +1451,13 @@ class TestAvailableTools:
                 tools = tool.available_tools()
 
         names = [tool.name for tool in tools]
-        assert names == []
+        assert names == [
+            "list_metrics",
+            "get_dimensions",
+            "query_metrics",
+            "validate_semantic",
+            "attribution_analyze",
+        ]
 
     def test_with_adapter_adds_validate_and_attribution_tools(self):
         with (
@@ -1471,7 +1477,7 @@ class TestAvailableTools:
         # 3 base + validate_semantic + attribution_analyze (both enabled when adapter is set)
         assert len(tools) == 5
 
-    def test_configured_adapter_load_failure_exposes_no_tools(self):
+    def test_configured_adapter_load_failure_is_reported_when_tool_runs(self):
         with (
             patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
             patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
@@ -1499,12 +1505,147 @@ class TestAvailableTools:
                 tools = tool.available_tools()
 
             names = [tool.name for tool in tools]
-            assert names == []
-            assert "attribution_analyze" not in names
+            assert names == [
+                "list_metrics",
+                "get_dimensions",
+                "query_metrics",
+                "validate_semantic",
+                "attribution_analyze",
+            ]
 
             result = tool.validate_semantic()
             assert result.success == 0
             assert "bad yaml" in result.error
+
+
+class TestRuntimeDbContext:
+    def test_adapter_config_receives_runtime_context_and_reloads_when_it_changes(self):
+        runtime_context = {"datasource": "college_exam", "database": "db_one"}
+        captured_builder_calls = []
+        adapter_config = object()
+        adapter_one = Mock()
+        adapter_two = Mock()
+
+        def build_config(adapter_type=None, database_name=None, runtime_db_context=None):
+            captured_builder_calls.append(
+                {
+                    "adapter_type": adapter_type,
+                    "database_name": database_name,
+                    "runtime_db_context": dict(runtime_db_context or {}),
+                }
+            )
+            return adapter_config
+
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+            patch("datus.tools.func_tool.semantic_tools.semantic_adapter_registry.get_metadata", return_value=None),
+            patch(
+                "datus.tools.func_tool.semantic_tools.semantic_adapter_registry.create_adapter",
+                side_effect=[adapter_one, adapter_two],
+            ) as create_adapter,
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            config.current_datasource = "college_exam"
+            config.resolve_semantic_adapter.side_effect = lambda adapter_type=None: adapter_type
+            config.build_semantic_adapter_config = build_config
+            tool = SemanticTools(
+                agent_config=config,
+                adapter_type="metricflow",
+                runtime_db_context_provider=lambda: runtime_context,
+            )
+
+            assert tool.adapter is adapter_one
+            assert tool.adapter is adapter_one
+            runtime_context["database"] = "db_two"
+            assert tool.adapter is adapter_two
+
+        assert create_adapter.call_count == 2
+        assert captured_builder_calls == [
+            {
+                "adapter_type": "metricflow",
+                "database_name": "college_exam",
+                "runtime_db_context": {"datasource": "college_exam", "database": "db_one"},
+            },
+            {
+                "adapter_type": "metricflow",
+                "database_name": "college_exam",
+                "runtime_db_context": {"datasource": "college_exam", "database": "db_two"},
+            },
+        ]
+
+    def test_validate_semantic_initializes_adapter_with_runtime_database(self, tmp_path):
+        from datus.configuration.agent_config import AgentConfig, NodeConfig
+        from datus.tools.func_tool.semantic_tools import SemanticTools
+
+        captured_configs = []
+
+        class FakeAdapter:
+            async def validate_semantic(self, scope="all"):
+                return ValidationResult(valid=True, issues=[])
+
+        def create_adapter(adapter_type, adapter_config):
+            captured_configs.append(adapter_config)
+            return FakeAdapter()
+
+        config = AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={
+                "mock": {
+                    "type": "openai",
+                    "api_key": "k",
+                    "model": "m",
+                    "base_url": "http://localhost:0",
+                }
+            },
+            services={
+                "datasources": {
+                    "college_exam": {
+                        "type": "mysql",
+                        "host": "mysql",
+                        "username": "user",
+                        "password": "pass",
+                        "default": True,
+                    },
+                },
+                "semantic_layer": {"metricflow": {"datasource": "college_exam"}},
+            },
+            skip_init_dirs=True,
+        )
+
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+            patch("datus.tools.func_tool.semantic_tools.semantic_adapter_registry.get_metadata", return_value=None),
+            patch(
+                "datus.tools.func_tool.semantic_tools.semantic_adapter_registry.create_adapter",
+                side_effect=create_adapter,
+            ),
+        ):
+            tool = SemanticTools(
+                agent_config=config,
+                adapter_type="metricflow",
+                runtime_db_context_provider=lambda: {
+                    "datasource": "college_exam",
+                    "database": "college_exam",
+                },
+            )
+
+            result = tool.validate_semantic(scope="semantic_model")
+
+        assert result.success == 1
+        assert result.result["valid"] is True
+        assert captured_configs
+        first_config = captured_configs[0]
+        assert first_config.datasource == "college_exam"
+        assert first_config.db_config["type"] == "mysql"
+        assert first_config.db_config["host"] == "mysql"
+        assert first_config.db_config["database"] == "college_exam"
 
 
 class TestListMetrics:
@@ -2027,7 +2168,7 @@ class TestExtractDbConfig:
         assert result["private_key_file_pwd"] == "1234"
         assert "extra" not in result
         assert "path_pattern" not in result
-        assert "catalog" not in result
+        assert result["catalog"] == "skip"
 
 
 class TestReloadAdapter:

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -4,6 +4,7 @@ Test cases for SemanticTools utility functions and query_metrics compression.
 
 import json
 from enum import Enum
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1519,6 +1520,29 @@ class TestAvailableTools:
 
 
 class TestRuntimeDbContext:
+    def test_normalize_runtime_context_handles_empty_and_aliases(self):
+        from datus.tools.func_tool.semantic_tools import SemanticTools
+
+        assert SemanticTools._normalize_runtime_db_context(None) == {}
+        assert SemanticTools._normalize_runtime_db_context(
+            {
+                "catalog_name": " runtime_catalog ",
+                "database_name": " runtime_db ",
+                "db_schema": " runtime_schema ",
+            }
+        ) == {
+            "catalog_name": "runtime_catalog",
+            "catalog": "runtime_catalog",
+            "database_name": "runtime_db",
+            "database": "runtime_db",
+            "db_schema": "runtime_schema",
+            "schema": "runtime_schema",
+        }
+        assert SemanticTools._normalize_runtime_db_context({"schema_name": "runtime_schema"}) == {
+            "schema_name": "runtime_schema",
+            "schema": "runtime_schema",
+        }
+
     def test_adapter_config_receives_runtime_context_and_reloads_when_it_changes(self):
         runtime_context = {"datasource": "college_exam", "database": "db_one"}
         captured_builder_calls = []
@@ -1625,6 +1649,128 @@ class TestRuntimeDbContext:
                 "runtime_db_context": {"datasource": "runtime_ds", "database": "agent_ctx_db"},
             }
         ]
+
+    def test_runtime_context_provider_failure_returns_empty_context(self):
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            tool = SemanticTools(
+                agent_config=config,
+                adapter_type="metricflow",
+                runtime_db_context_provider=Mock(side_effect=RuntimeError("boom")),
+            )
+
+        assert tool._runtime_db_context() == {}
+
+    def test_agent_config_runtime_context_failure_returns_empty_context(self):
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            config.runtime_db_context.side_effect = RuntimeError("boom")
+            tool = SemanticTools(agent_config=config, adapter_type="metricflow")
+
+        assert tool._runtime_db_context() == {}
+
+    def test_static_runtime_context_overrides_agent_config_context_and_is_idempotent(self):
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            config.runtime_db_context.return_value = {"database": "agent_db"}
+            tool = SemanticTools(agent_config=config, adapter_type="metricflow")
+
+        tool._adapter = Mock()
+        tool._attribution_tool = Mock()
+        tool._adapter_context_key = ("metricflow", "ds", "", "", "")
+        tool.set_runtime_db_context({"database_name": "static_db"})
+
+        assert tool._runtime_db_context() == {
+            "database_name": "static_db",
+            "database": "static_db",
+        }
+        assert tool._adapter is None
+        assert tool._attribution_tool is None
+        assert tool._adapter_context_key is None
+
+        adapter = Mock()
+        tool._adapter = adapter
+        tool.set_runtime_db_context({"database_name": "static_db"})
+
+        assert tool._adapter is adapter
+
+    def test_adapter_uses_default_config_when_builder_absent(self, tmp_path):
+        adapter = Mock()
+        path_manager = SimpleNamespace(semantic_model_path=lambda datasource: tmp_path / datasource)
+        config = SimpleNamespace(
+            active_model=lambda: SimpleNamespace(model="gpt-4o"),
+            current_datasource="runtime_ds",
+            path_manager=path_manager,
+        )
+
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+            patch("datus.tools.func_tool.semantic_tools.semantic_adapter_registry.get_metadata", return_value=None),
+            patch(
+                "datus.tools.func_tool.semantic_tools.semantic_adapter_registry.create_adapter",
+                return_value=adapter,
+            ) as create_adapter,
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            tool = SemanticTools(agent_config=config, adapter_type="metricflow")
+
+            assert tool.adapter is adapter
+
+        adapter_config = create_adapter.call_args.args[1]
+        assert adapter_config.datasource == "runtime_ds"
+
+    def test_adapter_uses_metadata_config_when_builder_absent(self, tmp_path):
+        adapter = Mock()
+
+        class FakeConfig:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        config = SimpleNamespace(
+            active_model=lambda: SimpleNamespace(model="gpt-4o"),
+            current_datasource="runtime_ds",
+            path_manager=SimpleNamespace(semantic_model_path=lambda datasource: tmp_path / datasource),
+        )
+        metadata = SimpleNamespace(config_class=FakeConfig)
+
+        with (
+            patch("datus.tools.func_tool.semantic_tools.SemanticModelRAG"),
+            patch("datus.tools.func_tool.semantic_tools.MetricRAG"),
+            patch("datus.tools.func_tool.semantic_tools.semantic_adapter_registry.get_metadata", return_value=metadata),
+            patch(
+                "datus.tools.func_tool.semantic_tools.semantic_adapter_registry.create_adapter",
+                return_value=adapter,
+            ) as create_adapter,
+        ):
+            from datus.tools.func_tool.semantic_tools import SemanticTools
+
+            tool = SemanticTools(agent_config=config, adapter_type="metricflow")
+
+            assert tool.adapter is adapter
+
+        adapter_config = create_adapter.call_args.args[1]
+        assert adapter_config.kwargs["datasource"] == "runtime_ds"
+        assert adapter_config.kwargs["semantic_models_path"] == str(tmp_path / "runtime_ds")
 
     def test_validate_semantic_initializes_adapter_with_runtime_database(self, tmp_path):
         from datus.configuration.agent_config import AgentConfig, NodeConfig


### PR DESCRIPTION
## Summary
- Propagate selected catalog/database/schema as runtime DB context through API and agent bootstrap paths.
- Apply runtime DB context when building semantic adapter config and reload SemanticTools adapters when that context changes.
- Cover semantic authoring, database service, generation tools, and SemanticTools runtime DB context behavior.

## Validation
- `uv run --project /Users/kangxue/work/datus/Datus-agent-runtime-semantic-db-context pytest tests/unit_tests/configuration/test_agent_config.py::TestSemanticAdapterDbConfig tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigServiceSelectors::test_build_semantic_adapter_config_runtime_datasource_overrides_configured_datasource tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigServiceSelectors::test_build_semantic_adapter_config_uses_runtime_database_when_datasource_omits_database tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestRuntimeDbContext tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestAvailableTools tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/api/services/test_database_service.py -q`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **New Features**
  * Semantic and metric-related actions now respect the active catalog, database, and schema from the current request or command-line context.
  * Explorer and semantic model APIs accept optional context fields so results can be resolved in the right namespace.

* **Bug Fixes**
  * Improved semantic model lookup and validation to use runtime context instead of relying only on static defaults.
  * Better adapter behavior when context changes, helping avoid stale results across requests.

* **Chores**
  * Added coverage for the new context-aware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic/metric actions now use request/CLI-scoped catalog, database, and schema context when building semantic adapter configuration and deriving semantic model names.
  * Explorer and table endpoints accept catalog/database/db_schema context (including structured input for metric dimensions and updated `/semantic_model` query params).
  * `bootstrap-kb` adds `--schema_name` for semantic validation/execution.
* **Bug Fixes**
  * Semantic validation and adapter initialization now more consistently prefer runtime context, including correct adapter reload behavior when context changes.
* **Tests**
  * Added/updated unit tests for runtime-context precedence, adapter reload, and namespace-aware lookups.
* **Chores**
  * Expanded CI coverage mappings for the new context-aware scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->