### PR TITLE
[UT] Remove execute_write assertion in test_gen_job_agentic

### DIFF
--- a/tests/integration/agent/test_gen_job_agentic.py
+++ b/tests/integration/agent/test_gen_job_agentic.py
@@ -137,7 +137,6 @@ class TestGenJobAgenticInit:
 
         tool_names = [tool.name for tool in node.tools]
         assert "execute_sql" in tool_names, f"missing execute_sql, got: {tool_names}"
-        assert "execute_write" in tool_names, f"missing execute_write, got: {tool_names}"
         assert "transfer_query_result" in tool_names, f"missing transfer_query_result, got: {tool_names}"
 
         logger.info("gen_job node initialized with %d tools: %s", len(node.tools), tool_names)
@@ -166,7 +165,7 @@ class TestGenJobAgenticRealLLM:
                 "Create a new table named nightly_job_school_summary with one integer "
                 "column total_schools, then load it by inserting a single row: the total "
                 "number of rows in the schools table (INSERT INTO ... SELECT COUNT(*) FROM schools). "
-                "Use execute_ddl for the CREATE TABLE and execute_write for the INSERT. "
+                "Use execute_sql for the CREATE TABLE and the INSERT. "
                 "This is an explicit, non-destructive request targeting a brand-new table."
             ),
         )


### PR DESCRIPTION
## Why

Nightly CI (run 28335781011) still failed after #1065 because `execute_write` was also consolidated into `execute_sql` by PR #1062, but the assertion was not removed in the previous fix.

## Solution

- Remove `assert "execute_write" in tool_names` from `TestGenJobAgenticInit::test_node_initialization` — the tool no longer exists as a separate entry
- Update the LLM prompt in the real-LLM smoke test to use `execute_sql` for both DDL and DML, replacing the stale `execute_ddl`/`execute_write` references

## Test Cases

No new tests. This is a follow-up to #1065 — same class of fix (tool name no longer exposed after consolidation).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in database-related workflows, helping table creation and data insertion follow the same path.
  * Updated automated checks to better reflect the supported behavior of the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->