### PR TITLE
[BugFix] Fix Claude-native web tools and session-resume turn persistence

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -158,14 +158,14 @@ def summarize_web_tool_result(res_block, query: str = ""):
 # them verbatim trips a 400 (e.g. ``server_tool_use.citations: Extra inputs are not
 # permitted``), which aborts the turn before it can be persisted — so the next turn
 # also "forgets" the conversation. Whitelist the input-permitted keys to avoid this.
-_SERVER_BLOCK_INPUT_KEYS = {
+_SERVER_BLOCK_INPUT_KEYS: Dict[str, tuple[str, ...]] = {
     "server_tool_use": ("type", "id", "name", "input"),
     "web_search_tool_result": ("type", "tool_use_id", "content"),
     "web_fetch_tool_result": ("type", "tool_use_id", "content"),
 }
 
 
-def sanitize_server_block_for_replay(block) -> Optional[dict]:
+def sanitize_server_block_for_replay(block: Any) -> Optional[Dict[str, Any]]:
     """Dump a server-side content block to the Anthropic message *input* schema.
 
     Returns a dict containing only the keys Anthropic accepts when the block is
@@ -668,7 +668,7 @@ class ClaudeModel(OpenAICompatibleModel):
                 builtin_web = kwargs.get("builtin_web_tools") or {}
                 if builtin_web.get("web_search"):
                     tools.append({"type": "web_search_20250305", "name": "web_search", "max_uses": 5})
-                if builtin_web.get("web_fetch"):
+                if builtin_web.get("web_fetch") and self.supports_builtin_web_fetch():
                     tools.append({"type": "web_fetch_20250910", "name": "web_fetch", "max_uses": 5})
 
                 # Re-apply cache control so the ephemeral marker lands on the final
@@ -972,6 +972,22 @@ class ClaudeModel(OpenAICompatibleModel):
                     # If no tool calls, conversation is complete
                     if not any(block.type == "tool_use" for block in message):
                         final_content = "\n".join([block.text for block in message if block.type == "text"])
+                        # Persist the final assistant message — including any
+                        # sanitized ``server_tool_use`` / ``web_search_tool_result``
+                        # blocks from a ``web_search``-only turn — before breaking.
+                        # The completion branch exits before the assistant-content
+                        # append below, so without this the native web-tool replay
+                        # history would be reduced to plain ``final_content``.
+                        final_replay_content: List[Dict[str, Any]] = []
+                        for block in message:
+                            if block.type == "text":
+                                final_replay_content.append({"type": "text", "text": block.text})
+                            else:
+                                sanitized = sanitize_server_block_for_replay(block)
+                                if sanitized is not None:
+                                    final_replay_content.append(sanitized)
+                        if final_replay_content:
+                            messages.append({"role": "assistant", "content": final_replay_content})
                         logger.debug("No tool calls, conversation completed")
                         break
 
@@ -1300,7 +1316,7 @@ class ClaudeModel(OpenAICompatibleModel):
             logger.error(f"Error in _generate_with_mcp_stream: {str(e)}")
             raise
 
-    async def _persist_failed_turn(self, frame_locals: dict, error: Exception) -> None:
+    async def _persist_failed_turn(self, frame_locals: Dict[str, Any], error: Exception) -> None:
         """Best-effort save of an interrupted turn so the next turn isn't amnesiac.
 
         When the native loop raises mid-turn (e.g. a 400 on replay, a network
@@ -1320,6 +1336,11 @@ class ClaudeModel(OpenAICompatibleModel):
             return
         try:
             partial = (frame_locals.get("final_content") or "").strip()
+            if not partial:
+                # On a mid-stream failure ``final_content`` is still empty, but
+                # the partial text the user already saw lives in
+                # ``thinking_accumulated`` — prefer it over the placeholder.
+                partial = (frame_locals.get("thinking_accumulated") or "").strip()
             assistant_text = partial or f"[Turn interrupted before completion: {type(error).__name__}]"
             # Preserve any completed tool_use/tool_result rounds from this turn
             # too, not just a placeholder — ``_replay_safe_turn_items`` drops a
@@ -1649,7 +1670,11 @@ class ClaudeModel(OpenAICompatibleModel):
         # only be expressed as raw tool dicts on the native Messages API, not via
         # the agents-SDK LiteLLM tool list. Non-web calls (e.g. compaction
         # summarization, which passes no builtin_web_tools) stay on LiteLLM.
-        _want_builtin_web = any((kwargs.get("builtin_web_tools") or {}).values())
+        _builtin_web_tools = kwargs.get("builtin_web_tools") or {}
+        _want_builtin_web = bool(
+            (_builtin_web_tools.get("web_search") and self.supports_builtin_web_search())
+            or (_builtin_web_tools.get("web_fetch") and self.supports_builtin_web_fetch())
+        )
         if (self.use_native_api and self._is_oauth_token) or _want_builtin_web:
             if action_history_manager is None:
                 action_history_manager = ActionHistoryManager()

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -700,6 +700,13 @@ class ClaudeModel(OpenAICompatibleModel):
                     "role": "user",
                     "content": [{"type": "text", "text": prompt_text}],
                 }
+                # Index of this turn's first NEW message in ``messages`` (prior
+                # session history was just replayed above, so anything before
+                # this index is already persisted). The end-of-turn persistence
+                # stores ``messages[turn_start_index:]`` — the full structured
+                # delta including every ``tool_use`` / ``tool_result`` — instead
+                # of only the final text.
+                turn_start_index = len(messages)
                 messages.append(user_turn_message)
                 tool_call_cache = {}
                 sql_contexts = []
@@ -1244,11 +1251,19 @@ class ClaudeModel(OpenAICompatibleModel):
                 # in that case so the next turn starts from a clean slate.
                 if session is not None and final_content:
                     try:
-                        assistant_turn_message = {
-                            "role": "assistant",
-                            "content": [{"type": "text", "text": final_content}],
-                        }
-                        await session.add_items([user_turn_message, assistant_turn_message])
+                        # Persist the FULL structured turn — every assistant
+                        # ``tool_use`` block and its matching ``tool_result``
+                        # reply — not just ``final_content``. ``messages`` from
+                        # ``turn_start_index`` on is exactly the sequence
+                        # Anthropic accepted during the loop, so replaying it on
+                        # resume is safe and keeps the tool-calling history
+                        # intact. Storing only the final text previously dropped
+                        # every tool call/result, leaving resumed turns with
+                        # broken history (and tool calls leaking into text).
+                        turn_items = self._replay_safe_turn_items(
+                            messages[turn_start_index:], user_turn_message, final_content
+                        )
+                        await session.add_items(turn_items)
                         turn_persisted = True
                         # Persist the turn's token usage into the durable
                         # ``turn_usage`` table. The native loop never calls
@@ -1306,14 +1321,78 @@ class ClaudeModel(OpenAICompatibleModel):
         try:
             partial = (frame_locals.get("final_content") or "").strip()
             assistant_text = partial or f"[Turn interrupted before completion: {type(error).__name__}]"
-            assistant_turn_message = {
-                "role": "assistant",
-                "content": [{"type": "text", "text": assistant_text}],
-            }
-            await session.add_items([user_turn_message, assistant_turn_message])
+            # Preserve any completed tool_use/tool_result rounds from this turn
+            # too, not just a placeholder — ``_replay_safe_turn_items`` drops a
+            # trailing dangling ``tool_use`` (interrupted before its result) and
+            # appends ``assistant_text`` so the history ends on an assistant
+            # message Anthropic will accept on replay.
+            messages = frame_locals.get("messages")
+            turn_start_index = frame_locals.get("turn_start_index")
+            if isinstance(messages, list) and isinstance(turn_start_index, int):
+                turn_items = self._replay_safe_turn_items(
+                    messages[turn_start_index:], user_turn_message, assistant_text
+                )
+            else:
+                turn_items = [
+                    user_turn_message,
+                    {"role": "assistant", "content": [{"type": "text", "text": assistant_text}]},
+                ]
+            await session.add_items(turn_items)
             logger.info("Persisted interrupted native Claude turn so history survives the failure.")
         except Exception as persist_err:
             logger.warning(f"Failed to persist interrupted native Claude turn: {persist_err}")
+
+    @staticmethod
+    def _replay_safe_turn_items(
+        turn_items: List[Dict[str, Any]],
+        user_turn_message: Dict[str, Any],
+        fallback_text: str,
+    ) -> List[Dict[str, Any]]:
+        """Trim one native-loop turn to a replay-safe item list for the session.
+
+        ``turn_items`` is the slice of the native loop's ``messages`` added
+        during a single user turn: the user message, then alternating assistant
+        (``text`` + ``tool_use``) and user (``tool_result``) messages, ending —
+        on the success path — with a clean assistant text message.
+
+        Anthropic rejects replay of (a) an assistant ``tool_use`` block with no
+        matching ``tool_result`` and (b) a history that ends on a
+        user/``tool_result`` message (it would collide with the next turn's
+        user message). This drops any trailing *dangling* ``tool_use`` (only the
+        tail can dangle — the loop appends each ``tool_result`` immediately after
+        its ``tool_use``) and guarantees the sequence ends on an assistant
+        message, appending a non-empty ``fallback_text`` placeholder when needed
+        so the turn is never lost. Completed tool rounds are preserved verbatim.
+        """
+        items = [m for m in turn_items if isinstance(m, dict)]
+
+        def _tool_use_ids(msg: Dict[str, Any]) -> List[Any]:
+            content = msg.get("content")
+            if not isinstance(content, list):
+                return []
+            return [b.get("id") for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
+
+        answered = set()
+        for m in items:
+            if m.get("role") == "user" and isinstance(m.get("content"), list):
+                for b in m["content"]:
+                    if isinstance(b, dict) and b.get("type") == "tool_result":
+                        answered.add(b.get("tool_use_id"))
+
+        # Drop a trailing assistant turn whose tool calls were never answered
+        # (interrupted between emitting the tool_use and recording its result).
+        while items:
+            last = items[-1]
+            if last.get("role") == "assistant" and any(tid not in answered for tid in _tool_use_ids(last)):
+                items.pop()
+                continue
+            break
+
+        if not items:
+            items = [user_turn_message]
+        if items[-1].get("role") != "assistant":
+            items.append({"role": "assistant", "content": [{"type": "text", "text": fallback_text or "[empty turn]"}]})
+        return items
 
     def _build_native_usage_info(
         self,

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -150,6 +150,41 @@ def summarize_web_tool_result(res_block, query: str = ""):
     return "completed", {}
 
 
+# Anthropic's message *input* schema for replayed server-side blocks is stricter
+# than the *output* schema: it accepts only the keys below per block type. The
+# streamed response (rehydrated via ``stream.get_final_message()``) attaches
+# output-only fields such as ``citations`` to these blocks — and because the SDK
+# block models use ``extra="allow"``, ``model_dump`` carries them through. Replaying
+# them verbatim trips a 400 (e.g. ``server_tool_use.citations: Extra inputs are not
+# permitted``), which aborts the turn before it can be persisted — so the next turn
+# also "forgets" the conversation. Whitelist the input-permitted keys to avoid this.
+_SERVER_BLOCK_INPUT_KEYS = {
+    "server_tool_use": ("type", "id", "name", "input"),
+    "web_search_tool_result": ("type", "tool_use_id", "content"),
+    "web_fetch_tool_result": ("type", "tool_use_id", "content"),
+}
+
+
+def sanitize_server_block_for_replay(block) -> Optional[dict]:
+    """Dump a server-side content block to the Anthropic message *input* schema.
+
+    Returns a dict containing only the keys Anthropic accepts when the block is
+    replayed inside an assistant message, or ``None`` if the block cannot be
+    serialized. Drops output-only fields (notably ``citations``) that would
+    otherwise raise ``Extra inputs are not permitted``.
+    """
+    try:
+        dumped = block.model_dump(mode="json")
+    except Exception:
+        logger.debug("Skipping non-serializable content block: %s", getattr(block, "type", "?"))
+        return None
+    allowed = _SERVER_BLOCK_INPUT_KEYS.get(dumped.get("type"))
+    if allowed is None:
+        # Unknown server block type — fall back to verbatim dump (best effort).
+        return dumped
+    return {k: dumped[k] for k in allowed if k in dumped}
+
+
 def convert_tools_for_anthropic(mcp_tools):
     """Convert MCP tools to Anthropic tool format.
 
@@ -243,8 +278,16 @@ class ClaudeModel(OpenAICompatibleModel):
         return True
 
     def supports_builtin_web_fetch(self) -> bool:
-        # Anthropic web_fetch_20250910 (beta) runs server-side via the native path.
-        return True
+        # web_fetch is served by the LOCAL httpx backend (``web_tool.web_fetch``)
+        # rather than Anthropic's server-side ``web_fetch_20250910``. The hosted
+        # tool emits ``server_tool_use`` / ``web_fetch_tool_result`` blocks that
+        # must be replayed verbatim next turn; the rehydrated blocks carry an
+        # output-only ``citations`` field the message *input* schema rejects
+        # (400 ``server_tool_use.citations: Extra inputs are not permitted``),
+        # which aborts the turn before it can be persisted. The local backend
+        # returns a plain ``tool_result`` instead, sidestepping that entirely.
+        # (web_search stays server-side — see ``sanitize_server_block_for_replay``.)
+        return False
 
     def _get_api_key(self) -> str:
         """Get Anthropic API key from config or environment."""
@@ -661,6 +704,10 @@ class ClaudeModel(OpenAICompatibleModel):
                 tool_call_cache = {}
                 sql_contexts = []
                 final_content = ""
+                # Guards the failure-path persistence below: the success path
+                # sets this once it has committed the turn, so the ``except``
+                # handler never double-writes a turn it already saved.
+                turn_persisted = False
                 # Accumulate token usage across all turns
                 cumulative_input_tokens = 0
                 cumulative_output_tokens = 0
@@ -1087,13 +1134,14 @@ class ClaudeModel(OpenAICompatibleModel):
                             tool_use_blocks.append(block)
                         else:
                             # Preserve server-side blocks (server_tool_use /
-                            # web_search_tool_result / web_fetch_tool_result) verbatim
-                            # so a mixed turn (server web tool + local tool_use) keeps a
-                            # valid assistant message when replayed to Anthropic next turn.
-                            try:
-                                content.append(block.model_dump(mode="json"))
-                            except Exception:
-                                logger.debug("Skipping non-serializable content block: %s", getattr(block, "type", "?"))
+                            # web_search_tool_result / web_fetch_tool_result) so a mixed
+                            # turn (server web tool + local tool_use) keeps a valid
+                            # assistant message when replayed to Anthropic next turn.
+                            # Sanitize to the input schema to drop output-only fields
+                            # (e.g. ``citations``) the API rejects on replay.
+                            sanitized = sanitize_server_block_for_replay(block)
+                            if sanitized is not None:
+                                content.append(sanitized)
 
                     if content:
                         messages.append({"role": "assistant", "content": content})
@@ -1201,6 +1249,7 @@ class ClaudeModel(OpenAICompatibleModel):
                             "content": [{"type": "text", "text": final_content}],
                         }
                         await session.add_items([user_turn_message, assistant_turn_message])
+                        turn_persisted = True
                         # Persist the turn's token usage into the durable
                         # ``turn_usage`` table. The native loop never calls
                         # ``Runner.run`` (which is what normally triggers
@@ -1226,13 +1275,45 @@ class ClaudeModel(OpenAICompatibleModel):
                 yield final_action
 
         except anthropic.AuthenticationError as e:
+            await self._persist_failed_turn(locals(), e)
             self._diagnose_oauth_401(e)
             raise
         except Exception as e:
+            await self._persist_failed_turn(locals(), e)
             if is_ssl_cert_verification_error(e):
                 raise DatusException(ErrorCode.MODEL_SSL_CERT_ERROR) from e
             logger.error(f"Error in _generate_with_mcp_stream: {str(e)}")
             raise
+
+    async def _persist_failed_turn(self, frame_locals: dict, error: Exception) -> None:
+        """Best-effort save of an interrupted turn so the next turn isn't amnesiac.
+
+        When the native loop raises mid-turn (e.g. a 400 on replay, a network
+        drop, or an interrupt), the normal end-of-loop persistence never runs, so
+        neither the user message nor any partial reply reaches the session — and
+        the user's *next* turn "forgets" what was just asked. This commits the
+        user message plus a placeholder/partial assistant message (kept non-empty
+        and role-alternating so Anthropic accepts the replay) before the original
+        error propagates. It must never mask that error: all failures here are
+        swallowed.
+        """
+        session = frame_locals.get("session")
+        if session is None or frame_locals.get("turn_persisted"):
+            return
+        user_turn_message = frame_locals.get("user_turn_message")
+        if not user_turn_message:
+            return
+        try:
+            partial = (frame_locals.get("final_content") or "").strip()
+            assistant_text = partial or f"[Turn interrupted before completion: {type(error).__name__}]"
+            assistant_turn_message = {
+                "role": "assistant",
+                "content": [{"type": "text", "text": assistant_text}],
+            }
+            await session.add_items([user_turn_message, assistant_turn_message])
+            logger.info("Persisted interrupted native Claude turn so history survives the failure.")
+        except Exception as persist_err:
+            logger.warning(f"Failed to persist interrupted native Claude turn: {persist_err}")
 
     def _build_native_usage_info(
         self,

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -1381,7 +1381,13 @@ class SessionManager:
 
         return messages
 
-    def _restore_native_tool_call(self, item, current_actions, assistant_progress, created_at):
+    def _restore_native_tool_call(
+        self,
+        item: Dict[str, Any],
+        current_actions: List[ActionHistory],
+        assistant_progress: List[str],
+        created_at: Optional[str],
+    ) -> None:
         """Build a PROCESSING tool action from a Claude-native content block.
 
         ``ClaudeModel``'s OAuth path persists tool calls as ``tool_use`` /
@@ -1410,7 +1416,13 @@ class SessionManager:
         )
         current_actions.append(action)
 
-    def _attach_native_tool_result(self, current_actions, tool_use_id, raw_content, created_at):
+    def _attach_native_tool_result(
+        self,
+        current_actions: List[ActionHistory],
+        tool_use_id: Optional[str],
+        raw_content: Any,
+        created_at: Optional[str],
+    ) -> None:
         """Pair a Claude-native tool result with its in-flight tool_use action.
 
         Mirrors the ``function_call_output`` path but for Anthropic blocks

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -1136,6 +1136,30 @@ class SessionManager:
 
                         # Handle user messages
                         if role == "user":
+                            raw_user_content = message_json.get("content", "")
+                            # Claude-native format carries tool RESULTS as user
+                            # messages with ``tool_result`` blocks. Those are not
+                            # real user turns: pair each with its in-flight
+                            # tool_use action (so the resumed transcript shows the
+                            # tool output) and do NOT flush/emit a user bubble —
+                            # otherwise every tool round splits the assistant
+                            # group and renders an empty user message.
+                            if isinstance(raw_user_content, list):
+                                tool_results = [
+                                    b
+                                    for b in raw_user_content
+                                    if isinstance(b, dict) and b.get("type") == "tool_result"
+                                ]
+                                has_user_text = any(
+                                    isinstance(b, dict) and b.get("type") in ("text", "input_text", "output_text")
+                                    for b in raw_user_content
+                                )
+                                if tool_results and not has_user_text:
+                                    for tr in tool_results:
+                                        self._attach_native_tool_result(
+                                            current_actions, tr.get("tool_use_id"), tr.get("content"), created_at
+                                        )
+                                    continue
                             # Before adding user message, flush any pending assistant group
                             if current_assistant_group:
                                 final_action = self._parse_final_output(current_actions, current_assistant_group)
@@ -1309,6 +1333,31 @@ class SessionManager:
                                     )
                                     current_actions.append(thinking_action)
 
+                                # Native tool calls live inside the assistant
+                                # content as tool_use / server_tool_use blocks.
+                                if item_type in ("tool_use", "server_tool_use"):
+                                    if not current_assistant_group:
+                                        current_assistant_group = {
+                                            "role": "assistant",
+                                            "content": "",
+                                            "timestamp": created_at_iso,
+                                            "created_at": created_at_iso,
+                                        }
+                                    self._restore_native_tool_call(
+                                        item, current_actions, assistant_progress, created_at
+                                    )
+
+                                # Server-side web tools return their result inline
+                                # in the same assistant message (not as a user
+                                # tool_result), keyed by tool_use_id.
+                                if item_type in ("web_search_tool_result", "web_fetch_tool_result"):
+                                    self._attach_native_tool_result(
+                                        current_actions,
+                                        item.get("tool_use_id"),
+                                        item.get("content"),
+                                        created_at,
+                                    )
+
                     except (json.JSONDecodeError, TypeError) as e:
                         logger.debug(f"Skipping malformed message: {e}")
                         continue
@@ -1331,6 +1380,91 @@ class SessionManager:
             logger.exception(f"Failed to load session messages for {session_id}: {e}")
 
         return messages
+
+    def _restore_native_tool_call(self, item, current_actions, assistant_progress, created_at):
+        """Build a PROCESSING tool action from a Claude-native content block.
+
+        ``ClaudeModel``'s OAuth path persists tool calls as ``tool_use`` /
+        ``server_tool_use`` blocks INSIDE the assistant message content (not as
+        flat ``function_call`` messages). Without restoring them here, the
+        resumed TUI shows assistant text but drops every tool-call card. Mirrors
+        the ``function_call`` branch's ActionHistory shape so the renderer treats
+        native and OpenAI sessions identically.
+        """
+        tool_name = item.get("name", "unknown")
+        tool_input = item.get("input", {})
+        try:
+            arguments = json.dumps(tool_input, ensure_ascii=False) if not isinstance(tool_input, str) else tool_input
+        except (TypeError, ValueError):
+            arguments = "{}"
+        assistant_progress.append(f"✓ Tool call: {tool_name}({arguments[:60]})")
+        action = ActionHistory(
+            action_id=item.get("id", str(uuid.uuid4())),
+            role=ActionRole.TOOL,
+            messages=f"Tool call: {tool_name}",
+            action_type=tool_name,
+            input={"function_name": tool_name, "arguments": arguments},
+            output=None,
+            status=ActionStatus.PROCESSING,
+            start_time=datetime.fromisoformat(created_at) if created_at else datetime.now(),
+        )
+        current_actions.append(action)
+
+    def _attach_native_tool_result(self, current_actions, tool_use_id, raw_content, created_at):
+        """Pair a Claude-native tool result with its in-flight tool_use action.
+
+        Mirrors the ``function_call_output`` path but for Anthropic blocks
+        (``tool_result`` in a user message, or ``web_search_tool_result`` /
+        ``web_fetch_tool_result`` inline in an assistant message), so the resumed
+        transcript renders the tool's output card instead of dropping it.
+        """
+        if not current_actions:
+            return
+        if isinstance(raw_content, list):
+            output_text = " ".join(p.get("text", "") for p in raw_content if isinstance(p, dict)).strip()
+        elif isinstance(raw_content, str):
+            output_text = raw_content
+        else:
+            output_text = json.dumps(raw_content, ensure_ascii=False) if raw_content is not None else ""
+
+        # Match by tool_use_id; fall back to the most recent in-flight tool call
+        # only when no id is available (mirrors function_call_output).
+        match = None
+        if tool_use_id:
+            for cand in reversed(current_actions):
+                if cand.action_id == tool_use_id and cand.status == ActionStatus.PROCESSING:
+                    match = cand
+                    break
+        else:
+            for cand in reversed(current_actions):
+                if cand.status == ActionStatus.PROCESSING and cand.role == ActionRole.TOOL:
+                    match = cand
+                    break
+        if match is None:
+            return
+
+        output_data = {}
+        if output_text:
+            try:
+                output_data = ast.literal_eval(output_text)
+            except (ValueError, SyntaxError):
+                try:
+                    output_data = json.loads(output_text)
+                except json.JSONDecodeError:
+                    output_data = {"result": output_text}
+
+        success_action = ActionHistory(
+            action_id="complete_" + (tool_use_id or match.action_id),
+            role=ActionRole.TOOL,
+            messages=f"Tool result: {match.action_type}",
+            action_type=match.action_type,
+            input=match.input,
+            output=output_data,
+            status=ActionStatus.SUCCESS,
+            start_time=match.start_time,
+            end_time=datetime.fromisoformat(created_at) if created_at else datetime.now(),
+        )
+        current_actions.append(success_action)
 
     def close_all_sessions(self) -> None:
         """Close all active sessions."""

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -43,11 +43,15 @@ def test_openai_search_yes_fetch_no():
     assert OpenAIModel.supports_builtin_web_fetch(s) is False
 
 
-def test_claude_enables_both():
+def test_claude_search_server_fetch_local():
     s = Mock()
-    # Claude serves both server tools via the native path (OAuth and API key).
+    # web_search runs server-side (Anthropic web_search_20250305, GA). web_fetch
+    # is served by the LOCAL httpx backend instead of the hosted
+    # web_fetch_20250910: the hosted tool emits server_tool_use blocks whose
+    # rehydrated form carries an output-only ``citations`` field the message
+    # input schema rejects on replay (400), so we keep fetch local.
     assert ClaudeModel.supports_builtin_web_search(s) is True
-    assert ClaudeModel.supports_builtin_web_fetch(s) is True
+    assert ClaudeModel.supports_builtin_web_fetch(s) is False
 
 
 def test_describe_hosted_tool_item_web_search_dict():
@@ -124,6 +128,68 @@ def test_summarize_web_tool_result_handles_missing():
     from datus.models.claude_model import summarize_web_tool_result
 
     assert summarize_web_tool_result(None) == ("completed", {})
+
+
+def test_sanitize_server_block_strips_citations_from_server_tool_use():
+    """A rehydrated server_tool_use block carries an output-only ``citations``
+    field (extra='allow'); replaying it verbatim trips a 400. The sanitizer must
+    keep only the input-schema keys."""
+    from anthropic.types import ServerToolUseBlock
+
+    from datus.models.claude_model import sanitize_server_block_for_replay
+
+    block = ServerToolUseBlock(id="srv_1", name="web_search", input={"query": "eth"}, type="server_tool_use")
+    # Simulate the field the streaming accumulator attaches.
+    block.__pydantic_extra__["citations"] = None
+    assert "citations" in block.model_dump(mode="json")  # precondition
+
+    out = sanitize_server_block_for_replay(block)
+    assert out == {"type": "server_tool_use", "id": "srv_1", "name": "web_search", "input": {"query": "eth"}}
+    assert "citations" not in out
+
+
+def test_sanitize_server_block_whitelists_web_search_tool_result():
+    """web_search_tool_result keeps only type/tool_use_id/content on replay."""
+    from types import SimpleNamespace
+
+    from datus.models.claude_model import sanitize_server_block_for_replay
+
+    block = SimpleNamespace(
+        model_dump=lambda mode="json": {
+            "type": "web_search_tool_result",
+            "tool_use_id": "srv_1",
+            "content": [{"type": "web_search_result", "title": "t", "url": "https://x"}],
+            "cache_control": {"type": "ephemeral"},  # extra output-only key
+        }
+    )
+    out = sanitize_server_block_for_replay(block)
+    assert set(out) == {"type", "tool_use_id", "content"}
+    assert out["tool_use_id"] == "srv_1"
+
+
+def test_sanitize_server_block_unknown_type_falls_back_to_verbatim():
+    """An unrecognized block type is dumped verbatim (best effort, no data loss)."""
+    from types import SimpleNamespace
+
+    from datus.models.claude_model import sanitize_server_block_for_replay
+
+    dumped = {"type": "some_future_block", "foo": "bar"}
+    block = SimpleNamespace(model_dump=lambda mode="json": dumped)
+    assert sanitize_server_block_for_replay(block) == dumped
+
+
+def test_sanitize_server_block_returns_none_when_unserializable():
+    """A block whose model_dump raises is skipped (returns None) rather than
+    aborting the whole assistant-message rebuild."""
+    from types import SimpleNamespace
+
+    from datus.models.claude_model import sanitize_server_block_for_replay
+
+    def _boom(mode="json"):
+        raise ValueError("not serializable")
+
+    block = SimpleNamespace(type="server_tool_use", model_dump=_boom)
+    assert sanitize_server_block_for_replay(block) is None
 
 
 def test_codex_hosted_completion_attaches_citations():
@@ -274,3 +340,101 @@ def test_describe_hosted_tool_item_ignores_non_web_hosted_calls():
     # the web_search canonical schema by the deferred completion logic).
     for itype in ("file_search_call", "image_generation_call", "code_interpreter_call", "computer_call"):
         assert describe_hosted_tool_item({"type": itype, "id": "x"}) is None
+
+
+def _user_msg(text="explore eth tables"):
+    return {"role": "user", "content": [{"type": "text", "text": text}]}
+
+
+@pytest.mark.asyncio
+async def test_persist_failed_turn_saves_user_and_placeholder():
+    """A turn that raises before normal persistence still commits the user
+    message (plus a non-empty placeholder assistant) so the next turn isn't
+    amnesiac. Role-alternating + non-empty text keeps the replay API-valid."""
+    from unittest.mock import AsyncMock
+
+    session = AsyncMock()
+    frame_locals = {
+        "session": session,
+        "turn_persisted": False,
+        "user_turn_message": _user_msg(),
+        "final_content": "",
+    }
+    await ClaudeModel._persist_failed_turn(Mock(), frame_locals, RuntimeError("boom"))
+
+    session.add_items.assert_awaited_once()
+    items = session.add_items.await_args.args[0]
+    assert [m["role"] for m in items] == ["user", "assistant"]
+    # Placeholder assistant text is non-empty (Anthropic rejects empty text).
+    assert items[1]["content"][0]["text"].strip()
+    assert "RuntimeError" in items[1]["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_persist_failed_turn_uses_partial_content():
+    """When the turn produced partial assistant text before failing, that text
+    is preserved rather than replaced by the error placeholder."""
+    from unittest.mock import AsyncMock
+
+    session = AsyncMock()
+    frame_locals = {
+        "session": session,
+        "turn_persisted": False,
+        "user_turn_message": _user_msg(),
+        "final_content": "partial answer so far",
+    }
+    await ClaudeModel._persist_failed_turn(Mock(), frame_locals, RuntimeError("boom"))
+    items = session.add_items.await_args.args[0]
+    assert items[1]["content"][0]["text"] == "partial answer so far"
+
+
+@pytest.mark.asyncio
+async def test_persist_failed_turn_skips_when_already_persisted():
+    """The success path already committed the turn; the failure path must not
+    double-write."""
+    from unittest.mock import AsyncMock
+
+    session = AsyncMock()
+    frame_locals = {
+        "session": session,
+        "turn_persisted": True,
+        "user_turn_message": _user_msg(),
+        "final_content": "done",
+    }
+    await ClaudeModel._persist_failed_turn(Mock(), frame_locals, RuntimeError("boom"))
+    session.add_items.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_failed_turn_noop_without_session_or_user_message():
+    """No session (e.g. one-shot call) or a failure before the user message was
+    built → nothing to persist, and no crash."""
+    from unittest.mock import AsyncMock
+
+    # No session.
+    await ClaudeModel._persist_failed_turn(Mock(), {"session": None}, RuntimeError("x"))
+
+    # Session present but exception fired before user_turn_message existed.
+    session = AsyncMock()
+    await ClaudeModel._persist_failed_turn(Mock(), {"session": session, "turn_persisted": False}, RuntimeError("x"))
+    session.add_items.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_failed_turn_swallows_persist_errors():
+    """The fallback must never mask the original error: a failing add_items is
+    logged and swallowed, not raised."""
+    from unittest.mock import AsyncMock
+
+    session = AsyncMock()
+    session.add_items.side_effect = RuntimeError("db locked")
+    frame_locals = {
+        "session": session,
+        "turn_persisted": False,
+        "user_turn_message": _user_msg(),
+        "final_content": "",
+    }
+    # Must complete without re-raising (would otherwise mask the real error)...
+    await ClaudeModel._persist_failed_turn(Mock(), frame_locals, ValueError("original"))
+    # ...while still having attempted the persist exactly once.
+    session.add_items.assert_awaited_once()

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -185,7 +185,7 @@ def test_sanitize_server_block_returns_none_when_unserializable():
 
     from datus.models.claude_model import sanitize_server_block_for_replay
 
-    def _boom(mode="json"):
+    def _boom(mode: str = "json") -> dict[str, object]:
         raise ValueError("not serializable")
 
     block = SimpleNamespace(type="server_tool_use", model_dump=_boom)
@@ -342,7 +342,7 @@ def test_describe_hosted_tool_item_ignores_non_web_hosted_calls():
         assert describe_hosted_tool_item({"type": itype, "id": "x"}) is None
 
 
-def _user_msg(text="explore eth tables"):
+def _user_msg(text: str = "explore eth tables") -> dict[str, object]:
     return {"role": "user", "content": [{"type": "text", "text": text}]}
 
 

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -389,6 +389,52 @@ async def test_persist_failed_turn_uses_partial_content():
 
 
 @pytest.mark.asyncio
+async def test_persist_failed_turn_uses_thinking_accumulated_when_final_empty():
+    """On a mid-stream failure ``final_content`` is empty but the visible text
+    lives in ``thinking_accumulated`` — prefer it over the placeholder."""
+    from unittest.mock import AsyncMock
+
+    session = AsyncMock()
+    frame_locals = {
+        "session": session,
+        "turn_persisted": False,
+        "user_turn_message": _user_msg(),
+        "final_content": "",
+        "thinking_accumulated": "streamed-but-not-finalized",
+    }
+    await ClaudeModel._persist_failed_turn(Mock(), frame_locals, RuntimeError("boom"))
+    items = session.add_items.await_args.args[0]
+    assert items[1]["content"][0]["text"] == "streamed-but-not-finalized"
+
+
+@pytest.mark.asyncio
+async def test_persist_failed_turn_preserves_completed_tool_rounds():
+    """When ``messages``/``turn_start_index`` are present, the interrupted turn is
+    rebuilt via ``_replay_safe_turn_items`` so completed tool rounds survive."""
+    from unittest.mock import AsyncMock
+
+    user = _user_msg()
+    session = AsyncMock()
+    frame_locals = {
+        "session": session,
+        "turn_persisted": False,
+        "user_turn_message": user,
+        "final_content": "",
+        "messages": [user, _tool_use_msg("t1"), _tool_result_msg("t1")],
+        "turn_start_index": 0,
+    }
+    # ``_persist_failed_turn`` calls ``self._replay_safe_turn_items`` — wire the
+    # real static method onto the stand-in self so the rebuild actually runs.
+    fake_self = Mock()
+    fake_self._replay_safe_turn_items = ClaudeModel._replay_safe_turn_items
+    await ClaudeModel._persist_failed_turn(fake_self, frame_locals, RuntimeError("boom"))
+    items = session.add_items.await_args.args[0]
+    # Completed tool round preserved, ends on an appended assistant placeholder.
+    assert _tool_use_msg("t1") in items
+    assert items[-1]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
 async def test_persist_failed_turn_skips_when_already_persisted():
     """The success path already committed the turn; the failure path must not
     double-write."""
@@ -438,3 +484,71 @@ async def test_persist_failed_turn_swallows_persist_errors():
     await ClaudeModel._persist_failed_turn(Mock(), frame_locals, ValueError("original"))
     # ...while still having attempted the persist exactly once.
     session.add_items.assert_awaited_once()
+
+
+def _tool_use_msg(tool_id="toolu_1"):
+    return {"role": "assistant", "content": [{"type": "tool_use", "id": tool_id, "name": "execute_sql", "input": {}}]}
+
+
+def _tool_result_msg(tool_id="toolu_1"):
+    return {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tool_id, "content": "ok"}]}
+
+
+def test_replay_safe_turn_items_preserves_completed_rounds():
+    """A finished turn (user → tool_use → tool_result → assistant text) is kept
+    verbatim and ends on the assistant message."""
+    user = _user_msg()
+    final = {"role": "assistant", "content": [{"type": "text", "text": "done"}]}
+    turn = [user, _tool_use_msg(), _tool_result_msg(), final]
+    items = ClaudeModel._replay_safe_turn_items(turn, user, "fallback")
+    assert items == turn
+    assert items[-1]["role"] == "assistant"
+
+
+def test_replay_safe_turn_items_drops_dangling_tool_use():
+    """A trailing assistant tool_use with no matching tool_result is dropped, and
+    a non-empty fallback assistant message is appended."""
+    user = _user_msg()
+    turn = [user, _tool_use_msg("toolu_x")]
+    items = ClaudeModel._replay_safe_turn_items(turn, user, "interrupted")
+    assert len(items) == 2
+    assert items[0] == user
+    assert items[1] == {"role": "assistant", "content": [{"type": "text", "text": "interrupted"}]}
+
+
+def test_replay_safe_turn_items_appends_fallback_when_ends_on_user():
+    """A history that ends on a user/tool_result message gets an assistant
+    fallback appended so it never collides with the next turn's user message."""
+    user = _user_msg()
+    answered_use = _tool_use_msg("toolu_1")
+    result = _tool_result_msg("toolu_1")
+    items = ClaudeModel._replay_safe_turn_items([user, answered_use, result], user, "placeholder")
+    assert items[-1] == {"role": "assistant", "content": [{"type": "text", "text": "placeholder"}]}
+    # The answered tool_use round is preserved (not dropped).
+    assert answered_use in items
+
+
+def test_replay_safe_turn_items_empty_falls_back_to_user_plus_assistant():
+    """When everything is dropped, the user message plus a fallback assistant
+    message are restored so the turn is never lost."""
+    user = _user_msg()
+    items = ClaudeModel._replay_safe_turn_items([_tool_use_msg("toolu_x")], user, "")
+    assert items[0] == user
+    assert items[-1] == {"role": "assistant", "content": [{"type": "text", "text": "[empty turn]"}]}
+
+
+def test_replay_safe_turn_items_skips_non_dict_entries():
+    """Non-dict entries in the raw turn slice are filtered out."""
+    user = _user_msg()
+    final = {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}
+    items = ClaudeModel._replay_safe_turn_items([user, "garbage", None, final], user, "fb")
+    assert items == [user, final]
+
+
+def test_replay_safe_turn_items_tolerates_non_list_assistant_content():
+    """A trailing assistant message whose content is a plain string (not a block
+    list) is treated as having no dangling tool_use and kept as-is."""
+    user = _user_msg()
+    final = {"role": "assistant", "content": "plain string reply"}
+    items = ClaudeModel._replay_safe_turn_items([user, final], user, "fb")
+    assert items == [user, final]

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -718,6 +718,37 @@ def _make_tool_use_block(name="read_query", block_id="tool_1", input_data=None):
     return block
 
 
+def _make_server_tool_use_block(block_id="srv_1", name="web_search", input_data=None):
+    """A server_tool_use block whose model_dump carries an output-only
+    ``citations`` field (as the streaming accumulator attaches it)."""
+    block = MagicMock()
+    block.type = "server_tool_use"
+    block.id = block_id
+    block.name = name
+    block.input = input_data or {"query": "datus"}
+    block.model_dump = lambda mode="json": {
+        "type": "server_tool_use",
+        "id": block_id,
+        "name": name,
+        "input": block.input,
+        "citations": None,
+    }
+    return block
+
+
+def _make_web_search_result_block(tool_use_id="srv_1"):
+    block = MagicMock()
+    block.type = "web_search_tool_result"
+    block.tool_use_id = tool_use_id
+    block.model_dump = lambda mode="json": {
+        "type": "web_search_tool_result",
+        "tool_use_id": tool_use_id,
+        "content": [{"type": "web_search_result", "title": "t", "url": "https://x"}],
+        "cache_control": {"type": "ephemeral"},
+    }
+    return block
+
+
 def _make_response(content_blocks, input_tokens=100, output_tokens=50):
     response = MagicMock()
     response.content = content_blocks
@@ -761,6 +792,56 @@ class TestGenerateWithMcpStream:
         assert actions[0].action_type == "final_response"
         assert actions[0].status == ActionStatus.SUCCESS
         assert "hello world" in actions[0].output["raw_output"]
+
+    @pytest.mark.asyncio
+    async def test_web_search_only_turn_persists_sanitized_server_blocks(self):
+        """A web_search-only completion (no local tool_use) must enable the
+        server-side web_search tool and persist its sanitized server_tool_use /
+        web_search_tool_result blocks into the session on the break path."""
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        message_blocks = [
+            _make_server_tool_use_block("srv_1"),
+            _make_web_search_result_block("srv_1"),
+            _make_text_block("Here is what I found."),
+        ]
+        model.anthropic_client.messages.create.return_value = _make_response(message_blocks)
+
+        session = AsyncMock()
+        ahm = ActionHistoryManager()
+        captured_tools = {}
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt="search the web",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                builtin_web_tools={"web_search": True, "web_fetch": True},
+                session=session,
+                action_history_manager=ahm,
+            ):
+                pass
+            captured_tools = model.anthropic_client.messages.create.call_args.kwargs.get("tools", [])
+
+        # The hosted web_search tool is enabled; the local-only web_fetch is NOT.
+        tool_types = {t.get("type") for t in captured_tools if isinstance(t, dict)}
+        assert "web_search_20250305" in tool_types
+        assert "web_fetch_20250910" not in tool_types
+
+        # The persisted assistant message keeps the sanitized server blocks
+        # (citations / cache_control stripped to the input schema).
+        session.add_items.assert_awaited()
+        persisted = session.add_items.await_args.args[0]
+        assistant_blocks = [b for m in persisted if m["role"] == "assistant" for b in m["content"]]
+        srv = next(b for b in assistant_blocks if b.get("type") == "server_tool_use")
+        assert set(srv) == {"type", "id", "name", "input"}
+        result = next(b for b in assistant_blocks if b.get("type") == "web_search_tool_result")
+        assert set(result) == {"type", "tool_use_id", "content"}
 
     @pytest.mark.asyncio
     async def test_tool_call_yields_processing_and_success(self):

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1349,6 +1349,207 @@ class TestGetSessionMessages:
         assert assistant_groups, "Anthropic-format assistant turn missing from resume payload"
         assert assistant_groups[0]["content"] == "Hi! 👋 Welcome to Datus."
 
+    def test_native_tool_use_and_result_resume(self, sm):
+        """Claude-native ``tool_use`` blocks and their ``tool_result`` user reply
+        are restored into the assistant group (not flushed as a user bubble).
+
+        Covers the resume dispatch for ``tool_use`` inside assistant content and
+        a ``tool_result``-only user message paired back to its in-flight call.
+        """
+        session_id = f"test_native_tool_{uuid.uuid4().hex[:8]}"
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (session_id,))
+            rows = [
+                (
+                    json.dumps({"role": "user", "content": [{"type": "text", "text": "count rows"}]}),
+                    "2026-05-21T00:00:00",
+                ),
+                (
+                    json.dumps(
+                        {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "Let me query."},
+                                {
+                                    "type": "tool_use",
+                                    "id": "toolu_1",
+                                    "name": "execute_sql",
+                                    "input": {"sql": "SELECT COUNT(*) FROM t"},
+                                },
+                            ],
+                        }
+                    ),
+                    "2026-05-21T00:00:01",
+                ),
+                (
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": "toolu_1",
+                                    "content": [{"type": "text", "text": "{'rows': 30000}"}],
+                                }
+                            ],
+                        }
+                    ),
+                    "2026-05-21T00:00:02",
+                ),
+                (
+                    json.dumps({"role": "assistant", "content": [{"type": "text", "text": "There are 30000 rows."}]}),
+                    "2026-05-21T00:00:03",
+                ),
+            ]
+            conn.executemany(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                [(session_id, data, ts) for data, ts in rows],
+            )
+            conn.commit()
+
+        messages = sm.get_session_messages(session_id)
+
+        # The tool_result-only user message must NOT surface as a user bubble.
+        user_messages = [m for m in messages if m["role"] == "user"]
+        assert len(user_messages) == 1
+        assert user_messages[0]["content"] == "count rows"
+
+        assistant_groups = [m for m in messages if m["role"] == "assistant"]
+        assert assistant_groups
+        actions = assistant_groups[0].get("actions", [])
+        # A PROCESSING tool_use action and its paired SUCCESS result.
+        tool_call = next(a for a in actions if a.action_id == "toolu_1")
+        assert tool_call.action_type == "execute_sql"
+        complete = next(a for a in actions if a.action_id == "complete_toolu_1")
+        assert complete.status == ActionStatus.SUCCESS
+        assert complete.output == {"rows": 30000}
+
+    def test_native_server_web_tool_result_resume(self, sm):
+        """A ``server_tool_use`` block plus inline ``web_search_tool_result`` in
+        the same assistant message restore a tool call and its result."""
+        session_id = f"test_native_web_{uuid.uuid4().hex[:8]}"
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (session_id,))
+            assistant_msg = {
+                "role": "assistant",
+                "content": [
+                    {"type": "server_tool_use", "id": "srv_1", "name": "web_search", "input": {"query": "datus"}},
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srv_1",
+                        "content": [{"type": "text", "text": "search hits"}],
+                    },
+                    {"type": "text", "text": "Found it."},
+                ],
+            }
+            conn.execute(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                (
+                    session_id,
+                    json.dumps({"role": "user", "content": [{"type": "text", "text": "search"}]}),
+                    "2026-05-21T00:00:00",
+                ),
+            )
+            conn.execute(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                (session_id, json.dumps(assistant_msg), "2026-05-21T00:00:01"),
+            )
+            conn.commit()
+
+        messages = sm.get_session_messages(session_id)
+        assistant_groups = [m for m in messages if m["role"] == "assistant"]
+        assert assistant_groups
+        actions = assistant_groups[0].get("actions", [])
+        srv_call = next(a for a in actions if a.action_id == "srv_1")
+        assert srv_call.action_type == "web_search"
+        assert any(a.action_id == "complete_srv_1" and a.status == ActionStatus.SUCCESS for a in actions)
+
+
+class TestNativeToolHelpers:
+    """Direct unit tests for SessionManager native-tool restore helpers."""
+
+    def test_restore_native_tool_call_builds_processing_action(self, sm):
+        actions: list = []
+        progress: list = []
+        sm._restore_native_tool_call(
+            {"id": "t1", "name": "execute_sql", "input": {"sql": "SELECT 1"}},
+            actions,
+            progress,
+            "2026-05-21T00:00:00",
+        )
+        assert len(actions) == 1
+        assert actions[0].action_id == "t1"
+        assert actions[0].status == ActionStatus.PROCESSING
+        assert actions[0].input["arguments"] == json.dumps({"sql": "SELECT 1"}, ensure_ascii=False)
+        assert progress and progress[0].startswith("✓ Tool call: execute_sql")
+
+    def test_restore_native_tool_call_unserializable_input_defaults_to_empty(self, sm):
+        """A tool input that json.dumps cannot serialize falls back to ``"{}"``
+        instead of crashing the resume."""
+
+        class _Unserializable:
+            pass
+
+        actions: list = []
+        sm._restore_native_tool_call(
+            {"id": "t1", "name": "fetch", "input": {"bad": _Unserializable()}},
+            actions,
+            [],
+            None,
+        )
+        assert actions[0].input["arguments"] == "{}"
+
+    def test_restore_native_tool_call_string_input_and_defaults(self, sm):
+        """A pre-serialized string input is kept verbatim; missing id/created_at
+        fall back to a generated uuid and now()."""
+        actions: list = []
+        sm._restore_native_tool_call({"input": "raw-args"}, actions, [], None)
+        assert actions[0].action_type == "unknown"
+        assert actions[0].input["arguments"] == "raw-args"
+        assert actions[0].action_id  # generated uuid
+
+    def test_attach_native_tool_result_pairs_by_id(self, sm):
+        actions: list = []
+        sm._restore_native_tool_call({"id": "t1", "name": "fetch", "input": {}}, actions, [], None)
+        sm._attach_native_tool_result(actions, "t1", [{"type": "text", "text": "{'k': 1}"}], None)
+        complete = actions[-1]
+        assert complete.action_id == "complete_t1"
+        assert complete.status == ActionStatus.SUCCESS
+        assert complete.output == {"k": 1}
+
+    def test_attach_native_tool_result_falls_back_to_recent_when_no_id(self, sm):
+        actions: list = []
+        sm._restore_native_tool_call({"id": "t1", "name": "fetch", "input": {}}, actions, [], None)
+        sm._attach_native_tool_result(actions, None, "plain string result", None)
+        complete = actions[-1]
+        assert complete.action_id == "complete_t1"
+        assert complete.output == {"result": "plain string result"}
+
+    def test_attach_native_tool_result_noop_without_actions(self, sm):
+        actions: list = []
+        sm._attach_native_tool_result(actions, "t1", "x", None)
+        assert actions == []
+
+    def test_attach_native_tool_result_noop_when_no_match(self, sm):
+        """An id with no matching PROCESSING action appends nothing."""
+        actions: list = []
+        sm._restore_native_tool_call({"id": "t1", "name": "fetch", "input": {}}, actions, [], None)
+        sm._attach_native_tool_result(actions, "nonexistent", "x", None)
+        assert len(actions) == 1  # only the original tool_use
+
+    def test_attach_native_tool_result_serializes_dict_content(self, sm):
+        """Non-list, non-str content is JSON-dumped before parsing."""
+        actions: list = []
+        sm._restore_native_tool_call({"id": "t1", "name": "fetch", "input": {}}, actions, [], None)
+        sm._attach_native_tool_result(actions, "t1", {"nested": "value"}, None)
+        assert actions[-1].output == {"nested": "value"}
+
 
 # ===========================================================================
 # TestParseOutputFromAction (migrated from test_session_loader.py)


### PR DESCRIPTION
## Why

Three related defects in the Claude-native (Anthropic SDK) path:

1. The hosted `web_fetch_20250910` tool emits `server_tool_use` blocks whose rehydrated form carries an output-only `citations` field. The Anthropic message **input** schema rejects that field on replay, so a follow-up turn fails with a 400.
2. Replayed `web_search` server blocks (`server_tool_use` / `web_search_tool_result`) likewise carry output-only keys (`cache_control`, `citations`) that the input schema does not accept, breaking multi-turn replay.
3. On **session resume**, `tool_use` / `server_tool_use` blocks and their `tool_result` replies were not reconstructed: the native loop persisted only the final text, so resumed transcripts split the assistant group on every tool round and rendered empty user bubbles, and tool calls leaked into text.

## Solution

- **web_fetch local backend**: `ClaudeModel.supports_builtin_web_fetch()` stays `False`, so the node mounts the local `web_tool.web_fetch`. `web_search` continues to run server-side (Anthropic `web_search_20250305`, GA).
- **Replay sanitizer**: `sanitize_server_block_for_replay()` whitelists only input-schema keys when rebuilding the assistant message — `server_tool_use` → `{type,id,name,input}`, `web_search_tool_result` → `{type,tool_use_id,content}`, unknown types dumped verbatim, unserializable blocks skipped.
- **Full structured-turn persistence**: persist every `tool_use` block and matching `tool_result` via `_replay_safe_turn_items` (which drops a trailing dangling `tool_use` and guarantees the history ends on a non-empty assistant message) instead of only `final_content`. The failed-turn path (`_persist_failed_turn`) reuses the same helper so interrupted turns survive replay.
- **Resume reconstruction** (`session_manager.py`): native `tool_use` / `server_tool_use` blocks are restored into the assistant group, and a `user` message that carries only `tool_result` blocks is attached to its in-flight `tool_use` action rather than flushed as a user bubble.

## Test Cases

Added unit tests in `tests/unit_tests/models/test_builtin_web_tools.py`:
- `test_claude_search_server_fetch_local` — capability truth table (search server-side, fetch local).
- `test_sanitize_server_block_*` — strips `citations` from `server_tool_use`, whitelists `web_search_tool_result`, verbatim fallback for unknown types, `None` when unserializable.
- `test_summarize_web_tool_result_*` — title/content extraction and missing-input handling.
- `test_persist_failed_turn_*` — interrupted turns persist user + non-empty placeholder/partial assistant, skip when already persisted, no-op without session, and swallow persist errors.

Hosted-tool injection and end-to-end resume against real APIs remain covered by existing nightly suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI message replay by sanitizing server-generated tool blocks to match expected input formats and avoid “extra inputs” errors.
  * Enhanced mid-turn failure handling to persist the user message and a safe placeholder (and avoid double-writes).
  * Strengthened transcript resume by restoring native tool calls and attaching tool results for Claude-native and web tools.

* **New Features**
  * Added support for reconstructing Claude-native tool call/result flows when resuming sessions.

* **Tests**
  * Expanded unit coverage for tool-block sanitization and failure persistence scenarios, and updated web tool capability expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
