### PR TITLE
[Enhancement] Render permission-request tool args as readable markdown, no truncation

### DIFF
--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -32,6 +32,7 @@ from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
 from datus.tools.permission.permission_config import PermissionLevel
 from datus.tools.registry.tool_registry import ToolRegistry
 from datus.utils.constants import SQLType
+from datus.utils.json_utils import to_pretty_str
 
 if TYPE_CHECKING:
     from datus.tools.permission.permission_manager import PermissionManager
@@ -92,6 +93,50 @@ def _get_permission_prompt_lock(broker: Any = None) -> asyncio.Lock:
         lock = asyncio.Lock()
         _loop_fallback_locks[loop] = lock
     return lock
+
+
+# Scalar strings at or below this length (and free of newlines) render inline on
+# the key line; anything longer moves into a fenced code block so the TUI's
+# syntax highlighting + scroll/pager handle it instead of cramming it onto one
+# line. Nothing is truncated — the InteractionApp already pages long content
+# (Shift+Up/Down) and opens it in a pager (``v``).
+_INLINE_ARG_MAX = 80
+
+
+def _format_tool_args_markdown(args: dict) -> str:
+    """Render tool arguments as a readable markdown key/value block.
+
+    Replaces the old single-line ``json.dumps`` + hard 200-char truncation,
+    which mangled nested structures and cut SQL mid-statement. Rendering rules:
+
+    * Scalars (short strings, ints, floats, bools, ``None``) render inline as
+      ``**key:** `value` ``.
+    * The ``sql`` argument and any multi-line / long string render in a fenced
+      code block — ``sql`` for the SQL argument (so it is highlighted),
+      language-less otherwise.
+    * ``dict`` / ``list`` values render as pretty (2-space) JSON in a ```json
+      block.
+
+    Each argument is emitted as its own top-level paragraph / code block rather
+    than nested under a list item, so ``RichMarkdown`` renders the fenced blocks
+    unambiguously. Nothing is truncated.
+
+    Returns an empty string for empty ``args`` so callers can skip the section.
+    """
+    if not args:
+        return ""
+
+    parts: List[str] = ["", "**Arguments**", ""]
+    for key, value in args.items():
+        if isinstance(value, (dict, list)):
+            pretty = to_pretty_str(value) or "{}"
+            parts.extend([f"**{key}:**", "", "```json", pretty, "```", ""])
+        elif isinstance(value, str) and ("\n" in value or len(value) > _INLINE_ARG_MAX):
+            lang = "sql" if key == "sql" else ""
+            parts.extend([f"**{key}:**", "", f"```{lang}", value, "```", ""])
+        else:
+            parts.append(f"**{key}:** `{value}`")
+    return "\n".join(parts)
 
 
 class PermissionDeniedException(Exception):
@@ -845,12 +890,12 @@ class PermissionHooks(AgentHooks):
 
         content = f"### Permission Request\n\n**Tool:** `{category}.{pattern_name}`\n"
 
-        # Show tool arguments if available (truncate long args)
-        if args:
-            args_str = json.dumps(args, ensure_ascii=False)
-            if len(args_str) > 200:
-                args_str = args_str[:197] + "..."
-            content += f"\n**Args:** `{args_str}`\n"
+        # Show tool arguments as a readable key/value block. Long SQL / nested
+        # values land in fenced code blocks (never truncated); the TUI pages and
+        # opens them in a pager.
+        args_md = _format_tool_args_markdown(args)
+        if args_md:
+            content += args_md + "\n"
 
         try:
             answers = await self.broker.request(

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -1764,3 +1764,118 @@ class TestExecuteSqlPermission:
         # A DDL (different type again) → prompts once more.
         await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
         assert mock_broker.request.await_count == 3
+
+
+class TestFormatToolArgsMarkdown:
+    """Unit tests for the ``_format_tool_args_markdown`` rendering helper.
+
+    Replaces the old single-line ``json.dumps`` + 200-char truncation: scalars
+    render inline, the ``sql`` arg / long strings move into fenced code blocks,
+    and nested structures render as pretty JSON — never truncated.
+    """
+
+    @staticmethod
+    def _fmt(args):
+        return permission_hooks_module._format_tool_args_markdown(args)
+
+    def test_empty_args_returns_empty_string(self):
+        """Empty args produce no markdown so callers can skip the section."""
+        assert self._fmt({}) == ""
+
+    def test_scalars_render_inline(self):
+        """Short scalars render inline as ``**key:** `value``` with no code fence."""
+        out = self._fmt({"database": "sales", "limit": 10, "dry_run": True, "note": None})
+        assert "**database:** `sales`" in out
+        assert "**limit:** `10`" in out
+        assert "**dry_run:** `True`" in out
+        assert "**note:** `None`" in out
+        assert "```" not in out
+        # Section header is present.
+        assert "**Arguments**" in out
+
+    def test_sql_arg_uses_sql_fence_and_is_not_truncated(self):
+        """The ``sql`` argument lands in a ```sql block with its full text."""
+        long_sql = "INSERT INTO orders (id, amount) VALUES " + ", ".join(f"({i}, {i * 1.5})" for i in range(50))
+        assert len(long_sql) > 200  # would have been truncated by the old code
+        out = self._fmt({"sql": long_sql})
+        assert "```sql" in out
+        assert long_sql in out  # full statement preserved
+        assert "..." not in out  # no truncation marker
+
+    def test_long_non_sql_string_uses_plain_fence(self):
+        """A long/multi-line non-sql string goes into a language-less fence."""
+        text = "line one\nline two\nline three"
+        out = self._fmt({"body": text})
+        assert "**body:**" in out
+        assert "```\n" in out  # language-less fence opener
+        assert "```sql" not in out
+        assert text in out
+
+    def test_nested_value_renders_pretty_json(self):
+        """dict/list values render as multi-line pretty JSON in a ```json block."""
+        nested = {"filters": {"region": {"in": ["us", "eu"]}}, "cols": ["a", "b"]}
+        out = self._fmt(nested)
+        assert "```json" in out
+        # Pretty-printed (indented, multi-line), not a single compact line.
+        assert "\n  " in out
+        # Deeply nested content is preserved.
+        assert '"region"' in out
+        assert '"in"' in out
+
+    def test_short_string_at_threshold_stays_inline(self):
+        """A string at the inline boundary is not forced into a code fence."""
+        value = "x" * permission_hooks_module._INLINE_ARG_MAX
+        out = self._fmt({"k": value})
+        assert f"**k:** `{value}`" in out
+        assert "```" not in out
+
+
+class TestPermissionPromptContent:
+    """End-to-end check that ``_request_user_confirmation`` builds rich content."""
+
+    def _make_hooks(self, mock_broker):
+        manager = PermissionManager(global_config=PermissionConfig())
+        return PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=ToolRegistry(),
+        )
+
+    @staticmethod
+    def _ctx(args):
+        import json
+
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps(args)
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_content_includes_sql_block_without_truncation(self, mock_broker):
+        """The InteractionEvent content carries a full, highlighted SQL block."""
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+        hooks = self._make_hooks(mock_broker)
+        long_sql = "INSERT INTO orders VALUES " + ", ".join(f"({i})" for i in range(60))
+
+        approved = await hooks._request_user_confirmation(
+            "db_tools", "execute_sql.insert", self._ctx({"sql": long_sql})
+        )
+
+        assert approved is True
+        event = mock_broker.request.call_args.args[0][0]
+        assert "```sql" in event.content
+        assert long_sql in event.content  # not truncated
+        assert "..." not in event.content
+
+    @pytest.mark.asyncio
+    async def test_content_has_no_arguments_section_when_args_empty(self, mock_broker):
+        """With no args, the content omits the Arguments section entirely."""
+        mock_broker.request = AsyncMock(return_value=[["n"]])
+        hooks = self._make_hooks(mock_broker)
+
+        approved = await hooks._request_user_confirmation("skills", "deep-analysis", self._ctx({}))
+
+        assert approved is False
+        event = mock_broker.request.call_args.args[0][0]
+        assert "**Arguments**" not in event.content
+        assert "Permission Request" in event.content


### PR DESCRIPTION
## Why

The permission-request prompt rendered tool arguments with a single-line `json.dumps` followed by a hard 200-char truncation. This mangled nested structures and cut SQL mid-statement, so the user approving a tool call could not actually see what they were approving.

## Solution

Replace the one-line dump + truncation with `_format_tool_args_markdown()`, which renders each argument as its own top-level markdown block:

- Scalars (short strings, ints, floats, bools, `None`) render inline as `**key:** \`value\``.
- The `sql` argument and any multi-line / long (`> 80` char) string render in a fenced code block — ` ```sql ` for the SQL arg (so the TUI highlights it), language-less otherwise.
- `dict` / `list` values render as pretty 2-space JSON in a ` ```json ` block.

Nothing is truncated — the `InteractionApp` already pages long content (Shift+Up/Down) and opens it in a pager (`v`). Each argument is emitted as its own paragraph/code block rather than nested under a list item, so `RichMarkdown` renders the fenced blocks unambiguously.

## Test Cases

Added `TestPermissionPromptContent` cases in `tests/unit_tests/tools/permission/test_permission_hooks.py`:
- SQL arguments render in a fenced `sql` block without truncation.
- Long/multi-line strings move into fenced blocks; short scalars stay inline.
- Nested dict/list values render as pretty JSON.
- No `Arguments` section is emitted when `args` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission prompts now display tool arguments more clearly, including full SQL formatting and structured JSON for complex values.
  * Long argument values are no longer truncated in approval messages, improving review accuracy.
  * Empty tool arguments are now omitted from permission prompts instead of showing an unnecessary section.

* **Tests**
  * Added coverage for the new permission prompt formatting behavior and argument display rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->