### PR TITLE
[BugFix] Offload synchronous tool calls to a worker thread to prevent event-loop freeze

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -3,6 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 # -*- coding: utf-8 -*-
+import asyncio
 import inspect
 import json
 from typing import Any, Callable, Dict, Iterable, List, Optional
@@ -180,7 +181,16 @@ def trans_to_function_tool(
             if inspect.iscoroutinefunction(method_to_call):
                 result = await method_to_call(**args_dict)
             else:
-                result = method_to_call(**args_dict)
+                # Offload synchronous tool methods to a worker thread. Many tools
+                # (DB metadata/queries, filesystem ops) make blocking I/O calls;
+                # ``final_invoker`` is awaited directly on the asyncio event-loop
+                # thread, so calling them inline freezes the loop — a single slow
+                # ``list_tables`` against a large StarRocks cluster would hang the
+                # whole server (all requests unresponsive). ``asyncio.to_thread``
+                # keeps the loop free and copies the current contextvars (trace
+                # context) into the worker. ``set_tool_context`` is applied above
+                # on the per-session tool instance, so it is visible in the thread.
+                result = await asyncio.to_thread(method_to_call, **args_dict)
             if isinstance(result, FuncToolResult):
                 return result.model_dump(mode="json")
             return result

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -3,7 +3,9 @@ Test cases for datus/tools/func_tool/base.py
 Focuses on trans_to_function_tool parameter filtering for LLM-hallucinated arguments.
 """
 
+import asyncio
 import json
+import threading
 
 import pytest
 
@@ -120,6 +122,58 @@ class TestTransToFunctionTool:
 
         assert result["success"] == 0
         assert result["error"] == "Unsupported parameters for this tool: catalog"
+
+    @pytest.mark.asyncio
+    async def test_sync_tool_runs_off_the_event_loop_thread(self):
+        """Synchronous tool methods must be offloaded to a worker thread.
+
+        ``final_invoker`` is awaited directly on the asyncio event-loop thread.
+        If a blocking sync tool (e.g. a StarRocks ``list_tables`` metadata query)
+        ran inline, it would freeze the loop and make the whole server
+        unresponsive. The fix dispatches sync methods via ``asyncio.to_thread``;
+        here we assert the method body executed on a different thread.
+        """
+        loop_thread_id = threading.get_ident()
+        ran_on: dict = {}
+
+        class FakeTool:
+            def list_tables(self) -> FuncToolResult:
+                ran_on["thread_id"] = threading.get_ident()
+                return FuncToolResult(result="ok")
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.list_tables)
+
+        result = await tool.on_invoke_tool(None, "{}")
+
+        assert result["success"] == 1
+        assert ran_on["thread_id"] != loop_thread_id
+
+    @pytest.mark.asyncio
+    async def test_blocking_sync_tool_does_not_stall_the_event_loop(self):
+        """A blocking sync tool must not prevent other coroutines from running."""
+        proceed = threading.Event()
+
+        class FakeTool:
+            def slow_io(self) -> FuncToolResult:
+                # Blocks the worker thread until the event loop releases it.
+                proceed.wait(2)
+                return FuncToolResult(result="done")
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.slow_io)
+
+        task = asyncio.create_task(tool.on_invoke_tool(None, "{}"))
+        # If slow_io blocked the loop, this yield would never resume and the
+        # event below would never be set (deadlock). Reaching here with the task
+        # still pending proves the loop stayed free while slow_io blocked.
+        await asyncio.sleep(0.05)
+        assert not task.done()
+
+        proceed.set()
+        result = await task
+        assert result["success"] == 1
+        assert result["result"] == "done"
 
 
 class TestFuncToolListResult:


### PR DESCRIPTION
## Why

Docker single-node deployments repeatedly froze: after a chat request the **entire server became unresponsive** (every endpoint hung), not just the one session.

A `py-spy dump` of the frozen process showed the asyncio event-loop thread blocked on a synchronous network read:

```
Thread 1 (idle): "MainThread"
    readinto (socket.py:720)
    ... pymysql / sqlalchemy sync query ...
    _get_metadata (datus_starrocks/connector.py)
    get_tables (datus_starrocks/connector.py)
    list_tables (database.py)
    final_invoker (datus/tools/func_tool/base.py)
    _execute_tool_with_hooks (agents/_run_impl.py)
    run (asyncio/runners.py:118)          <- the event loop; no to_thread frame in between
```

`final_invoker` (the tool dispatcher) is awaited directly on the event-loop thread. Synchronous tools such as `list_tables` were called **inline** (`method_to_call(**args_dict)`), so a slow StarRocks `information_schema` metadata scan blocked the loop and made the whole single-worker server hang. Fast queries hid the problem until a large cluster (`edw_brain_kfc_db`) was explored.

## Solution

Dispatch synchronous tool methods through `asyncio.to_thread` instead of calling them inline:

```python
if inspect.iscoroutinefunction(method_to_call):
    result = await method_to_call(**args_dict)
else:
    result = await asyncio.to_thread(method_to_call, **args_dict)
```

A blocking tool now only occupies a worker-pool thread; the event loop stays free and other requests keep being served. One change covers **all** synchronous tools (DB metadata/queries, filesystem ops), not just `list_tables`.

Notes / tradeoffs:
- `set_tool_context` is applied on the per-session tool instance before the call, so it remains visible in the worker thread; `asyncio.to_thread` also copies the current `contextvars` (trace context) into the worker.
- This does not add a driver-level query timeout — the StarRocks/pymysql `connect_timeout`/`read_timeout` lives in the separate adapters package and is a recommended follow-up so a stuck query cannot indefinitely hold a pool thread.

## Test Cases

Added two unit regression tests in `tests/unit_tests/tools/func_tool/test_base.py`:
- `test_sync_tool_runs_off_the_event_loop_thread` — asserts a sync tool body executes on a thread other than the event-loop thread.
- `test_blocking_sync_tool_does_not_stall_the_event_loop` — a blocking sync tool must not prevent other coroutines from running.

Verified failing→passing: both tests FAIL on the pre-fix inline dispatch (the blocking test fails at `assert not task.done()`, proving the loop was frozen) and PASS with the fix. `test_base.py` (13) plus the most-affected sync-tool suites `test_database.py` and `test_filesystem_tools.py` (188 total) all pass; ruff format/check clean. These are deterministic unit tests (no external services), so no nightly/integration tier was needed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when using synchronous tools by running them in the background instead of blocking the main event loop.
  * Async tools continue to work as before, with no change in expected behavior.
  * Added coverage to verify synchronous tool calls complete correctly without stalling other async work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->