### PR TITLE
[BugFix] Suppress LiteLLM console logs in CLI

### DIFF
--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -38,7 +38,7 @@ from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY, looks_like_failure
 from datus.utils.constants import LLMProvider
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_str
-from datus.utils.loggings import get_logger
+from datus.utils.loggings import configure_litellm_logging, get_logger
 from datus.utils.resource_utils import read_data_file_text
 from datus.utils.text_utils import LitellmPlaceholderStreamFilter, strip_litellm_placeholder
 from datus.utils.trace_context import build_agents_run_config_kwargs, build_trace_span_attributes
@@ -93,6 +93,7 @@ litellm.set_verbose = False
 # Suppress "Provider List: ..." debug prints to stdout when LiteLLM encounters
 # model names not in its built-in list (e.g. Coding Plan models like kimi-for-coding)
 litellm.suppress_debug_info = True
+configure_litellm_logging()
 
 # Module-level cache for model specs loaded from conf/providers.yml
 _MODEL_SPECS_CACHE: Optional[Dict[str, Dict[str, int]]] = None

--- a/datus/utils/loggings.py
+++ b/datus/utils/loggings.py
@@ -17,6 +17,8 @@ from rich.console import Console
 
 fileno = False
 
+_LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
+
 # Global log manager
 _log_manager = None
 
@@ -157,6 +159,19 @@ def get_log_manager(
     return _log_manager
 
 
+def configure_litellm_logging(file_handler: Optional[logging.Handler] = None) -> None:
+    """Route LiteLLM's verbose loggers away from the interactive console."""
+    if file_handler is None and _log_manager is not None:
+        file_handler = _log_manager.file_handler
+
+    for logger_name in _LITELLM_LOGGER_NAMES:
+        logger = logging.getLogger(logger_name)
+        logger.handlers.clear()
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        logger.addHandler(file_handler if file_handler is not None else logging.NullHandler())
+
+
 def configure_logging(
     debug=False,
     log_dir=None,
@@ -193,13 +208,11 @@ def configure_logging(
         agent_config=agent_config,
     )
 
-    # Configure LiteLLM logger to output to file only (not console)
-    # This prevents noisy "LiteLLM completion() model=..." messages from appearing in console
-    litellm_logger = logging.getLogger("LiteLLM")
-    litellm_logger.handlers.clear()  # Remove default handlers
-    litellm_logger.addHandler(_log_manager.file_handler)  # Only output to file
-    litellm_logger.propagate = False  # Don't propagate to root logger
-    litellm_logger.setLevel(logging.INFO)  # Keep INFO level for file logging
+    try:
+        import litellm  # noqa: F401
+    except Exception:
+        pass
+    configure_litellm_logging(_log_manager.file_handler)
 
     # Set output target based on console_output parameter
     if console_output:

--- a/datus/utils/loggings.py
+++ b/datus/utils/loggings.py
@@ -210,7 +210,7 @@ def configure_logging(
 
     try:
         import litellm  # noqa: F401
-    except Exception:
+    except ModuleNotFoundError:
         pass
     configure_litellm_logging(_log_manager.file_handler)
 

--- a/tests/unit_tests/utils/test_loggings.py
+++ b/tests/unit_tests/utils/test_loggings.py
@@ -385,14 +385,15 @@ class TestConfigureLogging:
 
         assert Path(mgr.log_dir) == path_manager.logs_dir
 
-    def test_configure_logging_routes_litellm_to_file_only(self, tmp_path, capsys):
+    @pytest.mark.parametrize("logger_name", ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"))
+    def test_configure_logging_routes_litellm_to_file_only(self, tmp_path, capsys, logger_name):
         from datus.utils.loggings import configure_logging
 
         mgr = configure_logging(console_output=False, log_dir=str(tmp_path / "logs"))
         import litellm  # noqa: F401
 
-        msg = "LiteLLM completion() model= test-model; provider = test-provider"
-        litellm_logger = logging.getLogger("LiteLLM")
+        msg = f"{logger_name} completion() model= test-model; provider = test-provider"
+        litellm_logger = logging.getLogger(logger_name)
         capsys.readouterr()
         litellm_logger.info(msg)
         for handler in litellm_logger.handlers:
@@ -403,18 +404,19 @@ class TestConfigureLogging:
         assert msg not in captured.err
         assert msg in Path(mgr.file_handler.baseFilename).read_text(encoding="utf-8")
 
-    def test_configure_litellm_logging_removes_late_console_handler(self, tmp_path, capsys):
+    @pytest.mark.parametrize("logger_name", ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"))
+    def test_configure_litellm_logging_removes_late_console_handler(self, tmp_path, capsys, logger_name):
         from datus.utils.loggings import configure_litellm_logging, configure_logging
 
         mgr = configure_logging(console_output=False, log_dir=str(tmp_path / "logs"))
-        litellm_logger = logging.getLogger("LiteLLM")
+        litellm_logger = logging.getLogger(logger_name)
         late_console_handler = logging.StreamHandler(sys.stdout)
         late_console_handler.setFormatter(logging.Formatter("%(message)s"))
         litellm_logger.addHandler(late_console_handler)
 
         configure_litellm_logging()
 
-        msg = "LiteLLM completion() model= late-import; provider = test-provider"
+        msg = f"{logger_name} completion() model= late-import; provider = test-provider"
         capsys.readouterr()
         litellm_logger.info(msg)
         for handler in litellm_logger.handlers:

--- a/tests/unit_tests/utils/test_loggings.py
+++ b/tests/unit_tests/utils/test_loggings.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -383,6 +384,47 @@ class TestConfigureLogging:
             mgr = loggings_module.configure_logging(agent_config=agent_config, console_output=False)
 
         assert Path(mgr.log_dir) == path_manager.logs_dir
+
+    def test_configure_logging_routes_litellm_to_file_only(self, tmp_path, capsys):
+        from datus.utils.loggings import configure_logging
+
+        mgr = configure_logging(console_output=False, log_dir=str(tmp_path / "logs"))
+        import litellm  # noqa: F401
+
+        msg = "LiteLLM completion() model= test-model; provider = test-provider"
+        litellm_logger = logging.getLogger("LiteLLM")
+        capsys.readouterr()
+        litellm_logger.info(msg)
+        for handler in litellm_logger.handlers:
+            handler.flush()
+
+        captured = capsys.readouterr()
+        assert msg not in captured.out
+        assert msg not in captured.err
+        assert msg in Path(mgr.file_handler.baseFilename).read_text(encoding="utf-8")
+
+    def test_configure_litellm_logging_removes_late_console_handler(self, tmp_path, capsys):
+        from datus.utils.loggings import configure_litellm_logging, configure_logging
+
+        mgr = configure_logging(console_output=False, log_dir=str(tmp_path / "logs"))
+        litellm_logger = logging.getLogger("LiteLLM")
+        late_console_handler = logging.StreamHandler(sys.stdout)
+        late_console_handler.setFormatter(logging.Formatter("%(message)s"))
+        litellm_logger.addHandler(late_console_handler)
+
+        configure_litellm_logging()
+
+        msg = "LiteLLM completion() model= late-import; provider = test-provider"
+        capsys.readouterr()
+        litellm_logger.info(msg)
+        for handler in litellm_logger.handlers:
+            handler.flush()
+
+        captured = capsys.readouterr()
+        assert late_console_handler not in litellm_logger.handlers
+        assert msg not in captured.out
+        assert msg not in captured.err
+        assert msg in Path(mgr.file_handler.baseFilename).read_text(encoding="utf-8")
 
 
 class TestAddExcInfo:


### PR DESCRIPTION
## Summary
- Route LiteLLM verbose loggers (`LiteLLM`, `LiteLLM Router`, `LiteLLM Proxy`) to the Datus file handler instead of the interactive console.
- Re-apply LiteLLM logger isolation after the model path imports LiteLLM, covering import-time default StreamHandlers.
- Add regression coverage for file-only LiteLLM logging and late console-handler removal.

## Root Cause
The CLI configures logging with console output disabled, but LiteLLM can be imported later by model code and attach its default StreamHandler at import time. Those INFO logs then leak into the TUI, showing messages such as `LiteLLM completion() model= ...` while subagents are running.

## Validation
- `python -m pytest tests/unit_tests/utils/test_loggings.py -q`
- `python -m pytest tests/unit_tests/models/test_openai_compatible.py -q`
- Smoke tested the real import order: stdout stayed clean while the LiteLLM INFO line was still written to the agent log file.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy LiteLLM logs from appearing in the interactive console.
  * Improved log routing so LiteLLM messages are sent to the configured log file instead of standard output when console logging is disabled.
  * Ensured existing LiteLLM handlers are cleaned up so duplicate or late-added console output does not leak through.

* **Tests**
  * Added coverage for LiteLLM log routing behavior and file logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy LiteLLM logs from appearing in the interactive console.
  * Improved log routing so LiteLLM messages are sent to the configured log file instead of standard output when console logging is disabled.
  * Ensured existing LiteLLM handlers are cleaned up so duplicate or late-added console output does not leak through.

* **Tests**
  * Added coverage for LiteLLM log routing behavior and file logging, including handler cleanup and output expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->