### PR TITLE
[Feature] emit retrieval hook + uid column for Hub consumption

### DIFF
--- a/datus/api/hooks/__init__.py
+++ b/datus/api/hooks/__init__.py
@@ -15,6 +15,14 @@ from datus.api.hooks.chat_hooks import (
     make_chat_hooks,
     set_chat_hooks,
 )
+from datus.api.hooks.metric_hooks import (
+    MetricRetrievalEvent,
+    MetricRetrievalHook,
+    RetrievalFn,
+    get_metric_retrieval_hook,
+    make_metric_retrieval_hook,
+    set_metric_retrieval_hook,
+)
 
 __all__ = [
     "ChatHooks",
@@ -25,4 +33,10 @@ __all__ = [
     "get_chat_hooks",
     "make_chat_hooks",
     "set_chat_hooks",
+    "MetricRetrievalEvent",
+    "MetricRetrievalHook",
+    "RetrievalFn",
+    "get_metric_retrieval_hook",
+    "make_metric_retrieval_hook",
+    "set_metric_retrieval_hook",
 ]

--- a/datus/api/hooks/metric_hooks.py
+++ b/datus/api/hooks/metric_hooks.py
@@ -1,0 +1,67 @@
+"""Metric-retrieval hook for hosts that embed datus-agent.
+
+``MetricRAG.search_metrics`` emits a :class:`MetricRetrievalEvent` after every
+search so a host (e.g. a SaaS wrapper) can count how often each Semantic Hub
+metric is consumed by chatbot / NL2SQL. The hook is optional and
+**fire-and-forget**: search never awaits it and swallows its errors, so a slow
+or failing host can never break retrieval.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
+
+
+@dataclass
+class MetricRetrievalEvent:
+    """One metric search and the metrics it returned.
+
+    ``metrics`` carries ``{"id", "name", "uid"}`` per hit; ``uid`` is the
+    Semantic Hub stable node id and is empty for metrics not governed by the Hub
+    (the host should ignore those when counting Hub consumption).
+    """
+
+    query_text: str
+    metrics: List[Dict[str, Any]]
+    datasource_id: Optional[str] = None
+    project_name: Optional[str] = None
+    sub_agent_name: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class MetricRetrievalHook(Protocol):
+    """Extension contract for counting metric retrieval consumption."""
+
+    def on_retrieval(self, event: MetricRetrievalEvent) -> None:
+        """Record a retrieval. Called fire-and-forget; must not raise."""
+        ...
+
+
+_metric_retrieval_hook: Optional[MetricRetrievalHook] = None
+
+
+def set_metric_retrieval_hook(hook: Optional[MetricRetrievalHook]) -> None:
+    """Register (or clear, with ``None``) the active metric-retrieval hook."""
+    global _metric_retrieval_hook
+    _metric_retrieval_hook = hook
+
+
+def get_metric_retrieval_hook() -> Optional[MetricRetrievalHook]:
+    """Return the active metric-retrieval hook, or ``None`` when unregistered."""
+    return _metric_retrieval_hook
+
+
+# Convenience factory for hosts that prefer a plain callable over a class.
+RetrievalFn = Callable[[MetricRetrievalEvent], None]
+
+
+def make_metric_retrieval_hook(on_retrieval: RetrievalFn) -> MetricRetrievalHook:
+    """Build a :class:`MetricRetrievalHook` from a single callable."""
+
+    class _LambdaHook:
+        def on_retrieval(self, event: MetricRetrievalEvent) -> None:
+            on_retrieval(event)
+
+    return _LambdaHook()

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1342,6 +1342,9 @@ class GenerationHooks(AgentHooks):
                         # Generated SQL from dry_run
                         "sql": metric_sqls.get(m_name, "") if metric_sqls else "",
                         "yaml_path": yaml_path_to_store,
+                        # Semantic Hub stable node id (empty when not Hub-governed),
+                        # used to count metric retrieval consumption per uid.
+                        "uid": locked_meta.get("uid", "") if locked_meta else "",
                     }
                     metric_objects.append(metric_obj)
                     synced_items.append(f"metric:{m_name}")

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -792,7 +792,9 @@ class MetricRAG:
                     datasource_id=self.datasource_id,
                     project_name=getattr(self.agent_config, "project_name", None),
                     sub_agent_name=self.sub_agent_name,
-                    metrics=[{"id": r.get("id"), "name": r.get("name"), "uid": r.get("uid")} for r in results],
+                    # uid is the contract's string field — normalize missing/null
+                    # to "" (empty = not Hub-governed) rather than forwarding None.
+                    metrics=[{"id": r.get("id"), "name": r.get("name"), "uid": r.get("uid") or ""} for r in results],
                 )
             )
         except Exception as exc:  # noqa: BLE001 — retrieval must never fail on telemetry

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -139,6 +139,10 @@ class MetricStorage(BaseSubjectEmbeddingStore):
                     # -- Operations & Lineage --
                     pa.field("yaml_path", pa.string()),
                     pa.field("updated_at", pa.timestamp("ms")),
+                    # Semantic Hub stable node id (locked_metadata.uid); empty for
+                    # metrics not governed by the Hub. Lets retrieval be counted
+                    # per Hub uid (consumption tracking).
+                    pa.field("uid", pa.string()),
                 ]
             ),
             vector_source_name="description",
@@ -159,6 +163,15 @@ class MetricStorage(BaseSubjectEmbeddingStore):
 
         self.create_subject_index()
         self.create_fts_index(["description", "name"])
+
+    def _scope_column_migration_exprs(self) -> Dict[str, str]:
+        # Also backfill the Hub uid column on pre-existing metric tables (empty
+        # default; real uids land on the next build-kb / pull vectorization),
+        # reusing the same best-effort ensure_columns migration as scope columns.
+        exprs = super()._scope_column_migration_exprs()
+        if self._schema is not None and "uid" in set(self._schema.names):
+            exprs = {**exprs, "uid": "''"}
+        return exprs
 
     def batch_store_metrics(self, metrics: List[Dict[str, Any]]) -> None:
         """Store multiple metrics in the database efficiently.
@@ -665,6 +678,7 @@ class MetricRAG:
         from datus.storage.registry import get_storage
 
         self.agent_config = agent_config
+        self.sub_agent_name = sub_agent_name
         self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self._provenance_enabled = is_knowledge_provenance_enabled(agent_config)
         self.storage: MetricStorage = get_storage(
@@ -759,7 +773,30 @@ class MetricRAG:
             extra_conditions=self._sub_agent_conditions(),
         )
         results = self._merge_search_results(exact_results, vector_results, top_n)
-        return self._enrich_metric_results(results)
+        enriched = self._enrich_metric_results(results)
+        self._emit_retrieval(query_text, enriched)
+        return enriched
+
+    def _emit_retrieval(self, query_text: str, results: List[Dict[str, Any]]) -> None:
+        # Fire-and-forget: report retrieved Hub metrics so the host can count
+        # consumption. Never let hook errors break a search.
+        try:
+            from datus.api.hooks import MetricRetrievalEvent, get_metric_retrieval_hook
+
+            hook = get_metric_retrieval_hook()
+            if hook is None:
+                return
+            hook.on_retrieval(
+                MetricRetrievalEvent(
+                    query_text=query_text,
+                    datasource_id=self.datasource_id,
+                    project_name=getattr(self.agent_config, "project_name", None),
+                    sub_agent_name=self.sub_agent_name,
+                    metrics=[{"id": r.get("id"), "name": r.get("name"), "uid": r.get("uid")} for r in results],
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — retrieval must never fail on telemetry
+            logger.debug(f"metric retrieval hook failed: {exc}")
 
     def _search_exact_metric_matches(
         self,

--- a/tests/unit_tests/api/hooks/test_metric_hooks.py
+++ b/tests/unit_tests/api/hooks/test_metric_hooks.py
@@ -62,15 +62,27 @@ def test_emit_retrieval_forwards_uid_and_context():
 
 
 def test_emit_retrieval_never_raises_when_hook_errors():
+    calls = []
+
     def _boom(_ev):
+        calls.append(1)
         raise RuntimeError("host blew up")
 
     set_metric_retrieval_hook(make_metric_retrieval_hook(_boom))
     fake = SimpleNamespace(datasource_id="ds1", sub_agent_name=None, agent_config=None)
-    # Must swallow the host error — a failing hook can never break a search.
-    MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
+    # The hook raises, but _emit_retrieval must swallow it (a failing host can
+    # never break a search) — it reaches the hook yet still returns cleanly.
+    result = MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
+    assert result is None
+    assert calls == [1]  # error path was actually exercised, not skipped
 
 
 def test_emit_retrieval_noop_without_hook():
+    seen = []
+    set_metric_retrieval_hook(make_metric_retrieval_hook(seen.append))
+    set_metric_retrieval_hook(None)  # no hook registered
+    assert get_metric_retrieval_hook() is None
+
     fake = SimpleNamespace(datasource_id="ds1", sub_agent_name=None, agent_config=None)
     MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
+    assert seen == []  # nothing emitted when no hook is registered

--- a/tests/unit_tests/api/hooks/test_metric_hooks.py
+++ b/tests/unit_tests/api/hooks/test_metric_hooks.py
@@ -4,6 +4,7 @@
 """Unit tests for ``datus.api.hooks.metric_hooks`` registry + helpers and the
 ``MetricRAG._emit_retrieval`` integration."""
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -16,9 +17,13 @@ from datus.api.hooks import (
 )
 from datus.storage.metric.store import MetricRAG
 
+_HOOK_FAIL_LOG = "metric retrieval hook failed"
+
 
 @pytest.fixture(autouse=True)
-def _clear_hook_after_test():
+def _isolate_hook():
+    # Clear before *and* after so a hook leaked by an earlier module can't bleed in.
+    set_metric_retrieval_hook(None)
     yield
     set_metric_retrieval_hook(None)
 
@@ -46,6 +51,7 @@ def test_emit_retrieval_forwards_uid_and_context():
     results = [
         {"id": "metric:dau", "name": "dau", "uid": "u1", "vector": [0.1]},
         {"id": "metric:rev", "name": "rev", "uid": ""},
+        {"id": "metric:loc", "name": "loc"},  # missing uid → normalized to ""
     ]
     MetricRAG._emit_retrieval(fake, "daily active", results)
 
@@ -54,14 +60,16 @@ def test_emit_retrieval_forwards_uid_and_context():
     assert ev.datasource_id == "ds1"
     assert ev.project_name == "proj"
     assert ev.sub_agent_name == "sub"
-    # Only id/name/uid are forwarded — heavy fields like the vector are dropped.
+    # Only id/name/uid are forwarded — heavy fields (vector) dropped — and a
+    # missing/null uid is normalized to "" rather than forwarded as None.
     assert ev.metrics == [
         {"id": "metric:dau", "name": "dau", "uid": "u1"},
         {"id": "metric:rev", "name": "rev", "uid": ""},
+        {"id": "metric:loc", "name": "loc", "uid": ""},
     ]
 
 
-def test_emit_retrieval_never_raises_when_hook_errors():
+def test_emit_retrieval_never_raises_when_hook_errors(caplog):
     calls = []
 
     def _boom(_ev):
@@ -70,19 +78,21 @@ def test_emit_retrieval_never_raises_when_hook_errors():
 
     set_metric_retrieval_hook(make_metric_retrieval_hook(_boom))
     fake = SimpleNamespace(datasource_id="ds1", sub_agent_name=None, agent_config=None)
-    # The hook raises, but _emit_retrieval must swallow it (a failing host can
-    # never break a search) — it reaches the hook yet still returns cleanly.
-    result = MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
+    with caplog.at_level(logging.DEBUG):
+        result = MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
+
+    # The hook is reached, its error is swallowed (no raise) and logged.
     assert result is None
-    assert calls == [1]  # error path was actually exercised, not skipped
+    assert calls == [1]
+    assert any(_HOOK_FAIL_LOG in r.message for r in caplog.records)
 
 
-def test_emit_retrieval_noop_without_hook():
-    seen = []
-    set_metric_retrieval_hook(make_metric_retrieval_hook(seen.append))
-    set_metric_retrieval_hook(None)  # no hook registered
-    assert get_metric_retrieval_hook() is None
+def test_emit_retrieval_noop_without_hook(caplog):
+    assert get_metric_retrieval_hook() is None  # isolated by the autouse fixture
 
     fake = SimpleNamespace(datasource_id="ds1", sub_agent_name=None, agent_config=None)
-    MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
-    assert seen == []  # nothing emitted when no hook is registered
+    with caplog.at_level(logging.DEBUG):
+        MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
+
+    # No hook → it returns without touching one and logs no failure.
+    assert not any(_HOOK_FAIL_LOG in r.message for r in caplog.records)

--- a/tests/unit_tests/api/hooks/test_metric_hooks.py
+++ b/tests/unit_tests/api/hooks/test_metric_hooks.py
@@ -1,0 +1,76 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for ``datus.api.hooks.metric_hooks`` registry + helpers and the
+``MetricRAG._emit_retrieval`` integration."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from datus.api.hooks import (
+    MetricRetrievalEvent,
+    get_metric_retrieval_hook,
+    make_metric_retrieval_hook,
+    set_metric_retrieval_hook,
+)
+from datus.storage.metric.store import MetricRAG
+
+
+@pytest.fixture(autouse=True)
+def _clear_hook_after_test():
+    yield
+    set_metric_retrieval_hook(None)
+
+
+def test_registry_set_get_clear():
+    assert get_metric_retrieval_hook() is None
+    seen = []
+    set_metric_retrieval_hook(make_metric_retrieval_hook(seen.append))
+    get_metric_retrieval_hook().on_retrieval(MetricRetrievalEvent(query_text="q", metrics=[]))
+    assert len(seen) == 1 and seen[0].query_text == "q"
+    set_metric_retrieval_hook(None)
+    assert get_metric_retrieval_hook() is None
+
+
+def test_emit_retrieval_forwards_uid_and_context():
+    seen = []
+    set_metric_retrieval_hook(make_metric_retrieval_hook(seen.append))
+
+    # Call the unbound method with a minimal fake self — no real storage needed.
+    fake = SimpleNamespace(
+        datasource_id="ds1",
+        sub_agent_name="sub",
+        agent_config=SimpleNamespace(project_name="proj"),
+    )
+    results = [
+        {"id": "metric:dau", "name": "dau", "uid": "u1", "vector": [0.1]},
+        {"id": "metric:rev", "name": "rev", "uid": ""},
+    ]
+    MetricRAG._emit_retrieval(fake, "daily active", results)
+
+    assert len(seen) == 1
+    ev = seen[0]
+    assert ev.datasource_id == "ds1"
+    assert ev.project_name == "proj"
+    assert ev.sub_agent_name == "sub"
+    # Only id/name/uid are forwarded — heavy fields like the vector are dropped.
+    assert ev.metrics == [
+        {"id": "metric:dau", "name": "dau", "uid": "u1"},
+        {"id": "metric:rev", "name": "rev", "uid": ""},
+    ]
+
+
+def test_emit_retrieval_never_raises_when_hook_errors():
+    def _boom(_ev):
+        raise RuntimeError("host blew up")
+
+    set_metric_retrieval_hook(make_metric_retrieval_hook(_boom))
+    fake = SimpleNamespace(datasource_id="ds1", sub_agent_name=None, agent_config=None)
+    # Must swallow the host error — a failing hook can never break a search.
+    MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])
+
+
+def test_emit_retrieval_noop_without_hook():
+    fake = SimpleNamespace(datasource_id="ds1", sub_agent_name=None, agent_config=None)
+    MetricRAG._emit_retrieval(fake, "q", [{"id": "metric:x", "name": "x", "uid": "u"}])


### PR DESCRIPTION
## What

Lets an embedding host (the SaaS Semantic Hub) count how often each metric is consumed by chatbot / NL2SQL, keyed by the Hub's stable **uid**.

## Changes

- **`tb_metrics` gains a `uid` column** — the Semantic Hub `locked_metadata.uid` (empty for metrics not governed by the Hub). Written during vectorization (`generation_hooks` metric build), and best-effort backfilled on pre-existing tables via the **same `ensure_columns` migration** already used for scope columns (`_scope_column_migration_exprs`), so no manual migration is needed.
- **New `datus.api.hooks.metric_hooks`** — `MetricRetrievalEvent` + a `set/get/make_metric_retrieval_hook` registry, mirroring the existing `chat_hooks` pattern. Exported from `datus.api.hooks`.
- **`MetricRAG.search_metrics` emits the event** (`{id, name, uid}` per hit) after enrichment. It's **fire-and-forget**: the hook is optional and its errors are swallowed, so telemetry can never break a search.

The host wiring (registering the hook) and the consumption store live in Datus-backend / Datus-saas.

## Tests

- `tests/unit_tests/api/hooks/test_metric_hooks.py`: registry set/get/clear; `_emit_retrieval` forwards uid + datasource/project/sub-agent context and drops heavy fields (vector); never raises when the host hook errors; no-op when unregistered.
- Existing `test_context_search*` / `test_storage_sync` suites pass (87) — the schema add + migration don't regress retrieval/sync.
- `ruff format` + `ruff check` clean.

## Notes

- A metric retrieved multiple times in one search counts each hit; de-duplication (if wanted) is the host's choice.
- `uid` is empty for non-Hub metrics; the host ignores those when counting Hub consumption.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **New Features**
  * Added support for metric retrieval tracking, including a new hook extension point for capturing search activity.
  * Metric records now include a stable identifier, improving consistency across metric lookups and stored results.

* **Bug Fixes**
  * Retrieval tracking is now fail-safe: hook errors won’t interrupt metric searches.
  * Existing metric data is automatically handled to keep the new identifier field usable on older records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a metric retrieval tracking hook extension point to capture metric search activity.
  * Metric records now store a stable `uid` (Semantic Hub stable node id) to improve consistency across saved and returned metrics.
* **Bug Fixes**
  * Retrieval tracking is fail-safe: hook errors no longer interrupt metric searches.
  * Existing metric tables are backfilled so the new `uid` field is usable for older data.
* **Tests**
  * Added unit tests for metric hook registration, event payloads, and fail-safe telemetry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->