### PR TITLE
[BugFix] Gate OpenAI hosted web_search on the Responses API route

### DIFF
--- a/datus/models/openai_model.py
+++ b/datus/models/openai_model.py
@@ -28,9 +28,14 @@ class OpenAIModel(OpenAICompatibleModel):
         super().__init__(model_config, **kwargs)
 
     def supports_builtin_web_search(self) -> bool:
-        # OpenAI Responses API exposes a hosted ``web_search`` tool (works with a
-        # standard API key, billed per call). Prefer it over the local Tavily backend.
-        return True
+        # The hosted ``web_search`` tool is ONLY accepted by the OpenAI Responses
+        # API. ``get_agents_sdk_model`` routes through ``OpenAIResponsesModel``
+        # solely for the canonical ``api.openai.com`` endpoint; a custom base_url
+        # (vLLM, OpenRouter relay, Coding Plan proxy, …) falls back to the LiteLLM
+        # ChatCompletions path, which rejects hosted tools with a ``UserError``.
+        # Gate on the real route so we never inject ``WebSearchTool`` into a
+        # ChatCompletions request — those endpoints use the local Tavily backend.
+        return self.litellm_adapter._is_official_openai()
 
     def supports_builtin_web_fetch(self) -> bool:
         # OpenAI Responses has no hosted fetch tool; web_fetch uses the local backend.

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -36,11 +36,24 @@ def test_codex_search_yes_fetch_no():
     assert CodexModel.supports_builtin_web_fetch(s) is False
 
 
-def test_openai_search_yes_fetch_no():
-    s = Mock()
-    # API-key OpenAI also uses the Responses hosted web_search; no hosted fetch.
-    assert OpenAIModel.supports_builtin_web_search(s) is True
-    assert OpenAIModel.supports_builtin_web_fetch(s) is False
+def test_openai_search_yes_only_on_official_endpoint():
+    # The hosted web_search tool is only accepted by the Responses API, which
+    # ``get_agents_sdk_model`` routes to ONLY for the canonical OpenAI host.
+    # supports_builtin_web_search must mirror that route exactly, otherwise the
+    # node injects WebSearchTool into a LiteLLM ChatCompletions request and the
+    # converter raises ``Hosted tools are not supported with the ChatCompletions
+    # API``.
+    official = Mock()
+    official.litellm_adapter._is_official_openai.return_value = True
+    assert OpenAIModel.supports_builtin_web_search(official) is True
+    assert OpenAIModel.supports_builtin_web_fetch(official) is False
+
+    # provider=openai but a custom base_url (vLLM / OpenRouter relay / Coding
+    # Plan proxy) → LiteLLM ChatCompletions path → hosted tool must be OFF.
+    proxy = Mock()
+    proxy.litellm_adapter._is_official_openai.return_value = False
+    assert OpenAIModel.supports_builtin_web_search(proxy) is False
+    assert OpenAIModel.supports_builtin_web_fetch(proxy) is False
 
 
 def test_claude_enables_both():


### PR DESCRIPTION
## Why

A chat turn crashes with:

```
agents.exceptions.UserError: Hosted tools are not supported with the ChatCompletions API.
Got tool type: <class 'agents.tool.WebSearchTool'>
```

`OpenAIModel.supports_builtin_web_search()` returned `True` unconditionally, but the hosted `WebSearchTool` is **only** accepted by the OpenAI Responses API. `litellm_adapter.get_agents_sdk_model()` routes to `OpenAIResponsesModel` solely for the canonical `api.openai.com` endpoint; a custom `base_url` (vLLM, OpenRouter relay, Coding Plan proxy, self-hosted gateway) falls back to the LiteLLM ChatCompletions path. The node still saw `supports_builtin_web_search() == True`, suppressed the local `web_tool.web_search`, and injected `WebSearchTool` into a ChatCompletions request, whose converter raises the `UserError` above and fails the whole turn.

## Solution

Gate the capability on the real route: `supports_builtin_web_search()` now returns `self.litellm_adapter._is_official_openai()`. Non-official endpoints fall back to the local Tavily `web_tool.web_search` backend instead of injecting a hosted tool the transport cannot serve. The official OpenAI path is unchanged.

## Test Cases

Updated `test_builtin_web_tools.py::test_openai_search_yes_only_on_official_endpoint` to pin the contract on both sides of the route:
- official endpoint (`_is_official_openai() == True`) → hosted `web_search` enabled, no hosted fetch;
- custom base_url proxy (`_is_official_openai() == False`) → hosted `web_search` **off** (local backend used).

Hosted-tool injection against the real Responses API remains covered by existing nightly suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Built-in web search is now only offered when using the official OpenAI endpoint, preventing it from appearing in unsupported routes.
  * Continued to keep built-in web fetch unavailable in all cases, matching current behavior.
  * Improved handling for proxy or relay configurations so they rely on the appropriate local search backend instead of hosted tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->